### PR TITLE
Fixes ActionView::Template::Error (undefined method `_reflect_on_association' for Spree::Calculator:Class)

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -2,7 +2,7 @@ module Spree
   class Calculator < Spree::Base
     acts_as_paranoid
 
-    belongs_to :calculable, polymorphic: true, optional: true
+    belongs_to :calculable, polymorphic: true, optional: true, inverse_of: :calculator
 
     # This method calls a compute_<computable> method. must be overridden in concrete calculator.
     #


### PR DESCRIPTION
The problem happens in development environment when source code is automatically reloaded after a change in source code. Development server needs to be restarted manually.
No need to restart the development server after a change in code when inverse_of is present.