### PR TITLE
Fix address not being saved on user in v2 controller

### DIFF
--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -45,7 +45,7 @@ module Spree
 
       def ship_address_attributes=(attributes)
         self.ship_address = update_or_create_address(attributes)
-        user.update(ship_address: bill_address) if user && user.bill_address.nil?
+        user.update(ship_address: ship_address) if user && user.ship_address.nil?
       end
 
       private

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -53,12 +53,12 @@ module Spree
       def update_or_create_address(attributes = {})
         return if attributes.blank?
 
-        attributes.transform_values!{ |v| v == "" ? nil : v }
+        attributes.transform_values!(&:presence)
 
         address_scope = user ? user.addresses : ::Spree::Address.where(user: nil)
         existing_address = address_scope.find_by(id: attributes[:id])
         new_address = address_scope.new(attributes)
-
+        
         if existing_address && new_address == existing_address
           existing_address
         elsif existing_address&.editable?

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -30,7 +30,7 @@ module Spree
 
       def bill_address_attributes=(attributes)
         self.bill_address = update_or_create_address(attributes)
-        user.update(bill_address: bill_address) if user && user.bill_address.nil?
+        user.class.unscoped.where(id: user).update_all(bill_address_id: bill_address.id) if user && user.bill_address.nil?
       end
 
       def ship_address_id=(id)
@@ -45,7 +45,7 @@ module Spree
 
       def ship_address_attributes=(attributes)
         self.ship_address = update_or_create_address(attributes)
-        user.update(ship_address: ship_address) if user && user.ship_address.nil?
+        user.class.unscoped.where(id: user).update_all(ship_address_id: ship_address.id) if user && user.ship_address.nil?
       end
 
       private
@@ -58,7 +58,7 @@ module Spree
         address_scope = user ? user.addresses : ::Spree::Address.where(user: nil)
         existing_address = address_scope.find_by(id: attributes[:id])
         new_address = address_scope.new(attributes)
-        
+
         if existing_address && new_address == existing_address
           existing_address
         elsif existing_address&.editable?

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -30,7 +30,7 @@ module Spree
 
       def bill_address_attributes=(attributes)
         self.bill_address = update_or_create_address(attributes)
-        user.class.unscoped.where(id: user).update_all(bill_address_id: bill_address.id) if user && user.bill_address.nil?
+        user.update(bill_address: bill_address) if user && user.bill_address.nil?
       end
 
       def ship_address_id=(id)
@@ -45,7 +45,7 @@ module Spree
 
       def ship_address_attributes=(attributes)
         self.ship_address = update_or_create_address(attributes)
-        user.class.unscoped.where(id: user).update_all(ship_address_id: ship_address.id) if user && user.ship_address.nil?
+        user.update(ship_address: ship_address) if user && user.ship_address.nil?
       end
 
       private
@@ -58,7 +58,7 @@ module Spree
         address_scope = user ? user.addresses : ::Spree::Address.where(user: nil)
         existing_address = address_scope.find_by(id: attributes[:id])
         new_address = address_scope.new(attributes)
-
+        
         if existing_address && new_address == existing_address
           existing_address
         elsif existing_address&.editable?


### PR DESCRIPTION
If we use the current checkout controller v2, a new address will not be automatically saved on the user. Although on line #33 and #48 the user.bill/ship_address is updated, this is not persisted to the databse. Instead of `user.bill_address` we'd prefer to have it saved to `user.addresses` as well. 

I think the current implementation of `update_or_create_address` also could inadvertedly return an address from another user. There could be a (hypothetical) race condition, where another user edits this address while the order is not yet complete.