### PR TITLE
Fix bug that shows removed item in cart

### DIFF
--- a/core/app/services/spree/cart/remove_line_item.rb
+++ b/core/app/services/spree/cart/remove_line_item.rb
@@ -11,6 +11,7 @@ module Spree
                                                                             line_item: line_item,
                                                                             options: options)
         end
+        order.reload
         success(line_item)
       end
     end

--- a/core/spec/services/spree/cart/remove_line_item_spec.rb
+++ b/core/spec/services/spree/cart/remove_line_item_spec.rb
@@ -11,13 +11,28 @@ module Spree
     let(:value) { execute.value }
 
     context 'remove line item' do
-      it 'with any quantity' do
-        expect(order.amount).to eq 200
-        expect { execute }.to change { order.line_items.count }.by(-1)
-        expect(execute).to be_success
-        expect(value).to eq line_item
-        order.reload
-        expect(order.amount).to eq 0
+      context 'with any quantity' do
+        it 'with any quantity' do
+          expect(order.amount).to eq 200
+          expect { execute }.to change { order.line_items.count }.by(-1)
+          expect(execute).to be_success
+          expect(value).to eq line_item
+          expect(order.amount).to eq 0
+        end
+      end
+
+      context 'with many unique items' do
+        let(:order) { create(:order_with_line_items, line_items_count: 2) }
+        let(:line_item) {order.line_items.first}
+
+        it 'from order with many unique items' do
+          expect(order.amount).to eq 20
+          expect(order.line_items.count).to eq 2
+          expect { execute }.to change { order.line_items.count }.by(-1)
+          expect(execute).to be_success
+          expect(value).to eq line_item
+          expect(order.amount).to eq 10
+        end
       end
     end
 


### PR DESCRIPTION
<h2> Bug description </h2>
After removing a line item from the cart with many unique items, the removed item still appears in the cart. After reloading, order is updated and the cart shows correct values.

<h2> Solution </h2>
Method RemoveLineItem.call will reload the order after destroying line_item and recalculating the cart. 
(Previously 

`order.reload`
 was in the tests).

<h2> Additional test case </h2>
I added an additional test because this bug doesn't appear when there is a single line item in order. 
