### PR TITLE
Fix created_at null error running CreateSpreeProductsStores migration

### DIFF
--- a/core/db/migrate/20210527094055_create_spree_products_stores.rb
+++ b/core/db/migrate/20210527094055_create_spree_products_stores.rb
@@ -11,7 +11,7 @@ class CreateSpreeProductsStores < ActiveRecord::Migration[5.2]
       create_table :spree_products_stores do |t|
         t.references :product, index: true
         t.references :store,  index: true
-        t.timestamps
+        t.timestamps default: Time.current
 
         t.index [:product_id, :store_id], unique: true
       end


### PR DESCRIPTION
### Summary

In #11363 there was an attempt to fix this issue. At that time the fix only covered the case in which the `created_at` column already existed,but it did not add a default value for timestamps in the `create_table` block so that it is taken into account when the table does not exist at all. This patch provides a default value also in that case.