### PR TITLE
Introduce Spree.admin_user_class

### DIFF
--- a/api/config/initializers/doorkeeper.rb
+++ b/api/config/initializers/doorkeeper.rb
@@ -24,7 +24,7 @@ Doorkeeper.configure do
   end
 
   admin_authenticator do |routes|
-    current_spree_user&.has_spree_role?('admin') || redirect_to(routes.root_url)
+    current_spree_user&.spree_admin? || redirect_to(routes.root_url)
   end
 
   grant_flows %w[password client_credentials]

--- a/core/app/models/concerns/spree/user_roles.rb
+++ b/core/app/models/concerns/spree/user_roles.rb
@@ -6,18 +6,36 @@ module Spree
       has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id, dependent: :destroy
       has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
 
-      scope :admin, -> { joins(:spree_roles).where(Spree::Role.table_name => { name: 'admin' }) }
+      scope :spree_admin, -> { joins(:spree_roles).where(Spree::Role.table_name => { name: 'admin' }) }
 
       # has_spree_role? simply needs to return true or false whether a user has a role or not.
       def has_spree_role?(role_name)
         spree_roles.exists?(name: role_name)
       end
 
+      def self.admin
+        ActiveSupport::Deprecation.warn('`User#admin` is deprecated and will be removed in Spree 5. Please use `User#spree_admin`')
+
+        spree_admin
+      end
+
       def self.admin_created?
-        admin.exists?
+        ActiveSupport::Deprecation.warn('`User#admin_created?` is deprecated and will be removed in Spree 5. Please use `User#spree_admin_created?`')
+
+        spree_admin_created?
       end
 
       def admin?
+        ActiveSupport::Deprecation.warn('`User#admin?` is deprecated and will be removed in Spree 5. Please use `User#spree_admin?`')
+
+        spree_admin?
+      end
+
+      def self.spree_admin_created?
+        spree_admin.exists?
+      end
+
+      def spree_admin?
         has_spree_role?('admin')
       end
     end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -28,7 +28,7 @@ module Spree
 
       user ||= Spree.user_class.new
 
-      if user.respond_to?(:has_spree_role?) && user.has_spree_role?('admin')
+      if user.try(:spree_admin?)
         apply_admin_permissions(user)
       else
         apply_user_permissions(user)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -70,11 +70,14 @@ module Spree
 
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s, optional: true
-      belongs_to :created_by, class_name: Spree.user_class.to_s, optional: true
-      belongs_to :approver, class_name: Spree.user_class.to_s, optional: true
-      belongs_to :canceler, class_name: Spree.user_class.to_s, optional: true
     else
       belongs_to :user, optional: true
+    end
+    if Spree.admin_user_class
+      belongs_to :created_by, class_name: Spree.admin_user_class.to_s, optional: true
+      belongs_to :approver, class_name: Spree.admin_user_class.to_s, optional: true
+      belongs_to :canceler, class_name: Spree.admin_user_class.to_s, optional: true
+    else
       belongs_to :created_by, optional: true
       belongs_to :approver, optional: true
       belongs_to :canceler, optional: true

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -16,7 +16,7 @@ module Spree
 
     belongs_to :user, class_name: Spree.user_class.to_s, foreign_key: 'user_id'
     belongs_to :category, class_name: 'Spree::StoreCreditCategory'
-    belongs_to :created_by, class_name: Spree.user_class.to_s, foreign_key: 'created_by_id'
+    belongs_to :created_by, class_name: Spree.admin_user_class.to_s, foreign_key: 'created_by_id'
     belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id'
     belongs_to :store, class_name: 'Spree::Store'
     has_many :store_credit_events, class_name: 'Spree::StoreCreditEvent'

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -24,13 +24,23 @@ require 'active_storage_validations'
 StateMachines::Machine.ignore_method_conflicts = true
 
 module Spree
-  mattr_accessor :user_class
+  mattr_accessor :user_class, :admin_user_class
 
   def self.user_class(constantize: true)
     if @@user_class.is_a?(Class)
       raise 'Spree.user_class MUST be a String or Symbol object, not a Class object.'
     elsif @@user_class.is_a?(String) || @@user_class.is_a?(Symbol)
       constantize ? @@user_class.to_s.constantize : @@user_class.to_s
+    end
+  end
+
+  def self.admin_user_class(constantize: true)
+    @@admin_user_class ||= @@user_class
+
+    if @@admin_user_class.is_a?(Class)
+      raise 'Spree.admin_user_class MUST be a String or Symbol object, not a Class object.'
+    elsif @@admin_user_class.is_a?(String) || @@admin_user_class.is_a?(Symbol)
+      constantize ? @@admin_user_class.to_s.constantize : @@admin_user_class.to_s
     end
   end
 

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -38,4 +38,50 @@ describe Spree do
       end
     end
   end
+
+  describe '.admin_user_class' do
+    after do
+      described_class.admin_user_class = nil
+    end
+
+    context 'when admin_user_class is nil' do
+      it 'fallbacks to user_class' do
+        described_class.user_class = 'Spree::LegacyUser'
+
+        expect(described_class.admin_user_class).to eq(Spree::LegacyUser)
+      end
+    end
+
+    context 'when admin_user_class is a Class instance' do
+      it 'raises an error' do
+        described_class.admin_user_class = Spree::LegacyUser
+
+        expect { described_class.admin_user_class }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when admin_user_class is a Symbol instance' do
+      it 'returns the admin_user_class constant' do
+        described_class.admin_user_class = :'Spree::LegacyUser'
+
+        expect(described_class.admin_user_class).to eq(Spree::LegacyUser)
+      end
+    end
+
+    context 'when admin_user_class is a String instance' do
+      it 'returns the admin_user_class constant' do
+        described_class.admin_user_class = 'Spree::LegacyUser'
+
+        expect(described_class.admin_user_class).to eq(Spree::LegacyUser)
+      end
+    end
+
+    context 'when constantize is false' do
+      it 'returns the admin_user_class as a String' do
+        described_class.admin_user_class = 'Spree::LegacyUser'
+
+        expect(described_class.admin_user_class(constantize: false)).to eq('Spree::LegacyUser')
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -77,12 +77,28 @@ describe Spree::Ability, type: :model do
     let(:fakedispatch_ability) { Spree::Ability.new(fakedispatch_user) }
 
     context 'with admin user' do
-      it 'is able to admin' do
-        allow(user).to receive(:has_spree_role?).with('admin').and_return(true)
-        expect(ability).to be_able_to :admin, resource
-        expect(ability).to be_able_to :index, resource_order
-        expect(ability).to be_able_to :show, resource_product
-        expect(ability).to be_able_to :create, resource_user
+      context 'admin user role' do
+        it 'is able to admin' do
+          allow(user).to receive(:spree_admin?).and_return(true)
+          expect(ability).to be_able_to :admin, resource
+          expect(ability).to be_able_to :index, resource_order
+          expect(ability).to be_able_to :show, resource_product
+          expect(ability).to be_able_to :create, resource_user
+        end
+      end
+
+      context 'admin user class' do
+        let(:user) { Spree::DummyModel.create(name: 'admin') }
+
+        before { Spree.admin_user_class = 'Spree::DummyModel' }
+
+        it 'is able to admin' do
+          allow(user).to receive(:spree_admin?).and_return(true)
+          expect(ability).to be_able_to :admin, resource
+          expect(ability).to be_able_to :index, resource_order
+          expect(ability).to be_able_to :show, resource_product
+          expect(ability).to be_able_to :create, resource_user
+        end
       end
     end
 

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -28,7 +28,26 @@ describe Spree::UserMethods do
     end
   end
 
+  describe '#spree_admin?' do
+    it do
+      expect(create(:admin_user).spree_admin?).to be true
+      expect(create(:user).spree_admin?).to be false
+    end
+  end
+
   describe '.admin_created?' do
+    it 'returns true when admin exists' do
+      create(:admin_user)
+
+      expect(Spree.user_class).to be_admin_created
+    end
+
+    it 'returns false when admin does not exist' do
+      expect(Spree.user_class).to_not be_admin_created
+    end
+  end
+
+  describe '.spree_admin_created?' do
     it 'returns true when admin exists' do
       create(:admin_user)
 


### PR DESCRIPTION
Allowing more flexibility for developers to use a different model for Admin users