### PR TITLE
failure payment when connection error is raised

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -152,6 +152,7 @@ module Spree
       def protect_from_connection_error
         yield
       rescue ActiveMerchant::ConnectionError => e
+        failure!
         gateway_error(e)
       end
 


### PR DESCRIPTION
When `ActiveMerchant::ConnectionError` is raised, it should fail the payment, like here:
https://github.com/spree/spree/blob/main/core/app/models/spree/payment/processing.rb#L143-L144

Otherwise, that payment has still `processing` state, which prevents the payment from being invalidated after user tries to add new payment:
https://github.com/spree/spree/blob/main/core/app/models/spree/payment.rb#L308