### PR TITLE
Don't cast eligible values to integers in Option Value Promo Rule

### DIFF
--- a/core/app/models/spree/promotion/rules/option_value.rb
+++ b/core/app/models/spree/promotion/rules/option_value.rb
@@ -4,9 +4,9 @@ module Spree
       module OptionValueWithNumerificationSupport
         def preferred_eligible_values
           values = super || {}
-          Hash[values.keys.map(&:to_i).zip(
+          Hash[values.keys.zip(
             values.values.map do |v|
-              (v.is_a?(Array) ? v : v.split(',')).map(&:to_i)
+              (v.is_a?(Array) ? v : v.split(','))
             end
           )]
         end

--- a/core/spec/models/spree/promotion/rules/option_value_spec.rb
+++ b/core/spec/models/spree/promotion/rules/option_value_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Promotion::Rules::OptionValue do
 
     it 'assigns a nicely formatted hash' do
       rule.preferred_eligible_values = Hash['5' => '1,2', '6' => '1']
-      expect(subject).to eq Hash[5 => [1, 2], 6 => [1]]
+      expect(subject).to eq Hash['5' => ['1', '2'], '6' => ['1']]
     end
   end
 


### PR DESCRIPTION
This breaks installations using UUIDs, and there's no reason or benefits of this casting