### PR TITLE
Fix incorrect inventory unit merge

### DIFF
--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -92,7 +92,7 @@ module Spree
     end
 
     def get_desired_shipment_inventory_unit(state)
-      desired_shipment.inventory_units.find_or_create_by(state: state) do |unit|
+      desired_shipment.inventory_units.find_or_create_by(state: state, variant: variant) do |unit|
         current_shipment_unit = current_shipment_units.first
         unit.variant_id = current_shipment_unit.variant_id
         unit.order_id = current_shipment_unit.order_id


### PR DESCRIPTION
Allows the Spree::FulfilmentChanger to add inventory units to a shipment if the shipment already contains inventory units of another variant type.

Fixes #11723 