### PR TITLE
[SD-1544] Don't fire webhooks touch events if only timestamps were changed

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -9,7 +9,7 @@ module Spree
         after_update_commit(proc { queue_webhooks_requests!(event_name(:update)) })
 
         def queue_webhooks_requests!(event)
-          return if disable_spree_webhooks? || body.blank?
+          return if disable_spree_webhooks? || updating_only_timestamps? || body.blank?
 
           Spree::Webhooks::Subscribers::QueueRequests.call(event: event, body: body)
         end
@@ -28,6 +28,10 @@ module Spree
       def resource_serializer
         demodulized_class_name = self.class.to_s.demodulize
         "Spree::Api::V2::Platform::#{demodulized_class_name}Serializer".constantize
+      end
+
+      def updating_only_timestamps?
+        (saved_changes.keys - %w[created_at updated_at]).empty?
       end
 
       def disable_spree_webhooks?

--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -31,7 +31,7 @@ module Spree
       end
 
       def updating_only_timestamps?
-        (saved_changes.keys - %w[created_at updated_at]).empty?
+        saved_changes.present? && (saved_changes.keys - %w[created_at updated_at]).empty?
       end
 
       def disable_spree_webhooks?

--- a/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
+++ b/api/app/models/spree/api/webhooks/stock_movement_decorator.rb
@@ -23,6 +23,7 @@ module Spree
           variant_was_out_of_stock = !variant.in_stock_or_backorderable?
           yield
           if variant_was_out_of_stock && variant.in_stock_or_backorderable?
+            reload
             variant.queue_webhooks_requests!('variant.back_in_stock')
           end
         end

--- a/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
+++ b/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
@@ -68,5 +68,41 @@ describe Spree::Webhooks::HasWebhooks do
         expect { cms_page }.to emit_webhook_event('cms_page.create')
       end
     end
+
+    context 'when only timestamps change' do
+      before { product.save }
+
+      context 'on created_at change' do
+        it do
+          expect do
+            product.update(created_at: Date.yesterday)
+          end.not_to emit_webhook_event('product.update')
+        end
+      end
+
+      context 'on updated_at change' do
+        it do
+          expect do
+            product.update(updated_at: Date.yesterday)
+          end.not_to emit_webhook_event('product.update')
+        end
+      end
+
+      context 'when using touch without arguments' do
+        it do
+          expect do
+            product.touch
+          end.not_to emit_webhook_event('product.update')
+        end
+      end
+
+      context 'when using touch with an argument other than created_at/updated_at' do
+        it do
+          expect do
+            product.touch(:deleted_at)
+          end.to emit_webhook_event('product.update')
+        end
+      end
+    end
   end
 end

--- a/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
+++ b/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
@@ -91,7 +91,9 @@ describe Spree::Webhooks::HasWebhooks do
       context 'when using touch without arguments' do
         it do
           expect do
-            product.touch
+            # Doing product.touch in Rails 5.2 doesn't work at the first time.
+            # It must be done twice in order to update the updated_at column.
+            Spree::Product.find(product.id).touch
           end.not_to emit_webhook_event('product.update')
         end
       end

--- a/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_item_decorator_spec.rb
@@ -64,6 +64,8 @@ describe Spree::Api::Webhooks::StockItemDecorator do
   end
 
   describe 'emitting variant.backorderable' do
+    subject { stock_item.save }
+
     context 'when variant was out of stock' do
       before do
         stock_location.stock_movements.new.tap do |stock_movement|
@@ -74,48 +76,24 @@ describe Spree::Api::Webhooks::StockItemDecorator do
       end
 
       context 'when variant was backorderable' do
-        before do
-          stock_item.backorderable = true
-        end
+        before { stock_item.backorderable = true }
 
-        it do
-          expect do
-            Timecop.freeze do
-              stock_item.save
-            end
-          end.not_to emit_webhook_event('variant.backorderable')
-        end
+        it { expect { subject }.not_to emit_webhook_event('variant.backorderable') }
       end
 
       context 'when variant was not backorderable' do
         before { variant.stock_items.update_all(backorderable: false) }
 
         context 'when variant is not set as backorderable' do
-          before do
-            stock_item.backorderable = false
-          end
+          before { stock_item.backorderable = false }
 
-          it do
-            expect do
-              Timecop.freeze do
-                stock_item.save
-              end
-            end.not_to emit_webhook_event('variant.backorderable')
-          end
+          it { expect { subject }.not_to emit_webhook_event('variant.backorderable') }
         end
 
         context 'when variant is set as backorderable' do
-          before do
-            stock_item.backorderable = true
-          end
+          before { stock_item.backorderable = true }
 
-          it do
-            expect do
-              Timecop.freeze do
-                stock_item.save
-              end
-            end.to emit_webhook_event('variant.backorderable')
-          end
+          it { expect { subject }.to emit_webhook_event('variant.backorderable') }
         end
       end
     end
@@ -131,13 +109,7 @@ describe Spree::Api::Webhooks::StockItemDecorator do
         stock_item.backorderable = true
       end
 
-      it do
-        expect do
-          Timecop.freeze do
-            stock_item.save
-          end
-        end.not_to emit_webhook_event('variant.backorderable')
-      end
+      it { expect { subject }.not_to emit_webhook_event('variant.backorderable') }
     end
   end
 end

--- a/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/stock_movement_decorator_spec.rb
@@ -17,14 +17,12 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
     context 'when all product variants are out of stock' do
       context 'when one of the variants is back in stock' do
         subject do
-          Timecop.freeze do
-            stock_location.stock_movements.new.tap do |stock_movement|
-              stock_movement.quantity = 1
-              stock_movement.stock_item = stock_location.set_up_stock_item(variant)
-              stock_movement.save
-            end
-            product.reload
+          stock_location.stock_movements.new.tap do |stock_movement|
+            stock_movement.quantity = 1
+            stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+            stock_movement.save
           end
+          product.reload
         end
 
         it { expect { subject }.to emit_webhook_event('product.back_in_stock') }
@@ -32,14 +30,12 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
 
       context 'when none of the variants is back in stock' do
         subject do
-          Timecop.freeze do
-            stock_location.stock_movements.new.tap do |stock_movement|
-              stock_movement.quantity = 0
-              stock_movement.stock_item = stock_location.set_up_stock_item(variant)
-              stock_movement.save
-            end
-            product.reload
+          stock_location.stock_movements.new.tap do |stock_movement|
+            stock_movement.quantity = 0
+            stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+            stock_movement.save
           end
+          product.reload
         end
 
         it { expect { subject }.not_to emit_webhook_event('product.back_in_stock') }
@@ -74,13 +70,11 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
       context 'when stock item changes to be in stock' do
         it do
           expect do
-            Timecop.freeze do
-              variant.stock_items.update_all(backorderable: false)
-              stock_location.stock_movements.new.tap do |stock_movement|
-                stock_movement.quantity = 1 # does make it to be in stock
-                stock_movement.stock_item = stock_location.set_up_stock_item(variant)
-                stock_movement.save
-              end
+            variant.stock_items.update_all(backorderable: false)
+            stock_location.stock_movements.new.tap do |stock_movement|
+              stock_movement.quantity = 1 # does make it to be in stock
+              stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+              stock_movement.save
             end
           end.to emit_webhook_event('variant.back_in_stock')
         end
@@ -89,13 +83,11 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
       context 'when stock item does not change to be in stock' do
         it do
           expect do
-            Timecop.freeze do
-              variant.stock_items.update_all(backorderable: false)
-              stock_location.stock_movements.new.tap do |stock_movement|
-                stock_movement.quantity = 0 # does not make it to be in stock
-                stock_movement.stock_item = stock_location.set_up_stock_item(variant)
-                stock_movement.save
-              end
+            variant.stock_items.update_all(backorderable: false)
+            stock_location.stock_movements.new.tap do |stock_movement|
+              stock_movement.quantity = 0 # does not make it to be in stock
+              stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+              stock_movement.save
             end
           end.not_to emit_webhook_event('variant.back_in_stock')
         end
@@ -105,14 +97,12 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
     context 'when stock item was in stock' do
       it do
         expect do
-          Timecop.freeze do
-            # make in_stock? return false based on track_inventory, the easiest case
-            variant.update(track_inventory: false)
-            stock_location.stock_movements.new.tap do |stock_movement|
-              stock_movement.quantity = 2
-              stock_movement.stock_item = stock_location.set_up_stock_item(variant)
-              stock_movement.save
-            end
+          # make in_stock? return false based on track_inventory, the easiest case
+          variant.update(track_inventory: false)
+          stock_location.stock_movements.new.tap do |stock_movement|
+            stock_movement.quantity = 2
+            stock_movement.stock_item = stock_location.set_up_stock_item(variant)
+            stock_movement.save
           end
         end.not_to emit_webhook_event('variant.back_in_stock')
       end
@@ -144,9 +134,7 @@ describe Spree::Api::Webhooks::StockMovementDecorator do
     end
 
     describe 'when the variant was out of stock before the update and after the update' do
-      before do
-        stock_item.set_count_on_hand(0)
-      end
+      before { stock_item.set_count_on_hand(0) }
 
       let(:movement_quantity) { 0 }
 


### PR DESCRIPTION
Webhooks are still emitted/enqueued when touch is used with an argument other than created_at/updated_at.