### PR TITLE
Feature: verify the authenticity of a webhook event

### DIFF
--- a/api/app/models/spree/webhooks/event.rb
+++ b/api/app/models/spree/webhooks/event.rb
@@ -7,6 +7,14 @@ module Spree
 
       self.whitelisted_ransackable_associations = %w[subscriber]
       self.whitelisted_ransackable_attributes = %w[name request_errors response_code success url]
+
+      # Computes the base64-encoded HMAC SHA256 signature of the event for the given payload.
+      #
+      # @param payload [Hash, String] The payload for to the webhook subscriber.
+      # @return [String]
+      def signature_for(payload)
+        EventSignature.new(self, payload).computed_signature
+      end
     end
   end
 end

--- a/api/app/models/spree/webhooks/event_signature.rb
+++ b/api/app/models/spree/webhooks/event_signature.rb
@@ -1,0 +1,33 @@
+require 'base64'
+require 'openssl'
+
+module Spree
+  module Webhooks
+    class EventSignature
+      def initialize(event, payload)
+        @event = event
+        @payload = payload
+      end
+
+      # Generates a base64-encoded HMAC SHA256 signature for the payload of the event.
+      #
+      # By using the stringified payload, the signature is made tamper-proof as any
+      # alterations of the data during transit will lead to an incorrect signature
+      # comparison by the client.
+      #
+      # @return [String] The computed signature
+      def computed_signature
+        @computed_signature ||=
+          Base64.strict_encode64(
+            OpenSSL::HMAC.digest('sha256', @event.subscriber.secret_key, payload)
+          )
+      end
+
+      private
+
+      def payload
+        @payload.is_a?(String) ? @payload : @payload.to_json
+      end
+    end
+  end
+end

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -40,13 +40,6 @@ module Spree
         end
       end
 
-      # Verifies the existence of the {#secret_key} attribute.
-      #
-      # @return [true, false]
-      def secret_key?
-        !secret_key.nil?
-      end
-
       private
 
       def check_uri_path

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -5,11 +5,11 @@ module Spree
         include Spree::VendorConcern
       end
 
+      has_secure_token :secret_key
+
       has_many :events, inverse_of: :subscriber
 
       validates :url, 'spree/url': true, presence: true
-      validates :secret_key, presence: true
-
       validate :check_uri_path
 
       self.whitelisted_ransackable_attributes = %w[active subscriptions url]
@@ -18,7 +18,6 @@ module Spree
       scope :active, -> { where(active: true) }
       scope :inactive, -> { where(active: false) }
 
-      before_validation :generate_secret_key, unless: :secret_key?
       before_save :parse_subscriptions
 
       def self.with_urls_for(event)
@@ -51,10 +50,6 @@ module Spree
         end
 
         errors.add(:url, 'the URL must have a path') if uri.blank? || uri.path.blank?
-      end
-
-      def generate_secret_key
-        self.secret_key = SecureRandom.urlsafe_base64(32)
       end
 
       def parse_subscriptions

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -40,6 +40,13 @@ module Spree
         end
       end
 
+      # Verifies the existance of the {#secret_key} attribute.
+      #
+      # @return [true, false]
+      def secret_key?
+        !secret_key.nil?
+      end
+
       private
 
       def check_uri_path

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -8,6 +8,7 @@ module Spree
       has_many :events, inverse_of: :subscriber
 
       validates :url, 'spree/url': true, presence: true
+      validates :secret_key, presence: true
 
       validate :check_uri_path
 

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -18,6 +18,7 @@ module Spree
       scope :active, -> { where(active: true) }
       scope :inactive, -> { where(active: false) }
 
+      before_validation :generate_secret_key, unless: :secret_key?
       before_save :parse_subscriptions
 
       def self.with_urls_for(event)
@@ -50,6 +51,10 @@ module Spree
         end
 
         errors.add(:url, 'the URL must have a path') if uri.blank? || uri.path.blank?
+      end
+
+      def generate_secret_key
+        assign_attributes(secret_key: SecureRandom.urlsafe_base64(32))
       end
 
       def parse_subscriptions

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -54,7 +54,7 @@ module Spree
       end
 
       def generate_secret_key
-        assign_attributes(secret_key: SecureRandom.urlsafe_base64(32))
+        self.secret_key = SecureRandom.urlsafe_base64(32)
       end
 
       def parse_subscriptions

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -40,7 +40,7 @@ module Spree
         end
       end
 
-      # Verifies the existance of the {#secret_key} attribute.
+      # Verifies the existence of the {#secret_key} attribute.
       #
       # @return [true, false]
       def secret_key?

--- a/api/app/services/spree/webhooks/subscribers/handle_request.rb
+++ b/api/app/services/spree/webhooks/subscribers/handle_request.rb
@@ -39,7 +39,11 @@ module Spree
 
         def request
           @request ||=
-            Spree::Webhooks::Subscribers::MakeRequest.new(webhook_payload_body: body_with_event_metadata, url: url)
+            Spree::Webhooks::Subscribers::MakeRequest.new(
+              signature: event.signature_for(body_with_event_metadata),
+              url: url,
+              webhook_payload_body: body_with_event_metadata
+            )
         end
         alias make_request request
 

--- a/api/app/services/spree/webhooks/subscribers/make_request.rb
+++ b/api/app/services/spree/webhooks/subscribers/make_request.rb
@@ -4,8 +4,9 @@ module Spree
   module Webhooks
     module Subscribers
       class MakeRequest
-        def initialize(url:, webhook_payload_body:)
+        def initialize(signature:, url:, webhook_payload_body:)
           @execution_time_in_milliseconds = 0
+          @signature = signature
           @url = url
           @webhook_payload_body = webhook_payload_body
           @webhooks_timeout = ENV['SPREE_WEBHOOKS_TIMEOUT']
@@ -49,7 +50,7 @@ module Spree
         end
 
         def request
-          req = Net::HTTP::Post.new(uri_path, HEADERS)
+          req = Net::HTTP::Post.new(uri_path, HEADERS.merge('X-Spree-Hmac-SHA256' => @signature))
           req.body = webhook_payload_body
           @request ||= begin
             start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/api/db/migrate/20221221122100_add_secret_key_to_spree_webhooks_subscribers.rb
+++ b/api/db/migrate/20221221122100_add_secret_key_to_spree_webhooks_subscribers.rb
@@ -1,0 +1,5 @@
+class AddSecretKeyToSpreeWebhooksSubscribers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_webhooks_subscribers, :secret_key, :string, null: true
+  end
+end

--- a/api/db/migrate/20221221122100_add_secret_key_to_spree_webhooks_subscribers.rb
+++ b/api/db/migrate/20221221122100_add_secret_key_to_spree_webhooks_subscribers.rb
@@ -1,4 +1,4 @@
-class AddSecretKeyToSpreeWebhooksSubscribers < ActiveRecord::Migration[7.0]
+class AddSecretKeyToSpreeWebhooksSubscribers < ActiveRecord::Migration[6.1]
   def change
     add_column :spree_webhooks_subscribers, :secret_key, :string, null: true
   end

--- a/api/db/migrate/20230116204600_backfill_secret_key_for_spree_webhooks_subscribers.rb
+++ b/api/db/migrate/20230116204600_backfill_secret_key_for_spree_webhooks_subscribers.rb
@@ -1,0 +1,5 @@
+class BackfillSecretKeyForSpreeWebhooksSubscribers < ActiveRecord::Migration[7.0]
+  def change
+    Spree::Webhooks::Subscriber.where(secret_key: nil).find_each(&:regenerate_secret_key)
+  end
+end

--- a/api/db/migrate/20230116204600_backfill_secret_key_for_spree_webhooks_subscribers.rb
+++ b/api/db/migrate/20230116204600_backfill_secret_key_for_spree_webhooks_subscribers.rb
@@ -1,4 +1,4 @@
-class BackfillSecretKeyForSpreeWebhooksSubscribers < ActiveRecord::Migration[7.0]
+class BackfillSecretKeyForSpreeWebhooksSubscribers < ActiveRecord::Migration[6.1]
   def change
     Spree::Webhooks::Subscriber.where(secret_key: nil).find_each(&:regenerate_secret_key)
   end

--- a/api/db/migrate/20230116205000_change_secret_key_to_non_null_column.rb
+++ b/api/db/migrate/20230116205000_change_secret_key_to_non_null_column.rb
@@ -1,0 +1,5 @@
+class ChangeSecretKeyToNonNullColumn < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :spree_webhooks_subscribers, :secret_key, false
+  end
+end

--- a/api/db/migrate/20230116205000_change_secret_key_to_non_null_column.rb
+++ b/api/db/migrate/20230116205000_change_secret_key_to_non_null_column.rb
@@ -1,4 +1,4 @@
-class ChangeSecretKeyToNonNullColumn < ActiveRecord::Migration[7.0]
+class ChangeSecretKeyToNonNullColumn < ActiveRecord::Migration[6.1]
   def change
     change_column_null :spree_webhooks_subscribers, :secret_key, false
   end

--- a/api/spec/models/spree/webhooks/event_signature_spec.rb
+++ b/api/spec/models/spree/webhooks/event_signature_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Spree::Webhooks::EventSignature do
+  subject(:signature) { described_class.new(webhook_event, event_payload) }
+
+  let(:event_payload) { { event_name: 'order.create', data: { id: 123 } } }
+  let(:webhook_event) { create(:webhook_event) }
+
+  describe '#computed_signature' do
+    it 'computes a unique signature per payload' do
+      order_finished_signature =
+        described_class.new(webhook_event, { event_name: 'order.finished', data: { id: 123 } })
+
+      expect(signature.computed_signature).
+        not_to eq(order_finished_signature.computed_signature)
+    end
+
+    it 'computes a stable signature for the same payload' do
+      order_created_signature = described_class.new(webhook_event, event_payload)
+
+      expect(signature.computed_signature).
+        to eq(order_created_signature.computed_signature)
+    end
+  end
+end

--- a/api/spec/models/spree/webhooks/event_spec.rb
+++ b/api/spec/models/spree/webhooks/event_spec.rb
@@ -28,4 +28,16 @@ describe Spree::Webhooks::Event do
       end
     end
   end
+
+  describe '#signature_for' do
+    subject(:signature) { event.signature_for(payload) }
+
+    let(:event) { create(:event) }
+    let(:payload) { { id: 123 }.to_json }
+
+    it 'computes a signature for the JSON payload' do
+      expect(signature).to \
+        eq(Spree::Webhooks::EventSignature.new(event, payload).computed_signature)
+    end
+  end
 end

--- a/api/spec/models/spree/webhooks/event_spec.rb
+++ b/api/spec/models/spree/webhooks/event_spec.rb
@@ -15,7 +15,7 @@ describe Spree::Webhooks::Event do
       end
     end
 
-    context 'susbcriber' do
+    context 'subscriber' do
       it 'is invalid without a subscriber' do
         event = build(:event, :successful, subscriber_id: nil)
         expect(event.valid?).to be(false)

--- a/api/spec/models/spree/webhooks/subscriber_spec.rb
+++ b/api/spec/models/spree/webhooks/subscriber_spec.rb
@@ -19,6 +19,28 @@ describe Spree::Webhooks::Subscriber do
     end
   end
 
+  describe 'before_validation' do
+    subject(:subscriber) { build(:subscriber, secret_key: nil) }
+
+    context 'without a secret key' do
+      it 'generates a new secret key' do
+        expect { subscriber.save }.to change(subscriber, :secret_key).from(nil)
+      end
+    end
+
+    context 'with secret key' do
+      let(:assigned_secret_key) { 'some-secret-key-for-webhooks' }
+
+      before do
+        subscriber.secret_key = assigned_secret_key
+      end
+
+      it 'does not overwrite the assigned secret key' do
+        expect { subscriber.save }.not_to change(subscriber, :secret_key)
+      end
+    end
+  end
+
   describe 'validations' do
     context 'url format (UrlValidator)' do
       it 'is invalid with an invalid url' do

--- a/api/spec/requests/spree/api/v2/platform/webhooks/subscribers_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/webhooks/subscribers_spec.rb
@@ -10,7 +10,7 @@ describe 'Platform API v2 Webhooks Subscribers spec', type: :request do
 
   describe '#index' do
     context 'filtering' do
-      let(:data_ids) { json_response['data'].pluck(:id) } 
+      let(:data_ids) { json_response['data'].pluck(:id) }
 
       context 'with no params' do
         before do
@@ -89,7 +89,7 @@ describe 'Platform API v2 Webhooks Subscribers spec', type: :request do
       }.to change {
         Spree::Webhooks::Subscriber.
           all.
-          as_json(except: %i[created_at id preferences updated_at]).
+          as_json(except: %i[created_at id preferences updated_at secret_key]).
           map(&:values)
       }.from([]).to([[url, active, events]])
     end

--- a/api/spec/serializers/spree/api/v2/platform/webhooks/subscriber_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/webhooks/subscriber_serializer_spec.rb
@@ -16,6 +16,7 @@ describe Spree::Api::V2::Platform::Webhooks::SubscriberSerializer do
         attributes: {
           active: resource.active,
           created_at: resource.created_at,
+          secret_key: resource.secret_key,
           subscriptions: resource.subscriptions,
           updated_at: resource.updated_at,
           url: resource.url

--- a/api/spec/services/spree/webhooks/subscribers/handle_request_spec.rb
+++ b/api/spec/services/spree/webhooks/subscribers/handle_request_spec.rb
@@ -35,6 +35,10 @@ describe Spree::Webhooks::Subscribers::HandleRequest do
           ).to_json
         end
 
+        let(:event_signature) do
+          Spree::Webhooks::EventSignature.new(event, body_with_event_metadata).computed_signature
+        end
+
         it 'debug logs' do
           allow(Rails.logger).to receive(:debug)
           allow(Spree::Webhooks::Subscribers::MakeRequest).to receive(:new).and_call_original
@@ -43,9 +47,14 @@ describe Spree::Webhooks::Subscribers::HandleRequest do
           message_snd = "[SPREE WEBHOOKS] 'order.canceled' webhook_payload_body: #{body_with_event_metadata}"
           expect(Rails.logger).to have_received(:debug).with(message_fst)
           expect(Rails.logger).to have_received(:debug).with(message_snd)
-          expect(Spree::Webhooks::Subscribers::MakeRequest).to(
-            have_received(:new).with(webhook_payload_body: body_with_event_metadata, url: url)
-          )
+
+          expect(Spree::Webhooks::Subscribers::MakeRequest).to \
+            have_received(:new).
+            with(
+              signature: event_signature,
+              url: url,
+              webhook_payload_body: body_with_event_metadata
+            )
         end
 
         it "#{with_log_level} logs" do
@@ -171,13 +180,21 @@ describe Spree::Webhooks::Subscribers::HandleRequest do
           ).to_json
         end
 
+        let(:event_signature) do
+          Spree::Webhooks::EventSignature.new(event, body_with_event_metadata).computed_signature
+        end
+
         it 'adds the event data to the body' do
           with_webhooks_enabled do
             allow(Spree::Webhooks::Subscribers::MakeRequest).to receive(:new).and_call_original
             order.finalize!
-            expect(Spree::Webhooks::Subscribers::MakeRequest).to(
-              have_received(:new).with(webhook_payload_body: body_with_event_metadata, url: url)
-            )
+            expect(Spree::Webhooks::Subscribers::MakeRequest).to \
+              have_received(:new).
+              with(
+                signature: event_signature,
+                url: url,
+                webhook_payload_body: body_with_event_metadata
+              )
           end
         end
       end


### PR DESCRIPTION
Fixes #11819 

---

When Spree sends a webhook event to a webhook subscriber, there is no way for the webhook subscriber to verify the authenticity of the webhook event. Due to this, a webhook subscriber needs to allow only certain IP-addresses to be sure the webhook event is actually coming from a verified source.

This PR adds support for an event signature (based on the subscriber's `secret_key` and the payload), so the webhook subscriber can verify the authenticity of the source of the event.

The event signature is added as an HTTP request header (`X-Spree-Hmac-SHA256` or `HTTP_X_SPREE_HMAC_SHA256` for PHP, or a Rack-based framework such as Ruby on Rails or Sinatra) for every request send to the webhook subscriber. 

**It's up to the webhook subscriber to implement the verification of the authenticity.**

Hereby an example (taken from Shopify's documentation):

```ruby
# The following example uses Ruby and the Sinatra web framework to verify a webhook request:
require 'rubygems'
require 'base64'
require 'openssl'
require 'sinatra'
require 'active_support/security_utils'

# The webhook secret key is viewable from the Spree Backend Dashboard. 
# In a production environment, it's recommended to set the client secret as an environment variable to prevent exposing it in code.
CLIENT_SECRET = 'my_client_secret'

helpers do
  # Compare the computed HMAC digest based on the client secret and the request contents to the reported HMAC in the headers
  def verify_webhook(data, hmac_header)
    calculated_hmac = Base64.strict_encode64(OpenSSL::HMAC.digest('sha256', CLIENT_SECRET, data))
    ActiveSupport::SecurityUtils.secure_compare(calculated_hmac, hmac_header)
  end
end

# Respond to HTTP POST requests sent to this web service
post '/' do
  request.body.rewind
  data = request.body.read
  verified = verify_webhook(data, env["HTTP_X_SPREE_HMAC_SHA256"])

  halt 401 unless verified

  # Process webhook payload
  # ...
end
```

Feedback I'm looking for:

- Is the addition of event's signature in the `Spree::Webhooks::Subscribers::MakeRequest` implemented in a way that is conform the code style of the Spree project?
- The chosen name of the HTTP header is `X-Spree-Hmac-SHA256`. Do you feel this is a suiting name?
- The visibility of the `WebhookSubscriber#secret_key` in the admin dashboard isn't implemented yet as I wanted to do that in a separate PR. Do you agree?

I haven't updated the documentation (`spree-dev-docs`) yet, but I also noticed there is no documentation yet for the webhooks. Is any help needed on that front?

Looking forward to your feedback. Merry Christmas 🎄 