### PR TITLE
Remove unnecessary build configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,18 +13,6 @@ defaults: &defaults
     - image: &ruby_2_7_image circleci/ruby:2.7-node-browsers
     - image: &redis_image circleci/redis:6.2-alpine
 
-defaults_3_0: &defaults_3_0
-  <<: *defaults
-  docker:
-    - image: &ruby_3_0_image circleci/ruby:3.0-node-browsers
-    - image: &redis_image circleci/redis:6.2-alpine
-
-defaults_3_1: &defaults_3_1
-  <<: *defaults
-  docker:
-    - image: &ruby_3_1_image cimg/ruby:3.1.3-browsers
-    - image: *redis_image
-
 defaults_3_2: &defaults_3_2
   <<: *defaults
   docker:
@@ -46,67 +34,6 @@ run_tests_2_7: &run_tests_2_7
     - run:
         name: Install libvips
         command: sudo apt-get update && sudo apt-get install libvips
-    - run:
-        name: Ensure Bundle Install
-        command: |
-          bundle install
-          ./bin/build-ci.rb install
-    - run:
-        name: Run rspec in parallel
-        command: ./bin/build-ci.rb test
-    - store_artifacts:
-        path: /tmp/test-artifacts
-        destination: test-artifacts
-    - store_artifacts:
-        path: /tmp/test-results
-        destination: raw-test-output
-    - store_test_results:
-        path: /tmp/test-results
-
-run_tests_3_0: &run_tests_3_0
-  <<: *defaults_3_0
-  parallelism: 3
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - spree-bundle-v10-ruby-3-0-{{ .Branch }}
-          - spree-bundle-v10-ruby-3-0
-    - run:
-        name: Add keyserver
-        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-    - run:
-        name: Install libvips
-        command: sudo apt-get update && sudo apt-get install libvips
-    - run:
-        name: Ensure Bundle Install
-        command: |
-          bundle install
-          ./bin/build-ci.rb install
-    - run:
-        name: Run rspec in parallel
-        command: ./bin/build-ci.rb test
-    - store_artifacts:
-        path: /tmp/test-artifacts
-        destination: test-artifacts
-    - store_artifacts:
-        path: /tmp/test-results
-        destination: raw-test-output
-    - store_test_results:
-        path: /tmp/test-results
-
-run_tests_3_1: &run_tests_3_1
-  <<: *defaults_3_1
-  parallelism: 3
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - spree-bundle-v10-ruby-3-1-{{ .Branch }}
-          - spree-bundle-v10-ruby-3-1
-    - run:
-        name: Install libvips
-        command: sudo apt-get update && sudo apt-get install libvips42
     - run:
         name: Ensure Bundle Install
         command: |
@@ -178,51 +105,6 @@ jobs:
           paths:
             - ~/spree/vendor/bundle
 
-  bundle_ruby_3_0:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - spree-bundle-v10-ruby-3-0-{{ .Branch }}
-            - spree-bundle-v10-ruby-3-0
-      - run:
-          name: Add keyserver
-          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-      - run:
-          name: Install libvips
-          command: sudo apt-get update && sudo apt-get install libvips
-      - run:
-          name: Bundle Install
-          command: |
-            bundle check || bundle install
-            ./bin/build-ci.rb install
-      - save_cache:
-          key: spree-bundle-v10-ruby-3-0-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/spree/vendor/bundle
-
-  bundle_ruby_3_1:
-    <<: *defaults_3_1
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - spree-bundle-v10-ruby-3-1-{{ .Branch }}
-            - spree-bundle-v10-ruby-3-1
-      - run:
-          name: Install libvips
-          command: sudo apt-get update && sudo apt-get install libvips42
-      - run:
-          name: Bundle Install
-          command: |
-            bundle check || bundle install
-            ./bin/build-ci.rb install
-      - save_cache:
-          key: spree-bundle-v10-ruby-3-1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/spree/vendor/bundle
-
   bundle_ruby_3_2:
     <<: *defaults_3_2
     steps:
@@ -284,24 +166,6 @@ jobs:
         environment:
           POSTGRES_USER: postgres
 
-  tests_ruby_3_0_rails_7_0_postgres:
-    <<: *run_tests_3_0
-    environment:
-      <<: *postgres_environment
-    docker:
-      - image: *ruby_3_0_image
-      - image: *postgres_image
-      - image: *redis_image
-
-  tests_ruby_3_1_rails_7_0_postgres:
-    <<: *run_tests_3_1
-    environment:
-      <<: *postgres_environment
-    docker:
-      - image: *ruby_3_1_image
-      - image: *postgres_image
-      - image: *redis_image
-
   tests_ruby_3_2_rails_7_0_postgres:
     <<: *run_tests_3_2
     environment:
@@ -317,8 +181,8 @@ jobs:
       <<: *postgres_environment
       RAILS_VERSION: '~> 6.1.0'
 
-  tests_ruby_3_0_rails_7_0_mysql:
-    <<: *run_tests_3_0
+  tests_ruby_3_2_rails_7_0_mysql:
+    <<: *run_tests_3_2
     environment:
       <<: *environment
       DB: mysql
@@ -327,7 +191,7 @@ jobs:
       COVERAGE: true
       COVERAGE_DIR: /tmp/workspace/simplecov
     docker:
-      - image: *ruby_3_0_image
+      - image: *ruby_3_2_image
       - image: *redis_image
       - image: circleci/mysql:8-ram
         command: [--default-authentication-plugin=mysql_native_password]
@@ -335,8 +199,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - spree-bundle-v10-ruby-3-0-{{ .Branch }}
-            - spree-bundle-v10-ruby-3-0
+            - spree-bundle-v10-ruby-3-2-{{ .Branch }}
+            - spree-bundle-v10-ruby-3-2
       - run:
           name: Add keyserver
           command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
@@ -399,8 +263,6 @@ workflows:
   main:
     jobs:
       - bundle_ruby_2_7
-      - bundle_ruby_3_0
-      - bundle_ruby_3_1
       - bundle_ruby_3_2
       - brakeman:
           requires:
@@ -408,21 +270,15 @@ workflows:
       - tests_ruby_3_2_rails_7_0_postgres:
           requires:
             - bundle_ruby_3_2
-      - tests_ruby_3_1_rails_7_0_postgres:
-          requires:
-            - bundle_ruby_3_1
-      - tests_ruby_3_0_rails_7_0_postgres:
-          requires:
-            - bundle_ruby_3_0
       - tests_ruby_2_7_rails_7_0_postgres:
           requires:
             - bundle_ruby_2_7
       - tests_ruby_2_7_rails_6_1_postgres:
           requires:
             - bundle_ruby_2_7
-      - tests_ruby_3_0_rails_7_0_mysql:
+      - tests_ruby_3_2_rails_7_0_mysql:
           requires:
-            - bundle_ruby_3_0
+            - bundle_ruby_3_2
       - send_test_coverage:
           requires:
-            - tests_ruby_3_0_rails_7_0_mysql
+            - tests_ruby_3_2_rails_7_0_mysql


### PR DESCRIPTION
This PR reduces the amount of build configurations to the essentials (Ruby 3.2 to support the last version, Ruby 2.7 for applications that still require it).