### PR TITLE
FIX:  digital_link update cache after authorized download.

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/digitals_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/digitals_controller.rb
@@ -6,6 +6,8 @@ module Spree
           def download
             if attachment.present?
               if digital_link.authorize!
+                digital_link.touch # touch the digital_link after authorize!
+
                 if defined?(ActiveStorage::Service::DiskService) && ActiveStorage::Blob.service.instance_of?(ActiveStorage::Service::DiskService)
                   # The asset is hosted on disk, use send_file.
 

--- a/api/app/controllers/spree/api/v2/storefront/digitals_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/digitals_controller.rb
@@ -6,8 +6,6 @@ module Spree
           def download
             if attachment.present?
               if digital_link.authorize!
-                digital_link.touch # touch the digital_link after authorize!
-
                 if defined?(ActiveStorage::Service::DiskService) && ActiveStorage::Blob.service.instance_of?(ActiveStorage::Service::DiskService)
                   # The asset is hosted on disk, use send_file.
 

--- a/core/app/models/spree/digital_link.rb
+++ b/core/app/models/spree/digital_link.rb
@@ -32,7 +32,13 @@ module Spree
     # This method should be called when a download is initiated.
     # It returns +true+ or +false+ depending on whether the authorization is granted.
     def authorize!
-      authorizable? && increment!(:access_counter) ? true : false
+      if authorizable?
+        increment!(:access_counter)
+        touch
+        true
+      else
+        false
+      end
     end
 
     def reset!

--- a/core/app/models/spree/digital_link.rb
+++ b/core/app/models/spree/digital_link.rb
@@ -32,13 +32,7 @@ module Spree
     # This method should be called when a download is initiated.
     # It returns +true+ or +false+ depending on whether the authorization is granted.
     def authorize!
-      if authorizable?
-        increment!(:access_counter)
-        touch
-        true
-      else
-        false
-      end
+      authorizable? && increment!(:access_counter, touch: true) ? true : false
     end
 
     def reset!

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -191,16 +191,19 @@ describe Spree::DigitalLink, type: :model do
     it 'touches the digital_link when autorized' do
       origional_updated_at = digital_link.updated_at
       sleep 2
+
       digital_link.authorize!
       digital_link.reload
       expect(digital_link.updated_at).not_to eq(origional_updated_at)
     end
 
     it 'does not touch the digital_link if not authorized' do
-      expect do
-        digital_link_expired.authorize!
-        digital_link_expired.reload
-      end.not_to change(digital_link_expired, :updated_at)
+      expired_origional_updated_at = digital_link_expired.updated_at
+      sleep 2
+
+      digital_link_expired.authorize!
+      digital_link_expired.reload
+      expect(digital_link_expired.updated_at).to eq(expired_origional_updated_at)
     end
   end
 end

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -42,6 +42,8 @@ describe Spree::DigitalLink, type: :model do
 
     it 'resets created_at timestamp' do
       origional_created_at = digital_link.created_at
+      sleep 2
+
       digital_link.reset!
       expect(digital_link.created_at).not_to eq(origional_created_at)
     end
@@ -203,7 +205,7 @@ describe Spree::DigitalLink, type: :model do
 
       digital_link_expired.authorize!
       digital_link_expired.reload
-      expect(digital_link_expired.updated_at).to eq(expired_origional_updated_at)
+      expect(digital_link_expired.updated_at.to_s).to eq(expired_origional_updated_at.to_s)
     end
   end
 end

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -41,10 +41,9 @@ describe Spree::DigitalLink, type: :model do
     end
 
     it 'resets created_at timestamp' do
-      expect do
-        digital_link.reset!
-        digital_link.reload
-      end.to change(digital_link, :created_at)
+      origional_created_at = digital_link.created_at
+      digital_link.reset!
+      expect(digital_link.created_at).not_to eq(origional_created_at)
     end
   end
 
@@ -190,10 +189,11 @@ describe Spree::DigitalLink, type: :model do
     end
 
     it 'touches the digital_link when autorized' do
-      expect do
-        digital_link.authorize!
-        digital_link.reload
-      end.to change(digital_link, :updated_at)
+      origional_updated_at = digital_link.updated_at
+
+      digital_link.authorize!
+      digital_link.reload
+      expect(digital_link.updated_at).not_to eq(origional_updated_at)
     end
 
     it 'does not touch the digital_link if not authorized' do

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -191,21 +191,11 @@ describe Spree::DigitalLink, type: :model do
     end
 
     it 'touches the digital_link when autorized' do
-      origional_updated_at = digital_link.updated_at
-      sleep 2
-
-      digital_link.authorize!
-      digital_link.reload
-      expect(digital_link.updated_at.to_s).not_to eq(origional_updated_at.to_s)
+      expect { digital_link.authorize! }.to change(digital_link, :updated_at)
     end
 
     it 'does not touch the digital_link if not authorized' do
-      expired_origional_updated_at = digital_link_expired.updated_at
-      sleep 2
-
-      digital_link_expired.authorize!
-      digital_link_expired.reload
-      expect(digital_link_expired.updated_at.to_s).to eq(expired_origional_updated_at.to_s)
+      expect { digital_link.authorize! }.not_to change(digital_link, :updated_at)
     end
   end
 end

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -190,7 +190,7 @@ describe Spree::DigitalLink, type: :model do
 
     it 'touches the digital_link when autorized' do
       origional_updated_at = digital_link.updated_at
-
+      sleep 2
       digital_link.authorize!
       digital_link.reload
       expect(digital_link.updated_at).not_to eq(origional_updated_at)

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -34,18 +34,22 @@ describe Spree::DigitalLink, type: :model do
 
   describe '#reset!' do
     let!(:digital_link) { create(:digital_link, access_counter: 5) }
+    after do
+      digital_link.update(access_counter: 5)
+      digital_link.save!
+      digital_link.reload
+    end
 
     it 'resets access_counter' do
-      digital_link.reset!
-      expect(digital_link.access_counter).to be(0)
+      expect { digital_link.reset! }.to change(digital_link, :access_counter).from(5).to(0)
     end
 
     it 'resets created_at timestamp' do
-      origional_created_at = digital_link.created_at
-      sleep 2
-
-      digital_link.reset!
-      expect(digital_link.created_at.to_s).not_to eq(origional_created_at.to_s)
+      expect do
+        sleep 1
+        digital_link.reset!
+        digital_link.reload
+      end.to change { digital_link.created_at.to_s }
     end
   end
 
@@ -186,16 +190,23 @@ describe Spree::DigitalLink, type: :model do
     end
 
     it 'increments the access counter' do
-      digital_link.authorize!
-      expect(digital_link.access_counter).to eq(3)
+      expect { digital_link.authorize! }.to change(digital_link, :access_counter).from(2).to(3)
     end
 
     it 'touches the digital_link when autorized' do
-      expect { digital_link.authorize! }.to change(digital_link, :updated_at)
+      expect do
+        sleep 1
+        digital_link.authorize!
+        digital_link.reload
+      end.to change { digital_link.updated_at.to_s }
     end
 
     it 'does not touch the digital_link if not authorized' do
-      expect { digital_link.authorize! }.not_to change(digital_link, :updated_at)
+      expect do
+        sleep 1
+        digital_link_expired.authorize!
+        digital_link_expired.reload
+      end.not_to change { digital_link_expired.updated_at.to_s }
     end
   end
 end

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -34,6 +34,7 @@ describe Spree::DigitalLink, type: :model do
 
   describe '#reset!' do
     let!(:digital_link) { create(:digital_link, access_counter: 5) }
+
     after do
       digital_link.update(access_counter: 5)
       digital_link.save!
@@ -45,11 +46,12 @@ describe Spree::DigitalLink, type: :model do
     end
 
     it 'resets created_at timestamp' do
-      expect do
-        sleep 1
-        digital_link.reset!
-        digital_link.reload
-      end.to change { digital_link.created_at.to_s }
+      Timecop.travel Time.current + 1.day do
+        expect do
+          digital_link.reset!
+          digital_link.reload
+        end.to change(digital_link, :created_at)
+      end
     end
   end
 
@@ -194,19 +196,21 @@ describe Spree::DigitalLink, type: :model do
     end
 
     it 'touches the digital_link when autorized' do
-      expect do
-        sleep 1
-        digital_link.authorize!
-        digital_link.reload
-      end.to change { digital_link.updated_at.to_s }
+      Timecop.travel Time.current + 1.day do
+        expect do
+          digital_link.authorize!
+          digital_link.reload
+        end.to change(digital_link, :updated_at)
+      end
     end
 
     it 'does not touch the digital_link if not authorized' do
-      expect do
-        sleep 1
-        digital_link_expired.authorize!
-        digital_link_expired.reload
-      end.not_to change { digital_link_expired.updated_at.to_s }
+      Timecop.travel Time.current + 1.day do
+        expect do
+          digital_link_expired.authorize!
+          digital_link_expired.reload
+        end.not_to change(digital_link_expired, :updated_at)
+      end
     end
   end
 end

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -45,7 +45,7 @@ describe Spree::DigitalLink, type: :model do
       sleep 2
 
       digital_link.reset!
-      expect(digital_link.created_at).not_to eq(origional_created_at)
+      expect(digital_link.created_at.to_s).not_to eq(origional_created_at.to_s)
     end
   end
 
@@ -196,7 +196,7 @@ describe Spree::DigitalLink, type: :model do
 
       digital_link.authorize!
       digital_link.reload
-      expect(digital_link.updated_at).not_to eq(origional_updated_at)
+      expect(digital_link.updated_at.to_s).not_to eq(origional_updated_at.to_s)
     end
 
     it 'does not touch the digital_link if not authorized' do

--- a/core/spec/models/spree/digital_link_spec.rb
+++ b/core/spec/models/spree/digital_link_spec.rb
@@ -50,7 +50,7 @@ describe Spree::DigitalLink, type: :model do
         expect do
           digital_link.reset!
           digital_link.reload
-        end.to change(digital_link, :created_at)
+        end.to change { digital_link.created_at.to_s }
       end
     end
   end
@@ -200,7 +200,7 @@ describe Spree::DigitalLink, type: :model do
         expect do
           digital_link.authorize!
           digital_link.reload
-        end.to change(digital_link, :updated_at)
+        end.to change { digital_link.updated_at.to_s }
       end
     end
 
@@ -209,7 +209,7 @@ describe Spree::DigitalLink, type: :model do
         expect do
           digital_link_expired.authorize!
           digital_link_expired.reload
-        end.not_to change(digital_link_expired, :updated_at)
+        end.not_to change { digital_link_expired.updated_at.to_s }
       end
     end
   end


### PR DESCRIPTION
If you download a digital asset using the storefront API GET request, the `access_counter` is incremented in the database correctly, but this is not reflected if you the return the digital_links list through the Platform API serializer.

To fix this I have put a `digital_link.touch` in the controller after the authorisation for the download, not sure if this is the best way to achieve this fix but it works.