### PR TITLE
Remove @spree/dashboard link before spree:backend:install

### DIFF
--- a/bin/sandbox.sh
+++ b/bin/sandbox.sh
@@ -107,7 +107,6 @@ RUBY
 bundle install --gemfile Gemfile
 
 bin/rails javascript:install:esbuild
-yarn link @spree/dashboard
 yarn install
 
 bin/rails db:drop || true


### PR DESCRIPTION
It seems this line isn't needed - and won't work - because the @spree/dashboard link is done with `bin/rails g spree:backend:install`. Removing it makes the script work, otherwise it fails with:

```bash
error No registered package found called "@spree/dashboard".
```