### PR TITLE
Give the fetch current store endpoint a title

### DIFF
--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -1251,10 +1251,11 @@ paths:
       summary: Retrieve a Product
   /api/v2/storefront/store:
     get:
+      summary: Return the current Store
       description: 'Returns the current Store. [Read more about Stores](https://dev-docs.spreecommerce.org/internals/stores)'
       tags:
         - Stores
-      operationId: show-store
+      operationId: show-current-store
       parameters:
         - $ref: '#/components/parameters/StoreIncludeParam'
         - $ref: '#/components/parameters/SparseFieldsStore'


### PR DESCRIPTION
https://api.spreecommerce.org/docs/api-v2/b3A6MzQ5MTU4MDE-show-store

Left out a title for the endpoint. Also giving it a more descriptive `operationId`