### PR TITLE
Fix missing shipping rate ID from estimated shipping rates response.

### DIFF
--- a/api/app/serializers/spree/v2/storefront/estimated_shipping_rate_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/estimated_shipping_rate_serializer.rb
@@ -3,6 +3,7 @@ module Spree
     module Storefront
       class EstimatedShippingRateSerializer < BaseSerializer
         set_type :shipping_rate
+        set_id :shipping_method_id
 
         cache_options store: nil
 


### PR DESCRIPTION
Estimate Shipping Rates Storefront API

Tests may fail if serialiser was setup to check for a null ID, if not will write a serialiser spec to match this...

BEFORE:
```json
{
    "data": [
        {
            "id": null,
            "type": "shipping_rate",
            "attributes": {
                "name": "UPS Ground (USD)",
                "selected": true,
                "cost": "5.0",
                "tax_amount": "0.0",
                "shipping_method_id": 1,
                "final_price": "5.0",
                "display_cost": "$5.00",
                "display_final_price": "$5.00",
                "display_tax_amount": "$0.00",
                "free": false
            }
        },
        {
            "id": null,
            "type": "shipping_rate",
            "attributes": {
                "name": "UPS Two Day (USD)",
                "selected": false,
                "cost": "10.0",
                "tax_amount": "0.0",
                "shipping_method_id": 2,
                "final_price": "10.0",
                "display_cost": "$10.00",
                "display_final_price": "$10.00",
                "display_tax_amount": "$0.00",
                "free": false
            }
        },
        {
            "id": null,
            "type": "shipping_rate",
            "attributes": {
                "name": "UPS One Day (USD)",
                "selected": false,
                "cost": "15.0",
                "tax_amount": "0.0",
                "shipping_method_id": 3,
                "final_price": "15.0",
                "display_cost": "$15.00",
                "display_final_price": "$15.00",
                "display_tax_amount": "$0.00",
                "free": false
            }
        }
    ]
}
```

AFTER:
```json
{
    "data": [
        {
            "id": "1",
            "type": "shipping_rate",
            "attributes": {
                "name": "UPS Ground (USD)",
                "selected": true,
                "cost": "5.0",
                "tax_amount": "0.0",
                "shipping_method_id": 1,
                "final_price": "5.0",
                "display_cost": "$5.00",
                "display_final_price": "$5.00",
                "display_tax_amount": "$0.00",
                "free": false
            }
        },
        {
            "id": "2",
            "type": "shipping_rate",
            "attributes": {
                "name": "UPS Two Day (USD)",
                "selected": false,
                "cost": "10.0",
                "tax_amount": "0.0",
                "shipping_method_id": 2,
                "final_price": "10.0",
                "display_cost": "$10.00",
                "display_final_price": "$10.00",
                "display_tax_amount": "$0.00",
                "free": false
            }
        },
        {
            "id": "3",
            "type": "shipping_rate",
            "attributes": {
                "name": "UPS One Day (USD)",
                "selected": false,
                "cost": "15.0",
                "tax_amount": "0.0",
                "shipping_method_id": 3,
                "final_price": "15.0",
                "display_cost": "$15.00",
                "display_final_price": "$15.00",
                "display_tax_amount": "$0.00",
                "free": false
            }
        }
    ]
}
```