### PR TITLE
Fix spree samples

### DIFF
--- a/sample/db/samples/variants.csv
+++ b/sample/db/samples/variants.csv
@@ -172,9 +172,9 @@ Sportswear,Tops,oversize t-shirt wrapped on back,pink
 Sportswear,Tops,long sleeves crop top,black
 Sportswear,Tops,laced crop top,black
 Sportswear,Tops,sports bra medium support,black
-Sportswear,Tops,sports bra ,green
-Sportswear,Tops,sports bra ,blue
-Sportswear,Tops,sports bra ,burgundy
+Sportswear,Tops,sports bra,green
+Sportswear,Tops,sports bra,blue
+Sportswear,Tops,sports bra,burgundy
 Sportswear,Tops,sport cropp top,burgundy
 Sportswear,Sweatshirts,running sweatshirt,light_blue
 Sportswear,Sweatshirts,lightweight running jacket,grey


### PR DESCRIPTION
When loading samples on Spree 4.5, there's an error with product that cannot be found. This is caused by a whitespace in the CSV file that's imported.