### PR TITLE
Removing Variant#track_inventory

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -285,10 +285,6 @@ module Spree
       track_inventory? && Spree::Config.track_inventory_levels
     end
 
-    def track_inventory
-      should_track_inventory?
-    end
-
     def volume
       (width || 0) * (height || 0) * (depth || 0)
     end


### PR DESCRIPTION
This method overshadows the `track_inventory` attribute and causes an infinite loop in Rails 7. Both of these reasons are good enough to remove it.

ref #11488 