### PR TITLE
Update cms_page & cms_section docs.

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/cms_pages_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/cms_pages_controller.rb
@@ -8,6 +8,10 @@ module Spree
           def model_class
             Spree::CmsPage
           end
+
+          def scope_includes
+            [:cms_sections]
+          end
         end
       end
     end

--- a/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
@@ -8,6 +8,20 @@ module Spree
           def model_class
             Spree::CmsSection
           end
+
+          def spree_permitted_attributes
+            stored_attributes = []
+
+            Spree::CmsSection::TYPES.each do |type|
+              type.constantize.stored_attributes.each do |_name, values|
+                values.each do |value|
+                  stored_attributes << value
+                end
+              end
+            end
+
+            super + stored_attributes.compact.uniq!
+          end
         end
       end
     end

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -1,12 +1,12 @@
 ---
 openapi: 3.0.3
 info:
-  title: Platform API v2
+  title: Platform API
   contact:
     name: Spark Solutions
     url: https://sparksolutions.co
     email: we@sparksolutions.co
-  description: Spree Platform API v2
+  description: Spree Platform API
   version: v2
 paths:
   "/api/v2/platform/addresses":
@@ -70,8 +70,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:35:35.844Z'
-                        updated_at: '2021-11-01T22:35:35.844Z'
+                        created_at: '2021-11-03T11:02:29.755Z'
+                        updated_at: '2021-11-03T11:02:29.755Z'
                         deleted_at:
                         label:
                       relationships:
@@ -98,8 +98,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:35:35.847Z'
-                        updated_at: '2021-11-01T22:35:35.847Z'
+                        created_at: '2021-11-03T11:02:29.758Z'
+                        updated_at: '2021-11-03T11:02:29.758Z'
                         deleted_at:
                         label:
                       relationships:
@@ -173,8 +173,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:35:36.055Z'
-                        updated_at: '2021-11-01T22:35:36.055Z'
+                        created_at: '2021-11-03T11:02:29.967Z'
+                        updated_at: '2021-11-03T11:02:29.967Z'
                         deleted_at:
                         label:
                       relationships:
@@ -268,8 +268,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:35:36.093Z'
-                        updated_at: '2021-11-01T22:35:36.093Z'
+                        created_at: '2021-11-03T11:02:30.013Z'
+                        updated_at: '2021-11-03T11:02:30.013Z'
                         deleted_at:
                         label:
                       relationships:
@@ -348,8 +348,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:35:36.157Z'
-                        updated_at: '2021-11-01T22:35:36.165Z'
+                        created_at: '2021-11-03T11:02:30.086Z'
+                        updated_at: '2021-11-03T11:02:30.095Z'
                         deleted_at:
                         label:
                       relationships:
@@ -493,8 +493,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:35:36.396Z'
-                        updated_at: '2021-11-01T22:35:36.396Z'
+                        created_at: '2021-11-03T11:02:30.341Z'
+                        updated_at: '2021-11-03T11:02:30.341Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -520,8 +520,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:35:36.419Z'
-                        updated_at: '2021-11-01T22:35:36.419Z'
+                        created_at: '2021-11-03T11:02:30.365Z'
+                        updated_at: '2021-11-03T11:02:30.365Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -594,8 +594,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:35:36.761Z'
-                        updated_at: '2021-11-01T22:35:36.761Z'
+                        created_at: '2021-11-03T11:02:30.703Z'
+                        updated_at: '2021-11-03T11:02:30.703Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -677,8 +677,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:35:36.875Z'
-                        updated_at: '2021-11-01T22:35:36.880Z'
+                        created_at: '2021-11-03T11:02:30.829Z'
+                        updated_at: '2021-11-03T11:02:30.834Z'
                         state: open
                         included: false
                         display_amount: "$1.00"
@@ -756,8 +756,8 @@ paths:
                         label: New label
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:35:37.076Z'
-                        updated_at: '2021-11-01T22:35:37.089Z'
+                        created_at: '2021-11-03T11:02:31.024Z'
+                        updated_at: '2021-11-03T11:02:31.044Z'
                         state: open
                         included: false
                         display_amount: "$15.00"
@@ -897,8 +897,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:35:37.616Z'
-                        updated_at: '2021-11-01T22:35:37.616Z'
+                        created_at: '2021-11-03T11:02:31.580Z'
+                        updated_at: '2021-11-03T11:02:31.580Z'
                       relationships:
                         product:
                           data:
@@ -912,8 +912,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:35:37.695Z'
-                        updated_at: '2021-11-01T22:35:37.695Z'
+                        created_at: '2021-11-03T11:02:31.660Z'
+                        updated_at: '2021-11-03T11:02:31.660Z'
                       relationships:
                         product:
                           data:
@@ -974,8 +974,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:35:38.155Z'
-                        updated_at: '2021-11-01T22:35:38.155Z'
+                        created_at: '2021-11-03T11:02:32.137Z'
+                        updated_at: '2021-11-03T11:02:32.137Z'
                       relationships:
                         product:
                           data:
@@ -1042,8 +1042,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:35:38.328Z'
-                        updated_at: '2021-11-01T22:35:38.328Z'
+                        created_at: '2021-11-03T11:02:32.315Z'
+                        updated_at: '2021-11-03T11:02:32.315Z'
                       relationships:
                         product:
                           data:
@@ -1109,8 +1109,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:35:38.636Z'
-                        updated_at: '2021-11-01T22:35:38.636Z'
+                        created_at: '2021-11-03T11:02:32.640Z'
+                        updated_at: '2021-11-03T11:02:32.640Z'
                       relationships:
                         product:
                           data:
@@ -1232,8 +1232,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-11-01T22:35:39.423Z'
-                        updated_at: '2021-11-01T22:35:39.448Z'
+                        created_at: '2021-11-03T11:02:33.492Z'
+                        updated_at: '2021-11-03T11:02:33.514Z'
                       relationships:
                         product:
                           data:
@@ -1308,10 +1308,16 @@ paths:
         example: cms_sections
         schema:
           type: string
-      - name: filter[type]
+      - name: filter[type_eq]
         in: query
         description: ''
-        example: homepage
+        example: Spree::Cms::Pages::FeaturePage
+        schema:
+          type: string
+      - name: filter[locale_eq]
+        in: query
+        description: ''
+        example: en
         schema:
           type: string
       - name: filter[title_cont]
@@ -1332,35 +1338,34 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Deserunt eum voluptate facilis minus eveniet facere.
+                        title: Enim ullam pariatur nisi nobis.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: deserunt-eum-voluptate-facilis-minus-eveniet-facere
+                        slug: enim-ullam-pariatur-nisi-nobis
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:35:39.804Z'
-                        updated_at: '2021-11-01T22:35:39.804Z'
+                        created_at: '2021-11-03T11:02:33.878Z'
+                        updated_at: '2021-11-03T11:02:33.878Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Beatae dolor illum ea necessitatibus quaerat neque
-                          excepturi.
+                        title: Illo adipisci dolorem quaerat maiores qui odio at.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: beatae-dolor-illum-ea-necessitatibus-quaerat-neque-excepturi
+                        slug: illo-adipisci-dolorem-quaerat-maiores-qui-odio-at
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:35:39.808Z'
-                        updated_at: '2021-11-01T22:35:39.808Z'
+                        created_at: '2021-11-03T11:02:33.882Z'
+                        updated_at: '2021-11-03T11:02:33.882Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1369,11 +1374,11 @@ paths:
                       total_count: 2
                       total_pages: 1
                     links:
-                      self: http://www.example.com/api/v2/platform/cms_pages?page=1&per_page=&include=&filter[type]=&filter[title_cont]=
-                      next: http://www.example.com/api/v2/platform/cms_pages?filter%5Btitle_cont%5D=&filter%5Btype%5D=&include=&page=1&per_page=
-                      prev: http://www.example.com/api/v2/platform/cms_pages?filter%5Btitle_cont%5D=&filter%5Btype%5D=&include=&page=1&per_page=
-                      last: http://www.example.com/api/v2/platform/cms_pages?filter%5Btitle_cont%5D=&filter%5Btype%5D=&include=&page=1&per_page=
-                      first: http://www.example.com/api/v2/platform/cms_pages?filter%5Btitle_cont%5D=&filter%5Btype%5D=&include=&page=1&per_page=
+                      self: http://www.example.com/api/v2/platform/cms_pages?page=1&per_page=&include=&filter[type_eq]=&filter[locale_eq]=&filter[title_cont]=
+                      next: http://www.example.com/api/v2/platform/cms_pages?filter%5Blocale_eq%5D=&filter%5Btitle_cont%5D=&filter%5Btype_eq%5D=&include=&page=1&per_page=
+                      prev: http://www.example.com/api/v2/platform/cms_pages?filter%5Blocale_eq%5D=&filter%5Btitle_cont%5D=&filter%5Btype_eq%5D=&include=&page=1&per_page=
+                      last: http://www.example.com/api/v2/platform/cms_pages?filter%5Blocale_eq%5D=&filter%5Btitle_cont%5D=&filter%5Btype_eq%5D=&include=&page=1&per_page=
+                      first: http://www.example.com/api/v2/platform/cms_pages?filter%5Blocale_eq%5D=&filter%5Btitle_cont%5D=&filter%5Btype_eq%5D=&include=&page=1&per_page=
               schema:
                 "$ref": "#/components/schemas/resources_list"
         '401':
@@ -1414,17 +1419,17 @@ paths:
                       id: '5'
                       type: cms_page
                       attributes:
-                        title: Modi veritatis animi aperiam sint.
+                        title: Consequatur veniam ex natus suscipit.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: modi-veritatis-animi-aperiam-sint
+                        slug: consequatur-veniam-ex-natus-suscipit
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:35:39.887Z'
-                        updated_at: '2021-11-01T22:35:39.887Z'
+                        created_at: '2021-11-03T11:02:33.968Z'
+                        updated_at: '2021-11-03T11:02:33.968Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1437,11 +1442,14 @@ paths:
               examples:
                 Example:
                   value:
-                    error: Title can't be blank and Locale can't be blank
+                    error: Title can't be blank, Locale can't be blank, and Type can't
+                      be blank
                     errors:
                       title:
                       - can't be blank
                       locale:
+                      - can't be blank
+                      type:
                       - can't be blank
               schema:
                 "$ref": "#/components/schemas/validation_errors"
@@ -1449,7 +1457,10 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/create_cms_page_params"
+              oneOf:
+              - "$ref": "#/components/schemas/create_standard_cms_page_params"
+              - "$ref": "#/components/schemas/create_homepage_cms_page_params"
+              - "$ref": "#/components/schemas/create_feature_cms_page_params"
   "/api/v2/platform/cms_pages/{id}":
     get:
       summary: Return a CMS Page
@@ -1484,17 +1495,18 @@ paths:
                       id: '6'
                       type: cms_page
                       attributes:
-                        title: Laudantium perferendis modi non inventore.
+                        title: Beatae eligendi qui totam quis laudantium optio distinctio
+                          cum.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: laudantium-perferendis-modi-non-inventore
+                        slug: beatae-eligendi-qui-totam-quis-laudantium-optio-distinctio-cum
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:35:39.930Z'
-                        updated_at: '2021-11-01T22:35:39.930Z'
+                        created_at: '2021-11-03T11:02:34.019Z'
+                        updated_at: '2021-11-03T11:02:34.019Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1558,12 +1570,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: sed-distinctio-quis-saepe-eligendi-nam-perspiciatis-nulla
+                        slug: sed-neque-voluptas-deleniti-et-inventore-optio
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:35:39.992Z'
-                        updated_at: '2021-11-01T22:35:40.000Z'
+                        created_at: '2021-11-03T11:02:34.084Z'
+                        updated_at: '2021-11-03T11:02:34.092Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1606,7 +1618,10 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/update_cms_page_params"
+              oneOf:
+              - "$ref": "#/components/schemas/update_standard_cms_page_params"
+              - "$ref": "#/components/schemas/update_homepage_cms_page_params"
+              - "$ref": "#/components/schemas/update_feature_cms_page_params"
     delete:
       summary: Delete a CMS Page
       tags:
@@ -1689,7 +1704,7 @@ paths:
                     - id: '1'
                       type: cms_section
                       attributes:
-                        name: Perferendis velit voluptatem corporis saepe.
+                        name: Veniam reprehenderit officiis hic sapiente maxime.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1698,8 +1713,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-01T22:35:40.168Z'
-                        updated_at: '2021-11-01T22:35:40.168Z'
+                        created_at: '2021-11-03T11:02:34.271Z'
+                        updated_at: '2021-11-03T11:02:34.271Z'
                       relationships:
                         cms_page:
                           data:
@@ -1710,7 +1725,7 @@ paths:
                     - id: '2'
                       type: cms_section
                       attributes:
-                        name: Quos sed impedit tempore sequi eligendi.
+                        name: Commodi nesciunt numquam aliquam voluptates maiores.
                         content:
                           link_type_one: Spree::Taxon
                           link_type_two: Spree::Taxon
@@ -1722,8 +1737,8 @@ paths:
                         type: Spree::Cms::Sections::ImageGallery
                         position: 2
                         linked_resource_type:
-                        created_at: '2021-11-01T22:35:40.172Z'
-                        updated_at: '2021-11-01T22:35:40.172Z'
+                        created_at: '2021-11-03T11:02:34.275Z'
+                        updated_at: '2021-11-03T11:02:34.275Z'
                       relationships:
                         cms_page:
                           data:
@@ -1734,8 +1749,8 @@ paths:
                     - id: '3'
                       type: cms_section
                       attributes:
-                        name: Praesentium assumenda ratione odit est harum suscipit
-                          mollitia eum.
+                        name: Illum deleniti voluptatum iure deserunt quam consectetur
+                          eius.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1744,8 +1759,8 @@ paths:
                         type: Spree::Cms::Sections::FeaturedArticle
                         position: 3
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-01T22:35:40.180Z'
-                        updated_at: '2021-11-01T22:35:40.180Z'
+                        created_at: '2021-11-03T11:02:34.283Z'
+                        updated_at: '2021-11-03T11:02:34.283Z'
                       relationships:
                         cms_page:
                           data:
@@ -1756,8 +1771,7 @@ paths:
                     - id: '4'
                       type: cms_section
                       attributes:
-                        name: Similique aliquid vel suscipit modi maiores at earum
-                          ipsam.
+                        name: Illo blanditiis odit maiores incidunt magnam.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1766,8 +1780,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:35:40.187Z'
-                        updated_at: '2021-11-01T22:35:40.187Z'
+                        created_at: '2021-11-03T11:02:34.290Z'
+                        updated_at: '2021-11-03T11:02:34.290Z'
                       relationships:
                         cms_page:
                           data:
@@ -1780,7 +1794,7 @@ paths:
                     - id: '5'
                       type: cms_section
                       attributes:
-                        name: Distinctio officiis quas necessitatibus laudantium incidunt.
+                        name: Eum sint nemo soluta repellendus eligendi accusamus.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1789,8 +1803,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 5
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:35:40.193Z'
-                        updated_at: '2021-11-01T22:35:40.193Z'
+                        created_at: '2021-11-03T11:02:34.296Z'
+                        updated_at: '2021-11-03T11:02:34.296Z'
                       relationships:
                         cms_page:
                           data:
@@ -1847,20 +1861,20 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '14'
+                      id: '13'
                       type: cms_section
                       attributes:
-                        name: Facilis quam quibusdam perspiciatis culpa id ullam possimus.
+                        name: Harum illum repellat odit quas itaque.
                         content: {}
                         settings:
                           gutters: No Gutters
                         fit: Screen
                         destination:
                         type: Spree::Cms::Sections::HeroImage
-                        position: 4
+                        position: 3
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:35:40.347Z'
-                        updated_at: '2021-11-01T22:35:40.347Z'
+                        created_at: '2021-11-03T11:02:34.461Z'
+                        updated_at: '2021-11-03T11:02:34.461Z'
                       relationships:
                         cms_page:
                           data:
@@ -1879,11 +1893,14 @@ paths:
               examples:
                 Example:
                   value:
-                    error: Name can't be blank and Cms page can't be blank
+                    error: Name can't be blank, Cms page can't be blank, and Type
+                      can't be blank
                     errors:
                       name:
                       - can't be blank
                       cms_page:
+                      - can't be blank
+                      type:
                       - can't be blank
               schema:
                 "$ref": "#/components/schemas/validation_errors"
@@ -1891,7 +1908,13 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/create_cms_section_params"
+              oneOf:
+              - "$ref": "#/components/schemas/create_hero_image_cms_section_params"
+              - "$ref": "#/components/schemas/create_product_carousel_cms_section_params"
+              - "$ref": "#/components/schemas/create_side_by_side_images_cms_section_params"
+              - "$ref": "#/components/schemas/create_featured_article_cms_section_params"
+              - "$ref": "#/components/schemas/create_image_gallery_cms_section_params"
+              - "$ref": "#/components/schemas/create_rich_text_cms_section_params"
   "/api/v2/platform/cms_sections/{id}":
     get:
       summary: Return a CMS Section
@@ -1923,11 +1946,10 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '21'
+                      id: '19'
                       type: cms_section
                       attributes:
-                        name: Sed nostrum eligendi labore tenetur beatae ipsam quibusdam
-                          nesciunt.
+                        name: Vero vel quaerat nemo magni hic ea illo cum.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1936,8 +1958,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:35:40.482Z'
-                        updated_at: '2021-11-01T22:35:40.482Z'
+                        created_at: '2021-11-03T11:02:34.672Z'
+                        updated_at: '2021-11-03T11:02:34.672Z'
                       relationships:
                         cms_page:
                           data:
@@ -1999,7 +2021,7 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '32'
+                      id: '29'
                       type: cms_section
                       attributes:
                         name: Super Hero
@@ -2011,8 +2033,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:35:40.760Z'
-                        updated_at: '2021-11-01T22:35:40.772Z'
+                        created_at: '2021-11-03T11:02:34.881Z'
+                        updated_at: '2021-11-03T11:02:34.892Z'
                       relationships:
                         cms_page:
                           data:
@@ -2061,7 +2083,13 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/update_cms_section_params"
+              oneOf:
+              - "$ref": "#/components/schemas/update_hero_image_cms_section_params"
+              - "$ref": "#/components/schemas/update_product_carousel_cms_section_params"
+              - "$ref": "#/components/schemas/update_side_by_side_images_cms_section_params"
+              - "$ref": "#/components/schemas/update_featured_article_cms_section_params"
+              - "$ref": "#/components/schemas/update_image_gallery_cms_section_params"
+              - "$ref": "#/components/schemas/update_rich_text_cms_section_params"
     delete:
       summary: Delete a CMS Section
       tags:
@@ -2126,9 +2154,9 @@ paths:
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-11-01T22:35:41.195Z'
+                        updated_at: '2021-11-03T11:02:35.345Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:35:41.195Z'
+                        created_at: '2021-11-03T11:02:35.345Z'
                       relationships:
                         states:
                           data: []
@@ -2141,9 +2169,9 @@ paths:
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T22:35:41.201Z'
+                        updated_at: '2021-11-03T11:02:35.350Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:35:41.201Z'
+                        created_at: '2021-11-03T11:02:35.350Z'
                       relationships:
                         states:
                           data: []
@@ -2156,9 +2184,9 @@ paths:
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T22:35:41.203Z'
+                        updated_at: '2021-11-03T11:02:35.352Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:35:41.203Z'
+                        created_at: '2021-11-03T11:02:35.352Z'
                       relationships:
                         states:
                           data: []
@@ -2217,9 +2245,9 @@ paths:
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T22:35:41.252Z'
+                        updated_at: '2021-11-03T11:02:35.405Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:35:41.252Z'
+                        created_at: '2021-11-03T11:02:35.405Z'
                       relationships:
                         states:
                           data: []
@@ -2277,7 +2305,7 @@ paths:
                     - id: '1'
                       type: digital_link
                       attributes:
-                        token: EF8LtnCnhuxAV1wLc2TqfTGD
+                        token: KiBmeGiHmhpPJvt7t2AmTz4s
                         access_counter: 0
                       relationships:
                         digital:
@@ -2291,7 +2319,7 @@ paths:
                     - id: '2'
                       type: digital_link
                       attributes:
-                        token: KyC6KpSscTbrVk95MMRt6oYV
+                        token: yRrbkBH5aVnyWMABzTf6vX9t
                         access_counter: 0
                       relationships:
                         digital:
@@ -2345,7 +2373,7 @@ paths:
                       id: '5'
                       type: digital_link
                       attributes:
-                        token: UVwvrYvEdRipbEgUzii4Bigi
+                        token: jBAmgDnzTMWkVuqpNcC65aDB
                         access_counter: 0
                       relationships:
                         digital:
@@ -2408,7 +2436,7 @@ paths:
                       id: '6'
                       type: digital_link
                       attributes:
-                        token: kvBzSVXF8GAKG7P8MUNRGkp9
+                        token: qgjeVysvgLHGD5pgDNumzCit
                         access_counter: 0
                       relationships:
                         digital:
@@ -2467,7 +2495,7 @@ paths:
                       id: '8'
                       type: digital_link
                       attributes:
-                        token: LU6TfUozEckSE9EL6PtWCYcM
+                        token: wTALoAmmaBoqU3oq1K5iguhJ
                         access_counter: 0
                       relationships:
                         digital:
@@ -2582,7 +2610,7 @@ paths:
                       id: '13'
                       type: digital_link
                       attributes:
-                        token: iPTgeEiEJopEihv1GsZZci1g
+                        token: ZpDEyiEUPhsdioxZPUYtXqRU
                         access_counter: 0
                       relationships:
                         digital:
@@ -2999,8 +3027,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:35:48.836Z'
-                        updated_at: '2021-11-01T22:35:48.845Z'
+                        created_at: '2021-11-03T11:02:43.237Z'
+                        updated_at: '2021-11-03T11:02:43.244Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3046,8 +3074,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:35:48.878Z'
-                        updated_at: '2021-11-01T22:35:48.883Z'
+                        created_at: '2021-11-03T11:02:43.270Z'
+                        updated_at: '2021-11-03T11:02:43.274Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3140,8 +3168,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:35:49.109Z'
-                        updated_at: '2021-11-01T22:35:49.152Z'
+                        created_at: '2021-11-03T11:02:43.534Z'
+                        updated_at: '2021-11-03T11:02:43.628Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3243,8 +3271,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:35:49.300Z'
-                        updated_at: '2021-11-01T22:35:49.307Z'
+                        created_at: '2021-11-03T11:02:43.764Z'
+                        updated_at: '2021-11-03T11:02:43.770Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3342,8 +3370,8 @@ paths:
                       attributes:
                         quantity: 4
                         price: '10.0'
-                        created_at: '2021-11-01T22:35:49.537Z'
-                        updated_at: '2021-11-01T22:35:49.574Z'
+                        created_at: '2021-11-03T11:02:44.009Z'
+                        updated_at: '2021-11-03T11:02:44.050Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3393,10 +3421,10 @@ paths:
               examples:
                 Example:
                   value:
-                    error: 'Quantity selected of "Product #130 - 5006" is not available.'
+                    error: 'Quantity selected of "Product #130 - 5681" is not available.'
                     errors:
                       quantity:
-                      - 'selected of "Product #130 - 5006" is not available.'
+                      - 'selected of "Product #130 - 5681" is not available.'
               schema:
                 "$ref": "#/components/schemas/validation_errors"
         '404':
@@ -3516,8 +3544,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.347Z'
-                        updated_at: '2021-11-01T22:35:50.352Z'
+                        created_at: '2021-11-03T11:02:44.639Z'
+                        updated_at: '2021-11-03T11:02:44.644Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3553,8 +3581,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.412Z'
-                        updated_at: '2021-11-01T22:35:50.417Z'
+                        created_at: '2021-11-03T11:02:44.701Z'
+                        updated_at: '2021-11-03T11:02:44.706Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3590,8 +3618,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.484Z'
-                        updated_at: '2021-11-01T22:35:50.488Z'
+                        created_at: '2021-11-03T11:02:44.767Z'
+                        updated_at: '2021-11-03T11:02:44.771Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3627,8 +3655,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.547Z'
-                        updated_at: '2021-11-01T22:35:50.551Z'
+                        created_at: '2021-11-03T11:02:44.828Z'
+                        updated_at: '2021-11-03T11:02:44.833Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3664,8 +3692,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.613Z'
-                        updated_at: '2021-11-01T22:35:50.618Z'
+                        created_at: '2021-11-03T11:02:44.896Z'
+                        updated_at: '2021-11-03T11:02:44.900Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3701,8 +3729,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.678Z'
-                        updated_at: '2021-11-01T22:35:50.682Z'
+                        created_at: '2021-11-03T11:02:44.959Z'
+                        updated_at: '2021-11-03T11:02:44.963Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3738,8 +3766,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-11-01T22:35:50.741Z'
-                        updated_at: '2021-11-01T22:35:50.745Z'
+                        created_at: '2021-11-03T11:02:45.019Z'
+                        updated_at: '2021-11-03T11:02:45.024Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3765,8 +3793,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Quod perferendis tempora doloribus voluptas necessitatibus
-                          mollitia.
+                        name: Amet ad dolorum id nesciunt libero impedit.
                         subtitle:
                         destination:
                         new_window: false
@@ -3776,8 +3803,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-11-01T22:35:50.280Z'
-                        updated_at: '2021-11-01T22:35:50.752Z'
+                        created_at: '2021-11-03T11:02:44.580Z'
+                        updated_at: '2021-11-03T11:02:45.035Z'
                         link:
                         is_container: true
                         is_root: true
@@ -3870,8 +3897,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:35:51.480Z'
-                        updated_at: '2021-11-01T22:35:51.484Z'
+                        created_at: '2021-11-03T11:02:45.767Z'
+                        updated_at: '2021-11-03T11:02:45.771Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3961,8 +3988,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:35:51.976Z'
-                        updated_at: '2021-11-01T22:35:51.981Z'
+                        created_at: '2021-11-03T11:02:46.274Z'
+                        updated_at: '2021-11-03T11:02:46.278Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4050,8 +4077,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:35:52.759Z'
-                        updated_at: '2021-11-01T22:35:52.784Z'
+                        created_at: '2021-11-03T11:02:47.078Z'
+                        updated_at: '2021-11-03T11:02:47.102Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4188,8 +4215,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-11-01T22:35:54.607Z'
-                        updated_at: '2021-11-01T22:35:54.634Z'
+                        created_at: '2021-11-03T11:02:48.956Z'
+                        updated_at: '2021-11-03T11:02:48.981Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4293,8 +4320,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:35:55.152Z'
-                        updated_at: '2021-11-01T22:35:55.282Z'
+                        created_at: '2021-11-03T11:02:49.500Z'
+                        updated_at: '2021-11-03T11:02:49.636Z'
                       relationships:
                         menu_items:
                           data:
@@ -4310,8 +4337,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-11-01T22:35:55.161Z'
-                        updated_at: '2021-11-01T22:35:55.406Z'
+                        created_at: '2021-11-03T11:02:49.509Z'
+                        updated_at: '2021-11-03T11:02:49.783Z'
                       relationships:
                         menu_items:
                           data:
@@ -4374,8 +4401,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:35:55.745Z'
-                        updated_at: '2021-11-01T22:35:55.751Z'
+                        created_at: '2021-11-03T11:02:50.127Z'
+                        updated_at: '2021-11-03T11:02:50.132Z'
                       relationships:
                         menu_items:
                           data:
@@ -4443,8 +4470,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:35:55.795Z'
-                        updated_at: '2021-11-01T22:35:55.801Z'
+                        created_at: '2021-11-03T11:02:50.184Z'
+                        updated_at: '2021-11-03T11:02:50.190Z'
                       relationships:
                         menu_items:
                           data:
@@ -4508,8 +4535,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:35:55.867Z'
-                        updated_at: '2021-11-01T22:35:55.873Z'
+                        created_at: '2021-11-03T11:02:50.264Z'
+                        updated_at: '2021-11-03T11:02:50.270Z'
                       relationships:
                         menu_items:
                           data:
@@ -4644,8 +4671,8 @@ paths:
                         name: foo-size-68
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:35:56.073Z'
-                        updated_at: '2021-11-01T22:35:56.073Z'
+                        created_at: '2021-11-03T11:02:50.463Z'
+                        updated_at: '2021-11-03T11:02:50.463Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4656,8 +4683,8 @@ paths:
                         name: foo-size-69
                         presentation: Size
                         position: 2
-                        created_at: '2021-11-01T22:35:56.074Z'
-                        updated_at: '2021-11-01T22:35:56.074Z'
+                        created_at: '2021-11-03T11:02:50.465Z'
+                        updated_at: '2021-11-03T11:02:50.465Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4708,8 +4735,8 @@ paths:
                         name: foo-size-72
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:35:56.125Z'
-                        updated_at: '2021-11-01T22:35:56.125Z'
+                        created_at: '2021-11-03T11:02:50.523Z'
+                        updated_at: '2021-11-03T11:02:50.523Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4766,8 +4793,8 @@ paths:
                         name: foo-size-73
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:35:56.158Z'
-                        updated_at: '2021-11-01T22:35:56.158Z'
+                        created_at: '2021-11-03T11:02:50.566Z'
+                        updated_at: '2021-11-03T11:02:50.566Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4823,8 +4850,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:35:56.216Z'
-                        updated_at: '2021-11-01T22:35:56.223Z'
+                        created_at: '2021-11-03T11:02:50.627Z'
+                        updated_at: '2021-11-03T11:02:50.636Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4960,8 +4987,8 @@ paths:
                         position: 1
                         name: Size-68
                         presentation: S
-                        created_at: '2021-11-01T22:35:56.350Z'
-                        updated_at: '2021-11-01T22:35:56.350Z'
+                        created_at: '2021-11-03T11:02:50.782Z'
+                        updated_at: '2021-11-03T11:02:50.782Z'
                       relationships:
                         option_type:
                           data:
@@ -4973,8 +5000,8 @@ paths:
                         position: 1
                         name: Size-69
                         presentation: S
-                        created_at: '2021-11-01T22:35:56.357Z'
-                        updated_at: '2021-11-01T22:35:56.357Z'
+                        created_at: '2021-11-03T11:02:50.787Z'
+                        updated_at: '2021-11-03T11:02:50.787Z'
                       relationships:
                         option_type:
                           data:
@@ -5033,8 +5060,8 @@ paths:
                         position: 1
                         name: Size-72
                         presentation: S
-                        created_at: '2021-11-01T22:35:56.417Z'
-                        updated_at: '2021-11-01T22:35:56.417Z'
+                        created_at: '2021-11-03T11:02:50.852Z'
+                        updated_at: '2021-11-03T11:02:50.852Z'
                       relationships:
                         option_type:
                           data:
@@ -5097,8 +5124,8 @@ paths:
                         position: 1
                         name: Size-73
                         presentation: S
-                        created_at: '2021-11-01T22:35:56.451Z'
-                        updated_at: '2021-11-01T22:35:56.451Z'
+                        created_at: '2021-11-03T11:02:50.891Z'
+                        updated_at: '2021-11-03T11:02:50.891Z'
                       relationships:
                         option_type:
                           data:
@@ -5162,8 +5189,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-11-01T22:35:56.518Z'
-                        updated_at: '2021-11-01T22:35:56.527Z'
+                        created_at: '2021-11-03T11:02:50.961Z'
+                        updated_at: '2021-11-03T11:02:50.969Z'
                       relationships:
                         option_type:
                           data:
@@ -5291,7 +5318,7 @@ paths:
                     - id: '40'
                       type: order
                       attributes:
-                        number: R164088632
+                        number: R441718787
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5300,10 +5327,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: stacie@wintheiserdurgan.co.uk
+                        email: johana_donnelly@gutkowski.us
                         special_instructions:
-                        created_at: '2021-11-01T22:35:56.678Z'
-                        updated_at: '2021-11-01T22:35:56.678Z'
+                        created_at: '2021-11-03T11:02:51.212Z'
+                        updated_at: '2021-11-03T11:02:51.212Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5375,7 +5402,7 @@ paths:
                     - id: '41'
                       type: order
                       attributes:
-                        number: R616918637
+                        number: R773561139
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5384,10 +5411,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: darla_lehner@nienow.biz
+                        email: ladonna.cole@gutkowski.info
                         special_instructions:
-                        created_at: '2021-11-01T22:35:56.686Z'
-                        updated_at: '2021-11-01T22:35:56.686Z'
+                        created_at: '2021-11-03T11:02:51.220Z'
+                        updated_at: '2021-11-03T11:02:51.220Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5506,7 +5533,7 @@ paths:
                       id: '44'
                       type: order
                       attributes:
-                        number: R914206362
+                        number: R903897198
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5517,8 +5544,8 @@ paths:
                         payment_state:
                         email:
                         special_instructions:
-                        created_at: '2021-11-01T22:35:56.989Z'
-                        updated_at: '2021-11-01T22:35:57.005Z'
+                        created_at: '2021-11-03T11:02:51.482Z'
+                        updated_at: '2021-11-03T11:02:51.497Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5632,7 +5659,7 @@ paths:
                       id: '45'
                       type: order
                       attributes:
-                        number: R577750598
+                        number: R025699839
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5641,10 +5668,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: maria@jacobikovacek.name
+                        email: anette.bailey@schupperippin.us
                         special_instructions:
-                        created_at: '2021-11-01T22:35:57.046Z'
-                        updated_at: '2021-11-01T22:35:57.212Z'
+                        created_at: '2021-11-03T11:02:51.536Z'
+                        updated_at: '2021-11-03T11:02:51.692Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5774,7 +5801,7 @@ paths:
                       id: '47'
                       type: order
                       attributes:
-                        number: R491366996
+                        number: R287690890
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5785,8 +5812,8 @@ paths:
                         payment_state:
                         email: new@example.com
                         special_instructions:
-                        created_at: '2021-11-01T22:35:57.392Z'
-                        updated_at: '2021-11-01T22:35:57.565Z'
+                        created_at: '2021-11-03T11:02:51.872Z'
+                        updated_at: '2021-11-03T11:02:51.956Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5972,7 +5999,7 @@ paths:
                       id: '52'
                       type: order
                       attributes:
-                        number: R107755103
+                        number: R707222577
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -5981,10 +6008,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: annita_kling@hahnlittle.ca
+                        email: clarice@zboncakdouglas.us
                         special_instructions:
-                        created_at: '2021-11-01T22:35:58.146Z'
-                        updated_at: '2021-11-01T22:35:58.285Z'
+                        created_at: '2021-11-03T11:02:52.513Z'
+                        updated_at: '2021-11-03T11:02:52.646Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6117,7 +6144,7 @@ paths:
                       id: '54'
                       type: order
                       attributes:
-                        number: R488204174
+                        number: R321469258
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -6126,10 +6153,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: alex@jakubowskihudson.com
+                        email: seth@kling.co.uk
                         special_instructions:
-                        created_at: '2021-11-01T22:35:58.479Z'
-                        updated_at: '2021-11-01T22:35:58.608Z'
+                        created_at: '2021-11-03T11:02:52.838Z'
+                        updated_at: '2021-11-03T11:02:52.958Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6262,19 +6289,19 @@ paths:
                       id: '56'
                       type: order
                       attributes:
-                        number: R747446949
+                        number: R949927585
                         item_total: '10.0'
                         total: '110.0'
                         state: complete
                         adjustment_total: '0.0'
-                        completed_at: '2021-11-01T22:35:58.998Z'
+                        completed_at: '2021-11-03T11:02:53.330Z'
                         payment_total: '0.0'
                         shipment_state: pending
                         payment_state: balance_due
-                        email: idell.homenick@predovictremblay.biz
+                        email: sharee@kshlerincarter.biz
                         special_instructions:
-                        created_at: '2021-11-01T22:35:58.779Z'
-                        updated_at: '2021-11-01T22:35:58.998Z'
+                        created_at: '2021-11-03T11:02:53.127Z'
+                        updated_at: '2021-11-03T11:02:53.330Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6418,7 +6445,7 @@ paths:
                       id: '59'
                       type: order
                       attributes:
-                        number: R221671065
+                        number: R364308130
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -6427,10 +6454,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: jamey@williamsonbeier.us
+                        email: michaele@purdyjohns.ca
                         special_instructions:
-                        created_at: '2021-11-01T22:35:59.301Z'
-                        updated_at: '2021-11-01T22:35:59.405Z'
+                        created_at: '2021-11-03T11:02:53.625Z'
+                        updated_at: '2021-11-03T11:02:53.726Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -6558,7 +6585,7 @@ paths:
                       id: '61'
                       type: order
                       attributes:
-                        number: R656135970
+                        number: R352605383
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -6567,10 +6594,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: harris_lowe@barton.info
+                        email: abel@townestokes.com
                         special_instructions:
-                        created_at: '2021-11-01T22:35:59.571Z'
-                        updated_at: '2021-11-01T22:35:59.652Z'
+                        created_at: '2021-11-03T11:02:53.987Z'
+                        updated_at: '2021-11-03T11:02:54.064Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6871,8 +6898,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 1
-                        created_at: '2021-11-01T22:36:01.301Z'
-                        updated_at: '2021-11-01T22:36:01.301Z'
+                        created_at: '2021-11-03T11:02:55.629Z'
+                        updated_at: '2021-11-03T11:02:55.629Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6890,8 +6917,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 2
-                        created_at: '2021-11-01T22:36:01.308Z'
-                        updated_at: '2021-11-01T22:36:01.308Z'
+                        created_at: '2021-11-03T11:02:55.635Z'
+                        updated_at: '2021-11-03T11:02:55.635Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6909,8 +6936,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T22:36:01.311Z'
-                        updated_at: '2021-11-01T22:36:01.311Z'
+                        created_at: '2021-11-03T11:02:55.638Z'
+                        updated_at: '2021-11-03T11:02:55.638Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6928,8 +6955,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-01T22:36:01.315Z'
-                        updated_at: '2021-11-01T22:36:01.315Z'
+                        created_at: '2021-11-03T11:02:55.641Z'
+                        updated_at: '2021-11-03T11:02:55.641Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -6950,8 +6977,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 5
-                        created_at: '2021-11-01T22:36:01.318Z'
-                        updated_at: '2021-11-01T22:36:01.318Z'
+                        created_at: '2021-11-03T11:02:55.645Z'
+                        updated_at: '2021-11-03T11:02:55.645Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7019,8 +7046,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T22:36:01.428Z'
-                        updated_at: '2021-11-01T22:36:01.428Z'
+                        created_at: '2021-11-03T11:02:55.755Z'
+                        updated_at: '2021-11-03T11:02:55.755Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7094,8 +7121,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-01T22:36:01.503Z'
-                        updated_at: '2021-11-01T22:36:01.503Z'
+                        created_at: '2021-11-03T11:02:55.832Z'
+                        updated_at: '2021-11-03T11:02:55.832Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7168,8 +7195,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T22:36:01.617Z'
-                        updated_at: '2021-11-01T22:36:01.628Z'
+                        created_at: '2021-11-03T11:02:56.026Z'
+                        updated_at: '2021-11-03T11:02:56.037Z'
                         deleted_at:
                         preferences:
                           dummy_key: UPDATED-DUMMY-KEY-123
@@ -7315,9 +7342,9 @@ paths:
                         state: invalid
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T22:36:01.889Z'
-                        updated_at: '2021-11-01T22:36:01.906Z'
-                        number: PVDU54GB
+                        created_at: '2021-11-03T11:02:56.322Z'
+                        updated_at: '2021-11-03T11:02:56.338Z'
+                        number: PGKBRB4P
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7352,9 +7379,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T22:36:01.903Z'
-                        updated_at: '2021-11-01T22:36:01.903Z'
-                        number: PHAOAOTZ
+                        created_at: '2021-11-03T11:02:56.335Z'
+                        updated_at: '2021-11-03T11:02:56.335Z'
+                        number: PAX0GJ8S
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7440,9 +7467,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T22:36:02.069Z'
-                        updated_at: '2021-11-01T22:36:02.069Z'
-                        number: PSD1MXQU
+                        created_at: '2021-11-03T11:02:56.498Z'
+                        updated_at: '2021-11-03T11:02:56.498Z'
+                        number: P3SL80UT
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7578,8 +7605,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:36:02.281Z'
-                        updated_at: '2021-11-01T22:36:02.281Z'
+                        created_at: '2021-11-03T11:02:56.725Z'
+                        updated_at: '2021-11-03T11:02:56.725Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7588,8 +7615,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:36:02.283Z'
-                        updated_at: '2021-11-01T22:36:02.283Z'
+                        created_at: '2021-11-03T11:02:56.727Z'
+                        updated_at: '2021-11-03T11:02:56.727Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7645,8 +7672,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:36:02.332Z'
-                        updated_at: '2021-11-01T22:36:02.332Z'
+                        created_at: '2021-11-03T11:02:56.781Z'
+                        updated_at: '2021-11-03T11:02:56.781Z'
                         code: 2021-BFM
                       relationships:
                         promotions:
@@ -7706,8 +7733,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:36:02.369Z'
-                        updated_at: '2021-11-01T22:36:02.369Z'
+                        created_at: '2021-11-03T11:02:56.822Z'
+                        updated_at: '2021-11-03T11:02:56.822Z'
                         code: MJO
                       relationships:
                         promotions:
@@ -7768,8 +7795,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: 2021 Promotions
-                        created_at: '2021-11-01T22:36:02.421Z'
-                        updated_at: '2021-11-01T22:36:02.427Z'
+                        created_at: '2021-11-03T11:02:56.879Z'
+                        updated_at: '2021-11-03T11:02:56.885Z'
                         code: 2021-Promos
                       relationships:
                         promotions:
@@ -7897,12 +7924,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H55115761949
+                        number: H88441639968
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:36:02.552Z'
-                        updated_at: '2021-11-01T22:36:02.555Z'
+                        created_at: '2021-11-03T11:02:57.020Z'
+                        updated_at: '2021-11-03T11:02:57.023Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7910,11 +7937,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$0.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$0.00"
                       relationships:
                         order:
                           data:
@@ -7944,12 +7971,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H95299716655
+                        number: H79094597173
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:36:02.582Z'
-                        updated_at: '2021-11-01T22:36:02.585Z'
+                        created_at: '2021-11-03T11:02:57.054Z'
+                        updated_at: '2021-11-03T11:02:57.057Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7957,11 +7984,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$0.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$0.00"
                       relationships:
                         order:
                           data:
@@ -8044,12 +8071,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H83811960445
+                        number: H84499342587
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:36:02.880Z'
-                        updated_at: '2021-11-01T22:36:02.898Z'
+                        created_at: '2021-11-03T11:02:57.354Z'
+                        updated_at: '2021-11-03T11:02:57.371Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8057,11 +8084,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$10.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$10.00"
                       relationships:
                         order:
                           data:
@@ -8183,12 +8210,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H44536023359
+                        number: H37402224501
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-01T22:36:03.825Z'
-                        updated_at: '2021-11-01T22:36:03.858Z'
+                        created_at: '2021-11-03T11:02:58.286Z'
+                        updated_at: '2021-11-03T11:02:58.317Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8196,11 +8223,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$10.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$10.00"
                       relationships:
                         order:
                           data:
@@ -8287,12 +8314,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H88854215341
+                        number: H66701052891
                         cost: '100.0'
-                        shipped_at: '2021-11-01T22:36:04.288Z'
+                        shipped_at: '2021-11-03T11:02:58.757Z'
                         state: shipped
-                        created_at: '2021-11-01T22:36:04.253Z'
-                        updated_at: '2021-11-01T22:36:04.288Z'
+                        created_at: '2021-11-03T11:02:58.723Z'
+                        updated_at: '2021-11-03T11:02:58.757Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8300,11 +8327,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$10.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$10.00"
                       relationships:
                         order:
                           data:
@@ -8391,12 +8418,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H26080304428
+                        number: H02358142093
                         cost: '100.0'
                         shipped_at:
                         state: canceled
-                        created_at: '2021-11-01T22:36:04.686Z'
-                        updated_at: '2021-11-01T22:36:04.713Z'
+                        created_at: '2021-11-03T11:02:59.162Z'
+                        updated_at: '2021-11-03T11:02:59.189Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8404,11 +8431,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$10.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$10.00"
                       relationships:
                         order:
                           data:
@@ -8495,12 +8522,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H93653327402
+                        number: H77557291835
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-01T22:36:05.117Z'
-                        updated_at: '2021-11-01T22:36:05.151Z'
+                        created_at: '2021-11-03T11:02:59.605Z'
+                        updated_at: '2021-11-03T11:02:59.635Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8508,11 +8535,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$10.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$10.00"
                       relationships:
                         order:
                           data:
@@ -8599,12 +8626,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H26635718038
+                        number: H16944195478
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:36:05.552Z'
-                        updated_at: '2021-11-01T22:36:05.580Z'
+                        created_at: '2021-11-03T11:03:00.127Z'
+                        updated_at: '2021-11-03T11:03:00.154Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8612,11 +8639,11 @@ paths:
                         pre_tax_amount: '0.0'
                         taxable_adjustment_total: '0.0'
                         non_taxable_adjustment_total: '0.0'
+                        display_discounted_cost: "$100.00"
+                        display_item_cost: "$10.00"
                         display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
-                        display_discounted_cost: "$100.00"
-                        display_item_cost: "$10.00"
                       relationships:
                         order:
                           data:
@@ -8707,14 +8734,14 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #116'
-                        created_at: '2021-11-01T22:36:05.889Z'
-                        updated_at: '2021-11-01T22:36:05.889Z'
+                        created_at: '2021-11-03T11:03:00.404Z'
+                        updated_at: '2021-11-03T11:03:00.404Z'
                     - id: '117'
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #117'
-                        created_at: '2021-11-01T22:36:05.890Z'
-                        updated_at: '2021-11-01T22:36:05.890Z'
+                        created_at: '2021-11-03T11:03:00.405Z'
+                        updated_at: '2021-11-03T11:03:00.405Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -8759,8 +8786,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #120'
-                        created_at: '2021-11-01T22:36:05.944Z'
-                        updated_at: '2021-11-01T22:36:05.944Z'
+                        created_at: '2021-11-03T11:03:00.461Z'
+                        updated_at: '2021-11-03T11:03:00.461Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8809,8 +8836,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #121'
-                        created_at: '2021-11-01T22:36:05.977Z'
-                        updated_at: '2021-11-01T22:36:05.977Z'
+                        created_at: '2021-11-03T11:03:00.501Z'
+                        updated_at: '2021-11-03T11:03:00.501Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -8860,8 +8887,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: Default
-                        created_at: '2021-11-01T22:36:06.028Z'
-                        updated_at: '2021-11-01T22:36:06.034Z'
+                        created_at: '2021-11-03T11:03:00.561Z'
+                        updated_at: '2021-11-03T11:03:00.567Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8995,8 +9022,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:36:06.155Z'
-                        updated_at: '2021-11-01T22:36:06.155Z'
+                        created_at: '2021-11-03T11:03:00.706Z'
+                        updated_at: '2021-11-03T11:03:00.706Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9019,8 +9046,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:36:06.164Z'
-                        updated_at: '2021-11-01T22:36:06.164Z'
+                        created_at: '2021-11-03T11:03:00.715Z'
+                        updated_at: '2021-11-03T11:03:00.715Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9090,8 +9117,8 @@ paths:
                         admin_name: DHL Express- Zone A
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:36:06.245Z'
-                        updated_at: '2021-11-01T22:36:06.245Z'
+                        created_at: '2021-11-03T11:03:00.796Z'
+                        updated_at: '2021-11-03T11:03:00.796Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9175,8 +9202,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:36:06.289Z'
-                        updated_at: '2021-11-01T22:36:06.289Z'
+                        created_at: '2021-11-03T11:03:00.848Z'
+                        updated_at: '2021-11-03T11:03:00.848Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9251,8 +9278,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:36:06.369Z'
-                        updated_at: '2021-11-01T22:36:06.382Z'
+                        created_at: '2021-11-03T11:03:00.930Z'
+                        updated_at: '2021-11-03T11:03:00.945Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9401,8 +9428,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:36:06.617Z'
-                        updated_at: '2021-11-01T22:36:06.621Z'
+                        created_at: '2021-11-03T11:03:01.204Z'
+                        updated_at: '2021-11-03T11:03:01.207Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9436,8 +9463,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-11-01T22:36:06.676Z'
-                        updated_at: '2021-11-01T22:36:06.679Z'
+                        created_at: '2021-11-03T11:03:01.267Z'
+                        updated_at: '2021-11-03T11:03:01.271Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9471,8 +9498,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-11-01T22:36:06.555Z'
-                        updated_at: '2021-11-01T22:36:06.690Z'
+                        created_at: '2021-11-03T11:03:01.137Z'
+                        updated_at: '2021-11-03T11:03:01.281Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9553,8 +9580,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:36:06.906Z'
-                        updated_at: '2021-11-01T22:36:06.910Z'
+                        created_at: '2021-11-03T11:03:01.528Z'
+                        updated_at: '2021-11-03T11:03:01.533Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9639,8 +9666,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:36:07.024Z'
-                        updated_at: '2021-11-01T22:36:07.028Z'
+                        created_at: '2021-11-03T11:03:01.646Z'
+                        updated_at: '2021-11-03T11:03:01.650Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9728,8 +9755,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:36:07.240Z'
-                        updated_at: '2021-11-01T22:36:07.266Z'
+                        created_at: '2021-11-03T11:03:01.888Z'
+                        updated_at: '2021-11-03T11:03:01.915Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9882,9 +9909,9 @@ paths:
                     - id: '97'
                       type: user
                       attributes:
-                        email: eddy_goldner@hartmann.info
-                        created_at: '2021-11-01T22:36:07.752Z'
-                        updated_at: '2021-11-01T22:36:07.752Z'
+                        email: idalia@mckenzie.com
+                        created_at: '2021-11-03T11:03:02.513Z'
+                        updated_at: '2021-11-03T11:03:02.513Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9896,9 +9923,9 @@ paths:
                     - id: '98'
                       type: user
                       attributes:
-                        email: cristy@reinger.biz
-                        created_at: '2021-11-01T22:36:07.758Z'
-                        updated_at: '2021-11-01T22:36:07.758Z'
+                        email: leandra.larson@ziemann.biz
+                        created_at: '2021-11-03T11:03:02.518Z'
+                        updated_at: '2021-11-03T11:03:02.518Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9910,9 +9937,9 @@ paths:
                     - id: '99'
                       type: user
                       attributes:
-                        email: jannet_schmidt@lockman.ca
-                        created_at: '2021-11-01T22:36:07.759Z'
-                        updated_at: '2021-11-01T22:36:07.759Z'
+                        email: tereasa.watsica@gaylord.us
+                        created_at: '2021-11-03T11:03:02.520Z'
+                        updated_at: '2021-11-03T11:03:02.520Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9971,9 +9998,9 @@ paths:
                       id: '104'
                       type: user
                       attributes:
-                        email: griselda@toyschuster.info
-                        created_at: '2021-11-01T22:36:07.826Z'
-                        updated_at: '2021-11-01T22:36:07.826Z'
+                        email: leonel_stehr@russelkrajcik.com
+                        created_at: '2021-11-03T11:03:02.601Z'
+                        updated_at: '2021-11-03T11:03:02.601Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10036,9 +10063,9 @@ paths:
                       id: '107'
                       type: user
                       attributes:
-                        email: margo_gleichner@cartwright.name
-                        created_at: '2021-11-01T22:36:07.878Z'
-                        updated_at: '2021-11-01T22:36:07.878Z'
+                        email: dakota@dicki.name
+                        created_at: '2021-11-03T11:03:02.652Z'
+                        updated_at: '2021-11-03T11:03:02.652Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10103,8 +10130,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-11-01T22:36:07.946Z'
-                        updated_at: '2021-11-01T22:36:07.954Z'
+                        created_at: '2021-11-03T11:03:02.732Z'
+                        updated_at: '2021-11-03T11:03:02.741Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10251,12 +10278,12 @@ paths:
                         position: 1
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:36:08.256Z'
+                        updated_at: '2021-11-03T11:03:02.968Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:36:08.250Z'
+                        created_at: '2021-11-03T11:03:02.963Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 4315'
+                        name: 'Product #181 - 4572'
                         options_text: ''
                         total_on_hand: 0
                         purchasable: true
@@ -10291,21 +10318,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-249
-                        weight: '150.2'
-                        height: '7.71'
-                        depth: '162.69'
+                        weight: '185.26'
+                        height: '175.51'
+                        depth: '6.65'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:36:08.285Z'
+                        updated_at: '2021-11-03T11:03:02.997Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:36:08.279Z'
+                        created_at: '2021-11-03T11:03:02.991Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 4315'
+                        name: 'Product #181 - 4572'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10342,21 +10369,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-250
-                        weight: '150.54'
-                        height: '89.18'
-                        depth: '47.63'
+                        weight: '197.57'
+                        height: '171.69'
+                        depth: '166.14'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 3
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:36:08.304Z'
+                        updated_at: '2021-11-03T11:03:03.016Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:36:08.298Z'
+                        created_at: '2021-11-03T11:03:03.009Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 4315'
+                        name: 'Product #181 - 4572'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10446,21 +10473,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-255
-                        weight: '149.44'
-                        height: '129.71'
-                        depth: '166.72'
+                        weight: '37.28'
+                        height: '26.22'
+                        depth: '192.91'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:36:08.519Z'
+                        updated_at: '2021-11-03T11:03:03.234Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:36:08.508Z'
+                        created_at: '2021-11-03T11:03:03.228Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #183 - 6694'
+                        name: 'Product #183 - 6109'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10621,14 +10648,14 @@ paths:
                     - id: '1'
                       type: event
                       attributes:
-                        execution_time: 30902
+                        execution_time: 37576
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url1.com/
-                        created_at: '2021-11-01T22:36:08.871Z'
-                        updated_at: '2021-11-01T22:36:08.871Z'
+                        created_at: '2021-11-03T11:03:03.680Z'
+                        updated_at: '2021-11-03T11:03:03.680Z'
                       relationships:
                         subscriber:
                           data:
@@ -10637,14 +10664,14 @@ paths:
                     - id: '2'
                       type: event
                       attributes:
-                        execution_time: 56945
+                        execution_time: 76145
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url2.com/
-                        created_at: '2021-11-01T22:36:08.875Z'
-                        updated_at: '2021-11-01T22:36:08.875Z'
+                        created_at: '2021-11-03T11:03:03.684Z'
+                        updated_at: '2021-11-03T11:03:03.684Z'
                       relationships:
                         subscriber:
                           data:
@@ -10720,8 +10747,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:36:08.924Z'
-                        updated_at: '2021-11-01T22:36:08.924Z'
+                        created_at: '2021-11-03T11:03:03.745Z'
+                        updated_at: '2021-11-03T11:03:03.745Z'
                     - id: '6'
                       type: subscriber
                       attributes:
@@ -10729,8 +10756,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:36:08.925Z'
-                        updated_at: '2021-11-01T22:36:08.925Z'
+                        created_at: '2021-11-03T11:03:03.746Z'
+                        updated_at: '2021-11-03T11:03:03.746Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -10778,8 +10805,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:36:08.978Z'
-                        updated_at: '2021-11-01T22:36:08.978Z'
+                        created_at: '2021-11-03T11:03:03.798Z'
+                        updated_at: '2021-11-03T11:03:03.798Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10834,8 +10861,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:36:09.010Z'
-                        updated_at: '2021-11-01T22:36:09.010Z'
+                        created_at: '2021-11-03T11:03:03.835Z'
+                        updated_at: '2021-11-03T11:03:03.835Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -10888,8 +10915,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:36:09.060Z'
-                        updated_at: '2021-11-01T22:36:09.060Z'
+                        created_at: '2021-11-03T11:03:03.897Z'
+                        updated_at: '2021-11-03T11:03:03.897Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -11010,8 +11037,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:36:09.311Z'
-                        updated_at: '2021-11-01T22:36:09.311Z'
+                        created_at: '2021-11-03T11:03:04.163Z'
+                        updated_at: '2021-11-03T11:03:04.163Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -11025,8 +11052,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:36:09.360Z'
-                        updated_at: '2021-11-01T22:36:09.360Z'
+                        created_at: '2021-11-03T11:03:04.212Z'
+                        updated_at: '2021-11-03T11:03:04.212Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -11040,8 +11067,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:36:09.406Z'
-                        updated_at: '2021-11-01T22:36:09.406Z'
+                        created_at: '2021-11-03T11:03:04.258Z'
+                        updated_at: '2021-11-03T11:03:04.258Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -11055,8 +11082,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:36:09.454Z'
-                        updated_at: '2021-11-01T22:36:09.454Z'
+                        created_at: '2021-11-03T11:03:04.304Z'
+                        updated_at: '2021-11-03T11:03:04.304Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -11117,8 +11144,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:36:09.911Z'
-                        updated_at: '2021-11-01T22:36:09.911Z'
+                        created_at: '2021-11-03T11:03:04.770Z'
+                        updated_at: '2021-11-03T11:03:04.770Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -11188,8 +11215,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:36:10.114Z'
-                        updated_at: '2021-11-01T22:36:10.114Z'
+                        created_at: '2021-11-03T11:03:04.983Z'
+                        updated_at: '2021-11-03T11:03:04.983Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -11255,8 +11282,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-11-01T22:36:10.454Z'
-                        updated_at: '2021-11-01T22:36:10.463Z'
+                        created_at: '2021-11-03T11:03:05.320Z'
+                        updated_at: '2021-11-03T11:03:05.329Z'
                         display_price: "$19.99"
                         display_total: "$59.97"
                         price: '19.99'
@@ -11391,9 +11418,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:36:11.146Z'
-                        updated_at: '2021-11-01T22:36:11.146Z'
-                        token: EYTETFvJ3BR7pLBcqNhRcHKX
+                        created_at: '2021-11-03T11:03:06.035Z'
+                        updated_at: '2021-11-03T11:03:06.035Z'
+                        token: BveCWJKL5oe3m2NqvJzAsTeG
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11408,9 +11435,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:36:11.148Z'
-                        updated_at: '2021-11-01T22:36:11.148Z'
-                        token: mB3yhtwWUxUthBtnn8vg89ui
+                        created_at: '2021-11-03T11:03:06.037Z'
+                        updated_at: '2021-11-03T11:03:06.037Z'
+                        token: MRz6sBZJ8ex5erYTFBJNcXcj
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11472,9 +11499,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:36:11.597Z'
-                        updated_at: '2021-11-01T22:36:11.597Z'
-                        token: XULmdkxnXtU3metp2xanXpEb
+                        created_at: '2021-11-03T11:03:06.486Z'
+                        updated_at: '2021-11-03T11:03:06.486Z'
+                        token: qi7ZtGeDCpqmYGSyUnjBPBz7
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11538,9 +11565,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:36:11.641Z'
-                        updated_at: '2021-11-01T22:36:11.641Z'
-                        token: x1xqg1wUJeX6ftB9RWVJ91wi
+                        created_at: '2021-11-03T11:03:06.535Z'
+                        updated_at: '2021-11-03T11:03:06.535Z'
+                        token: ZG2ihvWyZM2S9h7nsgqQFtuP
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11603,9 +11630,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:36:11.703Z'
-                        updated_at: '2021-11-01T22:36:11.711Z'
-                        token: Y8TkkpY33TiKQZD4W7RHcu7Z
+                        created_at: '2021-11-03T11:03:06.605Z'
+                        updated_at: '2021-11-03T11:03:06.613Z'
+                        token: a5HxXePc8Smg57Zv56RYnHZ1
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11961,7 +11988,7 @@ components:
       required:
       - classification
       x-internal: true
-    create_cms_page_params:
+    create_standard_cms_page_params:
       type: object
       properties:
         cms_page:
@@ -11969,25 +11996,151 @@ components:
           required:
           - title
           - locale
+          - type
           properties:
             title:
               type: string
+              example: About Us
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              description: Set the type of page.
             meta_title:
               type: string
+              nullable: true
+              example: Learn More About Super-Shop
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
             content:
               type: string
+              nullable: true
+              example: Lot's of text..
+              description: The text content of a standard page, this can be HTML from
+                a rich text editor.
             meta_description:
               type: string
+              nullable: true
+              example: Learn more about us on this page here...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
             visible:
-              type: string
+              type: boolean
+              enum:
+              - true
+              - false
+              description: This page is publicly visible when set to `true`.
             slug:
               type: string
+              nullable: true
+              example: about-us
+              description: Set a slug for this page.
             locale:
               type: string
+              example: en-US
+              description: The language this page is written in.
       required:
       - cms_page
+      title: Create a Standard Page
       x-internal: true
-    update_cms_page_params:
+    create_homepage_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          required:
+          - title
+          - locale
+          - type
+          properties:
+            title:
+              type: string
+              example: Our Flash Homepage
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::Homepage
+              description: Set the type of page.
+            meta_title:
+              type: string
+              nullable: true
+              example: Visit Our Store - Great Deals
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Discover great new products that we sell in this store...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
+            visible:
+              type: boolean
+              enum:
+              - true
+              - false
+              description: This page is publicly visible when set to `true`.
+            locale:
+              type: string
+              example: en-US
+              description: The language this page is written in.
+      required:
+      - cms_page
+      title: Create a Homepage
+      x-internal: true
+    create_feature_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          required:
+          - title
+          - locale
+          - type
+          properties:
+            title:
+              type: string
+              example: Featured Product
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page.
+            meta_title:
+              type: string
+              nullable: true
+              example: Learn More About This Featured Product
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Learn more about us this amazing product that we sell right
+                here...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
+            visible:
+              type: boolean
+              enum:
+              - true
+              - false
+              description: This page is publicly visible when set to `true`.
+            slug:
+              type: string
+              nullable: true
+              example: about-us
+              description: Set a slug for this page.
+            locale:
+              type: string
+              example: en-US
+              description: The language this page is written in.
+      required:
+      - cms_page
+      title: Create a Feature Page
+      x-internal: true
+    update_standard_cms_page_params:
       type: object
       properties:
         cms_page:
@@ -11995,22 +12148,145 @@ components:
           properties:
             title:
               type: string
+              example: About Us
+              description: Update the page title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Change the type of page.
             meta_title:
               type: string
+              nullable: true
+              example: Learn More About Super-Shop
+              description: Update the meta title for this page, this appears in the
+                title bar of the browser.
             content:
               type: string
+              nullable: true
+              example: Lot's of text..
+              description: Update the text content of a standard page, this can be
+                HTML from a rich text editor.
             meta_description:
               type: string
+              nullable: true
+              example: Learn more about us on this page here...
+              description: Update the meta description, used for SEO and displayed
+                in search results.
             visible:
-              type: string
+              type: boolean
+              enum:
+              - true
+              - false
+              description: This page is publicly visible when set to `true`.
             slug:
               type: string
+              nullable: true
+              example: about-us
+              description: Update the slug for this page.
             locale:
               type: string
+              example: en-US
+              description: Update the language of this page.
       required:
       - cms_page
+      title: Update a Standard Page
       x-internal: true
-    create_cms_section_params:
+    update_homepage_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          properties:
+            title:
+              type: string
+              example: Our Flash Homepage
+              description: Update the page title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Change the type of page.
+            meta_title:
+              type: string
+              nullable: true
+              example: Visit Our Store - Great Deals
+              description: Update the meta title for this page, this appears in the
+                title bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Discover great new products that we sell in this store...
+              description: Update the meta description, used for SEO and displayed
+                in search results.
+            visible:
+              type: boolean
+              enum:
+              - true
+              - false
+              description: This page is publicly visible when set to `true`.
+            locale:
+              type: string
+              example: en-US
+              description: Update the language of this page.
+      required:
+      - cms_page
+      title: Update a Homepage
+      x-internal: true
+    update_feature_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          properties:
+            title:
+              type: string
+              example: Featured Product
+              description: Update the page title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Change the type of page.
+            meta_title:
+              type: string
+              nullable: true
+              example: Learn More About This Featured Product
+              description: Update the meta title for this page, this appears in the
+                title bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Learn more about us this amazing product that we sell right
+                here...
+              description: Update the meta description, used for SEO and displayed
+                in search results.
+            visible:
+              type: boolean
+              enum:
+              - true
+              - false
+              description: This page is publicly visible when set to `true`.
+            slug:
+              type: string
+              nullable: true
+              example: about-us
+              description: Update the slug for this page.
+            locale:
+              type: string
+              example: en-US
+              description: Update the language of this page.
+      required:
+      - cms_page
+      title: Update a Feature Page
+      x-internal: true
+    create_hero_image_cms_section_params:
       type: object
       properties:
         cms_section:
@@ -12018,37 +12294,459 @@ components:
           required:
           - name
           - cms_page_id
+          - type
           properties:
             name:
               type: string
+              description: Give this section a name.
             cms_page_id:
               type: string
-            destination:
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
               type: string
-              example: https://getvendo.com
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              example: Spree::Cms::Sections::HeroImage
+              description: Set the section type.
             linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Set the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the resource that you would like this section
+                to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Set the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Create a title for the Hero Section.
+            digital[image_one]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+      required:
+      - cms_section
+      title: Create a Hero Image Section
+      x-internal: true
+    create_product_carousel_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::ProductCarousel
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the Taxon that you would like displayed as
+                a Product Carousel.
+      required:
+      - cms_section
+      title: Create a Product Carousel Section
+      x-internal: true
+    create_side_by_side_images_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::SideBySideImages
+              example: Spree::Cms::Sections::SideBySideImages
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            link_type_one:
               type: string
               example: Spree::Taxon
               enum:
               - Spree::Taxon
               - Spree::Product
-              - Spree::CmsPage
+              description: Set the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image two links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Set the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Set the slug or path that image two links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Set the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Set the title used in image two.
             fit:
               type: string
               example: Screen
-              description: This value is used by front end developers to manipulate
-                CSS values to fit the section into the Screen or within the Container
-                element.
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            subtitle_one:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Set the subtitle used in image one.
+            subtitle_two:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Set the subtitle used in image two.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            digital[image_one]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+            digital[image_two]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+      required:
+      - cms_section
+      title: Create a Side-by-Side Image Section
+      x-internal: true
+    create_image_gallery_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::ImageGallery
+              example: Spree::Cms::Sections::ImageGallery
+              description: Set the section type.
             position:
               type: integer
               example: 2
-              description: 'Pass the new position that you want this section to appear
+              description: 'Pass the position that you want this section to appear
                 in. (The list is not zero indexed, so the first item is position:
-                1)'
+                `1`)'
+            link_type_one:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image two links to.
+            link_type_three:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image three links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Set the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Set the slug or path that image two links to.
+            link_three:
+              type: string
+              example: red-shirt
+              nullable: true
+              description: Set the slug or path that image three links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Set the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Set the title used in image two.
+            title_three:
+              type: string
+              example: Buy This Women's Skirt
+              nullable: true
+              description: Set the title used in image three.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            layout_style:
+              type: string
+              example: Default
+              enum:
+              - Default
+              - Reversed
+              description: This value is used by front end developers for styling
+                the order the images appear.
+            display_labels:
+              type: string
+              example: Show
+              enum:
+              - Show
+              - Hide
+              description: This value is used by front end developers for showing
+                and hiding the label on the images.
+            digital[image_one]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+            digital[image_two]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+            digital[image_three]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
       required:
       - cms_section
+      title: Create an Image Gallery Section
       x-internal: true
-    update_cms_section_params:
+    create_featured_article_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::FeaturedArticle
+              example: Spree::Cms::Sections::FeaturedArticle
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Set the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the resource that you would like this section
+                to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Set the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Create a title for the Section.
+            subtitle:
+              type: string
+              example: Save Big!
+              description: Create a subtitle for the Section.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Set the content, here, this can be rich text editor content.
+      required:
+      - cms_section
+      title: Create a Featured Article Section
+      x-internal: true
+    create_rich_text_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::RichTextContent
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Set the content, here, this can be rich text editor content.
+      required:
+      - cms_section
+      title: Create a Rich Text Section
+      x-internal: true
+    update_hero_image_cms_section_params:
       type: object
       properties:
         cms_section:
@@ -12056,32 +12754,446 @@ components:
           properties:
             name:
               type: string
-            cms_page_id:
+              description: Update this section name.
+            type:
               type: string
-            destination:
-              type: string
-              example: https://getvendo.com
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              - Spree::Cms::Sections::FeaturedArticle
+              - Spree::Cms::Sections::ProductCarousel
+              - Spree::Cms::Sections::ImageGallery
+              - Spree::Cms::Sections::SideBySideImages
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
             linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Update the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the resource that you would like this section
+                to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Update the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Update the title for this section.
+            digital[image_one]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+      required:
+      - cms_section
+      title: Update a Hero Image Section
+      x-internal: true
+    update_product_carousel_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Change this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              - Spree::Cms::Sections::FeaturedArticle
+              - Spree::Cms::Sections::ProductCarousel
+              - Spree::Cms::Sections::ImageGallery
+              - Spree::Cms::Sections::SideBySideImages
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Update the ID of the Taxon that you would like displayed
+                as a Product Carousel.
+      required:
+      - cms_section
+      title: Update a Product Carousel Section
+      x-internal: true
+    update_side_by_side_images_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              - Spree::Cms::Sections::FeaturedArticle
+              - Spree::Cms::Sections::ProductCarousel
+              - Spree::Cms::Sections::ImageGallery
+              - Spree::Cms::Sections::SideBySideImages
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            link_type_one:
               type: string
               example: Spree::Taxon
               enum:
               - Spree::Taxon
               - Spree::Product
-              - Spree::CmsPage
+              description: Update the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image two links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Update the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Update the slug or path that image two links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Update the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Update the title used in image two.
             fit:
               type: string
               example: Screen
-              description: This value is used by front end developers to manipulate
-                CSS values to fit the section into the Screen or within the Container
-                element.
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            subtitle_one:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Update the subtitle used in image one.
+            subtitle_two:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Update the subtitle used in image two.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            digital[image_one]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+            digital[image_two]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+      required:
+      - cms_section
+      title: Update a Side-by-Side Image Section
+      x-internal: true
+    update_image_gallery_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              - Spree::Cms::Sections::FeaturedArticle
+              - Spree::Cms::Sections::ProductCarousel
+              - Spree::Cms::Sections::ImageGallery
+              - Spree::Cms::Sections::SideBySideImages
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
             position:
               type: integer
               example: 2
-              description: 'Pass the new position that you want this section to appear
+              description: 'Pass the position that you want this section to appear
                 in. (The list is not zero indexed, so the first item is position:
-                1)'
+                `1`)'
+            link_type_one:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image two links to.
+            link_type_three:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image three links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Update the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Update the slug or path that image two links to.
+            link_three:
+              type: string
+              example: red-shirt
+              nullable: true
+              description: Update the slug or path that image three links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Update the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Update the title used in image two.
+            title_three:
+              type: string
+              example: Buy This Women's Skirt
+              nullable: true
+              description: Update the title used in image three.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            layout_style:
+              type: string
+              example: Default
+              enum:
+              - Default
+              - Reversed
+              description: This value is used by front end developers for styling
+                the order the images appear.
+            display_labels:
+              type: string
+              example: Show
+              enum:
+              - Show
+              - Hide
+              description: This value is used by front end developers for showing
+                and hiding the label on the images.
+            digital[image_one]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+            digital[image_two]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
+            digital[image_three]:
+              type: string
+              format: binary
+              description: Use a `multipart/form-data` request to upload assets.
       required:
       - cms_section
+      title: Update an Image Gallery Section
+      x-internal: true
+    update_featured_article_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              - Spree::Cms::Sections::FeaturedArticle
+              - Spree::Cms::Sections::ProductCarousel
+              - Spree::Cms::Sections::ImageGallery
+              - Spree::Cms::Sections::SideBySideImages
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Set the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Change the ID of the resource that you would like this
+                section to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Update the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Update the title for the Section.
+            subtitle:
+              type: string
+              example: Save Big!
+              description: Update the subtitle for the Section.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Update the content here, this can be rich text editor content.
+      required:
+      - cms_section
+      title: Update a Featured Article Section
+      x-internal: true
+    update_rich_text_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              - Spree::Cms::Sections::FeaturedArticle
+              - Spree::Cms::Sections::ProductCarousel
+              - Spree::Cms::Sections::ImageGallery
+              - Spree::Cms::Sections::SideBySideImages
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Update the content, here, this can be rich text editor
+                content.
+      required:
+      - cms_section
+      title: Update a Rich Text Section
       x-internal: true
     create_digital_params:
       type: object
@@ -12221,17 +13333,17 @@ components:
             name:
               type: string
               example: Main Menu
-              description: Give this Menu a name.
+              description: Update this Menu name.
             location:
               type: string
               enum:
               - header
               - footer
-              description: Set the location this menu appears in the website.
+              description: Update the location this menu appears in the website.
             locale:
               type: string
               example: en-US
-              description: Set the language of this menu.
+              description: Change the language of this menu.
       required:
       - menu
       x-internal: true
@@ -12309,12 +13421,12 @@ components:
             name:
               type: string
               example: T-Shirts
-              description: The name of this Menu Item
+              description: Update the name of this Menu Item
             code:
               type: string
               nullable: true
               example: MEN-TS
-              description: Give this Menu Item a code to identify this Menu Item from
+              description: The Menu Item a code to identifies this Menu Item from
                 others. This is especially useful when using Container type Menu Items
                 to group items.
             subtitle:
@@ -12351,8 +13463,8 @@ components:
               - Spree::Taxon
               - Spree::Product
               - Spree::CmsPage
-              description: 'Set the type of resource you want to link to, or set to:
-                URL to use the destination field for an external link.'
+              description: 'Change the type of resource you want to link to, or set
+                to: URL to use the destination field for an external link.'
             linked_resource_id:
               type: integer
               example: 1
@@ -12481,7 +13593,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:35:35 UTC
+              example: 2021-11-03 11:02:29 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12549,7 +13661,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:35:35 UTC
+              example: 2021-11-03 11:02:29 UTC
             confirmation_delivered:
               type: boolean
               example: true
@@ -12616,7 +13728,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:35:35 UTC
+              example: 2021-11-03 11:02:29 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12684,7 +13796,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:35:35 UTC
+              example: 2021-11-03 11:02:29 UTC
             confirmation_delivered:
               type: boolean
               example: true

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -70,8 +70,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:32:56.262Z'
-                        updated_at: '2021-11-01T22:32:56.262Z'
+                        created_at: '2021-11-02T17:21:52.733Z'
+                        updated_at: '2021-11-02T17:21:52.733Z'
                         deleted_at:
                         label:
                       relationships:
@@ -98,8 +98,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:32:56.268Z'
-                        updated_at: '2021-11-01T22:32:56.268Z'
+                        created_at: '2021-11-02T17:21:52.737Z'
+                        updated_at: '2021-11-02T17:21:52.737Z'
                         deleted_at:
                         label:
                       relationships:
@@ -173,8 +173,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:32:56.495Z'
-                        updated_at: '2021-11-01T22:32:56.495Z'
+                        created_at: '2021-11-02T17:21:52.955Z'
+                        updated_at: '2021-11-02T17:21:52.955Z'
                         deleted_at:
                         label:
                       relationships:
@@ -268,8 +268,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:32:56.532Z'
-                        updated_at: '2021-11-01T22:32:56.532Z'
+                        created_at: '2021-11-02T17:21:52.997Z'
+                        updated_at: '2021-11-02T17:21:52.997Z'
                         deleted_at:
                         label:
                       relationships:
@@ -348,8 +348,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T22:32:56.594Z'
-                        updated_at: '2021-11-01T22:32:56.601Z'
+                        created_at: '2021-11-02T17:21:53.072Z'
+                        updated_at: '2021-11-02T17:21:53.080Z'
                         deleted_at:
                         label:
                       relationships:
@@ -493,8 +493,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:32:56.811Z'
-                        updated_at: '2021-11-01T22:32:56.811Z'
+                        created_at: '2021-11-02T17:21:53.317Z'
+                        updated_at: '2021-11-02T17:21:53.317Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -520,8 +520,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:32:56.830Z'
-                        updated_at: '2021-11-01T22:32:56.830Z'
+                        created_at: '2021-11-02T17:21:53.338Z'
+                        updated_at: '2021-11-02T17:21:53.338Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -594,8 +594,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:32:57.128Z'
-                        updated_at: '2021-11-01T22:32:57.128Z'
+                        created_at: '2021-11-02T17:21:53.654Z'
+                        updated_at: '2021-11-02T17:21:53.654Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -677,8 +677,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:32:57.237Z'
-                        updated_at: '2021-11-01T22:32:57.241Z'
+                        created_at: '2021-11-02T17:21:53.776Z'
+                        updated_at: '2021-11-02T17:21:53.780Z'
                         state: open
                         included: false
                         display_amount: "$1.00"
@@ -756,8 +756,8 @@ paths:
                         label: New label
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T22:32:57.419Z'
-                        updated_at: '2021-11-01T22:32:57.431Z'
+                        created_at: '2021-11-02T17:21:53.960Z'
+                        updated_at: '2021-11-02T17:21:53.972Z'
                         state: open
                         included: false
                         display_amount: "$15.00"
@@ -897,8 +897,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:32:57.894Z'
-                        updated_at: '2021-11-01T22:32:57.894Z'
+                        created_at: '2021-11-02T17:21:54.479Z'
+                        updated_at: '2021-11-02T17:21:54.479Z'
                       relationships:
                         product:
                           data:
@@ -912,8 +912,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:32:57.968Z'
-                        updated_at: '2021-11-01T22:32:57.968Z'
+                        created_at: '2021-11-02T17:21:54.555Z'
+                        updated_at: '2021-11-02T17:21:54.555Z'
                       relationships:
                         product:
                           data:
@@ -974,8 +974,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:32:58.392Z'
-                        updated_at: '2021-11-01T22:32:58.392Z'
+                        created_at: '2021-11-02T17:21:55.004Z'
+                        updated_at: '2021-11-02T17:21:55.004Z'
                       relationships:
                         product:
                           data:
@@ -1042,8 +1042,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:32:58.552Z'
-                        updated_at: '2021-11-01T22:32:58.552Z'
+                        created_at: '2021-11-02T17:21:55.173Z'
+                        updated_at: '2021-11-02T17:21:55.173Z'
                       relationships:
                         product:
                           data:
@@ -1109,8 +1109,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T22:32:58.850Z'
-                        updated_at: '2021-11-01T22:32:58.850Z'
+                        created_at: '2021-11-02T17:21:55.475Z'
+                        updated_at: '2021-11-02T17:21:55.475Z'
                       relationships:
                         product:
                           data:
@@ -1232,8 +1232,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-11-01T22:32:59.575Z'
-                        updated_at: '2021-11-01T22:32:59.597Z'
+                        created_at: '2021-11-02T17:21:56.229Z'
+                        updated_at: '2021-11-02T17:21:56.253Z'
                       relationships:
                         product:
                           data:
@@ -1332,34 +1332,34 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Voluptas vel officiis impedit natus similique quo.
+                        title: Voluptates assumenda cum repudiandae expedita.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: voluptas-vel-officiis-impedit-natus-similique-quo
+                        slug: voluptates-assumenda-cum-repudiandae-expedita
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:32:59.930Z'
-                        updated_at: '2021-11-01T22:32:59.930Z'
+                        created_at: '2021-11-02T17:21:56.598Z'
+                        updated_at: '2021-11-02T17:21:56.598Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Pariatur ipsum aspernatur in alias.
+                        title: Dolor itaque eligendi quis id occaecati exercitationem.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: pariatur-ipsum-aspernatur-in-alias
+                        slug: dolor-itaque-eligendi-quis-id-occaecati-exercitationem
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:32:59.934Z'
-                        updated_at: '2021-11-01T22:32:59.934Z'
+                        created_at: '2021-11-02T17:21:56.602Z'
+                        updated_at: '2021-11-02T17:21:56.602Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1413,17 +1413,17 @@ paths:
                       id: '5'
                       type: cms_page
                       attributes:
-                        title: Repellat tempora iusto quisquam animi et quos.
+                        title: Dolore libero rerum ipsam autem.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: repellat-tempora-iusto-quisquam-animi-et-quos
+                        slug: dolore-libero-rerum-ipsam-autem
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:33:00.014Z'
-                        updated_at: '2021-11-01T22:33:00.014Z'
+                        created_at: '2021-11-02T17:21:56.688Z'
+                        updated_at: '2021-11-02T17:21:56.688Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1436,11 +1436,14 @@ paths:
               examples:
                 Example:
                   value:
-                    error: Title can't be blank and Locale can't be blank
+                    error: Title can't be blank, Locale can't be blank, and Type can't
+                      be blank
                     errors:
                       title:
                       - can't be blank
                       locale:
+                      - can't be blank
+                      type:
                       - can't be blank
               schema:
                 "$ref": "#/components/schemas/validation_errors"
@@ -1486,18 +1489,17 @@ paths:
                       id: '6'
                       type: cms_page
                       attributes:
-                        title: Maxime quis similique laudantium enim necessitatibus
-                          odio nostrum quam.
+                        title: Animi quaerat voluptatum ad pariatur officia doloribus.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: maxime-quis-similique-laudantium-enim-necessitatibus-odio-nostrum-quam
+                        slug: animi-quaerat-voluptatum-ad-pariatur-officia-doloribus
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:33:00.051Z'
-                        updated_at: '2021-11-01T22:33:00.051Z'
+                        created_at: '2021-11-02T17:21:56.727Z'
+                        updated_at: '2021-11-02T17:21:56.727Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1561,12 +1563,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: occaecati-est-officiis-ratione-minus-labore-commodi
+                        slug: numquam-autem-quae-neque-deleniti-minima-accusantium-consequatur
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T22:33:00.108Z'
-                        updated_at: '2021-11-01T22:33:00.117Z'
+                        created_at: '2021-11-02T17:21:56.793Z'
+                        updated_at: '2021-11-02T17:21:56.802Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1695,7 +1697,7 @@ paths:
                     - id: '1'
                       type: cms_section
                       attributes:
-                        name: Similique tempora in veniam odit culpa pariatur.
+                        name: Enim est facere similique sint alias.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1704,8 +1706,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-01T22:33:00.284Z'
-                        updated_at: '2021-11-01T22:33:00.284Z'
+                        created_at: '2021-11-02T17:21:56.980Z'
+                        updated_at: '2021-11-02T17:21:56.980Z'
                       relationships:
                         cms_page:
                           data:
@@ -1716,8 +1718,8 @@ paths:
                     - id: '2'
                       type: cms_section
                       attributes:
-                        name: Molestiae minima natus autem consectetur accusantium
-                          cupiditate alias.
+                        name: Beatae excepturi a aspernatur quos laudantium impedit
+                          dolorum rem.
                         content:
                           link_type_one: Spree::Taxon
                           link_type_two: Spree::Taxon
@@ -1729,8 +1731,8 @@ paths:
                         type: Spree::Cms::Sections::ImageGallery
                         position: 2
                         linked_resource_type:
-                        created_at: '2021-11-01T22:33:00.288Z'
-                        updated_at: '2021-11-01T22:33:00.288Z'
+                        created_at: '2021-11-02T17:21:56.984Z'
+                        updated_at: '2021-11-02T17:21:56.984Z'
                       relationships:
                         cms_page:
                           data:
@@ -1741,7 +1743,7 @@ paths:
                     - id: '3'
                       type: cms_section
                       attributes:
-                        name: Sit nisi voluptates distinctio recusandae.
+                        name: Aperiam a laudantium error fuga esse ut dicta.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1750,8 +1752,8 @@ paths:
                         type: Spree::Cms::Sections::FeaturedArticle
                         position: 3
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-01T22:33:00.295Z'
-                        updated_at: '2021-11-01T22:33:00.295Z'
+                        created_at: '2021-11-02T17:21:56.994Z'
+                        updated_at: '2021-11-02T17:21:56.994Z'
                       relationships:
                         cms_page:
                           data:
@@ -1762,8 +1764,8 @@ paths:
                     - id: '4'
                       type: cms_section
                       attributes:
-                        name: Minima vel magnam dolor neque architecto numquam voluptatibus
-                          aliquam.
+                        name: Distinctio quisquam sequi sit numquam similique voluptatem
+                          expedita.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1772,8 +1774,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:33:00.302Z'
-                        updated_at: '2021-11-01T22:33:00.302Z'
+                        created_at: '2021-11-02T17:21:57.002Z'
+                        updated_at: '2021-11-02T17:21:57.002Z'
                       relationships:
                         cms_page:
                           data:
@@ -1786,7 +1788,7 @@ paths:
                     - id: '5'
                       type: cms_section
                       attributes:
-                        name: Eveniet quidem nemo provident vitae.
+                        name: Ab itaque excepturi sint beatae.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1795,8 +1797,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 5
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:33:00.309Z'
-                        updated_at: '2021-11-01T22:33:00.309Z'
+                        created_at: '2021-11-02T17:21:57.008Z'
+                        updated_at: '2021-11-02T17:21:57.008Z'
                       relationships:
                         cms_page:
                           data:
@@ -1853,20 +1855,20 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '14'
+                      id: '13'
                       type: cms_section
                       attributes:
-                        name: Non blanditiis accusantium quae nesciunt sed et.
+                        name: Doloribus provident ipsam aliquid temporibus neque.
                         content: {}
                         settings:
                           gutters: No Gutters
                         fit: Screen
                         destination:
                         type: Spree::Cms::Sections::HeroImage
-                        position: 4
+                        position: 3
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:33:00.457Z'
-                        updated_at: '2021-11-01T22:33:00.457Z'
+                        created_at: '2021-11-02T17:21:57.172Z'
+                        updated_at: '2021-11-02T17:21:57.172Z'
                       relationships:
                         cms_page:
                           data:
@@ -1885,11 +1887,14 @@ paths:
               examples:
                 Example:
                   value:
-                    error: Name can't be blank and Cms page can't be blank
+                    error: Name can't be blank, Cms page can't be blank, and Type
+                      can't be blank
                     errors:
                       name:
                       - can't be blank
                       cms_page:
+                      - can't be blank
+                      type:
                       - can't be blank
               schema:
                 "$ref": "#/components/schemas/validation_errors"
@@ -1897,7 +1902,13 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/create_cms_section_params"
+              oneOf:
+              - "$ref": "#/components/schemas/create_hero_image_cms_section_params"
+              - "$ref": "#/components/schemas/create_product_carousel_cms_section_params"
+              - "$ref": "#/components/schemas/create_side_by_side_images_cms_section_params"
+              - "$ref": "#/components/schemas/create_featured_article_cms_section_params"
+              - "$ref": "#/components/schemas/create_image_gallery_cms_section_params"
+              - "$ref": "#/components/schemas/create_rich_text_cms_section_params"
   "/api/v2/platform/cms_sections/{id}":
     get:
       summary: Return a CMS Section
@@ -1929,10 +1940,10 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '21'
+                      id: '19'
                       type: cms_section
                       attributes:
-                        name: Amet necessitatibus veritatis alias earum.
+                        name: Inventore beatae corporis culpa eligendi.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1941,8 +1952,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:33:00.577Z'
-                        updated_at: '2021-11-01T22:33:00.577Z'
+                        created_at: '2021-11-02T17:21:57.303Z'
+                        updated_at: '2021-11-02T17:21:57.303Z'
                       relationships:
                         cms_page:
                           data:
@@ -2004,7 +2015,7 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '32'
+                      id: '29'
                       type: cms_section
                       attributes:
                         name: Super Hero
@@ -2016,8 +2027,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T22:33:00.838Z'
-                        updated_at: '2021-11-01T22:33:00.848Z'
+                        created_at: '2021-11-02T17:21:57.572Z'
+                        updated_at: '2021-11-02T17:21:57.583Z'
                       relationships:
                         cms_page:
                           data:
@@ -2066,7 +2077,13 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/update_cms_section_params"
+              oneOf:
+              - "$ref": "#/components/schemas/update_hero_image_cms_section_params"
+              - "$ref": "#/components/schemas/update_product_carousel_cms_section_params"
+              - "$ref": "#/components/schemas/update_side_by_side_images_cms_section_params"
+              - "$ref": "#/components/schemas/update_featured_article_cms_section_params"
+              - "$ref": "#/components/schemas/update_image_gallery_cms_section_params"
+              - "$ref": "#/components/schemas/update_rich_text_cms_section_params"
     delete:
       summary: Delete a CMS Section
       tags:
@@ -2131,9 +2148,9 @@ paths:
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-11-01T22:33:01.255Z'
+                        updated_at: '2021-11-02T17:21:58.088Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:33:01.255Z'
+                        created_at: '2021-11-02T17:21:58.088Z'
                       relationships:
                         states:
                           data: []
@@ -2146,9 +2163,9 @@ paths:
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T22:33:01.260Z'
+                        updated_at: '2021-11-02T17:21:58.094Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:33:01.260Z'
+                        created_at: '2021-11-02T17:21:58.094Z'
                       relationships:
                         states:
                           data: []
@@ -2161,9 +2178,9 @@ paths:
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T22:33:01.262Z'
+                        updated_at: '2021-11-02T17:21:58.096Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:33:01.262Z'
+                        created_at: '2021-11-02T17:21:58.096Z'
                       relationships:
                         states:
                           data: []
@@ -2222,9 +2239,9 @@ paths:
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T22:33:01.310Z'
+                        updated_at: '2021-11-02T17:21:58.148Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T22:33:01.310Z'
+                        created_at: '2021-11-02T17:21:58.148Z'
                       relationships:
                         states:
                           data: []
@@ -2282,7 +2299,7 @@ paths:
                     - id: '1'
                       type: digital_link
                       attributes:
-                        token: RfgrpdFSjJ7ornAux2T6i2NL
+                        token: GJWRFiMm8nmoHjMjkyRDjnw9
                         access_counter: 0
                       relationships:
                         digital:
@@ -2296,7 +2313,7 @@ paths:
                     - id: '2'
                       type: digital_link
                       attributes:
-                        token: hvHQYUKpKqBULoukQ2hcvxMc
+                        token: VYHfjdEdghaknwWwVzS5wi7A
                         access_counter: 0
                       relationships:
                         digital:
@@ -2350,7 +2367,7 @@ paths:
                       id: '5'
                       type: digital_link
                       attributes:
-                        token: 4cYQqx1PojFCbrHHqFCDvHZM
+                        token: xBboQGRjA5mVPBSVTsK8sR6L
                         access_counter: 0
                       relationships:
                         digital:
@@ -2413,7 +2430,7 @@ paths:
                       id: '6'
                       type: digital_link
                       attributes:
-                        token: sJ9mRiUvBLz5hrvznMjLPxYT
+                        token: S7DoWrFBi24a4riUABNFsJgq
                         access_counter: 0
                       relationships:
                         digital:
@@ -2472,7 +2489,7 @@ paths:
                       id: '8'
                       type: digital_link
                       attributes:
-                        token: r5teQzVc2CZiqkWmNZQCrhxk
+                        token: rqKg67rVbDbJXeXHEMShXQo9
                         access_counter: 0
                       relationships:
                         digital:
@@ -2587,7 +2604,7 @@ paths:
                       id: '13'
                       type: digital_link
                       attributes:
-                        token: 24HwGgcgmQeLw57RYFAcy6ej
+                        token: 1nJWUfg5Tv1Sc4KyDSwAiCEp
                         access_counter: 0
                       relationships:
                         digital:
@@ -3004,8 +3021,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:33:08.651Z'
-                        updated_at: '2021-11-01T22:33:08.658Z'
+                        created_at: '2021-11-02T17:22:05.864Z'
+                        updated_at: '2021-11-02T17:22:05.873Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3051,8 +3068,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:33:08.687Z'
-                        updated_at: '2021-11-01T22:33:08.691Z'
+                        created_at: '2021-11-02T17:22:05.906Z'
+                        updated_at: '2021-11-02T17:22:05.911Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3145,8 +3162,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:33:08.899Z'
-                        updated_at: '2021-11-01T22:33:08.940Z'
+                        created_at: '2021-11-02T17:22:06.146Z'
+                        updated_at: '2021-11-02T17:22:06.189Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3248,8 +3265,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T22:33:09.077Z'
-                        updated_at: '2021-11-01T22:33:09.084Z'
+                        created_at: '2021-11-02T17:22:06.335Z'
+                        updated_at: '2021-11-02T17:22:06.342Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3347,8 +3364,8 @@ paths:
                       attributes:
                         quantity: 4
                         price: '10.0'
-                        created_at: '2021-11-01T22:33:09.280Z'
-                        updated_at: '2021-11-01T22:33:09.315Z'
+                        created_at: '2021-11-02T17:22:06.575Z'
+                        updated_at: '2021-11-02T17:22:06.615Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3398,10 +3415,10 @@ paths:
               examples:
                 Example:
                   value:
-                    error: 'Quantity selected of "Product #130 - 9106" is not available.'
+                    error: 'Quantity selected of "Product #130 - 7297" is not available.'
                     errors:
                       quantity:
-                      - 'selected of "Product #130 - 9106" is not available.'
+                      - 'selected of "Product #130 - 7297" is not available.'
               schema:
                 "$ref": "#/components/schemas/validation_errors"
         '404':
@@ -3521,8 +3538,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-11-01T22:33:09.974Z'
-                        updated_at: '2021-11-01T22:33:09.978Z'
+                        created_at: '2021-11-02T17:22:07.237Z'
+                        updated_at: '2021-11-02T17:22:07.242Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3558,8 +3575,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-11-01T22:33:10.035Z'
-                        updated_at: '2021-11-01T22:33:10.039Z'
+                        created_at: '2021-11-02T17:22:07.309Z'
+                        updated_at: '2021-11-02T17:22:07.313Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3595,8 +3612,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-11-01T22:33:10.099Z'
-                        updated_at: '2021-11-01T22:33:10.103Z'
+                        created_at: '2021-11-02T17:22:07.370Z'
+                        updated_at: '2021-11-02T17:22:07.375Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3632,8 +3649,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:33:10.161Z'
-                        updated_at: '2021-11-01T22:33:10.165Z'
+                        created_at: '2021-11-02T17:22:07.435Z'
+                        updated_at: '2021-11-02T17:22:07.439Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3669,8 +3686,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-11-01T22:33:10.223Z'
-                        updated_at: '2021-11-01T22:33:10.227Z'
+                        created_at: '2021-11-02T17:22:07.507Z'
+                        updated_at: '2021-11-02T17:22:07.511Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3706,8 +3723,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-11-01T22:33:10.285Z'
-                        updated_at: '2021-11-01T22:33:10.290Z'
+                        created_at: '2021-11-02T17:22:07.581Z'
+                        updated_at: '2021-11-02T17:22:07.586Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3743,8 +3760,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-11-01T22:33:10.349Z'
-                        updated_at: '2021-11-01T22:33:10.353Z'
+                        created_at: '2021-11-02T17:22:07.645Z'
+                        updated_at: '2021-11-02T17:22:07.650Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3770,7 +3787,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Adipisci accusantium dicta deleniti error nemo.
+                        name: Maiores magnam veritatis perspiciatis facere culpa aperiam.
                         subtitle:
                         destination:
                         new_window: false
@@ -3780,8 +3797,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-11-01T22:33:09.911Z'
-                        updated_at: '2021-11-01T22:33:10.362Z'
+                        created_at: '2021-11-02T17:22:07.175Z'
+                        updated_at: '2021-11-02T17:22:07.660Z'
                         link:
                         is_container: true
                         is_root: true
@@ -3874,8 +3891,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:33:11.095Z'
-                        updated_at: '2021-11-01T22:33:11.098Z'
+                        created_at: '2021-11-02T17:22:08.387Z'
+                        updated_at: '2021-11-02T17:22:08.391Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3965,8 +3982,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:33:11.639Z'
-                        updated_at: '2021-11-01T22:33:11.644Z'
+                        created_at: '2021-11-02T17:22:08.890Z'
+                        updated_at: '2021-11-02T17:22:08.894Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4054,8 +4071,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T22:33:12.488Z'
-                        updated_at: '2021-11-01T22:33:12.511Z'
+                        created_at: '2021-11-02T17:22:09.685Z'
+                        updated_at: '2021-11-02T17:22:09.710Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4192,8 +4209,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-11-01T22:33:14.467Z'
-                        updated_at: '2021-11-01T22:33:14.491Z'
+                        created_at: '2021-11-02T17:22:11.571Z'
+                        updated_at: '2021-11-02T17:22:11.599Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4291,16 +4308,16 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:33:15.032Z'
-                        updated_at: '2021-11-01T22:33:15.165Z'
+                        created_at: '2021-11-02T17:22:12.181Z'
+                        updated_at: '2021-11-02T17:22:12.310Z'
                       relationships:
                         menu_items:
                           data:
-                          - id: '89'
-                            type: menu_item
                           - id: '87'
                             type: menu_item
                           - id: '90'
+                            type: menu_item
+                          - id: '89'
                             type: menu_item
                     - id: '19'
                       type: menu
@@ -4308,8 +4325,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-11-01T22:33:15.041Z'
-                        updated_at: '2021-11-01T22:33:15.286Z'
+                        created_at: '2021-11-02T17:22:12.190Z'
+                        updated_at: '2021-11-02T17:22:12.434Z'
                       relationships:
                         menu_items:
                           data:
@@ -4372,8 +4389,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:33:15.667Z'
-                        updated_at: '2021-11-01T22:33:15.674Z'
+                        created_at: '2021-11-02T17:22:12.790Z'
+                        updated_at: '2021-11-02T17:22:12.796Z'
                       relationships:
                         menu_items:
                           data:
@@ -4441,8 +4458,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:33:15.714Z'
-                        updated_at: '2021-11-01T22:33:15.721Z'
+                        created_at: '2021-11-02T17:22:12.916Z'
+                        updated_at: '2021-11-02T17:22:12.923Z'
                       relationships:
                         menu_items:
                           data:
@@ -4506,8 +4523,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T22:33:15.803Z'
-                        updated_at: '2021-11-01T22:33:15.809Z'
+                        created_at: '2021-11-02T17:22:13.000Z'
+                        updated_at: '2021-11-02T17:22:13.006Z'
                       relationships:
                         menu_items:
                           data:
@@ -4642,8 +4659,8 @@ paths:
                         name: foo-size-68
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:33:15.982Z'
-                        updated_at: '2021-11-01T22:33:15.982Z'
+                        created_at: '2021-11-02T17:22:13.200Z'
+                        updated_at: '2021-11-02T17:22:13.200Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4654,8 +4671,8 @@ paths:
                         name: foo-size-69
                         presentation: Size
                         position: 2
-                        created_at: '2021-11-01T22:33:15.984Z'
-                        updated_at: '2021-11-01T22:33:15.984Z'
+                        created_at: '2021-11-02T17:22:13.201Z'
+                        updated_at: '2021-11-02T17:22:13.201Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4706,8 +4723,8 @@ paths:
                         name: foo-size-72
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:33:16.035Z'
-                        updated_at: '2021-11-01T22:33:16.035Z'
+                        created_at: '2021-11-02T17:22:13.257Z'
+                        updated_at: '2021-11-02T17:22:13.257Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4764,8 +4781,8 @@ paths:
                         name: foo-size-73
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:33:16.068Z'
-                        updated_at: '2021-11-01T22:33:16.068Z'
+                        created_at: '2021-11-02T17:22:13.302Z'
+                        updated_at: '2021-11-02T17:22:13.302Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4821,8 +4838,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T22:33:16.129Z'
-                        updated_at: '2021-11-01T22:33:16.137Z'
+                        created_at: '2021-11-02T17:22:13.365Z'
+                        updated_at: '2021-11-02T17:22:13.373Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4958,8 +4975,8 @@ paths:
                         position: 1
                         name: Size-68
                         presentation: S
-                        created_at: '2021-11-01T22:33:16.268Z'
-                        updated_at: '2021-11-01T22:33:16.268Z'
+                        created_at: '2021-11-02T17:22:13.518Z'
+                        updated_at: '2021-11-02T17:22:13.518Z'
                       relationships:
                         option_type:
                           data:
@@ -4971,8 +4988,8 @@ paths:
                         position: 1
                         name: Size-69
                         presentation: S
-                        created_at: '2021-11-01T22:33:16.274Z'
-                        updated_at: '2021-11-01T22:33:16.274Z'
+                        created_at: '2021-11-02T17:22:13.524Z'
+                        updated_at: '2021-11-02T17:22:13.524Z'
                       relationships:
                         option_type:
                           data:
@@ -5031,8 +5048,8 @@ paths:
                         position: 1
                         name: Size-72
                         presentation: S
-                        created_at: '2021-11-01T22:33:16.334Z'
-                        updated_at: '2021-11-01T22:33:16.334Z'
+                        created_at: '2021-11-02T17:22:13.592Z'
+                        updated_at: '2021-11-02T17:22:13.592Z'
                       relationships:
                         option_type:
                           data:
@@ -5095,8 +5112,8 @@ paths:
                         position: 1
                         name: Size-73
                         presentation: S
-                        created_at: '2021-11-01T22:33:16.372Z'
-                        updated_at: '2021-11-01T22:33:16.372Z'
+                        created_at: '2021-11-02T17:22:13.638Z'
+                        updated_at: '2021-11-02T17:22:13.638Z'
                       relationships:
                         option_type:
                           data:
@@ -5160,8 +5177,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-11-01T22:33:16.439Z'
-                        updated_at: '2021-11-01T22:33:16.449Z'
+                        created_at: '2021-11-02T17:22:13.707Z'
+                        updated_at: '2021-11-02T17:22:13.716Z'
                       relationships:
                         option_type:
                           data:
@@ -5289,7 +5306,7 @@ paths:
                     - id: '40'
                       type: order
                       attributes:
-                        number: R841283588
+                        number: R273788347
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5298,10 +5315,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: marlys@rohanklocko.name
+                        email: sherrie.fadel@hammeschristiansen.info
                         special_instructions:
-                        created_at: '2021-11-01T22:33:16.604Z'
-                        updated_at: '2021-11-01T22:33:16.604Z'
+                        created_at: '2021-11-02T17:22:13.882Z'
+                        updated_at: '2021-11-02T17:22:13.882Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5373,7 +5390,7 @@ paths:
                     - id: '41'
                       type: order
                       attributes:
-                        number: R441511355
+                        number: R049859363
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5382,10 +5399,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: kiera_beahan@rauheathcote.name
+                        email: melda_bode@lind.com
                         special_instructions:
-                        created_at: '2021-11-01T22:33:16.613Z'
-                        updated_at: '2021-11-01T22:33:16.613Z'
+                        created_at: '2021-11-02T17:22:13.890Z'
+                        updated_at: '2021-11-02T17:22:13.890Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5504,7 +5521,7 @@ paths:
                       id: '44'
                       type: order
                       attributes:
-                        number: R171863303
+                        number: R336210568
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5515,8 +5532,8 @@ paths:
                         payment_state:
                         email:
                         special_instructions:
-                        created_at: '2021-11-01T22:33:16.910Z'
-                        updated_at: '2021-11-01T22:33:16.926Z'
+                        created_at: '2021-11-02T17:22:14.194Z'
+                        updated_at: '2021-11-02T17:22:14.212Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5630,7 +5647,7 @@ paths:
                       id: '45'
                       type: order
                       attributes:
-                        number: R295541902
+                        number: R697241170
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5639,10 +5656,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: trinidad@klein.ca
+                        email: lilli_wehner@nienow.com
                         special_instructions:
-                        created_at: '2021-11-01T22:33:16.968Z'
-                        updated_at: '2021-11-01T22:33:17.130Z'
+                        created_at: '2021-11-02T17:22:14.255Z'
+                        updated_at: '2021-11-02T17:22:14.401Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5772,7 +5789,7 @@ paths:
                       id: '47'
                       type: order
                       attributes:
-                        number: R556257930
+                        number: R096701442
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5783,8 +5800,8 @@ paths:
                         payment_state:
                         email: new@example.com
                         special_instructions:
-                        created_at: '2021-11-01T22:33:17.380Z'
-                        updated_at: '2021-11-01T22:33:17.474Z'
+                        created_at: '2021-11-02T17:22:14.596Z'
+                        updated_at: '2021-11-02T17:22:14.691Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5970,7 +5987,7 @@ paths:
                       id: '52'
                       type: order
                       attributes:
-                        number: R193954467
+                        number: R166672757
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -5979,10 +5996,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: tracy_feil@conn.info
+                        email: shala@hermann.biz
                         special_instructions:
-                        created_at: '2021-11-01T22:33:18.061Z'
-                        updated_at: '2021-11-01T22:33:18.211Z'
+                        created_at: '2021-11-02T17:22:15.288Z'
+                        updated_at: '2021-11-02T17:22:15.433Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6115,7 +6132,7 @@ paths:
                       id: '54'
                       type: order
                       attributes:
-                        number: R362367020
+                        number: R850114572
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -6124,10 +6141,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: joselyn@dachflatley.info
+                        email: bettina.koepp@satterfieldkuhlman.com
                         special_instructions:
-                        created_at: '2021-11-01T22:33:18.406Z'
-                        updated_at: '2021-11-01T22:33:18.543Z'
+                        created_at: '2021-11-02T17:22:15.632Z'
+                        updated_at: '2021-11-02T17:22:15.761Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6260,19 +6277,19 @@ paths:
                       id: '56'
                       type: order
                       attributes:
-                        number: R625341963
+                        number: R978439828
                         item_total: '10.0'
                         total: '110.0'
                         state: complete
                         adjustment_total: '0.0'
-                        completed_at: '2021-11-01T22:33:18.937Z'
+                        completed_at: '2021-11-02T17:22:16.156Z'
                         payment_total: '0.0'
                         shipment_state: pending
                         payment_state: balance_due
-                        email: brunilda@schmidt.us
+                        email: charita_kozey@champlin.co.uk
                         special_instructions:
-                        created_at: '2021-11-01T22:33:18.716Z'
-                        updated_at: '2021-11-01T22:33:18.937Z'
+                        created_at: '2021-11-02T17:22:15.938Z'
+                        updated_at: '2021-11-02T17:22:16.156Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6416,7 +6433,7 @@ paths:
                       id: '59'
                       type: order
                       attributes:
-                        number: R395903908
+                        number: R824509963
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -6425,10 +6442,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: ricky_weimann@schneider.name
+                        email: eura.mclaughlin@schumm.name
                         special_instructions:
-                        created_at: '2021-11-01T22:33:19.247Z'
-                        updated_at: '2021-11-01T22:33:19.351Z'
+                        created_at: '2021-11-02T17:22:16.543Z'
+                        updated_at: '2021-11-02T17:22:16.654Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -6556,7 +6573,7 @@ paths:
                       id: '61'
                       type: order
                       attributes:
-                        number: R825200534
+                        number: R003969629
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -6565,10 +6582,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: jenell_runolfsdottir@gerhold.us
+                        email: josie.kessler@reilly.co.uk
                         special_instructions:
-                        created_at: '2021-11-01T22:33:19.516Z'
-                        updated_at: '2021-11-01T22:33:19.595Z'
+                        created_at: '2021-11-02T17:22:16.823Z'
+                        updated_at: '2021-11-02T17:22:16.909Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6869,8 +6886,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 1
-                        created_at: '2021-11-01T22:33:21.260Z'
-                        updated_at: '2021-11-01T22:33:21.260Z'
+                        created_at: '2021-11-02T17:22:18.509Z'
+                        updated_at: '2021-11-02T17:22:18.509Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6888,8 +6905,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 2
-                        created_at: '2021-11-01T22:33:21.267Z'
-                        updated_at: '2021-11-01T22:33:21.267Z'
+                        created_at: '2021-11-02T17:22:18.516Z'
+                        updated_at: '2021-11-02T17:22:18.516Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6907,8 +6924,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T22:33:21.270Z'
-                        updated_at: '2021-11-01T22:33:21.270Z'
+                        created_at: '2021-11-02T17:22:18.523Z'
+                        updated_at: '2021-11-02T17:22:18.523Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6926,8 +6943,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-01T22:33:21.274Z'
-                        updated_at: '2021-11-01T22:33:21.274Z'
+                        created_at: '2021-11-02T17:22:18.543Z'
+                        updated_at: '2021-11-02T17:22:18.543Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -6948,8 +6965,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 5
-                        created_at: '2021-11-01T22:33:21.277Z'
-                        updated_at: '2021-11-01T22:33:21.277Z'
+                        created_at: '2021-11-02T17:22:18.548Z'
+                        updated_at: '2021-11-02T17:22:18.548Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7017,8 +7034,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T22:33:21.393Z'
-                        updated_at: '2021-11-01T22:33:21.393Z'
+                        created_at: '2021-11-02T17:22:18.737Z'
+                        updated_at: '2021-11-02T17:22:18.737Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7092,8 +7109,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-01T22:33:21.485Z'
-                        updated_at: '2021-11-01T22:33:21.485Z'
+                        created_at: '2021-11-02T17:22:18.817Z'
+                        updated_at: '2021-11-02T17:22:18.817Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7166,8 +7183,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T22:33:21.595Z'
-                        updated_at: '2021-11-01T22:33:21.606Z'
+                        created_at: '2021-11-02T17:22:18.941Z'
+                        updated_at: '2021-11-02T17:22:18.952Z'
                         deleted_at:
                         preferences:
                           dummy_key: UPDATED-DUMMY-KEY-123
@@ -7313,9 +7330,9 @@ paths:
                         state: invalid
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T22:33:21.876Z'
-                        updated_at: '2021-11-01T22:33:21.894Z'
-                        number: P50ZB38L
+                        created_at: '2021-11-02T17:22:19.220Z'
+                        updated_at: '2021-11-02T17:22:19.237Z'
+                        number: PY8B0827
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7350,9 +7367,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T22:33:21.891Z'
-                        updated_at: '2021-11-01T22:33:21.891Z'
-                        number: P9J5LL9N
+                        created_at: '2021-11-02T17:22:19.234Z'
+                        updated_at: '2021-11-02T17:22:19.234Z'
+                        number: PPFP8VVM
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7438,9 +7455,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T22:33:22.054Z'
-                        updated_at: '2021-11-01T22:33:22.054Z'
-                        number: PYLT34F2
+                        created_at: '2021-11-02T17:22:19.405Z'
+                        updated_at: '2021-11-02T17:22:19.405Z'
+                        number: PYM6CMND
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7576,8 +7593,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:33:22.257Z'
-                        updated_at: '2021-11-01T22:33:22.257Z'
+                        created_at: '2021-11-02T17:22:19.636Z'
+                        updated_at: '2021-11-02T17:22:19.636Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7586,8 +7603,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:33:22.259Z'
-                        updated_at: '2021-11-01T22:33:22.259Z'
+                        created_at: '2021-11-02T17:22:19.639Z'
+                        updated_at: '2021-11-02T17:22:19.639Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7643,8 +7660,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:33:22.307Z'
-                        updated_at: '2021-11-01T22:33:22.307Z'
+                        created_at: '2021-11-02T17:22:19.700Z'
+                        updated_at: '2021-11-02T17:22:19.700Z'
                         code: 2021-BFM
                       relationships:
                         promotions:
@@ -7704,8 +7721,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T22:33:22.347Z'
-                        updated_at: '2021-11-01T22:33:22.347Z'
+                        created_at: '2021-11-02T17:22:19.736Z'
+                        updated_at: '2021-11-02T17:22:19.736Z'
                         code: MJO
                       relationships:
                         promotions:
@@ -7766,8 +7783,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: 2021 Promotions
-                        created_at: '2021-11-01T22:33:22.398Z'
-                        updated_at: '2021-11-01T22:33:22.403Z'
+                        created_at: '2021-11-02T17:22:19.799Z'
+                        updated_at: '2021-11-02T17:22:19.805Z'
                         code: 2021-Promos
                       relationships:
                         promotions:
@@ -7895,12 +7912,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H29329252366
+                        number: H72141562269
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:33:22.524Z'
-                        updated_at: '2021-11-01T22:33:22.527Z'
+                        created_at: '2021-11-02T17:22:19.941Z'
+                        updated_at: '2021-11-02T17:22:19.944Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7942,12 +7959,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H90182038540
+                        number: H31075362039
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:33:22.554Z'
-                        updated_at: '2021-11-01T22:33:22.557Z'
+                        created_at: '2021-11-02T17:22:19.972Z'
+                        updated_at: '2021-11-02T17:22:19.975Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8042,12 +8059,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H36038632030
+                        number: H66074729305
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:33:22.856Z'
-                        updated_at: '2021-11-01T22:33:22.874Z'
+                        created_at: '2021-11-02T17:22:20.280Z'
+                        updated_at: '2021-11-02T17:22:20.298Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8181,12 +8198,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H29594339458
+                        number: H99848712394
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-01T22:33:23.757Z'
-                        updated_at: '2021-11-01T22:33:23.787Z'
+                        created_at: '2021-11-02T17:22:21.205Z'
+                        updated_at: '2021-11-02T17:22:21.235Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8285,12 +8302,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H16216325235
+                        number: H81699142849
                         cost: '100.0'
-                        shipped_at: '2021-11-01T22:33:24.190Z'
+                        shipped_at: '2021-11-02T17:22:21.676Z'
                         state: shipped
-                        created_at: '2021-11-01T22:33:24.155Z'
-                        updated_at: '2021-11-01T22:33:24.190Z'
+                        created_at: '2021-11-02T17:22:21.642Z'
+                        updated_at: '2021-11-02T17:22:21.676Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8389,12 +8406,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H12447800246
+                        number: H66644451587
                         cost: '100.0'
                         shipped_at:
                         state: canceled
-                        created_at: '2021-11-01T22:33:24.571Z'
-                        updated_at: '2021-11-01T22:33:24.597Z'
+                        created_at: '2021-11-02T17:22:22.076Z'
+                        updated_at: '2021-11-02T17:22:22.107Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8493,12 +8510,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H88035404602
+                        number: H17668291910
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-01T22:33:24.992Z'
-                        updated_at: '2021-11-01T22:33:25.019Z'
+                        created_at: '2021-11-02T17:22:22.518Z'
+                        updated_at: '2021-11-02T17:22:22.545Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8597,12 +8614,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H91133774144
+                        number: H85756334291
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T22:33:25.404Z'
-                        updated_at: '2021-11-01T22:33:25.429Z'
+                        created_at: '2021-11-02T17:22:22.961Z'
+                        updated_at: '2021-11-02T17:22:22.989Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8705,14 +8722,14 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #116'
-                        created_at: '2021-11-01T22:33:25.731Z'
-                        updated_at: '2021-11-01T22:33:25.731Z'
+                        created_at: '2021-11-02T17:22:23.312Z'
+                        updated_at: '2021-11-02T17:22:23.312Z'
                     - id: '117'
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #117'
-                        created_at: '2021-11-01T22:33:25.732Z'
-                        updated_at: '2021-11-01T22:33:25.732Z'
+                        created_at: '2021-11-02T17:22:23.314Z'
+                        updated_at: '2021-11-02T17:22:23.314Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -8757,8 +8774,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #120'
-                        created_at: '2021-11-01T22:33:25.780Z'
-                        updated_at: '2021-11-01T22:33:25.780Z'
+                        created_at: '2021-11-02T17:22:23.368Z'
+                        updated_at: '2021-11-02T17:22:23.368Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8807,8 +8824,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #121'
-                        created_at: '2021-11-01T22:33:25.814Z'
-                        updated_at: '2021-11-01T22:33:25.814Z'
+                        created_at: '2021-11-02T17:22:23.405Z'
+                        updated_at: '2021-11-02T17:22:23.405Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -8858,8 +8875,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: Default
-                        created_at: '2021-11-01T22:33:25.872Z'
-                        updated_at: '2021-11-01T22:33:25.879Z'
+                        created_at: '2021-11-02T17:22:23.467Z'
+                        updated_at: '2021-11-02T17:22:23.474Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8993,8 +9010,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:33:26.005Z'
-                        updated_at: '2021-11-01T22:33:26.005Z'
+                        created_at: '2021-11-02T17:22:23.607Z'
+                        updated_at: '2021-11-02T17:22:23.607Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9017,8 +9034,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:33:26.014Z'
-                        updated_at: '2021-11-01T22:33:26.014Z'
+                        created_at: '2021-11-02T17:22:23.616Z'
+                        updated_at: '2021-11-02T17:22:23.616Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9088,8 +9105,8 @@ paths:
                         admin_name: DHL Express- Zone A
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:33:26.091Z'
-                        updated_at: '2021-11-01T22:33:26.091Z'
+                        created_at: '2021-11-02T17:22:23.697Z'
+                        updated_at: '2021-11-02T17:22:23.697Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9173,8 +9190,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:33:26.140Z'
-                        updated_at: '2021-11-01T22:33:26.140Z'
+                        created_at: '2021-11-02T17:22:23.750Z'
+                        updated_at: '2021-11-02T17:22:23.750Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9249,8 +9266,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T22:33:26.219Z'
-                        updated_at: '2021-11-01T22:33:26.234Z'
+                        created_at: '2021-11-02T17:22:23.832Z'
+                        updated_at: '2021-11-02T17:22:23.850Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9399,8 +9416,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:33:26.473Z'
-                        updated_at: '2021-11-01T22:33:26.477Z'
+                        created_at: '2021-11-02T17:22:24.115Z'
+                        updated_at: '2021-11-02T17:22:24.118Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9434,8 +9451,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-11-01T22:33:26.536Z'
-                        updated_at: '2021-11-01T22:33:26.539Z'
+                        created_at: '2021-11-02T17:22:24.181Z'
+                        updated_at: '2021-11-02T17:22:24.185Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9469,8 +9486,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-11-01T22:33:26.408Z'
-                        updated_at: '2021-11-01T22:33:26.554Z'
+                        created_at: '2021-11-02T17:22:24.031Z'
+                        updated_at: '2021-11-02T17:22:24.195Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9551,8 +9568,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:33:26.797Z'
-                        updated_at: '2021-11-01T22:33:26.802Z'
+                        created_at: '2021-11-02T17:22:24.450Z'
+                        updated_at: '2021-11-02T17:22:24.455Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9637,8 +9654,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:33:26.916Z'
-                        updated_at: '2021-11-01T22:33:26.920Z'
+                        created_at: '2021-11-02T17:22:24.574Z'
+                        updated_at: '2021-11-02T17:22:24.578Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9726,8 +9743,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T22:33:27.151Z'
-                        updated_at: '2021-11-01T22:33:27.178Z'
+                        created_at: '2021-11-02T17:22:24.815Z'
+                        updated_at: '2021-11-02T17:22:24.839Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9880,9 +9897,9 @@ paths:
                     - id: '97'
                       type: user
                       attributes:
-                        email: kennith@vandervort.biz
-                        created_at: '2021-11-01T22:33:27.698Z'
-                        updated_at: '2021-11-01T22:33:27.698Z'
+                        email: larae_hills@carter.info
+                        created_at: '2021-11-02T17:22:25.343Z'
+                        updated_at: '2021-11-02T17:22:25.343Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9894,9 +9911,9 @@ paths:
                     - id: '98'
                       type: user
                       attributes:
-                        email: margaretta.fritsch@bartellratke.co.uk
-                        created_at: '2021-11-01T22:33:27.704Z'
-                        updated_at: '2021-11-01T22:33:27.704Z'
+                        email: merle@zboncak.com
+                        created_at: '2021-11-02T17:22:25.348Z'
+                        updated_at: '2021-11-02T17:22:25.348Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9908,9 +9925,9 @@ paths:
                     - id: '99'
                       type: user
                       attributes:
-                        email: gabriela@brakusharber.name
-                        created_at: '2021-11-01T22:33:27.705Z'
-                        updated_at: '2021-11-01T22:33:27.705Z'
+                        email: syble.larson@smith.co.uk
+                        created_at: '2021-11-02T17:22:25.349Z'
+                        updated_at: '2021-11-02T17:22:25.349Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9969,9 +9986,9 @@ paths:
                       id: '104'
                       type: user
                       attributes:
-                        email: kimi@heller.name
-                        created_at: '2021-11-01T22:33:27.776Z'
-                        updated_at: '2021-11-01T22:33:27.776Z'
+                        email: mitsuko.feeney@schultz.biz
+                        created_at: '2021-11-02T17:22:25.510Z'
+                        updated_at: '2021-11-02T17:22:25.510Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10034,9 +10051,9 @@ paths:
                       id: '107'
                       type: user
                       attributes:
-                        email: carli@hickle.biz
-                        created_at: '2021-11-01T22:33:27.832Z'
-                        updated_at: '2021-11-01T22:33:27.832Z'
+                        email: benjamin@champlin.com
+                        created_at: '2021-11-02T17:22:25.563Z'
+                        updated_at: '2021-11-02T17:22:25.563Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10101,8 +10118,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-11-01T22:33:27.906Z'
-                        updated_at: '2021-11-01T22:33:27.915Z'
+                        created_at: '2021-11-02T17:22:25.642Z'
+                        updated_at: '2021-11-02T17:22:25.651Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10249,12 +10266,12 @@ paths:
                         position: 1
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:33:28.141Z'
+                        updated_at: '2021-11-02T17:22:25.881Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:33:28.132Z'
+                        created_at: '2021-11-02T17:22:25.876Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 5250'
+                        name: 'Product #181 - 6628'
                         options_text: ''
                         total_on_hand: 0
                         purchasable: true
@@ -10289,21 +10306,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-249
-                        weight: '3.97'
-                        height: '52.83'
-                        depth: '77.14'
+                        weight: '17.6'
+                        height: '73.1'
+                        depth: '56.12'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:33:28.259Z'
+                        updated_at: '2021-11-02T17:22:25.910Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:33:28.252Z'
+                        created_at: '2021-11-02T17:22:25.904Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 5250'
+                        name: 'Product #181 - 6628'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10340,21 +10357,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-250
-                        weight: '114.34'
-                        height: '150.68'
-                        depth: '72.47'
+                        weight: '197.16'
+                        height: '109.8'
+                        depth: '63.49'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 3
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:33:28.278Z'
+                        updated_at: '2021-11-02T17:22:25.929Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:33:28.272Z'
+                        created_at: '2021-11-02T17:22:25.923Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 5250'
+                        name: 'Product #181 - 6628'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10444,21 +10461,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-255
-                        weight: '118.52'
-                        height: '5.77'
-                        depth: '111.78'
+                        weight: '138.2'
+                        height: '195.68'
+                        depth: '131.79'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T22:33:28.488Z'
+                        updated_at: '2021-11-02T17:22:26.144Z'
                         discontinue_on:
-                        created_at: '2021-11-01T22:33:28.482Z'
+                        created_at: '2021-11-02T17:22:26.139Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #183 - 4184'
+                        name: 'Product #183 - 9161'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10619,14 +10636,14 @@ paths:
                     - id: '1'
                       type: event
                       attributes:
-                        execution_time: 642
+                        execution_time: 2137
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url1.com/
-                        created_at: '2021-11-01T22:33:28.843Z'
-                        updated_at: '2021-11-01T22:33:28.843Z'
+                        created_at: '2021-11-02T17:22:26.502Z'
+                        updated_at: '2021-11-02T17:22:26.502Z'
                       relationships:
                         subscriber:
                           data:
@@ -10635,14 +10652,14 @@ paths:
                     - id: '2'
                       type: event
                       attributes:
-                        execution_time: 65951
+                        execution_time: 24902
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url2.com/
-                        created_at: '2021-11-01T22:33:28.846Z'
-                        updated_at: '2021-11-01T22:33:28.846Z'
+                        created_at: '2021-11-02T17:22:26.506Z'
+                        updated_at: '2021-11-02T17:22:26.506Z'
                       relationships:
                         subscriber:
                           data:
@@ -10718,8 +10735,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:33:28.897Z'
-                        updated_at: '2021-11-01T22:33:28.897Z'
+                        created_at: '2021-11-02T17:22:26.557Z'
+                        updated_at: '2021-11-02T17:22:26.557Z'
                     - id: '6'
                       type: subscriber
                       attributes:
@@ -10727,8 +10744,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:33:28.898Z'
-                        updated_at: '2021-11-01T22:33:28.898Z'
+                        created_at: '2021-11-02T17:22:26.558Z'
+                        updated_at: '2021-11-02T17:22:26.558Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -10776,8 +10793,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:33:28.952Z'
-                        updated_at: '2021-11-01T22:33:28.952Z'
+                        created_at: '2021-11-02T17:22:26.614Z'
+                        updated_at: '2021-11-02T17:22:26.614Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10832,8 +10849,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:33:28.985Z'
-                        updated_at: '2021-11-01T22:33:28.985Z'
+                        created_at: '2021-11-02T17:22:26.650Z'
+                        updated_at: '2021-11-02T17:22:26.650Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -10886,8 +10903,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T22:33:29.038Z'
-                        updated_at: '2021-11-01T22:33:29.038Z'
+                        created_at: '2021-11-02T17:22:26.793Z'
+                        updated_at: '2021-11-02T17:22:26.793Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -11008,10 +11025,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:33:29.278Z'
-                        updated_at: '2021-11-01T22:33:29.278Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:27.054Z'
+                        updated_at: '2021-11-02T17:22:27.054Z'
                         display_total: "$19.99"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11023,10 +11040,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:33:29.323Z'
-                        updated_at: '2021-11-01T22:33:29.323Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:27.109Z'
+                        updated_at: '2021-11-02T17:22:27.109Z'
                         display_total: "$19.99"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11038,10 +11055,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:33:29.370Z'
-                        updated_at: '2021-11-01T22:33:29.370Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:27.156Z'
+                        updated_at: '2021-11-02T17:22:27.156Z'
                         display_total: "$19.99"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11053,10 +11070,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:33:29.416Z'
-                        updated_at: '2021-11-01T22:33:29.416Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:27.203Z'
+                        updated_at: '2021-11-02T17:22:27.203Z'
                         display_total: "$19.99"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11115,10 +11132,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:33:29.886Z'
-                        updated_at: '2021-11-01T22:33:29.886Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:27.678Z'
+                        updated_at: '2021-11-02T17:22:27.678Z'
                         display_total: "$19.99"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11186,10 +11203,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T22:33:30.101Z'
-                        updated_at: '2021-11-01T22:33:30.101Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:27.894Z'
+                        updated_at: '2021-11-02T17:22:27.894Z'
                         display_total: "$19.99"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11253,10 +11270,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-11-01T22:33:30.437Z'
-                        updated_at: '2021-11-01T22:33:30.444Z'
-                        display_price: "$19.99"
+                        created_at: '2021-11-02T17:22:28.243Z'
+                        updated_at: '2021-11-02T17:22:28.252Z'
                         display_total: "$59.97"
+                        display_price: "$19.99"
                         price: '19.99'
                         total: '59.97'
                       relationships:
@@ -11389,9 +11406,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:33:31.092Z'
-                        updated_at: '2021-11-01T22:33:31.092Z'
-                        token: 4HS8sxBRsw8AZ1Mk2c1UPzAY
+                        created_at: '2021-11-02T17:22:28.948Z'
+                        updated_at: '2021-11-02T17:22:28.948Z'
+                        token: AryJsm8XQMh1dDQYDVBU5uuN
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11406,9 +11423,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:33:31.094Z'
-                        updated_at: '2021-11-01T22:33:31.094Z'
-                        token: kboEiS3tUUMyo4zMEPmYNqWk
+                        created_at: '2021-11-02T17:22:28.950Z'
+                        updated_at: '2021-11-02T17:22:28.950Z'
+                        token: TaVeBbDxLTHkdM1nL4hQzRoJ
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11470,9 +11487,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:33:31.547Z'
-                        updated_at: '2021-11-01T22:33:31.547Z'
-                        token: NYqB7eeKhegf6DvcxpZwNW4T
+                        created_at: '2021-11-02T17:22:29.428Z'
+                        updated_at: '2021-11-02T17:22:29.428Z'
+                        token: R7va77cQwcMa6bXvXemmdTvW
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11536,9 +11553,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:33:31.584Z'
-                        updated_at: '2021-11-01T22:33:31.584Z'
-                        token: LXr4XHKWqSVZU1cEEPjB9e1q
+                        created_at: '2021-11-02T17:22:29.474Z'
+                        updated_at: '2021-11-02T17:22:29.474Z'
+                        token: rHXKd1RVXpFPQnF267pZY4b8
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11601,9 +11618,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T22:33:31.644Z'
-                        updated_at: '2021-11-01T22:33:31.652Z'
-                        token: ZLniiySuNbbncAzvcQKoRsGj
+                        created_at: '2021-11-02T17:22:29.541Z'
+                        updated_at: '2021-11-02T17:22:29.549Z'
+                        token: g7VkRHLgaYjyf79xudnQQMd9
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11967,6 +11984,7 @@ components:
           required:
           - title
           - locale
+          - type
           properties:
             title:
               type: string
@@ -12000,8 +12018,8 @@ components:
             visible:
               type: boolean
               enum:
-              - 'true'
-              - 'false'
+              - true
+              - false
               description: This page is publicly visible when set to `true`.
             slug:
               type: string
@@ -12024,6 +12042,7 @@ components:
           required:
           - title
           - locale
+          - type
           properties:
             title:
               type: string
@@ -12051,8 +12070,8 @@ components:
             visible:
               type: boolean
               enum:
-              - 'true'
-              - 'false'
+              - true
+              - false
               description: This page is publicly visible when set to `true`.
             locale:
               type: string
@@ -12070,6 +12089,7 @@ components:
           required:
           - title
           - locale
+          - type
           properties:
             title:
               type: string
@@ -12098,8 +12118,8 @@ components:
             visible:
               type: boolean
               enum:
-              - 'true'
-              - 'false'
+              - true
+              - false
               description: This page is publicly visible when set to `true`.
             slug:
               type: string
@@ -12152,8 +12172,8 @@ components:
             visible:
               type: boolean
               enum:
-              - 'true'
-              - 'false'
+              - true
+              - false
               description: This page is publicly visible when set to `true`.
             slug:
               type: string
@@ -12166,7 +12186,7 @@ components:
               description: The language this page is written in.
       required:
       - cms_page
-      title: Create a Standard Page
+      title: Update a Standard Page
       x-internal: true
     update_homepage_cms_page_params:
       type: object
@@ -12200,8 +12220,8 @@ components:
             visible:
               type: boolean
               enum:
-              - 'true'
-              - 'false'
+              - true
+              - false
               description: This page is publicly visible when set to `true`.
             locale:
               type: string
@@ -12209,7 +12229,7 @@ components:
               description: The language this page is written in.
       required:
       - cms_page
-      title: Create a Homepage
+      title: Update a Homepage
       x-internal: true
     update_feature_cms_page_params:
       type: object
@@ -12244,8 +12264,8 @@ components:
             visible:
               type: boolean
               enum:
-              - 'true'
-              - 'false'
+              - true
+              - false
               description: This page is publicly visible when set to `true`.
             slug:
               type: string
@@ -12258,9 +12278,9 @@ components:
               description: The language this page is written in.
       required:
       - cms_page
-      title: Create a Feature Page
+      title: Update a Feature Page
       x-internal: true
-    create_cms_section_params:
+    create_hero_image_cms_section_params:
       type: object
       properties:
         cms_section:
@@ -12268,37 +12288,435 @@ components:
           required:
           - name
           - cms_page_id
+          - type
           properties:
             name:
               type: string
+              description: Give this section a name.
             cms_page_id:
               type: string
-            destination:
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
               type: string
-              example: https://getvendo.com
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              example: Spree::Cms::Sections::HeroImage
+              description: Set the section type.
             linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Set the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the resource that you would like this section
+                to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Set the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Create a title for the Hero Section.
+      required:
+      - cms_section
+      title: Create a Hero Image Section
+      x-internal: true
+    create_product_carousel_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::ProductCarousel
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the Taxon that you would like displayed as
+                a Product Carousel.
+      required:
+      - cms_section
+      title: Create a Product Carousel Section
+      x-internal: true
+    create_side_by_side_images_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::SideBySideImages
+              example: Spree::Cms::Sections::SideBySideImages
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            link_type_one:
               type: string
               example: Spree::Taxon
               enum:
               - Spree::Taxon
               - Spree::Product
-              - Spree::CmsPage
+              description: Set the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image two links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Set the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Set the slug or path that image two links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Set the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Set the title used in image two.
             fit:
               type: string
               example: Screen
-              description: This value is used by front end developers to manipulate
-                CSS values to fit the section into the Screen or within the Container
-                element.
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            subtitle_one:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Set the subtitle used in image one.
+            subtitle_two:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Set the subtitle used in image two.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+      required:
+      - cms_section
+      title: Create a Side-by-Side Image Section
+      x-internal: true
+    create_image_gallery_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::ImageGallery
+              example: Spree::Cms::Sections::ImageGallery
+              description: Set the section type.
             position:
               type: integer
               example: 2
-              description: 'Pass the new position that you want this section to appear
+              description: 'Pass the position that you want this section to appear
                 in. (The list is not zero indexed, so the first item is position:
-                1)'
+                `1`)'
+            link_type_one:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image two links to.
+            link_type_three:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Set the resource type that image three links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Set the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Set the slug or path that image two links to.
+            link_three:
+              type: string
+              example: red-shirt
+              nullable: true
+              description: Set the slug or path that image three links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Set the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Set the title used in image two.
+            title_three:
+              type: string
+              example: Buy This Women's Skirt
+              nullable: true
+              description: Set the title used in image three.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            layout_style:
+              type: string
+              example: Default
+              enum:
+              - Default
+              - Reversed
+              description: This value is used by front end developers for styling
+                the order the images appear.
+            display_labels:
+              type: string
+              example: Show
+              enum:
+              - Show
+              - Hide
+              description: This value is used by front end developers for showing
+                and hiding the label on the images.
       required:
       - cms_section
+      title: Create an Image Gallery Section
       x-internal: true
-    update_cms_section_params:
+    create_featured_article_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::FeaturedArticle
+              example: Spree::Cms::Sections::FeaturedArticle
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Set the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the resource that you would like this section
+                to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Set the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Create a title for the Section.
+            subtitle:
+              type: string
+              example: Save Big!
+              description: Create a subtitle for the Section.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Set the content, here, this can be rich text editor content.
+      required:
+      - cms_section
+      title: Create a Featured Article Section
+      x-internal: true
+    create_rich_text_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          required:
+          - name
+          - cms_page_id
+          - type
+          properties:
+            name:
+              type: string
+              description: Give this section a name.
+            cms_page_id:
+              type: string
+              description: Set the `cms_page` ID that this section belongs to.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::RichTextContent
+              description: Set the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Set the content, here, this can be rich text editor content.
+      required:
+      - cms_section
+      title: Create a Rich Text Section
+      x-internal: true
+    update_hero_image_cms_section_params:
       type: object
       properties:
         cms_section:
@@ -12306,32 +12724,392 @@ components:
           properties:
             name:
               type: string
-            cms_page_id:
+              description: Update this section name.
+            type:
               type: string
-            destination:
-              type: string
-              example: https://getvendo.com
+              enum:
+              - Spree::Cms::Sections::HeroImage
+              example: Spree::Cms::Sections::HeroImage
+              description: Change the section type.
             linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Update the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Set the ID of the resource that you would like this section
+                to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Update the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Update the title for this section.
+      required:
+      - cms_section
+      title: Update a Hero Image Section
+      x-internal: true
+    update_product_carousel_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Change this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::ProductCarousel
+              example: Spree::Cms::Sections::ProductCarousel
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Update the ID of the Taxon that you would like displayed
+                as a Product Carousel.
+      required:
+      - cms_section
+      title: Update a Product Carousel Section
+      x-internal: true
+    update_side_by_side_images_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::SideBySideImages
+              example: Spree::Cms::Sections::SideBySideImages
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            link_type_one:
               type: string
               example: Spree::Taxon
               enum:
               - Spree::Taxon
               - Spree::Product
-              - Spree::CmsPage
+              description: Update the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image two links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Update the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Update the slug or path that image two links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Update the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Update the title used in image two.
             fit:
               type: string
               example: Screen
-              description: This value is used by front end developers to manipulate
-                CSS values to fit the section into the Screen or within the Container
-                element.
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            subtitle_one:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Update the subtitle used in image one.
+            subtitle_two:
+              type: string
+              example: Save 50% today
+              nullable: true
+              description: Update the subtitle used in image two.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+      required:
+      - cms_section
+      title: Update a Side-by-Side Image Section
+      x-internal: true
+    update_image_gallery_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::ImageGallery
+              example: Spree::Cms::Sections::ImageGallery
+              description: Change the section type.
             position:
               type: integer
               example: 2
-              description: 'Pass the new position that you want this section to appear
+              description: 'Pass the position that you want this section to appear
                 in. (The list is not zero indexed, so the first item is position:
-                1)'
+                `1`)'
+            link_type_one:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image one links to.
+            link_type_two:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image two links to.
+            link_type_three:
+              type: string
+              example: Spree::Taxon
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              description: Update the resource type that image three links to.
+            link_one:
+              type: string
+              example: men/shirts
+              nullable: true
+              description: Update the slug or path that image two links to.
+            link_two:
+              type: string
+              example: white-shirt
+              nullable: true
+              description: Update the slug or path that image two links to.
+            link_three:
+              type: string
+              example: red-shirt
+              nullable: true
+              description: Update the slug or path that image three links to.
+            title_one:
+              type: string
+              example: Shop Men's Shirts
+              nullable: true
+              description: Update the title used in image one.
+            title_two:
+              type: string
+              example: Buy This Men's Shirt
+              nullable: true
+              description: Update the title used in image two.
+            title_three:
+              type: string
+              example: Buy This Women's Skirt
+              nullable: true
+              description: Update the title used in image three.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            layout_style:
+              type: string
+              example: Default
+              enum:
+              - Default
+              - Reversed
+              description: This value is used by front end developers for styling
+                the order the images appear.
+            display_labels:
+              type: string
+              example: Show
+              enum:
+              - Show
+              - Hide
+              description: This value is used by front end developers for showing
+                and hiding the label on the images.
       required:
       - cms_section
+      title: Update an Image Gallery Section
+      x-internal: true
+    update_featured_article_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::FeaturedArticle
+              example: Spree::Cms::Sections::FeaturedArticle
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            linked_resource_type:
+              type: string
+              example: Spree::Taxon
+              nullable: true
+              enum:
+              - Spree::Taxon
+              - Spree::Product
+              - Spree::CmsPage
+              description: Set the resource type that this section links to.
+            linked_resource_id:
+              type: string
+              example: '1'
+              nullable: true
+              description: Change the ID of the resource that you would like this
+                section to link to.
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            gutters:
+              type: string
+              example: No Gutters
+              enum:
+              - Gutters
+              - No Gutters
+              description: This value is used by front end developers for styling
+                the section padding.
+            button_text:
+              type: string
+              example: Click Here
+              description: Update the text value of the button used in this section.
+            title:
+              type: string
+              example: Shop Today
+              description: Update the title for the Section.
+            subtitle:
+              type: string
+              example: Save Big!
+              description: Update the subtitle for the Section.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Update the content here, this can be rich text editor content.
+      required:
+      - cms_section
+      title: Update a Featured Article Section
+      x-internal: true
+    update_rich_text_cms_section_params:
+      type: object
+      properties:
+        cms_section:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Update this section name.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Sections::RichTextContent
+              example: Spree::Cms::Sections::RichTextContent
+              description: Change the section type.
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this section to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            fit:
+              type: string
+              example: Screen
+              enum:
+              - Screen
+              - Container
+              description: This value is used by front end developers to set CSS classes
+                for content that fits the screen edge-to-edge, or stays within the
+                boundaries of the central container.
+            rte_content:
+              type: string
+              example: Lots of text and content goes here.
+              description: Update the content, here, this can be rich text editor
+                content.
+      required:
+      - cms_section
+      title: Update a Rich Text Section
       x-internal: true
     create_digital_params:
       type: object
@@ -12635,7 +13413,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:32:55 UTC
+              example: 2021-11-02 17:21:52 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12703,7 +13481,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:32:55 UTC
+              example: 2021-11-02 17:21:52 UTC
             confirmation_delivered:
               type: boolean
               example: true
@@ -12770,7 +13548,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:32:55 UTC
+              example: 2021-11-02 17:21:52 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12838,7 +13616,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-01 22:32:55 UTC
+              example: 2021-11-02 17:21:52 UTC
             confirmation_delivered:
               type: boolean
               example: true

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -70,8 +70,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T16:15:03.922Z'
-                        updated_at: '2021-11-01T16:15:03.922Z'
+                        created_at: '2021-11-01T22:32:56.262Z'
+                        updated_at: '2021-11-01T22:32:56.262Z'
                         deleted_at:
                         label:
                       relationships:
@@ -98,8 +98,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T16:15:03.926Z'
-                        updated_at: '2021-11-01T16:15:03.926Z'
+                        created_at: '2021-11-01T22:32:56.268Z'
+                        updated_at: '2021-11-01T22:32:56.268Z'
                         deleted_at:
                         label:
                       relationships:
@@ -173,8 +173,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T16:15:04.134Z'
-                        updated_at: '2021-11-01T16:15:04.134Z'
+                        created_at: '2021-11-01T22:32:56.495Z'
+                        updated_at: '2021-11-01T22:32:56.495Z'
                         deleted_at:
                         label:
                       relationships:
@@ -268,8 +268,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T16:15:04.177Z'
-                        updated_at: '2021-11-01T16:15:04.177Z'
+                        created_at: '2021-11-01T22:32:56.532Z'
+                        updated_at: '2021-11-01T22:32:56.532Z'
                         deleted_at:
                         label:
                       relationships:
@@ -348,8 +348,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-01T16:15:04.235Z'
-                        updated_at: '2021-11-01T16:15:04.243Z'
+                        created_at: '2021-11-01T22:32:56.594Z'
+                        updated_at: '2021-11-01T22:32:56.601Z'
                         deleted_at:
                         label:
                       relationships:
@@ -493,8 +493,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T16:15:04.480Z'
-                        updated_at: '2021-11-01T16:15:04.480Z'
+                        created_at: '2021-11-01T22:32:56.811Z'
+                        updated_at: '2021-11-01T22:32:56.811Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -520,8 +520,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T16:15:04.502Z'
-                        updated_at: '2021-11-01T16:15:04.502Z'
+                        created_at: '2021-11-01T22:32:56.830Z'
+                        updated_at: '2021-11-01T22:32:56.830Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -594,8 +594,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T16:15:04.838Z'
-                        updated_at: '2021-11-01T16:15:04.838Z'
+                        created_at: '2021-11-01T22:32:57.128Z'
+                        updated_at: '2021-11-01T22:32:57.128Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -677,8 +677,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T16:15:04.951Z'
-                        updated_at: '2021-11-01T16:15:04.956Z'
+                        created_at: '2021-11-01T22:32:57.237Z'
+                        updated_at: '2021-11-01T22:32:57.241Z'
                         state: open
                         included: false
                         display_amount: "$1.00"
@@ -756,8 +756,8 @@ paths:
                         label: New label
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-01T16:15:05.142Z'
-                        updated_at: '2021-11-01T16:15:05.155Z'
+                        created_at: '2021-11-01T22:32:57.419Z'
+                        updated_at: '2021-11-01T22:32:57.431Z'
                         state: open
                         included: false
                         display_amount: "$15.00"
@@ -897,8 +897,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T16:15:05.678Z'
-                        updated_at: '2021-11-01T16:15:05.678Z'
+                        created_at: '2021-11-01T22:32:57.894Z'
+                        updated_at: '2021-11-01T22:32:57.894Z'
                       relationships:
                         product:
                           data:
@@ -912,8 +912,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T16:15:05.758Z'
-                        updated_at: '2021-11-01T16:15:05.758Z'
+                        created_at: '2021-11-01T22:32:57.968Z'
+                        updated_at: '2021-11-01T22:32:57.968Z'
                       relationships:
                         product:
                           data:
@@ -974,8 +974,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T16:15:06.218Z'
-                        updated_at: '2021-11-01T16:15:06.218Z'
+                        created_at: '2021-11-01T22:32:58.392Z'
+                        updated_at: '2021-11-01T22:32:58.392Z'
                       relationships:
                         product:
                           data:
@@ -1042,8 +1042,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T16:15:06.387Z'
-                        updated_at: '2021-11-01T16:15:06.387Z'
+                        created_at: '2021-11-01T22:32:58.552Z'
+                        updated_at: '2021-11-01T22:32:58.552Z'
                       relationships:
                         product:
                           data:
@@ -1109,8 +1109,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-01T16:15:06.675Z'
-                        updated_at: '2021-11-01T16:15:06.675Z'
+                        created_at: '2021-11-01T22:32:58.850Z'
+                        updated_at: '2021-11-01T22:32:58.850Z'
                       relationships:
                         product:
                           data:
@@ -1232,8 +1232,8 @@ paths:
                       type: classification
                       attributes:
                         position: 2
-                        created_at: '2021-11-01T16:15:07.436Z'
-                        updated_at: '2021-11-01T16:15:07.460Z'
+                        created_at: '2021-11-01T22:32:59.575Z'
+                        updated_at: '2021-11-01T22:32:59.597Z'
                       relationships:
                         product:
                           data:
@@ -1332,35 +1332,34 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Sequi ipsa ipsum perferendis suscipit.
+                        title: Voluptas vel officiis impedit natus similique quo.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: sequi-ipsa-ipsum-perferendis-suscipit
+                        slug: voluptas-vel-officiis-impedit-natus-similique-quo
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T16:15:07.808Z'
-                        updated_at: '2021-11-01T16:15:07.808Z'
+                        created_at: '2021-11-01T22:32:59.930Z'
+                        updated_at: '2021-11-01T22:32:59.930Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Ab labore corrupti at laboriosam officiis laborum provident
-                          veritatis.
+                        title: Pariatur ipsum aspernatur in alias.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: ab-labore-corrupti-at-laboriosam-officiis-laborum-provident-veritatis
+                        slug: pariatur-ipsum-aspernatur-in-alias
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T16:15:07.812Z'
-                        updated_at: '2021-11-01T16:15:07.812Z'
+                        created_at: '2021-11-01T22:32:59.934Z'
+                        updated_at: '2021-11-01T22:32:59.934Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1414,17 +1413,17 @@ paths:
                       id: '5'
                       type: cms_page
                       attributes:
-                        title: Id eveniet sit deleniti facilis possimus error.
+                        title: Repellat tempora iusto quisquam animi et quos.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: id-eveniet-sit-deleniti-facilis-possimus-error
+                        slug: repellat-tempora-iusto-quisquam-animi-et-quos
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T16:15:07.890Z'
-                        updated_at: '2021-11-01T16:15:07.890Z'
+                        created_at: '2021-11-01T22:33:00.014Z'
+                        updated_at: '2021-11-01T22:33:00.014Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1449,7 +1448,10 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/create_cms_page_params"
+              oneOf:
+              - "$ref": "#/components/schemas/create_standard_cms_page_params"
+              - "$ref": "#/components/schemas/create_homepage_cms_page_params"
+              - "$ref": "#/components/schemas/create_feature_cms_page_params"
   "/api/v2/platform/cms_pages/{id}":
     get:
       summary: Return a CMS Page
@@ -1484,17 +1486,18 @@ paths:
                       id: '6'
                       type: cms_page
                       attributes:
-                        title: Tempore dolores accusamus velit harum.
+                        title: Maxime quis similique laudantium enim necessitatibus
+                          odio nostrum quam.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: tempore-dolores-accusamus-velit-harum
+                        slug: maxime-quis-similique-laudantium-enim-necessitatibus-odio-nostrum-quam
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T16:15:07.928Z'
-                        updated_at: '2021-11-01T16:15:07.928Z'
+                        created_at: '2021-11-01T22:33:00.051Z'
+                        updated_at: '2021-11-01T22:33:00.051Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1558,12 +1561,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: optio-illum-veniam-unde-repellendus-tenetur-vitae-harum-totam
+                        slug: occaecati-est-officiis-ratione-minus-labore-commodi
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-01T16:15:07.993Z'
-                        updated_at: '2021-11-01T16:15:08.002Z'
+                        created_at: '2021-11-01T22:33:00.108Z'
+                        updated_at: '2021-11-01T22:33:00.117Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1606,7 +1609,10 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/update_cms_page_params"
+              oneOf:
+              - "$ref": "#/components/schemas/update_standard_cms_page_params"
+              - "$ref": "#/components/schemas/update_homepage_cms_page_params"
+              - "$ref": "#/components/schemas/update_feature_cms_page_params"
     delete:
       summary: Delete a CMS Page
       tags:
@@ -1689,7 +1695,7 @@ paths:
                     - id: '1'
                       type: cms_section
                       attributes:
-                        name: Necessitatibus iste in fugit cumque.
+                        name: Similique tempora in veniam odit culpa pariatur.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1698,8 +1704,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-01T16:15:08.165Z'
-                        updated_at: '2021-11-01T16:15:08.165Z'
+                        created_at: '2021-11-01T22:33:00.284Z'
+                        updated_at: '2021-11-01T22:33:00.284Z'
                       relationships:
                         cms_page:
                           data:
@@ -1710,7 +1716,8 @@ paths:
                     - id: '2'
                       type: cms_section
                       attributes:
-                        name: Quibusdam nihil nesciunt maxime accusantium vitae.
+                        name: Molestiae minima natus autem consectetur accusantium
+                          cupiditate alias.
                         content:
                           link_type_one: Spree::Taxon
                           link_type_two: Spree::Taxon
@@ -1722,8 +1729,8 @@ paths:
                         type: Spree::Cms::Sections::ImageGallery
                         position: 2
                         linked_resource_type:
-                        created_at: '2021-11-01T16:15:08.168Z'
-                        updated_at: '2021-11-01T16:15:08.168Z'
+                        created_at: '2021-11-01T22:33:00.288Z'
+                        updated_at: '2021-11-01T22:33:00.288Z'
                       relationships:
                         cms_page:
                           data:
@@ -1734,7 +1741,7 @@ paths:
                     - id: '3'
                       type: cms_section
                       attributes:
-                        name: Ab soluta laboriosam qui repudiandae voluptas neque.
+                        name: Sit nisi voluptates distinctio recusandae.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1743,8 +1750,8 @@ paths:
                         type: Spree::Cms::Sections::FeaturedArticle
                         position: 3
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-01T16:15:08.176Z'
-                        updated_at: '2021-11-01T16:15:08.176Z'
+                        created_at: '2021-11-01T22:33:00.295Z'
+                        updated_at: '2021-11-01T22:33:00.295Z'
                       relationships:
                         cms_page:
                           data:
@@ -1755,8 +1762,8 @@ paths:
                     - id: '4'
                       type: cms_section
                       attributes:
-                        name: Assumenda aperiam veniam enim minima sed magni sunt
-                          similique.
+                        name: Minima vel magnam dolor neque architecto numquam voluptatibus
+                          aliquam.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1765,8 +1772,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T16:15:08.184Z'
-                        updated_at: '2021-11-01T16:15:08.184Z'
+                        created_at: '2021-11-01T22:33:00.302Z'
+                        updated_at: '2021-11-01T22:33:00.302Z'
                       relationships:
                         cms_page:
                           data:
@@ -1779,7 +1786,7 @@ paths:
                     - id: '5'
                       type: cms_section
                       attributes:
-                        name: Exercitationem placeat ducimus cumque ipsa eius cum.
+                        name: Eveniet quidem nemo provident vitae.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1788,8 +1795,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 5
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T16:15:08.191Z'
-                        updated_at: '2021-11-01T16:15:08.191Z'
+                        created_at: '2021-11-01T22:33:00.309Z'
+                        updated_at: '2021-11-01T22:33:00.309Z'
                       relationships:
                         cms_page:
                           data:
@@ -1849,7 +1856,7 @@ paths:
                       id: '14'
                       type: cms_section
                       attributes:
-                        name: Itaque soluta exercitationem id minus dolore ab.
+                        name: Non blanditiis accusantium quae nesciunt sed et.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1858,8 +1865,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T16:15:08.343Z'
-                        updated_at: '2021-11-01T16:15:08.343Z'
+                        created_at: '2021-11-01T22:33:00.457Z'
+                        updated_at: '2021-11-01T22:33:00.457Z'
                       relationships:
                         cms_page:
                           data:
@@ -1925,7 +1932,7 @@ paths:
                       id: '21'
                       type: cms_section
                       attributes:
-                        name: Aliquid velit illo rem eaque ullam.
+                        name: Amet necessitatibus veritatis alias earum.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1934,8 +1941,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T16:15:08.477Z'
-                        updated_at: '2021-11-01T16:15:08.477Z'
+                        created_at: '2021-11-01T22:33:00.577Z'
+                        updated_at: '2021-11-01T22:33:00.577Z'
                       relationships:
                         cms_page:
                           data:
@@ -2009,8 +2016,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-01T16:15:08.745Z'
-                        updated_at: '2021-11-01T16:15:08.757Z'
+                        created_at: '2021-11-01T22:33:00.838Z'
+                        updated_at: '2021-11-01T22:33:00.848Z'
                       relationships:
                         cms_page:
                           data:
@@ -2124,9 +2131,9 @@ paths:
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-11-01T16:15:09.217Z'
+                        updated_at: '2021-11-01T22:33:01.255Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T16:15:09.217Z'
+                        created_at: '2021-11-01T22:33:01.255Z'
                       relationships:
                         states:
                           data: []
@@ -2139,9 +2146,9 @@ paths:
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T16:15:09.222Z'
+                        updated_at: '2021-11-01T22:33:01.260Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T16:15:09.222Z'
+                        created_at: '2021-11-01T22:33:01.260Z'
                       relationships:
                         states:
                           data: []
@@ -2154,9 +2161,9 @@ paths:
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T16:15:09.225Z'
+                        updated_at: '2021-11-01T22:33:01.262Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T16:15:09.225Z'
+                        created_at: '2021-11-01T22:33:01.262Z'
                       relationships:
                         states:
                           data: []
@@ -2215,9 +2222,9 @@ paths:
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-01T16:15:09.272Z'
+                        updated_at: '2021-11-01T22:33:01.310Z'
                         zipcode_required: true
-                        created_at: '2021-11-01T16:15:09.272Z'
+                        created_at: '2021-11-01T22:33:01.310Z'
                       relationships:
                         states:
                           data: []
@@ -2275,7 +2282,7 @@ paths:
                     - id: '1'
                       type: digital_link
                       attributes:
-                        token: Zj7hsmXmii7dM2UD6xVcpUjG
+                        token: RfgrpdFSjJ7ornAux2T6i2NL
                         access_counter: 0
                       relationships:
                         digital:
@@ -2289,7 +2296,7 @@ paths:
                     - id: '2'
                       type: digital_link
                       attributes:
-                        token: HtEFjzNuVqN6j5WUF57M7bjB
+                        token: hvHQYUKpKqBULoukQ2hcvxMc
                         access_counter: 0
                       relationships:
                         digital:
@@ -2343,7 +2350,7 @@ paths:
                       id: '5'
                       type: digital_link
                       attributes:
-                        token: AyHGXBxouVACPr7icfFGa7ZA
+                        token: 4cYQqx1PojFCbrHHqFCDvHZM
                         access_counter: 0
                       relationships:
                         digital:
@@ -2406,7 +2413,7 @@ paths:
                       id: '6'
                       type: digital_link
                       attributes:
-                        token: VL22EXnhQBx6VSWP4KV3JoX5
+                        token: sJ9mRiUvBLz5hrvznMjLPxYT
                         access_counter: 0
                       relationships:
                         digital:
@@ -2465,7 +2472,7 @@ paths:
                       id: '8'
                       type: digital_link
                       attributes:
-                        token: bR4yj43Y45tQ7fQc95ZkHz2o
+                        token: r5teQzVc2CZiqkWmNZQCrhxk
                         access_counter: 0
                       relationships:
                         digital:
@@ -2580,7 +2587,7 @@ paths:
                       id: '13'
                       type: digital_link
                       attributes:
-                        token: e94qfYCroztiknaz9crvxMbU
+                        token: 24HwGgcgmQeLw57RYFAcy6ej
                         access_counter: 0
                       relationships:
                         digital:
@@ -2652,7 +2659,7 @@ paths:
                     - id: '15'
                       type: digital
                       attributes:
-                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBJdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c47dbf57af644f5ee532f1a0e204a3f2877dad4c/thinking-cat.jpg"
+                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBJdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--7068626d70aa8c180fd961f26cdd4e449e7b34a7/thinking-cat.jpg"
                         content_type: image/jpeg
                         filename: thinking-cat.jpg
                         byte_size: 18090
@@ -2664,7 +2671,7 @@ paths:
                     - id: '16'
                       type: digital
                       attributes:
-                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBKQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--5966e723deb197b98be65665b695881d9bf77ce6/thinking-cat.jpg"
+                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBKQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--0a04fbab30a7c6e2c4e9f9c2e8bf0c1095244c2c/thinking-cat.jpg"
                         content_type: image/jpeg
                         filename: thinking-cat.jpg
                         byte_size: 18090
@@ -2676,7 +2683,7 @@ paths:
                     - id: '17'
                       type: digital
                       attributes:
-                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBKUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--128cb27a673c4157d05f7e8836100b74c4d841dd/thinking-cat.jpg"
+                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBKUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--23a31a7317ef6db70f5395a70c05320a3fb149ac/thinking-cat.jpg"
                         content_type: image/jpeg
                         filename: thinking-cat.jpg
                         byte_size: 18090
@@ -2735,7 +2742,7 @@ paths:
                       id: '24'
                       type: digital
                       attributes:
-                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBMQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9809c0317f79dda41a81c0af07fddd7da97abd8f/icon_256x256.jpg"
+                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBMQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--11b46e9ec4ad663736ae938d13056a21907a3884/icon_256x256.jpg"
                         content_type: image/png
                         filename: icon_256x256.jpg
                         byte_size: 818
@@ -2800,7 +2807,7 @@ paths:
                       id: '28'
                       type: digital
                       attributes:
-                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBNQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--efba9825dfa43ed3c60de95598803a804aee86ff/thinking-cat.jpg"
+                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBNQT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--396ec1b385c56f8b7b18fbc6420046ad9a4015a9/thinking-cat.jpg"
                         content_type: image/jpeg
                         filename: thinking-cat.jpg
                         byte_size: 18090
@@ -2864,7 +2871,7 @@ paths:
                       id: '36'
                       type: digital
                       attributes:
-                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBPdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--b476a895c0bc6c1c789ca9f1206cf5a829871e60/icon_256x256.jpg"
+                        url: "/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBPdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ff4acd7b7f42a036bece89f343c26bf7b91af26b/icon_256x256.jpg"
                         content_type: image/png
                         filename: icon_256x256.jpg
                         byte_size: 818
@@ -2997,8 +3004,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T16:15:16.594Z'
-                        updated_at: '2021-11-01T16:15:16.602Z'
+                        created_at: '2021-11-01T22:33:08.651Z'
+                        updated_at: '2021-11-01T22:33:08.658Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3044,8 +3051,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T16:15:16.633Z'
-                        updated_at: '2021-11-01T16:15:16.637Z'
+                        created_at: '2021-11-01T22:33:08.687Z'
+                        updated_at: '2021-11-01T22:33:08.691Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3138,8 +3145,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T16:15:16.862Z'
-                        updated_at: '2021-11-01T16:15:16.908Z'
+                        created_at: '2021-11-01T22:33:08.899Z'
+                        updated_at: '2021-11-01T22:33:08.940Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3241,8 +3248,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-01T16:15:17.051Z'
-                        updated_at: '2021-11-01T16:15:17.058Z'
+                        created_at: '2021-11-01T22:33:09.077Z'
+                        updated_at: '2021-11-01T22:33:09.084Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3340,8 +3347,8 @@ paths:
                       attributes:
                         quantity: 4
                         price: '10.0'
-                        created_at: '2021-11-01T16:15:17.283Z'
-                        updated_at: '2021-11-01T16:15:17.322Z'
+                        created_at: '2021-11-01T22:33:09.280Z'
+                        updated_at: '2021-11-01T22:33:09.315Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3391,10 +3398,10 @@ paths:
               examples:
                 Example:
                   value:
-                    error: 'Quantity selected of "Product #130 - 8962" is not available.'
+                    error: 'Quantity selected of "Product #130 - 9106" is not available.'
                     errors:
                       quantity:
-                      - 'selected of "Product #130 - 8962" is not available.'
+                      - 'selected of "Product #130 - 9106" is not available.'
               schema:
                 "$ref": "#/components/schemas/validation_errors"
         '404':
@@ -3514,8 +3521,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-11-01T16:15:17.997Z'
-                        updated_at: '2021-11-01T16:15:18.001Z'
+                        created_at: '2021-11-01T22:33:09.974Z'
+                        updated_at: '2021-11-01T22:33:09.978Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3551,8 +3558,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-11-01T16:15:18.061Z'
-                        updated_at: '2021-11-01T16:15:18.066Z'
+                        created_at: '2021-11-01T22:33:10.035Z'
+                        updated_at: '2021-11-01T22:33:10.039Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3588,8 +3595,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-11-01T16:15:18.122Z'
-                        updated_at: '2021-11-01T16:15:18.127Z'
+                        created_at: '2021-11-01T22:33:10.099Z'
+                        updated_at: '2021-11-01T22:33:10.103Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3625,8 +3632,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T16:15:18.185Z'
-                        updated_at: '2021-11-01T16:15:18.190Z'
+                        created_at: '2021-11-01T22:33:10.161Z'
+                        updated_at: '2021-11-01T22:33:10.165Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3662,8 +3669,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-11-01T16:15:18.248Z'
-                        updated_at: '2021-11-01T16:15:18.252Z'
+                        created_at: '2021-11-01T22:33:10.223Z'
+                        updated_at: '2021-11-01T22:33:10.227Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3699,8 +3706,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-11-01T16:15:18.311Z'
-                        updated_at: '2021-11-01T16:15:18.315Z'
+                        created_at: '2021-11-01T22:33:10.285Z'
+                        updated_at: '2021-11-01T22:33:10.290Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3736,8 +3743,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-11-01T16:15:18.372Z'
-                        updated_at: '2021-11-01T16:15:18.376Z'
+                        created_at: '2021-11-01T22:33:10.349Z'
+                        updated_at: '2021-11-01T22:33:10.353Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3763,7 +3770,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Quasi quos rem ratione optio error ipsam provident.
+                        name: Adipisci accusantium dicta deleniti error nemo.
                         subtitle:
                         destination:
                         new_window: false
@@ -3773,8 +3780,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-11-01T16:15:17.934Z'
-                        updated_at: '2021-11-01T16:15:18.396Z'
+                        created_at: '2021-11-01T22:33:09.911Z'
+                        updated_at: '2021-11-01T22:33:10.362Z'
                         link:
                         is_container: true
                         is_root: true
@@ -3867,8 +3874,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T16:15:19.114Z'
-                        updated_at: '2021-11-01T16:15:19.117Z'
+                        created_at: '2021-11-01T22:33:11.095Z'
+                        updated_at: '2021-11-01T22:33:11.098Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3958,8 +3965,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T16:15:19.599Z'
-                        updated_at: '2021-11-01T16:15:19.603Z'
+                        created_at: '2021-11-01T22:33:11.639Z'
+                        updated_at: '2021-11-01T22:33:11.644Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4047,8 +4054,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-01T16:15:20.372Z'
-                        updated_at: '2021-11-01T16:15:20.398Z'
+                        created_at: '2021-11-01T22:33:12.488Z'
+                        updated_at: '2021-11-01T22:33:12.511Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4185,8 +4192,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-11-01T16:15:22.185Z'
-                        updated_at: '2021-11-01T16:15:22.212Z'
+                        created_at: '2021-11-01T22:33:14.467Z'
+                        updated_at: '2021-11-01T22:33:14.491Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4284,16 +4291,16 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T16:15:22.724Z'
-                        updated_at: '2021-11-01T16:15:22.852Z'
+                        created_at: '2021-11-01T22:33:15.032Z'
+                        updated_at: '2021-11-01T22:33:15.165Z'
                       relationships:
                         menu_items:
                           data:
+                          - id: '89'
+                            type: menu_item
                           - id: '87'
                             type: menu_item
                           - id: '90'
-                            type: menu_item
-                          - id: '89'
                             type: menu_item
                     - id: '19'
                       type: menu
@@ -4301,8 +4308,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-11-01T16:15:22.733Z'
-                        updated_at: '2021-11-01T16:15:22.973Z'
+                        created_at: '2021-11-01T22:33:15.041Z'
+                        updated_at: '2021-11-01T22:33:15.286Z'
                       relationships:
                         menu_items:
                           data:
@@ -4365,8 +4372,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T16:15:23.324Z'
-                        updated_at: '2021-11-01T16:15:23.331Z'
+                        created_at: '2021-11-01T22:33:15.667Z'
+                        updated_at: '2021-11-01T22:33:15.674Z'
                       relationships:
                         menu_items:
                           data:
@@ -4434,8 +4441,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T16:15:23.368Z'
-                        updated_at: '2021-11-01T16:15:23.374Z'
+                        created_at: '2021-11-01T22:33:15.714Z'
+                        updated_at: '2021-11-01T22:33:15.721Z'
                       relationships:
                         menu_items:
                           data:
@@ -4499,8 +4506,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-01T16:15:23.445Z'
-                        updated_at: '2021-11-01T16:15:23.452Z'
+                        created_at: '2021-11-01T22:33:15.803Z'
+                        updated_at: '2021-11-01T22:33:15.809Z'
                       relationships:
                         menu_items:
                           data:
@@ -4635,8 +4642,8 @@ paths:
                         name: foo-size-68
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T16:15:23.618Z'
-                        updated_at: '2021-11-01T16:15:23.618Z'
+                        created_at: '2021-11-01T22:33:15.982Z'
+                        updated_at: '2021-11-01T22:33:15.982Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4647,8 +4654,8 @@ paths:
                         name: foo-size-69
                         presentation: Size
                         position: 2
-                        created_at: '2021-11-01T16:15:23.620Z'
-                        updated_at: '2021-11-01T16:15:23.620Z'
+                        created_at: '2021-11-01T22:33:15.984Z'
+                        updated_at: '2021-11-01T22:33:15.984Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4699,8 +4706,8 @@ paths:
                         name: foo-size-72
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T16:15:23.676Z'
-                        updated_at: '2021-11-01T16:15:23.676Z'
+                        created_at: '2021-11-01T22:33:16.035Z'
+                        updated_at: '2021-11-01T22:33:16.035Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4757,8 +4764,8 @@ paths:
                         name: foo-size-73
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T16:15:23.707Z'
-                        updated_at: '2021-11-01T16:15:23.707Z'
+                        created_at: '2021-11-01T22:33:16.068Z'
+                        updated_at: '2021-11-01T22:33:16.068Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4814,8 +4821,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-01T16:15:23.756Z'
-                        updated_at: '2021-11-01T16:15:23.763Z'
+                        created_at: '2021-11-01T22:33:16.129Z'
+                        updated_at: '2021-11-01T22:33:16.137Z'
                         filterable: true
                       relationships:
                         option_values:
@@ -4951,8 +4958,8 @@ paths:
                         position: 1
                         name: Size-68
                         presentation: S
-                        created_at: '2021-11-01T16:15:23.883Z'
-                        updated_at: '2021-11-01T16:15:23.883Z'
+                        created_at: '2021-11-01T22:33:16.268Z'
+                        updated_at: '2021-11-01T22:33:16.268Z'
                       relationships:
                         option_type:
                           data:
@@ -4964,8 +4971,8 @@ paths:
                         position: 1
                         name: Size-69
                         presentation: S
-                        created_at: '2021-11-01T16:15:23.890Z'
-                        updated_at: '2021-11-01T16:15:23.890Z'
+                        created_at: '2021-11-01T22:33:16.274Z'
+                        updated_at: '2021-11-01T22:33:16.274Z'
                       relationships:
                         option_type:
                           data:
@@ -5024,8 +5031,8 @@ paths:
                         position: 1
                         name: Size-72
                         presentation: S
-                        created_at: '2021-11-01T16:15:23.953Z'
-                        updated_at: '2021-11-01T16:15:23.953Z'
+                        created_at: '2021-11-01T22:33:16.334Z'
+                        updated_at: '2021-11-01T22:33:16.334Z'
                       relationships:
                         option_type:
                           data:
@@ -5088,8 +5095,8 @@ paths:
                         position: 1
                         name: Size-73
                         presentation: S
-                        created_at: '2021-11-01T16:15:23.987Z'
-                        updated_at: '2021-11-01T16:15:23.987Z'
+                        created_at: '2021-11-01T22:33:16.372Z'
+                        updated_at: '2021-11-01T22:33:16.372Z'
                       relationships:
                         option_type:
                           data:
@@ -5153,8 +5160,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-11-01T16:15:24.045Z'
-                        updated_at: '2021-11-01T16:15:24.054Z'
+                        created_at: '2021-11-01T22:33:16.439Z'
+                        updated_at: '2021-11-01T22:33:16.449Z'
                       relationships:
                         option_type:
                           data:
@@ -5282,7 +5289,7 @@ paths:
                     - id: '40'
                       type: order
                       attributes:
-                        number: R767427603
+                        number: R841283588
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5291,10 +5298,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: sybil@hauck.info
+                        email: marlys@rohanklocko.name
                         special_instructions:
-                        created_at: '2021-11-01T16:15:24.200Z'
-                        updated_at: '2021-11-01T16:15:24.200Z'
+                        created_at: '2021-11-01T22:33:16.604Z'
+                        updated_at: '2021-11-01T22:33:16.604Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5366,7 +5373,7 @@ paths:
                     - id: '41'
                       type: order
                       attributes:
-                        number: R860381766
+                        number: R441511355
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5375,10 +5382,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: orville@mcglynnhodkiewicz.co.uk
+                        email: kiera_beahan@rauheathcote.name
                         special_instructions:
-                        created_at: '2021-11-01T16:15:24.208Z'
-                        updated_at: '2021-11-01T16:15:24.208Z'
+                        created_at: '2021-11-01T22:33:16.613Z'
+                        updated_at: '2021-11-01T22:33:16.613Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5497,7 +5504,7 @@ paths:
                       id: '44'
                       type: order
                       attributes:
-                        number: R827438171
+                        number: R171863303
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5508,8 +5515,8 @@ paths:
                         payment_state:
                         email:
                         special_instructions:
-                        created_at: '2021-11-01T16:15:24.523Z'
-                        updated_at: '2021-11-01T16:15:24.592Z'
+                        created_at: '2021-11-01T22:33:16.910Z'
+                        updated_at: '2021-11-01T22:33:16.926Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5623,7 +5630,7 @@ paths:
                       id: '45'
                       type: order
                       attributes:
-                        number: R621193222
+                        number: R295541902
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5632,10 +5639,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: mayola_buckridge@roobmann.co.uk
+                        email: trinidad@klein.ca
                         special_instructions:
-                        created_at: '2021-11-01T16:15:24.649Z'
-                        updated_at: '2021-11-01T16:15:24.807Z'
+                        created_at: '2021-11-01T22:33:16.968Z'
+                        updated_at: '2021-11-01T22:33:17.130Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5765,7 +5772,7 @@ paths:
                       id: '47'
                       type: order
                       attributes:
-                        number: R108854973
+                        number: R556257930
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5776,8 +5783,8 @@ paths:
                         payment_state:
                         email: new@example.com
                         special_instructions:
-                        created_at: '2021-11-01T16:15:24.989Z'
-                        updated_at: '2021-11-01T16:15:25.081Z'
+                        created_at: '2021-11-01T22:33:17.380Z'
+                        updated_at: '2021-11-01T22:33:17.474Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5963,7 +5970,7 @@ paths:
                       id: '52'
                       type: order
                       attributes:
-                        number: R613373980
+                        number: R193954467
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -5972,10 +5979,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: del@considinekuhic.biz
+                        email: tracy_feil@conn.info
                         special_instructions:
-                        created_at: '2021-11-01T16:15:25.740Z'
-                        updated_at: '2021-11-01T16:15:25.887Z'
+                        created_at: '2021-11-01T22:33:18.061Z'
+                        updated_at: '2021-11-01T22:33:18.211Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6108,7 +6115,7 @@ paths:
                       id: '54'
                       type: order
                       attributes:
-                        number: R555606296
+                        number: R362367020
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -6117,10 +6124,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: marquita@barrowsschultz.biz
+                        email: joselyn@dachflatley.info
                         special_instructions:
-                        created_at: '2021-11-01T16:15:26.058Z'
-                        updated_at: '2021-11-01T16:15:26.187Z'
+                        created_at: '2021-11-01T22:33:18.406Z'
+                        updated_at: '2021-11-01T22:33:18.543Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6253,19 +6260,19 @@ paths:
                       id: '56'
                       type: order
                       attributes:
-                        number: R437940802
+                        number: R625341963
                         item_total: '10.0'
                         total: '110.0'
                         state: complete
                         adjustment_total: '0.0'
-                        completed_at: '2021-11-01T16:15:26.559Z'
+                        completed_at: '2021-11-01T22:33:18.937Z'
                         payment_total: '0.0'
                         shipment_state: pending
                         payment_state: balance_due
-                        email: evie.senger@hermann.ca
+                        email: brunilda@schmidt.us
                         special_instructions:
-                        created_at: '2021-11-01T16:15:26.345Z'
-                        updated_at: '2021-11-01T16:15:26.559Z'
+                        created_at: '2021-11-01T22:33:18.716Z'
+                        updated_at: '2021-11-01T22:33:18.937Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6409,7 +6416,7 @@ paths:
                       id: '59'
                       type: order
                       attributes:
-                        number: R583410208
+                        number: R395903908
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -6418,10 +6425,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: marquis.luettgen@mcclure.us
+                        email: ricky_weimann@schneider.name
                         special_instructions:
-                        created_at: '2021-11-01T16:15:26.853Z'
-                        updated_at: '2021-11-01T16:15:26.952Z'
+                        created_at: '2021-11-01T22:33:19.247Z'
+                        updated_at: '2021-11-01T22:33:19.351Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -6549,7 +6556,7 @@ paths:
                       id: '61'
                       type: order
                       attributes:
-                        number: R007488347
+                        number: R825200534
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -6558,10 +6565,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: shaniqua_schaden@goyettehowell.info
+                        email: jenell_runolfsdottir@gerhold.us
                         special_instructions:
-                        created_at: '2021-11-01T16:15:27.112Z'
-                        updated_at: '2021-11-01T16:15:27.190Z'
+                        created_at: '2021-11-01T22:33:19.516Z'
+                        updated_at: '2021-11-01T22:33:19.595Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6862,8 +6869,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 1
-                        created_at: '2021-11-01T16:15:28.804Z'
-                        updated_at: '2021-11-01T16:15:28.804Z'
+                        created_at: '2021-11-01T22:33:21.260Z'
+                        updated_at: '2021-11-01T22:33:21.260Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6881,8 +6888,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 2
-                        created_at: '2021-11-01T16:15:28.810Z'
-                        updated_at: '2021-11-01T16:15:28.810Z'
+                        created_at: '2021-11-01T22:33:21.267Z'
+                        updated_at: '2021-11-01T22:33:21.267Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6900,8 +6907,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T16:15:28.813Z'
-                        updated_at: '2021-11-01T16:15:28.813Z'
+                        created_at: '2021-11-01T22:33:21.270Z'
+                        updated_at: '2021-11-01T22:33:21.270Z'
                         deleted_at:
                         preferences: {}
                       relationships:
@@ -6919,8 +6926,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-01T16:15:28.817Z'
-                        updated_at: '2021-11-01T16:15:28.817Z'
+                        created_at: '2021-11-01T22:33:21.274Z'
+                        updated_at: '2021-11-01T22:33:21.274Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -6941,8 +6948,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 5
-                        created_at: '2021-11-01T16:15:28.820Z'
-                        updated_at: '2021-11-01T16:15:28.820Z'
+                        created_at: '2021-11-01T22:33:21.277Z'
+                        updated_at: '2021-11-01T22:33:21.277Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7010,8 +7017,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T16:15:28.931Z'
-                        updated_at: '2021-11-01T16:15:28.931Z'
+                        created_at: '2021-11-01T22:33:21.393Z'
+                        updated_at: '2021-11-01T22:33:21.393Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7085,8 +7092,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-01T16:15:29.018Z'
-                        updated_at: '2021-11-01T16:15:29.018Z'
+                        created_at: '2021-11-01T22:33:21.485Z'
+                        updated_at: '2021-11-01T22:33:21.485Z'
                         deleted_at:
                         preferences:
                           dummy_key: PUBLICKEY123
@@ -7159,8 +7166,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-01T16:15:29.151Z'
-                        updated_at: '2021-11-01T16:15:29.161Z'
+                        created_at: '2021-11-01T22:33:21.595Z'
+                        updated_at: '2021-11-01T22:33:21.606Z'
                         deleted_at:
                         preferences:
                           dummy_key: UPDATED-DUMMY-KEY-123
@@ -7306,9 +7313,9 @@ paths:
                         state: invalid
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T16:15:29.420Z'
-                        updated_at: '2021-11-01T16:15:29.436Z'
-                        number: PDYDZDPY
+                        created_at: '2021-11-01T22:33:21.876Z'
+                        updated_at: '2021-11-01T22:33:21.894Z'
+                        number: P50ZB38L
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7343,9 +7350,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T16:15:29.433Z'
-                        updated_at: '2021-11-01T16:15:29.433Z'
-                        number: P5T0GV41
+                        created_at: '2021-11-01T22:33:21.891Z'
+                        updated_at: '2021-11-01T22:33:21.891Z'
+                        number: P9J5LL9N
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7431,9 +7438,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-01T16:15:29.602Z'
-                        updated_at: '2021-11-01T16:15:29.602Z'
-                        number: PR4F6556
+                        created_at: '2021-11-01T22:33:22.054Z'
+                        updated_at: '2021-11-01T22:33:22.054Z'
+                        number: PYLT34F2
                         cvv_response_code:
                         cvv_response_message:
                         display_amount: "$45.75"
@@ -7569,8 +7576,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T16:15:29.811Z'
-                        updated_at: '2021-11-01T16:15:29.811Z'
+                        created_at: '2021-11-01T22:33:22.257Z'
+                        updated_at: '2021-11-01T22:33:22.257Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7579,8 +7586,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T16:15:29.813Z'
-                        updated_at: '2021-11-01T16:15:29.813Z'
+                        created_at: '2021-11-01T22:33:22.259Z'
+                        updated_at: '2021-11-01T22:33:22.259Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7636,8 +7643,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T16:15:29.861Z'
-                        updated_at: '2021-11-01T16:15:29.861Z'
+                        created_at: '2021-11-01T22:33:22.307Z'
+                        updated_at: '2021-11-01T22:33:22.307Z'
                         code: 2021-BFM
                       relationships:
                         promotions:
@@ -7697,8 +7704,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-01T16:15:29.897Z'
-                        updated_at: '2021-11-01T16:15:29.897Z'
+                        created_at: '2021-11-01T22:33:22.347Z'
+                        updated_at: '2021-11-01T22:33:22.347Z'
                         code: MJO
                       relationships:
                         promotions:
@@ -7759,8 +7766,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: 2021 Promotions
-                        created_at: '2021-11-01T16:15:29.949Z'
-                        updated_at: '2021-11-01T16:15:29.955Z'
+                        created_at: '2021-11-01T22:33:22.398Z'
+                        updated_at: '2021-11-01T22:33:22.403Z'
                         code: 2021-Promos
                       relationships:
                         promotions:
@@ -7888,12 +7895,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H88505663024
+                        number: H29329252366
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T16:15:30.080Z'
-                        updated_at: '2021-11-01T16:15:30.083Z'
+                        created_at: '2021-11-01T22:33:22.524Z'
+                        updated_at: '2021-11-01T22:33:22.527Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -7935,12 +7942,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H98428238361
+                        number: H90182038540
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T16:15:30.110Z'
-                        updated_at: '2021-11-01T16:15:30.113Z'
+                        created_at: '2021-11-01T22:33:22.554Z'
+                        updated_at: '2021-11-01T22:33:22.557Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8035,12 +8042,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H36188312911
+                        number: H36038632030
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T16:15:30.406Z'
-                        updated_at: '2021-11-01T16:15:30.424Z'
+                        created_at: '2021-11-01T22:33:22.856Z'
+                        updated_at: '2021-11-01T22:33:22.874Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8174,12 +8181,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H71866168944
+                        number: H29594339458
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-01T16:15:31.307Z'
-                        updated_at: '2021-11-01T16:15:31.336Z'
+                        created_at: '2021-11-01T22:33:23.757Z'
+                        updated_at: '2021-11-01T22:33:23.787Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8278,12 +8285,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H73130150181
+                        number: H16216325235
                         cost: '100.0'
-                        shipped_at: '2021-11-01T16:15:31.759Z'
+                        shipped_at: '2021-11-01T22:33:24.190Z'
                         state: shipped
-                        created_at: '2021-11-01T16:15:31.726Z'
-                        updated_at: '2021-11-01T16:15:31.759Z'
+                        created_at: '2021-11-01T22:33:24.155Z'
+                        updated_at: '2021-11-01T22:33:24.190Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8382,12 +8389,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H00303001213
+                        number: H12447800246
                         cost: '100.0'
                         shipped_at:
                         state: canceled
-                        created_at: '2021-11-01T16:15:32.142Z'
-                        updated_at: '2021-11-01T16:15:32.173Z'
+                        created_at: '2021-11-01T22:33:24.571Z'
+                        updated_at: '2021-11-01T22:33:24.597Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8486,12 +8493,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H57719834983
+                        number: H88035404602
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-01T16:15:32.566Z'
-                        updated_at: '2021-11-01T16:15:32.594Z'
+                        created_at: '2021-11-01T22:33:24.992Z'
+                        updated_at: '2021-11-01T22:33:25.019Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8590,12 +8597,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H41747708365
+                        number: H91133774144
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-01T16:15:32.990Z'
-                        updated_at: '2021-11-01T16:15:33.017Z'
+                        created_at: '2021-11-01T22:33:25.404Z'
+                        updated_at: '2021-11-01T22:33:25.429Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -8698,14 +8705,14 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #116'
-                        created_at: '2021-11-01T16:15:33.247Z'
-                        updated_at: '2021-11-01T16:15:33.247Z'
+                        created_at: '2021-11-01T22:33:25.731Z'
+                        updated_at: '2021-11-01T22:33:25.731Z'
                     - id: '117'
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #117'
-                        created_at: '2021-11-01T16:15:33.248Z'
-                        updated_at: '2021-11-01T16:15:33.248Z'
+                        created_at: '2021-11-01T22:33:25.732Z'
+                        updated_at: '2021-11-01T22:33:25.732Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -8750,8 +8757,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #120'
-                        created_at: '2021-11-01T16:15:33.372Z'
-                        updated_at: '2021-11-01T16:15:33.372Z'
+                        created_at: '2021-11-01T22:33:25.780Z'
+                        updated_at: '2021-11-01T22:33:25.780Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8800,8 +8807,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #121'
-                        created_at: '2021-11-01T16:15:33.405Z'
-                        updated_at: '2021-11-01T16:15:33.405Z'
+                        created_at: '2021-11-01T22:33:25.814Z'
+                        updated_at: '2021-11-01T22:33:25.814Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -8851,8 +8858,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: Default
-                        created_at: '2021-11-01T16:15:33.455Z'
-                        updated_at: '2021-11-01T16:15:33.461Z'
+                        created_at: '2021-11-01T22:33:25.872Z'
+                        updated_at: '2021-11-01T22:33:25.879Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -8986,8 +8993,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T16:15:33.579Z'
-                        updated_at: '2021-11-01T16:15:33.579Z'
+                        created_at: '2021-11-01T22:33:26.005Z'
+                        updated_at: '2021-11-01T22:33:26.005Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9010,8 +9017,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T16:15:33.588Z'
-                        updated_at: '2021-11-01T16:15:33.588Z'
+                        created_at: '2021-11-01T22:33:26.014Z'
+                        updated_at: '2021-11-01T22:33:26.014Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9081,8 +9088,8 @@ paths:
                         admin_name: DHL Express- Zone A
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T16:15:33.665Z'
-                        updated_at: '2021-11-01T16:15:33.665Z'
+                        created_at: '2021-11-01T22:33:26.091Z'
+                        updated_at: '2021-11-01T22:33:26.091Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9166,8 +9173,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T16:15:33.713Z'
-                        updated_at: '2021-11-01T16:15:33.713Z'
+                        created_at: '2021-11-01T22:33:26.140Z'
+                        updated_at: '2021-11-01T22:33:26.140Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9242,8 +9249,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-01T16:15:33.787Z'
-                        updated_at: '2021-11-01T16:15:33.801Z'
+                        created_at: '2021-11-01T22:33:26.219Z'
+                        updated_at: '2021-11-01T22:33:26.234Z'
                         deleted_at:
                       relationships:
                         shipping_categories:
@@ -9392,8 +9399,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T16:15:34.031Z'
-                        updated_at: '2021-11-01T16:15:34.035Z'
+                        created_at: '2021-11-01T22:33:26.473Z'
+                        updated_at: '2021-11-01T22:33:26.477Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9427,8 +9434,8 @@ paths:
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-11-01T16:15:34.091Z'
-                        updated_at: '2021-11-01T16:15:34.094Z'
+                        created_at: '2021-11-01T22:33:26.536Z'
+                        updated_at: '2021-11-01T22:33:26.539Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9462,8 +9469,8 @@ paths:
                         lft: 1
                         rgt: 6
                         description:
-                        created_at: '2021-11-01T16:15:33.968Z'
-                        updated_at: '2021-11-01T16:15:34.105Z'
+                        created_at: '2021-11-01T22:33:26.408Z'
+                        updated_at: '2021-11-01T22:33:26.554Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9544,8 +9551,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T16:15:34.342Z'
-                        updated_at: '2021-11-01T16:15:34.346Z'
+                        created_at: '2021-11-01T22:33:26.797Z'
+                        updated_at: '2021-11-01T22:33:26.802Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9630,8 +9637,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T16:15:34.456Z'
-                        updated_at: '2021-11-01T16:15:34.460Z'
+                        created_at: '2021-11-01T22:33:26.916Z'
+                        updated_at: '2021-11-01T22:33:26.920Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9719,8 +9726,8 @@ paths:
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-01T16:15:34.685Z'
-                        updated_at: '2021-11-01T16:15:34.711Z'
+                        created_at: '2021-11-01T22:33:27.151Z'
+                        updated_at: '2021-11-01T22:33:27.178Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -9873,9 +9880,9 @@ paths:
                     - id: '97'
                       type: user
                       attributes:
-                        email: caroyln@kuhncrist.us
-                        created_at: '2021-11-01T16:15:35.204Z'
-                        updated_at: '2021-11-01T16:15:35.204Z'
+                        email: kennith@vandervort.biz
+                        created_at: '2021-11-01T22:33:27.698Z'
+                        updated_at: '2021-11-01T22:33:27.698Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9887,9 +9894,9 @@ paths:
                     - id: '98'
                       type: user
                       attributes:
-                        email: cassi@mayertkihn.ca
-                        created_at: '2021-11-01T16:15:35.209Z'
-                        updated_at: '2021-11-01T16:15:35.209Z'
+                        email: margaretta.fritsch@bartellratke.co.uk
+                        created_at: '2021-11-01T22:33:27.704Z'
+                        updated_at: '2021-11-01T22:33:27.704Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9901,9 +9908,9 @@ paths:
                     - id: '99'
                       type: user
                       attributes:
-                        email: sammy_lockman@heathcotetorp.us
-                        created_at: '2021-11-01T16:15:35.210Z'
-                        updated_at: '2021-11-01T16:15:35.210Z'
+                        email: gabriela@brakusharber.name
+                        created_at: '2021-11-01T22:33:27.705Z'
+                        updated_at: '2021-11-01T22:33:27.705Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -9962,9 +9969,9 @@ paths:
                       id: '104'
                       type: user
                       attributes:
-                        email: cherish@stoltenberg.info
-                        created_at: '2021-11-01T16:15:35.288Z'
-                        updated_at: '2021-11-01T16:15:35.288Z'
+                        email: kimi@heller.name
+                        created_at: '2021-11-01T22:33:27.776Z'
+                        updated_at: '2021-11-01T22:33:27.776Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10027,9 +10034,9 @@ paths:
                       id: '107'
                       type: user
                       attributes:
-                        email: contessa_lind@hayes.co.uk
-                        created_at: '2021-11-01T16:15:35.335Z'
-                        updated_at: '2021-11-01T16:15:35.335Z'
+                        email: carli@hickle.biz
+                        created_at: '2021-11-01T22:33:27.832Z'
+                        updated_at: '2021-11-01T22:33:27.832Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10094,8 +10101,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-11-01T16:15:35.406Z'
-                        updated_at: '2021-11-01T16:15:35.415Z'
+                        created_at: '2021-11-01T22:33:27.906Z'
+                        updated_at: '2021-11-01T22:33:27.915Z'
                         average_order_value: []
                         lifetime_value: []
                         store_credits: []
@@ -10242,12 +10249,12 @@ paths:
                         position: 1
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T16:15:35.625Z'
+                        updated_at: '2021-11-01T22:33:28.141Z'
                         discontinue_on:
-                        created_at: '2021-11-01T16:15:35.620Z'
+                        created_at: '2021-11-01T22:33:28.132Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 116'
+                        name: 'Product #181 - 5250'
                         options_text: ''
                         total_on_hand: 0
                         purchasable: true
@@ -10282,21 +10289,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-249
-                        weight: '104.23'
-                        height: '146.44'
-                        depth: '173.52'
+                        weight: '3.97'
+                        height: '52.83'
+                        depth: '77.14'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T16:15:35.653Z'
+                        updated_at: '2021-11-01T22:33:28.259Z'
                         discontinue_on:
-                        created_at: '2021-11-01T16:15:35.647Z'
+                        created_at: '2021-11-01T22:33:28.252Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 116'
+                        name: 'Product #181 - 5250'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10333,21 +10340,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-250
-                        weight: '86.2'
-                        height: '132.54'
-                        depth: '194.2'
+                        weight: '114.34'
+                        height: '150.68'
+                        depth: '72.47'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 3
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T16:15:35.672Z'
+                        updated_at: '2021-11-01T22:33:28.278Z'
                         discontinue_on:
-                        created_at: '2021-11-01T16:15:35.666Z'
+                        created_at: '2021-11-01T22:33:28.272Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #181 - 116'
+                        name: 'Product #181 - 5250'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10437,21 +10444,21 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-255
-                        weight: '195.68'
-                        height: '31.86'
-                        depth: '6.16'
+                        weight: '118.52'
+                        height: '5.77'
+                        depth: '111.78'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-01T16:15:35.885Z'
+                        updated_at: '2021-11-01T22:33:28.488Z'
                         discontinue_on:
-                        created_at: '2021-11-01T16:15:35.879Z'
+                        created_at: '2021-11-01T22:33:28.482Z'
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #183 - 4666'
+                        name: 'Product #183 - 4184'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -10612,14 +10619,14 @@ paths:
                     - id: '1'
                       type: event
                       attributes:
-                        execution_time: 2695
+                        execution_time: 642
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url1.com/
-                        created_at: '2021-11-01T16:15:36.301Z'
-                        updated_at: '2021-11-01T16:15:36.301Z'
+                        created_at: '2021-11-01T22:33:28.843Z'
+                        updated_at: '2021-11-01T22:33:28.843Z'
                       relationships:
                         subscriber:
                           data:
@@ -10628,14 +10635,14 @@ paths:
                     - id: '2'
                       type: event
                       attributes:
-                        execution_time: 98173
+                        execution_time: 65951
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url2.com/
-                        created_at: '2021-11-01T16:15:36.304Z'
-                        updated_at: '2021-11-01T16:15:36.304Z'
+                        created_at: '2021-11-01T22:33:28.846Z'
+                        updated_at: '2021-11-01T22:33:28.846Z'
                       relationships:
                         subscriber:
                           data:
@@ -10711,8 +10718,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T16:15:36.359Z'
-                        updated_at: '2021-11-01T16:15:36.359Z'
+                        created_at: '2021-11-01T22:33:28.897Z'
+                        updated_at: '2021-11-01T22:33:28.897Z'
                     - id: '6'
                       type: subscriber
                       attributes:
@@ -10720,8 +10727,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T16:15:36.360Z'
-                        updated_at: '2021-11-01T16:15:36.360Z'
+                        created_at: '2021-11-01T22:33:28.898Z'
+                        updated_at: '2021-11-01T22:33:28.898Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -10769,8 +10776,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T16:15:36.408Z'
-                        updated_at: '2021-11-01T16:15:36.408Z'
+                        created_at: '2021-11-01T22:33:28.952Z'
+                        updated_at: '2021-11-01T22:33:28.952Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10825,8 +10832,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T16:15:36.439Z'
-                        updated_at: '2021-11-01T16:15:36.439Z'
+                        created_at: '2021-11-01T22:33:28.985Z'
+                        updated_at: '2021-11-01T22:33:28.985Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -10879,8 +10886,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-01T16:15:36.492Z'
-                        updated_at: '2021-11-01T16:15:36.492Z'
+                        created_at: '2021-11-01T22:33:29.038Z'
+                        updated_at: '2021-11-01T22:33:29.038Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -11001,10 +11008,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T16:15:36.733Z'
-                        updated_at: '2021-11-01T16:15:36.733Z'
-                        display_total: "$19.99"
+                        created_at: '2021-11-01T22:33:29.278Z'
+                        updated_at: '2021-11-01T22:33:29.278Z'
                         display_price: "$19.99"
+                        display_total: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11016,10 +11023,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T16:15:36.780Z'
-                        updated_at: '2021-11-01T16:15:36.780Z'
-                        display_total: "$19.99"
+                        created_at: '2021-11-01T22:33:29.323Z'
+                        updated_at: '2021-11-01T22:33:29.323Z'
                         display_price: "$19.99"
+                        display_total: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11031,10 +11038,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T16:15:36.826Z'
-                        updated_at: '2021-11-01T16:15:36.826Z'
-                        display_total: "$19.99"
+                        created_at: '2021-11-01T22:33:29.370Z'
+                        updated_at: '2021-11-01T22:33:29.370Z'
                         display_price: "$19.99"
+                        display_total: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11046,10 +11053,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T16:15:36.871Z'
-                        updated_at: '2021-11-01T16:15:36.871Z'
-                        display_total: "$19.99"
+                        created_at: '2021-11-01T22:33:29.416Z'
+                        updated_at: '2021-11-01T22:33:29.416Z'
                         display_price: "$19.99"
+                        display_total: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11108,10 +11115,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T16:15:37.319Z'
-                        updated_at: '2021-11-01T16:15:37.319Z'
-                        display_total: "$19.99"
+                        created_at: '2021-11-01T22:33:29.886Z'
+                        updated_at: '2021-11-01T22:33:29.886Z'
                         display_price: "$19.99"
+                        display_total: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11179,10 +11186,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-01T16:15:37.525Z'
-                        updated_at: '2021-11-01T16:15:37.525Z'
-                        display_total: "$19.99"
+                        created_at: '2021-11-01T22:33:30.101Z'
+                        updated_at: '2021-11-01T22:33:30.101Z'
                         display_price: "$19.99"
+                        display_total: "$19.99"
                         price: '19.99'
                         total: '19.99'
                       relationships:
@@ -11246,10 +11253,10 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-11-01T16:15:37.859Z'
-                        updated_at: '2021-11-01T16:15:37.867Z'
-                        display_total: "$59.97"
+                        created_at: '2021-11-01T22:33:30.437Z'
+                        updated_at: '2021-11-01T22:33:30.444Z'
                         display_price: "$19.99"
+                        display_total: "$59.97"
                         price: '19.99'
                         total: '59.97'
                       relationships:
@@ -11382,9 +11389,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T16:15:38.537Z'
-                        updated_at: '2021-11-01T16:15:38.537Z'
-                        token: FWxVNirxSL8hyJDQJpZeBx4y
+                        created_at: '2021-11-01T22:33:31.092Z'
+                        updated_at: '2021-11-01T22:33:31.092Z'
+                        token: 4HS8sxBRsw8AZ1Mk2c1UPzAY
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11399,9 +11406,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T16:15:38.538Z'
-                        updated_at: '2021-11-01T16:15:38.538Z'
-                        token: u7ttyfedUjYCZjoKVkDnjEgG
+                        created_at: '2021-11-01T22:33:31.094Z'
+                        updated_at: '2021-11-01T22:33:31.094Z'
+                        token: kboEiS3tUUMyo4zMEPmYNqWk
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11463,9 +11470,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T16:15:38.982Z'
-                        updated_at: '2021-11-01T16:15:38.982Z'
-                        token: eYsnp8KKEYoDYC57kNAdqXR5
+                        created_at: '2021-11-01T22:33:31.547Z'
+                        updated_at: '2021-11-01T22:33:31.547Z'
+                        token: NYqB7eeKhegf6DvcxpZwNW4T
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11529,9 +11536,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T16:15:39.020Z'
-                        updated_at: '2021-11-01T16:15:39.020Z'
-                        token: HAqhVZZtc7hTXi4ndQid4WTJ
+                        created_at: '2021-11-01T22:33:31.584Z'
+                        updated_at: '2021-11-01T22:33:31.584Z'
+                        token: LXr4XHKWqSVZU1cEEPjB9e1q
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11594,9 +11601,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-01T16:15:39.080Z'
-                        updated_at: '2021-11-01T16:15:39.087Z'
-                        token: oKXZZsptL87xzBuk1G8uqkhE
+                        created_at: '2021-11-01T22:33:31.644Z'
+                        updated_at: '2021-11-01T22:33:31.652Z'
+                        token: ZLniiySuNbbncAzvcQKoRsGj
                         variant_included: false
                       relationships:
                         wished_items:
@@ -11952,7 +11959,7 @@ components:
       required:
       - classification
       x-internal: true
-    create_cms_page_params:
+    create_standard_cms_page_params:
       type: object
       properties:
         cms_page:
@@ -11963,22 +11970,151 @@ components:
           properties:
             title:
               type: string
+              example: About Us
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.
             meta_title:
               type: string
+              nullable: true
+              example: Learn More About Super-Shop
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
             content:
               type: string
+              nullable: true
+              example: Lot's of text..
+              description: The text content of a standard page, this can be HTML from
+                a rich text editor.
             meta_description:
               type: string
+              nullable: true
+              example: Learn more about us on this page here...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
             visible:
-              type: string
+              type: boolean
+              enum:
+              - 'true'
+              - 'false'
+              description: This page is publicly visible when set to `true`.
             slug:
               type: string
+              nullable: true
+              example: about-us
+              description: Set a slug for this page.
             locale:
               type: string
+              example: en-US
+              description: The language this page is written in.
       required:
       - cms_page
+      title: Create a Standard Page
       x-internal: true
-    update_cms_page_params:
+    create_homepage_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          required:
+          - title
+          - locale
+          properties:
+            title:
+              type: string
+              example: Our Flash Homepage
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.
+            meta_title:
+              type: string
+              nullable: true
+              example: Visit Our Store - Great Deals
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Discover great new products that we sell in this store...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
+            visible:
+              type: boolean
+              enum:
+              - 'true'
+              - 'false'
+              description: This page is publicly visible when set to `true`.
+            locale:
+              type: string
+              example: en-US
+              description: The language this page is written in.
+      required:
+      - cms_page
+      title: Create a Homepage
+      x-internal: true
+    create_feature_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          required:
+          - title
+          - locale
+          properties:
+            title:
+              type: string
+              example: Featured Product
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.
+            meta_title:
+              type: string
+              nullable: true
+              example: Learn More About This Featured Product
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Learn more about us this amazing product that we sell right
+                here...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
+            visible:
+              type: boolean
+              enum:
+              - 'true'
+              - 'false'
+              description: This page is publicly visible when set to `true`.
+            slug:
+              type: string
+              nullable: true
+              example: about-us
+              description: Set a slug for this page.
+            locale:
+              type: string
+              example: en-US
+              description: The language this page is written in.
+      required:
+      - cms_page
+      title: Create a Feature Page
+      x-internal: true
+    update_standard_cms_page_params:
       type: object
       properties:
         cms_page:
@@ -11986,20 +12122,143 @@ components:
           properties:
             title:
               type: string
+              example: About Us
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.
             meta_title:
               type: string
+              nullable: true
+              example: Learn More About Super-Shop
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
             content:
               type: string
+              nullable: true
+              example: Lot's of text..
+              description: The text content of a standard page, this can be HTML from
+                a rich text editor.
             meta_description:
               type: string
+              nullable: true
+              example: Learn more about us on this page here...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
             visible:
-              type: string
+              type: boolean
+              enum:
+              - 'true'
+              - 'false'
+              description: This page is publicly visible when set to `true`.
             slug:
               type: string
+              nullable: true
+              example: about-us
+              description: Set a slug for this page.
             locale:
               type: string
+              example: en-US
+              description: The language this page is written in.
       required:
       - cms_page
+      title: Create a Standard Page
+      x-internal: true
+    update_homepage_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          properties:
+            title:
+              type: string
+              example: Our Flash Homepage
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.
+            meta_title:
+              type: string
+              nullable: true
+              example: Visit Our Store - Great Deals
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Discover great new products that we sell in this store...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
+            visible:
+              type: boolean
+              enum:
+              - 'true'
+              - 'false'
+              description: This page is publicly visible when set to `true`.
+            locale:
+              type: string
+              example: en-US
+              description: The language this page is written in.
+      required:
+      - cms_page
+      title: Create a Homepage
+      x-internal: true
+    update_feature_cms_page_params:
+      type: object
+      properties:
+        cms_page:
+          type: object
+          properties:
+            title:
+              type: string
+              example: Featured Product
+              description: Give your page a title.
+            type:
+              type: string
+              enum:
+              - Spree::Cms::Pages::StandardPage
+              - Spree::Cms::Pages::Homepage
+              - Spree::Cms::Pages::FeaturePage
+              description: Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.
+            meta_title:
+              type: string
+              nullable: true
+              example: Learn More About This Featured Product
+              description: Set the meta title for this page, this appears in the title
+                bar of the browser.
+            meta_description:
+              type: string
+              nullable: true
+              example: Learn more about us this amazing product that we sell right
+                here...
+              description: Set a meta description, used for SEO and displayed in search
+                results.
+            visible:
+              type: boolean
+              enum:
+              - 'true'
+              - 'false'
+              description: This page is publicly visible when set to `true`.
+            slug:
+              type: string
+              nullable: true
+              example: about-us
+              description: Set a slug for this page.
+            locale:
+              type: string
+              example: en-US
+              description: The language this page is written in.
+      required:
+      - cms_page
+      title: Create a Feature Page
       x-internal: true
     create_cms_section_params:
       type: object
@@ -12376,7 +12635,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-01 16:15:03 UTC
+              example: 2021-11-01 22:32:55 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12444,7 +12703,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-01 16:15:03 UTC
+              example: 2021-11-01 22:32:55 UTC
             confirmation_delivered:
               type: boolean
               example: true
@@ -12511,7 +12770,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-01 16:15:03 UTC
+              example: 2021-11-01 22:32:55 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -12579,7 +12838,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-01 16:15:03 UTC
+              example: 2021-11-01 22:32:55 UTC
             confirmation_delivered:
               type: boolean
               example: true

--- a/api/spec/integration/api/v2/platform/cms_pages_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_pages_spec.rb
@@ -7,7 +7,21 @@ describe 'CMS Pages API', swagger: true do
   options = {
     include_example: 'cms_sections',
     filter_examples: [{ name: 'filter[type]', example: 'homepage' },
-                      { name: 'filter[title_cont]', example: 'About Us' }]
+                      { name: 'filter[title_cont]', example: 'About Us' }],
+    custom_create_params: {
+      oneOf: [
+        { '$ref' => '#/components/schemas/create_standard_cms_page_params' },
+        { '$ref' => '#/components/schemas/create_homepage_cms_page_params' },
+        { '$ref' => '#/components/schemas/create_feature_cms_page_params' }
+      ]
+    },
+    custom_update_params: {
+      oneOf: [
+        { '$ref' => '#/components/schemas/update_standard_cms_page_params' },
+        { '$ref' => '#/components/schemas/update_homepage_cms_page_params' },
+        { '$ref' => '#/components/schemas/update_feature_cms_page_params' }
+      ]
+    }
   }
 
   let(:store) { Spree::Store.default }

--- a/api/spec/integration/api/v2/platform/cms_pages_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_pages_spec.rb
@@ -6,7 +6,8 @@ describe 'CMS Pages API', swagger: true do
   resource_name = 'CMS Page'
   options = {
     include_example: 'cms_sections',
-    filter_examples: [{ name: 'filter[type]', example: 'homepage' },
+    filter_examples: [{ name: 'filter[type_eq]', example: 'Spree::Cms::Pages::FeaturePage' },
+                      { name: 'filter[locale_eq]', example: 'en' },
                       { name: 'filter[title_cont]', example: 'About Us' }],
     custom_create_params: {
       oneOf: [

--- a/api/spec/integration/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/integration/api/v2/platform/cms_sections_spec.rb
@@ -6,13 +6,33 @@ describe 'CMS Section API', swagger: true do
   resource_name = 'CMS Section'
   options = {
     include_example: 'product',
-    filter_examples: [{ name: 'filter[name_eq]', example: 'Hero' }]
+    filter_examples: [{ name: 'filter[name_eq]', example: 'Hero' }],
+    custom_create_params: {
+      oneOf: [
+        { '$ref' => '#/components/schemas/create_hero_image_cms_section_params' },
+        { '$ref' => '#/components/schemas/create_product_carousel_cms_section_params' },
+        { '$ref' => '#/components/schemas/create_side_by_side_images_cms_section_params' },
+        { '$ref' => '#/components/schemas/create_featured_article_cms_section_params' },
+        { '$ref' => '#/components/schemas/create_image_gallery_cms_section_params' },
+        { '$ref' => '#/components/schemas/create_rich_text_cms_section_params' }
+      ]
+    },
+    custom_update_params: {
+      oneOf: [
+        { '$ref' => '#/components/schemas/update_hero_image_cms_section_params' },
+        { '$ref' => '#/components/schemas/update_product_carousel_cms_section_params' },
+        { '$ref' => '#/components/schemas/update_side_by_side_images_cms_section_params' },
+        { '$ref' => '#/components/schemas/update_featured_article_cms_section_params' },
+        { '$ref' => '#/components/schemas/update_image_gallery_cms_section_params' },
+        { '$ref' => '#/components/schemas/update_rich_text_cms_section_params' }
+      ]
+    }
   }
 
   let!(:store) { Spree::Store.default }
   let!(:product) { create(:product) }
   let!(:cms_page) { create(:cms_feature_page, store: store) }
-  let!(:cms_hero_section) { create(:cms_hero_image_section, cms_page: cms_page) }
+  let!(:cms_section) { create(:cms_hero_image_section, cms_page: cms_page) }
   let!(:cms_image_gallery_section) { create(:cms_image_gallery_section, cms_page: cms_page) }
   let!(:cms_featured_article_section) { create(:cms_featured_article_section, cms_page: cms_page) }
 
@@ -23,9 +43,11 @@ describe 'CMS Section API', swagger: true do
   let(:valid_update_param_value) do
     {
       name: 'Super Hero',
-      position: 1
+      position: 1,
+      type: 'Spree::Cms::Sections::HeroImage'
     }
   end
+
   let(:invalid_param_value) do
     {
       name: ''

--- a/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/cms_sections_spec.rb
@@ -7,11 +7,12 @@ describe 'Platform API v2 CmsSections', type: :request do
   let!(:store) { Spree::Store.default }
   let!(:page) { create(:cms_homepage, store: store) }
 
-  let!(:resource_a) { create(:cms_section, cms_page: page) }
-  let!(:resource_b) { create(:cms_section, cms_page: page) }
-  let!(:resource_c) { create(:cms_section, cms_page: page) }
-  let!(:resource_d) { create(:cms_section, cms_page: page) }
-  let!(:resource_e) { create(:cms_section, cms_page: page) }
+  let!(:resource_a) { create(:cms_hero_image_section, cms_page: page) }
+  let!(:resource_b) { create(:cms_featured_article_section, cms_page: page) }
+  let!(:resource_c) { create(:cms_product_carousel_section, cms_page: page) }
+  let!(:resource_d) { create(:cms_image_gallery_section, cms_page: page) }
+  let!(:resource_e) { create(:cms_side_by_side_images_section, cms_page: page) }
+  let!(:resource_f) { create(:cms_rich_text_content_section, cms_page: page) }
 
   let(:bearer_token) { { 'Authorization' => valid_authorization } }
 
@@ -37,6 +38,7 @@ describe 'Platform API v2 CmsSections', type: :request do
         expect(resource_d.position).to eq(3)
         expect(resource_e.position).to eq(4)
         expect(resource_a.position).to eq(5)
+        expect(resource_f.position).to eq(6)
       end
     end
 
@@ -69,6 +71,7 @@ describe 'Platform API v2 CmsSections', type: :request do
       resource_c.reload
       resource_d.reload
       resource_e.reload
+      resource_f.reload
     end
   end
 end

--- a/api/spec/requests/spree/api/v2/storefront/cms_pages_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cms_pages_spec.rb
@@ -112,14 +112,14 @@ describe 'Storefront API v2 CMS Pages spec', type: :request do
     context 'including cms sections with linked resources' do
       let(:taxonomy) { create(:taxonomy, store: store) }
       let(:taxon) { create(:taxon, taxonomy: taxonomy) }
-      let!(:cms_section) { create(:cms_section, cms_page: home_en, linked_resource: taxon) }
+      let!(:cms_section) { create(:cms_hero_image_section, cms_page: home_en, linked_resource: taxon) }
 
       before { get '/api/v2/storefront/cms_pages?include=cms_sections.linked_resource' }
 
       it_behaves_like 'returns 200 HTTP status'
       it_behaves_like 'returns proper JSON structure'
 
-      it 'returns cms sections and their associations' do
+      it 'returns sections and their associations' do
         expect(json_response['included']).to include(have_type('taxon').and(have_id(taxon.id.to_s)))
         expect(json_response['included']).to include(
           have_type('cms_section').
@@ -142,7 +142,7 @@ describe 'Storefront API v2 CMS Pages spec', type: :request do
       let!(:page) { create(:cms_standard_page, store: store) }
       let(:taxonomy) { create(:taxonomy, store: store) }
       let(:taxon) { create(:taxon, taxonomy: taxonomy) }
-      let!(:page_item) { create(:cms_section, cms_page: page, linked_resource: taxon) }
+      let!(:page_item) { create(:cms_hero_image_section, cms_page: page, linked_resource: taxon) }
 
       before { get "/api/v2/storefront/cms_pages/#{page.id}?include=cms_sections.linked_resource" }
 

--- a/api/spec/serializers/spree/api/v2/platform/cms_page_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/cms_page_serializer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Api::V2::Platform::CmsPageSerializer do
   subject { described_class.new(cms_page) }
 
-  let(:cms_page) { create(:base_cms_page, cms_sections: create_list(:cms_section, 2)) }
+  let(:cms_page) { create(:cms_feature_page, cms_sections: create_list(:cms_hero_image_section, 2)) }
 
   it { expect(subject.serializable_hash).to be_kind_of(Hash) }
 

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -220,14 +220,14 @@ RSpec.configure do |config|
             properties: {
               cms_page: {
                 type: :object,
-                required: %w[title locale],
+                required: %w[title locale type],
                 properties: {
                   title: { type: :string, example: 'About Us', description: 'Give your page a title.' },
                   type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.' },
                   meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   content: { type: :string, nullable: true, example: "Lot's of text..", description: 'The text content of a standard page, this can be HTML from a rich text editor.' },
                   meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
-                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
                   slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
                   locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
@@ -242,13 +242,13 @@ RSpec.configure do |config|
             properties: {
               cms_page: {
                 type: :object,
-                required: %w[title locale],
+                required: %w[title locale type],
                 properties: {
                   title: { type: :string, example: 'Our Flash Homepage', description: 'Give your page a title.' },
                   type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.' },
                   meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Set a meta description, used for SEO and displayed in search results.' },
-                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
                   locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
               }
@@ -262,13 +262,13 @@ RSpec.configure do |config|
             properties: {
               cms_page: {
                 type: :object,
-                required: %w[title locale],
+                required: %w[title locale type],
                 properties: {
                   title: { type: :string, example: 'Featured Product', description: 'Give your page a title.' },
                   type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.' },
                   meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
-                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
                   slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
                   locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
@@ -289,14 +289,14 @@ RSpec.configure do |config|
                   meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   content: { type: :string, nullable: true, example: "Lot's of text..", description: 'The text content of a standard page, this can be HTML from a rich text editor.' },
                   meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
-                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
                   slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
                   locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
               }
             },
             required: %w[cms_page],
-            title: 'Create a Standard Page',
+            title: 'Update a Standard Page',
             'x-internal': true
           },
           update_homepage_cms_page_params: {
@@ -309,13 +309,13 @@ RSpec.configure do |config|
                   type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.' },
                   meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Set a meta description, used for SEO and displayed in search results.' },
-                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
                   locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
               }
             },
             required: %w[cms_page],
-            title: 'Create a Homepage',
+            title: 'Update a Homepage',
             'x-internal': true
           },
           update_feature_cms_page_params: {
@@ -328,53 +328,298 @@ RSpec.configure do |config|
                   type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.' },
                   meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
-                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
                   slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
                   locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
               }
             },
             required: %w[cms_page],
-            title: 'Create a Feature Page',
+            title: 'Update a Feature Page',
             'x-internal': true
           },
 
           # CMS Section
-          create_cms_section_params: {
+          create_hero_image_cms_section_params: {
             type: :object,
             properties: {
               cms_section: {
                 type: :object,
-                required: %w[name cms_page_id],
+                required: %w[name cms_page_id type],
                 properties: {
-                  name: { type: :string },
-                  cms_page_id: { type: :string },
-                  destination: { type: :string, example: 'https://getvendo.com' },
-                  linked_resource_type: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'] },
-                  fit: { type: :string, example: 'Screen', description: 'This value is used by front end developers to manipulate CSS values to fit the section into the Screen or within the Container element.' },
-                  position: { type: :integer, example: 2, description: 'Pass the new position that you want this section to appear in. (The list is not zero indexed, so the first item is position: 1)' }
+                  name: { type: :string, description: 'Give this section a name.' },
+                  cms_page_id: { type: :string, description: 'Set the `cms_page` ID that this section belongs to.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage'], example: 'Spree::Cms::Sections::HeroImage', description: 'Set the section type.' },
+                  linked_resource_type: { type: :string, example: 'Spree::Taxon', nullable: true, enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Set the resource type that this section links to.' },
+                  linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Set the ID of the resource that you would like this section to link to.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
+                  button_text: { type: :string, example: 'Click Here', description: 'Set the text value of the button used in this section.' },
+                  title: { type: :string, example: 'Shop Today', description: 'Create a title for the Hero Section.' }
                 }
               }
             },
             required: %w[cms_section],
+            title: 'Create a Hero Image Section',
             'x-internal': true
           },
-          update_cms_section_params: {
+          create_product_carousel_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                required: %w[name cms_page_id type],
+                properties: {
+                  name: { type: :string, description: 'Give this section a name.' },
+                  cms_page_id: { type: :string, description: 'Set the `cms_page` ID that this section belongs to.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::ProductCarousel'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Set the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Set the ID of the Taxon that you would like displayed as a Product Carousel.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Create a Product Carousel Section',
+            'x-internal': true
+          },
+          create_side_by_side_images_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                required: %w[name cms_page_id type],
+                properties: {
+                  name: { type: :string, description: 'Give this section a name.' },
+                  cms_page_id: { type: :string, description: 'Set the `cms_page` ID that this section belongs to.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::SideBySideImages'], example: 'Spree::Cms::Sections::SideBySideImages', description: 'Set the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  link_type_one: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Set the resource type that image one links to.' },
+                  link_type_two: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Set the resource type that image two links to.' },
+                  link_one: { type: :string, example: 'men/shirts', nullable: true, description: 'Set the slug or path that image two links to.' },
+                  link_two: { type: :string, example: 'white-shirt', nullable: true, description: 'Set the slug or path that image two links to.' },
+                  title_one: { type: :string, example: "Shop Men's Shirts", nullable: true, description: 'Set the title used in image one.' },
+                  title_two: { type: :string, example: "Buy This Men's Shirt", nullable: true, description: 'Set the title used in image two.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  subtitle_one: { type: :string, example: 'Save 50% today', nullable: true, description: 'Set the subtitle used in image one.' },
+                  subtitle_two: { type: :string, example: 'Save 50% today', nullable: true, description: 'Set the subtitle used in image two.' },
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Create a Side-by-Side Image Section',
+            'x-internal': true
+          },
+          create_image_gallery_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                required: %w[name cms_page_id type],
+                properties: {
+                  name: { type: :string, description: 'Give this section a name.' },
+                  cms_page_id: { type: :string, description: 'Set the `cms_page` ID that this section belongs to.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::ImageGallery'], example: 'Spree::Cms::Sections::ImageGallery', description: 'Set the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  link_type_one: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Set the resource type that image one links to.' },
+                  link_type_two: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Set the resource type that image two links to.' },
+                  link_type_three: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Set the resource type that image three links to.' },
+                  link_one: { type: :string, example: 'men/shirts', nullable: true, description: 'Set the slug or path that image two links to.' },
+                  link_two: { type: :string, example: 'white-shirt', nullable: true, description: 'Set the slug or path that image two links to.' },
+                  link_three: { type: :string, example: 'red-shirt', nullable: true, description: 'Set the slug or path that image three links to.' },
+                  title_one: { type: :string, example: "Shop Men's Shirts", nullable: true, description: 'Set the title used in image one.' },
+                  title_two: { type: :string, example: "Buy This Men's Shirt", nullable: true, description: 'Set the title used in image two.' },
+                  title_three: { type: :string, example: "Buy This Women's Skirt", nullable: true, description: 'Set the title used in image three.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  layout_style: { type: :string, example: 'Default', enum: ['Default', 'Reversed'], description: 'This value is used by front end developers for styling the order the images appear.' },
+                  display_labels: { type: :string, example: 'Show', enum: ['Show', 'Hide'], description: 'This value is used by front end developers for showing and hiding the label on the images.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Create an Image Gallery Section',
+            'x-internal': true
+          },
+          create_featured_article_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                required: %w[name cms_page_id type],
+                properties: {
+                  name: { type: :string, description: 'Give this section a name.' },
+                  cms_page_id: { type: :string, description: 'Set the `cms_page` ID that this section belongs to.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::FeaturedArticle'], example: 'Spree::Cms::Sections::FeaturedArticle', description: 'Set the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  linked_resource_type: { type: :string, example: 'Spree::Taxon', nullable: true, enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Set the resource type that this section links to.' },
+                  linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Set the ID of the resource that you would like this section to link to.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
+                  button_text: { type: :string, example: 'Click Here', description: 'Set the text value of the button used in this section.' },
+                  title: { type: :string, example: 'Shop Today', description: 'Create a title for the Section.' },
+                  subtitle: { type: :string, example: 'Save Big!', description: 'Create a subtitle for the Section.' },
+                  rte_content: { type: :string, example: 'Lots of text and content goes here.', description: 'Set the content, here, this can be rich text editor content.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Create a Featured Article Section',
+            'x-internal': true
+          },
+          create_rich_text_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                required: %w[name cms_page_id type],
+                properties: {
+                  name: { type: :string, description: 'Give this section a name.' },
+                  cms_page_id: { type: :string, description: 'Set the `cms_page` ID that this section belongs to.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::RichTextContent', description: 'Set the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  rte_content: { type: :string, example: 'Lots of text and content goes here.', description: 'Set the content, here, this can be rich text editor content.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Create a Rich Text Section',
+            'x-internal': true
+          },
+          update_hero_image_cms_section_params: {
             type: :object,
             properties: {
               cms_section: {
                 type: :object,
                 properties: {
-                  name: { type: :string },
-                  cms_page_id: { type: :string },
-                  destination: { type: :string, example: 'https://getvendo.com' },
-                  linked_resource_type: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'] },
-                  fit: { type: :string, example: 'Screen', description: 'This value is used by front end developers to manipulate CSS values to fit the section into the Screen or within the Container element.' },
-                  position: { type: :integer, example: 2, description: 'Pass the new position that you want this section to appear in. (The list is not zero indexed, so the first item is position: 1)' }
+                  name: { type: :string, description: 'Update this section name.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage'], example: 'Spree::Cms::Sections::HeroImage', description: 'Change the section type.' },
+                  linked_resource_type: { type: :string, example: 'Spree::Taxon', nullable: true, enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Update the resource type that this section links to.' },
+                  linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Set the ID of the resource that you would like this section to link to.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
+                  button_text: { type: :string, example: 'Click Here', description: 'Update the text value of the button used in this section.' },
+                  title: { type: :string, example: 'Shop Today', description: 'Update the title for this section.' }
                 }
               }
             },
             required: %w[cms_section],
+            title: 'Update a Hero Image Section',
+            'x-internal': true
+          },
+          update_product_carousel_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                properties: {
+                  name: { type: :string, description: 'Change this section name.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::ProductCarousel'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Update the ID of the Taxon that you would like displayed as a Product Carousel.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Update a Product Carousel Section',
+            'x-internal': true
+          },
+          update_side_by_side_images_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                properties: {
+                  name: { type: :string, description: 'Update this section name.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::SideBySideImages'], example: 'Spree::Cms::Sections::SideBySideImages', description: 'Change the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  link_type_one: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image one links to.' },
+                  link_type_two: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image two links to.' },
+                  link_one: { type: :string, example: 'men/shirts', nullable: true, description: 'Update the slug or path that image two links to.' },
+                  link_two: { type: :string, example: 'white-shirt', nullable: true, description: 'Update the slug or path that image two links to.' },
+                  title_one: { type: :string, example: "Shop Men's Shirts", nullable: true, description: 'Update the title used in image one.' },
+                  title_two: { type: :string, example: "Buy This Men's Shirt", nullable: true, description: 'Update the title used in image two.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  subtitle_one: { type: :string, example: 'Save 50% today', nullable: true, description: 'Update the subtitle used in image one.' },
+                  subtitle_two: { type: :string, example: 'Save 50% today', nullable: true, description: 'Update the subtitle used in image two.' },
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Update a Side-by-Side Image Section',
+            'x-internal': true
+          },
+          update_image_gallery_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                properties: {
+                  name: { type: :string, description: 'Update this section name.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::ImageGallery'], example: 'Spree::Cms::Sections::ImageGallery', description: 'Change the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  link_type_one: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image one links to.' },
+                  link_type_two: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image two links to.' },
+                  link_type_three: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image three links to.' },
+                  link_one: { type: :string, example: 'men/shirts', nullable: true, description: 'Update the slug or path that image two links to.' },
+                  link_two: { type: :string, example: 'white-shirt', nullable: true, description: 'Update the slug or path that image two links to.' },
+                  link_three: { type: :string, example: 'red-shirt', nullable: true, description: 'Update the slug or path that image three links to.' },
+                  title_one: { type: :string, example: "Shop Men's Shirts", nullable: true, description: 'Update the title used in image one.' },
+                  title_two: { type: :string, example: "Buy This Men's Shirt", nullable: true, description: 'Update the title used in image two.' },
+                  title_three: { type: :string, example: "Buy This Women's Skirt", nullable: true, description: 'Update the title used in image three.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  layout_style: { type: :string, example: 'Default', enum: ['Default', 'Reversed'], description: 'This value is used by front end developers for styling the order the images appear.' },
+                  display_labels: { type: :string, example: 'Show', enum: ['Show', 'Hide'], description: 'This value is used by front end developers for showing and hiding the label on the images.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Update an Image Gallery Section',
+            'x-internal': true
+          },
+          update_featured_article_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                properties: {
+                  name: { type: :string, description: 'Update this section name.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::FeaturedArticle'], example: 'Spree::Cms::Sections::FeaturedArticle', description: 'Change the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  linked_resource_type: { type: :string, example: 'Spree::Taxon', nullable: true, enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Set the resource type that this section links to.' },
+                  linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Change the ID of the resource that you would like this section to link to.' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
+                  button_text: { type: :string, example: 'Click Here', description: 'Update the text value of the button used in this section.' },
+                  title: { type: :string, example: 'Shop Today', description: 'Update the title for the Section.' },
+                  subtitle: { type: :string, example: 'Save Big!', description: 'Update the subtitle for the Section.' },
+                  rte_content: { type: :string, example: 'Lots of text and content goes here.', description: 'Update the content here, this can be rich text editor content.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Update a Featured Article Section',
+            'x-internal': true
+          },
+          update_rich_text_cms_section_params: {
+            type: :object,
+            properties: {
+              cms_section: {
+                type: :object,
+                properties: {
+                  name: { type: :string, description: 'Update this section name.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::RichTextContent', description: 'Change the section type.' },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
+                  rte_content: { type: :string, example: 'Lots of text and content goes here.', description: 'Update the content, here, this can be rich text editor content.' }
+                }
+              }
+            },
+            required: %w[cms_section],
+            title: 'Update a Rich Text Section',
             'x-internal': true
           },
 

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -223,7 +223,7 @@ RSpec.configure do |config|
                 required: %w[title locale type],
                 properties: {
                   title: { type: :string, example: 'About Us', description: 'Give your page a title.' },
-                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage'], description: 'Set the type of page.' },
                   meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   content: { type: :string, nullable: true, example: "Lot's of text..", description: 'The text content of a standard page, this can be HTML from a rich text editor.' },
                   meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
@@ -245,7 +245,7 @@ RSpec.configure do |config|
                 required: %w[title locale type],
                 properties: {
                   title: { type: :string, example: 'Our Flash Homepage', description: 'Give your page a title.' },
-                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::Homepage'], description: 'Set the type of page.' },
                   meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Set a meta description, used for SEO and displayed in search results.' },
                   visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
@@ -265,7 +265,7 @@ RSpec.configure do |config|
                 required: %w[title locale type],
                 properties: {
                   title: { type: :string, example: 'Featured Product', description: 'Give your page a title.' },
-                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page.' },
                   meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
                   meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
                   visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
@@ -284,14 +284,14 @@ RSpec.configure do |config|
               cms_page: {
                 type: :object,
                 properties: {
-                  title: { type: :string, example: 'About Us', description: 'Give your page a title.' },
-                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.' },
-                  meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
-                  content: { type: :string, nullable: true, example: "Lot's of text..", description: 'The text content of a standard page, this can be HTML from a rich text editor.' },
-                  meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  title: { type: :string, example: 'About Us', description: 'Update the page title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Change the type of page.' },
+                  meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Update the meta title for this page, this appears in the title bar of the browser.' },
+                  content: { type: :string, nullable: true, example: "Lot's of text..", description: 'Update the text content of a standard page, this can be HTML from a rich text editor.' },
+                  meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Update the meta description, used for SEO and displayed in search results.' },
                   visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
-                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
-                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Update the slug for this page.' },
+                  locale: { type: :string, example: 'en-US', description: 'Update the language of this page.' }
                 }
               }
             },
@@ -305,12 +305,12 @@ RSpec.configure do |config|
               cms_page: {
                 type: :object,
                 properties: {
-                  title: { type: :string, example: 'Our Flash Homepage', description: 'Give your page a title.' },
-                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.' },
-                  meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
-                  meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  title: { type: :string, example: 'Our Flash Homepage', description: 'Update the page title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Change the type of page.' },
+                  meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Update the meta title for this page, this appears in the title bar of the browser.' },
+                  meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Update the meta description, used for SEO and displayed in search results.' },
                   visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
-                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                  locale: { type: :string, example: 'en-US', description: 'Update the language of this page.' }
                 }
               }
             },
@@ -324,13 +324,13 @@ RSpec.configure do |config|
               cms_page: {
                 type: :object,
                 properties: {
-                  title: { type: :string, example: 'Featured Product', description: 'Give your page a title.' },
-                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.' },
-                  meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
-                  meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  title: { type: :string, example: 'Featured Product', description: 'Update the page title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Change the type of page.' },
+                  meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Update the meta title for this page, this appears in the title bar of the browser.' },
+                  meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Update the meta description, used for SEO and displayed in search results.' },
                   visible: { type: :boolean, enum: [true, false], description: 'This page is publicly visible when set to `true`.' },
-                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
-                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Update the slug for this page.' },
+                  locale: { type: :string, example: 'en-US', description: 'Update the language of this page.' }
                 }
               }
             },
@@ -356,7 +356,8 @@ RSpec.configure do |config|
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
                   button_text: { type: :string, example: 'Click Here', description: 'Set the text value of the button used in this section.' },
-                  title: { type: :string, example: 'Shop Today', description: 'Create a title for the Hero Section.' }
+                  title: { type: :string, example: 'Shop Today', description: 'Create a title for the Hero Section.' },
+                  'digital[image_one]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' }
                 }
               }
             },
@@ -403,7 +404,9 @@ RSpec.configure do |config|
                   fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
                   subtitle_one: { type: :string, example: 'Save 50% today', nullable: true, description: 'Set the subtitle used in image one.' },
                   subtitle_two: { type: :string, example: 'Save 50% today', nullable: true, description: 'Set the subtitle used in image two.' },
-                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' }
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
+                  'digital[image_one]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' },
+                  'digital[image_two]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' }
                 }
               }
             },
@@ -433,7 +436,10 @@ RSpec.configure do |config|
                   title_three: { type: :string, example: "Buy This Women's Skirt", nullable: true, description: 'Set the title used in image three.' },
                   fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
                   layout_style: { type: :string, example: 'Default', enum: ['Default', 'Reversed'], description: 'This value is used by front end developers for styling the order the images appear.' },
-                  display_labels: { type: :string, example: 'Show', enum: ['Show', 'Hide'], description: 'This value is used by front end developers for showing and hiding the label on the images.' }
+                  display_labels: { type: :string, example: 'Show', enum: ['Show', 'Hide'], description: 'This value is used by front end developers for showing and hiding the label on the images.' },
+                  'digital[image_one]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' },
+                  'digital[image_two]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' },
+                  'digital[image_three]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' }
                 }
               }
             },
@@ -494,14 +500,16 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   name: { type: :string, description: 'Update this section name.' },
-                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage'], example: 'Spree::Cms::Sections::HeroImage', description: 'Change the section type.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage', 'Spree::Cms::Sections::FeaturedArticle', 'Spree::Cms::Sections::ProductCarousel', 'Spree::Cms::Sections::ImageGallery', 'Spree::Cms::Sections::SideBySideImages', 'Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
                   linked_resource_type: { type: :string, example: 'Spree::Taxon', nullable: true, enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Update the resource type that this section links to.' },
                   linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Set the ID of the resource that you would like this section to link to.' },
                   fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
                   button_text: { type: :string, example: 'Click Here', description: 'Update the text value of the button used in this section.' },
-                  title: { type: :string, example: 'Shop Today', description: 'Update the title for this section.' }
+                  title: { type: :string, example: 'Shop Today', description: 'Update the title for this section.' },
+                  'digital[image_one]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' }
+
                 }
               }
             },
@@ -516,7 +524,7 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   name: { type: :string, description: 'Change this section name.' },
-                  type: { type: :string, enum: ['Spree::Cms::Sections::ProductCarousel'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage', 'Spree::Cms::Sections::FeaturedArticle', 'Spree::Cms::Sections::ProductCarousel', 'Spree::Cms::Sections::ImageGallery', 'Spree::Cms::Sections::SideBySideImages', 'Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Update the ID of the Taxon that you would like displayed as a Product Carousel.' }
                 }
@@ -533,7 +541,7 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   name: { type: :string, description: 'Update this section name.' },
-                  type: { type: :string, enum: ['Spree::Cms::Sections::SideBySideImages'], example: 'Spree::Cms::Sections::SideBySideImages', description: 'Change the section type.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage', 'Spree::Cms::Sections::FeaturedArticle', 'Spree::Cms::Sections::ProductCarousel', 'Spree::Cms::Sections::ImageGallery', 'Spree::Cms::Sections::SideBySideImages', 'Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   link_type_one: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image one links to.' },
                   link_type_two: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image two links to.' },
@@ -544,7 +552,9 @@ RSpec.configure do |config|
                   fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
                   subtitle_one: { type: :string, example: 'Save 50% today', nullable: true, description: 'Update the subtitle used in image one.' },
                   subtitle_two: { type: :string, example: 'Save 50% today', nullable: true, description: 'Update the subtitle used in image two.' },
-                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' }
+                  gutters: { type: :string, example: 'No Gutters', enum: ['Gutters', 'No Gutters'], description: 'This value is used by front end developers for styling the section padding.' },
+                  'digital[image_one]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' },
+                  'digital[image_two]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' }
                 }
               }
             },
@@ -559,7 +569,7 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   name: { type: :string, description: 'Update this section name.' },
-                  type: { type: :string, enum: ['Spree::Cms::Sections::ImageGallery'], example: 'Spree::Cms::Sections::ImageGallery', description: 'Change the section type.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage', 'Spree::Cms::Sections::FeaturedArticle', 'Spree::Cms::Sections::ProductCarousel', 'Spree::Cms::Sections::ImageGallery', 'Spree::Cms::Sections::SideBySideImages', 'Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   link_type_one: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image one links to.' },
                   link_type_two: { type: :string, example: 'Spree::Taxon', enum: ['Spree::Taxon', 'Spree::Product'], description: 'Update the resource type that image two links to.' },
@@ -572,7 +582,10 @@ RSpec.configure do |config|
                   title_three: { type: :string, example: "Buy This Women's Skirt", nullable: true, description: 'Update the title used in image three.' },
                   fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
                   layout_style: { type: :string, example: 'Default', enum: ['Default', 'Reversed'], description: 'This value is used by front end developers for styling the order the images appear.' },
-                  display_labels: { type: :string, example: 'Show', enum: ['Show', 'Hide'], description: 'This value is used by front end developers for showing and hiding the label on the images.' }
+                  display_labels: { type: :string, example: 'Show', enum: ['Show', 'Hide'], description: 'This value is used by front end developers for showing and hiding the label on the images.' },
+                  'digital[image_one]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' },
+                  'digital[image_two]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' },
+                  'digital[image_three]': { type: :string, format: :binary, description: 'Use a `multipart/form-data` request to upload assets.' }
                 }
               }
             },
@@ -587,7 +600,7 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   name: { type: :string, description: 'Update this section name.' },
-                  type: { type: :string, enum: ['Spree::Cms::Sections::FeaturedArticle'], example: 'Spree::Cms::Sections::FeaturedArticle', description: 'Change the section type.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage', 'Spree::Cms::Sections::FeaturedArticle', 'Spree::Cms::Sections::ProductCarousel', 'Spree::Cms::Sections::ImageGallery', 'Spree::Cms::Sections::SideBySideImages', 'Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   linked_resource_type: { type: :string, example: 'Spree::Taxon', nullable: true, enum: ['Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Set the resource type that this section links to.' },
                   linked_resource_id: { type: :string, example: '1', nullable: true, description: 'Change the ID of the resource that you would like this section to link to.' },
@@ -611,7 +624,7 @@ RSpec.configure do |config|
                 type: :object,
                 properties: {
                   name: { type: :string, description: 'Update this section name.' },
-                  type: { type: :string, enum: ['Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::RichTextContent', description: 'Change the section type.' },
+                  type: { type: :string, enum: ['Spree::Cms::Sections::HeroImage', 'Spree::Cms::Sections::FeaturedArticle', 'Spree::Cms::Sections::ProductCarousel', 'Spree::Cms::Sections::ImageGallery', 'Spree::Cms::Sections::SideBySideImages', 'Spree::Cms::Sections::RichTextContent'], example: 'Spree::Cms::Sections::ProductCarousel', description: 'Change the section type.' },
                   position: { type: :integer, example: 2, description: 'Pass the position that you want this section to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
                   fit: { type: :string, example: 'Screen', enum: ['Screen', 'Container'], description: 'This value is used by front end developers to set CSS classes for content that fits the screen edge-to-edge, or stays within the boundaries of the central container.' },
                   rte_content: { type: :string, example: 'Lots of text and content goes here.', description: 'Update the content, here, this can be rich text editor content.' }
@@ -732,9 +745,9 @@ RSpec.configure do |config|
               menu: {
                 type: :object,
                 properties: {
-                  name: { type: :string, example: 'Main Menu', description: 'Give this Menu a name.' },
-                  location: { type: :string, enum: ['header', 'footer'], description: 'Set the location this menu appears in the website.' },
-                  locale: { type: :string, example: 'en-US', description: 'Set the language of this menu.' }
+                  name: { type: :string, example: 'Main Menu', description: 'Update this Menu name.' },
+                  location: { type: :string, enum: ['header', 'footer'], description: 'Update the location this menu appears in the website.' },
+                  locale: { type: :string, example: 'en-US', description: 'Change the language of this menu.' }
                 }
               }
             },
@@ -772,14 +785,14 @@ RSpec.configure do |config|
               menu_item: {
                 type: :object,
                 properties: {
-                  name: { type: :string, example: 'T-Shirts', description: 'The name of this Menu Item'},
-                  code: { type: :string, nullable: true, example: 'MEN-TS', description: 'Give this Menu Item a code to identify this Menu Item from others. This is especially useful when using Container type Menu Items to group items.' },
+                  name: { type: :string, example: 'T-Shirts', description: 'Update the name of this Menu Item'},
+                  code: { type: :string, nullable: true, example: 'MEN-TS', description: 'The Menu Item a code to identifies this Menu Item from others. This is especially useful when using Container type Menu Items to group items.' },
                   subtitle: { type: :string, nullable: true, example: "Shop men's T-Shirts", description: 'Set an optional subtitle for the Menu Item, this is useful if your menu has promotional links that require more than just a link name.' },
                   destination: { type: :string, nullable: true, example: 'https://getvendo.com', description: 'Used when the linked_resource_type is set to: URL' },
                   menu_id: { type: :integer, example: 1, description: 'Specify the ID of the Menu this item belongs to.' },
                   new_window: { type: :boolean, description: 'When set to `true` the link will be opened in a new tab or window.' },
                   item_type: { type: :string, enum: ['Link', 'Container'], description: 'Links are standard links, where as Containers are used to group links.' },
-                  linked_resource_type: { type: :string, enum: ['URL', 'Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Set the type of resource you want to link to, or set to: URL to use the destination field for an external link.' },
+                  linked_resource_type: { type: :string, enum: ['URL', 'Spree::Taxon', 'Spree::Product', 'Spree::CmsPage'], description: 'Change the type of resource you want to link to, or set to: URL to use the destination field for an external link.' },
                   linked_resource_id: { type: :integer, example: 1, nullable: true, description: 'The ID of the resource you are linking to.' }
                 }
               }

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -215,43 +215,127 @@ RSpec.configure do |config|
           },
 
           # CMS Page
-          create_cms_page_params: {
+          create_standard_cms_page_params: {
             type: :object,
             properties: {
               cms_page: {
                 type: :object,
                 required: %w[title locale],
                 properties: {
-                  title: { type: :string },
-                  meta_title: { type: :string },
-                  content: { type: :string, },
-                  meta_description: { type: :string },
-                  visible: { type: :string },
-                  slug: { type: :string },
-                  locale: { type: :string }
+                  title: { type: :string, example: 'About Us', description: 'Give your page a title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.' },
+                  meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
+                  content: { type: :string, nullable: true, example: "Lot's of text..", description: 'The text content of a standard page, this can be HTML from a rich text editor.' },
+                  meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
+                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
               }
             },
             required: %w[cms_page],
+            title: 'Create a Standard Page',
             'x-internal': true
           },
-          update_cms_page_params: {
+          create_homepage_cms_page_params: {
+            type: :object,
+            properties: {
+              cms_page: {
+                type: :object,
+                required: %w[title locale],
+                properties: {
+                  title: { type: :string, example: 'Our Flash Homepage', description: 'Give your page a title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.' },
+                  meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
+                  meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                }
+              }
+            },
+            required: %w[cms_page],
+            title: 'Create a Homepage',
+            'x-internal': true
+          },
+          create_feature_cms_page_params: {
+            type: :object,
+            properties: {
+              cms_page: {
+                type: :object,
+                required: %w[title locale],
+                properties: {
+                  title: { type: :string, example: 'Featured Product', description: 'Give your page a title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.' },
+                  meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
+                  meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
+                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                }
+              }
+            },
+            required: %w[cms_page],
+            title: 'Create a Feature Page',
+            'x-internal': true
+          },
+          update_standard_cms_page_params: {
             type: :object,
             properties: {
               cms_page: {
                 type: :object,
                 properties: {
-                  title: { type: :string },
-                  meta_title: { type: :string },
-                  content: { type: :string, },
-                  meta_description: { type: :string },
-                  visible: { type: :string },
-                  slug: { type: :string },
-                  locale: { type: :string }
+                  title: { type: :string, example: 'About Us', description: 'Give your page a title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::StandardPage`.' },
+                  meta_title: { type: :string, nullable: true, example: 'Learn More About Super-Shop', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
+                  content: { type: :string, nullable: true, example: "Lot's of text..", description: 'The text content of a standard page, this can be HTML from a rich text editor.' },
+                  meta_description: { type: :string, nullable: true, example: 'Learn more about us on this page here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
+                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
                 }
               }
             },
             required: %w[cms_page],
+            title: 'Create a Standard Page',
+            'x-internal': true
+          },
+          update_homepage_cms_page_params: {
+            type: :object,
+            properties: {
+              cms_page: {
+                type: :object,
+                properties: {
+                  title: { type: :string, example: 'Our Flash Homepage', description: 'Give your page a title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::Homepage`.' },
+                  meta_title: { type: :string, nullable: true, example: 'Visit Our Store - Great Deals', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
+                  meta_description: { type: :string, nullable: true, example: 'Discover great new products that we sell in this store...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                }
+              }
+            },
+            required: %w[cms_page],
+            title: 'Create a Homepage',
+            'x-internal': true
+          },
+          update_feature_cms_page_params: {
+            type: :object,
+            properties: {
+              cms_page: {
+                type: :object,
+                properties: {
+                  title: { type: :string, example: 'Featured Product', description: 'Give your page a title.' },
+                  type: { type: :string, enum: ['Spree::Cms::Pages::StandardPage', 'Spree::Cms::Pages::Homepage', 'Spree::Cms::Pages::FeaturePage'], description: 'Set the type of page, for this example we are using `Spree::Cms::Pages::FeaturePage`.' },
+                  meta_title: { type: :string, nullable: true, example: 'Learn More About This Featured Product', description: 'Set the meta title for this page, this appears in the title bar of the browser.' },
+                  meta_description: { type: :string, nullable: true, example: 'Learn more about us this amazing product that we sell right here...', description: 'Set a meta description, used for SEO and displayed in search results.' },
+                  visible: { type: :boolean, enum: ['true', 'false'], description: 'This page is publicly visible when set to `true`.' },
+                  slug: { type: :string, nullable: true, example: 'about-us', description: 'Set a slug for this page.' },
+                  locale: { type: :string, example: 'en-US', description: 'The language this page is written in.' }
+                }
+              }
+            },
+            required: %w[cms_page],
+            title: 'Create a Feature Page',
             'x-internal': true
           },
 

--- a/core/app/models/spree/cms_page.rb
+++ b/core/app/models/spree/cms_page.rb
@@ -28,7 +28,7 @@ module Spree
     scope :standard, -> { where(type: 'Spree::Cms::Pages::StandardPage') }
     scope :feature, -> { where(type: 'Spree::Cms::Pages::FeaturePage') }
 
-    self.whitelisted_ransackable_attributes = %w[title type locale store_id]
+    self.whitelisted_ransackable_attributes = %w[title type locale]
 
     def seo_title
       if meta_title.present?

--- a/core/app/models/spree/cms_page.rb
+++ b/core/app/models/spree/cms_page.rb
@@ -16,7 +16,7 @@ module Spree
 
     before_validation :handle_slug
 
-    validates :title, :store, :locale, presence: true
+    validates :title, :store, :locale, :type, presence: true
     validates :slug, uniqueness: { scope: :store_id, allow_nil: true, case_sensitive: true }
     validates :locale, uniqueness: { scope: [:store, :type] }, if: :homepage?
 

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -27,7 +27,7 @@ module Spree
 
     default_scope { order(position: :asc) }
 
-    validates :name, :cms_page, presence: true
+    validates :name, :cms_page, :type, presence: true
 
     validates :image_one, :image_two, :image_three, content_type: IMAGE_TYPES
 

--- a/core/lib/spree/testing_support/factories/cms_section_factory.rb
+++ b/core/lib/spree/testing_support/factories/cms_section_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
-  factory :cms_section, class: Spree::CmsSection do
+  factory :base_cms_section, class: Spree::CmsSection do
     name { generate(:random_string) }
 
-    association :cms_page, factory: :base_cms_page
+    association :cms_page, factory: :cms_feature_page
 
     factory :cms_hero_image_section do
       type { 'Spree::Cms::Sections::HeroImage' }

--- a/core/spec/models/spree/concerns/single_store_spec.rb
+++ b/core/spec/models/spree/concerns/single_store_spec.rb
@@ -10,7 +10,7 @@ module Spree
       let(:menu_b) { create :menu, location: 'footer' }
 
       it 'allows creation of a new instance, update the store then save without triggering validation error' do
-        object = Spree::CmsPage.new(title: 'Got Name', locale: 'de')
+        object = Spree::CmsPage.new(title: 'Got Name', locale: 'de', type: 'Spree::Cms::Pages::StandardPage')
         object.update(store: store)
 
         expect(object.save!).to be true


### PR DESCRIPTION
- Adds individual schema examples for creating and updating each type of ` cms_page`
- Adds individual schema examples for creating and updating each type of `cms_section`
- Adds presence check for `type` for `cms_section`.
- Adds presence check for `type` for `cms_page`.
- Fix filter examples for `cms_section` and `cms_page` in docs.
- Remove filter by `store_id` white listed, from `cms_page`, pages are by store so this is now redundant filter.