### PR TITLE
[SD-1494] - Add Taxonomies to Platform API

### DIFF
--- a/api/app/controllers/concerns/spree/api/v2/platform/nested_set_reposition_concern.rb
+++ b/api/app/controllers/concerns/spree/api/v2/platform/nested_set_reposition_concern.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     module V2
       module Platform
-        module NestedSetRepositionHelper
+        module NestedSetRepositionConcern
           def reposition
             spree_authorize! :update, resource if spree_current_user.present?
 

--- a/api/app/controllers/concerns/spree/api/v2/platform/nested_set_reposition_helper.rb
+++ b/api/app/controllers/concerns/spree/api/v2/platform/nested_set_reposition_helper.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        module NestedSetRepositionHelper
+          def reposition
+            spree_authorize! :update, resource if spree_current_user.present?
+
+            @new_parent = scope.find(permitted_resource_params[:new_parent_id])
+            new_index = permitted_resource_params[:new_position_idx].to_i
+
+            if resource.move_to_child_with_index(@new_parent, new_index)
+              render_serialized_payload { serialize_resource(resource) }
+            else
+              render_error_payload(resource.errors)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/spree/api/v2/platform/menu_items_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/menu_items_controller.rb
@@ -3,7 +3,7 @@ module Spree
     module V2
       module Platform
         class MenuItemsController < ResourceController
-          include ::Spree::Api::V2::Platform::NestedSetRepositionHelper
+          include ::Spree::Api::V2::Platform::NestedSetRepositionConcern
 
           private
 

--- a/api/app/controllers/spree/api/v2/platform/menu_items_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/menu_items_controller.rb
@@ -3,18 +3,7 @@ module Spree
     module V2
       module Platform
         class MenuItemsController < ResourceController
-          def reposition
-            spree_authorize! :update, resource if spree_current_user.present?
-
-            @new_parent = scope.find(permitted_resource_params[:new_parent_id])
-            new_index = permitted_resource_params[:new_position_idx].to_i
-
-            if resource.move_to_child_with_index(@new_parent, new_index)
-              render_serialized_payload { serialize_resource(resource) }
-            else
-              render_error_payload(resource.errors)
-            end
-          end
+          include ::Spree::Api::V2::Platform::NestedSetRepositionHelper
 
           private
 

--- a/api/app/controllers/spree/api/v2/platform/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/taxonomies_controller.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class TaxonomiesController < ResourceController
+
+          private
+
+          def model_class
+            Spree::Taxonomy
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/spree/api/v2/platform/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/taxonomies_controller.rb
@@ -3,7 +3,6 @@ module Spree
     module V2
       module Platform
         class TaxonomiesController < ResourceController
-
           private
 
           def model_class

--- a/api/app/controllers/spree/api/v2/platform/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/taxons_controller.rb
@@ -3,7 +3,7 @@ module Spree
     module V2
       module Platform
         class TaxonsController < ResourceController
-          include ::Spree::Api::V2::Platform::NestedSetRepositionHelper
+          include ::Spree::Api::V2::Platform::NestedSetRepositionConcern
 
           private
 

--- a/api/app/controllers/spree/api/v2/platform/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/taxons_controller.rb
@@ -3,6 +3,8 @@ module Spree
     module V2
       module Platform
         class TaxonsController < ResourceController
+          include ::Spree::Api::V2::Platform::NestedSetRepositionHelper
+
           private
 
           def model_class
@@ -22,6 +24,10 @@ module Spree
 
           def serializer_params
             super.merge(include_products: action_name == 'show')
+          end
+
+          def spree_permitted_attributes
+            super + [:new_parent_id, :new_position_idx]
           end
         end
       end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -205,7 +205,11 @@ Spree::Core::Engine.add_routes do
         # Product Catalog API
         resources :products
         resources :taxonomies
-        resources :taxons
+        resources :taxons do
+          member do
+            patch :reposition
+          end
+        end
         resources :classifications
         resources :images
         resources :variants

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -70,8 +70,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-11T12:51:01.357Z'
-                        updated_at: '2021-11-11T12:51:01.357Z'
+                        created_at: '2021-11-11T21:02:45.470Z'
+                        updated_at: '2021-11-11T21:02:45.470Z'
                         deleted_at:
                         label:
                         public_metadata: {}
@@ -100,8 +100,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-11T12:51:01.362Z'
-                        updated_at: '2021-11-11T12:51:01.362Z'
+                        created_at: '2021-11-11T21:02:45.474Z'
+                        updated_at: '2021-11-11T21:02:45.474Z'
                         deleted_at:
                         label:
                         public_metadata: {}
@@ -177,8 +177,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-11T12:51:01.611Z'
-                        updated_at: '2021-11-11T12:51:01.611Z'
+                        created_at: '2021-11-11T21:02:45.697Z'
+                        updated_at: '2021-11-11T21:02:45.697Z'
                         deleted_at:
                         label:
                         public_metadata: {}
@@ -274,8 +274,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-11T12:51:01.656Z'
-                        updated_at: '2021-11-11T12:51:01.656Z'
+                        created_at: '2021-11-11T21:02:45.744Z'
+                        updated_at: '2021-11-11T21:02:45.744Z'
                         deleted_at:
                         label:
                         public_metadata: {}
@@ -356,8 +356,8 @@ paths:
                         state_name:
                         alternative_phone: 555-555-0199
                         company: Company
-                        created_at: '2021-11-11T12:51:01.733Z'
-                        updated_at: '2021-11-11T12:51:01.741Z'
+                        created_at: '2021-11-11T21:02:45.824Z'
+                        updated_at: '2021-11-11T21:02:45.832Z'
                         deleted_at:
                         label:
                         public_metadata: {}
@@ -503,8 +503,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-11T12:51:02.001Z'
-                        updated_at: '2021-11-11T12:51:02.001Z'
+                        created_at: '2021-11-11T21:02:46.096Z'
+                        updated_at: '2021-11-11T21:02:46.096Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -530,8 +530,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-11T12:51:02.023Z'
-                        updated_at: '2021-11-11T12:51:02.023Z'
+                        created_at: '2021-11-11T21:02:46.120Z'
+                        updated_at: '2021-11-11T21:02:46.120Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -604,8 +604,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-11T12:51:02.362Z'
-                        updated_at: '2021-11-11T12:51:02.362Z'
+                        created_at: '2021-11-11T21:02:46.463Z'
+                        updated_at: '2021-11-11T21:02:46.463Z'
                         state: open
                         included: false
                         display_amount: "$100.00"
@@ -687,8 +687,8 @@ paths:
                         label: Shipping
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-11T12:51:02.492Z'
-                        updated_at: '2021-11-11T12:51:02.498Z'
+                        created_at: '2021-11-11T21:02:46.592Z'
+                        updated_at: '2021-11-11T21:02:46.596Z'
                         state: open
                         included: false
                         display_amount: "$1.00"
@@ -766,8 +766,8 @@ paths:
                         label: New label
                         mandatory:
                         eligible: true
-                        created_at: '2021-11-11T12:51:02.759Z'
-                        updated_at: '2021-11-11T12:51:02.772Z'
+                        created_at: '2021-11-11T21:02:46.894Z'
+                        updated_at: '2021-11-11T21:02:46.908Z'
                         state: open
                         included: false
                         display_amount: "$15.00"
@@ -907,8 +907,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-11T12:51:03.320Z'
-                        updated_at: '2021-11-11T12:51:03.320Z'
+                        created_at: '2021-11-11T21:02:47.470Z'
+                        updated_at: '2021-11-11T21:02:47.470Z'
                       relationships:
                         product:
                           data:
@@ -922,8 +922,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-11T12:51:03.399Z'
-                        updated_at: '2021-11-11T12:51:03.399Z'
+                        created_at: '2021-11-11T21:02:47.544Z'
+                        updated_at: '2021-11-11T21:02:47.544Z'
                       relationships:
                         product:
                           data:
@@ -984,8 +984,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-11T12:51:03.902Z'
-                        updated_at: '2021-11-11T12:51:03.902Z'
+                        created_at: '2021-11-11T21:02:48.027Z'
+                        updated_at: '2021-11-11T21:02:48.027Z'
                       relationships:
                         product:
                           data:
@@ -1052,8 +1052,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-11T12:51:04.077Z'
-                        updated_at: '2021-11-11T12:51:04.077Z'
+                        created_at: '2021-11-11T21:02:48.207Z'
+                        updated_at: '2021-11-11T21:02:48.207Z'
                       relationships:
                         product:
                           data:
@@ -1119,8 +1119,8 @@ paths:
                       type: classification
                       attributes:
                         position: 1
-                        created_at: '2021-11-11T12:51:04.400Z'
-                        updated_at: '2021-11-11T12:51:04.400Z'
+                        created_at: '2021-11-11T21:02:48.540Z'
+                        updated_at: '2021-11-11T21:02:48.540Z'
                       relationships:
                         product:
                           data:
@@ -1264,35 +1264,34 @@ paths:
                     - id: '1'
                       type: cms_page
                       attributes:
-                        title: Quia eius ratione fugit doloribus assumenda.
+                        title: Laudantium enim laboriosam quisquam ducimus eaque.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: quia-eius-ratione-fugit-doloribus-assumenda
+                        slug: laudantium-enim-laboriosam-quisquam-ducimus-eaque
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-11T12:51:05.098Z'
-                        updated_at: '2021-11-11T12:51:05.098Z'
+                        created_at: '2021-11-11T21:02:49.250Z'
+                        updated_at: '2021-11-11T21:02:49.250Z'
                       relationships:
                         cms_sections:
                           data: []
                     - id: '2'
                       type: cms_page
                       attributes:
-                        title: Quis officia tempora minus cupiditate ad repudiandae
-                          ut.
+                        title: Non itaque odit omnis ipsum rem minus aliquid pariatur.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: quis-officia-tempora-minus-cupiditate-ad-repudiandae-ut
+                        slug: non-itaque-odit-omnis-ipsum-rem-minus-aliquid-pariatur
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-11T12:51:05.102Z'
-                        updated_at: '2021-11-11T12:51:05.102Z'
+                        created_at: '2021-11-11T21:02:49.254Z'
+                        updated_at: '2021-11-11T21:02:49.254Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1346,18 +1345,17 @@ paths:
                       id: '5'
                       type: cms_page
                       attributes:
-                        title: Optio recusandae officia sit sapiente asperiores mollitia
-                          consectetur.
+                        title: Nemo dignissimos odit enim laborum nulla ratione quam.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: optio-recusandae-officia-sit-sapiente-asperiores-mollitia-consectetur
+                        slug: nemo-dignissimos-odit-enim-laborum-nulla-ratione-quam
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-11T12:51:05.201Z'
-                        updated_at: '2021-11-11T12:51:05.201Z'
+                        created_at: '2021-11-11T21:02:49.352Z'
+                        updated_at: '2021-11-11T21:02:49.352Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1423,18 +1421,17 @@ paths:
                       id: '6'
                       type: cms_page
                       attributes:
-                        title: Amet maxime veniam corrupti repellat eveniet veritatis
-                          rem.
+                        title: Minus et eum error assumenda aspernatur quibusdam.
                         meta_title:
                         content:
                         meta_description:
                         visible: true
-                        slug: amet-maxime-veniam-corrupti-repellat-eveniet-veritatis-rem
+                        slug: minus-et-eum-error-assumenda-aspernatur-quibusdam
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-11T12:51:05.249Z'
-                        updated_at: '2021-11-11T12:51:05.249Z'
+                        created_at: '2021-11-11T21:02:49.400Z'
+                        updated_at: '2021-11-11T21:02:49.400Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1498,12 +1495,12 @@ paths:
                         content:
                         meta_description:
                         visible: true
-                        slug: culpa-animi-tempore-quos-odio-odit
+                        slug: harum-nesciunt-qui-velit-rerum
                         type: Spree::Cms::Pages::StandardPage
                         locale: en
                         deleted_at:
-                        created_at: '2021-11-11T12:51:05.339Z'
-                        updated_at: '2021-11-11T12:51:05.348Z'
+                        created_at: '2021-11-11T21:02:49.470Z'
+                        updated_at: '2021-11-11T21:02:49.482Z'
                       relationships:
                         cms_sections:
                           data: []
@@ -1632,7 +1629,7 @@ paths:
                     - id: '1'
                       type: cms_section
                       attributes:
-                        name: Rerum veniam perferendis ipsa molestiae.
+                        name: Quaerat dolorem est facere similique minus sint incidunt.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1641,8 +1638,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-11T12:51:05.538Z'
-                        updated_at: '2021-11-11T12:51:05.538Z'
+                        created_at: '2021-11-11T21:02:49.673Z'
+                        updated_at: '2021-11-11T21:02:49.673Z'
                       relationships:
                         cms_page:
                           data:
@@ -1653,7 +1650,8 @@ paths:
                     - id: '2'
                       type: cms_section
                       attributes:
-                        name: Saepe ea autem aut laborum.
+                        name: Enim incidunt modi officiis iusto consequatur molestias
+                          odit non.
                         content:
                           link_type_one: Spree::Taxon
                           link_type_two: Spree::Taxon
@@ -1665,8 +1663,8 @@ paths:
                         type: Spree::Cms::Sections::ImageGallery
                         position: 2
                         linked_resource_type:
-                        created_at: '2021-11-11T12:51:05.542Z'
-                        updated_at: '2021-11-11T12:51:05.542Z'
+                        created_at: '2021-11-11T21:02:49.677Z'
+                        updated_at: '2021-11-11T21:02:49.677Z'
                       relationships:
                         cms_page:
                           data:
@@ -1677,7 +1675,7 @@ paths:
                     - id: '3'
                       type: cms_section
                       attributes:
-                        name: Eveniet et quo debitis aliquam iure.
+                        name: Dicta quos ad dignissimos sunt nam veritatis.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1686,8 +1684,8 @@ paths:
                         type: Spree::Cms::Sections::FeaturedArticle
                         position: 3
                         linked_resource_type: Spree::Taxon
-                        created_at: '2021-11-11T12:51:05.551Z'
-                        updated_at: '2021-11-11T12:51:05.551Z'
+                        created_at: '2021-11-11T21:02:49.685Z'
+                        updated_at: '2021-11-11T21:02:49.685Z'
                       relationships:
                         cms_page:
                           data:
@@ -1698,7 +1696,7 @@ paths:
                     - id: '4'
                       type: cms_section
                       attributes:
-                        name: Eos quos corrupti officia vel.
+                        name: Delectus libero eius distinctio officia.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1707,8 +1705,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-11T12:51:05.560Z'
-                        updated_at: '2021-11-11T12:51:05.560Z'
+                        created_at: '2021-11-11T21:02:49.694Z'
+                        updated_at: '2021-11-11T21:02:49.694Z'
                       relationships:
                         cms_page:
                           data:
@@ -1721,8 +1719,7 @@ paths:
                     - id: '5'
                       type: cms_section
                       attributes:
-                        name: Dolores cumque nam accusamus saepe ipsam voluptatem
-                          dignissimos.
+                        name: Ut dolores dolorum beatae expedita error.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1731,8 +1728,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 5
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-11T12:51:05.567Z'
-                        updated_at: '2021-11-11T12:51:05.567Z'
+                        created_at: '2021-11-11T21:02:49.701Z'
+                        updated_at: '2021-11-11T21:02:49.701Z'
                       relationships:
                         cms_page:
                           data:
@@ -1792,7 +1789,7 @@ paths:
                       id: '13'
                       type: cms_section
                       attributes:
-                        name: Laboriosam asperiores eaque earum quos corrupti.
+                        name: Facilis debitis pariatur et laboriosam.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1801,8 +1798,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 3
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-11T12:51:05.722Z'
-                        updated_at: '2021-11-11T12:51:05.722Z'
+                        created_at: '2021-11-11T21:02:49.860Z'
+                        updated_at: '2021-11-11T21:02:49.860Z'
                       relationships:
                         cms_page:
                           data:
@@ -1877,7 +1874,7 @@ paths:
                       id: '19'
                       type: cms_section
                       attributes:
-                        name: Delectus ducimus facere earum dignissimos illo quos.
+                        name: Ipsa modi adipisci quam porro tempore praesentium nulla.
                         content: {}
                         settings:
                           gutters: No Gutters
@@ -1886,8 +1883,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 4
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-11T12:51:05.863Z'
-                        updated_at: '2021-11-11T12:51:05.863Z'
+                        created_at: '2021-11-11T21:02:50.004Z'
+                        updated_at: '2021-11-11T21:02:50.004Z'
                       relationships:
                         cms_page:
                           data:
@@ -1961,8 +1958,8 @@ paths:
                         type: Spree::Cms::Sections::HeroImage
                         position: 1
                         linked_resource_type: Spree::Product
-                        created_at: '2021-11-11T12:51:06.072Z'
-                        updated_at: '2021-11-11T12:51:06.082Z'
+                        created_at: '2021-11-11T21:02:50.227Z'
+                        updated_at: '2021-11-11T21:02:50.237Z'
                       relationships:
                         cms_page:
                           data:
@@ -2082,9 +2079,9 @@ paths:
                         name: United States of America
                         numcode: 840
                         states_required: true
-                        updated_at: '2021-11-11T12:51:06.530Z'
+                        updated_at: '2021-11-11T21:02:50.666Z'
                         zipcode_required: true
-                        created_at: '2021-11-11T12:51:06.530Z'
+                        created_at: '2021-11-11T21:02:50.666Z'
                       relationships:
                         states:
                           data: []
@@ -2097,9 +2094,9 @@ paths:
                         name: NAME_2
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-11T12:51:06.536Z'
+                        updated_at: '2021-11-11T21:02:50.672Z'
                         zipcode_required: true
-                        created_at: '2021-11-11T12:51:06.536Z'
+                        created_at: '2021-11-11T21:02:50.672Z'
                       relationships:
                         states:
                           data: []
@@ -2112,9 +2109,9 @@ paths:
                         name: NAME_3
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-11T12:51:06.538Z'
+                        updated_at: '2021-11-11T21:02:50.674Z'
                         zipcode_required: true
-                        created_at: '2021-11-11T12:51:06.538Z'
+                        created_at: '2021-11-11T21:02:50.674Z'
                       relationships:
                         states:
                           data: []
@@ -2173,9 +2170,9 @@ paths:
                         name: NAME_6
                         numcode: 840
                         states_required: false
-                        updated_at: '2021-11-11T12:51:06.594Z'
+                        updated_at: '2021-11-11T21:02:50.731Z'
                         zipcode_required: true
-                        created_at: '2021-11-11T12:51:06.594Z'
+                        created_at: '2021-11-11T21:02:50.731Z'
                       relationships:
                         states:
                           data: []
@@ -2233,7 +2230,7 @@ paths:
                     - id: '1'
                       type: digital_link
                       attributes:
-                        token: vu2iRAKLUqs36934ghSd3mGA
+                        token: bZFnPFxtzXoXqDckwmSBnsSR
                         access_counter: 0
                       relationships:
                         digital:
@@ -2247,7 +2244,7 @@ paths:
                     - id: '2'
                       type: digital_link
                       attributes:
-                        token: uU33138ukUuojfrRKtMxLHDS
+                        token: KhmTeXU7STWBka8KvGiieJMF
                         access_counter: 0
                       relationships:
                         digital:
@@ -2301,7 +2298,7 @@ paths:
                       id: '5'
                       type: digital_link
                       attributes:
-                        token: NTeu15gx9m4gqkdn6WM5RoQz
+                        token: t7X6CM5mDYhPNpNtDWQ8ZAVb
                         access_counter: 0
                       relationships:
                         digital:
@@ -2364,7 +2361,7 @@ paths:
                       id: '6'
                       type: digital_link
                       attributes:
-                        token: 7gAyPuDzeZVH49HRLdJE9qm5
+                        token: 91rgGrK8JYpLePg3UJFV4YMQ
                         access_counter: 0
                       relationships:
                         digital:
@@ -2423,7 +2420,7 @@ paths:
                       id: '8'
                       type: digital_link
                       attributes:
-                        token: Xf1q5iVc8pXXDFvyQ2KXCQ9d
+                        token: NqTAnk9kRYTzadp3cNidEod1
                         access_counter: 0
                       relationships:
                         digital:
@@ -2538,7 +2535,7 @@ paths:
                       id: '13'
                       type: digital_link
                       attributes:
-                        token: 2pofAgmjtWPPSjUgig1fTieE
+                        token: 8NJfMf9MaFohbGsm7efAbdku
                         access_counter: 0
                       relationships:
                         digital:
@@ -2955,8 +2952,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-11T12:51:14.117Z'
-                        updated_at: '2021-11-11T12:51:14.124Z'
+                        created_at: '2021-11-11T21:02:58.410Z'
+                        updated_at: '2021-11-11T21:02:58.417Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3004,8 +3001,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-11T12:51:14.154Z'
-                        updated_at: '2021-11-11T12:51:14.158Z'
+                        created_at: '2021-11-11T21:02:58.445Z'
+                        updated_at: '2021-11-11T21:02:58.450Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3100,8 +3097,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-11T12:51:14.466Z'
-                        updated_at: '2021-11-11T12:51:14.511Z'
+                        created_at: '2021-11-11T21:02:58.677Z'
+                        updated_at: '2021-11-11T21:02:58.717Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3205,8 +3202,8 @@ paths:
                       attributes:
                         quantity: 1
                         price: '10.0'
-                        created_at: '2021-11-11T12:51:14.669Z'
-                        updated_at: '2021-11-11T12:51:14.676Z'
+                        created_at: '2021-11-11T21:02:58.871Z'
+                        updated_at: '2021-11-11T21:02:58.878Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3306,8 +3303,8 @@ paths:
                       attributes:
                         quantity: 4
                         price: '10.0'
-                        created_at: '2021-11-11T12:51:14.915Z'
-                        updated_at: '2021-11-11T12:51:14.954Z'
+                        created_at: '2021-11-11T21:02:59.193Z'
+                        updated_at: '2021-11-11T21:02:59.235Z'
                         currency: USD
                         cost_price: '17.0'
                         adjustment_total: '0.0'
@@ -3359,10 +3356,10 @@ paths:
               examples:
                 Example:
                   value:
-                    error: 'Quantity selected of "Product #127 - 4668" is not available.'
+                    error: 'Quantity selected of "Product #127 - 7512" is not available.'
                     errors:
                       quantity:
-                      - 'selected of "Product #127 - 4668" is not available.'
+                      - 'selected of "Product #127 - 7512" is not available.'
               schema:
                 "$ref": "#/components/schemas/validation_errors"
         '404':
@@ -3482,8 +3479,8 @@ paths:
                         lft: 2
                         rgt: 3
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.562Z'
-                        updated_at: '2021-11-11T12:51:15.567Z'
+                        created_at: '2021-11-11T21:02:59.874Z'
+                        updated_at: '2021-11-11T21:02:59.878Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3519,8 +3516,8 @@ paths:
                         lft: 4
                         rgt: 5
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.620Z'
-                        updated_at: '2021-11-11T12:51:15.625Z'
+                        created_at: '2021-11-11T21:02:59.940Z'
+                        updated_at: '2021-11-11T21:02:59.954Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3556,8 +3553,8 @@ paths:
                         lft: 6
                         rgt: 7
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.677Z'
-                        updated_at: '2021-11-11T12:51:15.682Z'
+                        created_at: '2021-11-11T21:03:00.008Z'
+                        updated_at: '2021-11-11T21:03:00.013Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3593,8 +3590,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.735Z'
-                        updated_at: '2021-11-11T12:51:15.739Z'
+                        created_at: '2021-11-11T21:03:00.065Z'
+                        updated_at: '2021-11-11T21:03:00.069Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3630,8 +3627,8 @@ paths:
                         lft: 10
                         rgt: 11
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.791Z'
-                        updated_at: '2021-11-11T12:51:15.796Z'
+                        created_at: '2021-11-11T21:03:00.122Z'
+                        updated_at: '2021-11-11T21:03:00.127Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3667,8 +3664,8 @@ paths:
                         lft: 12
                         rgt: 13
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.849Z'
-                        updated_at: '2021-11-11T12:51:15.854Z'
+                        created_at: '2021-11-11T21:03:00.191Z'
+                        updated_at: '2021-11-11T21:03:00.196Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3704,8 +3701,8 @@ paths:
                         lft: 14
                         rgt: 15
                         depth: 1
-                        created_at: '2021-11-11T12:51:15.907Z'
-                        updated_at: '2021-11-11T12:51:15.911Z'
+                        created_at: '2021-11-11T21:03:00.259Z'
+                        updated_at: '2021-11-11T21:03:00.263Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3731,7 +3728,7 @@ paths:
                     - id: '1'
                       type: menu_item
                       attributes:
-                        name: Sapiente impedit perferendis eos nihil dignissimos.
+                        name: Adipisci sit explicabo alias eaque repellat quo voluptates.
                         subtitle:
                         destination:
                         new_window: false
@@ -3741,8 +3738,8 @@ paths:
                         lft: 1
                         rgt: 16
                         depth: 0
-                        created_at: '2021-11-11T12:51:15.505Z'
-                        updated_at: '2021-11-11T12:51:15.922Z'
+                        created_at: '2021-11-11T21:02:59.815Z'
+                        updated_at: '2021-11-11T21:03:00.274Z'
                         link:
                         is_container: true
                         is_root: true
@@ -3835,8 +3832,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-11T12:51:16.602Z'
-                        updated_at: '2021-11-11T12:51:16.606Z'
+                        created_at: '2021-11-11T21:03:00.933Z'
+                        updated_at: '2021-11-11T21:03:00.937Z'
                         link:
                         is_container: false
                         is_root: false
@@ -3926,8 +3923,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-11T12:51:17.081Z'
-                        updated_at: '2021-11-11T12:51:17.085Z'
+                        created_at: '2021-11-11T21:03:01.394Z'
+                        updated_at: '2021-11-11T21:03:01.398Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4015,8 +4012,8 @@ paths:
                         lft: 8
                         rgt: 9
                         depth: 1
-                        created_at: '2021-11-11T12:51:17.810Z'
-                        updated_at: '2021-11-11T12:51:17.834Z'
+                        created_at: '2021-11-11T21:03:02.115Z'
+                        updated_at: '2021-11-11T21:03:02.136Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4153,8 +4150,8 @@ paths:
                         lft: 5
                         rgt: 6
                         depth: 2
-                        created_at: '2021-11-11T12:51:19.595Z'
-                        updated_at: '2021-11-11T12:51:19.621Z'
+                        created_at: '2021-11-11T21:03:03.839Z'
+                        updated_at: '2021-11-11T21:03:03.865Z'
                         link:
                         is_container: false
                         is_root: false
@@ -4258,8 +4255,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-11T12:51:20.112Z'
-                        updated_at: '2021-11-11T12:51:20.228Z'
+                        created_at: '2021-11-11T21:03:04.360Z'
+                        updated_at: '2021-11-11T21:03:04.481Z'
                       relationships:
                         menu_items:
                           data:
@@ -4275,8 +4272,8 @@ paths:
                         name: Footer Menu
                         location: footer
                         locale: en
-                        created_at: '2021-11-11T12:51:20.120Z'
-                        updated_at: '2021-11-11T12:51:20.340Z'
+                        created_at: '2021-11-11T21:03:04.370Z'
+                        updated_at: '2021-11-11T21:03:04.594Z'
                       relationships:
                         menu_items:
                           data:
@@ -4339,8 +4336,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-11T12:51:20.667Z'
-                        updated_at: '2021-11-11T12:51:20.673Z'
+                        created_at: '2021-11-11T21:03:04.923Z'
+                        updated_at: '2021-11-11T21:03:04.929Z'
                       relationships:
                         menu_items:
                           data:
@@ -4408,8 +4405,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-11T12:51:20.721Z'
-                        updated_at: '2021-11-11T12:51:20.727Z'
+                        created_at: '2021-11-11T21:03:04.978Z'
+                        updated_at: '2021-11-11T21:03:04.985Z'
                       relationships:
                         menu_items:
                           data:
@@ -4473,8 +4470,8 @@ paths:
                         name: Main Menu
                         location: header
                         locale: en
-                        created_at: '2021-11-11T12:51:20.811Z'
-                        updated_at: '2021-11-11T12:51:20.817Z'
+                        created_at: '2021-11-11T21:03:05.071Z'
+                        updated_at: '2021-11-11T21:03:05.078Z'
                       relationships:
                         menu_items:
                           data:
@@ -4609,8 +4606,8 @@ paths:
                         name: foo-size-68
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-11T12:51:21.010Z'
-                        updated_at: '2021-11-11T12:51:21.010Z'
+                        created_at: '2021-11-11T21:03:05.283Z'
+                        updated_at: '2021-11-11T21:03:05.283Z'
                         filterable: true
                         public_metadata: {}
                         private_metadata: {}
@@ -4623,8 +4620,8 @@ paths:
                         name: foo-size-69
                         presentation: Size
                         position: 2
-                        created_at: '2021-11-11T12:51:21.011Z'
-                        updated_at: '2021-11-11T12:51:21.011Z'
+                        created_at: '2021-11-11T21:03:05.287Z'
+                        updated_at: '2021-11-11T21:03:05.287Z'
                         filterable: true
                         public_metadata: {}
                         private_metadata: {}
@@ -4677,8 +4674,8 @@ paths:
                         name: foo-size-72
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-11T12:51:21.078Z'
-                        updated_at: '2021-11-11T12:51:21.078Z'
+                        created_at: '2021-11-11T21:03:05.364Z'
+                        updated_at: '2021-11-11T21:03:05.364Z'
                         filterable: true
                         public_metadata: {}
                         private_metadata: {}
@@ -4737,8 +4734,8 @@ paths:
                         name: foo-size-73
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-11T12:51:21.119Z'
-                        updated_at: '2021-11-11T12:51:21.119Z'
+                        created_at: '2021-11-11T21:03:05.407Z'
+                        updated_at: '2021-11-11T21:03:05.407Z'
                         filterable: true
                         public_metadata: {}
                         private_metadata: {}
@@ -4796,8 +4793,8 @@ paths:
                         name: Size-X
                         presentation: Size
                         position: 1
-                        created_at: '2021-11-11T12:51:21.189Z'
-                        updated_at: '2021-11-11T12:51:21.196Z'
+                        created_at: '2021-11-11T21:03:05.479Z'
+                        updated_at: '2021-11-11T21:03:05.486Z'
                         filterable: true
                         public_metadata: {}
                         private_metadata: {}
@@ -4935,8 +4932,8 @@ paths:
                         position: 1
                         name: Size-68
                         presentation: S
-                        created_at: '2021-11-11T12:51:21.349Z'
-                        updated_at: '2021-11-11T12:51:21.349Z'
+                        created_at: '2021-11-11T21:03:05.641Z'
+                        updated_at: '2021-11-11T21:03:05.641Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -4950,8 +4947,8 @@ paths:
                         position: 1
                         name: Size-69
                         presentation: S
-                        created_at: '2021-11-11T12:51:21.355Z'
-                        updated_at: '2021-11-11T12:51:21.355Z'
+                        created_at: '2021-11-11T21:03:05.646Z'
+                        updated_at: '2021-11-11T21:03:05.646Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -5012,8 +5009,8 @@ paths:
                         position: 1
                         name: Size-72
                         presentation: S
-                        created_at: '2021-11-11T12:51:21.427Z'
-                        updated_at: '2021-11-11T12:51:21.427Z'
+                        created_at: '2021-11-11T21:03:05.719Z'
+                        updated_at: '2021-11-11T21:03:05.719Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -5078,8 +5075,8 @@ paths:
                         position: 1
                         name: Size-73
                         presentation: S
-                        created_at: '2021-11-11T12:51:21.470Z'
-                        updated_at: '2021-11-11T12:51:21.470Z'
+                        created_at: '2021-11-11T21:03:05.763Z'
+                        updated_at: '2021-11-11T21:03:05.763Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -5145,8 +5142,8 @@ paths:
                         position: 1
                         name: M
                         presentation: S
-                        created_at: '2021-11-11T12:51:21.547Z'
-                        updated_at: '2021-11-11T12:51:21.555Z'
+                        created_at: '2021-11-11T21:03:05.842Z'
+                        updated_at: '2021-11-11T21:03:05.851Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -5276,7 +5273,7 @@ paths:
                     - id: '40'
                       type: order
                       attributes:
-                        number: R310395771
+                        number: R655726178
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5285,10 +5282,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: sylvie_collins@funkratke.co.uk
+                        email: roxane@reichert.ca
                         special_instructions:
-                        created_at: '2021-11-11T12:51:21.733Z'
-                        updated_at: '2021-11-11T12:51:21.733Z'
+                        created_at: '2021-11-11T21:03:06.036Z'
+                        updated_at: '2021-11-11T21:03:06.036Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5319,11 +5316,11 @@ paths:
                         display_ship_total: "$0.00"
                         display_shipment_total: "$0.00"
                         display_total: "$0.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -5362,7 +5359,7 @@ paths:
                     - id: '41'
                       type: order
                       attributes:
-                        number: R495949770
+                        number: R712212296
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5371,10 +5368,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: aurea.ruecker@torp.info
+                        email: minerva@barton.com
                         special_instructions:
-                        created_at: '2021-11-11T12:51:21.741Z'
-                        updated_at: '2021-11-11T12:51:21.741Z'
+                        created_at: '2021-11-11T21:03:06.044Z'
+                        updated_at: '2021-11-11T21:03:06.044Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5405,11 +5402,11 @@ paths:
                         display_ship_total: "$0.00"
                         display_shipment_total: "$0.00"
                         display_total: "$0.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -5495,7 +5492,7 @@ paths:
                       id: '44'
                       type: order
                       attributes:
-                        number: R163806903
+                        number: R542082951
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -5506,8 +5503,8 @@ paths:
                         payment_state:
                         email:
                         special_instructions:
-                        created_at: '2021-11-11T12:51:22.057Z'
-                        updated_at: '2021-11-11T12:51:22.073Z'
+                        created_at: '2021-11-11T21:03:06.364Z'
+                        updated_at: '2021-11-11T21:03:06.382Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -5538,11 +5535,11 @@ paths:
                         display_ship_total: "$0.00"
                         display_shipment_total: "$0.00"
                         display_total: "$0.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -5623,7 +5620,7 @@ paths:
                       id: '45'
                       type: order
                       attributes:
-                        number: R034858752
+                        number: R817996463
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5632,10 +5629,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: salvatore@labadie.name
+                        email: carri@corwin.com
                         special_instructions:
-                        created_at: '2021-11-11T12:51:22.128Z'
-                        updated_at: '2021-11-11T12:51:22.283Z'
+                        created_at: '2021-11-11T21:03:06.427Z'
+                        updated_at: '2021-11-11T21:03:06.577Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5666,11 +5663,11 @@ paths:
                         display_ship_total: "$100.00"
                         display_shipment_total: "$100.00"
                         display_total: "$110.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -5767,7 +5764,7 @@ paths:
                       id: '47'
                       type: order
                       attributes:
-                        number: R667714444
+                        number: R161286446
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -5778,8 +5775,8 @@ paths:
                         payment_state:
                         email: new@example.com
                         special_instructions:
-                        created_at: '2021-11-11T12:51:22.536Z'
-                        updated_at: '2021-11-11T12:51:22.630Z'
+                        created_at: '2021-11-11T21:03:06.856Z'
+                        updated_at: '2021-11-11T21:03:06.948Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -5810,11 +5807,11 @@ paths:
                         display_ship_total: "$100.00"
                         display_shipment_total: "$100.00"
                         display_total: "$110.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -5967,7 +5964,7 @@ paths:
                       id: '52'
                       type: order
                       attributes:
-                        number: R588438630
+                        number: R892779757
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -5976,10 +5973,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: shizue.lueilwitz@schamberger.ca
+                        email: pia@ondricka.name
                         special_instructions:
-                        created_at: '2021-11-11T12:51:23.223Z'
-                        updated_at: '2021-11-11T12:51:23.354Z'
+                        created_at: '2021-11-11T21:03:07.553Z'
+                        updated_at: '2021-11-11T21:03:07.694Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6010,11 +6007,11 @@ paths:
                         display_ship_total: "$100.00"
                         display_shipment_total: "$100.00"
                         display_total: "$110.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -6114,7 +6111,7 @@ paths:
                       id: '54'
                       type: order
                       attributes:
-                        number: R015429574
+                        number: R447986226
                         item_total: '10.0'
                         total: '110.0'
                         state: payment
@@ -6123,10 +6120,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: leonora@becker.biz
+                        email: evalyn.wuckert@kirlin.co.uk
                         special_instructions:
-                        created_at: '2021-11-11T12:51:23.559Z'
-                        updated_at: '2021-11-11T12:51:23.684Z'
+                        created_at: '2021-11-11T21:03:07.897Z'
+                        updated_at: '2021-11-11T21:03:08.032Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6157,11 +6154,11 @@ paths:
                         display_ship_total: "$100.00"
                         display_shipment_total: "$100.00"
                         display_total: "$110.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -6261,19 +6258,19 @@ paths:
                       id: '56'
                       type: order
                       attributes:
-                        number: R264305879
+                        number: R161105548
                         item_total: '10.0'
                         total: '110.0'
                         state: complete
                         adjustment_total: '0.0'
-                        completed_at: '2021-11-11T12:51:24.085Z'
+                        completed_at: '2021-11-11T21:03:08.430Z'
                         payment_total: '0.0'
                         shipment_state: pending
                         payment_state: balance_due
-                        email: jaimee.kunde@kozey.ca
+                        email: twyla.rutherford@deckow.ca
                         special_instructions:
-                        created_at: '2021-11-11T12:51:23.867Z'
-                        updated_at: '2021-11-11T12:51:24.085Z'
+                        created_at: '2021-11-11T21:03:08.214Z'
+                        updated_at: '2021-11-11T21:03:08.430Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6304,11 +6301,11 @@ paths:
                         display_ship_total: "$100.00"
                         display_shipment_total: "$100.00"
                         display_total: "$110.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -6419,7 +6416,7 @@ paths:
                       id: '59'
                       type: order
                       attributes:
-                        number: R009943242
+                        number: R476570076
                         item_total: '0.0'
                         total: '0.0'
                         state: cart
@@ -6428,10 +6425,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: milly.tremblay@wyman.ca
+                        email: jillian@parisian.name
                         special_instructions:
-                        created_at: '2021-11-11T12:51:24.398Z'
-                        updated_at: '2021-11-11T12:51:24.500Z'
+                        created_at: '2021-11-11T21:03:08.745Z'
+                        updated_at: '2021-11-11T21:03:08.853Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '0.0'
@@ -6462,11 +6459,11 @@ paths:
                         display_ship_total: "$0.00"
                         display_shipment_total: "$0.00"
                         display_total: "$0.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$0.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -6561,7 +6558,7 @@ paths:
                       id: '61'
                       type: order
                       attributes:
-                        number: R699753701
+                        number: R111702198
                         item_total: '10.0'
                         total: '110.0'
                         state: delivery
@@ -6570,10 +6567,10 @@ paths:
                         payment_total: '0.0'
                         shipment_state:
                         payment_state:
-                        email: julian.stark@boehm.biz
+                        email: jeanett_kuhlman@pagacbruen.ca
                         special_instructions:
-                        created_at: '2021-11-11T12:51:24.679Z'
-                        updated_at: '2021-11-11T12:51:24.756Z'
+                        created_at: '2021-11-11T21:03:09.028Z'
+                        updated_at: '2021-11-11T21:03:09.114Z'
                         currency: USD
                         last_ip_address:
                         shipment_total: '100.0'
@@ -6604,11 +6601,11 @@ paths:
                         display_ship_total: "$100.00"
                         display_shipment_total: "$100.00"
                         display_total: "$110.00"
+                        display_total_applicable_store_credit: "$0.00"
+                        display_total_applied_store_credit: "$0.00"
                         display_order_total_after_store_credit: "$110.00"
                         display_total_available_store_credit: "$0.00"
                         display_store_credit_remaining_after_capture: "$0.00"
-                        display_total_applicable_store_credit: "$0.00"
-                        display_total_applied_store_credit: "$0.00"
                       relationships:
                         user:
                           data:
@@ -6876,8 +6873,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 1
-                        created_at: '2021-11-11T12:51:26.416Z'
-                        updated_at: '2021-11-11T12:51:26.416Z'
+                        created_at: '2021-11-11T21:03:10.832Z'
+                        updated_at: '2021-11-11T21:03:10.832Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -6897,8 +6894,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 2
-                        created_at: '2021-11-11T12:51:26.422Z'
-                        updated_at: '2021-11-11T12:51:26.422Z'
+                        created_at: '2021-11-11T21:03:10.838Z'
+                        updated_at: '2021-11-11T21:03:10.838Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -6918,8 +6915,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-11T12:51:26.426Z'
-                        updated_at: '2021-11-11T12:51:26.426Z'
+                        created_at: '2021-11-11T21:03:10.841Z'
+                        updated_at: '2021-11-11T21:03:10.841Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -6939,8 +6936,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-11T12:51:26.429Z'
-                        updated_at: '2021-11-11T12:51:26.429Z'
+                        created_at: '2021-11-11T21:03:10.845Z'
+                        updated_at: '2021-11-11T21:03:10.845Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -6963,8 +6960,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 5
-                        created_at: '2021-11-11T12:51:26.433Z'
-                        updated_at: '2021-11-11T12:51:26.433Z'
+                        created_at: '2021-11-11T21:03:10.848Z'
+                        updated_at: '2021-11-11T21:03:10.848Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -7034,8 +7031,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-11T12:51:26.545Z'
-                        updated_at: '2021-11-11T12:51:26.545Z'
+                        created_at: '2021-11-11T21:03:10.960Z'
+                        updated_at: '2021-11-11T21:03:10.960Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -7111,8 +7108,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 4
-                        created_at: '2021-11-11T12:51:26.636Z'
-                        updated_at: '2021-11-11T12:51:26.636Z'
+                        created_at: '2021-11-11T21:03:11.049Z'
+                        updated_at: '2021-11-11T21:03:11.049Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -7187,8 +7184,8 @@ paths:
                         display_on: both
                         auto_capture:
                         position: 3
-                        created_at: '2021-11-11T12:51:26.758Z'
-                        updated_at: '2021-11-11T12:51:26.772Z'
+                        created_at: '2021-11-11T21:03:11.177Z'
+                        updated_at: '2021-11-11T21:03:11.188Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -7336,9 +7333,9 @@ paths:
                         state: invalid
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-11T12:51:27.066Z'
-                        updated_at: '2021-11-11T12:51:27.084Z'
-                        number: PBSC4TY2
+                        created_at: '2021-11-11T21:03:11.485Z'
+                        updated_at: '2021-11-11T21:03:11.502Z'
+                        number: PAN002ZS
                         cvv_response_code:
                         cvv_response_message:
                         public_metadata: {}
@@ -7375,9 +7372,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-11T12:51:27.081Z'
-                        updated_at: '2021-11-11T12:51:27.081Z'
-                        number: PVV8JV0C
+                        created_at: '2021-11-11T21:03:11.499Z'
+                        updated_at: '2021-11-11T21:03:11.499Z'
+                        number: PU5CAL9Y
                         cvv_response_code:
                         cvv_response_message:
                         public_metadata: {}
@@ -7465,9 +7462,9 @@ paths:
                         state: checkout
                         response_code: '12345'
                         avs_response:
-                        created_at: '2021-11-11T12:51:27.263Z'
-                        updated_at: '2021-11-11T12:51:27.263Z'
-                        number: PH77SZTW
+                        created_at: '2021-11-11T21:03:11.677Z'
+                        updated_at: '2021-11-11T21:03:11.677Z'
+                        number: PSGOPYLV
                         cvv_response_code:
                         cvv_response_message:
                         public_metadata: {}
@@ -7601,8 +7598,8 @@ paths:
                         position:
                         type:
                         deleted_at:
-                        created_at: '2021-11-11T12:51:27.495Z'
-                        updated_at: '2021-11-11T12:51:27.495Z'
+                        created_at: '2021-11-11T21:03:11.915Z'
+                        updated_at: '2021-11-11T21:03:11.915Z'
                       relationships:
                         promotion:
                           data:
@@ -7614,8 +7611,8 @@ paths:
                         position:
                         type:
                         deleted_at:
-                        created_at: '2021-11-11T12:51:27.496Z'
-                        updated_at: '2021-11-11T12:51:27.496Z'
+                        created_at: '2021-11-11T21:03:11.916Z'
+                        updated_at: '2021-11-11T21:03:11.916Z'
                       relationships:
                         promotion:
                           data:
@@ -7674,8 +7671,8 @@ paths:
                         position:
                         type:
                         deleted_at:
-                        created_at: '2021-11-11T12:51:27.578Z'
-                        updated_at: '2021-11-11T12:51:27.578Z'
+                        created_at: '2021-11-11T21:03:11.992Z'
+                        updated_at: '2021-11-11T21:03:11.992Z'
                       relationships:
                         promotion:
                           data:
@@ -7725,8 +7722,8 @@ paths:
                         position:
                         type:
                         deleted_at:
-                        created_at: '2021-11-11T12:51:27.604Z'
-                        updated_at: '2021-11-11T12:51:27.604Z'
+                        created_at: '2021-11-11T21:03:12.018Z'
+                        updated_at: '2021-11-11T21:03:12.018Z'
                       relationships:
                         promotion:
                           data:
@@ -7790,8 +7787,8 @@ paths:
                         position:
                         type: Spree::Promotion::Actions::CreateAdjustment
                         deleted_at:
-                        created_at: '2021-11-11T12:51:27.689Z'
-                        updated_at: '2021-11-11T12:51:27.695Z'
+                        created_at: '2021-11-11T21:03:12.101Z'
+                        updated_at: '2021-11-11T21:03:12.108Z'
                       relationships:
                         promotion:
                           data:
@@ -7888,13 +7885,13 @@ paths:
         example: promotions
         schema:
           type: string
-      - name: filter[code]
+      - name: filter[code_eq]
         in: query
         description: ''
         example: BLK-FRI
         schema:
           type: string
-      - name: filter[name]
+      - name: filter[name_eq]
         in: query
         description: ''
         example: 2020 Promotions
@@ -7913,8 +7910,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-11T12:51:27.840Z'
-                        updated_at: '2021-11-11T12:51:27.840Z'
+                        created_at: '2021-11-11T21:03:12.255Z'
+                        updated_at: '2021-11-11T21:03:12.255Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7923,8 +7920,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-11T12:51:27.842Z'
-                        updated_at: '2021-11-11T12:51:27.842Z'
+                        created_at: '2021-11-11T21:03:12.257Z'
+                        updated_at: '2021-11-11T21:03:12.257Z'
                         code: POP123
                       relationships:
                         promotions:
@@ -7934,11 +7931,11 @@ paths:
                       total_count: 2
                       total_pages: 1
                     links:
-                      self: http://www.example.com/api/v2/platform/promotion_categories?page=1&per_page=&include=&filter[code]=&filter[name]=
-                      next: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode%5D=&filter%5Bname%5D=&include=&page=1&per_page=
-                      prev: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode%5D=&filter%5Bname%5D=&include=&page=1&per_page=
-                      last: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode%5D=&filter%5Bname%5D=&include=&page=1&per_page=
-                      first: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode%5D=&filter%5Bname%5D=&include=&page=1&per_page=
+                      self: http://www.example.com/api/v2/platform/promotion_categories?page=1&per_page=&include=&filter[code_eq]=&filter[name_eq]=
+                      next: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode_eq%5D=&filter%5Bname_eq%5D=&include=&page=1&per_page=
+                      prev: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode_eq%5D=&filter%5Bname_eq%5D=&include=&page=1&per_page=
+                      last: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode_eq%5D=&filter%5Bname_eq%5D=&include=&page=1&per_page=
+                      first: http://www.example.com/api/v2/platform/promotion_categories?filter%5Bcode_eq%5D=&filter%5Bname_eq%5D=&include=&page=1&per_page=
               schema:
                 "$ref": "#/components/schemas/resources_list"
         '401':
@@ -7980,8 +7977,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-11T12:51:27.898Z'
-                        updated_at: '2021-11-11T12:51:27.898Z'
+                        created_at: '2021-11-11T21:03:12.320Z'
+                        updated_at: '2021-11-11T21:03:12.320Z'
                         code: 2021-BFM
                       relationships:
                         promotions:
@@ -8041,8 +8038,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: Promotion Category
-                        created_at: '2021-11-11T12:51:27.944Z'
-                        updated_at: '2021-11-11T12:51:27.944Z'
+                        created_at: '2021-11-11T21:03:12.360Z'
+                        updated_at: '2021-11-11T21:03:12.360Z'
                         code: MJO
                       relationships:
                         promotions:
@@ -8103,8 +8100,8 @@ paths:
                       type: promotion_category
                       attributes:
                         name: 2021 Promotions
-                        created_at: '2021-11-11T12:51:28.007Z'
-                        updated_at: '2021-11-11T12:51:28.013Z'
+                        created_at: '2021-11-11T21:03:12.429Z'
+                        updated_at: '2021-11-11T21:03:12.435Z'
                         code: 2021-Promos
                       relationships:
                         promotions:
@@ -8232,8 +8229,8 @@ paths:
                       type: promotion_rule
                       attributes:
                         type:
-                        created_at: '2021-11-11T12:51:28.163Z'
-                        updated_at: '2021-11-11T12:51:28.163Z'
+                        created_at: '2021-11-11T21:03:12.584Z'
+                        updated_at: '2021-11-11T21:03:12.584Z'
                         code:
                         preferences: {}
                       relationships:
@@ -8245,8 +8242,8 @@ paths:
                       type: promotion_rule
                       attributes:
                         type:
-                        created_at: '2021-11-11T12:51:28.165Z'
-                        updated_at: '2021-11-11T12:51:28.165Z'
+                        created_at: '2021-11-11T21:03:12.586Z'
+                        updated_at: '2021-11-11T21:03:12.586Z'
                         code:
                         preferences: {}
                       relationships:
@@ -8305,8 +8302,8 @@ paths:
                       type: promotion_rule
                       attributes:
                         type:
-                        created_at: '2021-11-11T12:51:28.238Z'
-                        updated_at: '2021-11-11T12:51:28.238Z'
+                        created_at: '2021-11-11T21:03:12.665Z'
+                        updated_at: '2021-11-11T21:03:12.665Z'
                         code:
                         preferences: {}
                       relationships:
@@ -8356,8 +8353,8 @@ paths:
                       type: promotion_rule
                       attributes:
                         type:
-                        created_at: '2021-11-11T12:51:28.269Z'
-                        updated_at: '2021-11-11T12:51:28.269Z'
+                        created_at: '2021-11-11T21:03:12.691Z'
+                        updated_at: '2021-11-11T21:03:12.691Z'
                         code:
                         preferences: {}
                       relationships:
@@ -8421,8 +8418,8 @@ paths:
                       type: promotion_rule
                       attributes:
                         type: Spree::Promotion::Rules::Country
-                        created_at: '2021-11-11T12:51:28.350Z'
-                        updated_at: '2021-11-11T12:51:28.357Z'
+                        created_at: '2021-11-11T21:03:12.777Z'
+                        updated_at: '2021-11-11T21:03:12.784Z'
                         code:
                         preferences: {}
                       relationships:
@@ -8555,8 +8552,8 @@ paths:
                         code:
                         advertise: false
                         path:
-                        created_at: '2021-11-11T12:51:28.512Z'
-                        updated_at: '2021-11-11T12:51:28.512Z'
+                        created_at: '2021-11-11T21:03:12.936Z'
+                        updated_at: '2021-11-11T21:03:12.936Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -8583,8 +8580,8 @@ paths:
                         code:
                         advertise: false
                         path:
-                        created_at: '2021-11-11T12:51:28.521Z'
-                        updated_at: '2021-11-11T12:51:28.521Z'
+                        created_at: '2021-11-11T21:03:12.944Z'
+                        updated_at: '2021-11-11T21:03:12.944Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -8615,8 +8612,8 @@ paths:
                         code:
                         advertise: false
                         path:
-                        created_at: '2021-11-11T12:51:28.535Z'
-                        updated_at: '2021-11-11T12:51:28.535Z'
+                        created_at: '2021-11-11T21:03:12.959Z'
+                        updated_at: '2021-11-11T21:03:12.959Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -8647,8 +8644,8 @@ paths:
                         code:
                         advertise: false
                         path:
-                        created_at: '2021-11-11T12:51:28.545Z'
-                        updated_at: '2021-11-11T12:51:28.545Z'
+                        created_at: '2021-11-11T21:03:12.973Z'
+                        updated_at: '2021-11-11T21:03:12.973Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -8719,8 +8716,8 @@ paths:
                       type: promotion
                       attributes:
                         description: First 1000 Customers Save 20%
-                        expires_at: '2021-11-15T12:51:28.711Z'
-                        starts_at: '2021-11-11T12:51:28.711Z'
+                        expires_at: '2021-11-15T21:03:13.184Z'
+                        starts_at: '2021-11-11T21:03:13.184Z'
                         name: Black Friday 20% Off
                         type: Spree::Promotion
                         usage_limit: 1000
@@ -8728,8 +8725,8 @@ paths:
                         code: BLK-20
                         advertise: true
                         path: "/black-fri/today"
-                        created_at: '2021-11-11T12:51:28.724Z'
-                        updated_at: '2021-11-11T12:51:28.724Z'
+                        created_at: '2021-11-11T21:03:13.239Z'
+                        updated_at: '2021-11-11T21:03:13.239Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -8813,8 +8810,8 @@ paths:
                         code:
                         advertise: false
                         path:
-                        created_at: '2021-11-11T12:51:28.881Z'
-                        updated_at: '2021-11-11T12:51:28.881Z'
+                        created_at: '2021-11-11T21:03:13.393Z'
+                        updated_at: '2021-11-11T21:03:13.393Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -8899,8 +8896,8 @@ paths:
                         code: RAND-10
                         advertise: false
                         path:
-                        created_at: '2021-11-11T12:51:29.200Z'
-                        updated_at: '2021-11-11T12:51:29.216Z'
+                        created_at: '2021-11-11T21:03:13.632Z'
+                        updated_at: '2021-11-11T21:03:13.649Z'
                         public_metadata: {}
                         private_metadata: {}
                       relationships:
@@ -9043,14 +9040,14 @@ paths:
                       type: role
                       attributes:
                         name: 'Role #1'
-                        created_at: '2021-11-11T12:51:29.716Z'
-                        updated_at: '2021-11-11T12:51:29.716Z'
+                        created_at: '2021-11-11T21:03:14.153Z'
+                        updated_at: '2021-11-11T21:03:14.153Z'
                     - id: '2'
                       type: role
                       attributes:
                         name: 'Role #2'
-                        created_at: '2021-11-11T12:51:29.718Z'
-                        updated_at: '2021-11-11T12:51:29.718Z'
+                        created_at: '2021-11-11T21:03:14.154Z'
+                        updated_at: '2021-11-11T21:03:14.154Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -9095,8 +9092,8 @@ paths:
                       type: role
                       attributes:
                         name: 'Role #5'
-                        created_at: '2021-11-11T12:51:29.782Z'
-                        updated_at: '2021-11-11T12:51:29.782Z'
+                        created_at: '2021-11-11T21:03:14.213Z'
+                        updated_at: '2021-11-11T21:03:14.213Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -9145,8 +9142,8 @@ paths:
                       type: role
                       attributes:
                         name: 'Role #6'
-                        created_at: '2021-11-11T12:51:29.823Z'
-                        updated_at: '2021-11-11T12:51:29.823Z'
+                        created_at: '2021-11-11T21:03:14.260Z'
+                        updated_at: '2021-11-11T21:03:14.260Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -9196,8 +9193,8 @@ paths:
                       type: role
                       attributes:
                         name: administrator
-                        created_at: '2021-11-11T12:51:29.889Z'
-                        updated_at: '2021-11-11T12:51:29.896Z'
+                        created_at: '2021-11-11T21:03:14.324Z'
+                        updated_at: '2021-11-11T21:03:14.330Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -9321,12 +9318,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H80949427431
+                        number: H68397453394
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-11T12:51:30.054Z'
-                        updated_at: '2021-11-11T12:51:30.057Z'
+                        created_at: '2021-11-11T21:03:14.499Z'
+                        updated_at: '2021-11-11T21:03:14.503Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9336,11 +9333,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$0.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -9370,12 +9367,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H76821114218
+                        number: H10719370268
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-11T12:51:30.085Z'
-                        updated_at: '2021-11-11T12:51:30.088Z'
+                        created_at: '2021-11-11T21:03:14.529Z'
+                        updated_at: '2021-11-11T21:03:14.532Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9385,11 +9382,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$0.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -9472,12 +9469,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H37739783228
+                        number: H18823069442
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-11T12:51:30.379Z'
-                        updated_at: '2021-11-11T12:51:30.394Z'
+                        created_at: '2021-11-11T21:03:14.840Z'
+                        updated_at: '2021-11-11T21:03:14.859Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9487,11 +9484,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$10.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -9613,12 +9610,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H94368375009
+                        number: H35371473635
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-11T12:51:31.218Z'
-                        updated_at: '2021-11-11T12:51:31.249Z'
+                        created_at: '2021-11-11T21:03:15.816Z'
+                        updated_at: '2021-11-11T21:03:15.849Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9628,11 +9625,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$10.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -9719,12 +9716,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H44447278595
+                        number: H74981958630
                         cost: '100.0'
-                        shipped_at: '2021-11-11T12:51:31.772Z'
+                        shipped_at: '2021-11-11T21:03:16.297Z'
                         state: shipped
-                        created_at: '2021-11-11T12:51:31.738Z'
-                        updated_at: '2021-11-11T12:51:31.772Z'
+                        created_at: '2021-11-11T21:03:16.262Z'
+                        updated_at: '2021-11-11T21:03:16.297Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9734,11 +9731,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$10.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -9825,12 +9822,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H39383646411
+                        number: H31817727641
                         cost: '100.0'
                         shipped_at:
                         state: canceled
-                        created_at: '2021-11-11T12:51:32.168Z'
-                        updated_at: '2021-11-11T12:51:32.194Z'
+                        created_at: '2021-11-11T21:03:16.713Z'
+                        updated_at: '2021-11-11T21:03:16.739Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9840,11 +9837,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$10.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -9931,12 +9928,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H55555211724
+                        number: H50833175393
                         cost: '100.0'
                         shipped_at:
                         state: ready
-                        created_at: '2021-11-11T12:51:32.624Z'
-                        updated_at: '2021-11-11T12:51:32.652Z'
+                        created_at: '2021-11-11T21:03:17.172Z'
+                        updated_at: '2021-11-11T21:03:17.202Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -9946,11 +9943,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$10.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -10037,12 +10034,12 @@ paths:
                       type: shipment
                       attributes:
                         tracking: U10000
-                        number: H69562340303
+                        number: H82741585078
                         cost: '100.0'
                         shipped_at:
                         state: pending
-                        created_at: '2021-11-11T12:51:33.066Z'
-                        updated_at: '2021-11-11T12:51:33.091Z'
+                        created_at: '2021-11-11T21:03:17.629Z'
+                        updated_at: '2021-11-11T21:03:17.657Z'
                         adjustment_total: '0.0'
                         additional_tax_total: '0.0'
                         promo_total: '0.0'
@@ -10052,11 +10049,11 @@ paths:
                         non_taxable_adjustment_total: '0.0'
                         public_metadata: {}
                         private_metadata: {}
+                        display_final_price: "$100.00"
                         display_amount: "$100.00"
                         display_cost: "$100.00"
                         display_discounted_cost: "$100.00"
                         display_item_cost: "$10.00"
-                        display_final_price: "$100.00"
                       relationships:
                         order:
                           data:
@@ -10147,14 +10144,14 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #113'
-                        created_at: '2021-11-11T12:51:33.321Z'
-                        updated_at: '2021-11-11T12:51:33.321Z'
+                        created_at: '2021-11-11T21:03:17.913Z'
+                        updated_at: '2021-11-11T21:03:17.913Z'
                     - id: '114'
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #114'
-                        created_at: '2021-11-11T12:51:33.322Z'
-                        updated_at: '2021-11-11T12:51:33.322Z'
+                        created_at: '2021-11-11T21:03:17.914Z'
+                        updated_at: '2021-11-11T21:03:17.914Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -10199,8 +10196,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #117'
-                        created_at: '2021-11-11T12:51:33.386Z'
-                        updated_at: '2021-11-11T12:51:33.386Z'
+                        created_at: '2021-11-11T21:03:17.978Z'
+                        updated_at: '2021-11-11T21:03:17.978Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10249,8 +10246,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: 'ShippingCategory #118'
-                        created_at: '2021-11-11T12:51:33.427Z'
-                        updated_at: '2021-11-11T12:51:33.427Z'
+                        created_at: '2021-11-11T21:03:18.021Z'
+                        updated_at: '2021-11-11T21:03:18.021Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -10300,8 +10297,8 @@ paths:
                       type: shipping_category
                       attributes:
                         name: Default
-                        created_at: '2021-11-11T12:51:33.495Z'
-                        updated_at: '2021-11-11T12:51:33.501Z'
+                        created_at: '2021-11-11T21:03:18.174Z'
+                        updated_at: '2021-11-11T21:03:18.181Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10435,8 +10432,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-11T12:51:33.649Z'
-                        updated_at: '2021-11-11T12:51:33.649Z'
+                        created_at: '2021-11-11T21:03:18.333Z'
+                        updated_at: '2021-11-11T21:03:18.333Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -10461,8 +10458,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-11T12:51:33.659Z'
-                        updated_at: '2021-11-11T12:51:33.659Z'
+                        created_at: '2021-11-11T21:03:18.341Z'
+                        updated_at: '2021-11-11T21:03:18.341Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -10534,8 +10531,8 @@ paths:
                         admin_name: DHL Express- Zone A
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-11T12:51:33.750Z'
-                        updated_at: '2021-11-11T12:51:33.750Z'
+                        created_at: '2021-11-11T21:03:18.434Z'
+                        updated_at: '2021-11-11T21:03:18.434Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -10621,8 +10618,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-11T12:51:33.825Z'
-                        updated_at: '2021-11-11T12:51:33.825Z'
+                        created_at: '2021-11-11T21:03:18.487Z'
+                        updated_at: '2021-11-11T21:03:18.487Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -10699,8 +10696,8 @@ paths:
                         admin_name:
                         display_on: both
                         tracking_url:
-                        created_at: '2021-11-11T12:51:33.976Z'
-                        updated_at: '2021-11-11T12:51:33.988Z'
+                        created_at: '2021-11-11T21:03:18.581Z'
+                        updated_at: '2021-11-11T21:03:18.594Z'
                         deleted_at:
                         public_metadata: {}
                         private_metadata: {}
@@ -10833,14 +10830,14 @@ paths:
                       type: store_credit_category
                       attributes:
                         name: Exchange
-                        created_at: '2021-11-11T12:51:34.183Z'
-                        updated_at: '2021-11-11T12:51:34.183Z'
+                        created_at: '2021-11-11T21:03:18.787Z'
+                        updated_at: '2021-11-11T21:03:18.787Z'
                     - id: '3'
                       type: store_credit_category
                       attributes:
                         name: Exchange
-                        created_at: '2021-11-11T12:51:34.184Z'
-                        updated_at: '2021-11-11T12:51:34.184Z'
+                        created_at: '2021-11-11T21:03:18.788Z'
+                        updated_at: '2021-11-11T21:03:18.788Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -10885,8 +10882,8 @@ paths:
                       type: store_credit_category
                       attributes:
                         name: Exchange
-                        created_at: '2021-11-11T12:51:34.240Z'
-                        updated_at: '2021-11-11T12:51:34.240Z'
+                        created_at: '2021-11-11T21:03:18.848Z'
+                        updated_at: '2021-11-11T21:03:18.848Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -10935,8 +10932,8 @@ paths:
                       type: store_credit_category
                       attributes:
                         name: Exchange
-                        created_at: '2021-11-11T12:51:34.280Z'
-                        updated_at: '2021-11-11T12:51:34.280Z'
+                        created_at: '2021-11-11T21:03:18.888Z'
+                        updated_at: '2021-11-11T21:03:18.888Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -10986,8 +10983,8 @@ paths:
                       type: store_credit_category
                       attributes:
                         name: refunded
-                        created_at: '2021-11-11T12:51:34.347Z'
-                        updated_at: '2021-11-11T12:51:34.353Z'
+                        created_at: '2021-11-11T21:03:18.955Z'
+                        updated_at: '2021-11-11T21:03:18.961Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -11099,15 +11096,15 @@ paths:
                       attributes:
                         name: Expiring
                         priority: 1
-                        created_at: '2021-11-11T12:51:34.488Z'
-                        updated_at: '2021-11-11T12:51:34.488Z'
+                        created_at: '2021-11-11T21:03:19.100Z'
+                        updated_at: '2021-11-11T21:03:19.100Z'
                     - id: '3'
                       type: store_credit_type
                       attributes:
                         name: Expiring
                         priority: 1
-                        created_at: '2021-11-11T12:51:34.488Z'
-                        updated_at: '2021-11-11T12:51:34.488Z'
+                        created_at: '2021-11-11T21:03:19.101Z'
+                        updated_at: '2021-11-11T21:03:19.101Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -11153,8 +11150,8 @@ paths:
                       attributes:
                         name: Expiring
                         priority: 1
-                        created_at: '2021-11-11T12:51:34.546Z'
-                        updated_at: '2021-11-11T12:51:34.546Z'
+                        created_at: '2021-11-11T21:03:19.160Z'
+                        updated_at: '2021-11-11T21:03:19.160Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -11204,8 +11201,8 @@ paths:
                       attributes:
                         name: Expiring
                         priority: 1
-                        created_at: '2021-11-11T12:51:34.585Z'
-                        updated_at: '2021-11-11T12:51:34.585Z'
+                        created_at: '2021-11-11T21:03:19.200Z'
+                        updated_at: '2021-11-11T21:03:19.200Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -11256,8 +11253,8 @@ paths:
                       attributes:
                         name: default
                         priority: 1
-                        created_at: '2021-11-11T12:51:34.651Z'
-                        updated_at: '2021-11-11T12:51:34.657Z'
+                        created_at: '2021-11-11T21:03:19.269Z'
+                        updated_at: '2021-11-11T21:03:19.275Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -11377,7 +11374,7 @@ paths:
       - name: filter[amount_gteq]
         in: query
         description: ''
-        example: 50.0
+        example: '50.0'
         schema:
           type: string
       - name: filter[currency_eq]
@@ -11405,12 +11402,12 @@ paths:
                         currency: USD
                         amount_authorized: '0.0'
                         originator_type:
-                        created_at: '2021-11-11T12:51:34.795Z'
-                        updated_at: '2021-11-11T12:51:34.795Z'
+                        created_at: '2021-11-11T21:03:19.418Z'
+                        updated_at: '2021-11-11T21:03:19.418Z'
                         public_metadata: {}
                         private_metadata: {}
-                        display_amount: "$150.00"
                         display_amount_used: "$0.00"
+                        display_amount: "$150.00"
                       relationships:
                         user:
                           data:
@@ -11442,12 +11439,12 @@ paths:
                         currency: USD
                         amount_authorized: '0.0'
                         originator_type:
-                        created_at: '2021-11-11T12:51:34.802Z'
-                        updated_at: '2021-11-11T12:51:34.802Z'
+                        created_at: '2021-11-11T21:03:19.425Z'
+                        updated_at: '2021-11-11T21:03:19.425Z'
                         public_metadata: {}
                         private_metadata: {}
-                        display_amount: "$150.00"
                         display_amount_used: "$0.00"
+                        display_amount: "$150.00"
                       relationships:
                         user:
                           data:
@@ -11526,12 +11523,12 @@ paths:
                         currency: USD
                         amount_authorized: '0.0'
                         originator_type:
-                        created_at: '2021-11-11T12:51:34.891Z'
-                        updated_at: '2021-11-11T12:51:34.891Z'
+                        created_at: '2021-11-11T21:03:19.516Z'
+                        updated_at: '2021-11-11T21:03:19.516Z'
                         public_metadata: {}
                         private_metadata: {}
-                        display_amount: "$150.00"
                         display_amount_used: "$0.00"
+                        display_amount: "$150.00"
                       relationships:
                         user:
                           data:
@@ -11631,12 +11628,12 @@ paths:
                         currency: USD
                         amount_authorized: '0.0'
                         originator_type:
-                        created_at: '2021-11-11T12:51:34.942Z'
-                        updated_at: '2021-11-11T12:51:34.942Z'
+                        created_at: '2021-11-11T21:03:19.655Z'
+                        updated_at: '2021-11-11T21:03:19.655Z'
                         public_metadata: {}
                         private_metadata: {}
-                        display_amount: "$150.00"
                         display_amount_used: "$0.00"
+                        display_amount: "$150.00"
                       relationships:
                         user:
                           data:
@@ -11720,13 +11717,13 @@ paths:
                         currency: CAD
                         amount_authorized: '0.0'
                         originator_type:
-                        created_at: '2021-11-11T12:51:35.026Z'
-                        updated_at: '2021-11-11T12:51:35.037Z'
+                        created_at: '2021-11-11T21:03:19.740Z'
+                        updated_at: '2021-11-11T21:03:19.751Z'
                         public_metadata:
                           loyalty_reward: true
                         private_metadata: {}
-                        display_amount: "$500.00"
                         display_amount_used: "$0.00"
+                        display_amount: "$500.00"
                       relationships:
                         user:
                           data:
@@ -11866,7 +11863,7 @@ paths:
       - name: filter[is_default_true]
         in: query
         description: ''
-        example: 1
+        example: '1'
         schema:
           type: string
       - name: filter[tax_code_eq]
@@ -11887,13 +11884,13 @@ paths:
                     - id: '123'
                       type: tax_category
                       attributes:
-                        name: TaxCategory - 542439
-                        description: Tempore voluptas reiciendis eaque illum et expedita
-                          optio adipisci.
+                        name: TaxCategory - 337181
+                        description: Perferendis quos inventore incidunt dolorum deleniti
+                          omnis illo debitis.
                         is_default: false
                         deleted_at:
-                        created_at: '2021-11-11T12:51:35.224Z'
-                        updated_at: '2021-11-11T12:51:35.224Z'
+                        created_at: '2021-11-11T21:03:19.939Z'
+                        updated_at: '2021-11-11T21:03:19.939Z'
                         tax_code:
                       relationships:
                         tax_rates:
@@ -11901,13 +11898,13 @@ paths:
                     - id: '124'
                       type: tax_category
                       attributes:
-                        name: TaxCategory - 26941
-                        description: Quibusdam perferendis expedita dicta eaque rem
-                          quam quia hic.
+                        name: TaxCategory - 337866
+                        description: Doloribus autem ad perferendis dolore facilis
+                          quidem nisi.
                         is_default: false
                         deleted_at:
-                        created_at: '2021-11-11T12:51:35.225Z'
-                        updated_at: '2021-11-11T12:51:35.225Z'
+                        created_at: '2021-11-11T21:03:19.940Z'
+                        updated_at: '2021-11-11T21:03:19.940Z'
                         tax_code:
                       relationships:
                         tax_rates:
@@ -11962,12 +11959,13 @@ paths:
                       id: '127'
                       type: tax_category
                       attributes:
-                        name: TaxCategory - 883230
-                        description: Quos incidunt eveniet nostrum nam quis.
+                        name: TaxCategory - 630819
+                        description: Excepturi delectus esse dolore necessitatibus
+                          sunt praesentium.
                         is_default: false
                         deleted_at:
-                        created_at: '2021-11-11T12:51:35.284Z'
-                        updated_at: '2021-11-11T12:51:35.284Z'
+                        created_at: '2021-11-11T21:03:19.998Z'
+                        updated_at: '2021-11-11T21:03:19.998Z'
                         tax_code:
                       relationships:
                         tax_rates:
@@ -12026,12 +12024,12 @@ paths:
                       id: '128'
                       type: tax_category
                       attributes:
-                        name: TaxCategory - 982747
-                        description: Adipisci fugit modi soluta necessitatibus maiores.
+                        name: TaxCategory - 725356
+                        description: Maxime delectus praesentium esse ipsam tempora.
                         is_default: false
                         deleted_at:
-                        created_at: '2021-11-11T12:51:35.362Z'
-                        updated_at: '2021-11-11T12:51:35.362Z'
+                        created_at: '2021-11-11T21:03:20.045Z'
+                        updated_at: '2021-11-11T21:03:20.045Z'
                         tax_code:
                       relationships:
                         tax_rates:
@@ -12095,8 +12093,8 @@ paths:
                         description: Men's, women's and children's clothing
                         is_default: true
                         deleted_at:
-                        created_at: '2021-11-11T12:51:35.429Z'
-                        updated_at: '2021-11-11T12:51:35.437Z'
+                        created_at: '2021-11-11T21:03:20.112Z'
+                        updated_at: '2021-11-11T21:03:20.120Z'
                         tax_code: 1233K
                       relationships:
                         tax_rates:
@@ -12237,8 +12235,8 @@ paths:
                       attributes:
                         amount: '0.1'
                         included_in_price: false
-                        created_at: '2021-11-11T12:51:35.585Z'
-                        updated_at: '2021-11-11T12:51:35.585Z'
+                        created_at: '2021-11-11T21:03:20.273Z'
+                        updated_at: '2021-11-11T21:03:20.273Z'
                         name:
                         show_rate_in_label: true
                         deleted_at:
@@ -12256,8 +12254,8 @@ paths:
                       attributes:
                         amount: '0.1'
                         included_in_price: false
-                        created_at: '2021-11-11T12:51:35.589Z'
-                        updated_at: '2021-11-11T12:51:35.589Z'
+                        created_at: '2021-11-11T21:03:20.276Z'
+                        updated_at: '2021-11-11T21:03:20.276Z'
                         name:
                         show_rate_in_label: true
                         deleted_at:
@@ -12322,8 +12320,8 @@ paths:
                       attributes:
                         amount: '0.1'
                         included_in_price: false
-                        created_at: '2021-11-11T12:51:35.660Z'
-                        updated_at: '2021-11-11T12:51:35.660Z'
+                        created_at: '2021-11-11T21:03:20.347Z'
+                        updated_at: '2021-11-11T21:03:20.347Z'
                         name:
                         show_rate_in_label: true
                         deleted_at:
@@ -12395,8 +12393,8 @@ paths:
                       attributes:
                         amount: '0.1'
                         included_in_price: false
-                        created_at: '2021-11-11T12:51:35.790Z'
-                        updated_at: '2021-11-11T12:51:35.790Z'
+                        created_at: '2021-11-11T21:03:20.396Z'
+                        updated_at: '2021-11-11T21:03:20.396Z'
                         name:
                         show_rate_in_label: true
                         deleted_at:
@@ -12466,8 +12464,8 @@ paths:
                       attributes:
                         amount: '25.9'
                         included_in_price: true
-                        created_at: '2021-11-11T12:51:35.863Z'
-                        updated_at: '2021-11-11T12:51:35.872Z'
+                        created_at: '2021-11-11T21:03:20.469Z'
+                        updated_at: '2021-11-11T21:03:20.478Z'
                         name:
                         show_rate_in_label: true
                         deleted_at:
@@ -12557,6 +12555,365 @@ paths:
                     error: The access token is invalid
               schema:
                 "$ref": "#/components/schemas/error"
+  "/api/v2/platform/taxonomies":
+    get:
+      summary: Return a list of Taxonomies
+      tags:
+      - Taxonomies
+      security:
+      - bearer_auth: []
+      description: Returns a list of Taxonomies
+      operationId: taxonomies-list
+      parameters:
+      - name: page
+        in: query
+        example: 1
+        schema:
+          type: integer
+      - name: per_page
+        in: query
+        example: 50
+        schema:
+          type: integer
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: taxon
+        schema:
+          type: string
+      - name: filter[name_eq]
+        in: query
+        description: ''
+        example: Category
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Records returned
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                    - id: '13'
+                      type: taxonomy
+                      attributes:
+                        name: taxonomy_13
+                        created_at: '2021-11-11T21:03:20.653Z'
+                        updated_at: '2021-11-11T21:03:20.671Z'
+                        position: 1
+                        public_metadata: {}
+                        private_metadata: {}
+                      relationships:
+                        taxons:
+                          data:
+                          - id: '25'
+                            type: taxon
+                        root:
+                          data:
+                            id: '25'
+                            type: taxon
+                    - id: '14'
+                      type: taxonomy
+                      attributes:
+                        name: taxonomy_14
+                        created_at: '2021-11-11T21:03:20.673Z'
+                        updated_at: '2021-11-11T21:03:20.689Z'
+                        position: 2
+                        public_metadata: {}
+                        private_metadata: {}
+                      relationships:
+                        taxons:
+                          data:
+                          - id: '26'
+                            type: taxon
+                        root:
+                          data:
+                            id: '26'
+                            type: taxon
+                    meta:
+                      count: 2
+                      total_count: 2
+                      total_pages: 1
+                    links:
+                      self: http://www.example.com/api/v2/platform/taxonomies?page=1&per_page=&include=&filter[name_eq]=
+                      next: http://www.example.com/api/v2/platform/taxonomies?filter%5Bname_eq%5D=&include=&page=1&per_page=
+                      prev: http://www.example.com/api/v2/platform/taxonomies?filter%5Bname_eq%5D=&include=&page=1&per_page=
+                      last: http://www.example.com/api/v2/platform/taxonomies?filter%5Bname_eq%5D=&include=&page=1&per_page=
+                      first: http://www.example.com/api/v2/platform/taxonomies?filter%5Bname_eq%5D=&include=&page=1&per_page=
+              schema:
+                "$ref": "#/components/schemas/resources_list"
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+    post:
+      summary: Create a Taxonomy
+      tags:
+      - Taxonomies
+      security:
+      - bearer_auth: []
+      description: Creates a Taxonomy
+      operationId: create-taxonomy
+      parameters:
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: taxon
+        schema:
+          type: string
+      responses:
+        '201':
+          description: Record created
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '17'
+                      type: taxonomy
+                      attributes:
+                        name: taxonomy_17
+                        created_at: '2021-11-11T21:03:20.789Z'
+                        updated_at: '2021-11-11T21:03:20.789Z'
+                        position: 1
+                        public_metadata: {}
+                        private_metadata: {}
+                      relationships:
+                        taxons:
+                          data:
+                          - id: '29'
+                            type: taxon
+                        root:
+                          data:
+                            id: '29'
+                            type: taxon
+              schema:
+                "$ref": "#/components/schemas/resource"
+        '422':
+          description: Invalid request
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: Name can't be blank
+                    errors:
+                      name:
+                      - can't be blank
+              schema:
+                "$ref": "#/components/schemas/validation_errors"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/create_taxonomy_params"
+  "/api/v2/platform/taxonomies/{id}":
+    get:
+      summary: Return a Taxonomy
+      tags:
+      - Taxonomies
+      security:
+      - bearer_auth: []
+      description: Returns a Taxonomy
+      operationId: show-taxonomy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: taxon
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Record found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '18'
+                      type: taxonomy
+                      attributes:
+                        name: taxonomy_18
+                        created_at: '2021-11-11T21:03:20.851Z'
+                        updated_at: '2021-11-11T21:03:20.866Z'
+                        position: 1
+                        public_metadata: {}
+                        private_metadata: {}
+                      relationships:
+                        taxons:
+                          data:
+                          - id: '30'
+                            type: taxon
+                        root:
+                          data:
+                            id: '30'
+                            type: taxon
+              schema:
+                "$ref": "#/components/schemas/resource"
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+    patch:
+      summary: Update a Taxonomy
+      tags:
+      - Taxonomies
+      security:
+      - bearer_auth: []
+      description: Updates a Taxonomy
+      operationId: update-taxonomy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: include
+        in: query
+        description: 'Select which associated resources you would like to fetch, see:
+          <a href="https://jsonapi.org/format/#fetching-includes">https://jsonapi.org/format/#fetching-includes</a>'
+        example: taxon
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Record updated
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '20'
+                      type: taxonomy
+                      attributes:
+                        name: Category
+                        created_at: '2021-11-11T21:03:20.962Z'
+                        updated_at: '2021-11-11T21:03:20.983Z'
+                        position: 1
+                        public_metadata: {}
+                        private_metadata: {}
+                      relationships:
+                        taxons:
+                          data:
+                          - id: '32'
+                            type: taxon
+                        root:
+                          data:
+                            id: '32'
+                            type: taxon
+              schema:
+                "$ref": "#/components/schemas/resource"
+        '422':
+          description: Invalid request
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: Name can't be blank
+                    errors:
+                      name:
+                      - can't be blank
+              schema:
+                "$ref": "#/components/schemas/validation_errors"
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/update_taxonomy_params"
+    delete:
+      summary: Delete a Taxonomy
+      tags:
+      - Taxonomies
+      security:
+      - bearer_auth: []
+      description: Deletes a Taxonomy
+      operationId: delete-taxonomy
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Record deleted
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+              schema:
+                "$ref": "#/components/schemas/error"
   "/api/v2/platform/taxons":
     get:
       summary: Return a list of Taxons
@@ -12605,36 +12962,36 @@ paths:
                 Example:
                   value:
                     data:
-                    - id: '26'
+                    - id: '38'
                       type: taxon
                       attributes:
                         position: 0
-                        name: taxon_13
-                        permalink: taxonomy-13/taxon-13
+                        name: Shorts
+                        permalink: taxonomy-25/shorts
                         lft: 2
                         rgt: 3
                         description:
-                        created_at: '2021-11-11T12:51:36.103Z'
-                        updated_at: '2021-11-11T12:51:36.107Z'
+                        created_at: '2021-11-11T21:03:21.424Z'
+                        updated_at: '2021-11-11T21:03:21.427Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
                         depth: 1
                         public_metadata: {}
                         private_metadata: {}
-                        pretty_name: taxonomy_13 -> taxon_13
-                        seo_title: taxon_13
+                        pretty_name: taxonomy_25 -> Shorts
+                        seo_title: Shorts
                         is_root: false
                         is_child: true
                         is_leaf: true
                       relationships:
                         parent:
                           data:
-                            id: '25'
+                            id: '37'
                             type: taxon
                         taxonomy:
                           data:
-                            id: '13'
+                            id: '25'
                             type: taxonomy
                         children:
                           data: []
@@ -12642,36 +12999,36 @@ paths:
                           data:
                             id: '89'
                             type: taxon_image
-                    - id: '27'
+                    - id: '39'
                       type: taxon
                       attributes:
                         position: 0
-                        name: taxon_14
-                        permalink: taxonomy-13/taxon-14
+                        name: taxon_13
+                        permalink: taxonomy-25/taxon-13
                         lft: 4
                         rgt: 5
                         description:
-                        created_at: '2021-11-11T12:51:36.163Z'
-                        updated_at: '2021-11-11T12:51:36.166Z'
+                        created_at: '2021-11-11T21:03:21.486Z'
+                        updated_at: '2021-11-11T21:03:21.489Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
                         depth: 1
                         public_metadata: {}
                         private_metadata: {}
-                        pretty_name: taxonomy_13 -> taxon_14
-                        seo_title: taxon_14
+                        pretty_name: taxonomy_25 -> taxon_13
+                        seo_title: taxon_13
                         is_root: false
                         is_child: true
                         is_leaf: true
                       relationships:
                         parent:
                           data:
-                            id: '25'
+                            id: '37'
                             type: taxon
                         taxonomy:
                           data:
-                            id: '13'
+                            id: '25'
                             type: taxonomy
                         children:
                           data: []
@@ -12679,25 +13036,62 @@ paths:
                           data:
                             id: '90'
                             type: taxon_image
-                    - id: '25'
+                    - id: '40'
                       type: taxon
                       attributes:
                         position: 0
-                        name: taxonomy_13
-                        permalink: taxonomy-13
-                        lft: 1
-                        rgt: 6
+                        name: taxon_14
+                        permalink: taxonomy-25/taxon-14
+                        lft: 6
+                        rgt: 7
                         description:
-                        created_at: '2021-11-11T12:51:36.047Z'
-                        updated_at: '2021-11-11T12:51:36.177Z'
+                        created_at: '2021-11-11T21:03:21.545Z'
+                        updated_at: '2021-11-11T21:03:21.548Z'
+                        meta_title:
+                        meta_description:
+                        meta_keywords:
+                        depth: 1
+                        public_metadata: {}
+                        private_metadata: {}
+                        pretty_name: taxonomy_25 -> taxon_14
+                        seo_title: taxon_14
+                        is_root: false
+                        is_child: true
+                        is_leaf: true
+                      relationships:
+                        parent:
+                          data:
+                            id: '37'
+                            type: taxon
+                        taxonomy:
+                          data:
+                            id: '25'
+                            type: taxonomy
+                        children:
+                          data: []
+                        image:
+                          data:
+                            id: '91'
+                            type: taxon_image
+                    - id: '37'
+                      type: taxon
+                      attributes:
+                        position: 0
+                        name: taxonomy_25
+                        permalink: taxonomy-25
+                        lft: 1
+                        rgt: 8
+                        description:
+                        created_at: '2021-11-11T21:03:21.324Z'
+                        updated_at: '2021-11-11T21:03:21.556Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
                         depth: 0
                         public_metadata: {}
                         private_metadata: {}
-                        pretty_name: taxonomy_13
-                        seo_title: taxonomy_13
+                        pretty_name: taxonomy_25
+                        seo_title: taxonomy_25
                         is_root: true
                         is_child: false
                         is_leaf: false
@@ -12706,19 +13100,21 @@ paths:
                           data:
                         taxonomy:
                           data:
-                            id: '13'
+                            id: '25'
                             type: taxonomy
                         children:
                           data:
-                          - id: '26'
+                          - id: '38'
                             type: taxon
-                          - id: '27'
+                          - id: '39'
+                            type: taxon
+                          - id: '40'
                             type: taxon
                         image:
                           data:
                     meta:
-                      count: 3
-                      total_count: 3
+                      count: 4
+                      total_count: 4
                       total_pages: 1
                     links:
                       self: http://www.example.com/api/v2/platform/taxons?page=1&per_page=&include=&filter[taxonomy_id_eq]=&filter[name_cont]=
@@ -12763,24 +13159,24 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '32'
+                      id: '47'
                       type: taxon
                       attributes:
                         position: 0
                         name: taxon_17
-                        permalink: taxonomy-15/taxon-17
-                        lft: 2
-                        rgt: 3
+                        permalink: taxonomy-27/taxon-17
+                        lft: 4
+                        rgt: 5
                         description:
-                        created_at: '2021-11-11T12:51:36.412Z'
-                        updated_at: '2021-11-11T12:51:36.416Z'
+                        created_at: '2021-11-11T21:03:21.915Z'
+                        updated_at: '2021-11-11T21:03:21.920Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
                         depth: 1
                         public_metadata: {}
                         private_metadata: {}
-                        pretty_name: taxonomy_15 -> taxon_17
+                        pretty_name: taxonomy_27 -> taxon_17
                         seo_title: taxon_17
                         is_root: false
                         is_child: true
@@ -12788,11 +13184,11 @@ paths:
                       relationships:
                         parent:
                           data:
-                            id: '31'
+                            id: '45'
                             type: taxon
                         taxonomy:
                           data:
-                            id: '15'
+                            id: '27'
                             type: taxonomy
                         children:
                           data: []
@@ -12851,24 +13247,24 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '34'
+                      id: '53'
                       type: taxon
                       attributes:
                         position: 0
                         name: taxon_18
-                        permalink: taxonomy-16/taxon-18
-                        lft: 2
-                        rgt: 3
+                        permalink: taxonomy-30/taxon-18
+                        lft: 6
+                        rgt: 7
                         description:
-                        created_at: '2021-11-11T12:51:36.531Z'
-                        updated_at: '2021-11-11T12:51:36.535Z'
+                        created_at: '2021-11-11T21:03:22.213Z'
+                        updated_at: '2021-11-11T21:03:22.217Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
                         depth: 1
                         public_metadata: {}
                         private_metadata: {}
-                        pretty_name: taxonomy_16 -> taxon_18
+                        pretty_name: taxonomy_30 -> taxon_18
                         seo_title: taxon_18
                         is_root: false
                         is_child: true
@@ -12876,11 +13272,11 @@ paths:
                       relationships:
                         parent:
                           data:
-                            id: '33'
+                            id: '52'
                             type: taxon
                         taxonomy:
                           data:
-                            id: '16'
+                            id: '30'
                             type: taxonomy
                         children:
                           data: []
@@ -12888,7 +13284,7 @@ paths:
                           data: []
                         image:
                           data:
-                            id: '93'
+                            id: '98'
                             type: taxon_image
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -12942,17 +13338,17 @@ paths:
                 Example:
                   value:
                     data:
-                      id: '38'
+                      id: '63'
                       type: taxon
                       attributes:
                         position: 0
                         name: T-Shirts
-                        permalink: taxonomy-18/taxon-20
-                        lft: 2
-                        rgt: 3
+                        permalink: taxonomy-35/taxon-20
+                        lft: 6
+                        rgt: 7
                         description:
-                        created_at: '2021-11-11T12:51:36.765Z'
-                        updated_at: '2021-11-11T12:51:36.790Z'
+                        created_at: '2021-11-11T21:03:22.715Z'
+                        updated_at: '2021-11-11T21:03:22.740Z'
                         meta_title:
                         meta_description:
                         meta_keywords:
@@ -12960,7 +13356,7 @@ paths:
                         public_metadata:
                           profitability: 3
                         private_metadata: {}
-                        pretty_name: taxonomy_18 -> T-Shirts
+                        pretty_name: taxonomy_35 -> T-Shirts
                         seo_title: T-Shirts
                         is_root: false
                         is_child: true
@@ -12968,17 +13364,17 @@ paths:
                       relationships:
                         parent:
                           data:
-                            id: '37'
+                            id: '62'
                             type: taxon
                         taxonomy:
                           data:
-                            id: '18'
+                            id: '35'
                             type: taxonomy
                         children:
                           data: []
                         image:
                           data:
-                            id: '95'
+                            id: '103'
                             type: taxon_image
               schema:
                 "$ref": "#/components/schemas/resource"
@@ -13057,6 +13453,94 @@ paths:
                     error: The access token is invalid
               schema:
                 "$ref": "#/components/schemas/error"
+  "/api/v2/platform/taxons/{id}/reposition":
+    patch:
+      summary: Reposition a Taxon
+      tags:
+      - Taxons
+      security:
+      - bearer_auth: []
+      operationId: reposition-taxon
+      description: Reposition a Taxon
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Record updated
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    data:
+                      id: '87'
+                      type: taxon
+                      attributes:
+                        position: 0
+                        name: taxon_25
+                        permalink: taxonomy-47/taxon-25
+                        lft: 3
+                        rgt: 4
+                        description:
+                        created_at: '2021-11-11T21:03:23.964Z'
+                        updated_at: '2021-11-11T21:03:23.990Z'
+                        meta_title:
+                        meta_description:
+                        meta_keywords:
+                        depth: 2
+                        public_metadata: {}
+                        private_metadata: {}
+                        pretty_name: taxonomy_46 -> Shorts -> taxon_25
+                        seo_title: taxon_25
+                        is_root: false
+                        is_child: true
+                        is_leaf: true
+                      relationships:
+                        parent:
+                          data:
+                            id: '85'
+                            type: taxon
+                        taxonomy:
+                          data:
+                            id: '47'
+                            type: taxonomy
+                        children:
+                          data: []
+                        image:
+                          data:
+                            id: '115'
+                            type: taxon_image
+              schema:
+                "$ref": "#/components/schemas/resource"
+        '404':
+          description: Record not found
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The resource you were looking for could not be found.
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: Authentication Failed
+          content:
+            application/vnd.api+json:
+              examples:
+                Example:
+                  value:
+                    error: The access token is invalid
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/taxon_reposition"
   "/api/v2/platform/users":
     get:
       summary: Return a list of Users
@@ -13108,9 +13592,9 @@ paths:
                     - id: '119'
                       type: user
                       attributes:
-                        email: gregg@flatley.us
-                        created_at: '2021-11-11T12:51:37.297Z'
-                        updated_at: '2021-11-11T12:51:37.297Z'
+                        email: valorie_pfeffer@reichellegros.info
+                        created_at: '2021-11-11T21:03:24.328Z'
+                        updated_at: '2021-11-11T21:03:24.328Z'
                         public_metadata: {}
                         private_metadata: {}
                         average_order_value: []
@@ -13124,9 +13608,9 @@ paths:
                     - id: '120'
                       type: user
                       attributes:
-                        email: raven@boyerschinner.co.uk
-                        created_at: '2021-11-11T12:51:37.303Z'
-                        updated_at: '2021-11-11T12:51:37.303Z'
+                        email: jerrie.wolff@lind.co.uk
+                        created_at: '2021-11-11T21:03:24.333Z'
+                        updated_at: '2021-11-11T21:03:24.333Z'
                         public_metadata: {}
                         private_metadata: {}
                         average_order_value: []
@@ -13140,9 +13624,9 @@ paths:
                     - id: '121'
                       type: user
                       attributes:
-                        email: racheal@kerlukejacobson.co.uk
-                        created_at: '2021-11-11T12:51:37.304Z'
-                        updated_at: '2021-11-11T12:51:37.304Z'
+                        email: bettye_beahan@schumm.name
+                        created_at: '2021-11-11T21:03:24.335Z'
+                        updated_at: '2021-11-11T21:03:24.335Z'
                         public_metadata: {}
                         private_metadata: {}
                         average_order_value: []
@@ -13203,9 +13687,9 @@ paths:
                       id: '126'
                       type: user
                       attributes:
-                        email: dawna@luettgenrogahn.co.uk
-                        created_at: '2021-11-11T12:51:37.389Z'
-                        updated_at: '2021-11-11T12:51:37.389Z'
+                        email: junko.morissette@predovic.com
+                        created_at: '2021-11-11T21:03:24.409Z'
+                        updated_at: '2021-11-11T21:03:24.409Z'
                         public_metadata: {}
                         private_metadata: {}
                         average_order_value: []
@@ -13270,9 +13754,9 @@ paths:
                       id: '129'
                       type: user
                       attributes:
-                        email: abel@kuphal.ca
-                        created_at: '2021-11-11T12:51:37.443Z'
-                        updated_at: '2021-11-11T12:51:37.443Z'
+                        email: larisa.ratke@bahringer.name
+                        created_at: '2021-11-11T21:03:24.481Z'
+                        updated_at: '2021-11-11T21:03:24.481Z'
                         public_metadata: {}
                         private_metadata: {}
                         average_order_value: []
@@ -13339,8 +13823,8 @@ paths:
                       type: user
                       attributes:
                         email: john@example.com
-                        created_at: '2021-11-11T12:51:37.529Z'
-                        updated_at: '2021-11-11T12:51:37.537Z'
+                        created_at: '2021-11-11T21:03:24.571Z'
+                        updated_at: '2021-11-11T21:03:24.580Z'
                         public_metadata: {}
                         private_metadata: {}
                         average_order_value: []
@@ -13489,14 +13973,14 @@ paths:
                         position: 1
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-11T12:51:37.767Z'
+                        updated_at: '2021-11-11T21:03:24.818Z'
                         discontinue_on:
-                        created_at: '2021-11-11T12:51:37.762Z'
+                        created_at: '2021-11-11T21:03:24.812Z'
                         public_metadata: {}
                         private_metadata: {}
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #178 - 504'
+                        name: 'Product #178 - 4489'
                         options_text: ''
                         total_on_hand: 0
                         purchasable: true
@@ -13531,23 +14015,23 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-246
-                        weight: '96.7'
-                        height: '2.73'
-                        depth: '199.94'
+                        weight: '130.52'
+                        height: '63.5'
+                        depth: '116.7'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-11T12:51:37.796Z'
+                        updated_at: '2021-11-11T21:03:24.846Z'
                         discontinue_on:
-                        created_at: '2021-11-11T12:51:37.790Z'
+                        created_at: '2021-11-11T21:03:24.840Z'
                         public_metadata: {}
                         private_metadata: {}
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #178 - 504'
+                        name: 'Product #178 - 4489'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -13584,23 +14068,23 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-247
-                        weight: '20.67'
-                        height: '66.16'
-                        depth: '42.18'
+                        weight: '12.38'
+                        height: '6.95'
+                        depth: '66.26'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 3
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-11T12:51:37.816Z'
+                        updated_at: '2021-11-11T21:03:24.864Z'
                         discontinue_on:
-                        created_at: '2021-11-11T12:51:37.810Z'
+                        created_at: '2021-11-11T21:03:24.858Z'
                         public_metadata: {}
                         private_metadata: {}
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #178 - 504'
+                        name: 'Product #178 - 4489'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -13690,23 +14174,23 @@ paths:
                       type: variant
                       attributes:
                         sku: SKU-252
-                        weight: '47.6'
-                        height: '51.5'
-                        depth: '158.75'
+                        weight: '83.12'
+                        height: '103.77'
+                        depth: '125.53'
                         deleted_at:
                         is_master: false
                         cost_price: '17.0'
                         position: 2
                         cost_currency: USD
                         track_inventory: true
-                        updated_at: '2021-11-11T12:51:38.127Z'
+                        updated_at: '2021-11-11T21:03:25.197Z'
                         discontinue_on:
-                        created_at: '2021-11-11T12:51:38.121Z'
+                        created_at: '2021-11-11T21:03:25.192Z'
                         public_metadata: {}
                         private_metadata: {}
                         display_compare_at_price:
                         display_price: "$19.99"
-                        name: 'Product #180 - 3834'
+                        name: 'Product #180 - 1538'
                         options_text: 'Size: S'
                         total_on_hand: 0
                         purchasable: true
@@ -13867,14 +14351,14 @@ paths:
                     - id: '1'
                       type: event
                       attributes:
-                        execution_time: 80577
+                        execution_time: 14569
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url1.com/
-                        created_at: '2021-11-11T12:51:38.489Z'
-                        updated_at: '2021-11-11T12:51:38.489Z'
+                        created_at: '2021-11-11T21:03:25.596Z'
+                        updated_at: '2021-11-11T21:03:25.596Z'
                       relationships:
                         subscriber:
                           data:
@@ -13883,14 +14367,14 @@ paths:
                     - id: '2'
                       type: event
                       attributes:
-                        execution_time: 65949
+                        execution_time: 29802
                         name: order.canceled
                         request_errors: ''
                         response_code: '200'
                         success: true
                         url: https://www.url2.com/
-                        created_at: '2021-11-11T12:51:38.493Z'
-                        updated_at: '2021-11-11T12:51:38.493Z'
+                        created_at: '2021-11-11T21:03:25.600Z'
+                        updated_at: '2021-11-11T21:03:25.600Z'
                       relationships:
                         subscriber:
                           data:
@@ -13966,8 +14450,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-11T12:51:38.552Z'
-                        updated_at: '2021-11-11T12:51:38.552Z'
+                        created_at: '2021-11-11T21:03:25.669Z'
+                        updated_at: '2021-11-11T21:03:25.669Z'
                     - id: '6'
                       type: subscriber
                       attributes:
@@ -13975,8 +14459,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-11T12:51:38.553Z'
-                        updated_at: '2021-11-11T12:51:38.553Z'
+                        created_at: '2021-11-11T21:03:25.670Z'
+                        updated_at: '2021-11-11T21:03:25.670Z'
                     meta:
                       count: 2
                       total_count: 2
@@ -14024,8 +14508,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-11T12:51:38.616Z'
-                        updated_at: '2021-11-11T12:51:38.616Z'
+                        created_at: '2021-11-11T21:03:25.744Z'
+                        updated_at: '2021-11-11T21:03:25.744Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -14080,8 +14564,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-11T12:51:38.655Z'
-                        updated_at: '2021-11-11T12:51:38.655Z'
+                        created_at: '2021-11-11T21:03:25.883Z'
+                        updated_at: '2021-11-11T21:03:25.883Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '404':
@@ -14134,8 +14618,8 @@ paths:
                         active: true
                         subscriptions:
                         - "*"
-                        created_at: '2021-11-11T12:51:38.805Z'
-                        updated_at: '2021-11-11T12:51:38.805Z'
+                        created_at: '2021-11-11T21:03:25.965Z'
+                        updated_at: '2021-11-11T21:03:25.965Z'
               schema:
                 "$ref": "#/components/schemas/resource"
         '422':
@@ -14256,8 +14740,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-11T12:51:39.081Z'
-                        updated_at: '2021-11-11T12:51:39.081Z'
+                        created_at: '2021-11-11T21:03:26.269Z'
+                        updated_at: '2021-11-11T21:03:26.269Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -14271,8 +14755,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-11T12:51:39.129Z'
-                        updated_at: '2021-11-11T12:51:39.129Z'
+                        created_at: '2021-11-11T21:03:26.321Z'
+                        updated_at: '2021-11-11T21:03:26.321Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -14286,8 +14770,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-11T12:51:39.175Z'
-                        updated_at: '2021-11-11T12:51:39.175Z'
+                        created_at: '2021-11-11T21:03:26.388Z'
+                        updated_at: '2021-11-11T21:03:26.388Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -14301,8 +14785,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-11T12:51:39.222Z'
-                        updated_at: '2021-11-11T12:51:39.222Z'
+                        created_at: '2021-11-11T21:03:26.443Z'
+                        updated_at: '2021-11-11T21:03:26.443Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -14363,8 +14847,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-11T12:51:39.681Z'
-                        updated_at: '2021-11-11T12:51:39.681Z'
+                        created_at: '2021-11-11T21:03:27.004Z'
+                        updated_at: '2021-11-11T21:03:27.004Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -14434,8 +14918,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 1
-                        created_at: '2021-11-11T12:51:39.885Z'
-                        updated_at: '2021-11-11T12:51:39.885Z'
+                        created_at: '2021-11-11T21:03:27.258Z'
+                        updated_at: '2021-11-11T21:03:27.258Z'
                         display_price: "$19.99"
                         display_total: "$19.99"
                         price: '19.99'
@@ -14501,8 +14985,8 @@ paths:
                       type: wished_item
                       attributes:
                         quantity: 3
-                        created_at: '2021-11-11T12:51:40.234Z'
-                        updated_at: '2021-11-11T12:51:40.242Z'
+                        created_at: '2021-11-11T21:03:27.683Z'
+                        updated_at: '2021-11-11T21:03:27.693Z'
                         display_price: "$19.99"
                         display_total: "$59.97"
                         price: '19.99'
@@ -14637,9 +15121,9 @@ paths:
                         name: Black Friday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-11T12:51:40.934Z'
-                        updated_at: '2021-11-11T12:51:40.934Z'
-                        token: sn2bVFiKqyRsWq1k84LgrtNp
+                        created_at: '2021-11-11T21:03:28.513Z'
+                        updated_at: '2021-11-11T21:03:28.513Z'
+                        token: wtE9HoZAsXwqA9U79dtvurkZ
                         variant_included: false
                       relationships:
                         wished_items:
@@ -14654,9 +15138,9 @@ paths:
                         name: Birthday
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-11T12:51:40.935Z'
-                        updated_at: '2021-11-11T12:51:40.935Z'
-                        token: KvD9whqEDx1LsmFtDqk7bCXH
+                        created_at: '2021-11-11T21:03:28.514Z'
+                        updated_at: '2021-11-11T21:03:28.514Z'
+                        token: KVrU3BgX2oPuZXJZW3Fuon3z
                         variant_included: false
                       relationships:
                         wished_items:
@@ -14718,9 +15202,9 @@ paths:
                         name: Wishlist_26
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-11T12:51:41.386Z'
-                        updated_at: '2021-11-11T12:51:41.386Z'
-                        token: ukJ4rT3yWset9uoSpg3opsSH
+                        created_at: '2021-11-11T21:03:29.004Z'
+                        updated_at: '2021-11-11T21:03:29.004Z'
+                        token: fMQP7VpVmEvBr5NvqVLS56tu
                         variant_included: false
                       relationships:
                         wished_items:
@@ -14784,9 +15268,9 @@ paths:
                         name: My Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-11T12:51:41.434Z'
-                        updated_at: '2021-11-11T12:51:41.434Z'
-                        token: x7qgDNmu26Nj6xvjguSEaTxs
+                        created_at: '2021-11-11T21:03:29.061Z'
+                        updated_at: '2021-11-11T21:03:29.061Z'
+                        token: DyZUQuY4WXzpzYNwvELLTMhG
                         variant_included: false
                       relationships:
                         wished_items:
@@ -14849,9 +15333,9 @@ paths:
                         name: My Super Wishlist
                         is_private: true
                         is_default: false
-                        created_at: '2021-11-11T12:51:41.506Z'
-                        updated_at: '2021-11-11T12:51:41.514Z'
-                        token: DVBj87Vd33aymLq48yeQWvh6
+                        created_at: '2021-11-11T21:03:29.149Z'
+                        updated_at: '2021-11-11T21:03:29.159Z'
+                        token: aALe875Wg5Nu5RcX3SKwXETW
                         variant_included: false
                       relationships:
                         wished_items:
@@ -14978,13 +15462,13 @@ paths:
                     - id: '96'
                       type: zone
                       attributes:
-                        name: Magnam earum possimus dolorem omnis aliquam quos.
-                        description: Explicabo doloribus omnis enim impedit ut beatae
-                          earum.
+                        name: Ratione cum eligendi ex doloremque saepe tempora magnam.
+                        description: Quidem earum dignissimos provident tempora vel
+                          corrupti facilis libero.
                         default_tax: false
                         zone_members_count: 0
-                        created_at: '2021-11-11T12:51:41.674Z'
-                        updated_at: '2021-11-11T12:51:41.674Z'
+                        created_at: '2021-11-11T21:03:29.361Z'
+                        updated_at: '2021-11-11T21:03:29.361Z'
                         kind: state
                       relationships:
                         zone_members:
@@ -14992,12 +15476,12 @@ paths:
                     - id: '97'
                       type: zone
                       attributes:
-                        name: Mollitia nemo molestiae quam quaerat.
-                        description: Incidunt fuga ad beatae nesciunt dicta vel cumque.
+                        name: Explicabo eaque illo dolorem quod.
+                        description: Fugit cupiditate nobis officiis distinctio.
                         default_tax: false
                         zone_members_count: 0
-                        created_at: '2021-11-11T12:51:41.675Z'
-                        updated_at: '2021-11-11T12:51:41.675Z'
+                        created_at: '2021-11-11T21:03:29.364Z'
+                        updated_at: '2021-11-11T21:03:29.364Z'
                         kind: state
                       relationships:
                         zone_members:
@@ -15052,13 +15536,12 @@ paths:
                       id: '100'
                       type: zone
                       attributes:
-                        name: Quas sit quis dicta vitae sed.
-                        description: Error mollitia dignissimos reiciendis quis nobis
-                          nostrum perspiciatis quam.
+                        name: Id nam sed cupiditate eos excepturi.
+                        description: Voluptatem illo accusantium repudiandae fugit.
                         default_tax: false
                         zone_members_count: 0
-                        created_at: '2021-11-11T12:51:41.731Z'
-                        updated_at: '2021-11-11T12:51:41.731Z'
+                        created_at: '2021-11-11T21:03:29.435Z'
+                        updated_at: '2021-11-11T21:03:29.435Z'
                         kind: state
                       relationships:
                         zone_members:
@@ -15117,13 +15600,13 @@ paths:
                       id: '101'
                       type: zone
                       attributes:
-                        name: Porro neque molestiae voluptatum illo.
-                        description: Veniam adipisci minima voluptatibus autem rerum
-                          repellat.
+                        name: Quod iure distinctio dolore et.
+                        description: Nisi voluptatibus necessitatibus blanditiis voluptate
+                          adipisci voluptatum in.
                         default_tax: false
                         zone_members_count: 0
-                        created_at: '2021-11-11T12:51:41.771Z'
-                        updated_at: '2021-11-11T12:51:41.771Z'
+                        created_at: '2021-11-11T21:03:29.483Z'
+                        updated_at: '2021-11-11T21:03:29.483Z'
                         kind: state
                       relationships:
                         zone_members:
@@ -15187,8 +15670,8 @@ paths:
                         description: The zone containing all EU countries
                         default_tax: false
                         zone_members_count: 0
-                        created_at: '2021-11-11T12:51:41.833Z'
-                        updated_at: '2021-11-11T12:51:41.839Z'
+                        created_at: '2021-11-11T21:03:29.569Z'
+                        updated_at: '2021-11-11T21:03:29.578Z'
                         kind: state
                       relationships:
                         zone_members:
@@ -15306,6 +15789,7 @@ tags:
 - name: Tax Categories
 - name: Tax Rates
 - name: Taxons
+- name: Taxonomies
 - name: Users
 - name: Webhook Events
 - name: Webhook Subscribers
@@ -17197,7 +17681,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-11 12:51:00 UTC
+              example: 2021-11-11 21:02:44 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -17265,7 +17749,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-11 12:51:00 UTC
+              example: 2021-11-11 21:02:44 UTC
             confirmation_delivered:
               type: boolean
               example: true
@@ -17336,7 +17820,7 @@ components:
             completed_at:
               type: string
               format: date_time
-              example: 2021-11-11 12:51:00 UTC
+              example: 2021-11-11 21:02:44 UTC
             bill_address_id:
               type: string
               example: '1'
@@ -17404,7 +17888,7 @@ components:
             approved_at:
               type: string
               format: date_time
-              example: 2021-11-11 12:51:00 UTC
+              example: 2021-11-11 21:02:44 UTC
             confirmation_delivered:
               type: boolean
               example: true
@@ -18322,6 +18806,21 @@ components:
       required:
       - store_credit_type
       x-internal: true
+    update_store_credit_type_params:
+      type: object
+      properties:
+        store_credit_type:
+          type: object
+          properties:
+            name:
+              type: string
+              example: refunded
+            priority:
+              type: integer
+              example: 1
+      required:
+      - store_credit_type
+      x-internal: true
     create_store_credit_params:
       type: object
       properties:
@@ -18610,6 +19109,79 @@ components:
               type: object
       required:
       - taxon
+      x-internal: true
+    taxon_reposition:
+      type: object
+      properties:
+        taxon:
+          type: object
+          required:
+          - new_parent_id
+          - new_position_idx
+          properties:
+            new_parent_id:
+              type: integer
+              example: 1
+              description: The ID of the new target parent Taxon.
+            new_position_idx:
+              type: integer
+              example: 1
+              description: The new index position of the Taxon within the parent Taxon.
+      required:
+      - taxon
+      title: Reposition a Taxon
+      x-internal: true
+    create_taxonomy_params:
+      type: object
+      properties:
+        taxonomy:
+          type: object
+          required:
+          - name
+          properties:
+            name:
+              type: string
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this Taxonomy to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            public_metadata:
+              type: object
+              example:
+                ability_to_recycle: 90%
+            private_metadata:
+              type: object
+              example:
+                profitability: 2
+      required:
+      - taxonomy
+      x-internal: true
+    update_taxonomy_params:
+      type: object
+      properties:
+        taxonomy:
+          type: object
+          properties:
+            name:
+              type: string
+            position:
+              type: integer
+              example: 2
+              description: 'Pass the position that you want this Taxonomy to appear
+                in. (The list is not zero indexed, so the first item is position:
+                `1`)'
+            public_metadata:
+              type: object
+              example:
+                ability_to_recycle: 90%
+            private_metadata:
+              type: object
+              example:
+                profitability: 2
+      required:
+      - taxonomy
       x-internal: true
     create_user_params:
       type: object

--- a/api/spec/integration/api/v2/platform/promotion_categories_spec.rb
+++ b/api/spec/integration/api/v2/platform/promotion_categories_spec.rb
@@ -6,8 +6,8 @@ describe 'Promotion Categories API', swagger: true do
   resource_name = 'Promotion Category'
   options = {
     include_example: 'promotions',
-    filter_examples: [{ name: 'filter[code]', example: 'BLK-FRI' },
-                      { name: 'filter[name]', example: '2020 Promotions' }]
+    filter_examples: [{ name: 'filter[code_eq]', example: 'BLK-FRI' },
+                      { name: 'filter[name_eq]', example: '2020 Promotions' }]
   }
 
   let(:id) { create(:promotion_category, code: 'MJO').id }

--- a/api/spec/integration/api/v2/platform/store_credits_spec.rb
+++ b/api/spec/integration/api/v2/platform/store_credits_spec.rb
@@ -8,7 +8,7 @@ describe 'Store Credits API', swagger: true do
     include_example: 'user,created_by,category,credit_type',
     filter_examples: [{ name: 'filter[user_id_eq]', example: '5' },
                       { name: 'filter[created_by_id_eq]', example: '2' },
-                      { name: 'filter[amount_gteq]', example: 50.0 },
+                      { name: 'filter[amount_gteq]', example: '50.0' },
                       { name: 'filter[currency_eq]', example: 'USD' }]
   }
 

--- a/api/spec/integration/api/v2/platform/tax_categories_spec.rb
+++ b/api/spec/integration/api/v2/platform/tax_categories_spec.rb
@@ -7,7 +7,7 @@ describe 'Tax Categories API', swagger: true do
   options = {
     include_example: 'tax_rates',
     filter_examples: [{ name: 'filter[name_eq]', example: 'Clothing' },
-                      { name: 'filter[is_default_true]', example: 1 },
+                      { name: 'filter[is_default_true]', example: '1' },
                       { name: 'filter[tax_code_eq]', example: '1257L' }]
   }
 

--- a/api/spec/integration/api/v2/platform/taxanomies_spec.rb
+++ b/api/spec/integration/api/v2/platform/taxanomies_spec.rb
@@ -1,0 +1,28 @@
+require 'swagger_helper'
+
+describe 'Taxonomies API', swagger: true do
+  include_context 'Platform API v2'
+
+  resource_name = 'Taxonomy'
+  options = {
+    include_example: 'taxon',
+    filter_examples: [{ name: 'filter[name_eq]', example: 'Category' }]
+  }
+
+  let(:id) { create(:taxonomy, store: store).id }
+  let(:records_list) { create_list(:taxonomy, 2) }
+  let(:valid_create_param_value) { build(:taxonomy).attributes }
+  let(:valid_update_param_value) do
+    {
+      name: 'Category',
+      position: 1
+    }
+  end
+  let(:invalid_param_value) do
+    {
+      name: ''
+    }
+  end
+
+  include_examples 'CRUD examples', resource_name, options
+end

--- a/api/spec/integration/api/v2/platform/taxons_spec.rb
+++ b/api/spec/integration/api/v2/platform/taxons_spec.rb
@@ -12,6 +12,8 @@ describe 'Taxons API', swagger: true do
 
   let(:id) { create(:taxon).id }
   let(:taxonomy) { create(:taxonomy, store: store) }
+  let!(:taxon_b) { create(:taxon, name: 'Shorts', taxonomy: taxonomy) }
+
   let(:records_list) { create_list(:taxon, 2, taxonomy: taxonomy) }
   let(:valid_create_param_value) { build(:taxon, taxonomy: taxonomy).attributes }
   let(:valid_update_param_value) do
@@ -25,6 +27,32 @@ describe 'Taxons API', swagger: true do
       name: '',
     }
   end
+  let(:valid_update_position_param_value) do
+    {
+      taxon: {
+        new_parent_id: taxon_b.id,
+        new_position_idx: 0
+      }
+    }
+  end
 
   include_examples 'CRUD examples', resource_name, options
+
+  path '/api/v2/platform/taxons/{id}/reposition' do
+    patch 'Reposition a Taxon' do
+      tags resource_name.pluralize
+      security [ bearer_auth: [] ]
+      operationId 'reposition-taxon'
+      description 'Reposition a Taxon'
+      consumes 'application/json'
+      parameter name: :id, in: :path, type: :string
+      parameter name: :taxon, in: :body, schema: { '$ref' => '#/components/schemas/taxon_reposition' }
+
+      let(:taxon) { valid_update_position_param_value }
+
+      it_behaves_like 'record updated'
+      it_behaves_like 'record not found', :taxon
+      it_behaves_like 'authentication failed'
+    end
+  end
 end

--- a/api/spec/requests/spree/api/v2/platform/menu_items_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/menu_items_spec.rb
@@ -62,7 +62,8 @@ describe 'Platform API v2 Menu Items spec', type: :request do
       it_behaves_like 'returns 200 HTTP status'
 
       it 'can be nested inside another item' do
-        menu_item_a.reload
+        reload_items
+
         expect(menu_item_a.parent_id).to eq(menu_item_b.id)
 
         # Root depth = 0
@@ -89,10 +90,17 @@ describe 'Platform API v2 Menu Items spec', type: :request do
       it_behaves_like 'returns 200 HTTP status'
 
       it 're-indexes the item' do
-        menu_item_a.reload
+        reload_items
+
         expect(menu_item_a.parent_id).to eq(menu_item_b.id)
-        expect(menu_item_a.lft).to eq(menu_item_c.lft)
+        expect(menu_item_a.lft).to eq(menu_item_c.rgt + 1)
       end
+    end
+
+    def reload_items
+      menu_item_a.reload
+      menu_item_b.reload
+      menu_item_c.reload
     end
   end
 end

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -70,6 +70,7 @@ RSpec.configure do |config|
         { name: 'Tax Categories' },
         { name: 'Tax Rates' },
         { name: 'Taxons' },
+        { name: 'Taxonomies' },
         { name: 'Users' },
         { name: 'Webhook Events' },
         { name: 'Webhook Subscribers' },
@@ -1644,12 +1645,11 @@ RSpec.configure do |config|
             required: %w[store_credit_type],
             'x-internal': true
           },
-          create_store_credit_type_params: {
+          update_store_credit_type_params: {
             type: :object,
             properties: {
               store_credit_type: {
                 type: :object,
-                required: %w[name],
                 properties: {
                   name: { type: :string, example: 'refunded' },
                   priority: { type: :integer, example: 1 }
@@ -1846,6 +1846,57 @@ RSpec.configure do |config|
               }
             },
             required: %w[taxon],
+            'x-internal': true
+          },
+          taxon_reposition: {
+            type: :object,
+            properties: {
+              taxon: {
+                type: :object,
+                required: %w[new_parent_id new_position_idx],
+                properties: {
+                  new_parent_id: { type: :integer, example: 1, description: 'The ID of the new target parent Taxon.' },
+                  new_position_idx: { type: :integer, example: 1, description: 'The new index position of the Taxon within the parent Taxon.' }
+                }
+              }
+            },
+            required: %w[taxon],
+            title: 'Reposition a Taxon',
+            'x-internal': true
+          },
+
+          # Taxonomies
+          create_taxonomy_params: {
+            type: :object,
+            properties: {
+              taxonomy: {
+                type: :object,
+                required: %w[name],
+                properties: {
+                  name: { type: :string },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this Taxonomy to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  public_metadata: { type: :object, example: { 'ability_to_recycle' => '90%' } },
+                  private_metadata: { type: :object, example: { 'profitability' => 2 } }
+                }
+              }
+            },
+            required: %w[taxonomy],
+            'x-internal': true
+          },
+          update_taxonomy_params: {
+            type: :object,
+            properties: {
+              taxonomy: {
+                type: :object,
+                properties: {
+                  name: { type: :string },
+                  position: { type: :integer, example: 2, description: 'Pass the position that you want this Taxonomy to appear in. (The list is not zero indexed, so the first item is position: `1`)' },
+                  public_metadata: { type: :object, example: { 'ability_to_recycle' => '90%' } },
+                  private_metadata: { type: :object, example: { 'profitability' => 2 } }
+                }
+              }
+            },
+            required: %w[taxonomy],
             'x-internal': true
           },
 


### PR DESCRIPTION
- Adds Taxonomies endpoint  to Platform API
- Adds `reposition` action to Taxon endpoint.

Sorry about this, I did this not realising it was already underway by @aleksandarpetrushev, my initial intention was to add `reposition` to the taxon endpoint, but looking in the admin UI I mistakenly thought it was on the taxonomies endpoint and so added taxonomies to the API, then realised the `reposition` action is actually on the taxon endpoint, so added it there.