### PR TITLE
Remove ActiveSupport#run_load_hooks calls

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -63,5 +63,3 @@ class Spree::Base < ApplicationRecord
     to_s.demodulize.underscore
   end
 end
-
-ActiveSupport.run_load_hooks(:spree_base, Spree::Base)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -741,5 +741,3 @@ module Spree
     end
   end
 end
-
-ActiveSupport.run_load_hooks(:spree_order, Spree::Order)

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -305,5 +305,3 @@ module Spree
     end
   end
 end
-
-ActiveSupport.run_load_hooks(:spree_payment, Spree::Payment)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -401,5 +401,3 @@ module Spree
     end
   end
 end
-
-ActiveSupport.run_load_hooks(:spree_shipment, Spree::Shipment)


### PR DESCRIPTION
This was accidently merged during our big Webhooks PR