### PR TITLE
add locale parameter to links in emails that should include it

### DIFF
--- a/emails/app/views/spree/shared/purchased_items_table/_line_item.html.erb
+++ b/emails/app/views/spree/shared/purchased_items_table/_line_item.html.erb
@@ -1,11 +1,11 @@
 <tr>
   <td class="purchase_image">
-    <%= link_to(image_tag(variant_image_url(line_item.variant)), spree_storefront_resource_url(line_item.product)) %>
+    <%= link_to(image_tag(variant_image_url(line_item.variant)), spree_storefront_resource_url(line_item.product, locale: I18n.locale)) %>
   </td>
   <td class="purchase_item">
     <strong>
       <span class="f-fallback">
-        <%= link_to raw(line_item.name), spree_storefront_resource_url(line_item.product) %>
+        <%= link_to raw(line_item.name), spree_storefront_resource_url(line_item.product, locale: I18n.locale) %>
       </span>
     </strong>
     <p class="purchase_item--additional"><%= raw(line_item.variant.options_text) -%></p>


### PR DESCRIPTION
The links to products in the order confirmation email should include user's locale, so the user will not get switched to the default locale (for example English, but the order was made in German). Specifically tested with legacy frontend but the same logic should apply to JS frontends.