### PR TITLE
Bug fix: update sample to accomodate changes in years

### DIFF
--- a/sample/db/samples/menu_items.rb
+++ b/sample/db/samples/menu_items.rb
@@ -207,7 +207,7 @@ MENUS.each do |menu|
     promos = []
   end
 
-  summer = Spree::Taxon.find_by!(permalink: 'categories/new-collection/summer-2021')
+  summer = Spree::Taxon.find_by!(permalink: "categories/new-collection/summer-#{Date.today.year}")
   offers = Spree::Taxon.find_by!(permalink: 'categories/special-offers/30-percent-off')
 
   #####################

--- a/sample/db/samples/taxons.rb
+++ b/sample/db/samples/taxons.rb
@@ -4,7 +4,7 @@ Spree::Sample.load_sample('taxonomies')
 
 ADDITIONAL_TAXONS = ['Bestsellers', 'Trending', 'Streetstyle', 'Summer Sale'].freeze
 
-SPECIAL_TAXONS = { 'New Collection': 'Summer 2021', 'Special Offers': '30% Off' }.freeze
+SPECIAL_TAXONS = { 'New Collection': "Summer #{Date.today.year}", 'Special Offers': '30% Off' }.freeze
 
 CHILDREN_TAXON_NAMES = CSV.read(File.join(__dir__, 'variants.csv')).map do |(parent_name, taxon_name, _product_name, _color_name)|
   [parent_name, taxon_name]


### PR DESCRIPTION
When a user runs:
`docker-compose run web rake spree_sample:load`
they get the following error:
```
Loaded Cms Homepages samples
rake aborted!
ActiveRecord::RecordNotFound: Couldn't find Spree::Taxon
/bundle/ruby/3.0.0/gems/activerecord-6.1.4.1/lib/active_record/core.rb:384:in `find_by!'
/bundle/ruby/3.0.0/gems/spree_sample-4.4.0.rc1/db/samples/cms_sections.rb:30:in `block in <main>'
/bundle/ruby/3.0.0/gems/spree_sample-4.4.0.rc1/db/samples/cms_sections.rb:10:in `each'
/bundle/ruby/3.0.0/gems/spree_sample-4.4.0.rc1/db/samples/cms_sections.rb:10:in `<main>'
```
## Cause of error
When the "Summer 2021" taxon is saved, it is saved with the hardcoded year, *2021*.
https://github.com/spree/spree/blob/95c092e303ec66a5a212226475dd63a05ccc9e83/sample/db/samples/taxons.rb#L7
However, when its queried, its referenced either by the hardcoded year or a dynamic year.
https://github.com/spree/spree/blob/95c092e303ec66a5a212226475dd63a05ccc9e83/sample/db/samples/menu_items.rb#L210
https://github.com/spree/spree/blob/95c092e303ec66a5a212226475dd63a05ccc9e83/sample/db/samples/cms_sections.rb#L30
## Possible solution
Use string interpolation in all cases so that the year is updated dynamically. This has the benefit of avoiding to update the dates every new year.