### PR TITLE
VEN-351 Touch includer of DefaultPrice when default_price is updated

### DIFF
--- a/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
+++ b/api/spec/models/spree/api/webhooks/product_decorator_spec.rb
@@ -46,10 +46,14 @@ describe Spree::Api::Webhooks::ProductDecorator do
     context 'to active' do
       let(:event_name) { 'product.activated' }
 
-      before { product.update_column(:status, :draft) }
+      before do
+        product.update_column(:status, :draft)
+      end
 
       it do
-        expect { product.activate }.to emit_webhook_event(event_name)
+        ActiveRecord::Base.no_touching do
+          expect { product.activate }.to emit_webhook_event(event_name)
+        end
       end
     end
 

--- a/api/spec/requests/spree/api/v2/caching_spec.rb
+++ b/api/spec/requests/spree/api/v2/caching_spec.rb
@@ -116,6 +116,7 @@ describe 'API v2 Caching spec', type: :request do
       end
 
       it 'auto expire cache after record being updated' do
+        product.reload
         get "/api/v2/storefront/products/#{product.id}"
 
         expect(json_response['data']).to have_attribute('name').with_value('Some name')
@@ -148,6 +149,7 @@ describe 'API v2 Caching spec', type: :request do
       end
 
       it 'includes currency and signed user in the cache key' do
+        product.reload
         get "/api/v2/storefront/products/#{product.id}?currency=#{currency}&locale=#{locale}", headers: headers_bearer
 
         expect(cache_entry).not_to be_nil

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -908,7 +908,10 @@ describe 'API V2 Storefront Products Spec', type: :request do
     end
 
     context 'with existing product' do
-      before { get "/api/v2/storefront/products/#{product.slug}" }
+      before do
+        product.reload
+        get "/api/v2/storefront/products/#{product.slug}"
+      end
 
       it_behaves_like 'returns 200 HTTP status'
 

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -29,7 +29,7 @@ module Spree
       end
 
       def save_default_price
-        default_price.save
+        default_price.save if default_price_changed?
       end
     end
   end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -25,7 +25,7 @@ module Spree
       private
 
       def default_price_changed?
-        default_price && (default_price.changed? || default_price.new_record?)
+        default_price && (default_price.has_changes_to_save? || default_price.new_record?)
       end
 
       def save_default_price

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -6,15 +6,14 @@ module Spree
       has_one :default_price,
               -> { with_deleted.where(currency: Spree::Store.default.default_currency) },
               class_name: 'Spree::Price',
-              inverse_of: :variant,
               dependent: :destroy
 
       delegate :display_price, :display_amount, :price, :currency, :price=,
                :price_including_vat_for, :currency=, :display_compare_at_price,
                :compare_at_price, :compare_at_price=, to: :find_or_build_default_price
 
+      before_save :touch_self_if_price_changed
       after_save :save_default_price
-      after_save :touch_variant
 
       def has_default_price?
         !default_price.nil?
@@ -34,8 +33,8 @@ module Spree
         default_price.save if default_price_changed?
       end
 
-      def touch_variant
-        touch if default_price_changed?
+      def touch_self_if_price_changed
+        touch if persisted? && default_price_changed?
       end
     end
   end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -14,6 +14,7 @@ module Spree
                :compare_at_price, :compare_at_price=, to: :find_or_build_default_price
 
       after_save :save_default_price
+      after_save :touch_variant
 
       def has_default_price?
         !default_price.nil?
@@ -31,6 +32,10 @@ module Spree
 
       def save_default_price
         default_price.save if default_price_changed?
+      end
+
+      def touch_variant
+        touch if default_price_changed?
       end
     end
   end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -6,7 +6,7 @@ module Spree
       has_one :default_price,
               -> { with_deleted.where(currency: Spree::Store.default.default_currency) },
               class_name: 'Spree::Price',
-              inverse_of: name.demodulize.tableize.singularize.to_sym,
+              inverse_of: :variant,
               dependent: :destroy
 
       delegate :display_price, :display_amount, :price, :currency, :price=,

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -12,7 +12,6 @@ module Spree
                :price_including_vat_for, :currency=, :display_compare_at_price,
                :compare_at_price, :compare_at_price=, to: :find_or_build_default_price
 
-      before_save :touch_self_if_price_changed
       after_save :save_default_price
 
       def has_default_price?
@@ -30,11 +29,7 @@ module Spree
       end
 
       def save_default_price
-        default_price.save if default_price_changed?
-      end
-
-      def touch_self_if_price_changed
-        touch if persisted? && default_price_changed?
+        default_price.save
       end
     end
   end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -6,6 +6,7 @@ module Spree
       has_one :default_price,
               -> { with_deleted.where(currency: Spree::Store.default.default_currency) },
               class_name: 'Spree::Price',
+              inverse_of: name.demodulize.tableize.singularize.to_sym,
               dependent: :destroy
 
       delegate :display_price, :display_amount, :price, :currency, :price=,

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -74,7 +74,6 @@ module Spree
     end
 
     def touch_variant
-      puts 'It gets to here 5552'
       variant.touch
     end
   end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -74,6 +74,7 @@ module Spree
     end
 
     def touch_variant
+      puts 'It gets to here 5552'
       variant.touch
     end
   end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -12,6 +12,7 @@ module Spree
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :prices, touch: true
 
     before_validation :ensure_currency
+    after_update :touch_variant
 
     validates :amount, allow_nil: true, numericality: {
       greater_than_or_equal_to: 0,
@@ -70,6 +71,10 @@ module Spree
 
     def ensure_currency
       self.currency ||= Spree::Store.default.default_currency
+    end
+
+    def touch_variant
+      variant.touch
     end
   end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -180,19 +180,18 @@ describe Spree::Adjustment, type: :model do
     end
 
     context 'when adjustment is open' do
-      let(:current_time) { Time.current }
-
       before do
         expect(adjustment).to receive(:closed?).and_return(false)
-        expect(Time).to receive(:current).and_return(current_time)
       end
 
       it 'updates the amount' do
         expect(adjustment).to receive(:adjustable).and_return(double('Adjustable')).at_least(:once)
         expect(adjustment).to receive(:source).and_return(double('Source')).at_least(:once)
         expect(adjustment.source).to receive('compute_amount').with(adjustment.adjustable).and_return(5)
-        expect(adjustment).to receive(:update_columns).with(amount: 5, updated_at: current_time)
-        adjustment.update!
+        Timecop.freeze do
+          expect(adjustment).to receive(:update_columns).with(amount: 5, updated_at: Time.current)
+          adjustment.update!
+        end
       end
     end
   end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -174,7 +174,7 @@ describe Spree::Adjustment, type: :model do
       before { expect(adjustment).to receive(:closed?).and_return(true) }
 
       it 'does not update the adjustment' do
-        expect(adjustment).not_to receive(:update_column)
+        expect(adjustment).not_to receive(:update_columns)
         adjustment.update!
       end
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -180,13 +180,18 @@ describe Spree::Adjustment, type: :model do
     end
 
     context 'when adjustment is open' do
-      before { expect(adjustment).to receive(:closed?).and_return(false) }
+      let(:current_time) { Time.current }
+
+      before do
+        expect(adjustment).to receive(:closed?).and_return(false)
+        expect(Time).to receive(:current).and_return(current_time)
+      end
 
       it 'updates the amount' do
         expect(adjustment).to receive(:adjustable).and_return(double('Adjustable')).at_least(:once)
         expect(adjustment).to receive(:source).and_return(double('Source')).at_least(:once)
         expect(adjustment.source).to receive('compute_amount').with(adjustment.adjustable).and_return(5)
-        expect(adjustment).to receive(:update_columns).with(amount: 5, updated_at: kind_of(Time))
+        expect(adjustment).to receive(:update_columns).with(amount: 5, updated_at: current_time)
         adjustment.update!
       end
     end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -103,8 +103,8 @@ describe Spree::Price, type: :model do
     subject(:price_with_vat) { price.price_including_vat_for(price_options) }
 
     let(:variant) { create(:variant) }
-    let(:default_zone) { Spree::Zone.new }
-    let(:zone) { Spree::Zone.new }
+    let(:default_zone) { create(:zone) }
+    let(:zone) { create(:zone) }
     let(:amount) { 10 }
     let(:tax_category) { Spree::TaxCategory.new }
     let(:price) { build :price, variant: variant, amount: amount }
@@ -153,8 +153,8 @@ describe Spree::Price, type: :model do
     subject(:compare_at_price_with_vat) { price.compare_at_price_including_vat_for(price_options) }
 
     let(:variant) { create(:variant) }
-    let(:default_zone) { Spree::Zone.new }
-    let(:zone) { Spree::Zone.new }
+    let(:default_zone) { create(:zone) }
+    let(:zone) { create(:zone) }
     let(:amount) { 10 }
     let(:compare_at_amount) { 100 }
     let(:tax_category) { Spree::TaxCategory.new }

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -115,8 +115,10 @@ describe Spree::Price, type: :model do
         allow(variant).to receive(:tax_category).and_return(tax_category)
         expect(price).to receive(:default_zone).at_least(:once).and_return(default_zone)
         allow(price).to receive(:apply_foreign_vat?).and_return(true)
+        allow(price).to receive(:included_tax_amount).and_call_original
         allow(price).to receive(:included_tax_amount).with(tax_zone: default_zone, tax_category: tax_category).and_return(0.19)
         allow(price).to receive(:included_tax_amount).with(tax_zone: zone, tax_category: tax_category).and_return(0.25)
+        variant.reload
       end
 
       it 'returns the correct price including another VAT to two digits' do
@@ -166,8 +168,10 @@ describe Spree::Price, type: :model do
         allow(variant).to receive(:tax_category).and_return(tax_category)
         expect(price).to receive(:default_zone).at_least(:once).and_return(default_zone)
         allow(price).to receive(:apply_foreign_vat?).and_return(true)
+        allow(price).to receive(:included_tax_amount).and_call_original
         allow(price).to receive(:included_tax_amount).with(tax_zone: default_zone, tax_category: tax_category).and_return(0.19)
         allow(price).to receive(:included_tax_amount).with(tax_zone: zone, tax_category: tax_category).and_return(0.25)
+        variant.reload
       end
 
       it 'returns the correct price including another VAT to two digits' do

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -106,7 +106,7 @@ describe Spree::Price, type: :model do
     let(:default_zone) { create(:zone) }
     let(:zone) { create(:zone) }
     let(:amount) { 10 }
-    let(:tax_category) { Spree::TaxCategory.new }
+    let(:tax_category) { create(:tax_category) }
     let(:price) { build :price, variant: variant, amount: amount }
     let(:price_options) { { tax_zone: zone } }
 
@@ -157,7 +157,7 @@ describe Spree::Price, type: :model do
     let(:zone) { create(:zone) }
     let(:amount) { 10 }
     let(:compare_at_amount) { 100 }
-    let(:tax_category) { Spree::TaxCategory.new }
+    let(:tax_category) { create(:tax_category) }
     let(:price) { build :price, variant: variant, amount: amount, compare_at_amount: compare_at_amount }
     let(:price_options) { { tax_zone: zone } }
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -1055,20 +1055,23 @@ describe Spree::Variant, type: :model do
     subject { variant.update(price: 50) }
 
     it 'updated_at changes when updating price' do
-      previous_updated_at = variant.updated_at
+      previous_updated_at = variant.updated_at.to_i
+      sleep 0.5
       subject
-      expect(variant.reload.updated_at).not_to eq(previous_updated_at)
+      expect(variant.reload.updated_at.to_i).not_to eq(previous_updated_at)
     end
 
     context 'cache is updated' do
       it do
         previous_cache_key_with_version = variant.cache_key_with_version
+        sleep 0.5
         subject
         expect(variant.reload.cache_key_with_version).not_to eq(previous_cache_key_with_version)
       end
 
       it 'updates price_in' do
         previous_price_in_usd = variant.price_in('USD')
+        sleep 0.5
         subject
         expect(variant.reload.price_in('USD').amount).not_to eq previous_price_in_usd.amount
       end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -1064,9 +1064,9 @@ describe Spree::Variant, type: :model do
       end
 
       it 'updates price_in' do
-        previous_price_in = variant.price_in('USD')
+        previous_price_in_usd = variant.price_in('USD')
         subject
-        expect(variant.price_in('USD').amount).not_to eq previous_price_in.amount
+        expect(variant.price_in('USD').amount).not_to eq previous_price_in_usd.amount
       end
     end
   end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -1049,4 +1049,25 @@ describe Spree::Variant, type: :model do
       expect(order.total).to eq(0)
     end
   end
+
+  # for VEN-351 bug
+  context 'touching by associated prices' do
+    subject { variant.update(price: 50) }
+
+    it 'updated_at changes when updating price' do
+      expect { subject }.to change(variant, :updated_at)
+    end
+
+    context 'cache is updated' do
+      it do
+        expect { subject }.to change(variant, :cache_key_with_version)
+      end
+
+      it 'updates price_in' do
+        previous_price_in = variant.price_in('USD')
+        subject
+        expect(variant.price_in('USD').amount).not_to eq previous_price_in.amount
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -1055,18 +1055,22 @@ describe Spree::Variant, type: :model do
     subject { variant.update(price: 50) }
 
     it 'updated_at changes when updating price' do
-      expect { subject }.to change(variant, :updated_at)
+      previous_updated_at = variant.updated_at
+      subject
+      expect(variant.reload.updated_at).not_to eq(previous_updated_at)
     end
 
     context 'cache is updated' do
       it do
-        expect { subject }.to change(variant, :cache_key_with_version)
+        previous_cache_key_with_version = variant.cache_key_with_version
+        subject
+        expect(variant.reload.cache_key_with_version).not_to eq(previous_cache_key_with_version)
       end
 
       it 'updates price_in' do
         previous_price_in_usd = variant.price_in('USD')
         subject
-        expect(variant.price_in('USD').amount).not_to eq previous_price_in_usd.amount
+        expect(variant.reload.price_in('USD').amount).not_to eq previous_price_in_usd.amount
       end
     end
   end


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-351 - Marketplace Owners and Vendor Owners are unable to update `Master Price`, `Variant Price` and `Compare at Price` for products without specific workarounds

The problem was that a Variant's updated_at field was not updated when it's price was updated. This led to cache_key not changing and the `#price_in` method returning the price that was cached from the previous version of the Variant, before the update. Occurred because in Spree::Price, `belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :prices, touch: true`, the `with_deleted` scope for some reason breaks `touch: true` (https://stackoverflow.com/questions/46448140/belongs-to-touch-true-not-fired-on-association-build-and-nested-attribute-assig/46452718). Also the `with_deleted.where(currency: Spree::Store.default.default_currency)` in Spree::DefaultPrice breaks the touch: true. We either remove one of them, or have the `inverse_of` option (in Spree::DefaultPrice) as I have done.

Similar to this: https://github.com/rails/rails/issues/26726#issuecomment-332761348