### PR TITLE
Fix typo in image resize params (gravity)

### DIFF
--- a/core/app/models/concerns/spree/image_methods.rb
+++ b/core/app/models/concerns/spree/image_methods.rb
@@ -2,7 +2,7 @@ module Spree
   module ImageMethods
     extend ActiveSupport::Concern
 
-    def generate_url(size:, gravity: 'centre', quality: 80, background: [0, 0, 0])
+    def generate_url(size:, gravity: 'center', quality: 80, background: [0, 0, 0])
       return if size.blank?
 
       size = size.gsub(/\s+/, '')


### PR DESCRIPTION
Typo, breaks if using mini_magick for image_processing.