### PR TITLE
Introduce `committee` OpenAPI response validation based on `docs/v2/storefront/index.yaml`

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -36,6 +36,7 @@ group :test do
   gem 'capybara', '~> 3.24'
   gem 'capybara-screenshot', '~> 1.0'
   gem 'capybara-select-2'
+  gem 'committee'
   gem 'database_cleaner-active_record'
   gem 'email_spec'
   gem 'factory_bot_rails', '~> 6.0'

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -39,4 +39,13 @@ Dummy::Application.configure do
   config.cache_store = :redis_cache_store
 
   routes.default_url_options = { host: 'localhost', port: 3000 }
+
+  # Validation based on Storefront API OpenAPI document
+  config.middleware.use(
+    Committee::Middleware::ResponseValidation,
+    parse_response_by_content_type: false,
+    query_hash_key: 'rack.request.query_hash',
+    raise: true,
+    schema_path: Rails.root.join('../../../api/docs/v2/storefront/index.yaml')
+  )
 end

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -41,11 +41,13 @@ Dummy::Application.configure do
   routes.default_url_options = { host: 'localhost', port: 3000 }
 
   # Validation based on Storefront API OpenAPI document
-  config.middleware.use(
-    Committee::Middleware::ResponseValidation,
-    parse_response_by_content_type: false,
-    query_hash_key: 'rack.request.query_hash',
-    raise: true,
-    schema_path: Rails.root.join('../../../api/docs/v2/storefront/index.yaml')
-  )
+  if defined?(Spree::Api)
+    config.middleware.use(
+      Committee::Middleware::ResponseValidation,
+      parse_response_by_content_type: false,
+      query_hash_key: 'rack.request.query_hash',
+      raise: true,
+      schema_path: Rails.root.join('../../../api/docs/v2/storefront/index.yaml')
+    )
+  end
 end


### PR DESCRIPTION
WIP 🚧 


If the response of the request specification does not match the OpenAPI document, an exception will be thrown.

This test is limited, as it does nothing if there is no OpenAPI documentation for the endpoint,
this is very useful because false alerts rarely occur.

