### PR TITLE
V-938 Allow skipping filters in the products list response Storefront API

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -48,7 +48,11 @@ module Spree
           end
 
           def collection_meta(collection)
-            super(collection).merge(filters: filters_meta)
+            if params[:skip_filters]
+              super(collection)
+            else
+              super(collection).merge(filters: filters_meta)
+            end
           end
 
           def filters_meta

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -1221,6 +1221,12 @@ paths:
               <li>updated_at (ascending/descending)</li>
               <li>sku (ascending/descending)</li>
             </ul> Use <q>-</q> sign to set descending sort, eg. <q>-updated_at</q>
+        - in: query
+            name: 'skip_filters'
+            schema:
+              type: boolean
+            example: true
+            description: Skips returning product filter metadata in response.
         - $ref: '#/components/parameters/PageParam'
         - $ref: '#/components/parameters/PerPageParam'
         - $ref: '#/components/parameters/ProductIncludeParam'

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -774,6 +774,13 @@ describe 'API V2 Storefront Products Spec', type: :request do
           expect(json_response['meta']['filters']['product_properties']).to contain_exactly(property3_response)
         end
       end
+
+      context 'skipping filters' do
+        it 'does not show filter information when skip_filters is provided' do
+          get "/api/v2/storefront/products", params: { skip_filters: true }
+          expect(json_response['meta']).not_to have_key(:filters)
+        end
+      end
     end
 
     context 'fetch products by curency param' do


### PR DESCRIPTION
https://linear.app/vendo/issue/V-938/add-skip-filters-option-for-storefront-products-api