### PR TITLE
add sudo apt-get update before install libvips

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,11 @@ run_tests_2_7: &run_tests_2_7
           - spree-bundle-v10-ruby-2-7-{{ .Branch }}
           - spree-bundle-v10-ruby-2-7
     - run:
+        name: Add keyserver
+        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+    - run:
         name: Install libvips
-        command: sudo apt-get install libvips
+        command: sudo apt-get update && sudo apt-get install libvips
     - run:
         name: Ensure Bundle Install
         command: |
@@ -70,8 +73,11 @@ run_tests_3_0: &run_tests_3_0
           - spree-bundle-v10-ruby-3-0-{{ .Branch }}
           - spree-bundle-v10-ruby-3-0
     - run:
+        name: Add keyserver
+        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+    - run:
         name: Install libvips
-        command: sudo apt-get install libvips
+        command: sudo apt-get update && sudo apt-get install libvips
     - run:
         name: Ensure Bundle Install
         command: |
@@ -157,8 +163,11 @@ jobs:
             - spree-bundle-v10-ruby-2-7-{{ .Branch }}
             - spree-bundle-v10-ruby-2-7
       - run:
+          name: Add keyserver
+          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+      - run:
           name: Install libvips
-          command: sudo apt-get install libvips
+          command: sudo apt-get update && sudo apt-get install libvips
       - run:
           name: Bundle Install
           command: |
@@ -178,8 +187,11 @@ jobs:
             - spree-bundle-v10-ruby-3-0-{{ .Branch }}
             - spree-bundle-v10-ruby-3-0
       - run:
+          name: Add keyserver
+          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+      - run:
           name: Install libvips
-          command: sudo apt-get install libvips
+          command: sudo apt-get update && sudo apt-get install libvips
       - run:
           name: Bundle Install
           command: |
@@ -326,8 +338,11 @@ jobs:
             - spree-bundle-v10-ruby-3-0-{{ .Branch }}
             - spree-bundle-v10-ruby-3-0
       - run:
+          name: Add keyserver
+          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+      - run:
           name: Install libvips
-          command: sudo apt-get install libvips
+          command: sudo apt-get update && sudo apt-get install libvips
       - run:
           name: Ensure Bundle Install
           command: |


### PR DESCRIPTION
Add sudo apt-get before install libvips to fix isses with E`rr:26 http://deb.debian.org/debian bullseye/main amd64 libpoppler102 amd64 20.09.0-3.1 404  Not Found`