### PR TITLE
If overriding tax_category, it only makes sense to update tax_categor…

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -220,6 +220,10 @@ module Spree
       @tax_category ||= super || TaxCategory.find_by(is_default: true)
     end
 
+    def tax_category_id
+      super || tax_category.try(:id)
+    end
+
     # Adding properties and option types on creation based on a chosen prototype
     attr_accessor :prototype_id
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -150,6 +150,10 @@ module Spree
                         end
     end
 
+    def tax_category_id
+      super || tax_category.try(:id)
+    end
+
     def options_text
       @options_text ||= Spree::Variants::OptionsPresenter.new(self).to_sentence
     end


### PR DESCRIPTION
…y_id as well

fixes confusing display of Tax category as "None" in admin, while it actually uses "Default"
ideally, it would be better to update the tax_category_id in the DB and re-update any time TaxCategory#is_default changes

<s>
I can also implement the "ideal" solution as described but it will require to add a migration (which means when updating spree, migrations need to be copied again, and ran).

Also in this case, is there any reason why Product#tax_category_id would actually be nil, or can we make it mandatory? In the current implementation it will always return the default category. Is it possible to create (and use) a product without having any tax categories?
On the other hand, I assume we always want Variant#tax_category_id to fallback to Product#tax_category_id unless explicitly set.
</s>

After some thinking, need a comment on this. Using this solution, the tax_category_id will also be set in the DB after the product is updated (in the backend) due to how Rails forms work. This means that if default TaxCategory is changed, these products will keep using the same TaxCategory as before. In the current implementation, they would switch to the new default, which may be the desired behavior.
But on the other hand having `tax_category_id` not reflect `tax_category`, and having it show up as `None` in the backend both sounds wrong. Honestly for the last 6 months I have been clicking to change it to `Default` (the name of my default TaxCategory) on every new product, since I wasn't clear what `None` would do.