### PR TITLE
[GitHub] Add minimum GitHub token permission for workflow

### DIFF
--- a/.github/workflows/spelling_lint.yml
+++ b/.github/workflows/spelling_lint.yml
@@ -3,6 +3,9 @@ name: Lint Code Spelling
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check spelling all files with codespell


### PR DESCRIPTION
## Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows. 
All GitHub Actions workflows have a GITHUB_TOKEN with `write` access to multiple scopes. 
Here is an example of the permissions in one of the workflows:
https://github.com/spree/spree/runs/7692233827?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for each workflow. 

## Motivation
- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced. 
- GitHub recommends defining minimum GITHUB_TOKEN permissions. 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>