### PR TITLE
List all available countries in checkout instead of all countries (even if not listed in any Zone).

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -167,7 +167,7 @@ module Spree
     end
 
     def countries_available_for_checkout
-      @countries_available_for_checkout ||= checkout_zone.try(:country_list) || Spree::Country.all
+      @countries_available_for_checkout ||= checkout_zone.try(:country_list) || all_available_countries
     end
 
     def states_available_for_checkout(country)
@@ -191,6 +191,17 @@ module Spree
     end
 
     private
+
+    def all_available_countries
+      zones = Spree::Zone.all.to_a
+      if zones.empty?
+        Spree::Country.all
+      else
+        zones.each_with_object([]) do |zone, a|
+          a.concat(zone.country_list)
+        end
+      end
+    end
 
     def ensure_default_exists_and_is_unique
       if default


### PR DESCRIPTION
Limit the list of Countries to all countries that are assigned to any Zone, instead of showing completely all Countries. A Country without a Zone does not specify tax nor delivery methods.

PS: A similar fix might need to be done for States (`states_available_for_checkout`). We don't use states here so I have not checked or changed that.