### PR TITLE
allow properties param to be in array form

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -179,7 +179,9 @@ module Spree
         properties.to_unsafe_hash.each do |property_filter_param, product_properties_values|
           next if property_filter_param.blank? || product_properties_values.empty?
 
-          values = product_properties_values.split(',').reject(&:empty?).uniq.map(&:parameterize)
+          values = product_properties_values
+          values = values.split(',') unless values.kind_of?(Array)
+          values = values.reject(&:empty?).uniq.map(&:parameterize)
 
           next if values.empty?
 

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -181,7 +181,7 @@ module Spree
 
           values = product_properties_values
           values = values.split(',') unless values.kind_of?(Array)
-          values = values.reject(&:empty?).uniq.map(&:parameterize)
+          values = values.flatten.reject(&:empty?).uniq.map(&:parameterize)
 
           next if values.empty?
 


### PR DESCRIPTION
Some crawlers use this format for some reason, perhaps some browsers too. Could help SEO, and also without this fix, it would raise an exception / runtime error.