### PR TITLE
VEN-341 Product State Machine with Webhooks

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -11,7 +11,7 @@ module Spree
         def queue_webhooks_requests!(event_name)
           return if disable_spree_webhooks?
           return if Spree::Webhooks::Subscriber.active.with_urls_for(event_name).none?
-          return if update_event?(event_name) && updating_only_timestamps?
+          return if update_event?(event_name) && updating_only_ignored_attributes?
           return if webhook_payload_body.blank?
 
           Spree::Webhooks::Subscribers::QueueRequests.call(event_name: event_name, webhook_payload_body: webhook_payload_body)
@@ -44,8 +44,15 @@ module Spree
         "Spree::Api::V2::Platform::#{demodulized_class_name}Serializer".constantize
       end
 
-      def updating_only_timestamps?
-        (saved_changes.keys - %w[created_at updated_at deleted_at]).empty?
+      def updating_only_ignored_attributes?
+        (saved_changes.keys - ignored_attributes).empty?
+      end
+
+      def ignored_attributes
+        timestamps = %w[created_at updated_at deleted_at]
+        return timestamps unless self.class.respond_to?(:ignored_attributes_for_update_webhook_event)
+
+        timestamps + self.class.ignored_attributes_for_update_webhook_event
       end
 
       def update_event?(event_name)

--- a/api/app/models/spree/api/webhooks/product_decorator.rb
+++ b/api/app/models/spree/api/webhooks/product_decorator.rb
@@ -4,10 +4,30 @@ module Spree
       module ProductDecorator
         def self.prepended(base)
           def base.custom_webhook_events
-            %w[product.back_in_stock product.backorderable product.discontinued product.out_of_stock]
+            %w[product.back_in_stock product.backorderable product.discontinued
+               product.out_of_stock product.activated product.archived product.drafted]
+          end
+
+          def base.ignored_attributes_for_update_webhook_event
+            %w[status]
           end
 
           base.after_update_commit :queue_webhooks_requests_for_product_discontinued!
+        end
+
+        def after_activate
+          super
+          queue_webhooks_requests!('product.activated')
+        end
+
+        def after_archive
+          super
+          queue_webhooks_requests!('product.archived')
+        end
+
+        def after_draft
+          super
+          queue_webhooks_requests!('product.drafted')
         end
 
         private
@@ -24,4 +44,3 @@ module Spree
 end
 
 Spree::Product.prepend(Spree::Api::Webhooks::ProductDecorator)
-

--- a/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
@@ -2,17 +2,15 @@ require 'spec_helper'
 
 describe Spree::Api::Webhooks::ProductDecorator do
   let(:product) { create(:product) }
-  let(:webhook_payload_body) { Spree::Api::V2::Platform::ProductSerializer.new(product).serializable_hash }
+  let(:webhook_payload_body) do
+    Spree::Api::V2::Platform::ProductSerializer.new(
+      product,
+      include: Spree::Api::V2::Platform::ProductSerializer.relationships_to_serialize.keys
+    ).serializable_hash
+  end
   let!(:webhook_subscriber) { create(:webhook_subscriber, :active, subscriptions: [event_name]) }
 
   context 'emitting product.discontinued' do
-    let(:webhook_payload_body) do
-      Spree::Api::V2::Platform::ProductSerializer.new(
-        product,
-        include: Spree::Api::V2::Platform::ProductSerializer.relationships_to_serialize.keys
-      ).serializable_hash
-    end
-    let!(:webhook_subscriber) { create(:webhook_subscriber, :active, subscriptions: [event_name]) }
     let(:event_name) { 'product.discontinued' }
 
     context 'when product discontinued_on changes' do

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -150,6 +150,23 @@ module Spree
 
     alias master_images images
 
+    state_machine :status, initial: :draft do
+      event :activate do
+        transition to: :active
+      end
+      after_transition to: :active, do: :after_activate
+
+      event :archive do
+        transition to: :archived
+      end
+      after_transition to: :archived, do: :after_archive
+
+      event :draft do
+        transition to: :draft
+      end
+      after_transition to: :draft, do: :after_draft
+    end
+
     # Can't use short form block syntax due to https://github.com/Netflix/fast_jsonapi/issues/259
     def purchasable?
       default_variant.purchasable? || variants.any?(&:purchasable?)
@@ -234,7 +251,7 @@ module Spree
     # deleted products and products with status different than active
     # are not available
     def available?
-      status == 'active' && !deleted?
+      active? && !deleted?
     end
 
     def discontinue!
@@ -513,6 +530,18 @@ module Spree
 
     def downcase_slug
       slug&.downcase!
+    end
+
+    def after_activate
+      # this method is prepended in api/ to queue Webhooks requests
+    end
+
+    def after_archive
+      # this method is prepended in api/ to queue Webhooks requests
+    end
+
+    def after_draft
+      # this method is prepended in api/ to queue Webhooks requests
     end
   end
 end


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-341

Enables emitting webhook events for status changes on Products. When we update only the status we get the custom event and not the "product.update" event. When we update several attributes we get: first the "product.update" with all the changes except status and second the "product.#{new_status}" where just the status has changed