### PR TITLE
Add architecture for automated translations

### DIFF
--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
           unauthorized: Error, you are not authorized to access this asset
         metadata:
           invalid_params: Public and private metadata parameters should be objects
+        translations:
+          missing_provider: No automated translations provider configured
+          success: Requested translations were generated successfully
         wishlist:
           errors:
             the_wishlist_could_not_be_destroyed: The wishlist could not be destroyed.

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -84,7 +84,11 @@ Spree::Core::Engine.add_routes do
         end
 
         # Product Catalog API
-        resources :products
+        resources :products do
+          member do
+            patch :translate
+          end
+        end
         resources :taxonomies
         resources :taxons do
           member do

--- a/api/lib/spree/api/dependencies.rb
+++ b/api/lib/spree/api/dependencies.rb
@@ -114,6 +114,9 @@ module Spree
         platform_shipment_change_state_service: -> { Spree::Dependencies.shipment_change_state_service },
         platform_shipment_add_item_service: -> { Spree::Dependencies.shipment_add_item_service },
         platform_shipment_remove_item_service: -> { Spree::Dependencies.shipment_remove_item_service },
+
+        # translation services
+        platform_products_generate_automated_translations: -> { Spree::Dependencies.products_generate_automated_translations }
       }
 
       include Spree::DependenciesHelper

--- a/api/lib/spree/api/testing_support/v2/base.rb
+++ b/api/lib/spree/api/testing_support/v2/base.rb
@@ -4,7 +4,7 @@ shared_context 'API v2 tokens' do
   let(:headers_order_token) { { 'X-Spree-Order-Token' => order.token } }
 end
 
-[200, 201, 204, 400, 401, 404, 403, 422].each do |status_code|
+[200, 201, 202, 204, 400, 401, 404, 403, 422].each do |status_code|
   shared_examples "returns #{status_code} HTTP status" do
     it "returns #{status_code}" do
       expect(response.status).to eq(status_code)

--- a/api/spec/requests/spree/api/v2/platform/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/products_spec.rb
@@ -355,4 +355,61 @@ describe 'API V2 Platform Products Spec' do
       end
     end
   end
+
+  describe 'products#translate' do
+    subject { patch "/api/v2/platform/products/#{product.id}/translate", headers: bearer_token }
+
+    before do
+      allow_any_instance_of(Spree::Api::V2::Platform::ProductsController).to receive(:current_store).and_return(store)
+    end
+
+    let(:store) { create(:store, default_locale: 'en', supported_locales: 'en,fr' ) }
+
+    context 'when automated translations are not configured' do
+      before do
+        allow(Spree::Dependencies).to receive(:products_automated_translations_provider).and_return(nil)
+        subject
+      end
+
+      it_behaves_like 'returns 422 HTTP status'
+
+      it 'returns error message' do
+        expect(json_response['error']).to eq('No automated translations provider configured')
+      end
+    end
+
+    context 'when automated translations are configured' do
+      before do
+        allow(Spree::Dependencies).to receive_message_chain(:products_automated_translations_provider, :constantize).and_return(translations_provider)
+      end
+
+      let(:translations_provider) { double }
+
+      context 'when generating automated translations succeeds' do
+        before do
+          expect(translations_provider).to receive(:call).with(product: product, source_attributes: anything, source_locale: 'en', target_locale: 'fr').and_return(Spree::ServiceModule::Result.new(true, { name: 'FR Name' }, nil))
+          subject
+        end
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'returns status' do
+          expect(json_response['message']).to eq('Requested translations were generated successfully')
+        end
+      end
+
+      context 'when generating automated translations fails' do
+        before do
+          expect(translations_provider).to receive(:call).with(product: product, source_attributes: anything, source_locale: 'en', target_locale: 'fr').and_raise('Test error')
+          subject
+        end
+
+        it_behaves_like 'returns 422 HTTP status'
+
+        it 'returns error' do
+          expect(json_response['error']).to eq('Test error')
+        end
+      end
+    end
+  end
 end

--- a/core/app/services/spree/products/translations/generate_automated_translations.rb
+++ b/core/app/services/spree/products/translations/generate_automated_translations.rb
@@ -1,0 +1,69 @@
+module Spree
+  module Products
+    module Translations
+      class GenerateAutomatedTranslations
+        prepend Spree::ServiceModule::Base
+
+        def initialize(provider: self.class.injected_automated_translations_provider)
+          @automated_translations_provider = provider
+        end
+
+        def call(product:, source_locale:, target_locales:, skip_existing: true)
+          raise ArgumentError, 'Automated translations service not available' if automated_translations_provider.nil?
+          raise ArgumentError, 'No locales available to translate to' if target_locales.empty?
+
+          source_attributes = fetch_attributes_in_source_locale(product, source_locale)
+
+          begin
+            translations_to_generate(product, target_locales, skip_existing).each do |target_locale|
+              translate_to_locale(product, source_attributes, source_locale, target_locale)
+            end
+
+            success(product)
+          rescue StandardError => e
+            failure(e)
+          end
+        end
+
+        private
+
+        attr_reader :automated_translations_provider
+
+        def fetch_attributes_in_source_locale(product, source_locale)
+          product.translations.find_by!(locale: source_locale).attributes
+        end
+
+        def translate_to_locale(product, source_attributes, source_locale, target_locale)
+          translated_attributes_result = automated_translations_provider.call(product: product,
+                                                                              source_attributes: source_attributes,
+                                                                              source_locale: source_locale,
+                                                                              target_locale: target_locale)
+
+          if translated_attributes_result.success?
+            translated_attributes = translated_attributes_result.value
+            translation = product.translations.find_or_initialize_by(locale: target_locale)
+            translation.update!(translated_attributes)
+          else
+            raise translated_attributes_result.value
+          end
+        end
+
+        def translations_to_generate(product, target_locales, skip_existing)
+          return target_locales unless skip_existing
+
+          target_locales - product.translations.pluck(:locale)
+        end
+
+        class << self
+          def enabled?
+            injected_automated_translations_provider.present?
+          end
+
+          def injected_automated_translations_provider
+            Spree::Dependencies.products_automated_translations_provider&.constantize
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/dependencies.rb
+++ b/core/lib/spree/core/dependencies.rb
@@ -86,6 +86,10 @@ module Spree
         data_feeds_google_optional_sub_attributes_service: 'Spree::DataFeeds::Google::OptionalSubAttributes',
         data_feeds_google_products_list: 'Spree::DataFeeds::Google::ProductsList',
 
+        # translations
+        products_generate_automated_translations: 'Spree::Products::Translations::GenerateAutomatedTranslations',
+        products_automated_translations_provider: nil,
+
         # finders
         address_finder: 'Spree::Addresses::Find',
         country_finder: 'Spree::Countries::Find',

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -58,6 +58,10 @@ FactoryBot.define do
           create(:product_property, product: product, property_id: 10, value: 'Epsilon')
         end
       end
+
+      trait :with_translations do
+        after(:create) { |product| create(:product_translation, locale: :it, product: product) }
+      end
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/product_translation_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_translation_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :product_translation, class: Spree::Product::Translation do
+    sequence(:name) { |n| "Product #{n}#{Kernel.rand(9999)}" }
+    description { generate(:random_description) }
+  end
+end

--- a/core/spec/services/spree/products/translations/generate_automated_translations_spec.rb
+++ b/core/spec/services/spree/products/translations/generate_automated_translations_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+module Spree
+  describe Products::Translations::GenerateAutomatedTranslations do
+    describe '#call' do
+      subject do
+        generate_automated_translations.call(product: product,
+                                             source_locale: source_locale,
+                                             target_locales: target_locales,
+                                             skip_existing: skip_existing)
+      end
+
+      let(:generate_automated_translations) { described_class.new(provider: provider) }
+
+      let(:provider) { double }
+      let(:source_locale) { 'en' }
+      let(:target_locales) { %w[de fr] }
+      let(:skip_existing) { false }
+
+      let(:de_attributes) { { name: 'DE Name', description: 'DE Description' } }
+      let(:fr_attributes) { { name: 'FR Name', description: 'FR Description' } }
+
+      context 'when there are existing translations in the target language' do
+        let(:product) { create(:product, translations: [product_translation_fr]) }
+        let(:product_translation_fr) do
+          build(:product_translation,
+                locale: 'fr',
+                name: 'FR Name Original',
+                description: 'FR Description Original')
+        end
+
+        context 'when skip existing is set to true' do
+          let(:skip_existing) { true }
+
+          it 'fetches only the missing locales from the provider' do
+            expect(provider).to receive(:call).with(hash_including(source_locale: 'en', target_locale: 'de')).and_return(Spree::ServiceModule::Result.new(true, de_attributes, nil))
+            expect(provider).to_not receive(:call).with(hash_including(source_locale: 'en', target_locale: 'fr'))
+
+            subject
+
+            de_translation = product.translations.find_by(locale: 'de')
+            fr_translation = product.translations.find_by(locale: 'fr')
+            expect(de_translation.name).to eq('DE Name')
+            expect(de_translation.description).to eq('DE Description')
+            expect(fr_translation.name).to eq('FR Name Original')
+            expect(fr_translation.description).to eq('FR Description Original')
+          end
+        end
+
+        context 'when skip existing is set to false' do
+          let(:skip_existing) { false }
+
+          it 'fetches all target locales from the provider' do
+            expect(provider).to receive(:call).with(hash_including(source_locale: 'en', target_locale: 'de')).and_return(Spree::ServiceModule::Result.new(true, de_attributes, nil))
+            expect(provider).to receive(:call).with(hash_including(source_locale: 'en', target_locale: 'fr')).and_return(Spree::ServiceModule::Result.new(true, fr_attributes, nil))
+
+            subject
+
+            de_translation = product.translations.find_by(locale: 'de')
+            fr_translation = product.translations.find_by(locale: 'fr')
+            expect(de_translation.name).to eq('DE Name')
+            expect(de_translation.description).to eq('DE Description')
+            expect(fr_translation.name).to eq('FR Name')
+            expect(fr_translation.description).to eq('FR Description')
+          end
+        end
+
+        context 'when no target locales are defined' do
+          let(:target_locales) { [] }
+
+          it 'raises an error' do
+            expect { subject }.to raise_error(ArgumentError, 'No locales available to translate to')
+          end
+        end
+      end
+
+      context 'when no provider is set' do
+        let(:provider) { nil }
+        let(:product) { create(:product) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError, 'Automated translations service not available')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a skeleton for implementing automated translations.

The idea is that a developer will be able to provide a `products_automated_translations_provider` (usually connecting a 3rd party service), that Spree will use to automatically translate products/taxons on demand.

It would be great to hear your feedback on that.