### PR TITLE
Fix user's shipping & billing address interaction with order

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -129,7 +129,7 @@ module Spree
     end
 
     def empty?
-      attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
+      attributes.except('id', 'created_at', 'updated_at', 'country_id', 'user_id').all? { |_, v| v.blank? }
     end
 
     # Generates an ActiveMerchant compatible address hash

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -689,12 +689,16 @@ module Spree
     end
 
     def use_billing
-      @use_billing.in?([true, 'true', '1']) ||
+      use_billing_form_choice ||
         ship_address.nil? || ship_address.empty? ||
         ship_address == bill_address
     end
 
     private
+
+    def use_billing_form_choice
+      @use_billing.in?([true, 'true', '1'])
+    end
 
     def link_by_email
       self.email = user.email if user

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -297,8 +297,8 @@ module Spree
       self.user           = user
       self.email          = user.email if override_email
       self.created_by   ||= user
-      self.bill_address ||= user.bill_address.try(:clone)
-      self.ship_address ||= user.ship_address.try(:clone)
+      self.bill_address_id ||= user.bill_address_id
+      self.ship_address_id ||= user.ship_address_id
 
       changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -151,7 +151,7 @@ module Spree
     before_validation :ensure_currency_presence
 
     before_validation :clone_billing_address, if: :use_billing?
-    attr_accessor :use_billing
+    attr_writer :use_billing
 
     before_create :create_token
     before_create :link_by_email
@@ -299,6 +299,9 @@ module Spree
       self.created_by   ||= user
       self.bill_address_id ||= user.bill_address_id
       self.ship_address_id ||= user.ship_address_id
+      if ship_address_id == bill_address_id
+        self.ship_address_id = nil
+      end
 
       changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
 
@@ -557,10 +560,6 @@ module Spree
       shipments.map { |s| s.refresh_rates(shipping_method_filter) }
     end
 
-    def shipping_eq_billing_address?
-      bill_address == ship_address
-    end
-
     def set_shipments_cost
       shipments.each(&:update_amounts)
       updater.update_shipment_total
@@ -689,6 +688,12 @@ module Spree
               spree_promotion_actions: { type: 'Spree::Promotion::Actions::FreeShipping' }).exists?
     end
 
+    def use_billing
+      @use_billing.in?([true, 'true', '1']) ||
+        ship_address.nil? || ship_address.empty? ||
+        ship_address == bill_address
+    end
+
     private
 
     def link_by_email
@@ -732,7 +737,7 @@ module Spree
     end
 
     def use_billing?
-      use_billing.in?([true, 'true', '1'])
+      use_billing
     end
 
     def ensure_currency_presence

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -44,8 +44,13 @@ module Spree
       end
 
       def ship_address_attributes=(attributes)
-        self.ship_address = update_or_create_address(attributes)
-        user.class.unscoped.where(id: user).update_all(ship_address_id: ship_address.id) if user && user.ship_address.nil?
+        self.ship_address =
+          if use_billing_form_choice
+            nil
+          else
+            update_or_create_address(attributes)
+          end
+        user.class.unscoped.where(id: user).update_all(ship_address_id: ship_address&.id) if user && user.ship_address.nil?
       end
 
       private

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -30,7 +30,7 @@ module Spree
 
       def bill_address_attributes=(attributes)
         self.bill_address = update_or_create_address(attributes)
-        user.bill_address = bill_address if user && user.bill_address.nil?
+        user.class.unscoped.where(id: user).update_all(bill_address_id: bill_address.id) if user && user.bill_address.nil?
       end
 
       def ship_address_id=(id)
@@ -45,7 +45,7 @@ module Spree
 
       def ship_address_attributes=(attributes)
         self.ship_address = update_or_create_address(attributes)
-        user.ship_address = ship_address if user && user.ship_address.nil?
+        user.class.unscoped.where(id: user).update_all(ship_address_id: ship_address.id) if user && user.ship_address.nil?
       end
 
       private

--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -64,7 +64,7 @@ module Spree
           return default_address
         end
 
-        ::Spree::Address.find_or_create_by(attributes.except(:id, :updated_at, :created_at))
+        default_address_scope.find_or_create_by(attributes.except(:id, :updated_at, :created_at))
       end
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1228,11 +1228,11 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe '#shipping_eq_billing_address' do
+  describe '#use_billing' do
     let!(:order) { create(:order) }
 
     context 'with only bill address' do
-      it { expect(order.shipping_eq_billing_address?).to eq(false) }
+      it { expect(order.use_billing).to eq(true) }
     end
 
     context 'blank addresses' do
@@ -1241,7 +1241,7 @@ describe Spree::Order, type: :model do
         order.ship_address = Spree::Address.new
       end
 
-      it { expect(order.shipping_eq_billing_address?).to eq(true) }
+      it { expect(order.use_billing).to eq(true) }
     end
 
     context 'no addresses' do
@@ -1250,7 +1250,7 @@ describe Spree::Order, type: :model do
         order.ship_address = nil
       end
 
-      it { expect(order.shipping_eq_billing_address?).to eq(true) }
+      it { expect(order.use_billing).to eq(true) }
     end
   end
 


### PR DESCRIPTION
There are several issues regarding this, see the individual commits.

This also makes legacy frontend work correctly:
- when order is created, the billing/shipping address will correctly be assigned to user if he doesn't have an address assigned
- when a new order is started, it will correctly use the user's billing/shipping address if present

**This was quite broken with even a security issue with the unscoped Spree::Address query. I suggest to merge asap due to this.**