### PR TITLE
Frontend - Ensure empty state option

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -59,6 +59,7 @@ Spree.ready(function($) {
 
       Spree.fillStates = function(data, region) {
         var selected
+        var emptyOpt
         var statesRequired = data.states_required
         var states = data.states
         var statePara = $('#' + region + 'state')
@@ -70,7 +71,10 @@ Spree.ready(function($) {
 
         if (states.length > 0) {
           selected = parseInt(stateSelect.val())
+          emptyOpt = stateSelect.find('option')[0]
+
           stateSelect.html('')
+          stateSelect.append(emptyOpt)
           $.each(states, function(idx, state) {
             var opt = $(document.createElement('option')).attr('value', state.id).html(state.name)
             if (selected.toString(10) === state.id.toString(10)) {


### PR DESCRIPTION
Currently, when a customer goes to input an address, the state dropdown has no "empty" option which causes the 1st option to be pre-selected.  This can cause customers to end up picking the wrong state.  This PR adds the default empty option (which will be addressed through validation) so that there's a bit more for a user to do to ensure they're choosing a correct address.

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/94377/175795787-423329bf-db4d-4f58-a487-500699c56c56.png">
