### PR TITLE
FriendlyId::Slug is not a reloadable class (like app/ files), so we s…

### DIFF
--- a/core/app/models/friendly_id/slug_decorator.rb
+++ b/core/app/models/friendly_id/slug_decorator.rb
@@ -1,9 +1,0 @@
-module FriendlyId
-  module SlugDecorator
-    def self.prepended(base)
-      base.acts_as_paranoid
-    end
-  end
-end
-
-FriendlyId::Slug.prepend FriendlyId::SlugDecorator

--- a/core/lib/friendly_id/paranoia.rb
+++ b/core/lib/friendly_id/paranoia.rb
@@ -1,0 +1,4 @@
+require 'friendly_id'
+require 'paranoia'
+
+FriendlyId::Slug.acts_as_paranoid

--- a/core/lib/spree_core.rb
+++ b/core/lib/spree_core.rb
@@ -1,1 +1,3 @@
+require 'friendly_id/paranoia'
+
 require 'spree/core'


### PR DESCRIPTION
…hould not prepend to it in a reloadable file

fixes [WARN] FriendlyId::Slug is calling acts_as_paranoid more than once!