### PR TITLE
Storefront API Docs Improvements

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -14339,6 +14339,7 @@ components:
           type: integer
           example: 1080
           description: Actual height of image
+      x-internal: true
     LineItem:
       properties:
         id:

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -16162,6 +16162,8 @@ components:
           type: boolean
           example: true
     Icon:
+      type: object
+      description: 'The Icon object contains a url attribute pointing to an Active Storage asset. '
       properties:
         id:
           type: string
@@ -16170,12 +16172,16 @@ components:
           type: string
           default: icon
         attributes:
-          $ref: '#/components/schemas/IconAttributes'
-    IconAttributes:
-      type: object
-      properties:
-        url:
-          type: string
+          type: object
+          required:
+            - url
+          properties:
+            url:
+              type: string
+      required:
+        - id
+        - type
+        - attributes
     Wishlist:
       properties:
         data:

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -132,11 +132,7 @@ paths:
       operationId: addresses-list
       responses:
         '200':
-          description: Listing user addresses.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/AddressList'
+          $ref: '#/components/responses/AddressList'
         '403':
           $ref: '#/components/responses/403Forbidden'
       security:
@@ -156,13 +152,24 @@ paths:
               properties:
                 address:
                   $ref: '#/components/schemas/AddressPayload'
+            examples:
+              Create a Address:
+                value:
+                  address:
+                    firstname: Mark
+                    lastname: Winterburn
+                    company: Paper Street Soap Co.
+                    address1: 775 Old Georgetown Road
+                    address2: 3nd Floor
+                    city: Qethesda
+                    phone: '3488545445002'
+                    zipcode: '90210'
+                    state_name: CA
+                    country_iso: US
+                    label: Work
       responses:
         '200':
-          description: Created Address.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/AddressList'
+          $ref: '#/components/responses/Address'
         '403':
           $ref: '#/components/responses/403Forbidden'
       security:
@@ -200,13 +207,24 @@ paths:
               properties:
                 address:
                   $ref: '#/components/schemas/AddressPayload'
+            examples:
+              Update an Address:
+                value:
+                  address:
+                    firstname: Stephen
+                    lastname: Smith
+                    company: Woodbank School
+                    address1: 234 Old Georgetown Road
+                    address2: 1nd Floor
+                    city: Aethesda
+                    phone: '34885493845002'
+                    zipcode: '90211'
+                    state_name: CA
+                    country_iso: US
+                    label: Office
       responses:
         '200':
-          description: Updated Address.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/AddressList'
+          $ref: '#/components/responses/Address'
         '403':
           $ref: '#/components/responses/403Forbidden'
       security:
@@ -13909,6 +13927,7 @@ components:
         error:
           type: string
       x-internal: true
+      title: Error
     ListLinks:
       x-internal: true
       type: object
@@ -13934,6 +13953,7 @@ components:
         - prev
         - last
         - first
+      title: Pagination Meta Links
     ListMeta:
       type: object
       properties:
@@ -13954,10 +13974,13 @@ components:
         - total_count
         - total_pages
       x-internal: true
+      title: Pagination Meta
     Timestamp:
       type: string
       format: date-time
       example: '2020-02-16T07:14:54.617Z'
+      x-internal: true
+      title: Time Stamp
     Address:
       type: object
       title: Address
@@ -14009,22 +14032,16 @@ components:
             company:
               type: string
               example: Google Inc.
+              description: Company name
               nullable: true
             label:
               type: string
+              description: 'The internal name for this address (Work, Home)'
               nullable: true
       required:
         - id
         - type
         - attributes
-    AddressList:
-      required:
-        - data
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/Address'
     Cart:
       description: 'The Cart provides a central place to collect information about an order, including line items, adjustments, payments, addresses, return authorizations, and shipments. [Read more in Spree docs](https://dev-docs.spreecommerce.org/internals/orders)'
       type: object
@@ -15346,6 +15363,10 @@ components:
         state_name: MD
         country_iso: US
       type: object
+      x-internal: true
+      title: Address Payload
+      x-examples: {}
+      description: ''
       properties:
         firstname:
           type: string
@@ -15371,6 +15392,14 @@ components:
         country_iso:
           type: string
           description: 'Country ISO (2-chars) or ISO3 (3-chars) code. [List of all codes](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)'
+        company:
+          type: string
+          example: Paper Street Soap Co.
+          description: Company name
+        label:
+          type: string
+          example: Work
+          description: 'The internal name for this address (Work, Home)'
       required:
         - firstname
         - lastname
@@ -17526,7 +17555,7 @@ components:
     User:
       description: 200 Success - Returns the User object.
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             type: object
             properties:
@@ -17607,6 +17636,55 @@ components:
                       country_iso3: USA
                       country_iso: US
                       state_code: NY
+    AddressList:
+      description: 200 Success - Returns an array containing one or more Address objects.
+      content:
+        application/vnd.api+json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+              meta:
+                $ref: '#/components/schemas/ListMeta'
+              links:
+                $ref: '#/components/schemas/ListLinks'
+            required:
+              - data
+              - meta
+              - links
+    Address:
+      description: 200 Success - Returns a data object containing the Address object.
+      content:
+        application/vnd.api+json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/Address'
+          examples:
+            Standard response:
+              value:
+                data:
+                  id: '29'
+                  type: address
+                  attributes:
+                    firstname: Mark
+                    lastname: Winterburn
+                    address1: 775645 Old Georgetown Road
+                    address2: 3nd Floor
+                    city: Qethesda
+                    zipcode: '90210'
+                    phone: '3488545445002'
+                    state_name: California
+                    company: Paper Street Soap Co.
+                    country_name: United States
+                    country_iso3: USA
+                    country_iso: US
+                    label: Work
+                    state_code: CA
 tags:
   - name: Account
   - name: Cart

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -14006,6 +14006,7 @@ components:
             address2:
               type: string
               example: Suite 1
+              nullable: true
             city:
               type: string
               example: Mountain View
@@ -14015,6 +14016,7 @@ components:
             phone:
               type: string
               example: (+1) 123 456 789
+              nullable: true
             state_name:
               type: string
               example: California
@@ -17655,6 +17657,71 @@ components:
               - data
               - meta
               - links
+          examples:
+            Standard response:
+              value:
+                data:
+                  - id: '11'
+                    type: address
+                    attributes:
+                      firstname: Tyler
+                      lastname: Durden
+                      address1: 12312 Street
+                      address2: Basment Entrance
+                      city: LA
+                      zipcode: '90210'
+                      phone: '08173762736'
+                      state_name: California
+                      company: Paper Street Soap Co
+                      country_name: United States
+                      country_iso3: USA
+                      country_iso: US
+                      label: Home
+                      state_code: CA
+                  - id: '28'
+                    type: address
+                    attributes:
+                      firstname: John
+                      lastname: Snow
+                      address1: 7735 Old Georgetown Road
+                      address2: 2nd Floor
+                      city: Bethesda
+                      zipcode: '20814'
+                      phone: '3014445002'
+                      state_name: Maryland
+                      company: null
+                      country_name: United States
+                      country_iso3: USA
+                      country_iso: US
+                      label: null
+                      state_code: MD
+                  - id: '29'
+                    type: address
+                    attributes:
+                      firstname: Emma
+                      lastname: Carragher
+                      address1: 775645 Old Georgetown Road
+                      address2: 3nd Floor
+                      city: Qethesda
+                      zipcode: '90210'
+                      phone: '3488545445002'
+                      state_name: California
+                      company: null
+                      country_name: United States
+                      country_iso3: USA
+                      country_iso: US
+                      label: Work
+                      state_code: CA
+                meta:
+                  count: 3
+                  total_count: 3
+                  total_pages: 1
+                links:
+                  self: 'http://localhost:3000/api/v2/storefront/account/addresses'
+                  next: 'http://localhost:3000/api/v2/storefront/account/addresses?page=1'
+                  prev: 'http://localhost:3000/api/v2/storefront/account/addresses?page=1'
+                  last: 'http://localhost:3000/api/v2/storefront/account/addresses?page=1'
+                  first: 'http://localhost:3000/api/v2/storefront/account/addresses?page=1'
     Address:
       description: 200 Success - Returns a data object containing the Address object.
       content:

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -14474,7 +14474,7 @@ components:
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
               - $ref: '#/components/schemas/Property'
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+              - $ref: '#/components/schemas/Variant'
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
     ProductsList:
@@ -14499,7 +14499,7 @@ components:
               - $ref: '#/components/schemas/OptionValue'
               - $ref: '#/components/schemas/ProductProperty'
               - $ref: '#/components/schemas/Property'
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+              - $ref: '#/components/schemas/Variant'
               - $ref: '#/components/schemas/Image'
               - $ref: '#/components/schemas/TaxonAttributesAndRelationships'
     ProductAttributes:
@@ -14908,94 +14908,13 @@ components:
                     data:
                       $ref: '#/components/schemas/Property'
     Variant:
-      required:
-        - data
-        - included
-      properties:
-        data:
-          $ref: '#/components/schemas/VariantAttributesAndRelationships'
-        included:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/Image'
-              - $ref: '#/components/schemas/OptionValue'
-              - $ref: '#/components/schemas/OptionType'
+      title: Variant
       description: |-
         Variant records track the individual variants of a Product. Variants are of two types: master variants and normal variants.
 
         Variant records can track some individual properties regarding a variant, such as height, width, depth, and cost price. These properties are unique to each variant, and so are different from Product Properties, which apply to all variants of that product.
-    VariantAttributes:
+      x-examples: {}
       type: object
-      properties:
-        sku:
-          type: string
-          example: SKU-1001
-        price:
-          type: string
-          example: '15.99'
-        currency:
-          type: string
-          example: USD
-        display_price:
-          type: string
-          example: $15.99
-        weight:
-          type: string
-          example: '10'
-        height:
-          type: string
-          example: '10'
-        width:
-          type: string
-          example: '10'
-        depth:
-          type: string
-          example: '10'
-        is_master:
-          type: boolean
-          example: false
-          description: Indicates if Variant is the master Variant
-        options_text:
-          type: string
-          example: 'Size: small, Color: red'
-        purchasable:
-          type: boolean
-          example: true
-          description: Indicates if Variant is in stock or backorderable
-        in_stock:
-          type: boolean
-          example: true
-          description: Indicates if Variant is in stock
-        backorderable:
-          type: boolean
-          example: true
-          description: Indicates if Variant is backorderable
-      title: Variant
-      description: ''
-    VariantRelationships:
-      type: object
-      properties:
-        product:
-          type: object
-          properties:
-            data:
-              $ref: '#/components/schemas/Relation'
-        images:
-          type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-        option_values:
-          type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: '#/components/schemas/Relation'
-    VariantAttributesAndRelationships:
       properties:
         id:
           type: string
@@ -15004,10 +14923,77 @@ components:
           type: string
           default: variant
         attributes:
-          $ref: '#/components/schemas/VariantAttributes'
+          type: object
+          properties:
+            sku:
+              type: string
+              example: SKU-1001
+            price:
+              type: string
+              example: '15.99'
+            currency:
+              type: string
+              example: USD
+            display_price:
+              type: string
+              example: $15.99
+            weight:
+              type: string
+              example: '10'
+            height:
+              type: string
+              example: '10'
+            width:
+              type: string
+              example: '10'
+            depth:
+              type: string
+              example: '10'
+            is_master:
+              type: boolean
+              example: false
+              description: Indicates if Variant is the master Variant
+            options_text:
+              type: string
+              example: 'Size: small, Color: red'
+            purchasable:
+              type: boolean
+              example: true
+              description: Indicates if Variant is in stock or backorderable
+            in_stock:
+              type: boolean
+              example: true
+              description: Indicates if Variant is in stock
+            backorderable:
+              type: boolean
+              example: true
         relationships:
-          $ref: '#/components/schemas/VariantRelationships'
-      title: Variant
+          type: object
+          properties:
+            product:
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/Relation'
+            images:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+            option_values:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Relation'
+      required:
+        - id
+        - type
+        - attributes
+        - relationships
     Country:
       required:
         - data
@@ -15291,6 +15277,7 @@ components:
     User:
       type: object
       title: User
+      description: ' '
       properties:
         id:
           type: string
@@ -15326,6 +15313,11 @@ components:
               properties:
                 data:
                   $ref: '#/components/schemas/Relation'
+      required:
+        - id
+        - type
+        - attributes
+        - relationships
     AddressPayload:
       example:
         firstname: John
@@ -16258,7 +16250,7 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+              - $ref: '#/components/schemas/Variant'
       required:
         - data
     WishedItemAttributes:
@@ -16654,7 +16646,7 @@ components:
                     - $ref: '#/components/schemas/Promotion'
                     - $ref: '#/components/schemas/User'
                     - $ref: '#/components/schemas/ShipmentAttributesAndRelationsips'
-                    - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+                    - $ref: '#/components/schemas/Variant'
                     - $ref: '#/components/schemas/LineItem'
                     - $ref: '#/components/schemas/Payment'
             required:
@@ -17137,7 +17129,7 @@ components:
                 type: array
                 items:
                   anyOf:
-                    - $ref: '#/components/schemas/VariantAttributesAndRelationships'
+                    - $ref: '#/components/schemas/Variant'
                     - $ref: '#/components/schemas/LineItem'
                     - $ref: '#/components/schemas/Promotion'
                     - $ref: '#/components/schemas/User'

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -13908,7 +13908,10 @@ components:
       properties:
         error:
           type: string
+      x-internal: true
     ListLinks:
+      x-internal: true
+      type: object
       properties:
         self:
           type: string
@@ -13925,7 +13928,14 @@ components:
         first:
           type: string
           description: URL to the first page of the listing
+      required:
+        - self
+        - next
+        - prev
+        - last
+        - first
     ListMeta:
+      type: object
       properties:
         count:
           type: number
@@ -13939,6 +13949,11 @@ components:
           type: number
           example: 10
           description: Number of all pages containing items matching the criteria
+      required:
+        - count
+        - total_count
+        - total_pages
+      x-internal: true
     Timestamp:
       type: string
       format: date-time


### PR DESCRIPTION
- Compress variant into one model, no need for a response as it is only returned through other objects, Product, Line Item...
- Set Image Style Model to an internal model only, no need for that to be seen in the schemas section on its own.
- Compress Icon into a single model representation and give it a description.
- Set Error, Links, Meta Time Stamp ... all as internal models, again no need to show those off in the Schema section of the docs.
- Update Address Model to be one representation of an Address Model, create the Address response and Address List response.
- Added Label to schema and company to address payload Schema.
- Update Create an Address an Update an Address endpoints to use the correct response type, was all using List address when those 2 return the single address, either the newly created or updated address.
- Added required to some items like ID Type   