### PR TITLE
Fix loading log entry from the database on Ruby 3.1 and 3.2

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -15,7 +15,11 @@ module Spree
     end
 
     def parsed_details
-      @details ||= YAML.safe_load(details, [ActiveMerchant::Billing::Response])
+      @details ||= if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+                     YAML.safe_load(details, permitted_classes: [ActiveMerchant::Billing::Response])
+                   else
+                     YAML.safe_load(details, [ActiveMerchant::Billing::Response])
+                   end
     end
   end
 end

--- a/core/spec/models/spree/log_entry_spec.rb
+++ b/core/spec/models/spree/log_entry_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Spree::LogEntry, type: :model do
+  let(:log_entry) { create(:log_entry, details: details) }
+  let(:details) { "--- !ruby/object:ActiveMerchant::Billing::Response\nparams: {}\nmessage: 'Bogus Gateway: Forced success'\nsuccess: true\ntest: true\nauthorization: \nfraud_review: \nerror_code: \nemv_authorization: \nnetwork_transaction_id: \navs_result:\n  code: \n  message: \n  street_match: \n  postal_match: \ncvv_result:\n  code: \n  message: \n" }
+
+  describe '#parsed_details' do
+    subject { log_entry.parsed_details }
+
+    it 'deserializes log entry with billing response' do
+      expect(subject).to be_instance_of(ActiveMerchant::Billing::Response)
+      expect(subject.message).to eq('Bogus Gateway: Forced success')
+    end
+  end
+end


### PR DESCRIPTION
The method signature for YAML.safe_load changed in Ruby 3.1, which causes payment log entires page to fail when running with latest versions of Ruby. This PR adds compatiility for both syntaxes.