### PR TITLE
Doorkeeper controllers now inherit from `Api::V2::BaseController`

### DIFF
--- a/api/config/initializers/doorkeeper.rb
+++ b/api/config/initializers/doorkeeper.rb
@@ -2,7 +2,8 @@ Doorkeeper.configure do
   orm :active_record
   use_refresh_token
   api_only
-  base_controller 'ActionController::API'
+  base_controller 'Spree::Api::V2::BaseController'
+  base_metal_controller 'Spree::Api::V2::BaseController'
 
   # FIXME: we should only skip this for Storefront API until v5
   # we should not skip this for Platform API

--- a/api/spec/controllers/doorkeeper/application_metal_controller_spec.rb
+++ b/api/spec/controllers/doorkeeper/application_metal_controller_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Doorkeeper::ApplicationMetalController, type: :controller do
+  it 'inherits from Spree::Api::V2::BaseController' do
+    expect(described_class.superclass).to eq Spree::Api::V2::BaseController
+  end
+end

--- a/api/spec/controllers/doorkeeper/tokens_controller_spec.rb
+++ b/api/spec/controllers/doorkeeper/tokens_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Doorkeeper::TokensController, type: :controller do
+  describe '#current_store' do
+    let!(:store) { create :store, default: true }
+
+    it 'returns current store' do
+      expect(controller.current_store).to eq(store)
+    end
+  end
+end


### PR DESCRIPTION
This allows us to call `current_store`, `current_locale` and other Spree methods