### PR TITLE
Fix Calculator to allow for one Calculator to be a subclass of another.

### DIFF
--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -18,7 +18,7 @@ module Spree
 
       def calculator_type=(calculator_type)
         klass = calculator_type.constantize if calculator_type
-        self.calculator = klass.new if klass && !calculator.is_a?(klass)
+        self.calculator = klass.new if klass && !calculator.instance_of?(klass)
       end
 
       private


### PR DESCRIPTION
is_a? usage is incorrect here, as it will not switch out the calculator if the new calculator is a superclass of the current calculator, which is incorrect behavior.

Example:
```ruby
class PriceSack < ShippingCalculator
end
class MyPriceSack < PriceSack
end

obj.calculator_type="...::PriceSack"
obj.calculator_type="...::MyPriceSack"
obj.calculator_type # => "...::PriceSack" - INCORRECT
```