### PR TITLE
Use naming via arel for tables in complex .or conditions

### DIFF
--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -339,7 +339,7 @@ module Spree
           case t
           when ApplicationRecord then t
           else
-            Taxon.where(name: t).or(Taxon.where(id: t)).or(Taxon.where("permalink LIKE ? OR permalink = ?", "%/#{t}/", "#{t}/")).first
+            Taxon.where(Taxon.arel_table[:name].eq(t)).or(Taxon.where(Taxon.arel_table[:id].eq(t))).or(Taxon.where(Taxon.arel_table[:permalink].matches("%/#{t}/"))).or(Taxon.where(Taxon.arel_table[:permalink].matches("#{t}/"))).first
           end
         end.compact.flatten.uniq
       end


### PR DESCRIPTION
- installed spree_globalize (globalize) to have the translations for products
- then during the fetching, all products API requests started to produce the errors like: `Relation passed to #or must be structurally compatible. Incompatible values: [:readonly]` and can't complete the request properly.
- I did the research and found that `product_scopes` has the problem in `get_taxons` method because of injecting `has_many: translations` by default to the query and then it started to collide with `.or` chain conditions.

Hope it could be helpful to someone!

WIP: Going to test it more with my current setup, probably it would require to apply the changes for more places to have the explicit table naming as part of the complex queries.