### PR TITLE
Move `searcher_class` from `Spree::Config` to `Spree`

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -26,7 +26,7 @@ StateMachines::Machine.ignore_method_conflicts = true
 
 module Spree
   mattr_accessor :user_class, :admin_user_class, :private_storage_service_name,
-                 :public_storage_service_name, :cdn_host
+                 :public_storage_service_name, :cdn_host, :searcher_class
 
   def self.user_class(constantize: true)
     if @@user_class.is_a?(Class)
@@ -63,6 +63,16 @@ module Spree
       else
         raise 'Spree.public_storage_service_name MUST be a String or Symbol object.'
       end
+    end
+  end
+
+  def self.searcher_class(constantize: true)
+    @@searcher_class ||= 'Spree::Core::Search::Base'
+
+    if @@searcher_class.is_a?(Class)
+      raise 'Spree.searcher_class MUST be a String or Symbol object, not a Class object.'
+    elsif @@searcher_class.is_a?(String) || @@searcher_class.is_a?(Symbol)
+      constantize ? @@searcher_class.to_s.constantize : @@searcher_class.to_s
     end
   end
 

--- a/core/lib/spree/core/configuration.rb
+++ b/core/lib/spree/core/configuration.rb
@@ -75,7 +75,8 @@ module Spree
 
       # searcher_class allows spree extension writers to provide their own Search class
       def searcher_class
-        @searcher_class ||= Spree::Core::Search::Base
+        ActiveSupport::Deprecation.warn('`Spree::Config.searcher_class` is deprecated and will be removed in Spree v5, please use `Spree.searcher_class` instead.')
+        @searcher_class ||= Spree.searcher_class
       end
 
       # Sets the path used for products, taxons and pages.

--- a/core/lib/spree/core/controller_helpers/search.rb
+++ b/core/lib/spree/core/controller_helpers/search.rb
@@ -3,7 +3,7 @@ module Spree
     module ControllerHelpers
       module Search
         def build_searcher(params)
-          Spree::Config.searcher_class.new(params).tap do |searcher|
+          Spree.searcher_class.new(params).tap do |searcher|
             searcher.current_user = try_spree_current_user
             searcher.current_currency = current_currency&.upcase
             searcher.current_store = current_store

--- a/core/spec/lib/spree/core/controller_helpers/search_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/search_spec.rb
@@ -10,7 +10,7 @@ describe Spree::Core::ControllerHelpers::Search, type: :controller do
   describe '#build_searcher' do
     it 'returns Spree::Core::Search::Base instance' do
       allow(controller).to receive_messages(try_spree_current_user: create(:user),
-                                            current_currency: 'USD')
+                                            current_currency: 'USD', current_store: Spree::Store.default)
       expect(controller.build_searcher({}).class).to eq Spree::Core::Search::Base
     end
   end

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -122,4 +122,42 @@ describe Spree do
       end
     end
   end
+
+  describe '.searcher_class' do
+    after do
+      described_class.searcher_class = 'Spree::Core::Search::Base'
+    end
+
+    context 'when searcher_class is a Class instance' do
+      it 'raises an error' do
+        described_class.searcher_class = Spree::Core::Search::Base
+
+        expect { described_class.searcher_class }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when searcher_class is a Symbol instance' do
+      it 'returns the searcher_class constant' do
+        described_class.searcher_class = :'Spree::Core::Search::Base'
+
+        expect(described_class.searcher_class).to eq(Spree::Core::Search::Base)
+      end
+    end
+
+    context 'when searcher_class is a String instance' do
+      it 'returns the searcher_class constant' do
+        described_class.searcher_class = 'Spree::Core::Search::Base'
+
+        expect(described_class.searcher_class).to eq(Spree::Core::Search::Base)
+      end
+    end
+
+    context 'when constantize is false' do
+      it 'returns the searcher_class as a String' do
+        described_class.searcher_class = 'Spree::Core::Search::Base'
+
+        expect(described_class.searcher_class(constantize: false)).to eq('Spree::Core::Search::Base')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This makes it independent from preferences and aligns with `user_class`