### PR TITLE
Fix Capybara untypable characters issue.

### DIFF
--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :base_product, class: Spree::Product do
-    sequence(:name)   { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
+    sequence(:name)   { |n| "Product #{n}#{Kernel.rand(9999)}" }
     description       { generate(:random_description) }
     price             { 19.99 }
     cost_price        { 17.00 }

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
   end
 
   factory :refund_reason, class: Spree::RefundReason do
-    sequence(:name) { |n| "Refund for return ##{n}" }
+    sequence(:name) { |n| "Refund for return #{n}" }
     active  { true }
     mutable { false }
   end

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
   end
 
   factory :return_authorization_reason, class: Spree::ReturnAuthorizationReason do
-    sequence(:name) { |n| "Defect ##{n}" }
+    sequence(:name) { |n| "Defect #{n}" }
     active          { true }
     mutable         { false }
   end

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :role, class: Spree::Role do
-    sequence(:name) { |n| "Role ##{n}" }
+    sequence(:name) { |n| "Role #{n}" }
 
     factory :admin_role do
       name { 'admin' }

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :shipping_category, class: Spree::ShippingCategory do
-    sequence(:name) { |n| "ShippingCategory ##{n}" }
+    sequence(:name) { |n| "ShippingCategory #{n}" }
   end
 end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -9,10 +9,10 @@ FactoryBot.define do
     password              { 'secret' }
     password_confirmation { password }
     authentication_token  { generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
-    
+
     first_name { FFaker::Name.first_name }
     last_name  { FFaker::Name.last_name }
-    
+
     public_metadata { {} }
     private_metadata { {} }
 


### PR DESCRIPTION
In Capybara when searching for items in a Select2 names that contain a hash (#) fail due to it being an untypable key.
This is more apparent on Spree Backend but in the intrest of future proofing this issue it might be advantagious to remove # from the names for items that might at some point be entered through the test suite key stroke.