### PR TITLE
VEN-244 Make product in stock when creating line item (via Factory)

### DIFF
--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -6,9 +6,9 @@ FactoryBot.define do
     currency { order.currency }
     product do
       if order&.store&.present?
-        create(:product, stores: [order.store])
+        create(:product_in_stock, stores: [order.store])
       else
-        create(:product)
+        create(:product_in_stock)
       end
     end
     variant { product.master }


### PR DESCRIPTION
Not sure why we would have creating line items with products out of stock by default. It messes with some factories such as `:shipped_order`