### PR TITLE
Add placeholder Serializers for Webhooks.

### DIFF
--- a/api/app/serializers/spree/api/v2/platform/feature_page_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/feature_page_serializer.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class FeaturePageSerializer < CmsPageSerializer
+          # Place holder serializer for Webhooks.
+        end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/homepage_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/homepage_serializer.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class HomepageSerializer < CmsPageSerializer
+          # Place holder serializer for Webhooks.
+        end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/standard_page_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/standard_page_serializer.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class StandardPageSerializer < CmsPageSerializer
+          # Place holder serializer for Webhooks.
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/cms_page.rb
+++ b/core/app/models/spree/cms_page.rb
@@ -38,7 +38,7 @@ module Spree
       end
     end
 
-    # Overide this if your page type uses cms_sections
+    # Override this if your page type uses cms_sections
     def sections?
       false
     end


### PR DESCRIPTION
The API is looking for the different types of cms_page serializers when a cms_section is updated the cms_page is touched, or if a standard page is updated the API looks for the serializers.