### PR TITLE
[VEN-105] Product states - pre-Orders support - drop available_on log…

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/orders_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/orders_controller.rb
@@ -100,7 +100,7 @@ module Spree
           end
 
           def allowed_sort_attributes
-            super.push(:available_on, :total, :payment_total, :item_total, :shipment_total,
+            super.push(:available_on, :make_active_at, :total, :payment_total, :item_total, :shipment_total,
                        :adjustment_total, :promo_total, :included_tax_total, :additional_tax_total,
                        :item_count, :tax_total, :completed_at)
           end

--- a/api/app/controllers/spree/api/v2/platform/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/products_controller.rb
@@ -16,7 +16,7 @@ module Spree
           end
 
           def allowed_sort_attributes
-            super << :available_on
+            super.push(:available_on, :make_active_at)
           end
 
           def sorted_collection

--- a/api/spec/requests/spree/api/v2/platform/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/products_spec.rb
@@ -196,6 +196,32 @@ describe 'API V2 Platform Products Spec' do
           end
         end
       end
+
+      context 'sorting by make_active_at' do
+        before { store.products.each_with_index { |p, i| p.update(make_active_at: Time.current - i.days) } }
+
+        context 'ascending order' do
+          before { get '/api/v2/platform/products?sort=make_active_at', headers: bearer_token }
+
+          it_behaves_like 'returns 200 HTTP status'
+
+          it 'returns products sorted by make_active_at' do
+            expect(json_response['data'].count).to      eq store.products.count
+            expect(json_response['data'].pluck(:id)).to eq store.products.order(:make_active_at).map(&:id).map(&:to_s)
+          end
+        end
+
+        context 'descending order' do
+          before { get '/api/v2/platform/products?sort=-make_active_at', headers: bearer_token }
+
+          it_behaves_like 'returns 200 HTTP status'
+
+          it 'returns products sorted by make_active_at with descending order' do
+            expect(json_response['data'].count).to      eq store.products.count
+            expect(json_response['data'].pluck(:id)).to eq store.products.order(make_active_at: :desc).map(&:id).map(&:to_s)
+          end
+        end
+      end
     end
 
     context 'paginate products' do

--- a/api/spec/serializers/spree/api/v2/platform/product_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/product_serializer_spec.rb
@@ -26,6 +26,7 @@ describe Spree::Api::V2::Platform::ProductSerializer do
           name: product.name,
           description: product.description,
           available_on: product.available_on,
+          make_active_at: product.make_active_at,
           status: product.status,
           deleted_at: product.deleted_at,
           slug: product.slug,

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -76,15 +76,20 @@ module Spree
 
     # will return a human readable string
     def available_status(product)
-      return Spree.t(:discontinued) if product.discontinued?
+      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        `Spree::ProductsHelper#available_status` method from spree/core is deprecated and will be removed.
+        Please use `Spree::Admin::ProductsHelper#available_status` from spree_backend instead.
+      DEPRECATION
+
+      return Spree.t(:archived) if product.discontinued?
       return Spree.t(:deleted) if product.deleted?
 
       if product.available?
-        Spree.t(:available)
-      elsif product.available_on&.future?
+        Spree.t(:active)
+      elsif product.make_active_at&.future?
         Spree.t(:pending_sale)
       else
-        Spree.t(:no_available_date_set)
+        Spree.t(:draft)
       end
     end
 

--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -284,7 +284,7 @@ module Spree
         if user.try(:has_spree_role?, 'admin')
           with_deleted
         else
-          not_deleted.not_discontinued.where("#{Product.quoted_table_name}.available_on <= ?", Time.current)
+          not_deleted.where(status: 'active')
         end
       end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -124,7 +124,7 @@ module Spree
     end
 
     validates :slug, presence: true, uniqueness: { allow_blank: true, case_sensitive: true, scope: spree_base_uniqueness_scope }
-    validate :discontinue_on_must_be_later_than_available_on, if: -> { available_on && discontinue_on }
+    validate :discontinue_on_must_be_later_than_make_active_at, if: -> { make_active_at && discontinue_on }
 
     scope :for_store, ->(store) { joins(:store_products).where(StoreProduct.table_name => { store_id: store.id }) }
 
@@ -497,8 +497,8 @@ module Spree
       removed_classifications.each &:remove_from_list
     end
 
-    def discontinue_on_must_be_later_than_available_on
-      if discontinue_on < available_on
+    def discontinue_on_must_be_later_than_make_active_at
+      if discontinue_on < make_active_at
         errors.add(:discontinue_on, :invalid_date_range)
       end
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -14,7 +14,7 @@ module Spree
     belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product', inverse_of: :variants
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
-    delegate :name, :name=, :description, :slug, :available_on, :shipping_category_id,
+    delegate :name, :name=, :description, :slug, :available_on, :make_active_at, :shipping_category_id,
              :meta_description, :meta_keywords, :shipping_category, to: :product
 
     # we need to have this callback before any dependent: :destroy associations

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
         name: Name
       spree/product:
         available_on: Available On
+        make_active_at: Make Active At
         discontinue_on: Discontinue On
         cost_currency: Cost Currency
         cost_price: Cost Price
@@ -583,6 +584,7 @@ en:
     auto_capture: Auto Capture
     availability: availability
     available_on: Available On
+    make_active_at: Make Active At
     available: Available
     average_order_value: Average Order Value
     avs_response: AVS Response

--- a/core/db/migrate/20220117100333_add_make_active_at_to_spree_products.rb
+++ b/core/db/migrate/20220117100333_add_make_active_at_to_spree_products.rb
@@ -1,0 +1,17 @@
+class AddMakeActiveAtToSpreeProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_products, :make_active_at, :datetime
+    add_index :spree_products, :make_active_at
+
+    Spree::Product.
+      where('discontinue_on IS NULL or discontinue_on > ?', Time.current).
+      where('available_on <= ?', Time.current).
+      where(status: 'draft').
+      update_all(status: 'active', updated_at: Time.current)
+
+    Spree::Product.
+      where('discontinue_on <= ?', Time.current).
+      where.not(status: 'archived').
+      update_all(status: 'archived', updated_at: Time.current)
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -89,7 +89,7 @@ module Spree
     @@product_properties_attributes = [:property_name, :value, :position]
 
     @@product_attributes = [
-      :name, :description, :available_on, :discontinue_on, :permalink, :meta_description,
+      :name, :description, :available_on, :make_active_at, :discontinue_on, :permalink, :meta_description,
       :meta_keywords, :price, :sku, :deleted_at, :prototype_id,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     cost_price        { 17.00 }
     sku               { generate(:sku) }
     available_on      { 1.year.ago }
+    make_active_at    { 1.year.ago }
     deleted_at        { nil }
     shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
     status            { 'active' }

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -187,9 +187,9 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
 end
 
 namespace :core do
-  desc 'Set "active" status on draft products where available_on is in the past'
+  desc 'Set "active" status on draft products where make_active_at is in the past'
   task activate_products: :environment do |_t, _args|
-    Spree::Product.where('available_on <= ?', Time.current).where(status: 'draft').update_all(status: 'active', updated_at: Time.current)
+    Spree::Product.where('make_active_at <= ?', Time.current).where(status: 'draft').update_all(status: 'active', updated_at: Time.current)
   end
 
   desc 'Set "archived" status on active products where discontinue_on is in the past'

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -507,7 +507,7 @@ module Spree
           params: params
         ).execute.map(&:id)
 
-        expect(product_ids).to eq Spree::Product.available.order(available_on: :desc).map(&:id)
+        expect(product_ids).to eq Spree::Product.available.order(make_active_at: :desc).map(&:id)
       end
 
       it 'returns products in price-high-to-low order' do

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -294,7 +294,7 @@ module Spree
 
       context 'product is available' do
         it 'has available status' do
-          expect(status).to eq(Spree.t(:available))
+          expect(status).to eq(Spree.t(:active))
         end
       end
 
@@ -314,18 +314,28 @@ module Spree
         end
 
         it 'has discontinued status' do
-          expect(status).to eq(Spree.t(:discontinued))
+          expect(status).to eq(Spree.t(:archived))
         end
       end
 
       context 'product will be available soon' do
         before do
           product.status = 'draft'
-          product.available_on = 1.month.from_now
+          product.make_active_at = 1.month.from_now
         end
 
         it 'has pending sale status' do
           expect(status).to eq(Spree.t(:pending_sale))
+        end
+      end
+
+      context 'draft product' do
+        before do
+          product.status = 'draft'
+        end
+
+        it 'has draft status' do
+          expect(status).to eq(Spree.t(:draft))
         end
       end
     end

--- a/core/spec/lib/tasks/core_spec.rb
+++ b/core/spec/lib/tasks/core_spec.rb
@@ -9,26 +9,26 @@ describe 'core:activate_products' do
     it { expect(subject.prerequisites).to include('environment') }
   end
 
-  it 'draft, available_on in the past -> active' do
-    product.update(status: 'draft', available_on: 1.day.ago)
+  it 'draft, make_active_at in the past -> active' do
+    product.update(status: 'draft', make_active_at: 1.day.ago)
     subject.invoke
     expect(product.reload.status).to eq('active')
   end
 
-  it 'draft, available_on in the future -> draft' do
-    product.update(status: 'draft', available_on: 1.day.from_now)
+  it 'draft, make_active_at in the future -> draft' do
+    product.update(status: 'draft', make_active_at: 1.day.from_now)
     subject.invoke
     expect(product.reload.status).to eq('draft')
   end
 
-  it 'archived, available_on in the past -> archived' do
-    product.update(status: 'archived', available_on: 1.day.ago)
+  it 'archived, make_active_at in the past -> archived' do
+    product.update(status: 'archived', make_active_at: 1.day.ago)
     subject.invoke
     expect(product.reload.status).to eq('archived')
   end
 
-  it 'archived, available_on in the future -> archived' do
-    product.update(status: 'archived', available_on: 1.day.from_now)
+  it 'archived, make_active_at in the future -> archived' do
+    product.update(status: 'archived', make_active_at: 1.day.from_now)
     subject.invoke
     expect(product.reload.status).to eq('archived')
   end

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -18,7 +18,7 @@ describe 'Product scopes', type: :model do
     end
 
     context 'when available' do
-      let!(:product_2) { create(:product, available_on: Time.current - 1.day,stores: [store]) }
+      let!(:product_2) { create(:product, status: 'active', stores: [store]) }
 
       it { expect(Spree::Product.available).to include(product_2) }
     end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -275,10 +275,10 @@ describe Spree::Product, type: :model do
       end
     end
 
-    describe '#discontinue_on_must_be_later_than_available_on' do
-      before { product.available_on = Date.today }
+    describe '#discontinue_on_must_be_later_than_make_active_at' do
+      before { product.make_active_at = Date.today }
 
-      context 'available_on is a date earlier than discontinue_on' do
+      context 'make_active_at is a date earlier than discontinue_on' do
         before { product.discontinue_on = 5.days.from_now }
 
         it 'is valid' do
@@ -286,7 +286,7 @@ describe Spree::Product, type: :model do
         end
       end
 
-      context 'available_on is a date earlier than discontinue_on' do
+      context 'make_active_at is a date earlier than discontinue_on' do
         before { product.discontinue_on = 5.days.ago }
 
         context 'is not valid' do
@@ -297,10 +297,10 @@ describe Spree::Product, type: :model do
         end
       end
 
-      context 'available_on and discontinue_on are nil' do
+      context 'make_active_at and discontinue_on are nil' do
         before do
           product.discontinue_on = nil
-          product.available_on = nil
+          product.make_active_at = nil
         end
 
         it 'is valid' do

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -23,6 +23,7 @@ PRODUCTS.each do |(parent_name, taxon_name, product_name)|
     product.price = rand(10...100) + 0.99
     product.description = FFaker::Lorem.paragraph
     product.available_on = Time.zone.now
+    product.make_active_at = Time.zone.now
     product.status = 'active'
     if parent_name == 'Women' and %w[Dresses Skirts].include?(taxon_name)
       product.option_types = [color, length, size]


### PR DESCRIPTION
…ic - with both fields

Notes:
- Platform API supports both available_on, make_active_at.
- Storefront API supports on available_on currently.