### PR TITLE
[SD-1461] fix money_methods for ruby version < 2.7

### DIFF
--- a/core/app/models/concerns/spree/display_money.rb
+++ b/core/app/models/concerns/spree/display_money.rb
@@ -27,7 +27,9 @@ module Spree
           define_method("display_#{method_name}") do |**args_list|
             default_opts = respond_to?(:currency) ? { currency: currency } : {}
 
-            Spree::Money.new(send(*[method_name, **args_list].reject(&:blank?)), default_opts.merge(opts).merge(args_list.slice(:currency)))
+            amount = args_list.blank? ? send(method_name) : send(method_name, **args_list)
+
+            Spree::Money.new(amount, default_opts.merge(opts).merge(args_list.slice(:currency)))
           end
         end
       end

--- a/core/app/models/concerns/spree/display_money.rb
+++ b/core/app/models/concerns/spree/display_money.rb
@@ -27,7 +27,7 @@ module Spree
           define_method("display_#{method_name}") do |**args_list|
             default_opts = respond_to?(:currency) ? { currency: currency } : {}
 
-            Spree::Money.new(send(method_name, **args_list), default_opts.merge(opts).merge(args_list.slice(:currency)))
+            Spree::Money.new(send(*[method_name, **args_list].reject(&:blank?)), default_opts.merge(opts).merge(args_list.slice(:currency)))
           end
         end
       end

--- a/core/spec/models/spree/concerns/display_money_spec.rb
+++ b/core/spec/models/spree/concerns/display_money_spec.rb
@@ -35,6 +35,7 @@ module Spree
             expect(test_class.new.display_total(currency: currency)).to eq Spree::Money.new(10.0, currency: currency)
           end
         end
+
         context 'wrapped method accepts `currency` argument' do
           let(:test_class) do
             Class.new do


### PR DESCRIPTION
Added photo because in Travis we use use newer ruby versions:
https://github.com/spree/spree/blob/main/cli/lib/spree_cli/templates/extension/travis.yml#L17-L19

<img width="637" alt="Screenshot 2021-09-30 at 16 49 59" src="https://user-images.githubusercontent.com/43354669/135478907-35f128e8-e88a-49e7-a728-84ea20cbcba0.png">

I considered moving `send(*[method_name, **args_list].reject(&:blank?))` to `amount` private method & `default_opts.merge(opts).merge(args_list.slice(:currency)` to `options` private method, but decided that passing arguments further will make it look too complicated.