### PR TITLE
Fix Taxonomy renaming the root Taxon on reposition.

### DIFF
--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -25,6 +25,8 @@ module Spree
     end
 
     def set_root_taxon_name
+      return unless saved_change_to_name?
+
       root.update(name: name)
     end
   end

--- a/core/spec/models/spree/taxonomy_spec.rb
+++ b/core/spec/models/spree/taxonomy_spec.rb
@@ -16,4 +16,36 @@ describe Spree::Taxonomy, type: :model do
       expect { Spree::Taxon.find(@child_taxon.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe '#set_root_taxon_name' do
+    before do
+      @taxonomy = create(:taxonomy, name: 'Clothing')
+    end
+
+    context 'when Taxonomy is created' do
+      it 'sets the root Taxonomy name to match' do
+        expect(@taxonomy.root.name).to eq('Clothing')
+      end
+    end
+
+    context 'when Taxonomy name is updated' do
+      it 'changes the root Taxon name to match' do
+        @taxonomy.update(name: 'Soft Goods')
+        @taxonomy.save!
+        @taxonomy.reload
+
+        expect(@taxonomy.root.name).to eq('Soft Goods')
+      end
+    end
+
+    context 'when Taxonomy position is updated' do
+      it 'does not change the root Taxon name' do
+        @taxonomy.update(position: 2)
+        @taxonomy.save!
+        @taxonomy.reload
+
+        expect(@taxonomy.root.name).to eq('Clothing')
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/taxonomy_spec.rb
+++ b/core/spec/models/spree/taxonomy_spec.rb
@@ -45,6 +45,7 @@ describe Spree::Taxonomy, type: :model do
         @taxonomy.reload
 
         expect(@taxonomy.root.name).to eq('Clothing')
+        expect(@taxonomy.position).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Fix Taxonomy renaming the root Taxon on reposition, only rename if name is is changed.