### PR TITLE
Add Spree::Migration::Version custom RuboCop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - ./lib/rubo_cop/cop/spree/migration/version.rb
 
 AllCops:
   TargetRubyVersion: 2.5
@@ -14,6 +16,9 @@ AllCops:
     - '**/vendor/**/*'
     - '**/spec_helper.rb'
     - '**/templates/**/*'
+
+Spree/Migration/Version:
+  RailsVersion: 5.2
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented

--- a/lib/rubo_cop/cop/spree/migration/version.rb
+++ b/lib/rubo_cop/cop/spree/migration/version.rb
@@ -1,0 +1,111 @@
+require 'pry'
+
+module RuboCop
+  module Cop
+    module Spree
+      module Migration
+        # This cop looks for the argument used when invoking Migration.[].
+        # It registers an offense when the version is other than the one
+        # defined in the cop configuration or the hardcoded default (5.2).
+        #
+        # @example
+        #   # bad
+        #   class AddDeletedAtToSpreeStores < ActiveRecord::Migration
+        #   end
+        #
+        #   class AddDeletedAtToSpreeStores < ActiveRecord::Migration[]
+        #   end
+        #
+        #   class AddDeletedAtToSpreeStores < ActiveRecord::Migration[6.1]
+        #   end
+        #
+        #   class AddDeletedAtToSpreeStores < ActiveRecord::Migration[4.2]
+        #   end
+        #
+        #
+        #   # good
+        #   class AddDeletedAtToSpreeStores < ActiveRecord::Migration[5.2]
+        #   end
+        #
+        class Version < RuboCop::Cop::Base
+          extend AutoCorrector
+
+          def_node_matcher :migration_without_version?, <<~PATTERN
+            (class
+              (const nil? _)
+              $(const
+                (const nil? :ActiveRecord) :Migration) _)
+          PATTERN
+          def_node_matcher :migration_with_empty_version?, <<~PATTERN
+            (class
+              (const nil? _)
+              $(send
+                (const
+                  (const nil? :ActiveRecord) :Migration) :[]) _)
+          PATTERN
+          def_node_matcher :unexpected_migration_version?, <<~PATTERN
+            (class
+              (const nil? _)
+              (send
+                (const
+                  (const nil? :ActiveRecord) :Migration) :[]
+                $({float | int} _))
+              _)
+          PATTERN
+
+          def on_class(node)
+            no_version_offense(offense: :migration_without_version?, node: node)
+            no_version_offense(offense: :migration_with_empty_version?, node: node)
+
+            unexpected_migration_version?(node) do |current_version|
+              next if current_version.value.to_s == expected_rails_version
+
+              expression = current_version.loc.expression
+              add_offense(
+                expression,
+                message: format(
+                  UNEXPECTED_MIGRATION_VERSION,
+                  current_version: current_version.value,
+                  expected_version: expected_rails_version
+                )
+              ) do |corrector|
+                corrector.replace(expression, expected_rails_version)
+              end
+            end
+          end
+
+          private
+
+          MIN_SUPPORTED_VERSION = '5.2'
+          NO_MIGRATION_VERSION =
+            "Append [%<expected_version>s] to ActiveRecord::Migration.".freeze
+          UNEXPECTED_MIGRATION_VERSION =
+            "Replace `%<current_version>s` with `%<expected_version>s`.".freeze
+          private_constant :MIN_SUPPORTED_VERSION, :NO_MIGRATION_VERSION,
+            :UNEXPECTED_MIGRATION_VERSION
+
+          def no_version_offense(offense:, node:)
+            send(offense, node) do |capture|
+              add_offense(
+                node,
+                message: format(
+                  NO_MIGRATION_VERSION,
+                  expected_version: expected_rails_version
+                )
+              ) do |corrector|
+                corrector.replace(
+                  capture.loc.expression,
+                  "ActiveRecord::Migration[#{expected_rails_version}]"
+                )
+              end
+            end 
+          end
+
+          def expected_rails_version
+            (cop_config['RailsVersion'] || MIN_SUPPORTED_VERSION).to_s
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a custom Rubocop cop specifically for correcting the usage of a wrong Rails version when editing a migration file.

Since there are migrations in different Spree projects, it might be useful on setting a minimum Rails version in each .rubocop.yml per project.

I added to the lib/ folder because didn't find other place, but that can be updated. The examples used are added below. As they depend on setting RSpec, I didn't add it to any project in particular.

```ruby
RSpec.configure do |config|
  config.include CopHelper
  config.include HostEnvironmentSimulatorHelper
  config.include RuboCop::RSpec::ExpectOffense
end

RSpec.describe RuboCop::Cop::Spree::Migration::Version, :config do
  subject(:cop) { described_class.new }

  context "when migration version is 5.2" do
    it do
      expect_no_offenses(<<~RUBY)
        class SpreeFourThree < ActiveRecord::Migration[5.2]
        end
      RUBY
    end
  end

  context "when ActiveRecord::Migration is referenced without creating a migration" do
    it do
      expect_no_offenses('ActiveRecord::Migration')
    end
  end

  context "when migration does not have a version" do
    it do
      expect_offense(<<~RUBY)
        class MigrationNoVersion < ActiveRecord::Migration
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Append [5.2] to ActiveRecord::Migration.
        end
      RUBY

      expect_correction(<<~RUBY)
        class MigrationNoVersion < ActiveRecord::Migration[5.2]
        end
      RUBY
    end
  end

  context "when migration version is empty" do
    it do
      expect_offense(<<~RUBY)
        class MigrationEmptyVersion < ActiveRecord::Migration[]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Append [5.2] to ActiveRecord::Migration.
        end
      RUBY

      expect_correction(<<~RUBY)
        class MigrationEmptyVersion < ActiveRecord::Migration[5.2]
        end
      RUBY
    end
  end

  context "when migration version is not 5.2" do
    it do
      expect_offense(<<~RUBY)
        class UnexpectedMigrationVersion < ActiveRecord::Migration[6.1]
                                                                   ^^^ Replace `6.1` with `5.2`.
        end
      RUBY

      expect_correction(<<~RUBY)
        class UnexpectedMigrationVersion < ActiveRecord::Migration[5.2]
        end
      RUBY
    end
  end

  context "with a common migration body" do
    it do
      expect_offense(<<~RUBY)
        class SpreeFourThree < ActiveRecord::Migration[6.1]
                                                       ^^^ Replace `6.1` with `5.2`.
          def change
            add_column :posts, :deleted_at, :datetime
          end
        end
      RUBY

      expect_correction(<<~RUBY)
        class SpreeFourThree < ActiveRecord::Migration[5.2]
          def change
            add_column :posts, :deleted_at, :datetime
          end
        end
      RUBY
    end
  end

  context "with the Rails version set in the cop config" do
    subject(:cop) { described_class.new(config) }

    let(:config) { RuboCop::Config.new("Spree/Migration/Version" => { "RailsVersion" => rails_version }) }
    let(:rails_version) { '1.0.0' }

    it 'uses the config Rails version in the offense message' do
      expect_offense(<<~RUBY)
        class SpreeFourThree < ActiveRecord::Migration[6.1]
                                                       ^^^ Replace `6.1` with `#{rails_version}`.
        end
      RUBY

      expect_correction(<<~RUBY)
        class SpreeFourThree < ActiveRecord::Migration[#{rails_version}]
        end
      RUBY
    end
  end

  it { expect_no_offenses('class ActiveRecord::Migration::NewClass; end') }
end
```

[Here](https://gist.github.com/sebastian-palma/f62f5c22fc6bbf48589cbe0e54211d43) there's a runnable version of the cop file.