### PR TITLE
Fix test: Add `:sv` to expected_locales

### DIFF
--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -28,8 +28,7 @@ describe 'i18n' do
 
       it 'returns all locales from the SpreeI18n' do
         locales = Spree.available_locales
-        expected_locales = [:en, :de, :nl, :ar, :az, :bg, :ca, :cs, :da, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :"pt-BR", :ro, :ru, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
-        expected_locales << :sv if Rails::VERSION::STRING >= '7.0'
+        expected_locales = [:en, :de, :nl, :ar, :az, :bg, :ca, :cs, :da, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :"pt-BR", :ro, :ru, :sk, :sv, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
         expect(locales).to match_array(expected_locales)
       end
@@ -45,8 +44,7 @@ describe 'i18n' do
       it 'returns just default locales' do
         locales = Spree.available_locales
 
-        expected_locales = [:en, :ar, :az, :bg, :ca, :cs, :da, :de, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :nl, :"pt-BR", :ro, :ru, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
-        expected_locales << :sv if Rails::VERSION::STRING >= '7.0'
+        expected_locales = [:en, :ar, :az, :bg, :ca, :cs, :da, :de, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :nl, :"pt-BR", :ro, :ru, :sv, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
         expect(locales).to match_array(expected_locales)
       end


### PR DESCRIPTION
follow up https://github.com/spree/spree/commit/2a031cc85c0df4e5ed88ca4e1ce53b526c93b86b

Now main branch CI `
ci/circleci: tests_postgres_rails_6_1` fails.

( ex: https://app.circleci.com/pipelines/github/spree/spree/5641/workflows/3fe2410e-fe18-4eca-9a55-edf7f945c631/jobs/49346)

Maybe there are no need to conditional branch because of rails-i18n 7.0 released.
