### PR TITLE
Specify case_sensitive on Store code validation

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -64,7 +64,7 @@ module Spree
 
     validates :digital_asset_authorized_clicks, numericality: { only_integer: true, greater_than: 0 }
     validates :digital_asset_authorized_days, numericality: { only_integer: true, greater_than: 0 }
-    validates :code, uniqueness: { case_sensitive: true, conditions: -> { with_deleted } }
+    validates :code, uniqueness: { case_sensitive: false, conditions: -> { with_deleted } }
     validates :mail_from_address, email: { allow_blank: false }
 
     # FIXME: we should remove this condition in v5

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -64,7 +64,7 @@ module Spree
 
     validates :digital_asset_authorized_clicks, numericality: { only_integer: true, greater_than: 0 }
     validates :digital_asset_authorized_days, numericality: { only_integer: true, greater_than: 0 }
-    validates :code, uniqueness: { conditions: -> { with_deleted } }
+    validates :code, uniqueness: { case_sensitive: true, conditions: -> { with_deleted } }
     validates :mail_from_address, email: { allow_blank: false }
 
     # FIXME: we should remove this condition in v5


### PR DESCRIPTION
Fixes DEPRECATION WARNING: Uniqueness validator will no longer enforce
 case sensitive comparison in Rails 6.1.
 To continue case sensitive comparison on the :code attribute
 in Spree::Store model, pass `case_sensitive: true` option
 explicitly to the uniqueness validator.