### PR TITLE
VEN-432 Remove including Security module by checking if defined

### DIFF
--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -4,9 +4,6 @@ module Spree
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
-    if defined?(Spree::Security::StockLocations)
-      include Spree::Security::StockLocations
-    end
     if defined?(Spree::VendorConcern)
       include Spree::VendorConcern
     end


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-432

This is causing some dependency issue. Best if we include this where it is defined