### PR TITLE
Prettify display of TaxRate percentage by stripping decimal zeroes - …

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -118,7 +118,8 @@ module Spree
 
       ' ' + ActiveSupport::NumberHelper::NumberToPercentageConverter.convert(
         amount * 100,
-        locale: I18n.locale
+        locale: I18n.locale,
+        strip_insignificant_zeros: true
       )
     end
   end


### PR DESCRIPTION
…e.g. 10.000% will now show as 10%