### PR TITLE
Only return eligible variants

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/variants_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/variants_controller.rb
@@ -12,6 +12,10 @@ module Spree
           def spree_permitted_attributes
             super + [:option_value_ids, :price, :currency]
           end
+
+          def scope
+            super.eligible
+          end
         end
       end
     end


### PR DESCRIPTION
**Product With No Option Types:** Returns the master variant.
**Product With Option Types:** Returns all variant except the master variant.