### PR TITLE
VEN-355 Separate model for Cms Section images

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -52,12 +52,8 @@ module Spree
       def resource_serializer
         @resource_serializer ||=
           begin
-            if self.class.respond_to? :platform_resource_serializer
-              self.class.platform_resource_serializer
-            else
-              demodulized_class_name = self.class.to_s.demodulize
-              "Spree::Api::V2::Platform::#{demodulized_class_name}Serializer".constantize
-            end
+            demodulized_class_name = self.class.to_s.demodulize
+            "Spree::Api::V2::Platform::#{demodulized_class_name}Serializer".constantize
           end
       end
 

--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -52,8 +52,12 @@ module Spree
       def resource_serializer
         @resource_serializer ||=
           begin
-            demodulized_class_name = self.class.to_s.demodulize
-            "Spree::Api::V2::Platform::#{demodulized_class_name}Serializer".constantize
+            if self.class.respond_to? :platform_resource_serializer
+              self.class.platform_resource_serializer
+            else
+              demodulized_class_name = self.class.to_s.demodulize
+              "Spree::Api::V2::Platform::#{demodulized_class_name}Serializer".constantize
+            end
           end
       end
 

--- a/api/app/serializers/spree/api/v2/platform/cms_section_image_one_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/cms_section_image_one_serializer.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class CmsSectionImageOneSerializer < AssetSerializer; end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/cms_section_image_three_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/cms_section_image_three_serializer.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class CmsSectionImageThreeSerializer < AssetSerializer; end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/cms_section_image_two_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/cms_section_image_two_serializer.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class CmsSectionImageTwoSerializer < AssetSerializer; end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/hero_image_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/hero_image_serializer.rb
@@ -1,0 +1,10 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class HeroImageSerializer < CmsSectionSerializer
+        end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/image_gallery_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/image_gallery_serializer.rb
@@ -1,0 +1,10 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class ImageGallerySerializer < CmsSectionSerializer
+        end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/api/v2/platform/side_by_side_image_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/side_by_side_image_serializer.rb
@@ -1,0 +1,10 @@
+module Spree
+  module Api
+    module V2
+      module Platform
+        class SideBySideImageSerializer < CmsSectionSerializer
+        end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/v2/storefront/cms_section_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/cms_section_serializer.rb
@@ -6,10 +6,10 @@ module Spree
 
         attributes :name, :content, :settings, :link, :fit, :type, :position
 
-        Spree::CmsSection::IMAGE_COUNT.each do |count|
-          Spree::CmsSection::IMAGE_SIZE.each do |size|
+        Spree::CmsSectionImage::IMAGE_COUNT.each do |count|
+          Spree::CmsSectionImage::IMAGE_SIZE.each do |size|
             attribute "img_#{count}_#{size}".to_sym do |section|
-              if section.send("image_#{count}").attached? && section.send("img_#{count}_#{size}").present?
+              if section.send("image_#{count}")&.attachment&.attached? && section.send("img_#{count}_#{size}").present?
                 url_helpers = Rails.application.routes.url_helpers
                 url_helpers.rails_representation_path(section.send("img_#{count}_#{size}"), only_path: true)
               end

--- a/api/spec/serializers/spree/v2/storefront/cms_section_serializer_spec.rb
+++ b/api/spec/serializers/spree/v2/storefront/cms_section_serializer_spec.rb
@@ -52,7 +52,8 @@ describe Spree::V2::Storefront::CmsSectionSerializer do
      let!(:homepage) { create(:cms_homepage, store: store) }
      let!(:cms_section) do
        section = create(:cms_hero_image_section, cms_page: homepage)
-       section.image_one.attach(io: file, filename: 't-shirt.png')
+       section.build_image_one
+       section.image_one.attachment.attach(io: file, filename: 't-shirt.png')
        section
      end
      let(:file) { File.open(file_fixture('icon_256x256.jpg')) }
@@ -72,7 +73,8 @@ describe Spree::V2::Storefront::CmsSectionSerializer do
     let!(:homepage) { create(:cms_homepage, store: store) }
     let!(:cms_section) do
       section = create(:cms_side_by_side_images_section, cms_page: homepage)
-      section.image_one.attach(io: file, filename: 't-shirt.png')
+      section.build_image_one
+      section.image_one.attachment.attach(io: file, filename: 't-shirt.png')
       section
     end
     let(:file) { File.open(file_fixture('icon_256x256.jpg')) }
@@ -85,7 +87,8 @@ describe Spree::V2::Storefront::CmsSectionSerializer do
     let!(:homepage) { create(:cms_homepage, store: store) }
     let!(:cms_section) do
       section = create(:cms_image_gallery_section, cms_page: homepage)
-      section.image_one.attach(io: file, filename: 't-shirt.png')
+      section.build_image_one
+      section.image_one.attachment.attach(io: file, filename: 't-shirt.png')
       section
     end
     let(:file) { File.open(file_fixture('icon_256x256.jpg')) }

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -19,8 +19,8 @@ module Spree
     Spree::CmsSectionImage::IMAGE_COUNT.each do |count|
       Spree::CmsSectionImage::IMAGE_SIZE.each do |size|
         define_method("img_#{count}_#{size}") do |dimensions = nil|
-          image = send("image_#{count}").attachment
-          return if !image.attached? || dimensions.nil?
+          image = send("image_#{count}")&.attachment
+          return if !image&.attached? || dimensions.nil?
 
           image.variant(resize_to_limit: dimensions.split('x').map(&:to_i))
         end

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -7,22 +7,22 @@ module Spree
 
     validate :reset_link_attributes
 
-    IMAGE_COUNT = ['one', 'two', 'three']
-    IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'].freeze
-    IMAGE_SIZE = ['sm', 'md', 'lg', 'xl']
+    has_one :image_one, class_name: 'Spree::CmsSectionImageOne', dependent: :destroy, as: :viewable
+    accepts_nested_attributes_for :image_one, reject_if: :all_blank
 
-    IMAGE_COUNT.each do |count|
-      if Spree.public_storage_service_name
-        send(:has_one_attached, "image_#{count}".to_sym, service: Spree.public_storage_service_name)
-      else
-        send(:has_one_attached, "image_#{count}".to_sym)
-      end
+    has_one :image_two, class_name: 'Spree::CmsSectionImageTwo', dependent: :destroy, as: :viewable
+    accepts_nested_attributes_for :image_two, reject_if: :all_blank
 
-      IMAGE_SIZE.each do |size|
+    has_one :image_three, class_name: 'Spree::CmsSectionImageThree', dependent: :destroy, as: :viewable
+    accepts_nested_attributes_for :image_three, reject_if: :all_blank
+
+    Spree::CmsSectionImage::IMAGE_COUNT.each do |count|
+      Spree::CmsSectionImage::IMAGE_SIZE.each do |size|
         define_method("img_#{count}_#{size}") do |dimensions = nil|
-          return if !send("image_#{count}").attached? || dimensions.nil?
+          image = send("image_#{count}").attachment
+          return if !image.attached? || dimensions.nil?
 
-          send("image_#{count}").variant(resize_to_limit: dimensions.split('x').map(&:to_i))
+          image.variant(resize_to_limit: dimensions.split('x').map(&:to_i))
         end
       end
     end
@@ -30,8 +30,6 @@ module Spree
     default_scope { order(position: :asc) }
 
     validates :name, :cms_page, :type, presence: true
-
-    validates :image_one, :image_two, :image_three, content_type: IMAGE_TYPES
 
     LINKED_RESOURCE_TYPE = []
 

--- a/core/app/models/spree/cms_section_image.rb
+++ b/core/app/models/spree/cms_section_image.rb
@@ -1,0 +1,19 @@
+module Spree
+  class CmsSectionImage < Asset
+    if Spree.public_storage_service_name
+      has_one_attached :attachment, service: Spree.public_storage_service_name
+    else
+      has_one_attached :attachment
+    end
+
+    IMAGE_COUNT = ['one', 'two', 'three']
+    IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'].freeze
+    IMAGE_SIZE = ['sm', 'md', 'lg', 'xl']
+
+    validates :attachment, attached: true, content_type: IMAGE_TYPES
+
+    def self.platform_resource_serializer
+      Spree::Api::V2::Platform::AssetSerializer
+    end
+  end
+end

--- a/core/app/models/spree/cms_section_image.rb
+++ b/core/app/models/spree/cms_section_image.rb
@@ -11,9 +11,5 @@ module Spree
     IMAGE_SIZE = ['sm', 'md', 'lg', 'xl']
 
     validates :attachment, attached: true, content_type: IMAGE_TYPES
-
-    def self.platform_resource_serializer
-      Spree::Api::V2::Platform::AssetSerializer
-    end
   end
 end

--- a/core/app/models/spree/cms_section_image_one.rb
+++ b/core/app/models/spree/cms_section_image_one.rb
@@ -1,0 +1,4 @@
+module Spree
+  class CmsSectionImageOne < CmsSectionImage
+  end
+end

--- a/core/app/models/spree/cms_section_image_three.rb
+++ b/core/app/models/spree/cms_section_image_three.rb
@@ -1,0 +1,4 @@
+module Spree
+  class CmsSectionImageThree < CmsSectionImage
+  end
+end

--- a/core/app/models/spree/cms_section_image_two.rb
+++ b/core/app/models/spree/cms_section_image_two.rb
@@ -1,0 +1,4 @@
+module Spree
+  class CmsSectionImageTwo < CmsSectionImage
+  end
+end

--- a/core/spec/models/spree/cms_section_spec.rb
+++ b/core/spec/models/spree/cms_section_spec.rb
@@ -18,14 +18,19 @@ describe Spree::CmsSection, type: :model do
 
     let(:section) do
       section = build(:cms_hero_image_section, cms_page: homepage)
-      section.image_one.attach(io: file, filename: 't-shirt.png')
+      section.build_image_one
+      section.image_one.attachment.attach(io: file, filename: 't-shirt.png')
       section
     end
 
     let(:file) { File.open(file_fixture('icon_256x256.png')) }
 
     it 'is valid' do
-      expect(section.valid?).to be(true)
+      expect(section).to be_valid
+    end
+
+    it 'image is valid' do
+      expect(section.image_one).to be_valid
     end
   end
 end


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-355

New CmsSectionImage models for each image were created, because when we have
just one new model and since it is polymorphic, we have the same viewable_id for each one.
When we now create a CmsSectionImage a webhook is emitted (since it is an Asset) and it tries
to serialize it with a name corresponding to the class, hence the new Serializers inheriting from AssetSerializer. 
Also when creating that new Asset, the viewable relationship is included, hence it tries to serialize HeroImages and SideBySideImages. That is why I have created those new serializers that just inherit from CmsSectionSerializer.
