### PR TITLE
Spree::Addresses::Create returns either success or failure

### DIFF
--- a/core/app/services/spree/addresses/update.rb
+++ b/core/app/services/spree/addresses/update.rb
@@ -13,7 +13,12 @@ module Spree
         if address&.editable?
           address.update(address_params) ? success(address) : failure(address)
         else
-          new_address(address_params).valid? ? address.destroy && success(new_address) : failure(new_address)
+          if new_address(address_params).valid?
+            address.destroy
+            success(new_address)
+          else
+            failure(new_address)
+          end
         end
       end
 


### PR DESCRIPTION
Using the address.destroy && success(new_address) notation, we are not assured that the service will return a success, leading to error when the consumer of the sevice checks for success or failure.