### PR TITLE
Always preserve User ID when creating a copy of non-editable address …

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,7 @@ Metrics/BlockLength:
     - '**/*.rake'
     - '**/factories/**/*'
     - '**/config/routes.rb'
+    - '**/lib/**/testing_support/**/*'
 
 Metrics/AbcSize:
  Max: 45

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -58,6 +58,7 @@ group :test, :development do
   gem 'webdrivers', '~> 4.1'
   gem 'puma'
   gem 'ffaker'
+  gem 'psych', '< 4'
 end
 
 group :development do

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -58,7 +58,6 @@ group :test, :development do
   gem 'webdrivers', '~> 4.1'
   gem 'puma'
   gem 'ffaker'
-  gem 'psych', '< 4'
 end
 
 group :development do

--- a/core/app/services/spree/addresses/update.rb
+++ b/core/app/services/spree/addresses/update.rb
@@ -9,6 +9,7 @@ module Spree
       def call(address:, address_params:)
         address_params[:country_id] ||= address.country_id
         address_params = fill_country_and_state_ids(address_params)
+        address_params[:user_id] = address.user_id if address.user_id.present?
 
         if address&.editable?
           address.update(address_params) ? success(address) : failure(address)

--- a/core/spec/services/spree/account/addresses/update_spec.rb
+++ b/core/spec/services/spree/account/addresses/update_spec.rb
@@ -32,6 +32,7 @@ module Spree
           expect(value).to have_attributes(new_address_params)
           expect(value.country).to eq(country)
           expect(value.state).to eq(state)
+          expect(value.user).to eq(user)
         end
       end
 


### PR DESCRIPTION
…during update