### PR TITLE
VEN-359 Show more specific error for why adding item to cart fails

### DIFF
--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -14,9 +14,15 @@ module Spree
         display_name = variant.name.to_s
         display_name += " (#{variant.options_text})" unless variant.options_text.blank?
 
-        line_item.errors.add(:quantity,
-                             :selected_quantity_not_available,
-                             message: Spree.t(:selected_quantity_not_available, item: display_name.inspect))
+        if variant.available?
+          line_item.errors.add(:quantity,
+                               :selected_quantity_not_available,
+                               message: Spree.t(:selected_quantity_not_available, item: display_name.inspect))
+        else
+          line_item.errors.add(:base,
+                               :only_active_products_can_be_added_to_cart,
+                               message: Spree.t(:only_active_products_can_be_added_to_cart))
+        end
       end
 
       private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1122,6 +1122,7 @@ en:
     number: Number
     ok: OK
     on_hand: On Hand
+    only_active_products_can_be_added_to_cart: Draft and archived products cannot be added to cart, please mark the product as active before.
     open: Open
     open_all_adjustments: Open All Adjustments
     option_type: Option Type


### PR DESCRIPTION
https://getvendo.atlassian.net/browse/VEN-359

When you try to add an item to the cart that cannot be supplied you get an error that the selected Quantity is not available. There is the case when you have the available quantity, but the variant is not .available? which happens when the product has status different from Active (i.e. Draft or Archived). For this case we also consider that the item cannot be supplied but we should specify that it is because of the status and not the quantity.