### PR TITLE
Update order after removing a line_item

### DIFF
--- a/core/app/services/spree/cart/remove_line_item.rb
+++ b/core/app/services/spree/cart/remove_line_item.rb
@@ -11,6 +11,7 @@ module Spree
                                                                             line_item: line_item,
                                                                             options: options)
         end
+        order.line_items.reload
         success(line_item)
       end
     end


### PR DESCRIPTION
When we call the `/api/v2/storefront/cart/remove_line_item` endpoint, the matching line_item is destroyed but the response still contains it. We use this response to update our cached cart state. I suggest to reload the line_items on the order in the ServiceModule.