### PR TITLE
Fix changing selected shipping_rate not busting serializer cache

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -250,6 +250,7 @@ module Spree
 
     def selected_shipping_rate_id=(id)
       shipping_rates.update_all(selected: false)
+      shipping_rates.touch_all # Bust cache dependent on "updated_at" timestamp
       shipping_rates.update(id, selected: true)
       save!
     end


### PR DESCRIPTION
## Expected Behavior
We expect to have only one selected shipping provider method for each shipment.

## Actual Behavior
Selecting shipping providers other than the one returned from the API as a default one for a user causes to have multiple shipping providers with the `selected: true` field returned.

Postman call for: `/api/v2/storefront/checkout/shipping_rates` after changing shipping method:
```
...
"included": [
        ...
        {
            "id": "<id 1>",
            "type": "shipping_rate",
            "attributes": {
                ...
                "selected": true,
            }
        },
        {
            "id": "<id 2>",
            "type": "shipping_rate",
            "attributes": {
                 ...
                "selected": true,
            }
        },
        {
            "id": "<id 3>",
            "type": "shipping_rate",
            "attributes": {
                ...
                "selected": false,
            }
        },
    ]
}
```
Only one method for each shipment should contain `"selected": true`.

## Steps to reproduce
1. Select any shipping provider
2. Continue to billing
3. Go back to the shipping
4. Select a different shipping provider than the one selected before
5. Request /api/v2/storefront/checkout/shipping_rates

## Cause
This issue is caused by faulty cache-busting in [Spree::V2::Storefront::EstimatedShippingRateSerializer](https://github.com/spree/spree/blob/main/api/app/serializers/spree/v2/storefront/estimated_shipping_rate_serializer.rb). JSONAPI serializers use the `updated_at` column as the key by default. `update_all` does not update the timestamps as it does not instantiate the models.

## Solution
Calling `touch_all` on the shipping rates after `update_all` bypasses the existing cache key, as the `updated_at` timestamp is changed.