### PR TITLE
Add package.json to test dummy for spree backend

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -57,6 +57,10 @@ module Spree
       template 'rails/test.rb', "#{dummy_path}/config/environments/test.rb", force: true
       template 'rails/script/rails', "#{dummy_path}/spec/dummy/script/rails", force: true
       template 'initializers/devise.rb', "#{dummy_path}/config/initializers/devise.rb", force: true
+
+      if lib_name == 'spree/backend'
+        template 'package.json', "#{dummy_path}/package.json", force: true
+      end
     end
 
     def test_dummy_inject_extension_requirements

--- a/core/lib/generators/spree/dummy/templates/package.json
+++ b/core/lib/generators/spree/dummy/templates/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "app",
+  "private": "true",
+  "dependencies": {
+    "@hotwired/turbo-rails": "^7.2.0",
+    "@spree/dashboard": "^0.2.1",
+    "esbuild": "^0.15.10"
+  },
+  "scripts": {
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds"
+  }
+}


### PR DESCRIPTION
Building test dummy for spree backend fails, on asset compilation. This is caused by the build task is not being defined in generated package.json. I added it explicitly.