### PR TITLE
SD-1491 I can pragmatically disable Webhooks for a block code

### DIFF
--- a/api/app/services/spree/webhooks.rb
+++ b/api/app/services/spree/webhooks.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Webhooks
+    def self.disable_webhooks(&block)
+      webhooks_disabled_previously = ENV['DISABLE_SPREE_WEBHOOKS']
+      begin
+        ENV['DISABLE_SPREE_WEBHOOKS'] = 'true'
+        block.call
+      ensure
+        ENV['DISABLE_SPREE_WEBHOOKS'] = webhooks_disabled_previously
+      end
+    end
+  end
+end

--- a/api/app/services/spree/webhooks.rb
+++ b/api/app/services/spree/webhooks.rb
@@ -1,10 +1,10 @@
 module Spree
   module Webhooks
-    def self.disable_webhooks(&block)
+    def self.disable_webhooks
       webhooks_disabled_previously = ENV['DISABLE_SPREE_WEBHOOKS']
       begin
         ENV['DISABLE_SPREE_WEBHOOKS'] = 'true'
-        block.call
+        yield
       ensure
         ENV['DISABLE_SPREE_WEBHOOKS'] = webhooks_disabled_previously
       end

--- a/api/spec/services/spree/webhooks_spec.rb
+++ b/api/spec/services/spree/webhooks_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Spree::Webhooks do
+  describe '#disable_webhooks' do
+    let(:variant) { create(:variant) }
+    let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
+    let(:queue_requests) { instance_double(Spree::Webhooks::Subscribers::QueueRequests) }
+
+    before do
+      allow(Spree::Webhooks::Subscribers::QueueRequests).to receive(:new).and_return(queue_requests)
+      allow(queue_requests).to receive(:call).with(any_args)
+    end
+
+    after { ENV['DISABLE_SPREE_WEBHOOKS'] = 'true' }
+
+    describe 'when block is not passed' do
+      it 'raises an error' do
+        expect { described_class.disable_webhooks }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe 'the value of DISABLE_SPREE_WEBHOOKS environment variable' do
+      before { ENV['DISABLE_SPREE_WEBHOOKS'] = 'some_value' }
+
+      describe 'when an error is not raised' do
+        it 'sets it to the original value' do
+          described_class.disable_webhooks { variant.discontinue! }
+          expect(ENV['DISABLE_SPREE_WEBHOOKS']).to eq('some_value')
+        end
+      end
+
+      describe 'when an error is raised' do
+        it 'sets it to the original value' do
+          begin
+            described_class.disable_webhooks { raise StandardError }
+          rescue StandardError
+          end
+          expect(ENV['DISABLE_SPREE_WEBHOOKS']).to eq('some_value')
+        end
+      end
+    end
+
+    describe 'when webhooks are already disabled' do
+      before { ENV['DISABLE_SPREE_WEBHOOKS'] = 'true' }
+
+      it 'does not emit the event' do
+        described_class.disable_webhooks { variant.discontinue! }
+        expect(queue_requests).not_to have_received(:call).with(event: 'variant.discontinued', body: body)
+      end
+    end
+
+    describe 'when webhooks are enabled' do
+      before { ENV['DISABLE_SPREE_WEBHOOKS'] = nil }
+
+      describe 'when not using #disable_webhooks' do
+        it 'emits the event' do
+          variant.discontinue!
+          expect(queue_requests).to have_received(:call).with(event: 'variant.discontinued', body: body).once
+        end
+      end
+
+      describe 'when using #disable_webhooks' do
+        it 'does not emit the event' do
+          described_class.disable_webhooks { variant.discontinue! }
+          expect(queue_requests).not_to have_received(:call).with(event: 'variant.discontinued', body: body)
+        end
+      end
+    end
+  end
+end

--- a/api/spec/services/spree/webhooks_spec.rb
+++ b/api/spec/services/spree/webhooks_spec.rb
@@ -13,12 +13,6 @@ describe Spree::Webhooks do
 
     after { ENV['DISABLE_SPREE_WEBHOOKS'] = 'true' }
 
-    describe 'when block is not passed' do
-      it 'raises an error' do
-        expect { described_class.disable_webhooks }.to raise_error(NoMethodError)
-      end
-    end
-
     describe 'the value of DISABLE_SPREE_WEBHOOKS environment variable' do
       before { ENV['DISABLE_SPREE_WEBHOOKS'] = 'some_value' }
 


### PR DESCRIPTION
https://spark-solutions.atlassian.net/browse/SD-1542

Defined a Spree::Webhooks.disable_webhooks method that takes in a
block of code. It disables the webhook events using the DISABLE_SPREE_WEBHOOKS
environment variable. After that it runs the block and then sets the
environment variable to its original value. If an error is raised
inside the given block, we do not handle it and let the caller do the
handling. In any given case (whether the block is executed fully or
it is interrupted), we set the environment variable to its original
value