### PR TITLE
Handle deletion of Tax Category

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -11,7 +11,7 @@ module Spree
       belongs_to :order, class_name: 'Spree::Order', touch: true
       belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
     end
-    belongs_to :tax_category, class_name: 'Spree::TaxCategory'
+    belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory'
 
     has_one :product, through: :variant
 

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -8,6 +8,8 @@ module Spree
     validates :name, presence: true, uniqueness: { case_sensitive: false, scope: spree_base_uniqueness_scope.push(:deleted_at) }
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
+    has_many :products, dependent: :nullify
+    has_many :variants, dependent: :nullify
 
     before_save :set_default_category
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -146,7 +146,7 @@ module Spree
       @tax_category ||= if self[:tax_category_id].nil?
                           product.tax_category
                         else
-                          Spree::TaxCategory.find(self[:tax_category_id])
+                          Spree::TaxCategory.find_by(id: self[:tax_category_id]) || product.tax_category
                         end
     end
 

--- a/core/spec/models/spree/tax_category_spec.rb
+++ b/core/spec/models/spree/tax_category_spec.rb
@@ -24,4 +24,22 @@ describe Spree::TaxCategory, type: :model do
       expect(tax_category.is_default).to be true
     end
   end
+
+  context '#destroy' do
+    let!(:tax_category) { create(:tax_category) }
+    let!(:tax_rate) { create(:tax_rate, tax_category: tax_category) }
+    let!(:product) { create(:product, tax_category: tax_category) }
+    let!(:variant) { create(:variant, product: product, tax_category: tax_category) }
+
+    it 'removes all tax rates' do
+      expect { tax_category.destroy }.to change { Spree::TaxRate.count }.by(-1)
+    end
+
+    it 'nullifies all products and variants' do
+      expect { tax_category.destroy }.not_to change { Spree::Product.count }
+      expect { tax_category.destroy }.not_to change { Spree::Variant.count }
+      expect(product.reload.tax_category).to be_nil
+      expect(variant.reload.tax_category).to be_nil
+    end
+  end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -720,6 +720,47 @@ describe Spree::Variant, type: :model do
         expect(variant.tax_category).to eq(tax_category)
       end
     end
+
+    context 'when tax category is deleted' do
+      let(:tax_category) { create(:tax_category) }
+      let(:variant) { build(:variant, tax_category: tax_category) }
+
+      before do
+        tax_category.destroy
+      end
+
+      it 'returns the parent products tax_category' do
+        expect(variant.tax_category).to eq(variant.product.tax_category)
+      end
+    end
+
+    context 'when tax category is deleted also in product' do
+      let(:tax_category) { create(:tax_category) }
+      let!(:default_tax_category) { create(:tax_category, is_default: true) }
+      let(:product) { create(:product, tax_category: tax_category) }
+      let(:variant) { build(:variant, product: product, tax_category: tax_category) }
+
+      before do
+        tax_category.destroy
+        product.reload
+      end
+
+      context 'with default tax category' do
+        it 'returns the default tax category' do
+          expect(variant.tax_category).to eq(default_tax_category)
+        end
+      end
+
+      context 'without default tax category' do
+        before do
+          default_tax_category.destroy
+        end
+
+        it 'returns nil' do
+          expect(variant.tax_category).to eq(nil)
+        end
+      end
+    end
   end
 
   describe 'touching' do


### PR DESCRIPTION
When Tax Category was deleted all Variants using that category would raise ActiveRecord::RecordNotFound when `#tax_category` was called on Variant object.