### PR TITLE
Locale in user

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/account_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/account_controller.rb
@@ -43,7 +43,7 @@ module Spree
           end
 
           def user_update_params
-            params.require(:user).permit(permitted_user_attributes, :saved_locale)
+            params.require(:user).permit(permitted_user_attributes)
           end
         end
       end

--- a/api/app/controllers/spree/api/v2/storefront/account_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/account_controller.rb
@@ -43,7 +43,7 @@ module Spree
           end
 
           def user_update_params
-            params.require(:user).permit(permitted_user_attributes)
+            params.require(:user).permit(permitted_user_attributes, :saved_locale)
           end
         end
       end

--- a/api/app/serializers/spree/api/v2/platform/user_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/user_serializer.rb
@@ -5,7 +5,7 @@ module Spree
         class UserSerializer < BaseSerializer
           set_type :user
 
-          attributes :email, :first_name, :last_name, :created_at, :updated_at, :public_metadata, :private_metadata, :saved_locale
+          attributes :email, :first_name, :last_name, :created_at, :updated_at, :public_metadata, :private_metadata, :selected_locale
 
           attribute :average_order_value do |user, params|
             price_stats(user.report_values_for(:average_order_value, params[:store]))

--- a/api/app/serializers/spree/api/v2/platform/user_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/user_serializer.rb
@@ -5,7 +5,7 @@ module Spree
         class UserSerializer < BaseSerializer
           set_type :user
 
-          attributes :email, :first_name, :last_name, :created_at, :updated_at, :public_metadata, :private_metadata
+          attributes :email, :first_name, :last_name, :created_at, :updated_at, :public_metadata, :private_metadata, :saved_locale
 
           attribute :average_order_value do |user, params|
             price_stats(user.report_values_for(:average_order_value, params[:store]))

--- a/api/app/serializers/spree/v2/storefront/user_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/user_serializer.rb
@@ -4,7 +4,7 @@ module Spree
       class UserSerializer < BaseSerializer
         set_type :user
 
-        attributes :email, :first_name, :last_name, :public_metadata
+        attributes :email, :first_name, :saved_locale, :last_name, :public_metadata
 
         attribute :store_credits do |user|
           user.total_available_store_credit

--- a/api/app/serializers/spree/v2/storefront/user_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/user_serializer.rb
@@ -4,7 +4,7 @@ module Spree
       class UserSerializer < BaseSerializer
         set_type :user
 
-        attributes :email, :first_name, :saved_locale, :last_name, :public_metadata
+        attributes :email, :first_name, :selected_locale, :last_name, :public_metadata
 
         attribute :store_credits do |user|
           user.total_available_store_credit

--- a/api/docs/v2/platform/index.yaml
+++ b/api/docs/v2/platform/index.yaml
@@ -15490,6 +15490,7 @@ paths:
                         email: ivonne.braun@smith.biz
                         first_name: Liberty
                         last_name: Becker
+                        selected_locale: nil
                         created_at: '2022-11-08T19:35:53.726Z'
                         updated_at: '2022-11-08T19:35:53.726Z'
                         public_metadata: {}
@@ -15508,6 +15509,7 @@ paths:
                         email: lenita.mayer@kulas.us
                         first_name: Chasidy
                         last_name: Strosin
+                        selected_locale: 'fr'
                         created_at: '2022-11-08T19:35:53.730Z'
                         updated_at: '2022-11-08T19:35:53.730Z'
                         public_metadata: {}
@@ -15526,6 +15528,7 @@ paths:
                         email: dewayne@terrybarton.info
                         first_name: Ruben
                         last_name: Schmidt
+                        selected_locale: 'de'
                         created_at: '2022-11-08T19:35:53.732Z'
                         updated_at: '2022-11-08T19:35:53.732Z'
                         public_metadata: {}
@@ -15591,6 +15594,7 @@ paths:
                         email: rex_champlin@breitenberg.com
                         first_name: Zenia
                         last_name: King
+                        selected_locale: 'pl'
                         created_at: '2022-11-08T19:35:54.351Z'
                         updated_at: '2022-11-08T19:35:54.351Z'
                         public_metadata: {}
@@ -15660,6 +15664,7 @@ paths:
                         email: gaynell@parisian.biz
                         first_name: Irwin
                         last_name: DuBuque
+                        selected_locale: 'en'
                         created_at: '2022-11-08T19:35:54.635Z'
                         updated_at: '2022-11-08T19:35:54.635Z'
                         public_metadata: {}
@@ -15730,6 +15735,7 @@ paths:
                         email: john@example.com
                         first_name: Astrid
                         last_name: Kohler
+                        selected_locale: 'fr'
                         created_at: '2022-11-08T19:35:55.180Z'
                         updated_at: '2022-11-08T19:35:55.414Z'
                         public_metadata: {}
@@ -21338,6 +21344,8 @@ components:
               type: string
             password_confirmation:
               type: string
+            selected_locale:
+              type: string
             ship_address_id:
               type: string
             bill_address_id:
@@ -21364,6 +21372,8 @@ components:
             password:
               type: string
             password_confirmation:
+              type: string
+            selected_locale:
               type: string
             ship_address_id:
               type: string

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -63,6 +63,9 @@ paths:
                     last_name:
                       type: string
                       example: Snow
+                    selected_locale:
+                      type: string
+                      example: 'en'
                     password:
                       type: string
                       example: spree123
@@ -110,6 +113,9 @@ paths:
                     last_name:
                       type: string
                       example: Snow
+                    selected_locale:
+                      type: string
+                      example: 'fr'
                     bill_address_id:
                       type: string
                       example: '1'
@@ -3650,6 +3656,9 @@ components:
             last_name:
               type: string
               example: Doe
+            selected_locale:
+              type: string
+              example: 'fr'
             store_credits:
               type: number
               example: 150.75
@@ -5109,6 +5118,7 @@ components:
                     email: spree@example.com
                     first_name: John
                     last_name: Snow
+                    selected_locale: 'en'
                     store_credits: 0
                     completed_orders: 0
                     public_metadata:

--- a/api/spec/controllers/spree/api/v2/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v2/base_controller_spec.rb
@@ -109,7 +109,7 @@ describe Spree::Api::V2::BaseController, type: :controller do
     shared_examples 'rescues from error' do
       it do
         expect(subject).to receive(:index).and_raise(exception)
-        expect(subject).to receive(:spree_current_user).and_return(user)
+        expect(subject).to receive(:spree_current_user).at_least(:once).and_return(user)
         expect_next_instance_of(::Spree::Api::ErrorHandler) do |instance|
           expect(instance).to receive(:call).with(
             exception: exception,

--- a/api/spec/serializers/spree/api/v2/platform/user_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/user_serializer_spec.rb
@@ -75,7 +75,7 @@ describe Spree::Api::V2::Platform::UserSerializer do
   context 'when user has selected non default locale' do
     let(:user) { create(:user_with_addresses, selected_locale: 'fr') }
 
-    it do
+    it 'returns the selected locale in the serialized hash' do
       expect(subject.serializable_hash[:data][:attributes][:selected_locale]).to eq('fr')
     end
   end

--- a/api/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
+++ b/api/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Api::V2::Platform::UserSerializer do
+describe Spree::V2::Storefront::UserSerializer do
   subject { described_class.new(user, params: serializer_params) }
 
   include_context 'API v2 serializers params'
@@ -16,26 +16,22 @@ describe Spree::Api::V2::Platform::UserSerializer do
           id: user.id.to_s,
           type: :user,
           attributes: {
+            completed_orders: 0,
             email: user.email,
             first_name: user.first_name,
             last_name: user.last_name,
-            average_order_value: [],
-            lifetime_value: [],
-            selected_locale: nil,
-            store_credits: [],
-            created_at: user.created_at,
-            updated_at: user.updated_at,
             public_metadata: {},
-            private_metadata: {}
+            selected_locale: nil,
+            store_credits: 0
           },
           relationships: {
-            bill_address: {
+            default_billing_address: {
               data: {
                 id: user.bill_address.id.to_s,
                 type: :address
               }
             },
-            ship_address: {
+            default_shipping_address: {
               data: {
                 id: user.ship_address.id.to_s,
                 type: :address
@@ -57,17 +53,13 @@ describe Spree::Api::V2::Platform::UserSerializer do
 
     it do
       expect(subject.serializable_hash[:data][:attributes]).to eq({
+        completed_orders: 2,
         email: user.email,
         first_name: user.first_name,
         last_name: user.last_name,
-        average_order_value: [{ amount: '110.00', currency: 'USD' }, { amount: '110.00', currency: 'EUR' }],
-        lifetime_value: [{ amount: '110.00', currency: 'USD' }, { amount: '110.00', currency: 'EUR' }],
-        selected_locale: nil,
-        store_credits: [{ amount: '100.00', currency: 'USD' }, { amount: '90.00', currency: 'EUR' }],
-        created_at: user.created_at,
-        updated_at: user.updated_at,
         public_metadata: {},
-        private_metadata: {}
+        selected_locale: nil,
+        store_credits: 0.1e3
       })
     end
   end

--- a/api/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
+++ b/api/spec/serializers/spree/v2/storefront/user_serializer_spec.rb
@@ -67,7 +67,7 @@ describe Spree::V2::Storefront::UserSerializer do
   context 'when user has selected non default locale' do
     let(:user) { create(:user_with_addresses, selected_locale: 'fr') }
 
-    it do
+    it 'returns the selected locale in the serialized hash' do
       expect(subject.serializable_hash[:data][:attributes][:selected_locale]).to eq('fr')
     end
   end

--- a/core/db/migrate/20221215151408_add_selected_locale_to_spree_users.rb
+++ b/core/db/migrate/20221215151408_add_selected_locale_to_spree_users.rb
@@ -1,0 +1,5 @@
+class AddSelectedLocaleToSpreeUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_users, :selected_locale, :string
+  end
+end

--- a/core/db/migrate/20221215151408_add_selected_locale_to_spree_users.rb
+++ b/core/db/migrate/20221215151408_add_selected_locale_to_spree_users.rb
@@ -1,5 +1,8 @@
 class AddSelectedLocaleToSpreeUsers < ActiveRecord::Migration[7.0]
   def change
-    add_column :spree_users, :selected_locale, :string
+    if Spree.user_class.present?
+      users_table_name = Spree.user_class.table_name
+      add_column users_table_name, :selected_locale, :string unless column_exists?(users_table_name, :selected_locale)
+    end
   end
 end

--- a/core/db/migrate/20221215151408_add_selected_locale_to_spree_users.rb
+++ b/core/db/migrate/20221215151408_add_selected_locale_to_spree_users.rb
@@ -1,4 +1,4 @@
-class AddSelectedLocaleToSpreeUsers < ActiveRecord::Migration[7.0]
+class AddSelectedLocaleToSpreeUsers < ActiveRecord::Migration[6.1]
   def change
     if Spree.user_class.present?
       users_table_name = Spree.user_class.table_name

--- a/core/lib/spree/core/configuration.rb
+++ b/core/lib/spree/core/configuration.rb
@@ -65,6 +65,7 @@ module Spree
       preference :show_raw_product_description, :boolean, deprecated: true
       preference :tax_using_ship_address, :boolean, default: true
       preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
+      preference :use_user_locale, :boolean, default: true
 
       # Store credits configurations
       preference :non_expiring_credit_types, :array, default: []

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -22,7 +22,7 @@ module Spree
         end
 
         def current_locale
-          @current_locale ||= if spree_current_user && supported_locale?(spree_current_user.selected_locale)
+          @current_locale ||= if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
                                 spree_current_user.selected_locale
                               elsif params[:locale].present? && supported_locale?(params[:locale])
                                 params[:locale]

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -22,7 +22,9 @@ module Spree
         end
 
         def current_locale
-          @current_locale ||= if params[:locale].present? && supported_locale?(params[:locale])
+          @current_locale ||= if spree_current_user && supported_locale?(spree_current_user.saved_locale)
+                                spree_current_user.saved_locale
+                              elsif params[:locale].present? && supported_locale?(params[:locale])
                                 params[:locale]
                               elsif respond_to?(:config_locale, true) && config_locale.present?
                                 config_locale

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -23,11 +23,9 @@ module Spree
 
         def current_locale
           if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
-            @current_locale ||= spree_current_user.selected_locale
+            @current_locale = spree_current_user.selected_locale
           else
-            @current_locale ||= if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
-                                  spree_current_user.selected_locale
-                                elsif params[:locale].present? && supported_locale?(params[:locale])
+            @current_locale ||= if params[:locale].present? && supported_locale?(params[:locale])
                                   params[:locale]
                                 elsif respond_to?(:config_locale, true) && config_locale.present?
                                   config_locale

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -22,15 +22,19 @@ module Spree
         end
 
         def current_locale
-          @current_locale ||= if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
-                                spree_current_user.selected_locale
-                              elsif params[:locale].present? && supported_locale?(params[:locale])
-                                params[:locale]
-                              elsif respond_to?(:config_locale, true) && config_locale.present?
-                                config_locale
-                              else
-                                current_store&.default_locale || Rails.application.config.i18n.default_locale || I18n.default_locale
-                              end
+          if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
+            @current_locale ||= spree_current_user.selected_locale
+          else
+            @current_locale ||= if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
+                                  spree_current_user.selected_locale
+                                elsif params[:locale].present? && supported_locale?(params[:locale])
+                                  params[:locale]
+                                elsif respond_to?(:config_locale, true) && config_locale.present?
+                                  config_locale
+                                else
+                                  current_store&.default_locale || Rails.application.config.i18n.default_locale || I18n.default_locale
+                                end
+          end
         end
 
         def supported_locales

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -22,8 +22,8 @@ module Spree
         end
 
         def current_locale
-          @current_locale ||= if spree_current_user && supported_locale?(spree_current_user.saved_locale)
-                                spree_current_user.saved_locale
+          @current_locale ||= if spree_current_user && supported_locale?(spree_current_user.selected_locale)
+                                spree_current_user.selected_locale
                               elsif params[:locale].present? && supported_locale?(params[:locale])
                                 params[:locale]
                               elsif respond_to?(:config_locale, true) && config_locale.present?

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -22,17 +22,27 @@ module Spree
         end
 
         def current_locale
-          if Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
-            @current_locale = spree_current_user.selected_locale
-          else
-            @current_locale ||= if params[:locale].present? && supported_locale?(params[:locale])
-                                  params[:locale]
-                                elsif respond_to?(:config_locale, true) && config_locale.present?
-                                  config_locale
-                                else
-                                  current_store&.default_locale || Rails.application.config.i18n.default_locale || I18n.default_locale
-                                end
-          end
+          @current_locale ||= if user_locale?
+                                spree_current_user.selected_locale
+                              elsif params_locale?
+                                params[:locale]
+                              elsif config_locale?
+                                config_locale
+                              else
+                                current_store&.default_locale || Rails.application.config.i18n.default_locale || I18n.default_locale
+                              end
+        end
+
+        def config_locale?
+          respond_to?(:config_locale, true) && config_locale.present?
+        end
+
+        def params_locale?
+          params[:locale].present? && supported_locale?(params[:locale])
+        end
+
+        def user_locale?
+          Spree::Config.use_user_locale && spree_current_user && supported_locale?(spree_current_user.selected_locale)
         end
 
         def supported_locales

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -147,7 +147,7 @@ module Spree
 
     # TODO: Should probably use something like Spree.user_class.attributes
     @@user_attributes = [:email, :bill_address_id, :ship_address_id, :password, :first_name, :last_name,
-                         :password_confirmation, { public_metadata: {}, private_metadata: {} }, :saved_locale]
+                         :password_confirmation, { public_metadata: {}, private_metadata: {} }, :selected_locale]
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :discontinue_on, :lock_version,

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -147,7 +147,7 @@ module Spree
 
     # TODO: Should probably use something like Spree.user_class.attributes
     @@user_attributes = [:email, :bill_address_id, :ship_address_id, :password, :first_name, :last_name,
-                         :password_confirmation, { public_metadata: {}, private_metadata: {} }]
+                         :password_confirmation, { public_metadata: {}, private_metadata: {} }, :saved_locale]
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :discontinue_on, :lock_version,

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       end
     end
 
-    let(:user) { build(:user, selected_locale: 'pl') }
+    let(:user) { build(:user) }
 
     before { allow(controller).to receive(:spree_current_user).and_return(user) }
 
@@ -53,7 +53,7 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       end
     end
 
-    let(:user) { build(:user, selected_locale: 'pl') }
+    let(:user) { build(:user) }
 
     before { allow(controller).to receive(:spree_current_user).and_return(user) }
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -24,6 +24,11 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
         redirect_back_or_default('/')
       end
     end
+
+    let(:user) { build(:user, selected_locale: 'pl') }
+
+    before { allow(controller).to receive(:spree_current_user).and_return(user) }
+
     it 'redirects to session url' do
       session[:spree_user_return_to] = '/redirect'
       get :index
@@ -47,6 +52,11 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
         render plain: 'index'
       end
     end
+
+    let(:user) { build(:user, selected_locale: 'pl') }
+
+    before { allow(controller).to receive(:spree_current_user).and_return(user) }
+
     it 'sends cookie header' do
       get :index
       expect(response.cookies['token']).not_to be_nil
@@ -85,6 +95,11 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
         redirect_unauthorized_access
       end
     end
+
+    let(:user) { build(:user, selected_locale: 'pl') }
+
+    before { allow(controller).to receive(:spree_current_user).and_return(user) }
+
     context 'when logged in' do
       before do
         allow(controller).to receive_messages(try_spree_current_user: double('User', id: 1, last_incomplete_spree_order: nil))


### PR DESCRIPTION
This pull request has two changes:
- changing function current_locale to first look at the locale saved for user (if the user i logged in and a locale is saved there)
- adding saved_locale to storefront's and platform's API that has to do with user information

It's part of bigger set of changes meant to allow storing locale in user and retrieving it whenever user is revisiting a page/when we're meant to send them an email etc.
See also:
- https://github.com/spree/spree_starter/pull/1039
- https://github.com/spree/spree_legacy_frontend/pull/42
- https://github.com/spree/spree_auth_devise/pull/574