### PR TITLE
Fixed slug uniqueness in CmsPage

### DIFF
--- a/core/db/migrate/20220329113557_fix_cms_pages_unique_indexes.rb
+++ b/core/db/migrate/20220329113557_fix_cms_pages_unique_indexes.rb
@@ -1,0 +1,8 @@
+class FixCmsPagesUniqueIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :spree_cms_pages, [:slug, :store_id, :deleted_at]
+    remove_index :spree_cms_pages, [:slug, :store_id], unique: true
+
+    add_index :spree_cms_pages, [:slug, :store_id, :deleted_at], unique: true
+  end
+end

--- a/core/spec/models/spree/cms_page_spec.rb
+++ b/core/spec/models/spree/cms_page_spec.rb
@@ -31,6 +31,11 @@ describe Spree::CmsPage, type: :model do
       it 'valid' do
         expect(described_class.new(title: 'Another Name', store: store_a, locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).to be_valid
       end
+
+      it 'omits previously deleted page' do
+        expect { page.destroy }.to change(page, :deleted_at).from(nil).to(Time)
+        expect(described_class.new(title: 'Got Name', store: store_a, slug: 'got-name', locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).to be_valid
+      end
     end
 
     context 'invalid' do
@@ -38,11 +43,6 @@ describe Spree::CmsPage, type: :model do
 
       it 'invalid' do
         expect(described_class.new(title: 'Got Name', store: store_a, slug: 'got-name', locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).not_to be_valid
-      end
-
-      it 'omits previosly deleted page' do
-        expect { page.destroy }.to change(page, :deleted_at).from(nil).to(Time)
-        expect(described_class.new(title: 'Got Name', store: store_a, slug: 'got-name', locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).to be_valid
       end
     end
   end

--- a/core/spec/models/spree/cms_page_spec.rb
+++ b/core/spec/models/spree/cms_page_spec.rb
@@ -24,6 +24,29 @@ describe Spree::CmsPage, type: :model do
     end
   end
 
+  describe 'validates uniqueness of slug' do
+    context 'valid' do
+      let!(:page) { create(:cms_standard_page, store: store_a, slug: 'got-name', locale: 'en') }
+
+      it 'valid' do
+        expect(described_class.new(title: 'Another Name', store: store_a, locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).to be_valid
+      end
+    end
+
+    context 'invalid' do
+      let!(:page) { create(:cms_standard_page, store: store_a, slug: 'got-name', locale: 'en') }
+
+      it 'invalid' do
+        expect(described_class.new(title: 'Got Name', store: store_a, slug: 'got-name', locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).not_to be_valid
+      end
+
+      it 'omits previosly deleted page' do
+        expect { page.destroy }.to change(page, :deleted_at).from(nil).to(Time)
+        expect(described_class.new(title: 'Got Name', store: store_a, slug: 'got-name', locale: 'en', type: 'Spree::Cms::Pages::StandardPage')).to be_valid
+      end
+    end
+  end
+
   describe 'Spree::Cms::Pages::Homepage' do
     let(:homepage) { create(:cms_homepage, store: store_a, locale: 'en') }
 


### PR DESCRIPTION
Previously our database index didn't correspond with model validations.

Now it's possible to create a page with the same slug as deleted page