### PR TITLE
VEN-291 Fix duplicated English (US) locales for #all_locales_options

### DIFF
--- a/core/app/helpers/spree/locale_helper.rb
+++ b/core/app/helpers/spree/locale_helper.rb
@@ -15,7 +15,7 @@ module Spree
     end
 
     def locale_presentation(locale)
-      if I18n.exists?('spree.i18n.this_file_language', locale: locale)
+      if I18n.exists?('spree.i18n.this_file_language', locale: locale, fallback: false)
         [locale_full_name(locale), locale.to_s]
       else
         locale.to_s == 'en' ? ['English (US)', 'en'] : [locale, locale.to_s]

--- a/core/spec/helpers/locale_helper_spec.rb
+++ b/core/spec/helpers/locale_helper_spec.rb
@@ -42,6 +42,10 @@ describe Spree::LocaleHelper, type: :helper do
 
   describe '#locale_presentation' do
     it { expect(locale_presentation(:fr)).to eq( ['Français (FR)', 'fr']) }
+
+    it 'returns the locale when no translation exists' do
+      expect(locale_presentation(:klingon)).to eq([:klingon, 'klingon'])
+    end
   end
 
   describe '#should_render_locale_dropdown?' do


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-291 - Duplicate locales in Store edit form

The problem was that `I18n.exists?('spree.i18n.this_file_language', locale: locale)` in https://github.com/spree/spree/blob/main/core/app/helpers/spree/locale_helper.rb would return true for any value for locale, because it would fallback to `:en` and there this key exists. Further on `Spree.t('i18n.this_file_language', locale: locale)` would also fallback and translate to "English (US)"

They changed the behaviour of the I18n.exists? method at some point to fallback (previously it did not): https://github.com/ruby-i18n/i18n/issues/365
The PR making possible to disable fallbacks: https://github.com/ruby-i18n/i18n/pull/482