### PR TITLE
SD-1477 Fix spree_sample:load task in main branch

### DIFF
--- a/core/app/services/spree/stock_locations/stock_items/create.rb
+++ b/core/app/services/spree/stock_locations/stock_items/create.rb
@@ -14,7 +14,7 @@ module Spree
                 'created_at', Time.current,
                 'updated_at', Time.current
               ]
-            end.uniq { |stock_item| stock_item.values_at('stock_location_id', 'variant_id', 'backorderable') }
+            end
             if prepared_stock_items.any?
               stock_location.stock_items.insert_all(prepared_stock_items)
               variants_scope.touch_all

--- a/core/db/migrate/20210929090344_create_stock_item_stock_location_id_variant_id_coalesce_deleted_at_unique_index.rb
+++ b/core/db/migrate/20210929090344_create_stock_item_stock_location_id_variant_id_coalesce_deleted_at_unique_index.rb
@@ -1,0 +1,32 @@
+class CreateStockItemStockLocationIdVariantIdCoalesceDeletedAtUniqueIndex < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :spree_stock_items, name: :stock_item_by_loc_var_id_deleted_at
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          CREATE UNIQUE INDEX stock_item_by_loc_var_id_deleted_at
+          ON spree_stock_items(
+            stock_location_id,
+            variant_id,
+            (COALESCE(deleted_at, CAST('1970-01-01 00:00:00' AS #{deleted_at_data_type})))
+          );
+        SQL
+      end
+
+      dir.down do
+        remove_index :spree_stock_items, name: :stock_item_by_loc_var_id_deleted_at
+      end
+    end
+  end
+
+  private
+
+  def deleted_at_data_type
+    case ActiveRecord::Base.connection.adapter_name
+    when 'Mysql2'
+      'DATETIME'
+    when 'PostgreSQL'
+      'TIMESTAMP'
+    end
+  end
+end

--- a/sample/db/samples/stock.rb
+++ b/sample/db/samples/stock.rb
@@ -1,7 +1,7 @@
 Spree::Sample.load_sample('variants')
 
 country =  Spree::Country.find_by(iso: 'US')
-location = Spree::StockLocation.find_or_create_by!(name: 'default')
+location = Spree::StockLocation.find_or_create_by!(name: 'default', propagate_all_variants: false)
 location.update(
   address1: 'Example Street',
   city: 'City',
@@ -10,6 +10,8 @@ location.update(
   state: country.states.first,
   active: true
 )
+
+Spree::StockLocations::StockItems::Create.call(stock_location: location)
 
 product_1 = Spree::Product.find_by!(name: 'Denim Shirt')
 product_2 = Spree::Product.find_by!(name: 'Checked Shirt')


### PR DESCRIPTION
Fixes [11356](https://github.com/spree/spree/issues/11356).

This [duplicate example](https://github.com/spree/spree/blob/main/core/spec/services/spree/stock_locations/stock_items/create_spec.rb#L42) was testing a difficult to happen scenario, while it should be relying on Spree::StockItems already in the db.

I updated the `stock_item_by_loc_var_id_deleted_at` unique index to use a default datetime/timestamp so we can use it with `insert_all`.

https://spark-solutions.atlassian.net/browse/SD-1477