### PR TITLE
Move auto-loading of Webhooks module to models itself

### DIFF
--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -26,20 +26,6 @@ module Spree
       end
 
       def self.activate
-        [
-          Spree::Address, Spree::Asset, Spree::CmsPage, Spree::CreditCard, Spree::CustomerReturn,
-          Spree::DigitalLink, Spree::Digital, Spree::InventoryUnit, Spree::LineItem, Spree::MenuItem,
-          Spree::Menu, Spree::OptionType, Spree::OptionValue, Spree::Order, Spree::PaymentCaptureEvent,
-          Spree::Payment, Spree::Price, Spree::Product, Spree::Promotion, Spree::Property, Spree::Prototype,
-          Spree::Refund, Spree::Reimbursement, Spree::ReturnAuthorization, Spree::ReturnItem, Spree::Role,
-          Spree::Shipment, Spree::ShippingCategory, Spree::ShippingMethod, Spree::ShippingRate,
-          Spree::StockItem, Spree::StockLocation, Spree::StockMovement, Spree::StockTransfer,
-          Spree::StoreCredit, Spree::Store, Spree::TaxCategory, Spree::TaxRate, Spree::Taxonomy,
-          Spree::Taxon, Spree::Variant, Spree::WishedItem, Spree::Wishlist, Spree::Zone
-        ].each do |webhookable_class|
-          webhookable_class.include(Spree::Webhooks::HasWebhooks)
-        end
-
         Dir.glob(File.join(File.dirname(__FILE__), '../../../app/models/spree/api/webhooks/*_decorator*.rb')) do |c|
           Rails.application.config.cache_classes ? require(c) : load(c)
         end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -4,6 +4,10 @@ module Spree
 
     include Metadata
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     if Rails::VERSION::STRING >= '6.1'
       serialize :preferences, Hash, default: {}
     end

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -2,6 +2,9 @@ module Spree
   class Asset < Spree::Base
     include Support::ActiveStorage
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     belongs_to :viewable, polymorphic: true, touch: true
     acts_as_list scope: [:viewable_id, :viewable_type]

--- a/core/app/models/spree/cms_page.rb
+++ b/core/app/models/spree/cms_page.rb
@@ -3,6 +3,10 @@ module Spree
     include SingleStoreResource
     include DisplayLink
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     acts_as_paranoid
 
     TYPES = ['Spree::Cms::Pages::StandardPage',

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -2,6 +2,9 @@ module Spree
   class CreditCard < Spree::Base
     include ActiveMerchant::Billing::CreditCardMethods
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     acts_as_paranoid
 
@@ -174,9 +177,9 @@ module Spree
 
     def self.json_api_permitted_attributes
       [
-        'number', 'month', 'year', 'expiry', 'verification_value', 'first_name', 'last_name', 
-        'cc_type', 'gateway_customer_profile_id', 'gateway_payment_profile_id', 'last_digits', 
-        'name', 'encrypted_data', 'address_id', 'created_at', 'updated_at', 'user_id', 
+        'number', 'month', 'year', 'expiry', 'verification_value', 'first_name', 'last_name',
+        'cc_type', 'gateway_customer_profile_id', 'gateway_payment_profile_id', 'last_digits',
+        'name', 'encrypted_data', 'address_id', 'created_at', 'updated_at', 'user_id',
         'payment_method_id', 'default', 'deleted_at'
       ]
     end

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -3,6 +3,9 @@ module Spree
     include Spree::Core::NumberGenerator.new(prefix: 'CR', length: 9)
     include NumberIdentifier
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     belongs_to :stock_location
     belongs_to :store, class_name: 'Spree::Store', inverse_of: :customer_returns

--- a/core/app/models/spree/digital.rb
+++ b/core/app/models/spree/digital.rb
@@ -3,6 +3,10 @@ module Spree
     belongs_to :variant
     has_many :digital_links, dependent: :destroy
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     if Spree.private_storage_service_name
       has_one_attached :attachment, service: Spree.private_storage_service_name
     else

--- a/core/app/models/spree/digital_link.rb
+++ b/core/app/models/spree/digital_link.rb
@@ -2,6 +2,10 @@ module Spree
   class DigitalLink < Spree::Base
     has_secure_token
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     belongs_to :digital
     belongs_to :line_item
 

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -1,5 +1,9 @@
 module Spree
   class InventoryUnit < Spree::Base
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     with_options inverse_of: :inventory_units do
       belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
       belongs_to :order, class_name: 'Spree::Order'

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -1,6 +1,9 @@
 module Spree
   class LineItem < Spree::Base
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     before_validation :ensure_valid_quantity
 

--- a/core/app/models/spree/menu.rb
+++ b/core/app/models/spree/menu.rb
@@ -1,6 +1,9 @@
 module Spree
   class Menu < Spree::Base
     include SingleStoreResource
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     MENU_LOCATIONS = ['Header', 'Footer']
     MENU_LOCATIONS_PARAMETERIZED = []

--- a/core/app/models/spree/menu_item.rb
+++ b/core/app/models/spree/menu_item.rb
@@ -1,6 +1,9 @@
 module Spree
   class MenuItem < Spree::Base
     include Spree::DisplayLink
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     acts_as_nested_set dependent: :destroy
 

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -2,6 +2,9 @@ module Spree
   class OptionType < Spree::Base
     include UniqueName
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     acts_as_list
 

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -1,6 +1,9 @@
 module Spree
   class OptionValue < Spree::Base
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     belongs_to :option_type, class_name: 'Spree::OptionType', touch: true, inverse_of: :option_values
     acts_as_list scope: :option_type

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -25,6 +25,9 @@ module Spree
     include SingleStoreResource
     include MemoizedData
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     MEMOIZED_METHODS = %w(tax_zone)
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -6,6 +6,9 @@ module Spree
     include NumberIdentifier
     include NumberAsParam
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     include Spree::Payment::Processing
 

--- a/core/app/models/spree/payment_capture_event.rb
+++ b/core/app/models/spree/payment_capture_event.rb
@@ -1,5 +1,9 @@
 module Spree
   class PaymentCaptureEvent < Spree::Base
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     belongs_to :payment, class_name: 'Spree::Payment'
 
     def display_amount

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,6 +1,9 @@
 module Spree
   class Price < Spree::Base
     include VatPriceCalculation
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     acts_as_paranoid
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -25,6 +25,9 @@ module Spree
     include MultiStoreResource
     include MemoizedData
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     MEMOIZED_METHODS = %w(total_on_hand taxonomy_ids taxon_and_ancestors category
                           default_variant_id tax_category default_variant
@@ -327,7 +330,7 @@ module Spree
     def any_variant_in_stock_or_backorderable?
       if variants.any?
         variants_including_master.in_stock_or_backorderable.exists?
-      else 
+      else
         master.in_stock_or_backorderable?
       end
     end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -2,6 +2,9 @@ module Spree
   class Promotion < Spree::Base
     include MultiStoreResource
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     MATCH_POLICIES = %w(all any)
     UNACTIVATABLE_ORDER_STATES = ['complete', 'awaiting_return', 'returned']

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -2,6 +2,9 @@ module Spree
   class Property < Spree::Base
     include Spree::FilterParam
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     auto_strip_attributes :name, :presentation
 

--- a/core/app/models/spree/prototype.rb
+++ b/core/app/models/spree/prototype.rb
@@ -1,6 +1,9 @@
 module Spree
   class Prototype < Spree::Base
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     has_many :property_prototypes, class_name: 'Spree::PropertyPrototype'
     has_many :properties, through: :property_prototypes, class_name: 'Spree::Property'

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -1,6 +1,9 @@
 module Spree
   class Refund < Spree::Base
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     with_options inverse_of: :refunds do
       belongs_to :payment

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -2,6 +2,9 @@ module Spree
   class Reimbursement < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'RI', length: 9)
     include NumberIdentifier
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     class IncompleteReimbursementError < StandardError; end
 

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -2,6 +2,9 @@ module Spree
   class ReturnAuthorization < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'RA', length: 9)
     include NumberIdentifier
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations
 

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -2,6 +2,10 @@ module Spree
   class ReturnItem < Spree::Base
     COMPLETED_RECEPTION_STATUSES = %w(received given_to_customer)
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     class_attribute :return_eligibility_validator
     self.return_eligibility_validator = ReturnItem::EligibilityValidator::Default
 

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -1,6 +1,9 @@
 module Spree
   class Role < Spree::Base
     include UniqueName
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     has_many :role_users, class_name: 'Spree::RoleUser', dependent: :destroy
     has_many :users, through: :role_users, class_name: Spree.user_class.to_s

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -6,6 +6,9 @@ module Spree
     include NumberIdentifier
     include NumberAsParam
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'

--- a/core/app/models/spree/shipping_category.rb
+++ b/core/app/models/spree/shipping_category.rb
@@ -1,6 +1,9 @@
 module Spree
   class ShippingCategory < Spree::Base
     include UniqueName
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     with_options inverse_of: :shipping_category do
       has_many :products

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -3,6 +3,9 @@ module Spree
     acts_as_paranoid
     include Spree::CalculatedAdjustments
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     DISPLAY = [:both, :front_end, :back_end]
 

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -2,6 +2,10 @@ module Spree
   class StockItem < Spree::Base
     acts_as_paranoid
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     with_options inverse_of: :stock_items do
       belongs_to :stock_location, class_name: 'Spree::StockLocation'
       belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -1,6 +1,9 @@
 module Spree
   class StockLocation < Spree::Base
     include UniqueName
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     has_many :shipments
     has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -5,6 +5,10 @@ module Spree
       min: -2**31
     }.freeze
 
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     belongs_to :stock_item, class_name: 'Spree::StockItem', inverse_of: :stock_movements
     belongs_to :originator, polymorphic: true
 

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -4,6 +4,9 @@ module Spree
     include NumberIdentifier
     include NumberAsParam
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     has_many :stock_movements, as: :originator
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,5 +1,9 @@
 module Spree
   class Store < Spree::Base
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     typed_store :settings, coder: ActiveRecord::TypedStore::IdentityCoder do |s|
       # Spree Digital Asset Configurations
       s.boolean :limit_digital_download_count, default: true, null: false

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -2,6 +2,9 @@ module Spree
   class StoreCredit < Spree::Base
     include SingleStoreResource
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     acts_as_paranoid
 

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,5 +1,9 @@
 module Spree
   class TaxCategory < Spree::Base
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     acts_as_paranoid
     validates :name, presence: true, uniqueness: { case_sensitive: false, scope: spree_base_uniqueness_scope.push(:deleted_at) }
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -4,6 +4,9 @@ module Spree
 
     include Spree::CalculatedAdjustments
     include Spree::AdjustmentSource
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     with_options inverse_of: :tax_rates do
       belongs_to :zone, class_name: 'Spree::Zone', optional: true

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -4,6 +4,9 @@ require 'stringex'
 module Spree
   class Taxon < Spree::Base
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     extend FriendlyId
     friendly_id :permalink, slug_column: :permalink, use: :history

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -1,6 +1,9 @@
 module Spree
   class Taxonomy < Spree::Base
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     acts_as_list
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -5,6 +5,9 @@ module Spree
 
     include MemoizedData
     include Metadata
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     MEMOIZED_METHODS = %w(purchasable in_stock backorderable tax_category options_text compare_at_price)
 

--- a/core/app/models/spree/wished_item.rb
+++ b/core/app/models/spree/wished_item.rb
@@ -1,5 +1,9 @@
 module Spree
   class WishedItem < Spree::Base
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
+
     extend DisplayMoney
     money_methods :total, :price
 

--- a/core/app/models/spree/wishlist.rb
+++ b/core/app/models/spree/wishlist.rb
@@ -1,6 +1,9 @@
 module Spree
   class Wishlist < Spree::Base
     include SingleStoreResource
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     has_secure_token
 

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -1,6 +1,9 @@
 module Spree
   class Zone < Spree::Base
     include UniqueName
+    if defined?(Spree::Webhooks)
+      include Spree::Webhooks::HasWebhooks
+    end
 
     with_options dependent: :destroy, inverse_of: :zone do
       has_many :zone_members, class_name: 'Spree::ZoneMember'


### PR DESCRIPTION
Auto-loading these models in engine activate method can lead to strange side effects
in developer applications prepending these specific models and adding some DB-oriented logic
such as AR encryption