### PR TITLE
Store translations

### DIFF
--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -167,7 +167,23 @@ describe 'API V2 Storefront Products Spec', type: :request do
       end
 
       context 'with locale set to polish' do
-        # create translated resources
+        # generate translations for default store
+        let!(:store) do
+          default_store = Spree::Store.default
+          Mobility.with_locale(:pl) do
+            default_store.name = 'Spree Sklep Testowy'
+            default_store.url = 'www.example.com'
+            default_store.mail_from_address = 'no-reply@example.com'
+            default_store.customer_support_email = 'support@example.com'
+            default_store.new_order_notifications_email = 'store-owner@example.com'
+            default_store.default_currency = 'PLN'
+            default_store.supported_currencies = 'PLN'
+            default_store.default_locale = 'pl'
+          end
+
+          default_store
+        end
+        # generate translated resources
         let!(:option_type_pl_locale)     { Mobility.with_locale(:pl) { create(:option_type) } }
         let!(:option_value_pl_locale)    { Mobility.with_locale(:pl) { create(:option_value, option_type: option_type_pl_locale) } }
         let!(:product_pl_locale)         { Mobility.with_locale(:pl) { create(:product, name: 'Produkt Superowy', option_types: [option_type_pl_locale], stores: [store]) } }

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -170,15 +170,13 @@ describe 'API V2 Storefront Products Spec', type: :request do
         # generate translations for default store
         let!(:store) do
           default_store = Spree::Store.default
+          default_store.default_locale = 'pl'
+
           Mobility.with_locale(:pl) do
             default_store.name = 'Spree Sklep Testowy'
-            default_store.url = 'www.example.com'
             default_store.mail_from_address = 'no-reply@example.com'
             default_store.customer_support_email = 'support@example.com'
             default_store.new_order_notifications_email = 'store-owner@example.com'
-            default_store.default_currency = 'PLN'
-            default_store.supported_currencies = 'PLN'
-            default_store.default_locale = 'pl'
           end
 
           default_store

--- a/api/spec/serializers/spree/api/v2/platform/store_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/store_serializer_spec.rb
@@ -15,7 +15,7 @@ describe Spree::Api::V2::Platform::StoreSerializer do
 
   it { expect(subject).to be_kind_of(Hash) }
 
-  it do
+  it 'generates the correct serialization' do
     expect(subject).to eq(
       {
         data: {

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -15,6 +15,7 @@ module Spree
 
     self::Translation.class_eval do
       acts_as_paranoid
+      # deleted translation values still need to be accessible - remove deleted_at scope
       default_scope { unscope(where: :deleted_at) }
     end
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,11 +1,18 @@
 module Spree
   class Store < Spree::Base
+    include TranslatableResource
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end
     if defined?(Spree::Security::Stores)
       include Spree::Security::Stores
     end
+
+    TRANSLATABLE_FIELDS = %i[name url meta_description meta_keywords seo_title default_currency
+                             supported_currencies facebook twitter instagram customer_support_email
+                             default_country_id description address contact_phone new_order_notifications_email
+                             checkout_zone_id].freeze
+    translate(*TRANSLATABLE_FIELDS)
 
     typed_store :settings, coder: ActiveRecord::TypedStore::IdentityCoder do |s|
       # Spree Digital Asset Configurations

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -8,9 +8,9 @@ module Spree
       include Spree::Security::Stores
     end
 
-    TRANSLATABLE_FIELDS = %i[name url meta_description meta_keywords seo_title default_currency
-                             supported_currencies facebook twitter instagram customer_support_email
-                             description address contact_phone new_order_notifications_email].freeze
+    TRANSLATABLE_FIELDS = %i[name meta_description meta_keywords seo_title facebook
+                             twitter instagram customer_support_email description
+                             address contact_phone new_order_notifications_email].freeze
     translates(*TRANSLATABLE_FIELDS)
 
     self::Translation.class_eval do

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -10,8 +10,7 @@ module Spree
 
     TRANSLATABLE_FIELDS = %i[name url meta_description meta_keywords seo_title default_currency
                              supported_currencies facebook twitter instagram customer_support_email
-                             default_country_id description address contact_phone new_order_notifications_email
-                             checkout_zone_id].freeze
+                             description address contact_phone new_order_notifications_email].freeze
     translates(*TRANSLATABLE_FIELDS)
 
     self::Translation.class_eval do
@@ -141,6 +140,8 @@ module Spree
     end
 
     def supported_currencies_list
+      ensure_supported_currencies
+
       @supported_currencies_list ||= (supported_currencies.split(',') << default_currency).sort.map(&:to_s).map do |code|
         ::Money::Currency.find(code.strip)
       end.uniq.compact

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -106,7 +106,7 @@ module Spree
     before_destroy :validate_not_last, unless: :skip_validate_not_last
     before_destroy :pass_default_flag_to_other_store
 
-    scope :by_url, ->(url_param) { i18n { url.matches("%#{url_param}%") } }
+    scope :by_url, ->(url) { where('url like ?', "%#{url}%") }
 
     after_commit :clear_cache
 
@@ -146,8 +146,6 @@ module Spree
     end
 
     def supported_currencies_list
-      ensure_supported_currencies
-
       @supported_currencies_list ||= (supported_currencies.split(',') << default_currency).sort.map(&:to_s).map do |code|
         ::Money::Currency.find(code.strip)
       end.uniq.compact

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -124,7 +124,12 @@ module Spree
     # this behaviour is very buggy and unpredictable
     def self.default
       Rails.cache.fetch('default_store') do
-        where(default: true).first_or_initialize
+        # workaround for Mobility bug with first_or_initialize
+        if where(default: true).any?
+          where(default: true).first
+        else
+          new(default: true)
+        end
       end
     end
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -146,7 +146,7 @@ module Spree
     end
 
     def supported_currencies_list
-      @supported_currencies_list ||= (supported_currencies.split(',') << default_currency).sort.map(&:to_s).map do |code|
+      @supported_currencies_list ||= (read_attribute(:supported_currencies).to_s.split(',') << default_currency).sort.map(&:to_s).map do |code|
         ::Money::Currency.find(code.strip)
       end.uniq.compact
     end

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -6,7 +6,7 @@ module Spree
       include Spree::Webhooks::HasWebhooks
     end
 
-    TRANSLATABLE_FIELDS = %i[name]
+    TRANSLATABLE_FIELDS = %i[name].freeze
     translates(*TRANSLATABLE_FIELDS)
 
     acts_as_list

--- a/core/brakeman.ignore
+++ b/core/brakeman.ignore
@@ -24,6 +24,29 @@
       "note": "interpolating table name"
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "05d3870f66d650510c859a8949d5686b05eb028825083b096d0f65fedf80b118",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "lib/spree/core/controller_helpers/auth.rb",
+      "line": 25,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to((session[\"spree_user_return_to\"] or (request.env[\"HTTP_REFERER\"] or default)))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Spree::Core::ControllerHelpers::Auth",
+        "method": "redirect_back_or_default"
+      },
+      "user_input": "request.env[\"HTTP_REFERER\"]",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "1f02952550c2f54d044c9577a45e7ba7c7990c8b8a59d1dac83a96790237f507",
@@ -254,6 +277,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-01-18 14:40:41 +0100",
-  "brakeman_version": "5.4.0"
+  "updated": "2023-02-24 11:32:53 +0100",
+  "brakeman_version": "5.4.1"
 }

--- a/core/db/migrate/20230210142732_create_store_translations.rb
+++ b/core/db/migrate/20230210142732_create_store_translations.rb
@@ -1,19 +1,7 @@
 class CreateStoreTranslations < ActiveRecord::Migration[6.1]
   def change
     if ActiveRecord::Base.connection.table_exists?('spree_store_translations')
-      # manually check for index since Rails if_exists does not always work correctly
-      if ActiveRecord::Migration.connection.index_exists?(:spree_store_translations, :spree_store_id)
-        remove_index :spree_store_translations, column: :spree_store_id, if_exists: true
-      end
-
-      add_column :spree_store_translations, :facebook, :string
-      add_column :spree_store_translations, :twitter, :string
-      add_column :spree_store_translations, :instagram, :string
-      add_column :spree_store_translations, :customer_support_email, :string
-      add_column :spree_store_translations, :description, :text
-      add_column :spree_store_translations, :address, :text
-      add_column :spree_store_translations, :contact_phone, :string
-      add_column :spree_store_translations, :new_order_notifications_email, :string
+      add_new_translation_columns_to_globalize_table
     else
       create_table :spree_store_translations do |t|
         # Translated attribute(s)
@@ -40,5 +28,23 @@ class CreateStoreTranslations < ActiveRecord::Migration[6.1]
     end
 
     add_index :spree_store_translations, [:spree_store_id, :locale], name: :index_spree_store_translations_on_spree_store_id_locale, unique: true
+  end
+
+  private
+
+  def add_new_translation_columns_to_globalize_table
+    # manually check for index since Rails if_exists does not always work correctly
+    if ActiveRecord::Migration.connection.index_exists?(:spree_store_translations, :spree_store_id)
+      remove_index :spree_store_translations, column: :spree_store_id, if_exists: true
+    end
+
+    add_column :spree_store_translations, :facebook, :string
+    add_column :spree_store_translations, :twitter, :string
+    add_column :spree_store_translations, :instagram, :string
+    add_column :spree_store_translations, :customer_support_email, :string
+    add_column :spree_store_translations, :description, :text
+    add_column :spree_store_translations, :address, :text
+    add_column :spree_store_translations, :contact_phone, :string
+    add_column :spree_store_translations, :new_order_notifications_email, :string
   end
 end

--- a/core/db/migrate/20230210142732_create_store_translations.rb
+++ b/core/db/migrate/20230210142732_create_store_translations.rb
@@ -1,0 +1,54 @@
+class CreateStoreTranslations < ActiveRecord::Migration[6.1]
+  def change
+    if ActiveRecord::Base.connection.table_exists?('spree_store_translations')
+      # manually check for index since Rails if_exists does not always work correctly
+      if ActiveRecord::Migration.connection.index_exists?(:spree_store_translations, :spree_store_id)
+        remove_index :spree_store_translations, column: :spree_store_id, if_exists: true
+      end
+
+      add_column :spree_store_translations, :url, :string
+      add_column :spree_store_translations, :default_currency, :string
+      add_column :spree_store_translations, :supported_currencies, :string
+      add_column :spree_store_translations, :facebook, :string
+      add_column :spree_store_translations, :twitter, :string
+      add_column :spree_store_translations, :instagram, :string
+      add_column :spree_store_translations, :customer_support_email, :string
+      add_column :spree_store_translations, :default_country_id, :integer
+      add_column :spree_store_translations, :description, :text
+      add_column :spree_store_translations, :address, :text
+      add_column :spree_store_translations, :contact_phone, :string
+      add_column :spree_store_translations, :new_order_notifications_email, :string
+      add_column :spree_store_translations, :checkout_zone_id, :integer
+    else
+      create_table :spree_store_translations do |t|
+        # Translated attribute(s)
+        t.string :name
+        t.string :url
+        t.text :meta_description
+        t.text :meta_keywords
+        t.string :seo_title
+        t.string :default_currency
+        t.string :supported_currencies
+        t.string :facebook
+        t.string :twitter
+        t.string :instagram
+        t.string :customer_support_email
+        t.integer :default_country_id
+        t.text :description
+        t.text :address
+        t.string :contact_phone
+        t.string :new_order_notifications_email
+        t.integer :checkout_zone_id
+
+        t.string  :locale, null: false
+        t.references :spree_store, null: false, foreign_key: true, index: false
+
+        t.timestamps null: false
+      end
+
+      add_index :spree_store_translations, :locale, name: :index_spree_store_translations_on_locale
+    end
+
+    add_index :spree_store_translations, [:spree_store_id, :locale], name: :index_spree_store_translations_on_spree_store_id_locale, unique: true
+  end
+end

--- a/core/db/migrate/20230210142732_create_store_translations.rb
+++ b/core/db/migrate/20230210142732_create_store_translations.rb
@@ -6,9 +6,6 @@ class CreateStoreTranslations < ActiveRecord::Migration[6.1]
         remove_index :spree_store_translations, column: :spree_store_id, if_exists: true
       end
 
-      add_column :spree_store_translations, :url, :string
-      add_column :spree_store_translations, :default_currency, :string
-      add_column :spree_store_translations, :supported_currencies, :string
       add_column :spree_store_translations, :facebook, :string
       add_column :spree_store_translations, :twitter, :string
       add_column :spree_store_translations, :instagram, :string
@@ -21,12 +18,9 @@ class CreateStoreTranslations < ActiveRecord::Migration[6.1]
       create_table :spree_store_translations do |t|
         # Translated attribute(s)
         t.string :name
-        t.string :url
         t.text :meta_description
         t.text :meta_keywords
         t.string :seo_title
-        t.string :default_currency
-        t.string :supported_currencies
         t.string :facebook
         t.string :twitter
         t.string :instagram

--- a/core/db/migrate/20230210142732_create_store_translations.rb
+++ b/core/db/migrate/20230210142732_create_store_translations.rb
@@ -13,12 +13,10 @@ class CreateStoreTranslations < ActiveRecord::Migration[6.1]
       add_column :spree_store_translations, :twitter, :string
       add_column :spree_store_translations, :instagram, :string
       add_column :spree_store_translations, :customer_support_email, :string
-      add_column :spree_store_translations, :default_country_id, :integer
       add_column :spree_store_translations, :description, :text
       add_column :spree_store_translations, :address, :text
       add_column :spree_store_translations, :contact_phone, :string
       add_column :spree_store_translations, :new_order_notifications_email, :string
-      add_column :spree_store_translations, :checkout_zone_id, :integer
     else
       create_table :spree_store_translations do |t|
         # Translated attribute(s)
@@ -33,12 +31,10 @@ class CreateStoreTranslations < ActiveRecord::Migration[6.1]
         t.string :twitter
         t.string :instagram
         t.string :customer_support_email
-        t.integer :default_country_id
         t.text :description
         t.text :address
         t.string :contact_phone
         t.string :new_order_notifications_email
-        t.integer :checkout_zone_id
 
         t.string  :locale, null: false
         t.references :spree_store, null: false, foreign_key: true, index: false

--- a/core/db/migrate/20230210142849_transfer_store_data_to_translatable_tables.rb
+++ b/core/db/migrate/20230210142849_transfer_store_data_to_translatable_tables.rb
@@ -1,0 +1,11 @@
+class TransferStoreDataToTranslatableTables < ActiveRecord::Migration[6.1]
+  TRANSLATION_MIGRATION = Spree::TranslationMigrations.new(Spree::Store, 'en')
+
+  def up
+    TRANSLATION_MIGRATION.transfer_translation_data
+  end
+
+  def down
+    TRANSLATION_MIGRATION.revert_translation_data_transfer
+  end
+end

--- a/core/db/migrate/20230210230434_add_deleted_at_to_store_translations.rb
+++ b/core/db/migrate/20230210230434_add_deleted_at_to_store_translations.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToStoreTranslations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_store_translations, :deleted_at, :datetime
+    add_index :spree_store_translations, :deleted_at
+  end
+end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -183,8 +183,8 @@ describe Spree::Store, type: :model do
     end
 
     it 'returns store for domain' do
-      expect(subject.class.current('spreecommerce.com')).to eql(store_1)
-      expect(subject.class.current('www.subdomain.com')).to eql(store_2)
+      expect(Spree::Stores::FindCurrent.new(url: 'spreecommerce.com').execute).to eql(store_1)
+      expect(Spree::Stores::FindCurrent.new(url: 'www.subdomain.com').execute).to eql(store_2)
     end
   end
 
@@ -225,12 +225,19 @@ describe Spree::Store, type: :model do
     end
 
     context 'when a default store is not present' do
-      it 'builds a new default store' do
+      before do
+        described_class::Translation.delete_all
         described_class.delete_all
         Rails.cache.clear
+      end
+
+      it 'builds a new default store' do
         expect(described_class.default.class).to eq(described_class)
-        expect(described_class.default.persisted?).to eq(false)
         expect(described_class.default.default).to be(true)
+      end
+
+      it 'does not persist the original default store' do
+        expect(described_class.default.persisted?).to eq(false)
       end
     end
   end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -646,7 +646,7 @@ describe Spree::Store, type: :model do
 
       it "doesn't destroy associations" do
         associations = described_class.reflect_on_all_associations(:has_many)
-        expect(associations.select { |a| a.options[:dependent] }).to be_empty
+        expect(associations.select { |a| a.options[:dependent] }.count).to equal(1)
       end
     end
   end

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -5,7 +5,7 @@ describe Spree::OrderMailer, type: :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
 
-  let(:first_store) { create(:store, name: 'First Store') }
+  let(:first_store) { create(:store, name: 'First Store', default: true) }
   let(:second_store) { create(:store, name: 'Second Store', url: 'other.example.com') }
 
   let(:order) do
@@ -172,7 +172,6 @@ describe Spree::OrderMailer, type: :mailer do
         pt_br_cancel_mail = { spree: { order_mailer: { cancel_email: { order_summary_canceled: 'Resumo da Pedido [CANCELADA]' } } } }
         I18n.backend.store_translations :'pt-BR', pt_br_confirm_mail
         I18n.backend.store_translations :'pt-BR', pt_br_cancel_mail
-        first_store.update(default_locale: 'pt-BR')
       end
 
       after do
@@ -197,7 +196,12 @@ describe Spree::OrderMailer, type: :mailer do
 
       context 'via I18n' do
         before do
-          allow(I18n).to receive(:locale).and_return(:'pt-BR')
+          I18n.locale = :'pt-BR'
+          first_store.update(default_locale: 'pt-BR')
+        end
+
+        after do
+          I18n.locale = :en
         end
 
         it_behaves_like 'translates emails'


### PR DESCRIPTION
A handful of tests are randomly failing, but core functionality for translations is complete.

`acts_as_paranoid` is applied to store translations, so that translatable values for soft-deleted stores can still be viewed.

### Translated Fields
* name
* meta_description
* meta_keywords
* seo_title
* facebook
* twitter
* instagram
* customer_support_email
* description
* address
* contact_phone
* new_order_notifications_email