### PR TITLE
Fixed relationships for Stock Location serializer in Platform API

### DIFF
--- a/api/app/serializers/spree/api/v2/platform/stock_location_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/stock_location_serializer.rb
@@ -6,9 +6,7 @@ module Spree
           include ResourceSerializerConcern
 
           attributes :name
-
-          has_many :shipments
-          has_many :stock_items
+          belongs_to :country
         end
       end
     end

--- a/api/spec/serializers/spree/api/v2/platform/stock_location_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/stock_location_serializer_spec.rb
@@ -5,9 +5,9 @@ describe Spree::Api::V2::Platform::StockLocationSerializer do
 
   subject { described_class.new(resource, params: serializer_params).serializable_hash }
 
-  let(:resource) { create(:stock_location_with_items, shipments: [shipment]) }
+  let(:resource) { create(:stock_location, country: country) }
   let(:type) { :stock_location }
-  let(:shipment) { create(:shipment) }
+  let(:country) { create(:country) }
 
   it do
     expect(subject).to eq(
@@ -31,20 +31,11 @@ describe Spree::Api::V2::Platform::StockLocationSerializer do
           zipcode: resource.zipcode
         },
         relationships: {
-          shipments: {
-            data: [{
-              id: shipment.id.to_s,
-              type: :shipment
-            }]
-          },
-          stock_items: {
-            data: [{
-              id: resource.stock_items[0].id.to_s,
-              type: :stock_item
-            }, {
-              id: resource.stock_items[1].id.to_s,
-              type: :stock_item
-            }]
+          country: {
+            data: {
+              id: country.id.to_s,
+              type: :country
+            }
           }
         }
       }


### PR DESCRIPTION
Fetching shipmens or stock items would be insanely heavy for performance. On the other hand we need the stock location country which was missing