### PR TITLE
Revert "Add ability to extend/add new CMS sections types"

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/cms_sections_controller.rb
@@ -12,7 +12,7 @@ module Spree
           def spree_permitted_attributes
             stored_attributes = []
 
-            Rails.application.config.spree.cms.sections.map(&:to_s).each do |type|
+            Spree::CmsSection::TYPES.each do |type|
               type.constantize.stored_attributes.each do |_name, values|
                 values.each do |value|
                   stored_attributes << value

--- a/core/app/models/spree/cms_section.rb
+++ b/core/app/models/spree/cms_section.rb
@@ -33,6 +33,13 @@ module Spree
 
     LINKED_RESOURCE_TYPE = []
 
+    TYPES = ['Spree::Cms::Sections::HeroImage',
+             'Spree::Cms::Sections::FeaturedArticle',
+             'Spree::Cms::Sections::ProductCarousel',
+             'Spree::Cms::Sections::ImageGallery',
+             'Spree::Cms::Sections::SideBySideImages',
+             'Spree::Cms::Sections::RichTextContent']
+
     def boundaries
       ['Container', 'Screen']
     end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -11,11 +11,9 @@ module Spree
                                :adjusters,
                                :stock_splitters,
                                :promotions,
-                               :cms,
                                :line_item_comparison_hooks)
       SpreeCalculators = Struct.new(:shipping_methods, :tax_rates, :promotion_actions_create_adjustments, :promotion_actions_create_item_adjustments)
       PromoEnvironment = Struct.new(:rules, :actions)
-      CmsEnvironment   = Struct.new(:sections)
       isolate_namespace Spree
       engine_name 'spree'
 
@@ -123,16 +121,6 @@ module Spree
           Promotion::Actions::CreateItemAdjustments,
           Promotion::Actions::CreateLineItems,
           Promotion::Actions::FreeShipping
-        ]
-
-        Rails.application.config.spree.cms = CmsEnvironment.new
-        Rails.application.config.spree.cms.sections = [
-          Spree::Cms::Sections::HeroImage,
-          Spree::Cms::Sections::FeaturedArticle,
-          Spree::Cms::Sections::ProductCarousel,
-          Spree::Cms::Sections::ImageGallery,
-          Spree::Cms::Sections::SideBySideImages,
-          Spree::Cms::Sections::RichTextContent
         ]
       end
 


### PR DESCRIPTION
Reverts spree/spree#11694

this breaks backward compatibility, need a better way to achieve this