### PR TITLE
Add/fix remaining Webhooks events

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -5,7 +5,7 @@ module Spree
 
       included do
         after_create_commit(proc { queue_webhooks_requests!(event_name(:create)) })
-        after_destroy_commit(proc { queue_webhooks_requests!(event_name(:destroy)) })
+        after_destroy_commit(proc { queue_webhooks_requests!(event_name(:delete)) })
         after_update_commit(proc { queue_webhooks_requests!(event_name(:update)) })
 
         def queue_webhooks_requests!(event)

--- a/api/app/models/spree/api/webhooks/product_decorator.rb
+++ b/api/app/models/spree/api/webhooks/product_decorator.rb
@@ -2,8 +2,16 @@ module Spree
   module Api
     module Webhooks
       module ProductDecorator
-        def discontinue!
-          super
+        def self.prepended(base)
+          base.after_update_commit :queue_webhooks_requests_for_product_discontinued!
+        end
+
+        private
+
+        def queue_webhooks_requests_for_product_discontinued!
+          return unless discontinue_on_previously_changed?
+          return if (change = discontinue_on_previous_change).blank? || change.last.blank?
+
           queue_webhooks_requests!('product.discontinued')
         end
       end

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -3,19 +3,10 @@ module Spree
     module Webhooks
       module StockItemDecorator
         def self.prepended(base)
-          base.around_save :queue_webhooks_requests_for_variant_back_in_stock!
           base.around_save :queue_webhooks_requests_for_variant_backorderable!
         end
 
         private
-
-        def queue_webhooks_requests_for_variant_back_in_stock!
-          was_out_of_stock = !variant_in_stock?
-          yield
-          if was_out_of_stock && variant_in_stock?
-            variant.queue_webhooks_requests!('variant.back_in_stock')
-          end
-        end
 
         def queue_webhooks_requests_for_variant_backorderable!
           was_out_of_stock = !variant_in_stock?

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -19,7 +19,7 @@ module Spree
         end
 
         def variant_backorderable?
-          Spree::Variant.backorderable.exists?(id: variant.id)
+          variant.stock_items.exists?(backorderable: true)
         end
       end
     end

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -12,6 +12,7 @@ module Spree
         def queue_webhooks_requests_for_variant_backorderable_on_create!
           was_out_of_stock = variant.out_of_stock?
           yield
+          reload
           return unless emits_webhook_event_on_create?(variant.reload, was_out_of_stock)
 
           variant.queue_webhooks_requests!('variant.backorderable') 
@@ -27,8 +28,7 @@ module Spree
           was_out_of_stock = variant.out_of_stock?
           was_not_orderable = !variant.backorderable?
           yield
-          variant.reload
-          variant.touch # changes must be reflected before instantiating the serializer
+          touch # changes must be reflected before instantiating the serializer
           return unless emits_webhook_event_on_update?(variant, was_out_of_stock, was_not_orderable)
 
           variant.queue_webhooks_requests!('variant.backorderable')

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -1,0 +1,45 @@
+module Spree
+  module Api
+    module Webhooks
+      module StockItemDecorator
+        def self.prepended(base)
+          base.around_create :queue_webhooks_requests_for_variant_backorderable_on_create!
+          base.around_update :queue_webhooks_requests_for_variant_backorderable_on_update!
+        end
+
+        private
+
+        def queue_webhooks_requests_for_variant_backorderable_on_create!
+          was_out_of_stock = variant.out_of_stock?
+          yield
+          return unless emits_webhook_event_on_create?(variant.reload, was_out_of_stock)
+
+          variant.queue_webhooks_requests!('variant.backorderable') 
+        end
+
+        def emits_webhook_event_on_create?(variant, was_out_of_stock)
+          was_out_of_stock && variant.in_stock? &&
+            # rewritting `variant.backorderable?` as is currently being cached
+            variant.stock_items.with_active_stock_location.any?(&:backorderable)
+        end
+
+        def queue_webhooks_requests_for_variant_backorderable_on_update!
+          was_out_of_stock = variant.out_of_stock?
+          was_not_orderable = !variant.backorderable?
+          yield
+          variant.reload
+          variant.touch # changes must be reflected before instantiating the serializer
+          return unless emits_webhook_event_on_update?(variant, was_out_of_stock, was_not_orderable)
+
+          variant.queue_webhooks_requests!('variant.backorderable')
+        end
+
+        def emits_webhook_event_on_update?(variant, was_out_of_stock, was_not_orderable)
+          was_out_of_stock && was_not_orderable && variant.in_stock? && variant.backorderable?
+        end
+      end
+    end
+  end
+end
+
+Spree::StockItem.prepend(Spree::Api::Webhooks::StockItemDecorator)

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -20,7 +20,7 @@ module Spree
 
         def emits_webhook_event_on_create?(variant, was_out_of_stock)
           was_out_of_stock && variant.in_stock? &&
-            # rewritting `variant.backorderable?` as is currently being cached
+            # rewriting `variant.backorderable?` as is currently being cached
             variant.stock_items.with_active_stock_location.any?(&:backorderable)
         end
 

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -24,7 +24,6 @@ module Spree
           product_was_not_backorderable = !product_backorderable?
           yield
           if product_was_out_of_stock && product_was_not_backorderable && product_backorderable?
-            touch
             variant.product.queue_webhooks_requests!('product.backorderable')
           end
         end

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -12,8 +12,8 @@ module Spree
           was_out_of_stock = !variant.in_stock_or_backorderable?
           was_not_backorderable = !variant_backorderable?
           yield
-          touch # changes must be reflected before instantiating the serializer
           if was_out_of_stock && was_not_backorderable && variant_backorderable?
+            reload
             variant.queue_webhooks_requests!('variant.backorderable')
           end
         end

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -20,7 +20,7 @@ module Spree
         end
 
         def queue_webhooks_requests_for_product_backorderable!
-          product_was_out_of_stock = !product.full_in_stock?
+          product_was_out_of_stock = !product.any_variant_in_stock_or_backorderable?
           product_was_not_backorderable = !product_backorderable?
           yield
           if product_was_out_of_stock && product_was_not_backorderable && product_backorderable?

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -21,7 +21,7 @@ module Spree
 
         def queue_webhooks_requests_for_product_backorderable!
           product_was_out_of_stock = !product.full_in_stock?
-          product_was_not_backorderable = !product.backorderable?
+          product_was_not_backorderable = !product_backorderable?
           yield
           if product_was_out_of_stock && product_was_not_backorderable && product_backorderable?
             touch

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -9,7 +9,7 @@ module Spree
         private
 
         def queue_webhooks_requests_for_variant_backorderable!
-          was_out_of_stock = !variant.full_in_stock?
+          was_out_of_stock = !variant.in_stock_or_backorderable?
           was_not_backorderable = !variant_backorderable?
           yield
           touch # changes must be reflected before instantiating the serializer

--- a/api/app/models/spree/api/webhooks/stock_item_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_item_decorator.rb
@@ -20,8 +20,8 @@ module Spree
         end
 
         def queue_webhooks_requests_for_product_backorderable!
-          product_was_out_of_stock = !product_full_in_stock?
-          product_was_not_backorderable = !product_backorderable?
+          product_was_out_of_stock = !product.full_in_stock?
+          product_was_not_backorderable = !product.backorderable?
           yield
           if product_was_out_of_stock && product_was_not_backorderable && product_backorderable?
             touch
@@ -31,11 +31,6 @@ module Spree
 
         def product_backorderable?
           Spree::StockItem.exists?(backorderable: true, variant_id: variant.product.variants.ids)
-        end
-
-        def product_full_in_stock?
-          Spree::Product.joins(:variants).merge(Spree::Variant.full_in_stock).
-            exists?(id: product.id)
         end
 
         def variant_backorderable?

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -6,6 +6,7 @@ module Spree
           base.around_save :queue_webhooks_requests_for_variant_back_in_stock!
         end
 
+        # [TODO]: update, this remains as it was
         def update_stock_item_quantity
           variant_in_stock_before_update = stock_item.variant.in_stock?
           super
@@ -15,26 +16,16 @@ module Spree
 
         private
 
-        delegate :id, to: :variant, prefix: true
-
         def queue_webhooks_requests_for_variant_back_in_stock!
-          variant_was_out_of_stock = !variant_in_stock?
+          variant_was_out_of_stock = !variant.full_in_stock?
           yield
-          if variant_was_out_of_stock && variant_in_stock?
+          if variant_was_out_of_stock && variant.full_in_stock?
             variant.queue_webhooks_requests!('variant.back_in_stock')
           end
         end
 
         def variant
           stock_item.variant
-        end
-
-        def variant_in_stock?
-          Spree::Variant.joins(:stock_items).where(id: variant_id).where(<<~SQL).exists?
-            #{Spree::StockItem.table_name}.count_on_hand > 0 OR
-            #{Spree::Variant.table_name}.track_inventory = FALSE OR
-            #{Spree::StockItem.table_name}.backorderable = TRUE
-          SQL
         end
       end
     end

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -2,17 +2,39 @@ module Spree
   module Api
     module Webhooks
       module StockMovementDecorator
+        def self.prepended(base)
+          base.around_save :queue_webhooks_requests_for_variant_back_in_stock!
+        end
+
         def update_stock_item_quantity
-          variant_in_stock_before_update = variant_in_stock?
+          variant_in_stock_before_update = stock_item.variant.in_stock?
           super
           variant = stock_item.variant
-          variant.queue_webhooks_requests!('variant.out_of_stock') if variant_in_stock_before_update && !variant_in_stock?
+          variant.queue_webhooks_requests!('variant.out_of_stock') if variant_in_stock_before_update && !stock_item.variant.in_stock?
         end
 
         private
 
+        delegate :id, to: :variant, prefix: true
+
+        def queue_webhooks_requests_for_variant_back_in_stock!
+          variant_was_out_of_stock = !variant_in_stock?
+          yield
+          if variant_was_out_of_stock && variant_in_stock?
+            variant.queue_webhooks_requests!('variant.back_in_stock')
+          end
+        end
+
+        def variant
+          stock_item.variant
+        end
+
         def variant_in_stock?
-          stock_item.variant.in_stock?
+          Spree::Variant.joins(:stock_items).where(id: variant_id).where(<<~SQL).exists?
+            #{Spree::StockItem.table_name}.count_on_hand > 0 OR
+            #{Spree::Variant.table_name}.track_inventory = FALSE OR
+            #{Spree::StockItem.table_name}.backorderable = TRUE
+          SQL
         end
       end
     end

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -29,16 +29,11 @@ module Spree
         end
 
         def queue_webhooks_requests_for_product_back_in_stock!
-          product_was_out_of_stock = !product_full_in_stock?
+          product_was_out_of_stock = !product.full_in_stock?
           yield
-          if product_was_out_of_stock && product_full_in_stock?
+          if product_was_out_of_stock && product.full_in_stock?
             product.queue_webhooks_requests!('product.back_in_stock')
           end
-        end
-
-        def product_full_in_stock?
-          Spree::Product.joins(:variants).merge(Spree::Variant.full_in_stock).
-            exists?(id: product.id)
         end
       end
     end

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -10,9 +10,6 @@ module Spree
 
         private
 
-        delegate :variant, to: :stock_item
-        delegate :product, to: :variant
-
         def queue_webhooks_requests_for_variant_out_of_stock!
           variant_in_stock_before_update = variant.in_stock_or_backorderable?
           yield

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -17,9 +17,9 @@ module Spree
         private
 
         def queue_webhooks_requests_for_variant_back_in_stock!
-          variant_was_out_of_stock = !variant.full_in_stock?
+          variant_was_out_of_stock = !variant.in_stock_or_backorderable?
           yield
-          if variant_was_out_of_stock && variant.full_in_stock?
+          if variant_was_out_of_stock && variant.in_stock_or_backorderable?
             variant.queue_webhooks_requests!('variant.back_in_stock')
           end
         end

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -3,22 +3,24 @@ module Spree
     module Webhooks
       module StockMovementDecorator
         def self.prepended(base)
+          base.around_save :queue_webhooks_requests_for_variant_out_of_stock!
           base.around_save :queue_webhooks_requests_for_variant_back_in_stock!
           base.around_save :queue_webhooks_requests_for_product_back_in_stock!
-        end
-
-        # [TODO]: update, this remains as it was
-        def update_stock_item_quantity
-          variant_in_stock_before_update = stock_item.variant.in_stock?
-          super
-          variant = stock_item.variant
-          variant.queue_webhooks_requests!('variant.out_of_stock') if variant_in_stock_before_update && !stock_item.variant.in_stock?
         end
 
         private
 
         delegate :variant, to: :stock_item
         delegate :product, to: :variant
+
+        def queue_webhooks_requests_for_variant_out_of_stock!
+          variant_in_stock_before_update = variant.in_stock_or_backorderable?
+          yield
+          if variant_in_stock_before_update && !variant.in_stock_or_backorderable?
+            reload
+            stock_item.variant.queue_webhooks_requests!('variant.out_of_stock')
+          end
+        end
 
         def queue_webhooks_requests_for_variant_back_in_stock!
           variant_was_out_of_stock = !variant.in_stock_or_backorderable?

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -4,6 +4,7 @@ module Spree
       module StockMovementDecorator
         def self.prepended(base)
           base.around_save :queue_webhooks_requests_for_variant_back_in_stock!
+          base.around_save :queue_webhooks_requests_for_product_back_in_stock!
         end
 
         # [TODO]: update, this remains as it was
@@ -16,6 +17,9 @@ module Spree
 
         private
 
+        delegate :variant, to: :stock_item
+        delegate :product, to: :variant
+
         def queue_webhooks_requests_for_variant_back_in_stock!
           variant_was_out_of_stock = !variant.in_stock_or_backorderable?
           yield
@@ -24,8 +28,17 @@ module Spree
           end
         end
 
-        def variant
-          stock_item.variant
+        def queue_webhooks_requests_for_product_back_in_stock!
+          product_was_out_of_stock = !product_full_in_stock?
+          yield
+          if product_was_out_of_stock && product_full_in_stock?
+            product.queue_webhooks_requests!('product.back_in_stock')
+          end
+        end
+
+        def product_full_in_stock?
+          Spree::Product.joins(:variants).merge(Spree::Variant.full_in_stock).
+            exists?(id: product.id)
         end
       end
     end

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -28,9 +28,9 @@ module Spree
         end
 
         def queue_webhooks_requests_for_product_back_in_stock!
-          product_was_out_of_stock = !product.full_in_stock?
+          product_was_out_of_stock = !product.any_variant_in_stock_or_backorderable?
           yield
-          if product_was_out_of_stock && product.full_in_stock?
+          if product_was_out_of_stock && product.any_variant_in_stock_or_backorderable?
             product.queue_webhooks_requests!('product.back_in_stock')
           end
         end

--- a/api/app/models/spree/api/webhooks/variant_decorator.rb
+++ b/api/app/models/spree/api/webhooks/variant_decorator.rb
@@ -2,8 +2,16 @@ module Spree
   module Api
     module Webhooks
       module VariantDecorator
-        def discontinue!
-          super
+        def self.prepended(base)
+          base.after_update_commit :queue_webhooks_requests_for_variant_discontinued!
+        end
+
+        private
+
+        def queue_webhooks_requests_for_variant_discontinued!
+          return unless discontinue_on_previously_changed?
+          return if (change = discontinue_on_previous_change).blank? || change.last.blank?
+
           queue_webhooks_requests!('variant.discontinued')
         end
       end

--- a/api/lib/spree/api/testing_support/matchers/webhooks.rb
+++ b/api/lib/spree/api/testing_support/matchers/webhooks.rb
@@ -50,7 +50,7 @@ RSpec::Matchers.define :emit_webhook_event do |event_to_emit|
     block_body_def = block_body_definition(obj_method)
     "Expected that executing `#{block_body_def}` emits the `#{event_to_emit}` Webhook event.\n" \
       "Check that `#{block_body_def}` does implement `queue_webhooks_requests!` for " \
-      "`#{event_to_emit}` with the following body: #{body}."
+      "`#{event_to_emit}` with the following body: \n\n#{body}."
   end
 
   failure_message_when_negated do |obj_method|

--- a/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
+++ b/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
@@ -31,7 +31,7 @@ describe Spree::Webhooks::HasWebhooks do
     context 'after_destroy_commit' do
       before { product.destroy }
 
-      it_behaves_like 'not queueing an event request', 'product.destroy'
+      it_behaves_like 'not queueing an event request', 'product.delete'
     end
 
     context 'after_update_commit' do
@@ -51,7 +51,7 @@ describe Spree::Webhooks::HasWebhooks do
     context 'after_destroy_commit' do
       before { product.save }
 
-      it { expect { product.destroy }.to emit_webhook_event('product.destroy') }
+      it { expect { product.destroy }.to emit_webhook_event('product.delete') }
     end
 
     context 'after_update_commit' do

--- a/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
+++ b/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
@@ -31,13 +31,13 @@ describe Spree::Webhooks::HasWebhooks do
     context 'after_destroy_commit' do
       before { product.destroy }
 
-      it_behaves_like 'not queueing an event request', 'product.create'
+      it_behaves_like 'not queueing an event request', 'product.destroy'
     end
 
     context 'after_update_commit' do
       before { product.update(name: 'updated') }
 
-      it_behaves_like 'not queueing an event request', 'product.create'
+      it_behaves_like 'not queueing an event request', 'product.update'
     end
   end
 

--- a/api/spec/models/spree/api/webhooks/order_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/order_decorator_spec.rb
@@ -16,7 +16,7 @@ describe Spree::Api::Webhooks::OrderDecorator do
 
   describe 'order.placed' do
     describe 'checkout -> completed' do
-      let(:order) { described_class.create(email: 'test@example.com', store: store) }
+      let(:order) { create(:order, email: 'test@example.com', store: store) }
 
       it { expect { Timecop.freeze { order.finalize! } }.to emit_webhook_event('order.placed') }
     end

--- a/api/spec/models/spree/api/webhooks/order_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/order_decorator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Order do
+describe Spree::Api::Webhooks::OrderDecorator do
   let(:store) { create(:store, default: true) }
   let(:body) do
     Spree::Api::V2::Platform::OrderSerializer.new(order).serializable_hash.to_json

--- a/api/spec/models/spree/api/webhooks/order_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/order_decorator_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 describe Spree::Api::Webhooks::OrderDecorator do
   let(:store) { create(:store, default: true) }
-  let(:body) do
-    Spree::Api::V2::Platform::OrderSerializer.new(order).serializable_hash.to_json
-  end
+  let(:body) { Spree::Api::V2::Platform::OrderSerializer.new(order).serializable_hash.to_json }
 
   describe 'order.canceled' do
     describe 'completed -> canceled' do
@@ -23,10 +21,46 @@ describe Spree::Api::Webhooks::OrderDecorator do
   end
 
   describe 'order.resumed' do
-    describe 'canceled -> resumed' do
-      let(:order) { create(:order, store: store, state: :canceled) }
+    let(:order) { create(:order, store: store, state: :canceled) }
 
-      it { expect { Timecop.freeze { order.resume! } }.to emit_webhook_event('order.resumed') }
+    context 'when order state changes' do
+      context 'when order state changes "resumed"' do
+        context 'when manually setting the state' do
+          # this case does not create a state change record
+          subject { Timecop.freeze { order.update(state: 'resumed') } }
+
+          it { expect { subject }.to emit_webhook_event('order.resumed') }
+        end
+
+        context 'when doing it through resume!' do
+          it do
+            expect do
+              Timecop.freeze do
+                order.resume!
+              end
+            end.to emit_webhook_event('order.resumed')
+          end
+
+          context 'after emitting the webhook' do
+            it 'correctly sets state_machine_resumed used to avoid emitting the same event twice' do
+              # it does so because an update is for setting the state
+              # and another one is for setting the order state_changes
+              order.state_machine_resumed = true
+              expect(order.state_machine_resumed).to eq(true)
+              order.resume!
+              expect(order.state_machine_resumed).to eq(false)
+            end
+          end
+        end
+      end
+
+      context 'when order state does not change to "resumed"' do
+        it do
+          expect do
+            order.update(email: 'me@spreecommerce.org')
+          end.not_to emit_webhook_event('order.resumed')
+        end
+      end
     end
   end
 end

--- a/api/spec/models/spree/api/webhooks/payment_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/payment_decorator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Payment do
+describe Spree::Api::Webhooks::PaymentDecorator do
   let(:body) { Spree::Api::V2::Platform::PaymentSerializer.new(payment).serializable_hash.to_json }
   let(:payment) { create(:payment) }
 

--- a/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Product do
+describe Spree::Api::Webhooks::ProductDecorator do
   let(:product) { create(:product) }
   let(:body) { Spree::Api::V2::Platform::ProductSerializer.new(product).serializable_hash.to_json }
 

--- a/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
@@ -2,11 +2,36 @@ require 'spec_helper'
 
 describe Spree::Api::Webhooks::ProductDecorator do
   let(:product) { create(:product) }
-  let(:body) { Spree::Api::V2::Platform::ProductSerializer.new(product).serializable_hash.to_json }
 
-  describe '#discontinue!' do
-    it 'emits the product.discontinued event' do
-      expect { product.discontinue! }.to emit_webhook_event('product.discontinued')
+  context 'emitting product.discontinued' do
+    let(:body) { Spree::Api::V2::Platform::ProductSerializer.new(product).serializable_hash.to_json }
+
+    context 'when product discontinued_on changes' do
+      context 'when the new value is "present"' do
+        it do
+          expect do
+            product.discontinue!
+          end.to emit_webhook_event('product.discontinued')
+        end
+      end
+
+      context 'when the new value is not "present"' do
+        before { product.update(discontinue_on: Date.yesterday) }
+
+        it do
+          expect do
+            product.update(discontinue_on: nil)
+          end.not_to emit_webhook_event('product.discontinued')
+        end
+      end
+    end
+
+    context 'when product discontinued_on does not change' do
+      it do
+        expect do
+          product.update(width: 180)
+        end.not_to emit_webhook_event('product.discontinued')
+      end
     end
   end
 end

--- a/api/spec/models/spree/api/webhooks/shipment_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/shipment_decorator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Shipment do
+describe Spree::Api::Webhooks::ShipmentDecorator do
   let(:order) { create(:order) }
   let(:shipment) { create(:shipment) }
 

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -4,13 +4,12 @@ describe Spree::Api::Webhooks::StockItemDecorator do
   describe 'emitting variant.backorderable' do
     let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant.reload).serializable_hash.to_json }
     let(:variant) { create(:variant) }
+    let(:stock_item) { variant.stock_items.first }
 
     before do
       # makes sure variant.backorderable == false
       stock_item.update(backorderable: false)
     end
-
-    let(:stock_item) { variant.stock_items.first }
 
     context 'when creating a variant stock item' do
       context 'when variant has no stock items' do
@@ -20,6 +19,7 @@ describe Spree::Api::Webhooks::StockItemDecorator do
           context 'when variant changes to be backorderable' do
             it do
               expect do
+                variant.reload
                 Timecop.freeze do
                   create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
                 end

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -5,49 +5,6 @@ describe Spree::Api::Webhooks::StockItemDecorator do
   let(:variant) { create(:variant) }
   let(:stock_item) { variant.stock_items.first }
 
-  describe 'emitting variant.back_in_stock' do
-    context 'when variant was out of stock' do
-      before do
-        variant.stock_items.each do |stock_item|
-          stock_item.set_count_on_hand(0)
-        end
-      end
-
-      context 'when variant changes to be in stock' do
-        it do
-          expect do
-            variant.stock_items.first.update(backorderable: true)
-            Timecop.freeze { variant.stock_items.first.set_count_on_hand(1) }
-          end.to emit_webhook_event('variant.back_in_stock')
-        end
-      end
-
-      context 'when variant does not change to be in stock' do
-        it do
-          expect do
-            Timecop.freeze { variant.stock_items.first.update(backorderable: true) }
-          end.not_to emit_webhook_event('variant.back_in_stock')
-        end
-      end
-    end
-
-    context 'when variant was in stock' do
-      before do
-        variant.stock_items.each do |stock_item|
-          stock_item.set_count_on_hand(1)
-        end
-      end
-
-      it do
-        expect do
-          Timecop.freeze do
-            variant.stock_items.first.update(backorderable: true)
-          end
-        end.not_to emit_webhook_event('variant.back_in_stock')
-      end
-    end
-  end
-
   describe 'emitting variant.backorderable' do
     before do
       # makes sure variant.backorderable == false

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -4,163 +4,82 @@ describe Spree::Api::Webhooks::StockItemDecorator do
   let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant.reload).serializable_hash.to_json }
   let(:variant) { create(:variant) }
   let(:stock_item) { variant.stock_items.first }
+  let(:stock_location) { variant.stock_locations.first }
 
   describe 'emitting variant.backorderable' do
-    before do
-      # makes sure variant.backorderable == false
-      stock_item.update(backorderable: false)
-    end
-
-    context 'when creating a variant stock item' do
-      context 'when variant has no stock items' do
-        before { variant.stock_items.delete_all }
-
-        context 'when variant changes to be in stock' do
-          context 'when variant changes to be backorderable' do
-            it do
-              expect do
-                variant.reload
-                Timecop.freeze do
-                  create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
-                end
-              end.to emit_webhook_event('variant.backorderable')
-            end
-          end
-
-          context 'when variant does not change to be backorderable' do
-            it do
-              expect do
-                Timecop.freeze do
-                  create(:stock_item, variant: variant, backorderable: false, count_on_hand: 1)
-                end
-              end.not_to emit_webhook_event('variant.backorderable')
-            end
-          end
-        end
-
-        context 'when variant does not change to be in stock' do
-          it do
-            expect do
-              Timecop.freeze do
-                create(:stock_item, variant: variant, backorderable: true, count_on_hand: 0)
-              end
-            end.not_to emit_webhook_event('variant.backorderable')
-          end
+    context 'when variant was out of stock' do
+      before do
+        stock_location.stock_movements.new.tap do |stock_movement|
+          stock_movement.quantity = 0
+          stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+          stock_movement.save
         end
       end
 
-      context 'when variant has stock items' do
-        context 'when variant was out of stock' do
-          context 'when variant changes to be in stock' do
-            context 'when variant changes to be backorderable' do
-              it do
-                expect do
-                  Timecop.freeze do
-                    create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
-                  end
-                end.to emit_webhook_event('variant.backorderable')
-              end
-            end
-
-            context 'when variant does not change to be backorderable' do
-              it do
-                expect do
-                  Timecop.freeze do
-                    create(:stock_item, variant: variant, backorderable: false, count_on_hand: 1)
-                  end
-                end.not_to emit_webhook_event('variant.backorderable')
-              end
-            end
-          end
-
-          context 'when variant does not change to be in stock' do
-            it do
-              expect do
-                Timecop.freeze do
-                  create(:stock_item, variant: variant, backorderable: true, count_on_hand: 0)
-                end
-              end.not_to emit_webhook_event('variant.backorderable')
-            end
-          end
+      context 'when variant was backorderable' do
+        before do
+          stock_item.backorderable = true
         end
-
-        context 'when variant was not out of stock' do
-          before { variant.stock_items.update_all(count_on_hand: 1, backorderable: true) }
-
-          it do
-            expect do
-              Timecop.freeze do
-                create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
-              end
-            end.not_to emit_webhook_event('variant.backorderable')
-          end
-        end
-      end
-    end
-
-    context 'when updating a variant stock item' do
-      context 'when variant was out of stock' do
-        context 'when variant changes to be in stock' do
-          context 'when variant changes to backorderable' do
-            before { variant.stock_items.update_all(backorderable: false) }
-
-            it do
-              expect do
-                Timecop.freeze do
-                  stock_item.update(backorderable: true, count_on_hand: 1)
-                end
-              end.to emit_webhook_event('variant.backorderable')
-            end
-          end
-
-          context 'when variant does not change to backorderable' do
-            before { variant.stock_items.update_all(backorderable: false) }
-
-            it do
-              expect do
-                Timecop.freeze do
-                  stock_item.update(backorderable: false, count_on_hand: 1)
-                end
-              end.not_to emit_webhook_event('variant.backorderable')
-            end
-          end
-
-          context 'when variant was already backorderable' do
-            before { stock_item.update(backorderable: true) }
-
-            it do
-              expect do
-                Timecop.freeze do
-                  stock_item.update(backorderable: true, count_on_hand: 1)
-                end
-              end.not_to emit_webhook_event('variant.backorderable')
-            end
-          end
-        end
-
-        context 'when variant does not change to be in stock' do
-          before { variant.stock_items.update_all(backorderable: false) }
-
-          it do
-            expect do
-              Timecop.freeze do
-                stock_item.update(backorderable: true, count_on_hand: 0)
-              end
-            end.not_to emit_webhook_event('variant.backorderable')
-          end
-        end
-      end
-
-      context 'when variant was not out of stock' do
-        before { stock_item.set_count_on_hand(1) }
 
         it do
           expect do
             Timecop.freeze do
-              stock_item.update(backorderable: true)
+              stock_item.save
             end
           end.not_to emit_webhook_event('variant.backorderable')
         end
+      end
+
+      context 'when variant was not backorderable' do
+        before { variant.stock_items.update_all(backorderable: false) }
+
+        context 'when variant is not set as backorderable' do
+          before do
+            stock_item.backorderable = false
+          end
+
+          it do
+            expect do
+              Timecop.freeze do
+                stock_item.save
+              end
+            end.not_to emit_webhook_event('variant.backorderable')
+          end
+        end
+
+        context 'when variant is set as backorderable' do
+          before do
+            stock_item.backorderable = true
+          end
+
+          it do
+            expect do
+              Timecop.freeze do
+                stock_item.save
+              end
+            end.to emit_webhook_event('variant.backorderable')
+          end
+        end
+      end
+    end
+
+    context 'when variant was not out of stock' do
+      before do
+        variant.stock_items.update_all(backorderable: false)
+        stock_location.stock_movements.new.tap do |stock_movement|
+          stock_movement.quantity = 1
+          stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+          stock_movement.save
+        end
+        stock_item.backorderable = true
+      end
+
+      it do
+        expect do
+          Timecop.freeze do
+            stock_item.save
+          end
+        end.not_to emit_webhook_event('variant.backorderable')
       end
     end
   end

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -5,8 +5,6 @@ describe Spree::Api::Webhooks::StockItemDecorator do
   let(:variant) { create(:variant) }
   let(:stock_item) { variant.stock_items.first }
 
-  let!(:images) { create_list(:image, 2) }
-
   describe 'emitting variant.back_in_stock' do
     context 'when variant was out of stock' do
       before do

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::Api::Webhooks::StockItemDecorator do
   describe 'emitting variant.backorderable' do
-    let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
+    let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant.reload).serializable_hash.to_json }
     let(:variant) { create(:variant) }
 
     before do

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+describe Spree::Api::Webhooks::StockItemDecorator do
+  describe 'emitting variant.backorderable' do
+    let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
+    let(:variant) { create(:variant) }
+
+    before do
+      # makes sure variant.backorderable == false
+      stock_item.update(backorderable: false)
+    end
+
+    let(:stock_item) { variant.stock_items.first }
+
+    context 'when creating a variant stock item' do
+      context 'when variant has no stock items' do
+        before { variant.stock_items.delete_all }
+
+        context 'when variant changes to be in stock' do
+          context 'when variant changes to be backorderable' do
+            it do
+              expect do
+                Timecop.freeze do
+                  create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
+                end
+              end.to emit_webhook_event('variant.backorderable')
+            end
+          end
+
+          context 'when variant does not change to be backorderable' do
+            it do
+              expect do
+                Timecop.freeze do
+                  create(:stock_item, variant: variant, backorderable: false, count_on_hand: 1)
+                end
+              end.not_to emit_webhook_event('variant.backorderable')
+            end
+          end
+        end
+
+        context 'when variant does not change to be in stock' do
+          it do
+            expect do
+              Timecop.freeze do
+                create(:stock_item, variant: variant, backorderable: true, count_on_hand: 0)
+              end
+            end.not_to emit_webhook_event('variant.backorderable')
+          end
+        end
+      end
+
+      context 'when variant has stock items' do
+        context 'when variant was out of stock' do
+          context 'when variant changes to be in stock' do
+            context 'when variant changes to be backorderable' do
+              it do
+                expect do
+                  Timecop.freeze do
+                    create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
+                  end
+                end.to emit_webhook_event('variant.backorderable')
+              end
+            end
+
+            context 'when variant does not change to be backorderable' do
+              it do
+                expect do
+                  Timecop.freeze do
+                    create(:stock_item, variant: variant, backorderable: false, count_on_hand: 1)
+                  end
+                end.not_to emit_webhook_event('variant.backorderable')
+              end
+            end
+          end
+
+          context 'when variant does not change to be in stock' do
+            it do
+              expect do
+                Timecop.freeze do
+                  create(:stock_item, variant: variant, backorderable: true, count_on_hand: 0)
+                end
+              end.not_to emit_webhook_event('variant.backorderable')
+            end
+          end
+        end
+
+        context 'when variant was not out of stock' do
+          before { variant.stock_items.update_all(count_on_hand: 1, backorderable: true) }
+
+          it do
+            expect do
+              Timecop.freeze do
+                create(:stock_item, variant: variant, backorderable: true, count_on_hand: 1)
+              end
+            end.not_to emit_webhook_event('variant.backorderable')
+          end
+        end
+      end
+    end
+
+    context 'when updating a variant stock item' do
+      context 'when variant was out of stock' do
+        context 'when variant changes to be in stock' do
+          context 'when variant changes to backorderable' do
+            before { variant.stock_items.update_all(backorderable: false) }
+
+            it do
+              expect do
+                Timecop.freeze do
+                  stock_item.update(backorderable: true, count_on_hand: 1)
+                end
+              end.to emit_webhook_event('variant.backorderable')
+            end
+          end
+
+          context 'when variant does not change to backorderable' do
+            before { variant.stock_items.update_all(backorderable: false) }
+
+            it do
+              expect do
+                Timecop.freeze do
+                  stock_item.update(backorderable: false, count_on_hand: 1)
+                end
+              end.not_to emit_webhook_event('variant.backorderable')
+            end
+          end
+
+          context 'when variant was already backorderable' do
+            before { stock_item.update(backorderable: true) }
+
+            it do
+              expect do
+                Timecop.freeze do
+                  stock_item.update(backorderable: true, count_on_hand: 1)
+                end
+              end.not_to emit_webhook_event('variant.backorderable')
+            end
+          end
+        end
+
+        context 'when variant does not change to be in stock' do
+          before { variant.stock_items.update_all(backorderable: false) }
+
+          it do
+            expect do
+              Timecop.freeze do
+                stock_item.update(backorderable: true, count_on_hand: 0)
+              end
+            end.not_to emit_webhook_event('variant.backorderable')
+          end
+        end
+      end
+
+      context 'when variant was not out of stock' do
+        before { stock_item.set_count_on_hand(1) }
+
+        it do
+          expect do
+            Timecop.freeze do
+              stock_item.update(backorderable: true)
+            end
+          end.not_to emit_webhook_event('variant.backorderable')
+        end
+      end
+    end
+  end
+end

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -7,7 +7,10 @@ describe Spree::Api::Webhooks::StockItemDecorator do
   let(:stock_location) { variant.stock_locations.first }
 
   describe 'emitting product.backorderable' do
-    subject { Timecop.freeze { stock_item.update(backorderable: backorderable) } }
+    subject do
+      product.reload
+      Timecop.freeze { stock_item.update(backorderable: backorderable) }
+    end
 
     let(:body) { Spree::Api::V2::Platform::ProductSerializer.new(product.reload).serializable_hash.to_json }
     let(:product) { variant.product }

--- a/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
@@ -1,13 +1,69 @@
 require 'spec_helper'
 
-describe Spree::StockMovement do
+describe Spree::Api::Webhooks::StockMovementDecorator do
   let(:stock_item) { create(:stock_item) }
-  let(:variant) { stock_item.variant }
+  let(:stock_location) { variant.stock_locations.first }
   let(:stock_movement) { create(:stock_movement, stock_item: stock_item, quantity: movement_quantity) }
   let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
 
+  let!(:images) { create_list(:image, 2) }
+
+  describe 'emitting variant.back_in_stock' do
+    let(:variant) { create(:variant, track_inventory: true) }
+
+    context 'when stock item was out of stock' do
+      context 'when variant changes to be in stock' do
+        it do
+          expect do
+            Timecop.freeze do
+              variant.stock_items.update_all(backorderable: false)
+              stock_location.stock_movements.new.tap do |stock_movement|
+                stock_movement.quantity = 1
+                stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+                stock_movement.save
+              end
+            end
+          end.to emit_webhook_event('variant.back_in_stock')
+        end
+      end
+
+      context 'when variant does not change to be in stock' do
+        it do
+          expect do
+            Timecop.freeze do
+              variant.stock_items.update_all(backorderable: false)
+              stock_location.stock_movements.new.tap do |stock_movement|
+                stock_movement.quantity = 0
+                stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+                stock_movement.save
+              end
+            end
+          end.not_to emit_webhook_event('variant.back_in_stock')
+        end
+      end
+    end
+
+    context 'when variant was in stock' do
+      it do
+        expect do
+          Timecop.freeze do
+            # make in_stock? return false based on track_inventory, the easiest case
+            variant.update(track_inventory: false)
+            stock_location.stock_movements.new.tap do |stock_movement|
+              stock_movement.quantity = 2
+              stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+              stock_movement.save
+            end
+          end
+        end.not_to emit_webhook_event('variant.back_in_stock')
+      end
+    end
+  end
+
   describe '#update_stock_item_quantity' do
     subject { stock_movement }
+
+    let(:variant) { stock_item.variant }
 
     describe 'when the variant goes out of stock' do
       let(:movement_quantity) { -stock_item.count_on_hand }

--- a/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
@@ -18,7 +18,7 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
             Timecop.freeze do
               variant.stock_items.update_all(backorderable: false)
               stock_location.stock_movements.new.tap do |stock_movement|
-                stock_movement.quantity = 1
+                stock_movement.quantity = 1 # does make it to be in stock
                 stock_movement.stock_item = stock_location.set_up_stock_item(variant)
                 stock_movement.save
               end
@@ -33,7 +33,7 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
             Timecop.freeze do
               variant.stock_items.update_all(backorderable: false)
               stock_location.stock_movements.new.tap do |stock_movement|
-                stock_movement.quantity = 0
+                stock_movement.quantity = 0 # does not make it to be in stock
                 stock_movement.stock_item = stock_location.set_up_stock_item(variant)
                 stock_movement.save
               end

--- a/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
@@ -6,13 +6,11 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
   let(:stock_movement) { create(:stock_movement, stock_item: stock_item, quantity: movement_quantity) }
   let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
 
-  let!(:images) { create_list(:image, 2) }
-
   describe 'emitting variant.back_in_stock' do
     let(:variant) { create(:variant, track_inventory: true) }
 
     context 'when stock item was out of stock' do
-      context 'when variant changes to be in stock' do
+      context 'when stock item changes to be in stock' do
         it do
           expect do
             Timecop.freeze do
@@ -27,7 +25,7 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
         end
       end
 
-      context 'when variant does not change to be in stock' do
+      context 'when stock item does not change to be in stock' do
         it do
           expect do
             Timecop.freeze do
@@ -43,7 +41,7 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
       end
     end
 
-    context 'when variant was in stock' do
+    context 'when stock item was in stock' do
       it do
         expect do
           Timecop.freeze do

--- a/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 describe Spree::Api::Webhooks::StockMovementDecorator do
   let(:stock_item) { create(:stock_item) }
   let(:stock_location) { variant.stock_locations.first }
-  let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
-  let!(:f) { create_list(:image, 2) }
+  let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant.reload).serializable_hash.to_json }
 
   describe 'emitting product.back_in_stock' do
     let!(:store) { create(:store) }
@@ -124,7 +123,9 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
     subject { stock_movement }
 
     let(:stock_movement) { create(:stock_movement, stock_item: stock_item, quantity: movement_quantity) }
-    let(:variant) { stock_item.variant }
+    let!(:variant) { stock_item.variant }
+
+    before { Spree::StockItem.update_all(backorderable: false) }
 
     describe 'when the variant goes out of stock' do
       let(:movement_quantity) { -stock_item.count_on_hand }

--- a/api/spec/models/spree/api/webhooks/variant_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/variant_decorator_spec.rb
@@ -3,13 +3,35 @@ require 'spec_helper'
 describe Spree::Api::Webhooks::VariantDecorator do
   let(:variant) { create(:variant) }
 
-  describe '#discontinue!' do
-    context 'emitting variant.discontinued' do
-      subject { variant.discontinue! }
+  context 'emitting variant.discontinued' do
+    let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
 
-      let(:body) { Spree::Api::V2::Platform::VariantSerializer.new(variant).serializable_hash.to_json }
+    context 'when variant discontinued_on changes' do
+      context 'when the new value is "present"' do
+        it do
+          expect do
+            variant.discontinue!
+          end.to emit_webhook_event('variant.discontinued')
+        end
+      end
 
-      it { expect { subject }.to emit_webhook_event('variant.discontinued') }
+      context 'when the new value is not "present"' do
+        before { variant.update(discontinue_on: Date.yesterday) }
+
+        it do
+          expect do
+            variant.update(discontinue_on: nil)
+          end.not_to emit_webhook_event('variant.discontinued')
+        end
+      end
+    end
+
+    context 'when variant discontinued_on does not change' do
+      it do
+        expect do
+          variant.update(width: 180)
+        end.not_to emit_webhook_event('variant.discontinued')
+      end
     end
   end
 end

--- a/api/spec/models/spree/api/webhooks/variant_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/variant_decorator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Variant do
+describe Spree::Api::Webhooks::VariantDecorator do
   let(:variant) { create(:variant) }
 
   describe '#discontinue!' do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -73,6 +73,7 @@ module Spree
 
     attr_reader :coupon_code
     attr_accessor :temporary_address, :temporary_credit_card
+
     attribute :state_machine_resumed, :boolean
 
     if Spree.user_class

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -73,6 +73,7 @@ module Spree
 
     attr_reader :coupon_code
     attr_accessor :temporary_address, :temporary_credit_card
+    attribute :state_machine_resumed, :boolean
 
     if Spree.user_class
       belongs_to :user, class_name: Spree.user_class.to_s, optional: true

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -112,6 +112,7 @@ module Spree
 
               before_transition to: :resumed, do: :ensure_line_item_variants_are_not_discontinued
               before_transition to: :resumed, do: :ensure_line_items_are_in_stock
+              before_transition to: :resumed, do: proc { |order| order.state_machine_resumed = true }
 
               after_transition to: :complete, do: :finalize!
               after_transition to: :resumed, do: :after_resume

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -322,8 +322,12 @@ module Spree
       end
     end
 
-    def full_in_stock?
-      variants_including_master.in_stock_or_backorderable.exists?
+    def any_variant_in_stock_or_backorderable?
+      if variants.any?
+        variants_including_master.in_stock_or_backorderable.exists?
+      else 
+        master.in_stock_or_backorderable?
+      end
     end
 
     private

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -323,7 +323,7 @@ module Spree
     end
 
     def full_in_stock?
-      variants.full_in_stock.exists?
+      variants.in_stock_or_backorderable.exists?(product_id: id)
     end
 
     private

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -323,7 +323,7 @@ module Spree
     end
 
     def full_in_stock?
-      variants.in_stock_or_backorderable.exists?(product_id: id)
+      variants.in_stock_or_backorderable.exists?
     end
 
     private

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -322,6 +322,10 @@ module Spree
       end
     end
 
+    def full_in_stock?
+      variants.full_in_stock.exists?
+    end
+
     private
 
     def add_associations_from_prototype

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -323,7 +323,7 @@ module Spree
     end
 
     def full_in_stock?
-      variants.in_stock_or_backorderable.exists?
+      variants_including_master.in_stock_or_backorderable.exists?
     end
 
     private

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -31,7 +31,7 @@ module Spree
       private
 
       def scope_to_location(collection)
-        return collection.with_active_stock_location unless stock_location.present?
+        return collection.with_active_stock_location if stock_location.blank?
 
         collection.where(stock_location: stock_location)
       end

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -21,6 +21,9 @@ module Spree
 
     scope :recent, -> { order(created_at: :desc) }
 
+    delegate :variant, to: :stock_item
+    delegate :product, to: :variant
+
     self.whitelisted_ransackable_attributes = ['quantity']
 
     def readonly?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -91,6 +91,20 @@ module Spree
       )
     end
 
+    # [TODO]: test
+    scope :full_in_stock, -> do
+      joins(:stock_items).where(<<~SQL)
+        #{Spree::StockItem.table_name}.count_on_hand > 0 OR
+        #{Spree::Variant.table_name}.track_inventory = FALSE OR
+        #{Spree::StockItem.table_name}.backorderable = TRUE
+      SQL
+    end
+
+    # [TODO]: test
+    def full_in_stock?
+      Spree::Variant.full_in_stock.exists?(id: id)
+    end
+
     scope :not_deleted, -> { where("#{Spree::Variant.quoted_table_name}.deleted_at IS NULL") }
 
     scope :for_currency_and_available_price_amount, ->(currency = nil) do

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -261,6 +261,10 @@ module Spree
       end
     end
 
+    def out_of_stock?
+      !in_stock?
+    end
+
     def backorderable?
       @backorderable ||= Rails.cache.fetch(['variant-backorderable', cache_key_with_version]) do
         quantifier.backorderable?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -132,7 +132,6 @@ module Spree
       !discontinued? && product.available?
     end
 
-    # [TODO]: test
     def in_stock_or_backorderable?
       self.class.in_stock_or_backorderable.exists?(id: id)
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -132,6 +132,7 @@ module Spree
       !discontinued? && product.available?
     end
 
+    # [TODO]: test
     def in_stock_or_backorderable?
       self.class.in_stock_or_backorderable.exists?(id: id)
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -83,14 +83,6 @@ module Spree
       )
     }
 
-    scope :full_in_stock, -> do
-      joins(:stock_items).where(<<~SQL)
-        #{Spree::StockItem.table_name}.count_on_hand > 0 OR
-        #{Spree::Variant.table_name}.track_inventory = FALSE OR
-        #{Spree::StockItem.table_name}.backorderable = TRUE
-      SQL
-    end
-
     scope :not_discontinued, -> do
       where(
         arel_table[:discontinue_on].eq(nil).or(
@@ -140,8 +132,8 @@ module Spree
       !discontinued? && product.available?
     end
 
-    def full_in_stock?
-      Spree::Variant.full_in_stock.exists?(id: id)
+    def in_stock_or_backorderable?
+      self.class.in_stock_or_backorderable.exists?(id: id)
     end
 
     def tax_category

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -831,6 +831,12 @@ describe Spree::Product, type: :model do
     let!(:product) { create(:product, stores: [store]) }
     let(:stock_item) { variant.stock_items.first }
 
+    context 'when in stock or backorderable variants belong to another product' do
+      let!(:another_product_variant) { create(:variant, product: create(:product, stores: [store])) }
+
+      it { expect(subject).to eq(false) }
+    end
+
     context 'when product has no variants' do
       it do
         expect(product.variants).to eq([])

--- a/core/spec/models/spree/stock_movement_spec.rb
+++ b/core/spec/models/spree/stock_movement_spec.rb
@@ -30,9 +30,18 @@ describe Spree::StockMovement, type: :model do
     end
   end
 
-  describe 'Insatance Methods' do
+  describe 'Instance Methods' do
     let(:stock_location) { create(:stock_location_with_items) }
     let(:stock_item) { stock_location.stock_items.order(:id).first }
+    let(:stock_movement) { build(:stock_movement, stock_item: stock_item) }
+
+    describe '.product' do
+      it { expect(stock_movement.product).to eq(stock_item.variant.product) }
+    end
+
+    describe '.variant' do
+      it { expect(stock_movement.variant).to eq(stock_item.variant) }
+    end
 
     describe '#readonly?' do
       let(:stock_movement) { create(:stock_movement, stock_item: stock_item) }
@@ -43,8 +52,6 @@ describe Spree::StockMovement, type: :model do
     end
 
     describe '#update_stock_item_quantity' do
-      let(:stock_movement) { build(:stock_movement, stock_item: stock_item) }
-
       context 'when track inventory levels is false' do
         before do
           Spree::Config[:track_inventory_levels] = false

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -98,12 +98,14 @@ describe Spree::Variant, type: :model do
 
       context 'when product is created without variants but with stock' do
         it { expect(product.master).to be_in_stock }
+        it { expect(product.master).not_to be_out_of_stock }
       end
 
       context 'when a variant is created' do
         let!(:new_variant) { create(:variant, product: product) }
 
         it { expect(product.master).not_to be_in_stock }
+        it { expect(product.master).to be_out_of_stock }
       end
     end
   end
@@ -534,6 +536,7 @@ describe Spree::Variant, type: :model do
 
         it 'returns true if stock_items in stock' do
           expect(variant.in_stock?).to be true
+          expect(variant.out_of_stock?).to be false
         end
       end
 
@@ -545,6 +548,7 @@ describe Spree::Variant, type: :model do
 
         it 'return false if stock_items out of stock' do
           expect(variant.in_stock?).to be false
+          expect(variant.out_of_stock?).to be true
         end
       end
     end
@@ -569,6 +573,7 @@ describe Spree::Variant, type: :model do
 
         it 'in_stock? returns false' do
           expect(variant.in_stock?).to be false
+          expect(variant.out_of_stock?).to be true
         end
 
         it 'can_supply? return true' do


### PR DESCRIPTION
- Add `product.back_in_stock`. 
- Add `product.backorderable`.
- Add `variant.back_in_stock`.
- Add `variant.backorderable`.
- Fix `product.discountinued` to work on after_update_commit.
- Fix `order.resumed` to emit event on after_update_commit alongside order.resume!.
- Fix `variant.discountinued` to work on after_update_commit.
- Fix `variant.out_of_stock`.
- Update <resource>.destroy to <resource>.delete.
- Add `Variant#in_stock_or_backorderable?`.
