### PR TITLE
SD-1452 As a Storefront API user I can set Order MetaData when creating a Cart - clean

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -20,8 +20,8 @@ module Spree
               user: spree_current_user,
               store: current_store,
               currency: current_currency,
-              public_metadata: metadata_params[:public_metadata],
-              private_metadata: metadata_params[:private_metadata],
+              public_metadata: add_item_params[:public_metadata],
+              private_metadata: add_item_params[:private_metadata],
             }
 
             order   = spree_current_order if spree_current_order.present?
@@ -38,8 +38,8 @@ module Spree
               order: spree_current_order,
               variant: @variant,
               quantity: add_item_params[:quantity],
-              public_metadata: metadata_params[:public_metadata],
-              private_metadata: metadata_params[:private_metadata],
+              public_metadata: add_item_params[:public_metadata],
+              private_metadata: add_item_params[:private_metadata],
               options: add_item_params[:options]
             )
 
@@ -235,12 +235,8 @@ module Spree
             ).serializable_hash
           end
 
-          def metadata_params
-            params.permit(public_metadata: {}, private_metadata: {})
-          end
-
           def add_item_params
-            params.permit(:quantity, :variant_id, options: {})
+            params.permit(:quantity, :variant_id, public_metadata: {}, private_metadata: {}, options: {})
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -37,10 +37,10 @@ module Spree
             result = add_item_service.call(
               order: spree_current_order,
               variant: @variant,
-              quantity: params[:quantity],
+              quantity: add_item_params[:quantity],
               public_metadata: metadata_params[:public_metadata],
               private_metadata: metadata_params[:private_metadata],
-              options: params[:options]
+              options: add_item_params[:options]
             )
 
             render_order(result)
@@ -217,7 +217,7 @@ module Spree
           end
 
           def load_variant
-            @variant = current_store.variants.find(params[:variant_id])
+            @variant = current_store.variants.find(add_item_params[:variant_id])
           end
 
           def render_error_item_quantity
@@ -237,6 +237,10 @@ module Spree
 
           def metadata_params
             params.permit(public_metadata: {}, private_metadata: {})
+          end
+
+          def add_item_params
+            params.permit(:quantity, :variant_id, :options)
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -20,10 +20,8 @@ module Spree
               user: spree_current_user,
               store: current_store,
               currency: current_currency,
-              order_params: {
-                public_metadata: metadata_params[:public_metadata].to_h,
-                private_metadata: metadata_params[:private_metadata].to_h,
-              }
+              public_metadata: metadata_params[:public_metadata].to_h,
+              private_metadata: metadata_params[:private_metadata].to_h,
             }
 
             order   = spree_current_order if spree_current_order.present?

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -20,8 +20,8 @@ module Spree
               user: spree_current_user,
               store: current_store,
               currency: current_currency,
-              public_metadata: metadata_params[:public_metadata].to_h,
-              private_metadata: metadata_params[:private_metadata].to_h,
+              public_metadata: metadata_params[:public_metadata],
+              private_metadata: metadata_params[:private_metadata],
             }
 
             order   = spree_current_order if spree_current_order.present?

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -240,7 +240,7 @@ module Spree
           end
 
           def add_item_params
-            params.permit(:quantity, :variant_id, :options)
+            params.permit(:quantity, :variant_id, options: {})
           end
         end
       end

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -373,6 +373,24 @@ paths:
       parameters:
         - $ref: '#/components/parameters/CartIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsCart'
+      requestBody:
+        required: false
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              example:
+                public_metadata:
+                  total_weight: 3250
+                private_metadata:
+                  had_same_cart_items: true
+              properties:
+                public_metadata:
+                  type: object
+                  description: 'The public metadata for the cart.'
+                private_metadata:
+                  type: object
+                  description: 'The private metadata for the cart.'
       summary: Create a Cart
     delete:
       description: |-

--- a/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/cart_spec.rb
@@ -31,11 +31,26 @@ describe 'API V2 Storefront Cart Spec', type: :request do
     let(:params) { {} }
     let(:execute) { post '/api/v2/storefront/cart', headers: headers, params: params }
 
+    shared_examples 'sets public and private metadata' do
+      let(:params) do
+        {
+          public_metadata: { 'property1' => 'value1' },
+          private_metadata: { 'property2' => 'value2' }
+        }
+      end
+
+      it do
+        expect(order.public_metadata).to eq(params[:public_metadata])
+        expect(order.private_metadata).to eq(params[:private_metadata])
+      end
+    end
+
     shared_examples 'creates an order' do
       before { execute }
 
       it_behaves_like 'returns valid cart JSON'
       it_behaves_like 'returns 201 HTTP status'
+      it_behaves_like 'sets public and private metadata'
     end
 
     shared_examples 'creates an order with different currency' do

--- a/core/app/services/spree/cart/create.rb
+++ b/core/app/services/spree/cart/create.rb
@@ -13,8 +13,8 @@ module Spree
           user: user,
           currency: currency || store.default_currency,
           token: Spree::GenerateToken.new.call(Spree::Order),
-          public_metadata: public_metadata,
-          private_metadata: private_metadata
+          public_metadata: public_metadata.to_h,
+          private_metadata: private_metadata.to_h
         }
 
         order = store.orders.create!(default_params.merge(order_params))

--- a/core/app/services/spree/cart/create.rb
+++ b/core/app/services/spree/cart/create.rb
@@ -12,7 +12,9 @@ module Spree
         default_params = {
           user: user,
           currency: currency || store.default_currency,
-          token: Spree::GenerateToken.new.call(Spree::Order)
+          token: Spree::GenerateToken.new.call(Spree::Order),
+          public_metadata: public_metadata,
+          private_metadata: private_metadata
         }
 
         order = store.orders.create!(default_params.merge(order_params))

--- a/core/app/services/spree/cart/create.rb
+++ b/core/app/services/spree/cart/create.rb
@@ -3,7 +3,7 @@ module Spree
     class Create
       prepend Spree::ServiceModule::Base
 
-      def call(user:, store:, currency:, order_params: nil)
+      def call(user:, store:, currency:, public_metadata: {}, private_metadata: {}, order_params: {})
         order_params ||= {}
 
         # we cannot create an order without store

--- a/core/spec/services/spree/cart/create_spec.rb
+++ b/core/spec/services/spree/cart/create_spec.rb
@@ -7,10 +7,12 @@ module Spree
     let(:user) { create :user }
     let(:store) { create :store, default_currency: 'EUR' }
     let(:currency) { 'USD' }
+    let(:public_metadata) { { prop1: 2 } }
+    let(:private_metadata) { { prop2: 'val2' } }
     let(:expected) { Order.first }
 
     context 'create an order' do
-      let(:execute) { subject.call user: user, store: store, currency: currency }
+      let(:execute) { subject.call user: user, store: store, currency: currency, public_metadata: public_metadata, private_metadata: private_metadata }
       let(:value) { execute.value }
 
       it do


### PR DESCRIPTION
https://github.com/spree/spree/pull/11501 became too messy, this is a PR containing the commits necessary for the change