### PR TITLE
Add Spree Security placeholders

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -3,9 +3,11 @@ module Spree
     require 'validates_zipcode'
 
     include Metadata
-
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
+    end
+    if defined?(Spree::Security::Addresses)
+      include Spree::Security::Addresses
     end
 
     if Rails::VERSION::STRING >= '6.1'

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -5,6 +5,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::CreditCards)
+      include Spree::Security::CreditCards
+    end
 
     acts_as_paranoid
 

--- a/core/app/models/spree/digital_link.rb
+++ b/core/app/models/spree/digital_link.rb
@@ -5,6 +5,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::DigitalLinks)
+      include Spree::Security::DigitalLinks
+    end
 
     belongs_to :digital
     belongs_to :line_item

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -1,5 +1,9 @@
 module Spree
   class LogEntry < Spree::Base
+    if defined?(Spree::Security::LogEntries)
+      include Spree::Security::LogEntries
+    end
+
     belongs_to :source, polymorphic: true
 
     # Fix for #1767

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -28,6 +28,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::Orders)
+      include Spree::Security::Orders
+    end
 
     MEMOIZED_METHODS = %w(tax_zone)
 

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -3,4 +3,8 @@ class Spree::Preference < Spree::Base
 
   validates :key, presence: true,
                   uniqueness: { case_sensitive: false, allow_blank: true, scope: spree_base_uniqueness_scope }
+
+  if defined?(Spree::Security::Preferences)
+    include Spree::Security::Preferences
+  end
 end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -5,6 +5,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::Promotions)
+      include Spree::Security::Promotions
+    end
 
     MATCH_POLICIES = %w(all any)
     UNACTIVATABLE_ORDER_STATES = ['complete', 'awaiting_return', 'returned']

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -4,6 +4,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::Refunds)
+      include Spree::Security::Refunds
+    end
 
     with_options inverse_of: :refunds do
       belongs_to :payment

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -9,6 +9,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::Shipments)
+      include Spree::Security::Shipments
+    end
 
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -4,6 +4,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::StockLocations)
+      include Spree::Security::StockLocations
+    end
 
     has_many :shipments
     has_many :stock_items, dependent: :delete_all, inverse_of: :stock_location

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -3,6 +3,9 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
+    if defined?(Spree::Security::Stores)
+      include Spree::Security::Stores
+    end
 
     typed_store :settings, coder: ActiveRecord::TypedStore::IdentityCoder do |s|
       # Spree Digital Asset Configurations


### PR DESCRIPTION
This can be extended by developers to add additional level of security or encryption to their apps.