### PR TITLE
Fix Failing Specs For Missing i18n-tasks Gem

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -27,9 +27,7 @@ end
 
 require 'rspec/rails'
 require 'ffaker'
-
 require 'i18n/tasks'
-
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -44,6 +44,7 @@ end
 group :test, :development do
   gem 'awesome_print'
   gem 'gem-release'
+  gem 'i18n-tasks'
   gem 'redis'
   gem 'rubocop', '~> 1.0', require: false
   gem 'rubocop-rspec', require: false

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -30,7 +30,7 @@ describe 'i18n' do
         locales = Spree.available_locales
         expected_locales = [:en, :de, :nl, :ar, :az, :bg, :ca, :cs, :da, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :"pt-BR", :ro, :ru, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
-        expect(locales).to eq expected_locales
+        expect(locales).to match_array(expected_locales)
       end
 
       it 'returns an array with the string "en" removed' do
@@ -46,7 +46,7 @@ describe 'i18n' do
 
         expected_locales = [:en, :ar, :az, :bg, :ca, :cs, :da, :de, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :nl, :"pt-BR", :ro, :ru, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
-        expect(locales).to eq expected_locales
+        expect(locales).to match_array(expected_locales)
       end
     end
   end


### PR DESCRIPTION
Add gem 'i18n-tasks' to common dependencies.