### PR TITLE
Stub i18n.locale to fix flaky webhooks tests

### DIFF
--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -151,7 +151,7 @@ describe Spree::BaseHelper, type: :helper do
 
     context 'when try_spree_current_user defined' do
       before do
-        I18n.locale = I18n.default_locale
+        allow(I18n).to receive(:locale).and_return(I18n.default_locale)
         allow_any_instance_of(described_class).to receive(:try_spree_current_user).and_return(user)
       end
 
@@ -183,7 +183,9 @@ describe Spree::BaseHelper, type: :helper do
     context 'when try_spree_current_user is undefined' do
       let(:current_currency) { 'USD' }
 
-      before { I18n.locale = I18n.default_locale }
+      before do
+        allow(I18n).to receive(:locale) { I18n.default_locale }
+      end
 
       it 'returns base cache key' do
         expect(base_cache_key).to eq [:en, 'USD', nil, nil]

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -184,7 +184,7 @@ describe Spree::BaseHelper, type: :helper do
       let(:current_currency) { 'USD' }
 
       before do
-        allow(I18n).to receive(:locale) { I18n.default_locale }
+        allow(I18n).to receive(:locale).and_return(I18n.default_locale)
       end
 
       it 'returns base cache key' do

--- a/core/spec/lib/spree/core/controller_helpers/locale_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/locale_spec.rb
@@ -67,9 +67,9 @@ describe Spree::Core::ControllerHelpers::Locale, type: :controller do
         end
 
         context 'with I18n.default_locale set' do
-          before { I18n.default_locale = :de }
-
-          after { I18n.default_locale = :en }
+          before do
+            allow(I18n).to receive(:default_locale).and_return(:de)
+          end
 
           it 'fallbacks to the default application locale' do
             expect(controller.current_locale.to_s).to eq('de')
@@ -95,15 +95,17 @@ describe Spree::Core::ControllerHelpers::Locale, type: :controller do
     let!(:store) { create :store, default: true, default_locale: 'en', supported_locales: 'en,de,fr' }
 
     context 'same as store default locale' do
-      before { I18n.locale = :en }
+      before do
+        allow(I18n).to receive(:locale).and_return(:en)
+      end
 
       it { expect(controller.locale_param).to eq(nil) }
     end
 
     context 'different than store locale' do
-      before { I18n.locale = :de }
-
-      after { I18n.locale = :en }
+      before do
+        allow(I18n).to receive(:locale).and_return(:de)
+      end
 
       it { expect(controller.locale_param).to eq('de') }
     end

--- a/core/spec/lib/spree/localized_number_spec.rb
+++ b/core/spec/lib/spree/localized_number_spec.rb
@@ -21,6 +21,8 @@ describe Spree::LocalizedNumber do
     context 'with decimal comma' do
       it 'captures the proper amount for a formatted price' do
         allow(I18n).to receive(:locale).and_return(:de)
+        allow(I18n.config).to receive(:locale).and_return(:de)
+
         expect(subject.class.parse('1.599,99')).to eq 1599.99
       end
     end
@@ -28,6 +30,8 @@ describe Spree::LocalizedNumber do
     context 'with a numeric price' do
       it 'uses the price as is' do
         allow(I18n).to receive(:locale).and_return(:de)
+        allow(I18n.config).to receive(:locale).and_return(:de)
+
         expect(subject.class.parse(1599.99)).to eq 1599.99
       end
     end

--- a/core/spec/lib/spree/localized_number_spec.rb
+++ b/core/spec/lib/spree/localized_number_spec.rb
@@ -4,12 +4,11 @@ describe Spree::LocalizedNumber do
   context '.parse' do
     before do
       I18n.enforce_available_locales = false
-      I18n.locale = I18n.default_locale
+      allow(I18n).to receive(:locale).and_return(I18n.default_locale)
       I18n.backend.store_translations(:de, number: { currency: { format: { delimiter: '.', separator: ',' } } })
     end
 
     after do
-      I18n.locale = I18n.default_locale
       I18n.enforce_available_locales = true
     end
 
@@ -21,21 +20,21 @@ describe Spree::LocalizedNumber do
 
     context 'with decimal comma' do
       it 'captures the proper amount for a formatted price' do
-        I18n.locale = :de
+        allow(I18n).to receive(:locale).and_return(:de)
         expect(subject.class.parse('1.599,99')).to eq 1599.99
       end
     end
 
     context 'with a numeric price' do
       it 'uses the price as is' do
-        I18n.locale = :de
+        allow(I18n).to receive(:locale).and_return(:de)
         expect(subject.class.parse(1599.99)).to eq 1599.99
       end
     end
 
     context 'string argument' do
       it 'is not modified' do
-        I18n.locale = :de
+        allow(I18n).to receive(:locale).and_return(:de)
         number = '1.599,99'
         number_bak = number.dup
         subject.class.parse(number)

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -855,12 +855,8 @@ describe Spree::Payment, type: :model do
     context 'when the locale uses a coma as a decimal separator' do
       before do
         I18n.backend.store_translations(:fr, number: { currency: { format: { delimiter: ' ', separator: ',' } } })
-        I18n.locale = :fr
+        allow(I18n).to receive(:locale).and_return(:fr)
         subject.amount = amount
-      end
-
-      after do
-        I18n.locale = I18n.default_locale
       end
 
       context 'amount is a decimal' do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -856,6 +856,8 @@ describe Spree::Payment, type: :model do
       before do
         I18n.backend.store_translations(:fr, number: { currency: { format: { delimiter: ' ', separator: ',' } } })
         allow(I18n).to receive(:locale).and_return(:fr)
+        allow(I18n.config).to receive(:locale).and_return(:fr)
+
         subject.amount = amount
       end
 

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -196,7 +196,9 @@ describe Spree::OrderMailer, type: :mailer do
       end
 
       context 'via I18n' do
-        before { I18n.locale = :'pt-BR' }
+        before do
+          allow(I18n).to receive(:locale).and_return(:'pt-BR')
+        end
 
         it_behaves_like 'translates emails'
       end


### PR DESCRIPTION
Instead of setting `i18n.locale` in tests (which requires manual cleanup), stub `i18n.locale` value. This should resolve [randomly failing webhooks tests](https://app.circleci.com/pipelines/github/spree/spree/6219/workflows/aead9aba-c520-4dd8-acc8-944984d90180/jobs/53462).