### PR TITLE
Reset shipments and checkout flow after changing currency

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -155,7 +155,7 @@ module Spree
 
     before_create :create_token
     before_create :link_by_email
-    before_update :homogenize_line_item_currencies, if: :currency_changed?
+    before_update :ensure_updated_shipments, :homogenize_line_item_currencies, if: :currency_changed?
 
     with_options presence: true do
       # we want to have this case_sentive: true as changing it to false causes all SQL to use LOWER(slug)

--- a/core/spec/services/spree/cart/change_currency_spec.rb
+++ b/core/spec/services/spree/cart/change_currency_spec.rb
@@ -19,6 +19,23 @@ module Spree
           expect(order.currency).to eq('EUR')
           expect(order.line_items.first.currency).to eq('EUR')
         end
+
+        it 'removes the shipment and restarts the checkout flow' do
+          expect(subject).to be_success
+          order.reload
+          expect(order.shipments).to be_empty
+          expect(order.state).to eq('address')
+        end
+
+        context 'when the order has no shipment' do
+          let(:order) { create(:order_with_totals, store: store, currency: 'USD', state: 'delivery') }
+
+          it 'does not restart the checkout flow' do
+            expect(subject).to be_success
+            order.reload
+            expect(order.state).to eq('delivery')
+          end
+        end
       end
 
       context 'when product does not have a price in given currency' do


### PR DESCRIPTION
## Expected Behavior
After changing currencies with an existing cart that already has a shipping method assigned, the shipping method should be unassigned and the user should be given the option to select a different one.

## Actual Behavior
The shipping method stays the same with the previous rate and changed to an arbitrary method after finishing the checkouot flow.

## Steps to reproduce

#### Prerequisites:
1. Two currencies are configured in the store: EUR, USD
2. There are two shipping methods configured for the same zone (e.g. EU_VAT) 
    - DHL (EUR) - with the price set in EUR
    - DHL (USD) - with the price set in USD
   
#### Steps:
1. Create a cart
2. Set cart's currency to EUR
3. Start the checkout process via the API
4. Fill in shipping details for an address in EU_VAT zone (e.g. Germany)
5. You'll see DHL (EUR) as available shipping method
6. Choose DHL (EUR) as a shipping method
7. The total order price should be price in EUR (line items) + shipping price for DHL (EUR)
8. Change currency of the cart to USD
9. The value of line items will be converted to USD, but DHL (EUR) will still be chosen as a shipping method
10. Go through the shipping address step again (call orderUpdate)
11. When fetching available shipping methods, DHL (USD) won't be visible, DHL (EUR) will be visible
12. You can still select DHL (EUR), even though its price is in a different currency
13. When you finalize the order, the shipping methods will automatically switch to DHL (USD) or a random shipping method for USD if there are multiple available

## Cause
The shipping method is neither changed or removed after selecting a different currency.

## Solution
Resetting the checkout flow and removing the assigned shipments from the order.
