### PR TITLE
Enhances documentation for alternate use case

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -354,6 +354,8 @@ paths:
         Creates a new cart.
 
         **Please be aware**; The `token` value found in the response body is used to authorize all future operations on this cart through the Auth API Key `X-Spree-Order-Token`.
+
+        To associate a user with a cart on creation, pass `request["Authorization"] = 'Bearer undefined'`
       tags:
         - Cart
       operationId: create-cart


### PR DESCRIPTION
In one use case cart will be completely created and filled for a customer with items. 

Bearer header will scope the order to the user who it is created for. Without the header the api call creates an anonymous cart.