### PR TITLE
Fix user association namespace when using custom Spree.user_class

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -37,7 +37,7 @@ module Spree
 
     belongs_to :country, class_name: 'Spree::Country'
     belongs_to :state, class_name: 'Spree::State', optional: true
-    belongs_to :user, class_name: Spree.user_class.name, optional: true
+    belongs_to :user, class_name: "::#{Spree.user_class}", optional: true
 
     has_many :shipments, inverse_of: :address
 

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -12,7 +12,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :payment_method
-    belongs_to :user, class_name: Spree.user_class.to_s, foreign_key: 'user_id',
+    belongs_to :user, class_name: "::#{Spree.user_class}", foreign_key: 'user_id',
                       optional: true
     has_many :payments, as: :source
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -86,7 +86,7 @@ module Spree
     attribute :state_machine_resumed, :boolean
 
     if Spree.user_class
-      belongs_to :user, class_name: Spree.user_class.to_s, optional: true
+      belongs_to :user, class_name: "::#{Spree.user_class}", optional: true
     else
       belongs_to :user, optional: true
     end

--- a/core/app/models/spree/promotion_rule_user.rb
+++ b/core/app/models/spree/promotion_rule_user.rb
@@ -1,7 +1,7 @@
 module Spree
   class PromotionRuleUser < Spree::Base
     belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: "::#{Spree.user_class}"
 
     validates :user, :promotion_rule, presence: true
     validates :user_id, uniqueness: { scope: :promotion_rule_id }, allow_nil: true

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -3,6 +3,6 @@ module Spree
     include UniqueName
 
     has_many :role_users, class_name: 'Spree::RoleUser', dependent: :destroy
-    has_many :users, through: :role_users, class_name: Spree.user_class.to_s
+    has_many :users, through: :role_users, class_name: "::#{Spree.user_class}"
   end
 end

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -1,6 +1,6 @@
 module Spree
   class RoleUser < Spree::Base
     belongs_to :role, class_name: 'Spree::Role'
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: "::#{Spree.user_class}"
   end
 end

--- a/core/app/models/spree/state_change.rb
+++ b/core/app/models/spree/state_change.rb
@@ -1,6 +1,6 @@
 module Spree
   class StateChange < Spree::Base
-    belongs_to :user, class_name: Spree.user_class.to_s, optional: true
+    belongs_to :user, class_name: "::#{Spree.user_class}", optional: true
     belongs_to :stateful, polymorphic: true
 
     def <=>(other)

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -18,7 +18,7 @@ module Spree
 
     DEFAULT_CREATED_BY_EMAIL = 'spree@example.com'.freeze
 
-    belongs_to :user, class_name: Spree.user_class.to_s, foreign_key: 'user_id'
+    belongs_to :user, class_name: "::#{Spree.user_class}", foreign_key: 'user_id'
     belongs_to :category, class_name: 'Spree::StoreCreditCategory'
     belongs_to :created_by, class_name: Spree.admin_user_class.to_s, foreign_key: 'created_by_id'
     belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id'

--- a/core/app/models/spree/wishlist.rb
+++ b/core/app/models/spree/wishlist.rb
@@ -7,7 +7,7 @@ module Spree
 
     has_secure_token
 
-    belongs_to :user, class_name: Spree.user_class.name, touch: true
+    belongs_to :user, class_name: "::#{Spree.user_class}", touch: true
     belongs_to :store, class_name: 'Spree::Store'
 
     has_many :wished_items, class_name: 'Spree::WishedItem', dependent: :destroy


### PR DESCRIPTION
Fixes #11731

When using a custom user class, e.g. `Spree.user_class = "User"`, the class_name association needs to escape the Spree namespace or Rails tries to load the wrong model. See #11731 for more info. 