### PR TITLE
Add void to INVALID_STATES

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -410,7 +410,7 @@ module Spree
 
     # Helper methods for checkout steps
     def paid?
-      payments.valid.completed.size == payments.valid.size && payments.valid.sum(:amount) >= total
+      payments.valid.completed.sum(:amount) >= total
     end
 
     def available_payment_methods(store = nil)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -410,7 +410,7 @@ module Spree
 
     # Helper methods for checkout steps
     def paid?
-      payments.valid.completed.size == payments.valid.size && payments.valid.completed.sum(:amount) >= total
+      payments.valid.completed.size == payments.valid.size && payments.valid.sum(:amount) >= total
     end
 
     def available_payment_methods(store = nil)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -410,7 +410,7 @@ module Spree
 
     # Helper methods for checkout steps
     def paid?
-      payments.valid.completed.sum(:amount) >= total
+      payments.valid.completed.size == payments.valid.size && payments.valid.completed.sum(:amount) >= total
     end
 
     def available_payment_methods(store = nil)

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -17,7 +17,7 @@ module Spree
 
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
     RISKY_AVS_CODES     = ['A', 'C', 'E', 'F', 'G', 'I', 'K', 'L', 'N', 'O', 'P', 'R', 'S', 'U', 'W', 'Z'].freeze
-    INVALID_STATES      = %w(failed invalid).freeze
+    INVALID_STATES      = %w(failed invalid void).freeze
 
     with_options inverse_of: :payments do
       belongs_to :order, class_name: 'Spree::Order', touch: true

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1612,9 +1612,65 @@ describe Spree::Order, type: :model do
       end
     end
 
-    context 'when not all order payments are valid and completed' do
+    context 'when not all order payments are completed one is void' do
       before do
         payment_0.void
+        payment_1.complete
+        payment_2.complete
+      end
+
+      context 'when the amount of the valid payments < the order total' do
+        let(:total) { 201 }
+
+        it { expect(subject).to eq(false) }
+      end
+
+      context 'when the amount of the valid payments == the order total' do
+        let(:total) { 200 }
+
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when the amount of the valid payments > the order total' do
+        let(:total) { 199 }
+
+        it { expect(subject).to eq(true) }
+      end
+    end
+
+    context 'when not all order payments are completed one is failed' do
+      before do
+        payment_0.state = 'failed'
+        payment_0.save!
+
+        payment_1.complete
+        payment_2.complete
+      end
+
+      context 'when the amount of the valid payments < the order total' do
+        let(:total) { 201 }
+
+        it { expect(subject).to eq(false) }
+      end
+
+      context 'when the amount of the valid payments == the order total' do
+        let(:total) { 200 }
+
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when the amount of the valid payments > the order total' do
+        let(:total) { 199 }
+
+        it { expect(subject).to eq(true) }
+      end
+    end
+
+    context 'when not all order payments are completed one is invalid' do
+      before do
+        payment_0.state = 'invalid'
+        payment_0.save!
+
         payment_1.complete
         payment_2.complete
       end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Payment, type: :model do
   it_behaves_like 'metadata'
 
   describe 'Constants' do
-    it { expect(Spree::Payment::INVALID_STATES).to eq(%w(failed invalid)) }
+    it { expect(Spree::Payment::INVALID_STATES).to eq(%w(failed invalid void)) }
   end
 
   describe 'scopes' do


### PR DESCRIPTION
If a void payment was created an order would never then be moved to .paid? if a subsequent completed payment was made.