### PR TITLE
Make sure to use Metadata module from Spree namespace to prevent conflicts

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -24,7 +24,7 @@ module Spree
     include NumberAsParam
     include SingleStoreResource
     include MemoizedData
-    include Metadata
+    include Spree::Metadata
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end


### PR DESCRIPTION
Received the following error while installing Spree. Solved by making sure we use the `Spree::Metadata` module, which I assume is the intention here.

```
» bin/rails g spree:install --user_class=User

/Users/lkol/.rvm/gems/ruby-3.1.3@spree/gems/spree_core-4.5.0/app/models/spree/order.rb:27:in `include': wrong argument type Class (expected Module) (TypeError)
	from /Users/lkol/.rvm/gems/ruby-3.1.3@spree/gems/spree_core-4.5.0/app/models/spree/order.rb:27:in `<class:Order>'
	from /Users/lkol/.rvm/gems/ruby-3.1.3@spree/gems/spree_core-4.5.0/app/models/spree/order.rb:9:in `<module:Spree>'
	from /Users/lkol/.rvm/gems/ruby-3.1.3@spree/gems/spree_core-4.5.0/app/models/spree/order.rb:8:in `<main>'
```

The conflicting class which was passed as argument was `ActiveStorageValidations::Metadata`.

After fixing this the installation passed.
