### PR TITLE
Fix caching issues with nested models

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -62,4 +62,13 @@ class Spree::Base < ApplicationRecord
   def self.json_api_type
     to_s.demodulize.underscore
   end
+
+  private
+  # Rails bug: https://github.com/rails/rails/issues/26726
+  # Even adding `inverse_of` to `belongs_to` does not solve the issue for us.
+  # We can disable the TouchLater functionality that we don't really need.
+  # TouchLater explanation: https://github.com/rails/rails/issues/18606
+  def belongs_to_touch_method
+    :touch
+  end
 end


### PR DESCRIPTION
Due to a Rails bug (https://github.com/rails/rails/issues/26726), cache is not correctly invalidated when updating child models. For example, if updating a product price in admin, the variant and product updated_at is not touch-ed, but should be. Fix by not using TouchLater.

Basically, explained on example, if we update 2 Variants at the same time, without TouchLater, the Product will be touched twice. With TouchLater, it would be only touched once. I think in the case of Spree, we don't have a case where we are updating many (hundreds) of child models at once, so TouchLater would have little performance gain. Besides, it does not work correctly, so we can just turn it off until it's fixed.

Better fix for: https://github.com/spree/spree/pull/11621