### PR TITLE
When ordering by price, needs a GROUP BY, otherwise even with DISTINC…

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -216,14 +216,14 @@ module Spree
           products.order(available_on: :desc)
         when 'price-high-to-low'
           products.
-            select("#{Product.table_name}.*, #{Spree::Price.table_name}.amount").
-            reorder('').
-            send(:descend_by_master_price)
+            group(:id).
+            select("#{Product.table_name}.*, MIN(#{Spree::Price.table_name}.amount)").
+            reorder("MIN(#{Spree::Price.table_name}.amount) DESC")
         when 'price-low-to-high'
           products.
-            select("#{Product.table_name}.*, #{Spree::Price.table_name}.amount").
-            reorder('').
-            send(:ascend_by_master_price)
+            group(:id).
+            select("#{Product.table_name}.*, MIN(#{Spree::Price.table_name}.amount)").
+            reorder("MIN(#{Spree::Price.table_name}.amount)")
         end
       end
 


### PR DESCRIPTION
…T it would return duplicate products with multiple variants (with different prices)

Current implementation produces duplicate results when ordering search results by price. When products have multiple variants.