### PR TITLE
Backend - Ensure persisted addresses have proper state selected

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/address_states.es6
+++ b/backend/app/assets/javascripts/spree/backend/address_states.es6
@@ -1,4 +1,4 @@
-function updateAddressState(region, successCallback) {
+function updateAddressState(region, currentSelection, successCallback) {
   const countryId = $('#' + region + 'country select').val()
   const stateContainer = $('#' + region + 'state').parent()
   const stateSelect = $('#' + region + 'state select')
@@ -20,6 +20,7 @@ function updateAddressState(region, successCallback) {
                 .html(state.attributes.name)
               stateSelect.append(opt).trigger('change')
             })
+            stateSelect.val(currentSelection).trigger('change')
             stateSelect.prop('disabled', false).show()
             stateSelect.select2()
             stateInput.hide().prop('disabled', true)

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -38,8 +38,8 @@
 <% content_for :head do %>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      updateAddressState('<%= s_or_b %>');
-      $('#<%= s_or_b %>country select').on('change', function() { updateAddressState('<%= s_or_b %>'); });
+      updateAddressState('<%= s_or_b %>', '<%= f.object.state_id %>');
+      $('#<%= s_or_b %>country select').on('change', function() { updateAddressState('<%= s_or_b %>', '<%= f.object.state_id %>'); });
     })
   </script>
 <% end %>


### PR DESCRIPTION
Currently, when updating a user's address or viewing a persisted address on an order, the state dropdown menu is not correctly displaying.

<img width="805" alt="image" src="https://user-images.githubusercontent.com/94377/174932513-6c18bf35-d7b9-464e-9a27-45247d0c6100.png">

This pull request allows the ID for the state to be passed into the javascript that gets run to set the value appropriately. 