### PR TITLE
Clean Up Platform API Controllers

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
@@ -3,28 +3,6 @@ module Spree
     module V2
       module Platform
         class CmsSectionsController < ResourceController
-          def reposition
-            spree_authorize! :update, @moved_section if spree_current_user.present?
-
-            unless params[:new_position_idx].present?
-              render json: { error: I18n.t('spree.api.v2.cms_sections.pass_position_index') }, status: 422
-              return
-            end
-
-            @moved_section = scope.find(params[:id])
-            new_index = params[:new_position_idx].to_i + 1
-
-            if @moved_section && new_index
-              @moved_section.set_list_position(new_index)
-            else
-              head :bad_request
-            end
-
-            if @moved_section.save
-              render_serialized_payload { serialize_resource(resource) }
-            end
-          end
-
           private
 
           def model_class

--- a/api/app/controllers/spree/api/v2/platform/digitals_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/digitals_controller.rb
@@ -9,8 +9,8 @@ module Spree
             Spree::Digital
           end
 
-          def permitted_resource_params
-            params.require(model_param_name).permit(spree_permitted_attributes << :attachment)
+          def spree_permitted_attributes
+            super + [:attachment]
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/platform/orders_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/orders_controller.rb
@@ -149,7 +149,7 @@ module Spree
           end
 
           def spree_permitted_attributes
-            Spree::Order.json_api_permitted_attributes + [
+            super + [
               bill_address_attributes: Spree::Address.json_api_permitted_attributes,
               ship_address_attributes: Spree::Address.json_api_permitted_attributes,
               line_items_attributes: Spree::LineItem.json_api_permitted_attributes,

--- a/api/app/controllers/spree/api/v2/platform/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/resource_controller.rb
@@ -52,7 +52,7 @@ module Spree
             resource_serializer
           end
 
-          # overwiting to utilize ransack gem for filtering
+          # overwriting to utilize ransack gem for filtering
           # https://github.com/activerecord-hackery/ransack#search-matchers
           def collection
             @collection ||= scope.ransack(params[:filter]).result

--- a/api/app/controllers/spree/api/v2/platform/resource_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/resource_controller.rb
@@ -14,7 +14,6 @@ module Spree
 
           def create
             resource = model_class.new(permitted_resource_params)
-
             ensure_current_store(resource)
 
             if resource.save
@@ -25,8 +24,10 @@ module Spree
           end
 
           def update
-            if resource.update(permitted_resource_params)
-              ensure_current_store(resource)
+            resource.assign_attributes(permitted_resource_params)
+            ensure_current_store(resource)
+
+            if resource.save
               render_serialized_payload { serialize_resource(resource) }
             else
               render_error_payload(resource.errors)

--- a/api/app/controllers/spree/api/v2/platform/shipping_methods_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/shipping_methods_controller.rb
@@ -10,7 +10,7 @@ module Spree
           end
 
           def spree_permitted_attributes
-            Spree::ShippingMethod.json_api_permitted_attributes + [
+            super + [
               {
                 shipping_category_ids: [],
                 calculator_attributes: {}

--- a/api/app/controllers/spree/api/v2/platform/variants_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/variants_controller.rb
@@ -10,7 +10,7 @@ module Spree
           end
 
           def spree_permitted_attributes
-            Spree::Order.json_api_permitted_attributes + [:option_value_ids, :price, :currency]
+            super + [:option_value_ids, :price, :currency]
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/platform/wished_items_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/wished_items_controller.rb
@@ -12,10 +12,6 @@ module Spree
           def model_class
             Spree::WishedItem
           end
-
-          def permitted_resource_params
-            params.require(model_param_name).permit(spree_permitted_attributes << :wishlist_id)
-          end
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/platform/wishlists_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/wishlists_controller.rb
@@ -12,10 +12,6 @@ module Spree
           def scope_includes
             [:wished_items]
           end
-
-          def permitted_resource_params
-            params.require(model_param_name).permit(spree_permitted_attributes << :user_id)
-          end
         end
       end
     end

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -26,8 +26,6 @@ en:
         cart:
           no_coupon_code: No coupon code provided and the Order doesn't have any coupon code promotions applied
           wrong_quantity: Quantity has to be greater than 0
-        cms_sections:
-          pass_position_index: Pass 'new_position_idx' with an interger value in the request body
         digitals:
           missing_file: 'Missing Digital Item: attachment'
           unauthorized: Error, you are not authorized to access this asset

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -285,11 +285,7 @@ Spree::Core::Engine.add_routes do
         end
 
         # CMS Sections API
-        resources :cms_sections do
-          member do
-            patch :reposition
-          end
-        end
+        resources :cms_sections
 
         # Wishlists API
         resources :wishlists

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -70,8 +70,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-10-29T23:51:21.898Z'
-                        updated_at: '2021-10-29T23:51:21.898Z'
+                        created_at: '2021-10-30T11:23:56.203Z'
+                        updated_at: '2021-10-30T11:23:56.203Z'
                         deleted_at:
                         label:
                       relationships:
@@ -98,8 +98,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-10-29T23:51:21.902Z'
-                        updated_at: '2021-10-29T23:51:21.902Z'
+                        created_at: '2021-10-30T11:23:56.207Z'
+                        updated_at: '2021-10-30T11:23:56.207Z'
                         deleted_at:
                         label:
                       relationships:
@@ -173,8 +173,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-10-29T23:51:22.113Z'
-                        updated_at: '2021-10-29T23:51:22.113Z'
+                        created_at: '2021-10-30T11:23:56.417Z'
+                        updated_at: '2021-10-30T11:23:56.417Z'
                         deleted_at:
                         label:
                       relationships:
@@ -268,8 +268,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-10-29T23:51:22.148Z'
-                        updated_at: '2021-10-29T23:51:22.148Z'
+                        created_at: '2021-10-30T11:23:56.452Z'
+                        updated_at: '2021-10-30T11:23:56.452Z'
                         deleted_at:
                         label:
                       relationships:
@@ -348,8 +348,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-10-29T23:51:22.209Z'
-                        updated_at: '2021-10-29T23:51:22.217Z'
+                        created_at: '2021-10-30T11:23:56.512Z'
+                        updated_at: '2021-10-30T11:23:56.520Z'
                         deleted_at:
                         label:
                       relationships:
@@ -493,8 +493,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-10-29T23:51:22.437Z'
-                        updated_at: '2021-10-29T23:51:22.437Z'
+                        created_at: '2021-10-30T11:23:56.742Z'
+                        updated_at: '2021-10-30T11:23:56.742Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -520,8 +520,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-10-29T23:51:22.457Z'
-                        updated_at: '2021-10-29T23:51:22.457Z'
+                        created_at: '2021-10-30T11:23:56.763Z'
+                        updated_at: '2021-10-30T11:23:56.763Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -594,8 +594,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-10-29T23:51:22.788Z'
-                        updated_at: '2021-10-29T23:51:22.788Z'
+                        created_at: '2021-10-30T11:23:57.062Z'
+                        updated_at: '2021-10-30T11:23:57.062Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -677,8 +677,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-10-29T23:51:22.898Z'
-                        updated_at: '2021-10-29T23:51:22.903Z'
+                        created_at: '2021-10-30T11:23:57.159Z'
+                        updated_at: '2021-10-30T11:23:57.163Z'
                         state: open
                         included: false
                         display_amount: "$1.00"
@@ -756,8 +756,8 @@ paths:
                         label: New label
                         mandatory:
                         eligible: true
-                        created_at: '2021-10-29T23:51:23.082Z'
-                        updated_at: '2021-10-29T23:51:23.095Z'
+                        created_at: '2021-10-30T11:23:57.360Z'
+                        updated_at: '2021-10-30T11:23:57.375Z'
                         state: open
                         included: false
                         display_amount: "$15.00"
@@ -897,8 +897,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-10-29T23:51:23.646Z'
-                        updated_at: '2021-10-29T23:51:23.646Z'
+                        created_at: '2021-10-30T11:23:57.951Z'
+                        updated_at: '2021-10-30T11:23:57.951Z'
                       relationships:
                         product:
                           data:
@@ -912,8 +912,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-10-29T23:51:23.725Z'
-                        updated_at: '2021-10-29T23:51:23.725Z'
+                        created_at: '2021-10-30T11:23:58.029Z'
+                        updated_at: '2021-10-30T11:23:58.029Z'
                       relationships:
                         product:
                           data:
@@ -974,8 +974,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-10-29T23:51:24.246Z'
-                        updated_at: '2021-10-29T23:51:24.246Z'
+                        created_at: '2021-10-30T11:23:58.503Z'
+                        updated_at: '2021-10-30T11:23:58.503Z'
                       relationships:
                         product:
                           data:
@@ -1042,8 +1042,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-10-29T23:51:24.401Z'
-                        updated_at: '2021-10-29T23:51:24.401Z'
+                        created_at: '2021-10-30T11:23:58.664Z'
+                        updated_at: '2021-10-30T11:23:58.664Z'
                       relationships:
                         product:
                           data:
@@ -1109,8 +1109,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-10-29T23:51:24.697Z'
-                        updated_at: '2021-10-29T23:51:24.697Z'
+                        created_at: '2021-10-30T11:23:58.936Z'
+                        updated_at: '2021-10-30T11:23:58.936Z'
                       relationships:
                         product:
                           data:
@@ -1232,8 +1232,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-10-29T23:51:25.502Z'
-                        updated_at: '2021-10-29T23:51:25.524Z'
+                        created_at: '2021-10-30T11:23:59.739Z'
+                        updated_at: '2021-10-30T11:23:59.761Z'
                       relationships:
                         product:
                           data:
@@ -1332,34 +1332,34 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Totam corrupti sed soluta magni illum voluptatem.
+                        title: Cupiditate unde voluptatibus labore voluptates.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: totam-corrupti-sed-soluta-magni-illum-voluptatem
+                        slug: cupiditate-unde-voluptatibus-labore-voluptates
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-10-29T23:51:25.856Z'
-                        updated_at: '2021-10-29T23:51:25.856Z'
+                        created_at: '2021-10-30T11:24:00.097Z'
+                        updated_at: '2021-10-30T11:24:00.097Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Molestiae suscipit beatae dicta ullam consectetur sed.
+                        title: Quidem quasi nobis optio fuga a.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: molestiae-suscipit-beatae-dicta-ullam-consectetur-sed
+                        slug: quidem-quasi-nobis-optio-fuga-a
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-10-29T23:51:25.860Z'
-                        updated_at: '2021-10-29T23:51:25.860Z'
+                        created_at: '2021-10-30T11:24:00.101Z'
+                        updated_at: '2021-10-30T11:24:00.101Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1413,17 +1413,17 @@ paths:
                       id: '5'
                       type: cms_page
                       attributes:
-                        title: Dolores dolore unde esse repellendus sequi quae.
+                        title: Provident aliquam maxime natus sunt minus consequatur.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: dolores-dolore-unde-esse-repellendus-sequi-quae
+                        slug: provident-aliquam-maxime-natus-sunt-minus-consequatur
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-10-29T23:51:25.934Z'
-                        updated_at: '2021-10-29T23:51:25.934Z'
+                        created_at: '2021-10-30T11:24:00.183Z'
+                        updated_at: '2021-10-30T11:24:00.183Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1483,17 +1483,17 @@ paths:
                       id: '6'
                       type: cms_page
                       attributes:
-                        title: Asperiores dolorem delectus voluptatem minus.
+                        title: Consectetur ab quibusdam ratione asperiores sapiente.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: asperiores-dolorem-delectus-voluptatem-minus
+                        slug: consectetur-ab-quibusdam-ratione-asperiores-sapiente
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-10-29T23:51:25.975Z'
-                        updated_at: '2021-10-29T23:51:25.975Z'
+                        created_at: '2021-10-30T11:24:00.224Z'
+                        updated_at: '2021-10-30T11:24:00.224Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1557,12 +1557,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: perspiciatis-occaecati-odio-totam-perferendis-officia-voluptatem-aperiam
+                        slug: iusto-vel-sapiente-delectus-explicabo
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-10-29T23:51:26.032Z'
-                        updated_at: '2021-10-29T23:51:26.041Z'
+                        created_at: '2021-10-30T11:24:00.281Z'
+                        updated_at: '2021-10-30T11:24:00.290Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1688,7 +1688,8 @@ paths:
                     - id: '1'
                       type: cms_section
                       attributes:
-                        name: Quo eligendi sit qui laboriosam.
+                        name: Doloremque pariatur exercitationem unde laborum ab doloribus
+                          id.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1697,8 +1698,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-10-29T23:51:26.215Z'
-                        updated_at: '2021-10-29T23:51:26.215Z'
+                        created_at: '2021-10-30T11:24:00.466Z'
+                        updated_at: '2021-10-30T11:24:00.466Z'
                       relationships:
                         cms_page:
                           data:
@@ -1709,7 +1710,7 @@ paths:
                     - id: '2'
                       type: cms_section
                       attributes:
-                        name: Similique minima rem nam modi porro quia aliquam illum.
+                        name: Voluptatum eius quam optio repudiandae.
                         content:
                           link_type_one: Spree::Taxon
                           link_type_two: Spree::Taxon
@@ -1721,8 +1722,8 @@ paths:
                         type: Spree::Cms::Sections::ImageGallery
                         position: 2
                         linked_resource_type:
-                        created_at: '2021-10-29T23:51:26.219Z'
-                        updated_at: '2021-10-29T23:51:26.219Z'
+                        created_at: '2021-10-30T11:24:00.471Z'
+                        updated_at: '2021-10-30T11:24:00.471Z'
                       relationships:
                         cms_page:
                           data:
@@ -1733,8 +1734,7 @@ paths:
                     - id: '3'
                       type: cms_section
                       attributes:
-                        name: Nesciunt expedita labore architecto voluptatibus asperiores
-                          harum.
+                        name: Eaque maiores quos cum pariatur.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1743,8 +1743,8 @@ paths:
                         type: Spree::Cms::Sections::FeaturedArticle
                         position: 3
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-10-29T23:51:26.227Z'
-                        updated_at: '2021-10-29T23:51:26.227Z'
+                        created_at: '2021-10-30T11:24:00.479Z'
+                        updated_at: '2021-10-30T11:24:00.479Z'
                       relationships:
                         cms_page:
                           data:
@@ -1755,7 +1755,8 @@ paths:
                     - id: '4'
                       type: cms_section
                       attributes:
-                        name: Libero fuga quia nam beatae placeat sapiente eos mollitia.
+                        name: Aliquam ipsam nostrum esse fugit beatae laboriosam consequatur
+                          quo.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1764,8 +1765,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-10-29T23:51:26.234Z'
-                        updated_at: '2021-10-29T23:51:26.234Z'
+                        created_at: '2021-10-30T11:24:00.487Z'
+                        updated_at: '2021-10-30T11:24:00.487Z'
                       relationships:
                         cms_page:
                           data:
@@ -1778,7 +1779,7 @@ paths:
                     - id: '5'
                       type: cms_section
                       attributes:
-                        name: Itaque quos autem accusantium repellat cum rerum consectetur.
+                        name: Officia nulla suscipit illo repudiandae quia harum.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1787,8 +1788,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 5
                         linked_resource_type: Spree::Product
-                        created_at: '2021-10-29T23:51:26.241Z'
-                        updated_at: '2021-10-29T23:51:26.241Z'
+                        created_at: '2021-10-30T11:24:00.494Z'
+                        updated_at: '2021-10-30T11:24:00.494Z'
                       relationships:
                         cms_page:
                           data:
@@ -1848,8 +1849,7 @@ paths:
                       id: '14'
                       type: cms_section
                       attributes:
-                        name: Qui voluptatibus eligendi sit voluptas occaecati delectus
-                          quae.
+                        name: Architecto pariatur incidunt vitae reprehenderit.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1858,8 +1858,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-10-29T23:51:26.396Z'
-                        updated_at: '2021-10-29T23:51:26.396Z'
+                        created_at: '2021-10-30T11:24:00.658Z'
+                        updated_at: '2021-10-30T11:24:00.658Z'
                       relationships:
                         cms_page:
                           data:
@@ -1925,7 +1925,7 @@ paths:
                       id: '21'
                       type: cms_section
                       attributes:
-                        name: Blanditiis nisi odio in maiores sed.
+                        name: Quia enim minima eos unde.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1934,8 +1934,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-10-29T23:51:26.556Z'
-                        updated_at: '2021-10-29T23:51:26.556Z'
+                        created_at: '2021-10-30T11:24:00.847Z'
+                        updated_at: '2021-10-30T11:24:00.847Z'
                       relationships:
                         cms_page:
                           data:
@@ -2007,10 +2007,10 @@ paths:
                         fit: Screen
                         destination:
                         type: Spree::Cms::Sections::HeroImage
-                        position: 4
+                        position: 1
                         linked_resource_type: Spree::Product
-                        created_at: '2021-10-29T23:51:26.817Z'
-                        updated_at: '2021-10-29T23:51:26.828Z'
+                        created_at: '2021-10-30T11:24:01.093Z'
+                        updated_at: '2021-10-30T11:24:01.103Z'
                       relationships:
                         cms_page:
                           data:
@@ -2097,81 +2097,6 @@ paths:
                     error: The access token is invalid
               schema:
                 "$ref": "#/components/schemas/error"
-  "/api/v2/platform/cms_sections/{id}/reposition":
-    patch:
-      summary: Reposition a CMS Section
-      tags:
-      - CMS Sections
-      security:
-      - bearer_auth: []
-      operationId: reposition-cms-section
-      description: Reposition a Menu Item
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Record updated
-          content:
-            application/vnd.api+json:
-              examples:
-                Example:
-                  value:
-                    data:
-                      id: '58'
-                      type: cms_section
-                      attributes:
-                        name: Veritatis sit fugit exercitationem numquam consectetur
-                          facilis iusto neque.
-                        content: {}
-                        settings:
-                          gutters: No Gutters
-                        fit: Screen
-                        destination:
-                        type: Spree::Cms::Sections::HeroImage
-                        position: 3
-                        linked_resource_type: Spree::Product
-                        created_at: '2021-10-29T23:51:27.327Z'
-                        updated_at: '2021-10-29T23:51:27.336Z'
-                      relationships:
-                        cms_page:
-                          data:
-                            id: '27'
-                            type: cms_page
-                        linked_resource:
-                          data:
-                            id: '38'
-                            type: product
-              schema:
-                "$ref": "#/components/schemas/resource"
-        '404':
-          description: Record not found
-          content:
-            application/vnd.api+json:
-              examples:
-                Example:
-                  value:
-                    error: The resource you were looking for could not be found.
-              schema:
-                "$ref": "#/components/schemas/error"
-        '401':
-          description: Authentication Failed
-          content:
-            application/vnd.api+json:
-              examples:
-                Example:
-                  value:
-                    error: The access token is invalid
-              schema:
-                "$ref": "#/components/schemas/error"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/cms_section_reposition_params"
   "/api/v2/platform/countries":
     get:
       summary: Returns a list of Countries
@@ -2190,7 +2115,7 @@ paths:
                 Example:
                   value:
                     data:
-                    - id: '79'
+                    - id: '76'
                       type: country
                       attributes:
                         iso_name: UNITED STATES
@@ -2199,13 +2124,13 @@ paths:
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-10-29T23:51:27.477Z'
+                        updated_at: '2021-10-30T11:24:01.541Z'
                         zipcode_required: true
-                        created_at: '2021-10-29T23:51:27.477Z'
+                        created_at: '2021-10-30T11:24:01.541Z'
                       relationships:
                         states:
                           data: []
-                    - id: '80'
+                    - id: '77'
                       type: country
                       attributes:
                         iso_name: ISO_NAME_2
@@ -2214,13 +2139,13 @@ paths:
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-10-29T23:51:27.482Z'
+                        updated_at: '2021-10-30T11:24:01.547Z'
                         zipcode_required: true
-                        created_at: '2021-10-29T23:51:27.482Z'
+                        created_at: '2021-10-30T11:24:01.547Z'
                       relationships:
                         states:
                           data: []
-                    - id: '81'
+                    - id: '78'
                       type: country
                       attributes:
                         iso_name: ISO_NAME_3
@@ -2229,9 +2154,9 @@ paths:
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-10-29T23:51:27.484Z'
+                        updated_at: '2021-10-30T11:24:01.549Z'
                         zipcode_required: true
-                        created_at: '2021-10-29T23:51:27.484Z'
+                        created_at: '2021-10-30T11:24:01.549Z'
                       relationships:
                         states:
                           data: []
@@ -2281,7 +2206,7 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '86'
+                      id: '83'
                       type: country
                       attributes:
                         iso_name: ISO_NAME_6
@@ -2290,9 +2215,9 @@ paths:
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-10-29T23:51:27.536Z'
+                        updated_at: '2021-10-30T11:24:01.594Z'
                         zipcode_required: true
-                        created_at: '2021-10-29T23:51:27.536Z'
+                        created_at: '2021-10-30T11:24:01.594Z'
                       relationships:
                         states:
                           data: []
@@ -2350,7 +2275,7 @@ paths:
                     - id: '1'
                       type: digital_link
                       attributes:
-                        token: E9Few5ibTGXyK2KwXFFpFnFa
+                        token: gM423vgvEH6uTsZJwSQUgAK7
                         access_counter: 0
                       relationships:
                         digital:
@@ -2364,7 +2289,7 @@ paths:
                     - id: '2'
                       type: digital_link
                       attributes:
-                        token: XUYdyqHMDKQMim3bFvajFznX
+                        token: 6T9u9yg9a5Dd6773XuWFKA7M
                         access_counter: 0
                       relationships:
                         digital:
@@ -2418,7 +2343,7 @@ paths:
                       id: '5'
                       type: digital_link
                       attributes:
-                        token: WJcE7NAqapG9czitxYBigCRK
+                        token: uvCoMeo2zoV48Ftua8ZE2muq
                         access_counter: 0
                       relationships:
                         digital:
@@ -2481,7 +2406,7 @@ paths:
                       id: '6'
                       type: digital_link
                       attributes:
-                        token: NNsHL4dF99RQowZUavQoDbwr
+                        token: p5gy4qoFkXZLsFnK5M3spHhp
                         access_counter: 0
                       relationships:
                         digital:
@@ -2540,7 +2465,7 @@ paths:
                       id: '8'
                       type: digital_link
                       attributes:
-                        token: 3VrbuniokrPV3nGarmcVNN9s
+                        token: wa4App964XNTNk2t91ee2Sxk
                         access_counter: 0
                       relationships:
                         digital:
@@ -2655,7 +2580,7 @@ paths:
                       id: '13'
                       type: digital_link
                       attributes:
-                        token: 6moU2c8fGEvtfwqgvQcJ3Kmf
+                        token: ximJRCSRsJwSKm39q9HrZw6X
                         access_counter: 0
                       relationships:
                         digital:
@@ -2734,7 +2659,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '86'
+                            id: '83'
                             type: variant
                     - id: '16'
                       type: digital
@@ -2746,7 +2671,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '88'
+                            id: '85'
                             type: variant
                     - id: '17'
                       type: digital
@@ -2758,7 +2683,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '90'
+                            id: '87'
                             type: variant
                     meta:
                       count: 3
@@ -2817,7 +2742,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '100'
+                            id: '97'
                             type: variant
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -2882,7 +2807,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '118'
+                            id: '115'
                             type: variant
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -2946,7 +2871,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '140'
+                            id: '137'
                             type: variant
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -3072,8 +2997,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-10-29T23:51:34.353Z'
-                        updated_at: '2021-10-29T23:51:34.362Z'
+                        created_at: '2021-10-30T11:24:08.519Z'
+                        updated_at: '2021-10-30T11:24:08.536Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3083,7 +3008,6 @@ paths:
                         pre_tax_amount: '10.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_amount: "$10.00"
                         display_adjustment_total: "$0.00"
@@ -3095,6 +3019,7 @@ paths:
                         display_subtotal: "$10.00"
                         display_final_amount: "$10.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                       relationships:
                         order:
                           data:
@@ -3102,11 +3027,11 @@ paths:
                             type: order
                         tax_category:
                           data:
-                            id: '76'
+                            id: '73'
                             type: tax_category
                         variant:
                           data:
-                            id: '189'
+                            id: '186'
                             type: variant
                         adjustments:
                           data: []
@@ -3119,8 +3044,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-10-29T23:51:34.394Z'
-                        updated_at: '2021-10-29T23:51:34.400Z'
+                        created_at: '2021-10-30T11:24:08.578Z'
+                        updated_at: '2021-10-30T11:24:08.584Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3130,7 +3055,6 @@ paths:
                         pre_tax_amount: '10.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_amount: "$10.00"
                         display_adjustment_total: "$0.00"
@@ -3142,6 +3066,7 @@ paths:
                         display_subtotal: "$10.00"
                         display_final_amount: "$10.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                       relationships:
                         order:
                           data:
@@ -3149,11 +3074,11 @@ paths:
                             type: order
                         tax_category:
                           data:
-                            id: '76'
+                            id: '73'
                             type: tax_category
                         variant:
                           data:
-                            id: '190'
+                            id: '187'
                             type: variant
                         adjustments:
                           data: []
@@ -3213,8 +3138,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-10-29T23:51:34.614Z'
-                        updated_at: '2021-10-29T23:51:34.648Z'
+                        created_at: '2021-10-30T11:24:08.805Z'
+                        updated_at: '2021-10-30T11:24:08.841Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3224,7 +3149,6 @@ paths:
                         pre_tax_amount: '10.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_amount: "$10.00"
                         display_adjustment_total: "$0.00"
@@ -3236,6 +3160,7 @@ paths:
                         display_subtotal: "$10.00"
                         display_final_amount: "$10.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                       relationships:
                         order:
                           data:
@@ -3243,11 +3168,11 @@ paths:
                             type: order
                         tax_category:
                           data:
-                            id: '78'
+                            id: '75'
                             type: tax_category
                         variant:
                           data:
-                            id: '193'
+                            id: '190'
                             type: variant
                         adjustments:
                           data: []
@@ -3316,8 +3241,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-10-29T23:51:34.779Z'
-                        updated_at: '2021-10-29T23:51:34.785Z'
+                        created_at: '2021-10-30T11:24:08.989Z'
+                        updated_at: '2021-10-30T11:24:08.997Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3327,7 +3252,6 @@ paths:
                         pre_tax_amount: '10.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_amount: "$10.00"
                         display_adjustment_total: "$0.00"
@@ -3339,6 +3263,7 @@ paths:
                         display_subtotal: "$10.00"
                         display_final_amount: "$10.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                       relationships:
                         order:
                           data:
@@ -3346,11 +3271,11 @@ paths:
                             type: order
                         tax_category:
                           data:
-                            id: '79'
+                            id: '76'
                             type: tax_category
                         variant:
                           data:
-                            id: '194'
+                            id: '191'
                             type: variant
                         adjustments:
                           data: []
@@ -3415,8 +3340,8 @@ paths:
                       attributes:
                         quantity: 4
                         price: '10.0'
-                        created_at: '2021-10-29T23:51:35.009Z'
-                        updated_at: '2021-10-29T23:51:35.045Z'
+                        created_at: '2021-10-30T11:24:09.235Z'
+                        updated_at: '2021-10-30T11:24:09.274Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3426,7 +3351,6 @@ paths:
                         pre_tax_amount: '40.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_amount: "$40.00"
                         display_adjustment_total: "$0.00"
@@ -3438,6 +3362,7 @@ paths:
                         display_subtotal: "$40.00"
                         display_final_amount: "$40.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                       relationships:
                         order:
                           data:
@@ -3445,11 +3370,11 @@ paths:
                             type: order
                         tax_category:
                           data:
-                            id: '81'
+                            id: '78'
                             type: tax_category
                         variant:
                           data:
-                            id: '198'
+                            id: '195'
                             type: variant
                         adjustments:
                           data: []
@@ -3466,10 +3391,10 @@ paths:
               examples:
                 Example:
                   value:
-                    error: 'Quantity selected of "Product #133 - 8936" is not available.'
+                    error: 'Quantity selected of "Product #130 - 5356" is not available.'
                     errors:
                       quantity:
-                      - 'selected of "Product #133 - 8936" is not available.'
+                      - 'selected of "Product #130 - 5356" is not available.'
               schema:
                 "$ref": "#/components/schemas/validation_errors"
         '404':
@@ -3589,8 +3514,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-10-29T23:51:35.689Z'
-                        updated_at: '2021-10-29T23:51:35.693Z'
+                        created_at: '2021-10-30T11:24:09.968Z'
+                        updated_at: '2021-10-30T11:24:09.972Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3626,8 +3551,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-10-29T23:51:35.741Z'
-                        updated_at: '2021-10-29T23:51:35.746Z'
+                        created_at: '2021-10-30T11:24:10.023Z'
+                        updated_at: '2021-10-30T11:24:10.026Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3663,8 +3588,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-10-29T23:51:35.791Z'
-                        updated_at: '2021-10-29T23:51:35.796Z'
+                        created_at: '2021-10-30T11:24:10.077Z'
+                        updated_at: '2021-10-30T11:24:10.081Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3700,8 +3625,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-10-29T23:51:35.842Z'
-                        updated_at: '2021-10-29T23:51:35.847Z'
+                        created_at: '2021-10-30T11:24:10.128Z'
+                        updated_at: '2021-10-30T11:24:10.132Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3737,8 +3662,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-10-29T23:51:35.899Z'
-                        updated_at: '2021-10-29T23:51:35.905Z'
+                        created_at: '2021-10-30T11:24:10.177Z'
+                        updated_at: '2021-10-30T11:24:10.182Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3774,8 +3699,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-10-29T23:51:35.955Z'
-                        updated_at: '2021-10-29T23:51:35.961Z'
+                        created_at: '2021-10-30T11:24:10.230Z'
+                        updated_at: '2021-10-30T11:24:10.234Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3811,8 +3736,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-10-29T23:51:36.022Z'
-                        updated_at: '2021-10-29T23:51:36.027Z'
+                        created_at: '2021-10-30T11:24:10.281Z'
+                        updated_at: '2021-10-30T11:24:10.285Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3838,7 +3763,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Veniam odio minima ipsa saepe itaque.
+                        name: Nulla eligendi ratione vero tempora hic quae saepe ducimus.
                         subtitle:
                         destination:
                         new_window: false
@@ -3848,8 +3773,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-10-29T23:51:35.640Z'
-                        updated_at: '2021-10-29T23:51:36.038Z'
+                        created_at: '2021-10-30T11:24:09.914Z'
+                        updated_at: '2021-10-30T11:24:10.295Z'
                         link:
                         is_container: true
                         is_root: true
@@ -3942,8 +3867,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-10-29T23:51:36.661Z'
-                        updated_at: '2021-10-29T23:51:36.665Z'
+                        created_at: '2021-10-30T11:24:10.898Z'
+                        updated_at: '2021-10-30T11:24:10.902Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4033,8 +3958,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-10-29T23:51:37.092Z'
-                        updated_at: '2021-10-29T23:51:37.096Z'
+                        created_at: '2021-10-30T11:24:11.332Z'
+                        updated_at: '2021-10-30T11:24:11.337Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4122,8 +4047,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-10-29T23:51:37.758Z'
-                        updated_at: '2021-10-29T23:51:37.783Z'
+                        created_at: '2021-10-30T11:24:11.986Z'
+                        updated_at: '2021-10-30T11:24:12.008Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4260,8 +4185,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-10-29T23:51:39.323Z'
-                        updated_at: '2021-10-29T23:51:39.348Z'
+                        created_at: '2021-10-30T11:24:13.546Z'
+                        updated_at: '2021-10-30T11:24:13.570Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4359,16 +4284,16 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-10-29T23:51:39.801Z'
-                        updated_at: '2021-10-29T23:51:39.912Z'
+                        created_at: '2021-10-30T11:24:14.010Z'
+                        updated_at: '2021-10-30T11:24:14.119Z'
                       relationships:
                         menu_items:
                           data:
-                          - id: '89'
-                            type: menu_item
                           - id: '87'
                             type: menu_item
                           - id: '90'
+                            type: menu_item
+                          - id: '89'
                             type: menu_item
                     - id: '19'
                       type: menu
@@ -4376,8 +4301,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-10-29T23:51:39.810Z'
-                        updated_at: '2021-10-29T23:51:40.013Z'
+                        created_at: '2021-10-30T11:24:14.019Z'
+                        updated_at: '2021-10-30T11:24:14.221Z'
                       relationships:
                         menu_items:
                           data:
@@ -4440,8 +4365,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-10-29T23:51:40.295Z'
-                        updated_at: '2021-10-29T23:51:40.302Z'
+                        created_at: '2021-10-30T11:24:14.512Z'
+                        updated_at: '2021-10-30T11:24:14.518Z'
                       relationships:
                         menu_items:
                           data:
@@ -4509,8 +4434,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-10-29T23:51:40.350Z'
-                        updated_at: '2021-10-29T23:51:40.357Z'
+                        created_at: '2021-10-30T11:24:14.559Z'
+                        updated_at: '2021-10-30T11:24:14.565Z'
                       relationships:
                         menu_items:
                           data:
@@ -4574,8 +4499,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-10-29T23:51:40.428Z'
-                        updated_at: '2021-10-29T23:51:40.435Z'
+                        created_at: '2021-10-30T11:24:14.635Z'
+                        updated_at: '2021-10-30T11:24:14.642Z'
                       relationships:
                         menu_items:
                           data:
@@ -4710,8 +4635,8 @@ paths:
                         name: foo-size-68
                         presentation: Size
                         position: 1
-                        created_at: '2021-10-29T23:51:40.616Z'
-                        updated_at: '2021-10-29T23:51:40.616Z'
+                        created_at: '2021-10-30T11:24:14.818Z'
+                        updated_at: '2021-10-30T11:24:14.818Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4722,8 +4647,8 @@ paths:
                         name: foo-size-69
                         presentation: Size
                         position: 2
-                        created_at: '2021-10-29T23:51:40.618Z'
-                        updated_at: '2021-10-29T23:51:40.618Z'
+                        created_at: '2021-10-30T11:24:14.820Z'
+                        updated_at: '2021-10-30T11:24:14.820Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4774,8 +4699,8 @@ paths:
                         name: foo-size-72
                         presentation: Size
                         position: 1
-                        created_at: '2021-10-29T23:51:40.673Z'
-                        updated_at: '2021-10-29T23:51:40.673Z'
+                        created_at: '2021-10-30T11:24:14.868Z'
+                        updated_at: '2021-10-30T11:24:14.868Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4832,8 +4757,8 @@ paths:
                         name: foo-size-73
                         presentation: Size
                         position: 1
-                        created_at: '2021-10-29T23:51:40.707Z'
-                        updated_at: '2021-10-29T23:51:40.707Z'
+                        created_at: '2021-10-30T11:24:14.899Z'
+                        updated_at: '2021-10-30T11:24:14.899Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4889,8 +4814,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-10-29T23:51:40.760Z'
-                        updated_at: '2021-10-29T23:51:40.767Z'
+                        created_at: '2021-10-30T11:24:14.948Z'
+                        updated_at: '2021-10-30T11:24:14.954Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -5026,8 +4951,8 @@ paths:
                         position: 1
                         name: Size-68
                         presentation: S
-                        created_at: '2021-10-29T23:51:40.894Z'
-                        updated_at: '2021-10-29T23:51:40.894Z'
+                        created_at: '2021-10-30T11:24:15.071Z'
+                        updated_at: '2021-10-30T11:24:15.071Z'
                       relationships:
                         option_type:
                           data:
@@ -5039,8 +4964,8 @@ paths:
                         position: 1
                         name: Size-69
                         presentation: S
-                        created_at: '2021-10-29T23:51:40.900Z'
-                        updated_at: '2021-10-29T23:51:40.900Z'
+                        created_at: '2021-10-30T11:24:15.077Z'
+                        updated_at: '2021-10-30T11:24:15.077Z'
                       relationships:
                         option_type:
                           data:
@@ -5099,8 +5024,8 @@ paths:
                         position: 1
                         name: Size-72
                         presentation: S
-                        created_at: '2021-10-29T23:51:40.965Z'
-                        updated_at: '2021-10-29T23:51:40.965Z'
+                        created_at: '2021-10-30T11:24:15.135Z'
+                        updated_at: '2021-10-30T11:24:15.135Z'
                       relationships:
                         option_type:
                           data:
@@ -5163,8 +5088,8 @@ paths:
                         position: 1
                         name: Size-73
                         presentation: S
-                        created_at: '2021-10-29T23:51:41.005Z'
-                        updated_at: '2021-10-29T23:51:41.005Z'
+                        created_at: '2021-10-30T11:24:15.169Z'
+                        updated_at: '2021-10-30T11:24:15.169Z'
                       relationships:
                         option_type:
                           data:
@@ -5228,8 +5153,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-10-29T23:51:41.070Z'
-                        updated_at: '2021-10-29T23:51:41.081Z'
+                        created_at: '2021-10-30T11:24:15.237Z'
+                        updated_at: '2021-10-30T11:24:15.245Z'
                       relationships:
                         option_type:
                           data:
@@ -5357,7 +5282,7 @@ paths:
                     - id: '40'
                       type: order
                       attributes:
-                        number: R957384594
+                        number: R849292836
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5366,10 +5291,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: blake@schuppe.info
+                        email: leeanna.emmerich@beahanschimmel.biz
                         special_instructions:
-                        created_at: '2021-10-29T23:51:41.232Z'
-                        updated_at: '2021-10-29T23:51:41.232Z'
+                        created_at: '2021-10-30T11:24:15.396Z'
+                        updated_at: '2021-10-30T11:24:15.396Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5385,7 +5310,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$0.00"
                         display_ship_total: "$0.00"
@@ -5398,6 +5322,7 @@ paths:
                         display_pre_tax_item_amount: "$0.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
@@ -5441,7 +5366,7 @@ paths:
                     - id: '41'
                       type: order
                       attributes:
-                        number: R345299700
+                        number: R861172977
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5450,10 +5375,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: al@leffler.com
+                        email: jonna_wiza@robel.info
                         special_instructions:
-                        created_at: '2021-10-29T23:51:41.240Z'
-                        updated_at: '2021-10-29T23:51:41.240Z'
+                        created_at: '2021-10-30T11:24:15.405Z'
+                        updated_at: '2021-10-30T11:24:15.405Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5469,7 +5394,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$0.00"
                         display_ship_total: "$0.00"
@@ -5482,6 +5406,7 @@ paths:
                         display_pre_tax_item_amount: "$0.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
@@ -5572,7 +5497,7 @@ paths:
                       id: '44'
                       type: order
                       attributes:
-                        number: R510823435
+                        number: R068850488
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5583,8 +5508,8 @@ paths:
                         payment_state:
                         email:
                         special_instructions:
-                        created_at: '2021-10-29T23:51:41.532Z'
-                        updated_at: '2021-10-29T23:51:41.545Z'
+                        created_at: '2021-10-30T11:24:15.710Z'
+                        updated_at: '2021-10-30T11:24:15.730Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5600,7 +5525,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$20.00"
                         display_ship_total: "$0.00"
@@ -5613,6 +5537,7 @@ paths:
                         display_pre_tax_item_amount: "$20.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
@@ -5698,7 +5623,7 @@ paths:
                       id: '45'
                       type: order
                       attributes:
-                        number: R862395508
+                        number: R090923044
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5707,10 +5632,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: enid.huel@rogahn.co.uk
+                        email: selina@wehner.ca
                         special_instructions:
-                        created_at: '2021-10-29T23:51:41.583Z'
-                        updated_at: '2021-10-29T23:51:41.722Z'
+                        created_at: '2021-10-30T11:24:15.793Z'
+                        updated_at: '2021-10-30T11:24:15.927Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5726,7 +5651,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$10.00"
                         display_ship_total: "$100.00"
@@ -5739,6 +5663,7 @@ paths:
                         display_pre_tax_item_amount: "$10.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
@@ -5840,7 +5765,7 @@ paths:
                       id: '47'
                       type: order
                       attributes:
-                        number: R124258375
+                        number: R250595441
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5851,8 +5776,8 @@ paths:
                         payment_state:
                         email: new@example.com
                         special_instructions:
-                        created_at: '2021-10-29T23:51:41.912Z'
-                        updated_at: '2021-10-29T23:51:42.013Z'
+                        created_at: '2021-10-30T11:24:16.098Z'
+                        updated_at: '2021-10-30T11:24:16.188Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5868,7 +5793,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$10.00"
                         display_ship_total: "$100.00"
@@ -5881,6 +5805,7 @@ paths:
                         display_pre_tax_item_amount: "$10.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
@@ -6038,7 +5963,7 @@ paths:
                       id: '52'
                       type: order
                       attributes:
-                        number: R754090478
+                        number: R326211346
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -6047,10 +5972,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: viviana.ruecker@schmitt.name
+                        email: renea@mitchellrunte.biz
                         special_instructions:
-                        created_at: '2021-10-29T23:51:42.586Z'
-                        updated_at: '2021-10-29T23:51:42.725Z'
+                        created_at: '2021-10-30T11:24:16.735Z'
+                        updated_at: '2021-10-30T11:24:16.867Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6066,7 +5991,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$110.00"
                         display_ship_total: "$100.00"
@@ -6079,6 +6003,7 @@ paths:
                         display_pre_tax_item_amount: "$10.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
@@ -6183,7 +6108,7 @@ paths:
                       id: '54'
                       type: order
                       attributes:
-                        number: R520621097
+                        number: R611595544
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -6192,10 +6117,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: sherie@cummerata.name
+                        email: nannette_leannon@considine.com
                         special_instructions:
-                        created_at: '2021-10-29T23:51:42.894Z'
-                        updated_at: '2021-10-29T23:51:43.015Z'
+                        created_at: '2021-10-30T11:24:17.047Z'
+                        updated_at: '2021-10-30T11:24:17.172Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6211,7 +6136,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$110.00"
                         display_ship_total: "$100.00"
@@ -6224,6 +6148,7 @@ paths:
                         display_pre_tax_item_amount: "$10.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
@@ -6328,19 +6253,19 @@ paths:
                       id: '56'
                       type: order
                       attributes:
-                        number: R831874558
+                        number: R770832984
                         item_total: '10.0'
                         total: '110.0'
                         state: complete
                         adjustment_total: '0.0'
-                        completed_at: '2021-10-29T23:51:43.385Z'
+                        completed_at: '2021-10-30T11:24:17.543Z'
                         payment_total: '0.0'
                         shipment_state: pending
                         payment_state: balance_due
-                        email: janise_marquardt@kassulke.com
+                        email: latanya@reichel.name
                         special_instructions:
-                        created_at: '2021-10-29T23:51:43.186Z'
-                        updated_at: '2021-10-29T23:51:43.385Z'
+                        created_at: '2021-10-30T11:24:17.346Z'
+                        updated_at: '2021-10-30T11:24:17.543Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6356,7 +6281,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$110.00"
                         display_ship_total: "$100.00"
@@ -6369,6 +6293,7 @@ paths:
                         display_pre_tax_item_amount: "$10.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
@@ -6484,7 +6409,7 @@ paths:
                       id: '59'
                       type: order
                       attributes:
-                        number: R171015818
+                        number: R425191745
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -6493,10 +6418,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: gena.flatley@kesslerschroeder.ca
+                        email: heriberto.schaefer@jenkins.name
                         special_instructions:
-                        created_at: '2021-10-29T23:51:43.685Z'
-                        updated_at: '2021-10-29T23:51:43.787Z'
+                        created_at: '2021-10-30T11:24:17.832Z'
+                        updated_at: '2021-10-30T11:24:17.926Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -6512,7 +6437,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$0.00"
                         display_ship_total: "$0.00"
@@ -6525,6 +6449,7 @@ paths:
                         display_pre_tax_item_amount: "$0.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
@@ -6624,7 +6549,7 @@ paths:
                       id: '61'
                       type: order
                       attributes:
-                        number: R008395984
+                        number: R009106072
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -6633,10 +6558,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: chassidy@dicki.us
+                        email: danielle_koch@mcglynn.com
                         special_instructions:
-                        created_at: '2021-10-29T23:51:43.949Z'
-                        updated_at: '2021-10-29T23:51:44.028Z'
+                        created_at: '2021-10-30T11:24:18.078Z'
+                        updated_at: '2021-10-30T11:24:18.159Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6652,7 +6577,6 @@ paths:
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
                         store_owner_notification_delivered:
-                        display_promo_total: "$0.00"
                         display_included_tax_total: "$0.00"
                         display_pre_tax_total: "$10.00"
                         display_ship_total: "$100.00"
@@ -6665,6 +6589,7 @@ paths:
                         display_pre_tax_item_amount: "$10.00"
                         display_adjustment_total: "$0.00"
                         display_additional_tax_total: "$0.00"
+                        display_promo_total: "$0.00"
                         display_total_applicable_store_credit: "$0.00"
                         display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
@@ -6941,9 +6866,9 @@ paths:
                         state: invalid
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-10-29T23:51:45.571Z'
-                        updated_at: '2021-10-29T23:51:45.590Z'
-                        number: PETJRNZI
+                        created_at: '2021-10-30T11:24:19.722Z'
+                        updated_at: '2021-10-30T11:24:19.740Z'
+                        number: PWPUO6XD
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -6978,9 +6903,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-10-29T23:51:45.587Z'
-                        updated_at: '2021-10-29T23:51:45.587Z'
-                        number: PA7J1E4X
+                        created_at: '2021-10-30T11:24:19.737Z'
+                        updated_at: '2021-10-30T11:24:19.737Z'
+                        number: PDOORC4E
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7066,9 +6991,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-10-29T23:51:45.739Z'
-                        updated_at: '2021-10-29T23:51:45.739Z'
-                        number: PQORGTC1
+                        created_at: '2021-10-30T11:24:19.905Z'
+                        updated_at: '2021-10-30T11:24:19.905Z'
+                        number: PAMGJ03K
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7204,8 +7129,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-10-29T23:51:45.953Z'
-                        updated_at: '2021-10-29T23:51:45.953Z'
+                        created_at: '2021-10-30T11:24:20.118Z'
+                        updated_at: '2021-10-30T11:24:20.118Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7214,8 +7139,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-10-29T23:51:45.955Z'
-                        updated_at: '2021-10-29T23:51:45.955Z'
+                        created_at: '2021-10-30T11:24:20.120Z'
+                        updated_at: '2021-10-30T11:24:20.120Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7271,8 +7196,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-10-29T23:51:46.000Z'
-                        updated_at: '2021-10-29T23:51:46.000Z'
+                        created_at: '2021-10-30T11:24:20.173Z'
+                        updated_at: '2021-10-30T11:24:20.173Z'
                         code: 2021-BFM
                       relationships:
                         promotions:
@@ -7332,8 +7257,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-10-29T23:51:46.030Z'
-                        updated_at: '2021-10-29T23:51:46.030Z'
+                        created_at: '2021-10-30T11:24:20.204Z'
+                        updated_at: '2021-10-30T11:24:20.204Z'
                         code: MJO
                       relationships:
                         promotions:
@@ -7394,8 +7319,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: 2021 Promotions
-                        created_at: '2021-10-29T23:51:46.091Z'
-                        updated_at: '2021-10-29T23:51:46.098Z'
+                        created_at: '2021-10-30T11:24:20.265Z'
+                        updated_at: '2021-10-30T11:24:20.272Z'
                         code: 2021-Promos
                       relationships:
                         promotions:
@@ -7523,12 +7448,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H78225282031
+                        number: H80713946891
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-10-29T23:51:46.223Z'
-                        updated_at: '2021-10-29T23:51:46.226Z'
+                        created_at: '2021-10-30T11:24:20.410Z'
+                        updated_at: '2021-10-30T11:24:20.413Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7550,7 +7475,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '130'
+                            id: '127'
                             type: stock_location
                         adjustments:
                           data: []
@@ -7570,12 +7495,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H17884988870
+                        number: H61878101094
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-10-29T23:51:46.253Z'
-                        updated_at: '2021-10-29T23:51:46.256Z'
+                        created_at: '2021-10-30T11:24:20.439Z'
+                        updated_at: '2021-10-30T11:24:20.442Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7597,7 +7522,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '131'
+                            id: '128'
                             type: stock_location
                         adjustments:
                           data: []
@@ -7670,12 +7595,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H73247562285
+                        number: H14154299516
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-10-29T23:51:46.546Z'
-                        updated_at: '2021-10-29T23:51:46.563Z'
+                        created_at: '2021-10-30T11:24:20.722Z'
+                        updated_at: '2021-10-30T11:24:20.739Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7697,7 +7622,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '136'
+                            id: '133'
                             type: stock_location
                         adjustments:
                           data: []
@@ -7809,12 +7734,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H58037144478
+                        number: H51615482546
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-10-29T23:51:47.352Z'
-                        updated_at: '2021-10-29T23:51:47.388Z'
+                        created_at: '2021-10-30T11:24:21.589Z'
+                        updated_at: '2021-10-30T11:24:21.618Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7836,7 +7761,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '148'
+                            id: '145'
                             type: stock_location
                         adjustments:
                           data: []
@@ -7913,12 +7838,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H94790364748
+                        number: H46674457264
                         cost: '100.0'
-                        shipped_at: '2021-10-29T23:51:47.817Z'
+                        shipped_at: '2021-10-30T11:24:22.066Z'
                         state: shipped
-                        created_at: '2021-10-29T23:51:47.782Z'
-                        updated_at: '2021-10-29T23:51:47.817Z'
+                        created_at: '2021-10-30T11:24:22.030Z'
+                        updated_at: '2021-10-30T11:24:22.066Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7940,7 +7865,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '154'
+                            id: '151'
                             type: stock_location
                         adjustments:
                           data: []
@@ -8017,12 +7942,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H24898051846
+                        number: H29918026100
                         cost: '100.0'
                         shipped_at:
                         state: canceled
-                        created_at: '2021-10-29T23:51:48.209Z'
-                        updated_at: '2021-10-29T23:51:48.286Z'
+                        created_at: '2021-10-30T11:24:22.460Z'
+                        updated_at: '2021-10-30T11:24:22.487Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8044,7 +7969,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '160'
+                            id: '157'
                             type: stock_location
                         adjustments:
                           data: []
@@ -8121,12 +8046,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H31274760772
+                        number: H95956106156
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-10-29T23:51:48.688Z'
-                        updated_at: '2021-10-29T23:51:48.721Z'
+                        created_at: '2021-10-30T11:24:23.036Z'
+                        updated_at: '2021-10-30T11:24:23.061Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8148,7 +8073,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '166'
+                            id: '163'
                             type: stock_location
                         adjustments:
                           data: []
@@ -8225,12 +8150,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H95010611456
+                        number: H25165182614
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-10-29T23:51:49.111Z'
-                        updated_at: '2021-10-29T23:51:49.137Z'
+                        created_at: '2021-10-30T11:24:23.480Z'
+                        updated_at: '2021-10-30T11:24:23.507Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8252,7 +8177,7 @@ paths:
                           data:
                         stock_location:
                           data:
-                            id: '172'
+                            id: '169'
                             type: stock_location
                         adjustments:
                           data: []
@@ -8329,18 +8254,18 @@ paths:
                 Example:
                   value:
                     data:
-                    - id: '119'
+                    - id: '116'
                       type: shipping_category
                       attributes:
-                        name: 'ShippingCategory #119'
-                        created_at: '2021-10-29T23:51:49.475Z'
-                        updated_at: '2021-10-29T23:51:49.475Z'
-                    - id: '120'
+                        name: 'ShippingCategory #116'
+                        created_at: '2021-10-30T11:24:23.744Z'
+                        updated_at: '2021-10-30T11:24:23.744Z'
+                    - id: '117'
                       type: shipping_category
                       attributes:
-                        name: 'ShippingCategory #120'
-                        created_at: '2021-10-29T23:51:49.476Z'
-                        updated_at: '2021-10-29T23:51:49.476Z'
+                        name: 'ShippingCategory #117'
+                        created_at: '2021-10-30T11:24:23.746Z'
+                        updated_at: '2021-10-30T11:24:23.746Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -8381,12 +8306,12 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '123'
+                      id: '120'
                       type: shipping_category
                       attributes:
-                        name: 'ShippingCategory #123'
-                        created_at: '2021-10-29T23:51:49.526Z'
-                        updated_at: '2021-10-29T23:51:49.526Z'
+                        name: 'ShippingCategory #120'
+                        created_at: '2021-10-30T11:24:23.797Z'
+                        updated_at: '2021-10-30T11:24:23.797Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8431,12 +8356,12 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '124'
+                      id: '121'
                       type: shipping_category
                       attributes:
-                        name: 'ShippingCategory #124'
-                        created_at: '2021-10-29T23:51:49.562Z'
-                        updated_at: '2021-10-29T23:51:49.562Z'
+                        name: 'ShippingCategory #121'
+                        created_at: '2021-10-30T11:24:23.841Z'
+                        updated_at: '2021-10-30T11:24:23.841Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -8482,12 +8407,12 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '126'
+                      id: '123'
                       type: shipping_category
                       attributes:
                         name: Default
-                        created_at: '2021-10-29T23:51:49.616Z'
-                        updated_at: '2021-10-29T23:51:49.623Z'
+                        created_at: '2021-10-30T11:24:23.921Z'
+                        updated_at: '2021-10-30T11:24:23.928Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8621,13 +8546,13 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-10-29T23:51:49.771Z'
-                        updated_at: '2021-10-29T23:51:49.771Z'
+                        created_at: '2021-10-30T11:24:24.064Z'
+                        updated_at: '2021-10-30T11:24:24.064Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
                           data:
-                          - id: '131'
+                          - id: '128'
                             type: shipping_category
                         shipping_rates:
                           data: []
@@ -8645,13 +8570,13 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-10-29T23:51:49.781Z'
-                        updated_at: '2021-10-29T23:51:49.781Z'
+                        created_at: '2021-10-30T11:24:24.074Z'
+                        updated_at: '2021-10-30T11:24:24.074Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
                           data:
-                          - id: '131'
+                          - id: '128'
                             type: shipping_category
                         shipping_rates:
                           data: []
@@ -8716,19 +8641,19 @@ paths:
                         admin_name: DHL Express- Zone A
                         display_on: both
                         tracking_url:
-                        created_at: '2021-10-29T23:51:49.861Z'
-                        updated_at: '2021-10-29T23:51:49.861Z'
+                        created_at: '2021-10-30T11:24:24.155Z'
+                        updated_at: '2021-10-30T11:24:24.155Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
                           data:
-                          - id: '133'
+                          - id: '130'
                             type: shipping_category
                         shipping_rates:
                           data: []
                         tax_category:
                           data:
-                            id: '128'
+                            id: '125'
                             type: tax_category
                         calculator:
                           data:
@@ -8801,13 +8726,13 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-10-29T23:51:49.905Z'
-                        updated_at: '2021-10-29T23:51:49.905Z'
+                        created_at: '2021-10-30T11:24:24.204Z'
+                        updated_at: '2021-10-30T11:24:24.204Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
                           data:
-                          - id: '134'
+                          - id: '131'
                             type: shipping_category
                         shipping_rates:
                           data: []
@@ -8877,13 +8802,13 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-10-29T23:51:49.980Z'
-                        updated_at: '2021-10-29T23:51:49.994Z'
+                        created_at: '2021-10-30T11:24:24.298Z'
+                        updated_at: '2021-10-30T11:24:24.330Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
                           data:
-                          - id: '136'
+                          - id: '133'
                             type: shipping_category
                         shipping_rates:
                           data: []
@@ -9027,8 +8952,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-10-29T23:51:50.241Z'
-                        updated_at: '2021-10-29T23:51:50.245Z'
+                        created_at: '2021-10-30T11:24:24.590Z'
+                        updated_at: '2021-10-30T11:24:24.594Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9062,8 +8987,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-10-29T23:51:50.292Z'
-                        updated_at: '2021-10-29T23:51:50.296Z'
+                        created_at: '2021-10-30T11:24:24.644Z'
+                        updated_at: '2021-10-30T11:24:24.649Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9097,8 +9022,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-10-29T23:51:50.176Z'
-                        updated_at: '2021-10-29T23:51:50.305Z'
+                        created_at: '2021-10-30T11:24:24.516Z'
+                        updated_at: '2021-10-30T11:24:24.659Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9179,8 +9104,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-10-29T23:51:50.518Z'
-                        updated_at: '2021-10-29T23:51:50.523Z'
+                        created_at: '2021-10-30T11:24:24.905Z'
+                        updated_at: '2021-10-30T11:24:24.910Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9265,8 +9190,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-10-29T23:51:50.632Z'
-                        updated_at: '2021-10-29T23:51:50.636Z'
+                        created_at: '2021-10-30T11:24:25.011Z'
+                        updated_at: '2021-10-30T11:24:25.015Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9354,8 +9279,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-10-29T23:51:50.836Z'
-                        updated_at: '2021-10-29T23:51:50.862Z'
+                        created_at: '2021-10-30T11:24:25.260Z'
+                        updated_at: '2021-10-30T11:24:25.287Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9508,9 +9433,9 @@ paths:
                     - id: '97'
                       type: user
                       attributes:
-                        email: salley@prosaccoschmitt.ca
-                        created_at: '2021-10-29T23:51:51.471Z'
-                        updated_at: '2021-10-29T23:51:51.471Z'
+                        email: margarita.kohler@osinski.com
+                        created_at: '2021-10-30T11:24:25.785Z'
+                        updated_at: '2021-10-30T11:24:25.785Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9522,9 +9447,9 @@ paths:
                     - id: '98'
                       type: user
                       attributes:
-                        email: joleen@schoen.us
-                        created_at: '2021-10-29T23:51:51.476Z'
-                        updated_at: '2021-10-29T23:51:51.476Z'
+                        email: latonia@hodkiewicz.biz
+                        created_at: '2021-10-30T11:24:25.791Z'
+                        updated_at: '2021-10-30T11:24:25.791Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9536,9 +9461,9 @@ paths:
                     - id: '99'
                       type: user
                       attributes:
-                        email: leighann@schaefer.biz
-                        created_at: '2021-10-29T23:51:51.477Z'
-                        updated_at: '2021-10-29T23:51:51.477Z'
+                        email: daniel.kutch@runte.co.uk
+                        created_at: '2021-10-30T11:24:25.792Z'
+                        updated_at: '2021-10-30T11:24:25.792Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9597,9 +9522,9 @@ paths:
                       id: '104'
                       type: user
                       attributes:
-                        email: vinita.cartwright@streichkertzmann.name
-                        created_at: '2021-10-29T23:51:51.546Z'
-                        updated_at: '2021-10-29T23:51:51.546Z'
+                        email: bert_hudson@cummings.name
+                        created_at: '2021-10-30T11:24:25.866Z'
+                        updated_at: '2021-10-30T11:24:25.866Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9662,9 +9587,9 @@ paths:
                       id: '107'
                       type: user
                       attributes:
-                        email: penelope@abbottkrajcik.co.uk
-                        created_at: '2021-10-29T23:51:51.593Z'
-                        updated_at: '2021-10-29T23:51:51.593Z'
+                        email: juliann@leschoreilly.co.uk
+                        created_at: '2021-10-30T11:24:25.923Z'
+                        updated_at: '2021-10-30T11:24:25.923Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9729,8 +9654,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-10-29T23:51:51.673Z'
-                        updated_at: '2021-10-29T23:51:51.683Z'
+                        created_at: '2021-10-30T11:24:25.996Z'
+                        updated_at: '2021-10-30T11:24:26.006Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9864,10 +9789,10 @@ paths:
                 Example:
                   value:
                     data:
-                    - id: '251'
+                    - id: '248'
                       type: variant
                       attributes:
-                        sku: SKU-251
+                        sku: SKU-248
                         weight: '0.0'
                         height:
                         depth:
@@ -9877,12 +9802,12 @@ paths:
                         position: 1
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-10-29T23:51:51.896Z'
+                        updated_at: '2021-10-30T11:24:26.210Z'
                         discontinue_on:
-                        created_at: '2021-10-29T23:51:51.890Z'
+                        created_at: '2021-10-30T11:24:26.205Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #184 - 2764'
+                        name: 'Product #181 - 6099'
                         options_text: ''
                         total_on_hand: 0
                         purchasable: true
@@ -9895,7 +9820,7 @@ paths:
                       relationships:
                         product:
                           data:
-                            id: '184'
+                            id: '181'
                             type: product
                         tax_category:
                           data:
@@ -9907,31 +9832,31 @@ paths:
                           data: []
                         stock_items:
                           data:
-                          - id: '306'
+                          - id: '303'
                             type: stock_item
                         stock_locations:
                           data:
-                          - id: '176'
+                          - id: '173'
                             type: stock_location
-                    - id: '252'
+                    - id: '249'
                       type: variant
                       attributes:
-                        sku: SKU-252
-                        weight: '181.56'
-                        height: '40.59'
-                        depth: '62.32'
+                        sku: SKU-249
+                        weight: '47.79'
+                        height: '139.2'
+                        depth: '147.76'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-10-29T23:51:51.925Z'
+                        updated_at: '2021-10-30T11:24:26.240Z'
                         discontinue_on:
-                        created_at: '2021-10-29T23:51:51.918Z'
+                        created_at: '2021-10-30T11:24:26.234Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #184 - 2764'
+                        name: 'Product #181 - 6099'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -9944,7 +9869,7 @@ paths:
                       relationships:
                         product:
                           data:
-                            id: '184'
+                            id: '181'
                             type: product
                         tax_category:
                           data:
@@ -9958,31 +9883,31 @@ paths:
                             type: option_value
                         stock_items:
                           data:
-                          - id: '307'
+                          - id: '304'
                             type: stock_item
                         stock_locations:
                           data:
-                          - id: '176'
+                          - id: '173'
                             type: stock_location
-                    - id: '253'
+                    - id: '250'
                       type: variant
                       attributes:
-                        sku: SKU-253
-                        weight: '47.3'
-                        height: '96.84'
-                        depth: '192.64'
+                        sku: SKU-250
+                        weight: '115.29'
+                        height: '71.69'
+                        depth: '132.58'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 3
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-10-29T23:51:51.943Z'
+                        updated_at: '2021-10-30T11:24:26.261Z'
                         discontinue_on:
-                        created_at: '2021-10-29T23:51:51.937Z'
+                        created_at: '2021-10-30T11:24:26.255Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #184 - 2764'
+                        name: 'Product #181 - 6099'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -9995,7 +9920,7 @@ paths:
                       relationships:
                         product:
                           data:
-                            id: '184'
+                            id: '181'
                             type: product
                         tax_category:
                           data:
@@ -10009,11 +9934,11 @@ paths:
                             type: option_value
                         stock_items:
                           data:
-                          - id: '308'
+                          - id: '305'
                             type: stock_item
                         stock_locations:
                           data:
-                          - id: '176'
+                          - id: '173'
                             type: stock_location
                     meta:
                       count: 3
@@ -10068,25 +9993,25 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '258'
+                      id: '255'
                       type: variant
                       attributes:
-                        sku: SKU-258
-                        weight: '126.34'
-                        height: '143.96'
-                        depth: '159.88'
+                        sku: SKU-255
+                        weight: '71.15'
+                        height: '22.81'
+                        depth: '160.29'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-10-29T23:51:52.155Z'
+                        updated_at: '2021-10-30T11:24:26.469Z'
                         discontinue_on:
-                        created_at: '2021-10-29T23:51:52.149Z'
+                        created_at: '2021-10-30T11:24:26.463Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #186 - 1060'
+                        name: 'Product #183 - 1265'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10099,7 +10024,7 @@ paths:
                       relationships:
                         product:
                           data:
-                            id: '186'
+                            id: '183'
                             type: product
                         tax_category:
                           data:
@@ -10113,11 +10038,11 @@ paths:
                             type: option_value
                         stock_items:
                           data:
-                          - id: '313'
+                          - id: '310'
                             type: stock_item
                         stock_locations:
                           data:
-                          - id: '178'
+                          - id: '175'
                             type: stock_location
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -10247,14 +10172,14 @@ paths:
                     - id: '1'
                       type: event
                       attributes:
-                        execution_time: 51160
+                        execution_time: 32374
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url1.com/
-                        created_at: '2021-10-29T23:51:52.494Z'
-                        updated_at: '2021-10-29T23:51:52.494Z'
+                        created_at: '2021-10-30T11:24:26.797Z'
+                        updated_at: '2021-10-30T11:24:26.797Z'
                       relationships:
                         subscriber:
                           data:
@@ -10263,14 +10188,14 @@ paths:
                     - id: '2'
                       type: event
                       attributes:
-                        execution_time: 74082
+                        execution_time: 81797
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url2.com/
-                        created_at: '2021-10-29T23:51:52.497Z'
-                        updated_at: '2021-10-29T23:51:52.497Z'
+                        created_at: '2021-10-30T11:24:26.799Z'
+                        updated_at: '2021-10-30T11:24:26.799Z'
                       relationships:
                         subscriber:
                           data:
@@ -10346,8 +10271,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-10-29T23:51:52.546Z'
-                        updated_at: '2021-10-29T23:51:52.546Z'
+                        created_at: '2021-10-30T11:24:26.842Z'
+                        updated_at: '2021-10-30T11:24:26.842Z'
                     - id: '6'
                       type: subscriber
                       attributes:
@@ -10355,8 +10280,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-10-29T23:51:52.547Z'
-                        updated_at: '2021-10-29T23:51:52.547Z'
+                        created_at: '2021-10-30T11:24:26.843Z'
+                        updated_at: '2021-10-30T11:24:26.843Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -10404,8 +10329,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-10-29T23:51:52.596Z'
-                        updated_at: '2021-10-29T23:51:52.596Z'
+                        created_at: '2021-10-30T11:24:26.887Z'
+                        updated_at: '2021-10-30T11:24:26.887Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10460,8 +10385,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-10-29T23:51:52.631Z'
-                        updated_at: '2021-10-29T23:51:52.631Z'
+                        created_at: '2021-10-30T11:24:26.925Z'
+                        updated_at: '2021-10-30T11:24:26.925Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -10514,8 +10439,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-10-29T23:51:52.689Z'
-                        updated_at: '2021-10-29T23:51:52.689Z'
+                        created_at: '2021-10-30T11:24:26.977Z'
+                        updated_at: '2021-10-30T11:24:26.977Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10636,8 +10561,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-10-29T23:51:52.952Z'
-                        updated_at: '2021-10-29T23:51:52.952Z'
+                        created_at: '2021-10-30T11:24:27.221Z'
+                        updated_at: '2021-10-30T11:24:27.221Z'
                         display_total: "$19.99"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10645,14 +10570,14 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '268'
+                            id: '265'
                             type: variant
                     - id: '2'
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-10-29T23:51:53.006Z'
-                        updated_at: '2021-10-29T23:51:53.006Z'
+                        created_at: '2021-10-30T11:24:27.270Z'
+                        updated_at: '2021-10-30T11:24:27.270Z'
                         display_total: "$19.99"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10660,14 +10585,14 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '270'
+                            id: '267'
                             type: variant
                     - id: '3'
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-10-29T23:51:53.052Z'
-                        updated_at: '2021-10-29T23:51:53.052Z'
+                        created_at: '2021-10-30T11:24:27.316Z'
+                        updated_at: '2021-10-30T11:24:27.316Z'
                         display_total: "$19.99"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10675,14 +10600,14 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '272'
+                            id: '269'
                             type: variant
                     - id: '4'
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-10-29T23:51:53.104Z'
-                        updated_at: '2021-10-29T23:51:53.104Z'
+                        created_at: '2021-10-30T11:24:27.362Z'
+                        updated_at: '2021-10-30T11:24:27.362Z'
                         display_total: "$19.99"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10690,7 +10615,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '274'
+                            id: '271'
                             type: variant
                     meta:
                       count: 4
@@ -10743,8 +10668,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-10-29T23:51:53.468Z'
-                        updated_at: '2021-10-29T23:51:53.468Z'
+                        created_at: '2021-10-30T11:24:27.754Z'
+                        updated_at: '2021-10-30T11:24:27.754Z'
                         display_total: "$19.99"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10752,7 +10677,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '286'
+                            id: '283'
                             type: variant
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -10814,8 +10739,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-10-29T23:51:53.687Z'
-                        updated_at: '2021-10-29T23:51:53.687Z'
+                        created_at: '2021-10-30T11:24:27.977Z'
+                        updated_at: '2021-10-30T11:24:27.977Z'
                         display_total: "$19.99"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10823,7 +10748,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '292'
+                            id: '289'
                             type: variant
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -10881,8 +10806,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-10-29T23:51:54.053Z'
-                        updated_at: '2021-10-29T23:51:54.061Z'
+                        created_at: '2021-10-30T11:24:28.342Z'
+                        updated_at: '2021-10-30T11:24:28.351Z'
                         display_total: "$59.97"
                         display_price: "$19.99"
                         price: '19.99'
@@ -10890,7 +10815,7 @@ paths:
                       relationships:
                         variant:
                           data:
-                            id: '302'
+                            id: '299'
                             type: variant
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -11017,9 +10942,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-10-29T23:51:54.807Z'
-                        updated_at: '2021-10-29T23:51:54.807Z'
-                        token: YpxDjUtuArjCTTqWYithwxqy
+                        created_at: '2021-10-30T11:24:29.057Z'
+                        updated_at: '2021-10-30T11:24:29.057Z'
+                        token: vRNxTLXPHygNAha3TX3WeSjw
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11034,9 +10959,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-10-29T23:51:54.809Z'
-                        updated_at: '2021-10-29T23:51:54.809Z'
-                        token: aaMyjYRauqPmUoMM2wnG1Hih
+                        created_at: '2021-10-30T11:24:29.059Z'
+                        updated_at: '2021-10-30T11:24:29.059Z'
+                        token: yWj4WqUybGoBykJfjCgWiYbX
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11098,9 +11023,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-10-29T23:51:55.306Z'
-                        updated_at: '2021-10-29T23:51:55.306Z'
-                        token: ut2VMyvnZVGqFrrMigr16gqd
+                        created_at: '2021-10-30T11:24:29.529Z'
+                        updated_at: '2021-10-30T11:24:29.529Z'
+                        token: Cmg2QJKEkhTXiwNVdM8k1L9o
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11164,9 +11089,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-10-29T23:51:55.349Z'
-                        updated_at: '2021-10-29T23:51:55.349Z'
-                        token: GHi3wZgNQ3KfFaJpKkMAS37M
+                        created_at: '2021-10-30T11:24:29.569Z'
+                        updated_at: '2021-10-30T11:24:29.569Z'
+                        token: L8XkKPNUEQmMDfwNWeK6AEBu
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11229,9 +11154,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-10-29T23:51:55.420Z'
-                        updated_at: '2021-10-29T23:51:55.428Z'
-                        token: FQnEg1t2VCGNEH5kEfEYDDiz
+                        created_at: '2021-10-30T11:24:29.633Z'
+                        updated_at: '2021-10-30T11:24:29.641Z'
+                        token: jmp6WtwK9sjr7NyxEEdQQojc
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11648,14 +11573,28 @@ components:
               type: string
             cms_page_id:
               type: string
-            content:
-              type: object
-            settings:
-              type: object
-            fit:
-              type: string
             destination:
               type: string
+              example: https://getvendo.com
+            linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+            fit:
+              type: string
+              example: Screen
+              description: This value is used by front end developers to manipulate
+                CSS values to fit the section into the Screen or within the Container
+                element.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the new position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                1)'
       required:
       - cms_section
       x-internal: true
@@ -11669,24 +11608,30 @@ components:
               type: string
             cms_page_id:
               type: string
-            content:
-              type: object
-            settings:
-              type: object
-            fit:
-              type: string
             destination:
               type: string
+              example: https://getvendo.com
+            linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+            fit:
+              type: string
+              example: Screen
+              description: This value is used by front end developers to manipulate
+                CSS values to fit the section into the Screen or within the Container
+                element.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the new position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                1)'
       required:
       - cms_section
-      x-internal: true
-    cms_section_reposition_params:
-      type: object
-      properties:
-        new_position_idx:
-          type: integer
-      required:
-      - new_position_idx
       x-internal: true
     create_digital_params:
       type: object
@@ -11990,7 +11935,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-10-29 23:51:21 UTC
+              example: 2021-10-30 11:23:55 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12058,7 +12003,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-10-29 23:51:21 UTC
+              example: 2021-10-30 11:23:55 UTC
             confirmation_delivered:
               type: boolean
               example: true
@@ -12125,7 +12070,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-10-29 23:51:21 UTC
+              example: 2021-10-30 11:23:55 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12193,7 +12138,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-10-29 23:51:21 UTC
+              example: 2021-10-30 11:23:55 UTC
             confirmation_delivered:
               type: boolean
               example: true

--- a/api/spec/integration/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_sections_spec.rb
@@ -22,7 +22,8 @@ describe 'CMS Section API', swagger: true do
   let(:valid_create_param_value) { build(:cms_hero_image_section, cms_page: cms_page, linked_resource: product).attributes }
   let(:valid_update_param_value) do
     {
-      name: 'Super Hero'
+      name: 'Super Hero',
+      position: 1
     }
   end
   let(:invalid_param_value) do
@@ -30,34 +31,6 @@ describe 'CMS Section API', swagger: true do
       name: ''
     }
   end
-  let(:valid_update_position_param_value) do
-    {
-      new_position_idx: 2
-    }
-  end
 
   include_examples 'CRUD examples', resource_name, options
-
-  path '/api/v2/platform/cms_sections/{id}/reposition' do
-    patch 'Reposition a CMS Section' do
-      tags resource_name.pluralize
-      security [ bearer_auth: [] ]
-      operationId 'reposition-cms-section'
-      description 'Reposition a Menu Item'
-      consumes 'application/json'
-      parameter name: :id, in: :path, type: :string
-      parameter name: :cms_section, in: :body, schema: { '$ref' => '#/components/schemas/cms_section_reposition_params' }
-
-      let(:cms_section) { valid_update_position_param_value }
-      let(:invalid_param_value) do
-        {
-          new_position_idx: 'invalid'
-        }
-      end
-
-      it_behaves_like 'record updated'
-      it_behaves_like 'record not found', :cms_section
-      it_behaves_like 'authentication failed'
-    end
-  end
 end

--- a/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
@@ -4,57 +4,69 @@ describe 'Platform API v2 CmsSections', type: :request do
   include_context 'API v2 tokens'
   include_context 'Platform API v2'
 
-  let(:store) { Spree::Store.default }
-  let(:page) { create(:cms_homepage, store: store) }
-  let(:section_a) { create(:cms_section, cms_page: page) }
-  let(:section_b) { create(:cms_section, cms_page: page) }
-  let(:section_c) { create(:cms_section, cms_page: page) }
-  let(:section_d) { create(:cms_section, cms_page: page) }
+  let!(:store) { Spree::Store.default }
+  let!(:page) { create(:cms_homepage, store: store) }
+  let!(:section_a) { create(:cms_section, cms_page: page) }
+  let!(:section_b) { create(:cms_section, cms_page: page) }
+  let!(:section_c) { create(:cms_section, cms_page: page) }
+  let!(:section_d) { create(:cms_section, cms_page: page) }
+  let!(:section_e) { create(:cms_section, cms_page: page) }
   let(:bearer_token) { { 'Authorization' => valid_authorization } }
 
-  describe 'cms_section#reposition' do
-    context 'with no params' do
-      let(:params) { }
-
-      before do
-        patch "/api/v2/platform/cms_sections/#{section_a.id}/reposition", headers: bearer_token, params: params
+  describe 'cms_section#update' do
+    context 'move section_a from position 1 down to position 5' do
+      let(:params) do
+        {
+          cms_section: { position: 5 }
+        }
       end
 
-      it_behaves_like 'returns 422 HTTP status'
-    end
-
-    context 'with correct params' do
-      let(:params) { { new_position_idx: 0 } }
-
       before do
-        patch "/api/v2/platform/cms_sections/#{section_d.id}/reposition", headers: bearer_token, params: params
+        patch "/api/v2/platform/cms_sections/#{section_a.id}", headers: bearer_token, params: params
       end
 
       it_behaves_like 'returns 200 HTTP status'
 
-      it 'repositions section from position 4 to position 1' do
-        # acts_as_list is not zero indexed so moving to
-        # position 0 results in a saved postiton at 1.
-        section_d.reload
+      it 'moves section_a from position 1 to position 5 and updates the positions of the other sections accordingly' do
+        reload_sections
+
+        expect(section_b.position).to eq(1)
+        expect(section_c.position).to eq(2)
+        expect(section_d.position).to eq(3)
+        expect(section_e.position).to eq(4)
+        expect(section_a.position).to eq(5)
+      end
+    end
+
+    context 'can accept 0 and move the item to position 1' do
+      let(:params) do
+        {
+          cms_section: {
+            name: 'Rename section and update Position!',
+            position: 0
+          }
+        }
+      end
+
+      before do
+        patch "/api/v2/platform/cms_sections/#{section_d.id}", headers: bearer_token, params: params
+      end
+
+      it_behaves_like 'returns 200 HTTP status'
+
+      it 'moves section_d from position 4 to position 1 by passing position: 0, and renames the section' do
+        reload_sections
         expect(section_d.position).to eq(1)
+        expect(section_d.name).to eq('Rename section and update Position!')
       end
     end
 
-    context 'with correct params' do
-      let(:params) { { new_position_idx: 3 } }
-
-      before do
-        patch "/api/v2/platform/cms_sections/#{section_a.id}/reposition", headers: bearer_token, params: params
-      end
-
-      it_behaves_like 'returns 200 HTTP status'
-
-      it 'moves item from position 1 to position 4' do
-        # acts_as_list is not zero indexed so moving to
-        # position 3 results in a saved postiton at 4.
-        section_a.reload
-        expect(section_a.position).to eq(4)
-      end
+    def reload_sections
+      section_a.reload
+      section_b.reload
+      section_c.reload
+      section_d.reload
+      section_e.reload
     end
   end
 end

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -264,10 +264,10 @@ RSpec.configure do |config|
                 properties: {
                   name: { type: :string },
                   cms_page_id: { type: :string },
-                  content: { type: :object, },
-                  settings: { type: :object },
-                  fit: { type: :string },
-                  destination: { type: :string }
+                  destination: { type: :string, example: 'https://getvendo.com' },
+                  linked_resource_type: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'] },
+                  fit: { type: :string, example: 'Screen', description: 'This value is used by front end developers to manipulate CSS values to fit the section into the Screen or within the Container element.' },
+                  position: { type: :integer, example: 2, description: 'Pass the new position that you want this section to appear in. (The list is not zero indexed, so the first item is position: 1)' }
                 }
               }
             },
@@ -282,22 +282,14 @@ RSpec.configure do |config|
                 properties: {
                   name: { type: :string },
                   cms_page_id: { type: :string },
-                  content: { type: :object, },
-                  settings: { type: :object },
-                  fit: { type: :string },
-                  destination: { type: :string }
+                  destination: { type: :string, example: 'https://getvendo.com' },
+                  linked_resource_type: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'] },
+                  fit: { type: :string, example: 'Screen', description: 'This value is used by front end developers to manipulate CSS values to fit the section into the Screen or within the Container element.' },
+                  position: { type: :integer, example: 2, description: 'Pass the new position that you want this section to appear in. (The list is not zero indexed, so the first item is position: 1)' }
                 }
               }
             },
             required: %w[cms_section],
-            'x-internal': true
-          },
-          cms_section_reposition_params: {
-            type: :object,
-            properties: {
-              new_position_idx: { type: :integer }
-            },
-            required: %w[new_position_idx],
             'x-internal': true
           },
 


### PR DESCRIPTION
- checked if we still need to add certain attributes manually since updating request body and unify how they are added if needed in the controllers, using `super + [:new_attribute]`
- Improve update action in resource controller to guarantee `#ensure_current_store` is called between setting attributes and saving the changes.
- Removed `reposition` action from `cms_sections`, this is no longer needed, and can be handled through the update action.