### PR TITLE
SD-1544 Do not emit webhooks on touch events

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -42,7 +42,7 @@ module Spree
       end
 
       def updating_only_timestamps?
-        saved_changes.present? && (saved_changes.keys - %w[created_at updated_at]).empty?
+        saved_changes && (saved_changes.keys - %w[created_at updated_at]).empty?
       end
 
       def disable_spree_webhooks?

--- a/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
+++ b/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
@@ -107,18 +107,21 @@ describe Spree::Webhooks::HasWebhooks do
       context 'when using touch with an argument other than created_at/updated_at' do
         it do
           expect do
-            product.touch(:deleted_at)
+            product.touch(:available_on)
           end.to emit_webhook_event(event_name)
         end
       end
+    end
 
-      context 'on touch events from callbacks' do
-        let(:cms_page) { create(:cms_homepage, store: store, locale: 'en') }
-        let(:body) { Spree::Api::V2::Platform::StoreSerializer.new(store).serializable_hash }
+    context 'on touch events from callbacks' do
+      let!(:store2) { create(:store) }
+      let!(:cms_page) { create(:cms_homepage, store: store2, locale: 'en') }
+      let(:body) { Spree::Api::V2::Platform::StoreSerializer.new(store2).serializable_hash }
 
-        it 'does not emit the touched model\'s update event' do
-          expect { cms_page.update(title: 'Homepage #1') }.not_to emit_webhook_event('store.update')
-        end
+      before { store2.changes_applied }
+
+      it 'does not emit the touched model\'s update event' do
+        expect { cms_page.update(title: 'Homepage #1') }.not_to emit_webhook_event('store.update')
       end
     end
   end

--- a/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
+++ b/api/spec/models/concerns/spree/webhooks/has_webhooks_spec.rb
@@ -111,6 +111,15 @@ describe Spree::Webhooks::HasWebhooks do
           end.to emit_webhook_event(event_name)
         end
       end
+
+      context 'on touch events from callbacks' do
+        let(:cms_page) { create(:cms_homepage, store: store, locale: 'en') }
+        let(:body) { Spree::Api::V2::Platform::StoreSerializer.new(store).serializable_hash }
+
+        it 'does not emit the touched model\'s update event' do
+          expect { cms_page.update(title: 'Homepage #1') }.not_to emit_webhook_event('store.update')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
@sebastian-palma You were getting a false positive and we still get a false positive. Tested manually, works fine now. There is some issue with ENV['DISABLE_SPREE_WEBHOOKS'] in the specs. Even when I set it to nil it is somehow set to 'true' when it gets to #queue_webhooks_requests!.