### PR TITLE
Improve StoreFront API Docs

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -350,11 +350,7 @@ paths:
       operationId: completed-orders
       responses:
         '200':
-          description: Listing user completed orders.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/CartList'
+          $ref: '#/components/responses/CartList'
         '403':
           $ref: '#/components/responses/403Forbidden'
       parameters:
@@ -373,11 +369,7 @@ paths:
       operationId: completed-user-order
       responses:
         '200':
-          description: Listing user completed order.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
+          $ref: '#/components/responses/Cart'
         '403':
           $ref: '#/components/responses/403Forbidden'
       parameters:
@@ -398,11 +390,7 @@ paths:
       operationId: order-status
       responses:
         '200':
-          description: Requested Order information
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Cart'
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
       parameters:
@@ -424,372 +412,7 @@ paths:
       operationId: create-cart
       responses:
         '201':
-          description: Cart was successfully created
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
       parameters:
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsParam'
@@ -817,372 +440,7 @@ paths:
       operationId: get-cart
       responses:
         '200':
-          description: Correct cart was returned
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
       security:
@@ -1205,352 +463,7 @@ paths:
       operationId: add-item
       responses:
         '200':
-          description: Item was added to the Cart successfully
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
       security:
@@ -1585,352 +498,7 @@ paths:
       operationId: set-quantity
       responses:
         '200':
-          description: New quantity has been successfully set for a requested Line Item
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '422':
           description: Stock quantity is not sufficient for this request to be fulfielled
           content:
@@ -1973,352 +541,7 @@ paths:
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
         '200':
-          description: Requested Line Item has been removed from the Cart
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
       security:
@@ -2336,189 +559,7 @@ paths:
       operationId: empty-cart
       responses:
         '200':
-          description: Cart has been successfully emptied
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '15'
-                      type: cart
-                      attributes:
-                        number: R977693548
-                        item_total: '0.0'
-                        total: '0.0'
-                        ship_total: '0.0'
-                        adjustment_total: '0.0'
-                        created_at: '2021-09-28T15:06:54.612Z'
-                        updated_at: '2021-09-28T15:23:49.241Z'
-                        completed_at: null
-                        included_tax_total: '0.0'
-                        additional_tax_total: '0.0'
-                        display_additional_tax_total: $0.00
-                        display_included_tax_total: $0.00
-                        tax_total: '0.0'
-                        currency: USD
-                        state: cart
-                        token: ndhMCvJDgyx5vNLzisFOJQ1632841614595
-                        email: john@snow.org
-                        display_item_total: $0.00
-                        display_ship_total: $0.00
-                        display_adjustment_total: $0.00
-                        display_tax_total: $0.00
-                        promo_total: '0.0'
-                        display_promo_total: $0.00
-                        item_count: 0
-                        special_instructions: null
-                        display_total: $0.00
-                        pre_tax_item_amount: '0.0'
-                        display_pre_tax_item_amount: $0.00
-                        pre_tax_total: '0.0'
-                        display_pre_tax_total: $0.00
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data: []
-                        variants:
-                          data: []
-                        promotions:
-                          data: []
-                        payments:
-                          data:
-                            - id: '6'
-                              type: payment
-                        shipments:
-                          data: []
-                        user:
-                          data: null
-                        billing_address:
-                          data:
-                            id: '26'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '27'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '15'
-                      type: cart
-                      attributes:
-                        number: R977693548
-                        item_total: '0.0'
-                        total: '0.0'
-                        ship_total: '0.0'
-                        adjustment_total: '0.0'
-                        created_at: '2021-09-28T15:06:54.612Z'
-                        updated_at: '2021-09-28T15:25:47.167Z'
-                        completed_at: null
-                        included_tax_total: '0.0'
-                        additional_tax_total: '0.0'
-                        display_additional_tax_total: $0.00
-                        display_included_tax_total: $0.00
-                        tax_total: '0.0'
-                        currency: USD
-                        state: cart
-                        token: ndhMCvJDgyx5vNLzisFOJQ1632841614595
-                        email: john@snow.org
-                        display_item_total: $0.00
-                        display_ship_total: $0.00
-                        display_adjustment_total: $0.00
-                        display_tax_total: $0.00
-                        promo_total: '0.0'
-                        display_promo_total: $0.00
-                        item_count: 0
-                        special_instructions: null
-                        display_total: $0.00
-                        pre_tax_item_amount: '0.0'
-                        display_pre_tax_item_amount: $0.00
-                        pre_tax_total: '0.0'
-                        display_pre_tax_total: $0.00
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data: []
-                        variants:
-                          data: []
-                        promotions:
-                          data: []
-                        payments:
-                          data:
-                            - id: '6'
-                              type: payment
-                        shipments:
-                          data: []
-                        user:
-                          data: null
-                        billing_address:
-                          data:
-                            id: '26'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '27'
-                            type: address
-                    included:
-                      - id: '26'
-                        type: address
-                        attributes:
-                          firstname: John
-                          lastname: Snow
-                          address1: 7735 Old Georgetown Road
-                          address2: 2nd Floor
-                          city: Bethesda
-                          zipcode: '20814'
-                          phone: '3014445002'
-                          state_name: Maryland
-                          company: null
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: MD
-                      - id: '27'
-                        type: address
-                        attributes:
-                          firstname: John
-                          lastname: Snow
-                          address1: 7735 Old Georgetown Road
-                          address2: 2nd Floor
-                          city: Bethesda
-                          zipcode: '20814'
-                          phone: '3014445002'
-                          state_name: Maryland
-                          company: null
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: MD
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
       security:
@@ -2536,352 +577,7 @@ paths:
       operationId: apply-coupon-code
       responses:
         '200':
-          description: Coupon code was applied successfully
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '422':
           description: Coupon code couldn't be applied
           content:
@@ -2923,352 +619,7 @@ paths:
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
         '200':
-          description: Coupon code was removed successfully
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '422':
           description: Coupon code couldn't be removed
           content:
@@ -3322,352 +673,7 @@ paths:
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
         '200':
-          description: Cart has been successfully associated
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '403':
           $ref: '#/components/responses/403Forbidden'
         '422':
@@ -3695,352 +701,7 @@ paths:
         - $ref: '#/components/parameters/SparseFieldsParam'
       responses:
         '200':
-          description: Currency has been successfully changed
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '403':
           $ref: '#/components/responses/403Forbidden'
         '422':
@@ -4164,352 +825,7 @@ paths:
       operationId: update-checkout
       responses:
         '200':
-          description: Checkout was updated
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -4562,352 +878,7 @@ paths:
       operationId: checkout-next
       responses:
         '200':
-          description: Checkout transitioned to the next step
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -4931,352 +902,7 @@ paths:
       operationId: advance-checkout
       responses:
         '200':
-          description: Checkout was advanced to the furthest step
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -5300,352 +926,7 @@ paths:
       operationId: complete-checkout
       responses:
         '200':
-          description: Checkout was completed
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: complete
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: complete
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -5668,352 +949,7 @@ paths:
       operationId: add-store-credit
       responses:
         '200':
-          description: Store Credit payment created
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -6043,352 +979,7 @@ paths:
       operationId: remove-store-credit
       responses:
         '200':
-          description: Store Credit payment removed
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Cart'
-              examples:
-                Standard response:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                Including related objects:
-                  value:
-                    data:
-                      id: '11'
-                      type: cart
-                      attributes:
-                        number: R823511564
-                        item_total: '287.97'
-                        total: '316.0'
-                        ship_total: '5.0'
-                        adjustment_total: '23.03'
-                        created_at: '2021-09-28T12:57:15.148Z'
-                        updated_at: '2021-09-28T13:06:02.689Z'
-                        completed_at: null
-                        included_tax_total: '26.18'
-                        additional_tax_total: '51.83'
-                        display_additional_tax_total: $51.83
-                        display_included_tax_total: $26.18
-                        tax_total: '78.01'
-                        currency: USD
-                        state: payment
-                        token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
-                        email: spree@example.com
-                        display_item_total: $287.97
-                        display_ship_total: $5.00
-                        display_adjustment_total: $23.03
-                        display_tax_total: $78.01
-                        promo_total: '-28.8'
-                        display_promo_total: '-$28.80'
-                        item_count: 3
-                        special_instructions: null
-                        display_total: $316.00
-                        pre_tax_item_amount: '261.7909'
-                        display_pre_tax_item_amount: $261.79
-                        pre_tax_total: '266.7909'
-                        display_pre_tax_total: $266.79
-                        shipment_state: null
-                        payment_state: null
-                      relationships:
-                        line_items:
-                          data:
-                            - id: '6'
-                              type: line_item
-                        variants:
-                          data:
-                            - id: '130'
-                              type: variant
-                        promotions:
-                          data:
-                            - id: '2'
-                              type: promotion
-                        payments:
-                          data: []
-                        shipments:
-                          data:
-                            - id: '7'
-                              type: shipment
-                        user:
-                          data:
-                            id: '1'
-                            type: user
-                        billing_address:
-                          data:
-                            id: '25'
-                            type: address
-                        shipping_address:
-                          data:
-                            id: '25'
-                            type: address
-                    included:
-                      - id: '6'
-                        type: line_item
-                        attributes:
-                          name: 3 4 Sleeve T Shirt
-                          quantity: 3
-                          price: '95.99'
-                          slug: 3-4-sleeve-t-shirt
-                          options_text: 'Color: white, Size: XS'
-                          currency: USD
-                          display_price: $95.99
-                          total: '311.0'
-                          display_total: $311.00
-                          adjustment_total: '23.03'
-                          display_adjustment_total: $23.03
-                          additional_tax_total: '51.83'
-                          discounted_amount: '259.17'
-                          display_discounted_amount: $259.17
-                          display_additional_tax_total: $51.83
-                          promo_total: '-28.8'
-                          display_promo_total: '-$28.80'
-                          included_tax_total: '26.18'
-                          display_included_tax_total: $26.18
-                          pre_tax_amount: '261.7909'
-                          display_pre_tax_amount: $261.79
-                        relationships:
-                          variant:
-                            data:
-                              id: '130'
-                              type: variant
-                      - id: '1'
-                        type: image
-                        attributes:
-                          transformed_url: null
-                          styles:
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--5f94074b42f94dcde26991ebc0fa266f4136b5c5/3-4-shirt-red.png
-                              size: 48x48>
-                              width: '48'
-                              height: '48'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--f4c0ccb3ebc15c5becf44fd2b9dc9526bb2bf552/3-4-shirt-red.png
-                              size: 100x100>
-                              width: '100'
-                              height: '100'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--23c27823d8d23107f80822c67372ac3f36595dee/3-4-shirt-red.png
-                              size: 240x240>
-                              width: '240'
-                              height: '240'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--38efb9fba02d35b716d55de13df775845624d150/3-4-shirt-red.png
-                              size: 160x200>
-                              width: '160'
-                              height: '200'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--899ad54650e27f9fea5e3904ec628b273b4c89a6/3-4-shirt-red.png
-                              size: 448x600>
-                              width: '448'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3afb6d475a0cef62acf388c777c996366de12d1b/3-4-shirt-red.png
-                              size: 254x340>
-                              width: '254'
-                              height: '340'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--dbc0d7d9522d385998e8e40e0b54da5d0970f16f/3-4-shirt-red.png
-                              size: 350x468>
-                              width: '350'
-                              height: '468'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d1708c5d0787e793e900e2ca752fd02d862b1b9b/3-4-shirt-red.png
-                              size: 222x297>
-                              width: '222'
-                              height: '297'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--ac2e6c29e35e5b56a28a5e9c85f84b9797cc4156/3-4-shirt-red.png
-                              size: 600x600>
-                              width: '600'
-                              height: '600'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--071e560ce1ac34723119e27e00030c89a05b57da/3-4-shirt-red.png
-                              size: 278x371>
-                              width: '278'
-                              height: '371'
-                            - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--54c1c6d442b3f7663ec0052aff4aaeb4f08d24e1/3-4-shirt-red.png
-                              size: 650x870>
-                              width: '650'
-                              height: '870'
-                          position: 1
-                          alt: ''
-                          original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--940b84e3b5df01c826fbc382e751046c8aaafaec/3-4-shirt-red.png
-                      - id: '130'
-                        type: variant
-                        attributes:
-                          sku: T-shirts_3_4sleevet-shirt_95.99_white_xs
-                          weight: '60.0'
-                          height: '10.0'
-                          width: '16.0'
-                          depth: '5.0'
-                          is_master: false
-                          options_text: 'Color: white, Size: XS'
-                          purchasable: true
-                          in_stock: true
-                          backorderable: true
-                          currency: USD
-                          price: '95.99'
-                          display_price: $95.99
-                          compare_at_price: '100.0'
-                          display_compare_at_price: $100.00
-                        relationships:
-                          product:
-                            data:
-                              id: '14'
-                              type: product
-                          images:
-                            data:
-                              - id: '1'
-                                type: image
-                          option_values:
-                            data:
-                              - id: '1'
-                                type: option_value
-                              - id: '23'
-                                type: option_value
-                      - id: '25'
-                        type: address
-                        attributes:
-                          firstname: ' Tyler'
-                          lastname: Durden
-                          address1: 3029 Street Way Drive
-                          address2: Basement Entrance
-                          city: LA
-                          zipcode: '90210'
-                          phone: '09128386372'
-                          state_name: California
-                          company: Paper Street Soap Co.
-                          country_name: United States
-                          country_iso3: USA
-                          country_iso: US
-                          label: null
-                          state_code: CA
-                      - id: '1'
-                        type: user
-                        attributes:
-                          email: spree@example.com
-                          store_credits: 0
-                          completed_orders: 0
-                        relationships:
-                          default_billing_address:
-                            data:
-                              id: '11'
-                              type: address
-                          default_shipping_address:
-                            data:
-                              id: '11'
-                              type: address
-                      - id: '7'
-                        type: shipment
-                        attributes:
-                          number: H72371700543
-                          final_price: '5.0'
-                          display_final_price: $5.00
-                          state: pending
-                          shipped_at: null
-                          tracking_url: null
-                          free: false
-                        relationships:
-                          shipping_rates:
-                            data:
-                              - id: '97'
-                                type: shipping_rate
-                              - id: '98'
-                                type: shipping_rate
-                              - id: '99'
-                                type: shipping_rate
-                          stock_location:
-                            data:
-                              id: '1'
-                              type: stock_location
-                      - id: '2'
-                        type: promotion
-                        attributes:
-                          name: Black Friday
-                          description: ''
-                          amount: '-28.8'
-                          display_amount: '-$28.80'
-                          code: BLKFRI
-                      - id: '6'
-                        type: payment
-                        attributes:
-                          amount: '479.95'
-                          response_code: null
-                          number: PV7B4YH0
-                          cvv_response_code: null
-                          cvv_response_message: null
-                          payment_method_id: 1
-                          payment_method_name: Credit Card
-                          state: checkout
-                        relationships:
-                          source:
-                            data:
-                              id: '2'
-                              type: credit_card
-                          payment_method:
-                            data:
-                              id: '1'
-                              type: payment_method
+          $ref: '#/components/responses/Cart'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -19479,53 +14070,9 @@ components:
           items:
             $ref: '#/components/schemas/Address'
     Cart:
-      x-examples: {}
+      description: 'The Cart provides a central place to collect information about an order, including line items, adjustments, payments, addresses, return authorizations, and shipments. [Read more in Spree docs](https://dev-docs.spreecommerce.org/internals/orders)'
       type: object
-      description: 'Cart provides a central place around which to collect information about a customer order - including line items, adjustments, payments, addresses, return authorizations, and shipments. [Read more in Spree docs](https://dev-docs.spreecommerce.org/internals/orders)'
-      properties:
-        data:
-          $ref: '#/components/schemas/CartAttributesWithRelationships'
-        included:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/Promotion'
-              - $ref: '#/components/schemas/User'
-              - $ref: '#/components/schemas/Address'
-              - $ref: '#/components/schemas/ShipmentAttributesAndRelationsips'
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
-              - $ref: '#/components/schemas/LineItem'
-              - $ref: '#/components/schemas/Payment'
-      required:
-        - data
-    CartList:
-      required:
-        - data
-        - included
-      properties:
-        data:
-          required:
-            - id
-            - type
-            - attributes
-            - relationships
-          type: array
-          items:
-            $ref: '#/components/schemas/CartAttributesWithRelationships'
-        included:
-          type: array
-          items:
-            type: object
-            anyOf:
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
-              - $ref: '#/components/schemas/LineItem'
-              - $ref: '#/components/schemas/Promotion'
-              - $ref: '#/components/schemas/User'
-              - $ref: '#/components/schemas/Address'
-              - $ref: '#/components/schemas/ShipmentAttributesWithoutRelationsips'
-    CartAttributesWithRelationships:
-      description: ''
-      type: object
+      title: Cart
       properties:
         id:
           type: string
@@ -19537,207 +14084,204 @@ components:
           example: cart
           pattern: ^cart$
         attributes:
-          $ref: '#/components/schemas/CartAttributes'
+          type: object
+          properties:
+            number:
+              type: string
+              example: R123456789
+              pattern: ^R\d+$
+            item_total:
+              type: string
+              example: '19.99'
+            total:
+              type: string
+              example: '29.99'
+            ship_total:
+              type: string
+              example: '0.0'
+            adjustment_total:
+              type: string
+              example: '10.0'
+            created_at:
+              $ref: '#/components/schemas/Timestamp'
+            updated_at:
+              $ref: '#/components/schemas/Timestamp'
+            completed_at:
+              type: string
+              format: date-time
+              nullable: true
+            included_tax_total:
+              type: string
+              example: '5.00'
+            additional_tax_total:
+              type: string
+              example: '5.0'
+            display_additional_tax_total:
+              type: string
+              example: $5.00
+            tax_total:
+              type: string
+              example: '10.0'
+            currency:
+              type: string
+              example: USD
+            state:
+              type: string
+              example: cart
+              enum:
+                - cart
+                - address
+                - delivery
+                - payment
+                - confirm
+                - complete
+              description: |-
+                State of the Cart in the Checkout flow. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#the-order-state-machine">
+                  The Order State machine
+                </a> for a full list with description.
+            token:
+              type: string
+              example: abcdef123456
+              description: Used for authorizing any action for an Order within Spree’s API.
+            email:
+              type: string
+              format: email
+              example: spree@example.com
+              nullable: true
+            display_item_total:
+              type: string
+              example: $19.99
+            display_ship_total:
+              type: string
+              example: $19.99
+            display_adjustment_total:
+              type: string
+              example: $10.00
+            display_included_tax_total:
+              type: string
+              example: $5.00
+            promo_total:
+              type: string
+              example: '-10.0'
+            display_promo_total:
+              type: string
+              example: '-$10.00'
+            item_count:
+              type: number
+              description: Total quantity number of all items added to the Cart
+              example: 2
+              minimum: 0
+            special_instructions:
+              type: string
+              example: Please wrap it as a gift
+              description: Message added by the Customer
+              nullable: true
+            display_total:
+              type: string
+              example: $29.99
+            pre_tax_item_amount:
+              type: string
+              example: '17.00'
+            display_pre_tax_item_amount:
+              type: string
+              example: $17.00
+            pre_tax_total:
+              type: string
+              example: '20.00'
+            display_tax_total:
+              type: string
+              example: $10.00
+            display_pre_tax_total:
+              type: string
+              example: $20.00
+            shipment_state:
+              type: string
+              enum:
+                - pending
+                - backorder
+                - canceled
+                - partial
+                - ready
+                - shipped
+                - null
+              description: |-
+                Overall state of the Shipments. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#order-shipment-states-1">
+                  Order Shipments states
+                </a> for a full list with description.
+              nullable: true
+            payment_state:
+              type: string
+              enum:
+                - balance_due
+                - credit_owed
+                - failed
+                - paid
+                - void
+                - null
+              description: |-
+                Overall state of the Payments. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#order-payment-states">
+                  Order Payments states
+                </a> for a full list with description.
+              nullable: true
         relationships:
-          $ref: '#/components/schemas/CartRelationships'
+          type: object
+          properties:
+            line_items:
+              type: object
+              description: ''
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+            variants:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+            promotions:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+            payments:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+            shipments:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+            user:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/Relation'
+            billing_address:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/Relation'
+            shipping_address:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/Relation'
       required:
         - id
         - type
         - attributes
         - relationships
-    CartRelationships:
-      type: object
-      properties:
-        line_items:
-          type: object
-          description: ''
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-        variants:
-          type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-        promotions:
-          type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-        payments:
-          type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-        shipments:
-          type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-        user:
-          type: object
-          properties:
-            data:
-              $ref: '#/components/schemas/Relation'
-        billing_address:
-          type: object
-          properties:
-            data:
-              $ref: '#/components/schemas/Relation'
-        shipping_address:
-          type: object
-          properties:
-            data:
-              $ref: '#/components/schemas/Relation'
-    CartAttributes:
-      type: object
-      properties:
-        number:
-          type: string
-          example: R123456789
-          pattern: ^R\d+$
-        item_total:
-          type: string
-          example: '19.99'
-        total:
-          type: string
-          example: '29.99'
-        ship_total:
-          type: string
-          example: '0.0'
-        adjustment_total:
-          type: string
-          example: '10.0'
-        created_at:
-          $ref: '#/components/schemas/Timestamp'
-        updated_at:
-          $ref: '#/components/schemas/Timestamp'
-        completed_at:
-          type: string
-          format: date-time
-          nullable: true
-        included_tax_total:
-          type: string
-          example: '5.00'
-        additional_tax_total:
-          type: string
-          example: '5.0'
-        display_additional_tax_total:
-          type: string
-          example: $5.00
-        tax_total:
-          type: string
-          example: '10.0'
-        currency:
-          type: string
-          example: USD
-        state:
-          type: string
-          example: cart
-          enum:
-            - cart
-            - address
-            - delivery
-            - payment
-            - confirm
-            - complete
-          description: |-
-            State of the Cart in the Checkout flow. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#the-order-state-machine">
-              The Order State machine
-            </a> for a full list with description.
-        token:
-          type: string
-          example: abcdef123456
-          description: Used for authorizing any action for an Order within Spree’s API.
-        email:
-          type: string
-          format: email
-          example: spree@example.com
-        display_item_total:
-          type: string
-          example: $19.99
-        display_ship_total:
-          type: string
-          example: $19.99
-        display_adjustment_total:
-          type: string
-          example: $10.00
-        display_included_tax_total:
-          type: string
-          example: $5.00
-        promo_total:
-          type: string
-          example: '-10.0'
-        display_promo_total:
-          type: string
-          example: '-$10.00'
-        item_count:
-          type: number
-          description: Total quantity number of all items added to the Cart
-          example: 2
-          minimum: 0
-        special_instructions:
-          type: string
-          example: Please wrap it as a gift
-          description: Message added by the Customer
-          nullable: true
-        display_total:
-          type: string
-          example: $29.99
-        pre_tax_item_amount:
-          type: string
-          example: '17.00'
-        display_pre_tax_item_amount:
-          type: string
-          example: $17.00
-        pre_tax_total:
-          type: string
-          example: '20.00'
-        display_tax_total:
-          type: string
-          example: $10.00
-        display_pre_tax_total:
-          type: string
-          example: $20.00
-        shipment_state:
-          type: string
-          enum:
-            - pending
-            - backorder
-            - canceled
-            - partial
-            - ready
-            - shipped
-            - null
-          description: |-
-            Overall state of the Shipments. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#order-shipment-states-1">
-              Order Shipments states
-            </a> for a full list with description.
-          nullable: true
-        payment_state:
-          type: string
-          enum:
-            - balance_due
-            - credit_owed
-            - failed
-            - paid
-            - void
-            - null
-          description: |-
-            Overall state of the Payments. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#order-payment-states">
-              Order Payments states
-            </a> for a full list with description.
-          nullable: true
     CreditCardList:
       required:
         - included
@@ -20133,14 +14677,16 @@ components:
         relationships:
           $ref: '#/components/schemas/ProductRelationships'
     Relation:
-      required:
-        - id
-        - type
+      type: object
+      nullable: true
       properties:
         id:
           type: string
         type:
           type: string
+      required:
+        - id
+        - type
     Taxon:
       required:
         - data
@@ -20502,7 +15048,7 @@ components:
           type: boolean
           example: true
           description: Indicates if Variant is backorderable
-      title: ''
+      title: Variant
       description: ''
     VariantRelationships:
       type: object
@@ -22157,7 +16703,7 @@ components:
         type: string
   responses:
     404NotFound:
-      description: Resource not found
+      description: 404 Not Found - Resource not found.
       content:
         application/vnd.api+json:
           schema:
@@ -22166,8 +16712,12 @@ components:
                 type: string
                 example: The resource you were looking for could not be found.
                 default: The resource you were looking for could not be found.
+          examples:
+            404 Example:
+              value:
+                error: The resource you were looking for could not be found.
     403Forbidden:
-      description: You are not authorized to access this page.
+      description: 403 Forbidden - You are not authorized to access this page.
       content:
         application/vnd.api+json:
           schema:
@@ -22176,6 +16726,856 @@ components:
                 type: string
                 example: You are not authorized to access this page.
                 default: You are not authorized to access this page.
+    Cart:
+      description: 200 Success - Returns the Cart object.
+      content:
+        application/vnd.api+json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Cart'
+              included:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/Promotion'
+                    - $ref: '#/components/schemas/User'
+                    - $ref: '#/components/schemas/Address'
+                    - $ref: '#/components/schemas/ShipmentAttributesAndRelationsips'
+                    - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+                    - $ref: '#/components/schemas/LineItem'
+                    - $ref: '#/components/schemas/Payment'
+            required:
+              - data
+          examples:
+            Empty Cart:
+              value:
+                data:
+                  id: '17'
+                  type: cart
+                  attributes:
+                    number: R233871560
+                    item_total: '0.0'
+                    total: '0.0'
+                    ship_total: '0.0'
+                    adjustment_total: '0.0'
+                    created_at: '2021-09-28T22:15:07.471Z'
+                    updated_at: '2021-09-28T22:15:07.471Z'
+                    completed_at: null
+                    included_tax_total: '0.0'
+                    additional_tax_total: '0.0'
+                    display_additional_tax_total: $0.00
+                    display_included_tax_total: $0.00
+                    tax_total: '0.0'
+                    currency: USD
+                    state: cart
+                    token: zTEpsukRq_yEUcXVCSv0uw1632867307450
+                    email: null
+                    display_item_total: $0.00
+                    display_ship_total: $0.00
+                    display_adjustment_total: $0.00
+                    display_tax_total: $0.00
+                    promo_total: '0.0'
+                    display_promo_total: $0.00
+                    item_count: 0
+                    special_instructions: null
+                    display_total: $0.00
+                    pre_tax_item_amount: '0.0'
+                    display_pre_tax_item_amount: $0.00
+                    pre_tax_total: '0.0'
+                    display_pre_tax_total: $0.00
+                    shipment_state: null
+                    payment_state: null
+                  relationships:
+                    line_items:
+                      data: []
+                    variants:
+                      data: []
+                    promotions:
+                      data: []
+                    payments:
+                      data: []
+                    shipments:
+                      data: []
+                    user:
+                      data: null
+                    billing_address:
+                      data: null
+                    shipping_address:
+                      data: null
+            Populated Cart:
+              value:
+                data:
+                  id: '11'
+                  type: cart
+                  attributes:
+                    number: R823511564
+                    item_total: '287.97'
+                    total: '316.0'
+                    ship_total: '5.0'
+                    adjustment_total: '23.03'
+                    created_at: '2021-09-28T12:57:15.148Z'
+                    updated_at: '2021-09-28T13:06:02.689Z'
+                    completed_at: null
+                    included_tax_total: '26.18'
+                    additional_tax_total: '51.83'
+                    display_additional_tax_total: $51.83
+                    display_included_tax_total: $26.18
+                    tax_total: '78.01'
+                    currency: USD
+                    state: payment
+                    token: VDK_6q_NNdWFc81VZRpUfQ1632833835148
+                    email: spree@example.com
+                    display_item_total: $287.97
+                    display_ship_total: $5.00
+                    display_adjustment_total: $23.03
+                    display_tax_total: $78.01
+                    promo_total: '-28.8'
+                    display_promo_total: '-$28.80'
+                    item_count: 3
+                    special_instructions: null
+                    display_total: $316.00
+                    pre_tax_item_amount: '261.7909'
+                    display_pre_tax_item_amount: $261.79
+                    pre_tax_total: '266.7909'
+                    display_pre_tax_total: $266.79
+                    shipment_state: null
+                    payment_state: null
+                  relationships:
+                    line_items:
+                      data:
+                        - id: '6'
+                          type: line_item
+                    variants:
+                      data:
+                        - id: '130'
+                          type: variant
+                    promotions:
+                      data:
+                        - id: '2'
+                          type: promotion
+                    payments:
+                      data: []
+                    shipments:
+                      data:
+                        - id: '7'
+                          type: shipment
+                    user:
+                      data:
+                        id: '1'
+                        type: user
+                    billing_address:
+                      data:
+                        id: '25'
+                        type: address
+                    shipping_address:
+                      data:
+                        id: '25'
+                        type: address
+            Completed Cart:
+              value:
+                data:
+                  id: '18'
+                  type: cart
+                  attributes:
+                    number: R177608027
+                    item_total: '474.95'
+                    total: '527.45'
+                    ship_total: '5.0'
+                    adjustment_total: '47.5'
+                    created_at: '2021-09-28T22:31:47.401Z'
+                    updated_at: '2021-09-28T22:33:20.257Z'
+                    completed_at: '2021-09-28T22:33:18.372Z'
+                    included_tax_total: '0.0'
+                    additional_tax_total: '47.5'
+                    display_additional_tax_total: $47.50
+                    display_included_tax_total: $0.00
+                    tax_total: '47.5'
+                    currency: USD
+                    state: complete
+                    token: 5DUe7Jg40Lu-SoEvAKRKcQ1632868307387
+                    email: spree@example.com
+                    display_item_total: $474.95
+                    display_ship_total: $5.00
+                    display_adjustment_total: $47.50
+                    display_tax_total: $47.50
+                    promo_total: '0.0'
+                    display_promo_total: $0.00
+                    item_count: 5
+                    special_instructions: null
+                    display_total: $527.45
+                    pre_tax_item_amount: '474.95'
+                    display_pre_tax_item_amount: $474.95
+                    pre_tax_total: '479.95'
+                    display_pre_tax_total: $479.95
+                    shipment_state: ready
+                    payment_state: paid
+                  relationships:
+                    line_items:
+                      data:
+                        - id: '1'
+                          type: line_item
+                    variants:
+                      data:
+                        - id: '131'
+                          type: variant
+                    promotions:
+                      data: []
+                    payments:
+                      data:
+                        - id: '1'
+                          type: payment
+                    shipments:
+                      data:
+                        - id: '1'
+                          type: shipment
+                    user:
+                      data:
+                        id: '1'
+                        type: user
+                    billing_address:
+                      data:
+                        id: '5'
+                        type: address
+                    shipping_address:
+                      data:
+                        id: '5'
+                        type: address
+            Completed Cart with all included objects:
+              value:
+                data:
+                  id: '18'
+                  type: cart
+                  attributes:
+                    number: R177608027
+                    item_total: '474.95'
+                    total: '527.45'
+                    ship_total: '5.0'
+                    adjustment_total: '47.5'
+                    created_at: '2021-09-28T22:31:47.401Z'
+                    updated_at: '2021-09-28T22:57:22.132Z'
+                    completed_at: '2021-09-28T22:33:18.372Z'
+                    included_tax_total: '0.0'
+                    additional_tax_total: '47.5'
+                    display_additional_tax_total: $47.50
+                    display_included_tax_total: $0.00
+                    tax_total: '47.5'
+                    currency: USD
+                    state: complete
+                    token: 5DUe7Jg40Lu-SoEvAKRKcQ1632868307387
+                    email: spree@example.com
+                    display_item_total: $474.95
+                    display_ship_total: $5.00
+                    display_adjustment_total: $47.50
+                    display_tax_total: $47.50
+                    promo_total: '0.0'
+                    display_promo_total: $0.00
+                    item_count: 5
+                    special_instructions: null
+                    display_total: $527.45
+                    pre_tax_item_amount: '474.95'
+                    display_pre_tax_item_amount: $474.95
+                    pre_tax_total: '479.95'
+                    display_pre_tax_total: $479.95
+                    shipment_state: shipped
+                    payment_state: paid
+                  relationships:
+                    line_items:
+                      data:
+                        - id: '1'
+                          type: line_item
+                    variants:
+                      data:
+                        - id: '131'
+                          type: variant
+                    promotions:
+                      data: []
+                    payments:
+                      data:
+                        - id: '1'
+                          type: payment
+                    shipments:
+                      data:
+                        - id: '1'
+                          type: shipment
+                    user:
+                      data:
+                        id: '1'
+                        type: user
+                    billing_address:
+                      data:
+                        id: '5'
+                        type: address
+                    shipping_address:
+                      data:
+                        id: '5'
+                        type: address
+                included:
+                  - id: '1'
+                    type: line_item
+                    attributes:
+                      name: 3 4 Sleeve T Shirt
+                      quantity: 5
+                      price: '94.99'
+                      slug: 3-4-sleeve-t-shirt
+                      options_text: 'Color: white, Size: XS'
+                      currency: USD
+                      display_price: $94.99
+                      total: '522.45'
+                      display_total: $522.45
+                      adjustment_total: '47.5'
+                      display_adjustment_total: $47.50
+                      additional_tax_total: '47.5'
+                      discounted_amount: '474.95'
+                      display_discounted_amount: $474.95
+                      display_additional_tax_total: $47.50
+                      promo_total: '0.0'
+                      display_promo_total: $0.00
+                      included_tax_total: '0.0'
+                      display_included_tax_total: $0.00
+                      pre_tax_amount: '474.95'
+                      display_pre_tax_amount: $474.95
+                    relationships:
+                      variant:
+                        data:
+                          id: '131'
+                          type: variant
+                  - id: '2'
+                    type: image
+                    attributes:
+                      transformed_url: null
+                      styles:
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--d0a7a0441914cd12bba3deaa22e75ad707bbe414/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 48x48>
+                          width: '48'
+                          height: '48'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d762ce7883e0795601c092269daa49688aa534a2/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 100x100>
+                          width: '100'
+                          height: '100'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--a2fea1e7c9a6d545cfb8bbe33a5c79fc7f8ec39f/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 240x240>
+                          width: '240'
+                          height: '240'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--325e7fb25376c8fd2db0ca1da35518354db00b11/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 160x200>
+                          width: '160'
+                          height: '200'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3a7df15bde83cebd64c00bfea26fd006c7f25ab2/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 448x600>
+                          width: '448'
+                          height: '600'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--438f3bed4c80d9865e1344c03f456aaccd2a9f57/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 254x340>
+                          width: '254'
+                          height: '340'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--941f9ccf86ad66e34328dc82c0bef4655208ee17/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 350x468>
+                          width: '350'
+                          height: '468'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--87e51af0bc0da167f5be35ba227a2c207dcac76a/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 222x297>
+                          width: '222'
+                          height: '297'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--af798399e91d3d2d727103129483c0c59acdaa64/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 278x371>
+                          width: '278'
+                          height: '371'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--8bb21c9fc5f9a942fa9374de8860186465d99f8e/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 600x600>
+                          width: '600'
+                          height: '600'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--af798399e91d3d2d727103129483c0c59acdaa64/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 278x371>
+                          width: '278'
+                          height: '371'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--5546099d5e7c15cd4ea705d244dddd64f0e47fbc/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 650x870>
+                          width: '650'
+                          height: '870'
+                      position: 1
+                      alt: ''
+                      original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/Screenshot%202021-09-22%20at%2011.49.05.png
+                  - id: '131'
+                    type: variant
+                    attributes:
+                      sku: T-shirts_3_4sleevet-shirt_94.99_white_xs
+                      weight: '0.0'
+                      height: null
+                      width: null
+                      depth: null
+                      is_master: false
+                      options_text: 'Color: white, Size: XS'
+                      purchasable: true
+                      in_stock: true
+                      backorderable: false
+                      currency: USD
+                      price: '94.99'
+                      display_price: $94.99
+                      compare_at_price: null
+                      display_compare_at_price: null
+                    relationships:
+                      product:
+                        data:
+                          id: '15'
+                          type: product
+                      images:
+                        data:
+                          - id: '2'
+                            type: image
+                      option_values:
+                        data:
+                          - id: '1'
+                            type: option_value
+                          - id: '23'
+                            type: option_value
+                  - id: '5'
+                    type: address
+                    attributes:
+                      firstname: ' Tyler'
+                      lastname: Durden
+                      address1: 3029 Street Way Drive
+                      address2: Basement Entrance
+                      city: LA
+                      zipcode: '90210'
+                      phone: '09128386372'
+                      state_name: California
+                      company: Paper Street Soap Co.
+                      country_name: United States
+                      country_iso3: USA
+                      country_iso: US
+                      label: null
+                      state_code: CA
+                  - id: '1'
+                    type: user
+                    attributes:
+                      email: spree@example.com
+                      store_credits: 0
+                      completed_orders: 1
+                    relationships:
+                      default_billing_address:
+                        data: null
+                      default_shipping_address:
+                        data: null
+                  - id: '1'
+                    type: payment
+                    attributes:
+                      amount: '527.45'
+                      response_code: null
+                      number: PN43O2GK
+                      cvv_response_code: null
+                      cvv_response_message: null
+                      payment_method_id: 2
+                      payment_method_name: Check
+                      state: completed
+                    relationships:
+                      source:
+                        data: null
+                      payment_method:
+                        data:
+                          id: '2'
+                          type: payment_method
+                  - id: '1'
+                    type: shipment
+                    attributes:
+                      number: H77361385341
+                      final_price: '5.0'
+                      display_final_price: $5.00
+                      state: shipped
+                      shipped_at: '2021-09-28T22:57:22.108Z'
+                      tracking_url: null
+                      free: false
+                    relationships:
+                      shipping_rates:
+                        data:
+                          - id: '10'
+                            type: shipping_rate
+                          - id: '11'
+                            type: shipping_rate
+                          - id: '12'
+                            type: shipping_rate
+                      stock_location:
+                        data:
+                          id: '1'
+                          type: stock_location
+    CartList:
+      description: 200 Success - Returns an array of Cart objects.
+      content:
+        application/vnd.api+json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Cart'
+              included:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+                    - $ref: '#/components/schemas/LineItem'
+                    - $ref: '#/components/schemas/Promotion'
+                    - $ref: '#/components/schemas/User'
+                    - $ref: '#/components/schemas/Address'
+                    - $ref: '#/components/schemas/ShipmentAttributesWithoutRelationsips'
+                  type: object
+              meta:
+                $ref: '#/components/schemas/ListMeta'
+              links:
+                $ref: '#/components/schemas/ListLinks'
+            required:
+              - data
+              - meta
+              - links
+          examples:
+            Standard response:
+              value:
+                data:
+                  - id: '18'
+                    type: cart
+                    attributes:
+                      number: R177608027
+                      item_total: '474.95'
+                      total: '527.45'
+                      ship_total: '5.0'
+                      adjustment_total: '47.5'
+                      created_at: '2021-09-28T22:31:47.401Z'
+                      updated_at: '2021-09-28T22:33:20.257Z'
+                      completed_at: '2021-09-28T22:33:18.372Z'
+                      included_tax_total: '0.0'
+                      additional_tax_total: '47.5'
+                      display_additional_tax_total: $47.50
+                      display_included_tax_total: $0.00
+                      tax_total: '47.5'
+                      currency: USD
+                      state: complete
+                      token: 5DUe7Jg40Lu-SoEvAKRKcQ1632868307387
+                      email: spree@example.com
+                      display_item_total: $474.95
+                      display_ship_total: $5.00
+                      display_adjustment_total: $47.50
+                      display_tax_total: $47.50
+                      promo_total: '0.0'
+                      display_promo_total: $0.00
+                      item_count: 5
+                      special_instructions: null
+                      display_total: $527.45
+                      pre_tax_item_amount: '474.95'
+                      display_pre_tax_item_amount: $474.95
+                      pre_tax_total: '479.95'
+                      display_pre_tax_total: $479.95
+                      shipment_state: ready
+                      payment_state: paid
+                    relationships:
+                      line_items:
+                        data:
+                          - id: '1'
+                            type: line_item
+                      variants:
+                        data:
+                          - id: '131'
+                            type: variant
+                      promotions:
+                        data: []
+                      payments:
+                        data:
+                          - id: '1'
+                            type: payment
+                      shipments:
+                        data:
+                          - id: '1'
+                            type: shipment
+                      user:
+                        data:
+                          id: '1'
+                          type: user
+                      billing_address:
+                        data:
+                          id: '5'
+                          type: address
+                      shipping_address:
+                        data:
+                          id: '5'
+                          type: address
+                meta:
+                  count: 1
+                  total_count: 1
+                  total_pages: 1
+                links:
+                  self: 'http://localhost:3000/api/v2/storefront/account/orders'
+                  next: 'http://localhost:3000/api/v2/storefront/account/orders?page=1'
+                  prev: 'http://localhost:3000/api/v2/storefront/account/orders?page=1'
+                  last: 'http://localhost:3000/api/v2/storefront/account/orders?page=1'
+                  first: 'http://localhost:3000/api/v2/storefront/account/orders?page=1'
+            Including all related objects:
+              value:
+                data:
+                  - id: '18'
+                    type: cart
+                    attributes:
+                      number: R177608027
+                      item_total: '474.95'
+                      total: '527.45'
+                      ship_total: '5.0'
+                      adjustment_total: '47.5'
+                      created_at: '2021-09-28T22:31:47.401Z'
+                      updated_at: '2021-09-28T22:33:20.257Z'
+                      completed_at: '2021-09-28T22:33:18.372Z'
+                      included_tax_total: '0.0'
+                      additional_tax_total: '47.5'
+                      display_additional_tax_total: $47.50
+                      display_included_tax_total: $0.00
+                      tax_total: '47.5'
+                      currency: USD
+                      state: complete
+                      token: 5DUe7Jg40Lu-SoEvAKRKcQ1632868307387
+                      email: spree@example.com
+                      display_item_total: $474.95
+                      display_ship_total: $5.00
+                      display_adjustment_total: $47.50
+                      display_tax_total: $47.50
+                      promo_total: '0.0'
+                      display_promo_total: $0.00
+                      item_count: 5
+                      special_instructions: null
+                      display_total: $527.45
+                      pre_tax_item_amount: '474.95'
+                      display_pre_tax_item_amount: $474.95
+                      pre_tax_total: '479.95'
+                      display_pre_tax_total: $479.95
+                      shipment_state: ready
+                      payment_state: paid
+                    relationships:
+                      line_items:
+                        data:
+                          - id: '1'
+                            type: line_item
+                      variants:
+                        data:
+                          - id: '131'
+                            type: variant
+                      promotions:
+                        data: []
+                      payments:
+                        data:
+                          - id: '1'
+                            type: payment
+                      shipments:
+                        data:
+                          - id: '1'
+                            type: shipment
+                      user:
+                        data:
+                          id: '1'
+                          type: user
+                      billing_address:
+                        data:
+                          id: '5'
+                          type: address
+                      shipping_address:
+                        data:
+                          id: '5'
+                          type: address
+                included:
+                  - id: '1'
+                    type: line_item
+                    attributes:
+                      name: 3 4 Sleeve T Shirt
+                      quantity: 5
+                      price: '94.99'
+                      slug: 3-4-sleeve-t-shirt
+                      options_text: 'Color: white, Size: XS'
+                      currency: USD
+                      display_price: $94.99
+                      total: '522.45'
+                      display_total: $522.45
+                      adjustment_total: '47.5'
+                      display_adjustment_total: $47.50
+                      additional_tax_total: '47.5'
+                      discounted_amount: '474.95'
+                      display_discounted_amount: $474.95
+                      display_additional_tax_total: $47.50
+                      promo_total: '0.0'
+                      display_promo_total: $0.00
+                      included_tax_total: '0.0'
+                      display_included_tax_total: $0.00
+                      pre_tax_amount: '474.95'
+                      display_pre_tax_amount: $474.95
+                    relationships:
+                      variant:
+                        data:
+                          id: '131'
+                          type: variant
+                  - id: '2'
+                    type: image
+                    attributes:
+                      transformed_url: null
+                      styles:
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnczBPSGcwT0Q0R093WlVPZ3RsZUhSbGJuUkFDRG9QWW1GamEyZHliM1Z1WkVraUNYTm9iM2NHT3daVU9neHhkV0ZzYVhSNWFWVT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--d0a7a0441914cd12bba3deaa22e75ad707bbe414/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 48x48>
+                          width: '48'
+                          height: '48'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhNREI0TVRBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--d762ce7883e0795601c092269daa49688aa534a2/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 100x100>
+                          width: '100'
+                          height: '100'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOREI0TWpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--a2fea1e7c9a6d545cfb8bbe33a5c79fc7f8ec39f/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 240x240>
+                          width: '240'
+                          height: '240'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHhOakI0TWpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--325e7fb25376c8fd2db0ca1da35518354db00b11/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 160x200>
+                          width: '160'
+                          height: '200'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDBORGg0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--3a7df15bde83cebd64c00bfea26fd006c7f25ab2/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 448x600>
+                          width: '448'
+                          height: '600'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOVFI0TXpRd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--438f3bed4c80d9865e1344c03f456aaccd2a9f57/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 254x340>
+                          width: '254'
+                          height: '340'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHpOVEI0TkRZNFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--941f9ccf86ad66e34328dc82c0bef4655208ee17/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 350x468>
+                          width: '350'
+                          height: '468'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlNako0TWprM1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--87e51af0bc0da167f5be35ba227a2c207dcac76a/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 222x297>
+                          width: '222'
+                          height: '297'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--af798399e91d3d2d727103129483c0c59acdaa64/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 278x371>
+                          width: '278'
+                          height: '371'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJNREI0TmpBd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--8bb21c9fc5f9a942fa9374de8860186465d99f8e/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 600x600>
+                          width: '600'
+                          height: '600'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMHlOemg0TXpjeFBnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--af798399e91d3d2d727103129483c0c59acdaa64/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 278x371>
+                          width: '278'
+                          height: '371'
+                        - url: /rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2REdkeVlYWnBkSGxKSWd0alpXNTBaWElHT3daVU9ndHlaWE5wZW1WSklnMDJOVEI0T0Rjd1BnWTdCbFE2QzJWNGRHVnVkRUFJT2c5aVlXTnJaM0p2ZFc1a1NTSUpjMmh2ZHdZN0JsUTZESEYxWVd4cGRIbHBWUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--5546099d5e7c15cd4ea705d244dddd64f0e47fbc/Screenshot%202021-09-22%20at%2011.49.05.png
+                          size: 650x870>
+                          width: '650'
+                          height: '870'
+                      position: 1
+                      alt: ''
+                      original_url: /rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ac481084a722edc7b7da2d96a29c3c4f4081c234/Screenshot%202021-09-22%20at%2011.49.05.png
+                  - id: '131'
+                    type: variant
+                    attributes:
+                      sku: T-shirts_3_4sleevet-shirt_94.99_white_xs
+                      weight: '0.0'
+                      height: null
+                      width: null
+                      depth: null
+                      is_master: false
+                      options_text: 'Color: white, Size: XS'
+                      purchasable: true
+                      in_stock: true
+                      backorderable: false
+                      currency: USD
+                      price: '94.99'
+                      display_price: $94.99
+                      compare_at_price: null
+                      display_compare_at_price: null
+                    relationships:
+                      product:
+                        data:
+                          id: '15'
+                          type: product
+                      images:
+                        data:
+                          - id: '2'
+                            type: image
+                      option_values:
+                        data:
+                          - id: '1'
+                            type: option_value
+                          - id: '23'
+                            type: option_value
+                  - id: '5'
+                    type: address
+                    attributes:
+                      firstname: Matthew
+                      lastname: Kennedy
+                      address1: 123 Street
+                      address2: null
+                      city: LA
+                      zipcode: '90210'
+                      phone: '18189712983723'
+                      state_name: California
+                      company: null
+                      country_name: United States
+                      country_iso3: USA
+                      country_iso: US
+                      label: null
+                      state_code: CA
+                  - id: '1'
+                    type: user
+                    attributes:
+                      email: spree@example.com
+                      store_credits: 0
+                      completed_orders: 1
+                    relationships:
+                      default_billing_address:
+                        data: null
+                      default_shipping_address:
+                        data: null
+                  - id: '1'
+                    type: payment
+                    attributes:
+                      amount: '527.45'
+                      response_code: null
+                      number: PN43O2GK
+                      cvv_response_code: null
+                      cvv_response_message: null
+                      payment_method_id: 2
+                      payment_method_name: Check
+                      state: completed
+                    relationships:
+                      source:
+                        data: null
+                      payment_method:
+                        data:
+                          id: '2'
+                          type: payment_method
+                  - id: '1'
+                    type: shipment
+                    attributes:
+                      number: H77361385341
+                      final_price: '5.0'
+                      display_final_price: $5.00
+                      state: ready
+                      shipped_at: null
+                      tracking_url: null
+                      free: false
+                    relationships:
+                      shipping_rates:
+                        data:
+                          - id: '10'
+                            type: shipping_rate
+                          - id: '11'
+                            type: shipping_rate
+                          - id: '12'
+                            type: shipping_rate
+                      stock_location:
+                        data:
+                          id: '1'
+                          type: stock_location
+                meta:
+                  count: 1
+                  total_count: 1
+                  total_pages: 1
+                links:
+                  self: 'http://localhost:3000/api/v2/storefront/account/orders?include=line_items,variants,variants.images,billing_address,shipping_address,user,payments,shipments,promotions'
+                  next: 'http://localhost:3000/api/v2/storefront/account/orders?include=line_items%2Cvariants%2Cvariants.images%2Cbilling_address%2Cshipping_address%2Cuser%2Cpayments%2Cshipments%2Cpromotions&page=1'
+                  prev: 'http://localhost:3000/api/v2/storefront/account/orders?include=line_items%2Cvariants%2Cvariants.images%2Cbilling_address%2Cshipping_address%2Cuser%2Cpayments%2Cshipments%2Cpromotions&page=1'
+                  last: 'http://localhost:3000/api/v2/storefront/account/orders?include=line_items%2Cvariants%2Cvariants.images%2Cbilling_address%2Cshipping_address%2Cuser%2Cpayments%2Cshipments%2Cpromotions&page=1'
+                  first: 'http://localhost:3000/api/v2/storefront/account/orders?include=line_items%2Cvariants%2Cvariants.images%2Cbilling_address%2Cshipping_address%2Cuser%2Cpayments%2Cshipments%2Cpromotions&page=1'
 tags:
   - name: Account
   - name: Cart

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -726,27 +726,29 @@ paths:
         ```
 
         ```json
-          "order": {
-            "email": "john@snow.org",
-            "bill_address_attributes": {
-              "firstname": "John",
-              "lastname": "Snow",
-              "address1": "7735 Old Georgetown Road",
-              "city": "Bethesda",
-              "phone": "3014445002",
-              "zipcode": "20814",
-              "state_name": "MD",
-              "country_iso": "US"
-            },
-            "ship_address_attributes": {
-              "firstname": "John",
-              "lastname": "Snow",
-              "address1": "7735 Old Georgetown Road",
-              "city": "Bethesda",
-              "phone": "3014445002",
-              "zipcode": "20814",
-              "state_name": "MD",
-              "country_iso": "US"
+          {
+            "order": {
+              "email": "john@snow.org",
+              "bill_address_attributes": {
+                "firstname": "John",
+                "lastname": "Snow",
+                "address1": "7735 Old Georgetown Road",
+                "city": "Bethesda",
+                "phone": "3014445002",
+                "zipcode": "20814",
+                "state_name": "MD",
+                "country_iso": "US"
+              },
+              "ship_address_attributes": {
+                "firstname": "John",
+                "lastname": "Snow",
+                "address1": "7735 Old Georgetown Road",
+                "city": "Bethesda",
+                "phone": "3014445002",
+                "zipcode": "20814",
+                "state_name": "MD",
+                "country_iso": "US"
+              }
             }
           }
         ```
@@ -16726,6 +16728,10 @@ components:
                 type: string
                 example: You are not authorized to access this page.
                 default: You are not authorized to access this page.
+          examples:
+            403 Example:
+              value:
+                error: You are not authorized to access this page.
     Cart:
       description: 200 Success - Returns the Cart object.
       content:

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -4060,7 +4060,7 @@ paths:
 
         ### Update the Customer information
 
-        ```texttext
+        ```request
         PATCH /checkout
         ```
 
@@ -4092,7 +4092,7 @@ paths:
 
         ###  Fetch Shipping Rates
 
-        ```text
+        ```request
         GET /checkout/shipping_rates
         ```
 
@@ -4104,7 +4104,7 @@ paths:
 
         ### Select shipping method(s)
 
-        ```text
+        ```request
         PATCH /checkout
         ```
 
@@ -4127,7 +4127,7 @@ paths:
 
         ### Add Payment Source(s)
 
-        ```text
+        ```request
         PATCH /checkout
         ```
 
@@ -4154,7 +4154,7 @@ paths:
 
         ### Complete checkout
 
-        ```text
+        ```request
         PATCH /checkout/complete
         ```
 
@@ -19711,31 +19711,33 @@ components:
           example: $20.00
         shipment_state:
           type: string
-          example: pending
           enum:
+            - pending
             - backorder
             - canceled
             - partial
-            - pending
             - ready
             - shipped
+            - null
           description: |-
             Overall state of the Shipments. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#order-shipment-states-1">
               Order Shipments states
             </a> for a full list with description.
+          nullable: true
         payment_state:
           type: string
-          example: balance_due
           enum:
             - balance_due
             - credit_owed
             - failed
             - paid
             - void
+            - null
           description: |-
             Overall state of the Payments. Please see <a href="https://dev-docs.spreecommerce.org/internals/orders#order-payment-states">
               Order Payments states
             </a> for a full list with description.
+          nullable: true
     CreditCardList:
       required:
         - included


### PR DESCRIPTION
- Fix lint issues in Stoplight API
- Move Cart model into one schema and take advantage of dedicated shared responses for list and single response schema.
- Setup accurate cart Schema to fix all errors when running Postman on Cart endpoints. 13 errors down to 0

The idea is to de-clutter the schema section of the API yml taking advantage of shared responses and request to document the response schema for multiple and single response, so viewers of the docs can see just the schemas that are relevant, and not lots of half schemas for attributes and relationships, those can be combine and moved to shared request and responses as required leaving a nice neat schema section.

This de-clutter of the schema section will also reduce issue like having an account schema and a user schema that are both the same objects we currently have.

Example of reducing the Cart from 4 broken up schemas to one.
Going from this:
<img width="280" alt="Screenshot 2021-09-29 at 01 00 58" src="https://user-images.githubusercontent.com/1240766/135181251-509c959d-9551-4904-b69b-4e8d858f97b0.png">

Down to:
<img width="278" alt="Screenshot 2021-09-29 at 01 01 25" src="https://user-images.githubusercontent.com/1240766/135181276-7d80f951-ee10-4c55-be3d-b5e4bc85acea.png">

Postman Errors running Create a Cart Before:
<img width="420" alt="Screenshot 2021-09-29 at 01 03 30" src="https://user-images.githubusercontent.com/1240766/135181420-aa098d35-429a-40d2-ba24-ac345d59213d.png">

Postman Errors running Create a Cart Before:
<img width="868" alt="Screenshot 2021-09-29 at 01 05 37" src="https://user-images.githubusercontent.com/1240766/135181546-90e80ac7-a82b-4e2a-a5ee-01308d7770ae.png">

