### PR TITLE
add name attribute to api platform serializer

### DIFF
--- a/api/app/serializers/spree/api/v2/platform/option_type_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/option_type_serializer.rb
@@ -5,6 +5,8 @@ module Spree
         class OptionTypeSerializer < BaseSerializer
           include ::Spree::Api::V2::ResourceSerializerConcern
 
+          attributes :name
+
           has_many :option_values
         end
       end


### PR DESCRIPTION
On Spree Backend & Product Edit Page if you search select Option Type field, you cant because response the from ajax is:
localhost:3000/api/v2/platform/option_types?fields[option_type]=name&filter[name_i_cont]=color
response ->:
```
{
	"data": [
		{
			"id": "2",
			"type": "option_type",
			"attributes": {},
			"relationships": {}
		},
		{
			"id": "3",
			"type": "option_type",
			"attributes": {},
			"relationships": {}
		}
	]
}
```
and because that response, select2 is empty. the attrubytes is empty.
the solution is to add attributes :name to OptionType Serializer