### PR TITLE
Use JSON coder for typed_store in Spree::Store.settings

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,6 +1,6 @@
 module Spree
   class Store < Spree::Base
-    typed_store :settings do |s|
+    typed_store :settings, coder: ActiveRecord::TypedStore::IdentityCoder do |s|
       # Spree Digital Asset Configurations
       s.boolean :limit_digital_download_count, default: true, null: false
       s.boolean :limit_digital_download_days, default: true, null: false


### PR DESCRIPTION
When an existing Spree::Store is updated, the contents of the settings column targeted but the typed_store get covered to JSON format.