### PR TITLE
Change after_save hook to after_update, because on create, this updat…

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -42,7 +42,7 @@ module Spree
 
     before_validation :copy_taxonomy_from_parent
     after_save :touch_ancestors_and_taxonomy
-    after_save :sync_taxonomy_name
+    after_update :sync_taxonomy_name
     after_touch :touch_ancestors_and_taxonomy
 
     has_one :icon, as: :viewable, dependent: :destroy, class_name: 'Spree::TaxonImage'

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -15,7 +15,7 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store'
 
     after_create :set_root
-    after_save :set_root_taxon_name
+    after_update :set_root_taxon_name
 
     default_scope { order("#{table_name}.position, #{table_name}.created_at") }
 


### PR DESCRIPTION
…e is not necessary. Additionally, these updates on create cause issues with translations (such as spree_globalize or spree_mobility)

As said in commit message, these hooks should be after_update, as they serve no purpose on create. Also, even if they should technically work, they break spree_globalize or spree_mobility translations in a very edge-casey way. Also see https://github.com/mrbrdo/spree_mobility/issues/6

Besides, all it does on create is make a bunch of unnecessary queries and slow things down.