### PR TITLE
Refactor dependencies for spree core

### DIFF
--- a/api/lib/spree/api/dependencies.rb
+++ b/api/lib/spree/api/dependencies.rb
@@ -1,165 +1,122 @@
 module Spree
   module Api
     class ApiDependencies
-      include Spree::DependenciesHelper
-
-      INJECTION_POINTS = [
-        :storefront_cart_create_service, :storefront_cart_add_item_service, :storefront_cart_remove_line_item_service,
-        :storefront_cart_remove_item_service, :storefront_cart_set_item_quantity_service, :storefront_cart_recalculate_service,
-        :storefront_cms_page_serializer, :storefront_cms_page_finder,
-        :storefront_cart_update, :storefront_coupon_handler, :storefront_checkout_next_service, :storefront_checkout_advance_service,
-        :storefront_checkout_update_service, :storefront_checkout_complete_service, :storefront_checkout_add_store_credit_service,
-        :storefront_checkout_remove_store_credit_service, :storefront_checkout_get_shipping_rates_service,
-        :storefront_cart_compare_line_items_service, :storefront_cart_serializer, :storefront_credit_card_serializer,
-        :storefront_credit_card_finder, :storefront_shipment_serializer, :storefront_payment_method_serializer, :storefront_country_finder,
-        :storefront_country_serializer, :storefront_menu_serializer, :storefront_menu_finder, :storefront_current_order_finder,
-        :storefront_completed_order_finder, :storefront_order_sorter, :storefront_collection_paginator, :storefront_user_serializer,
-        :storefront_products_sorter, :storefront_products_finder, :storefront_product_serializer, :storefront_taxon_serializer,
-        :storefront_taxon_finder, :storefront_find_by_variant_finder, :storefront_cart_update_service, :storefront_cart_associate_service,
-        :storefront_cart_estimate_shipping_rates_service, :storefront_estimated_shipment_serializer,
-        :storefront_store_serializer, :storefront_address_serializer, :storefront_order_serializer,
-        :storefront_account_create_address_service, :storefront_account_update_address_service, :storefront_address_finder,
-        :storefront_account_create_service, :storefront_account_update_service, :storefront_collection_sorter, :error_handler,
-        :storefront_cart_empty_service, :storefront_cart_destroy_service, :storefront_credit_cards_destroy_service, :platform_products_sorter,
-        :storefront_cart_change_currency_service, :storefront_payment_serializer,
-        :storefront_payment_create_service, :storefront_address_create_service, :storefront_address_update_service,
-        :storefront_checkout_select_shipping_method_service,
-
-        :platform_admin_user_serializer, :platform_coupon_handler, :platform_order_update_service,
-        :platform_order_use_store_credit_service, :platform_order_remove_store_credit_service,
-        :platform_order_complete_service, :platform_order_empty_service, :platform_order_destroy_service,
-        :platform_order_next_service, :platform_order_advance_service,
-        :platform_line_item_create_service, :platform_line_item_update_service, :platform_line_item_destroy_service,
-        :platform_order_approve_service, :platform_order_cancel_service,
-        :platform_shipment_change_state_service, :platform_shipment_create_service, :platform_shipment_update_service,
-        :platform_shipment_add_item_service, :platform_shipment_remove_item_service
-      ].freeze
-
-      attr_accessor *INJECTION_POINTS
-
-      def initialize
-        set_storefront_defaults
-        set_platform_defaults
-      end
-
-      private
-
-      def set_storefront_defaults
+      INJECTION_POINTS_WITH_DEFAULTS = {
         # cart services
-        @storefront_cart_create_service = Spree::Dependencies.cart_create_service
-        @storefront_cart_add_item_service = Spree::Dependencies.cart_add_item_service
-        @storefront_cart_compare_line_items_service = Spree::Dependencies.cart_compare_line_items_service
-        @storefront_cart_update_service = Spree::Dependencies.cart_update_service
-        @storefront_cart_remove_line_item_service = Spree::Dependencies.cart_remove_line_item_service
-        @storefront_cart_remove_item_service = Spree::Dependencies.cart_remove_item_service
-        @storefront_cart_set_item_quantity_service = Spree::Dependencies.cart_set_item_quantity_service
-        @storefront_cart_recalculate_service = Spree::Dependencies.cart_recalculate_service
-        @storefront_cart_estimate_shipping_rates_service = Spree::Dependencies.cart_estimate_shipping_rates_service
-        @storefront_cart_empty_service = Spree::Dependencies.cart_empty_service
-        @storefront_cart_destroy_service = Spree::Dependencies.cart_destroy_service
-        @storefront_cart_associate_service = Spree::Dependencies.cart_associate_service
-        @storefront_cart_change_currency_service = Spree::Dependencies.cart_change_currency_service
+        storefront_cart_create_service: -> { Spree::Dependencies.cart_create_service },
+        storefront_cart_add_item_service: -> { Spree::Dependencies.cart_add_item_service },
+        storefront_cart_compare_line_items_service: -> { Spree::Dependencies.cart_compare_line_items_service },
+        storefront_cart_update_service: -> { Spree::Dependencies.cart_update_service },
+        storefront_cart_remove_line_item_service: -> { Spree::Dependencies.cart_remove_line_item_service },
+        storefront_cart_remove_item_service: -> { Spree::Dependencies.cart_remove_item_service },
+        storefront_cart_set_item_quantity_service: -> { Spree::Dependencies.cart_set_item_quantity_service },
+        storefront_cart_recalculate_service: -> { Spree::Dependencies.cart_recalculate_service },
+        storefront_cart_estimate_shipping_rates_service: -> { Spree::Dependencies.cart_estimate_shipping_rates_service },
+        storefront_cart_empty_service: -> { Spree::Dependencies.cart_empty_service },
+        storefront_cart_destroy_service: -> { Spree::Dependencies.cart_destroy_service },
+        storefront_cart_associate_service: -> { Spree::Dependencies.cart_associate_service },
+        storefront_cart_change_currency_service: -> { Spree::Dependencies.cart_change_currency_service },
 
         # coupon code handler
-        @storefront_coupon_handler = Spree::Dependencies.coupon_handler
+        storefront_coupon_handler: -> { Spree::Dependencies.coupon_handler },
 
         # checkout services
-        @storefront_checkout_next_service = Spree::Dependencies.checkout_next_service
-        @storefront_checkout_advance_service = Spree::Dependencies.checkout_advance_service
-        @storefront_checkout_update_service = Spree::Dependencies.checkout_update_service
-        @storefront_checkout_complete_service = Spree::Dependencies.checkout_complete_service
-        @storefront_checkout_add_store_credit_service = Spree::Dependencies.checkout_add_store_credit_service
-        @storefront_checkout_remove_store_credit_service = Spree::Dependencies.checkout_remove_store_credit_service
-        @storefront_checkout_get_shipping_rates_service = Spree::Dependencies.checkout_get_shipping_rates_service
-        @storefront_checkout_select_shipping_method_service = Spree::Dependencies.checkout_select_shipping_method_service
+        storefront_checkout_next_service: -> { Spree::Dependencies.checkout_next_service },
+        storefront_checkout_advance_service: -> { Spree::Dependencies.checkout_advance_service },
+        storefront_checkout_update_service: -> { Spree::Dependencies.checkout_update_service },
+        storefront_checkout_complete_service: -> { Spree::Dependencies.checkout_complete_service },
+        storefront_checkout_add_store_credit_service: -> { Spree::Dependencies.checkout_add_store_credit_service },
+        storefront_checkout_remove_store_credit_service: -> { Spree::Dependencies.checkout_remove_store_credit_service },
+        storefront_checkout_get_shipping_rates_service: -> { Spree::Dependencies.checkout_get_shipping_rates_service },
+        storefront_checkout_select_shipping_method_service: -> { Spree::Dependencies.checkout_select_shipping_method_service },
 
         # account services
-        @storefront_account_create_service = Spree::Dependencies.account_create_service
-        @storefront_account_update_service = Spree::Dependencies.account_update_service
+        storefront_account_create_service: -> { Spree::Dependencies.account_create_service },
+        storefront_account_update_service: -> { Spree::Dependencies.account_update_service },
 
         # address services
-        @storefront_address_create_service = Spree::Dependencies.address_create_service
-        @storefront_address_update_service = Spree::Dependencies.address_update_service
+        storefront_address_create_service: -> { Spree::Dependencies.address_create_service },
+        storefront_address_update_service: -> { Spree::Dependencies.address_update_service },
 
         # credit card services
-        @storefront_credit_cards_destroy_service = Spree::Dependencies.credit_cards_destroy_service
+        storefront_credit_cards_destroy_service: -> { Spree::Dependencies.credit_cards_destroy_service },
 
         # payment services
-        @storefront_payment_create_service = Spree::Dependencies.payment_create_service
+        storefront_payment_create_service: -> { Spree::Dependencies.payment_create_service },
 
         # serializers
-        @storefront_address_serializer = 'Spree::V2::Storefront::AddressSerializer'
-        @storefront_cart_serializer = 'Spree::V2::Storefront::CartSerializer'
-        @storefront_cms_page_serializer = 'Spree::V2::Storefront::CmsPageSerializer'
-        @storefront_credit_card_serializer = 'Spree::V2::Storefront::CreditCardSerializer'
-        @storefront_country_serializer = 'Spree::V2::Storefront::CountrySerializer'
-        @storefront_menu_serializer = 'Spree::V2::Storefront::MenuSerializer'
-        @storefront_user_serializer = 'Spree::V2::Storefront::UserSerializer'
-        @storefront_shipment_serializer = 'Spree::V2::Storefront::ShipmentSerializer'
-        @storefront_taxon_serializer = 'Spree::V2::Storefront::TaxonSerializer'
-        @storefront_payment_method_serializer = 'Spree::V2::Storefront::PaymentMethodSerializer'
-        @storefront_payment_serializer = 'Spree::V2::Storefront::PaymentSerializer'
-        @storefront_product_serializer = 'Spree::V2::Storefront::ProductSerializer'
-        @storefront_estimated_shipment_serializer = 'Spree::V2::Storefront::EstimatedShippingRateSerializer'
-        @storefront_store_serializer = 'Spree::V2::Storefront::StoreSerializer'
-        @storefront_order_serializer = 'Spree::V2::Storefront::OrderSerializer'
+        storefront_address_serializer: 'Spree::V2::Storefront::AddressSerializer',
+        storefront_cart_serializer: 'Spree::V2::Storefront::CartSerializer',
+        storefront_cms_page_serializer: 'Spree::V2::Storefront::CmsPageSerializer',
+        storefront_credit_card_serializer: 'Spree::V2::Storefront::CreditCardSerializer',
+        storefront_country_serializer: 'Spree::V2::Storefront::CountrySerializer',
+        storefront_menu_serializer: 'Spree::V2::Storefront::MenuSerializer',
+        storefront_user_serializer: 'Spree::V2::Storefront::UserSerializer',
+        storefront_shipment_serializer: 'Spree::V2::Storefront::ShipmentSerializer',
+        storefront_taxon_serializer: 'Spree::V2::Storefront::TaxonSerializer',
+        storefront_payment_method_serializer: 'Spree::V2::Storefront::PaymentMethodSerializer',
+        storefront_payment_serializer: 'Spree::V2::Storefront::PaymentSerializer',
+        storefront_product_serializer: 'Spree::V2::Storefront::ProductSerializer',
+        storefront_estimated_shipment_serializer: 'Spree::V2::Storefront::EstimatedShippingRateSerializer',
+        storefront_store_serializer: 'Spree::V2::Storefront::StoreSerializer',
+        storefront_order_serializer: 'Spree::V2::Storefront::OrderSerializer',
 
         # sorters
-        @storefront_collection_sorter = Spree::Dependencies.collection_sorter
-        @storefront_order_sorter = Spree::Dependencies.collection_sorter
-        @storefront_products_sorter = Spree::Dependencies.products_sorter
-        @platform_products_sorter = Spree::Dependencies.products_sorter
+        storefront_collection_sorter: -> { Spree::Dependencies.collection_sorter },
+        storefront_order_sorter: -> { Spree::Dependencies.collection_sorter },
+        storefront_products_sorter: -> { Spree::Dependencies.products_sorter },
+        platform_products_sorter: -> { Spree::Dependencies.products_sorter },
 
         # paginators
-        @storefront_collection_paginator = Spree::Dependencies.collection_paginator
+        storefront_collection_paginator: -> { Spree::Dependencies.collection_paginator },
 
         # finders
-        @storefront_address_finder = Spree::Dependencies.address_finder
-        @storefront_country_finder = Spree::Dependencies.country_finder
-        @storefront_cms_page_finder = Spree::Dependencies.cms_page_finder
-        @storefront_menu_finder = Spree::Dependencies.menu_finder
-        @storefront_current_order_finder = Spree::Dependencies.current_order_finder
-        @storefront_completed_order_finder = Spree::Dependencies.completed_order_finder
-        @storefront_credit_card_finder = Spree::Dependencies.credit_card_finder
-        @storefront_find_by_variant_finder = Spree::Dependencies.line_item_by_variant_finder
-        @storefront_products_finder = Spree::Dependencies.products_finder
-        @storefront_taxon_finder = Spree::Dependencies.taxon_finder
+        storefront_address_finder: -> { Spree::Dependencies.address_finder },
+        storefront_country_finder: -> { Spree::Dependencies.country_finder },
+        storefront_cms_page_finder: -> { Spree::Dependencies.cms_page_finder },
+        storefront_menu_finder: -> { Spree::Dependencies.menu_finder },
+        storefront_current_order_finder: -> { Spree::Dependencies.current_order_finder },
+        storefront_completed_order_finder: -> { Spree::Dependencies.completed_order_finder },
+        storefront_credit_card_finder: -> { Spree::Dependencies.credit_card_finder },
+        storefront_find_by_variant_finder: -> { Spree::Dependencies.line_item_by_variant_finder },
+        storefront_products_finder: -> { Spree::Dependencies.products_finder },
+        storefront_taxon_finder: -> { Spree::Dependencies.taxon_finder },
 
-        @error_handler = 'Spree::Api::ErrorHandler'
-      end
+        error_handler: 'Spree::Api::ErrorHandler',
 
-      def set_platform_defaults
         # serializers
-        @platform_admin_user_serializer = 'Spree::Api::V2::Platform::UserSerializer'
+        platform_admin_user_serializer: 'Spree::Api::V2::Platform::UserSerializer',
 
         # coupon code handler
-        @platform_coupon_handler = Spree::Dependencies.coupon_handler
+        platform_coupon_handler: -> { Spree::Dependencies.coupon_handler },
 
         # order services
-        @platform_order_recalculate_service = Spree::Dependencies.cart_recalculate_service
-        @platform_order_update_service = Spree::Dependencies.checkout_update_service
-        @platform_order_empty_service = Spree::Dependencies.cart_empty_service
-        @platform_order_destroy_service = Spree::Dependencies.cart_destroy_service
-        @platform_order_next_service = Spree::Dependencies.checkout_next_service
-        @platform_order_advance_service = Spree::Dependencies.checkout_advance_service
-        @platform_order_complete_service = Spree::Dependencies.checkout_complete_service
-        @platform_order_use_store_credit_service = Spree::Dependencies.checkout_add_store_credit_service
-        @platform_order_remove_store_credit_service = Spree::Dependencies.checkout_remove_store_credit_service
-        @platform_order_approve_service = Spree::Dependencies.order_approve_service
-        @platform_order_cancel_service = Spree::Dependencies.order_cancel_service
+        platform_order_recalculate_service: -> { Spree::Dependencies.cart_recalculate_service },
+        platform_order_update_service: -> { Spree::Dependencies.checkout_update_service },
+        platform_order_empty_service: -> { Spree::Dependencies.cart_empty_service },
+        platform_order_destroy_service: -> { Spree::Dependencies.cart_destroy_service },
+        platform_order_next_service: -> { Spree::Dependencies.checkout_next_service },
+        platform_order_advance_service: -> { Spree::Dependencies.checkout_advance_service },
+        platform_order_complete_service: -> { Spree::Dependencies.checkout_complete_service },
+        platform_order_use_store_credit_service: -> { Spree::Dependencies.checkout_add_store_credit_service },
+        platform_order_remove_store_credit_service: -> { Spree::Dependencies.checkout_remove_store_credit_service },
+        platform_order_approve_service: -> { Spree::Dependencies.order_approve_service },
+        platform_order_cancel_service: -> { Spree::Dependencies.order_cancel_service },
 
         # line item services
-        @platform_line_item_create_service = Spree::Dependencies.line_item_create_service
-        @platform_line_item_update_service = Spree::Dependencies.line_item_update_service
-        @platform_line_item_destroy_service = Spree::Dependencies.line_item_destroy_service
+        platform_line_item_create_service: -> { Spree::Dependencies.line_item_create_service },
+        platform_line_item_update_service: -> { Spree::Dependencies.line_item_update_service },
+        platform_line_item_destroy_service: -> { Spree::Dependencies.line_item_destroy_service },
 
         # shipment services
-        @platform_shipment_create_service = Spree::Dependencies.shipment_create_service
-        @platform_shipment_update_service = Spree::Dependencies.shipment_update_service
-        @platform_shipment_change_state_service = Spree::Dependencies.shipment_change_state_service
-        @platform_shipment_add_item_service = Spree::Dependencies.shipment_add_item_service
-        @platform_shipment_remove_item_service = Spree::Dependencies.shipment_remove_item_service
-      end
+        platform_shipment_create_service: -> { Spree::Dependencies.shipment_create_service },
+        platform_shipment_update_service: -> { Spree::Dependencies.shipment_update_service },
+        platform_shipment_change_state_service: -> { Spree::Dependencies.shipment_change_state_service },
+        platform_shipment_add_item_service: -> { Spree::Dependencies.shipment_add_item_service },
+        platform_shipment_remove_item_service: -> { Spree::Dependencies.shipment_remove_item_service },
+      }
+
+      include Spree::DependenciesHelper
     end
   end
 end

--- a/core/lib/spree/core/dependencies.rb
+++ b/core/lib/spree/core/dependencies.rb
@@ -3,136 +3,104 @@ require_relative 'dependencies_helper'
 module Spree
   module Core
     class Dependencies
-      include Spree::DependenciesHelper
+      INJECTION_POINTS_WITH_DEFAULTS = {
+        # ability
+        ability_class: 'Spree::Ability',
 
-      INJECTION_POINTS = [
-        :ability_class,
-        :cart_create_service, :cart_add_item_service, :cart_remove_item_service,
-        :cart_remove_line_item_service, :cart_set_item_quantity_service, :cart_recalculate_service,
-        :cms_page_finder, :cart_update_service, :checkout_next_service, :checkout_advance_service, :checkout_update_service,
-        :checkout_complete_service, :checkout_add_store_credit_service, :checkout_remove_store_credit_service, :checkout_get_shipping_rates_service,
-        :coupon_handler, :menu_finder, :country_finder, :current_order_finder, :credit_card_finder,
-        :completed_order_finder, :order_sorter, :cart_compare_line_items_service, :collection_paginator, :products_sorter,
-        :products_finder, :taxon_finder, :line_item_by_variant_finder, :cart_estimate_shipping_rates_service,
-        :account_create_address_service, :account_update_address_service, :account_create_service, :account_update_service,
-        :address_finder, :collection_sorter, :error_handler, :current_store_finder, :cart_empty_service, :cart_destroy_service,
-        :classification_reposition_service, :credit_cards_destroy_service, :cart_associate_service, :cart_change_currency_service,
-        :line_item_create_service, :line_item_update_service, :line_item_destroy_service,
-        :order_approve_service, :order_cancel_service, :shipment_change_state_service, :shipment_update_service,
-        :shipment_create_service, :shipment_add_item_service, :shipment_remove_item_service,
-        :payment_create_service, :address_create_service, :address_update_service,
-        :checkout_select_shipping_method_service, :data_feeds_google_rss_service, :data_feeds_google_optional_attributes_service,
-        :data_feeds_google_required_attributes_service, :data_feeds_google_optional_sub_attributes_service, :data_feeds_google_products_list
-      ].freeze
-
-      attr_accessor *INJECTION_POINTS
-
-      def initialize
-        set_default_ability
-        set_default_services
-        set_default_finders
-      end
-
-      private
-
-      def set_default_ability
-        @ability_class = 'Spree::Ability'
-      end
-
-      def set_default_services
         # cart
-        @cart_compare_line_items_service = 'Spree::CompareLineItems'
-        @cart_create_service = 'Spree::Cart::Create'
-        @cart_add_item_service = 'Spree::Cart::AddItem'
-        @cart_update_service = 'Spree::Cart::Update'
-        @cart_recalculate_service = 'Spree::Cart::Recalculate'
-        @cart_remove_item_service = 'Spree::Cart::RemoveItem'
-        @cart_remove_line_item_service = 'Spree::Cart::RemoveLineItem'
-        @cart_set_item_quantity_service = 'Spree::Cart::SetQuantity'
-        @cart_estimate_shipping_rates_service = 'Spree::Cart::EstimateShippingRates'
-        @cart_empty_service = 'Spree::Cart::Empty'
-        @cart_destroy_service = 'Spree::Cart::Destroy'
-        @cart_associate_service = 'Spree::Cart::Associate'
-        @cart_change_currency_service = 'Spree::Cart::ChangeCurrency'
+        cart_compare_line_items_service: 'Spree::CompareLineItems',
+        cart_create_service: 'Spree::Cart::Create',
+        cart_add_item_service: 'Spree::Cart::AddItem',
+        cart_update_service: 'Spree::Cart::Update',
+        cart_recalculate_service: 'Spree::Cart::Recalculate',
+        cart_remove_item_service: 'Spree::Cart::RemoveItem',
+        cart_remove_line_item_service: 'Spree::Cart::RemoveLineItem',
+        cart_set_item_quantity_service: 'Spree::Cart::SetQuantity',
+        cart_estimate_shipping_rates_service: 'Spree::Cart::EstimateShippingRates',
+        cart_empty_service: 'Spree::Cart::Empty',
+        cart_destroy_service: 'Spree::Cart::Destroy',
+        cart_associate_service: 'Spree::Cart::Associate',
+        cart_change_currency_service: 'Spree::Cart::ChangeCurrency',
 
         # checkout
-        @checkout_next_service = 'Spree::Checkout::Next'
-        @checkout_advance_service = 'Spree::Checkout::Advance'
-        @checkout_update_service = 'Spree::Checkout::Update'
-        @checkout_complete_service = 'Spree::Checkout::Complete'
-        @checkout_add_store_credit_service = 'Spree::Checkout::AddStoreCredit'
-        @checkout_remove_store_credit_service = 'Spree::Checkout::RemoveStoreCredit'
-        @checkout_get_shipping_rates_service = 'Spree::Checkout::GetShippingRates'
-        @checkout_select_shipping_method_service = 'Spree::Checkout::SelectShippingMethod'
+        checkout_next_service: 'Spree::Checkout::Next',
+        checkout_advance_service: 'Spree::Checkout::Advance',
+        checkout_update_service: 'Spree::Checkout::Update',
+        checkout_complete_service: 'Spree::Checkout::Complete',
+        checkout_add_store_credit_service: 'Spree::Checkout::AddStoreCredit',
+        checkout_remove_store_credit_service: 'Spree::Checkout::RemoveStoreCredit',
+        checkout_get_shipping_rates_service: 'Spree::Checkout::GetShippingRates',
+        checkout_select_shipping_method_service: 'Spree::Checkout::SelectShippingMethod',
 
         # order
-        @order_approve_service = 'Spree::Orders::Approve'
-        @order_cancel_service = 'Spree::Orders::Cancel'
+        order_approve_service: 'Spree::Orders::Approve',
+        order_cancel_service: 'Spree::Orders::Cancel',
 
         # shipment
-        @shipment_change_state_service = 'Spree::Shipments::ChangeState'
-        @shipment_create_service = 'Spree::Shipments::Create'
-        @shipment_update_service = 'Spree::Shipments::Update'
-        @shipment_add_item_service = 'Spree::Shipments::AddItem'
-        @shipment_remove_item_service = 'Spree::Shipments::RemoveItem'
+        shipment_change_state_service: 'Spree::Shipments::ChangeState',
+        shipment_create_service: 'Spree::Shipments::Create',
+        shipment_update_service: 'Spree::Shipments::Update',
+        shipment_add_item_service: 'Spree::Shipments::AddItem',
+        shipment_remove_item_service: 'Spree::Shipments::RemoveItem',
 
         # sorter
-        @collection_sorter = 'Spree::BaseSorter'
-        @order_sorter = 'Spree::BaseSorter'
-        @products_sorter = 'Spree::Products::Sort'
+        collection_sorter: 'Spree::BaseSorter',
+        order_sorter: 'Spree::BaseSorter',
+        products_sorter: 'Spree::Products::Sort',
 
         # paginator
-        @collection_paginator = 'Spree::Shared::Paginate'
+        collection_paginator: 'Spree::Shared::Paginate',
 
         # coupons
         # TODO: we should split this service into 2 separate - Add and Remove
-        @coupon_handler = 'Spree::PromotionHandler::Coupon'
+        coupon_handler: 'Spree::PromotionHandler::Coupon',
 
         # account
-        @account_create_service = 'Spree::Account::Create'
-        @account_update_service = 'Spree::Account::Update'
+        account_create_service: 'Spree::Account::Create',
+        account_update_service: 'Spree::Account::Update',
 
         # addresses
-        @address_create_service = 'Spree::Addresses::Create'
-        @address_update_service = 'Spree::Addresses::Update'
+        address_create_service: 'Spree::Addresses::Create',
+        address_update_service: 'Spree::Addresses::Update',
 
         # credit cards
-        @credit_cards_destroy_service = 'Spree::CreditCards::Destroy'
+        credit_cards_destroy_service: 'Spree::CreditCards::Destroy',
 
         # classifications
-        @classification_reposition_service = 'Spree::Classifications::Reposition'
+        classification_reposition_service: 'Spree::Classifications::Reposition',
 
         # line items
-        @line_item_create_service = 'Spree::LineItems::Create'
-        @line_item_update_service = 'Spree::LineItems::Update'
-        @line_item_destroy_service = 'Spree::LineItems::Destroy'
+        line_item_create_service: 'Spree::LineItems::Create',
+        line_item_update_service: 'Spree::LineItems::Update',
+        line_item_destroy_service: 'Spree::LineItems::Destroy',
 
-        @payment_create_service = 'Spree::Payments::Create'
+        payment_create_service: 'Spree::Payments::Create',
 
         # errors
-        @error_handler = 'Spree::ErrorReporter'
+        error_handler: 'Spree::ErrorReporter',
 
-        # data feeds for Google
-        @data_feeds_google_rss_service = 'Spree::DataFeeds::Google::Rss'
-        @data_feeds_google_optional_attributes_service = 'Spree::DataFeeds::Google::OptionalAttributes'
-        @data_feeds_google_required_attributes_service = 'Spree::DataFeeds::Google::RequiredAttributes'
-        @data_feeds_google_optional_sub_attributes_service = 'Spree::DataFeeds::Google::OptionalSubAttributes'
-        @data_feeds_google_products_list = 'Spree::DataFeeds::Google::ProductsList'
-      end
+        # data feeds
+        data_feeds_google_rss_service: 'Spree::DataFeeds::Google::Rss',
+        data_feeds_google_optional_attributes_service: 'Spree::DataFeeds::Google::OptionalAttributes',
+        data_feeds_google_required_attributes_service: 'Spree::DataFeeds::Google::RequiredAttributes',
+        data_feeds_google_optional_sub_attributes_service: 'Spree::DataFeeds::Google::OptionalSubAttributes',
+        data_feeds_google_products_list: 'Spree::DataFeeds::Google::ProductsList',
 
-      def set_default_finders
-        @address_finder = 'Spree::Addresses::Find'
-        @country_finder = 'Spree::Countries::Find'
-        @cms_page_finder = 'Spree::CmsPages::Find'
-        @menu_finder = 'Spree::Menus::Find'
-        @current_order_finder = 'Spree::Orders::FindCurrent'
-        @current_store_finder = 'Spree::Stores::FindCurrent'
-        @completed_order_finder = 'Spree::Orders::FindComplete'
-        @credit_card_finder = 'Spree::CreditCards::Find'
-        @products_finder = 'Spree::Products::Find'
-        @taxon_finder = 'Spree::Taxons::Find'
-        @line_item_by_variant_finder = 'Spree::LineItems::FindByVariant'
-      end
+        # finders
+        address_finder: 'Spree::Addresses::Find',
+        country_finder: 'Spree::Countries::Find',
+        cms_page_finder: 'Spree::CmsPages::Find',
+        menu_finder: 'Spree::Menus::Find',
+        current_order_finder: 'Spree::Orders::FindCurrent',
+        current_store_finder: 'Spree::Stores::FindCurrent',
+        completed_order_finder: 'Spree::Orders::FindComplete',
+        credit_card_finder: 'Spree::CreditCards::Find',
+        products_finder: 'Spree::Products::Find',
+        taxon_finder: 'Spree::Taxons::Find',
+        line_item_by_variant_finder: 'Spree::LineItems::FindByVariant'
+      }.freeze
+
+      include Spree::DependenciesHelper
     end
   end
 end

--- a/core/lib/spree/core/dependencies_helper.rb
+++ b/core/lib/spree/core/dependencies_helper.rb
@@ -1,11 +1,30 @@
 module Spree
   module DependenciesHelper
+    def self.included(base)
+      injection_points = base::INJECTION_POINTS_WITH_DEFAULTS.keys.freeze
+      base.const_set(:INJECTION_POINTS, injection_points)
+      base.attr_accessor(*injection_points)
+    end
+
+    def initialize
+      set_default_values
+    end
+
     def current_values
       values = []
       self.class::INJECTION_POINTS.each do |injection_point|
         values << { injection_point.to_s => instance_variable_get("@#{injection_point}") }
       end
       values
+    end
+
+    private
+
+    def set_default_values
+      self.class::INJECTION_POINTS_WITH_DEFAULTS.each do |injection_point, default_value|
+        value = default_value.respond_to?(:call) ? default_value.call : default_value
+        instance_variable_set("@#{injection_point}", value)
+      end
     end
   end
 end


### PR DESCRIPTION
When working on translations, I got warnings from code climate that methods in the `spree/core/dependencies.rb` grew to be too big.

I gave it some thought and I noticed that:
1. There's a large array called `INJECTION_POINTS` defined at the top of the file. It defines names of the methods that will be created as attr_accessors
2. The `initialize` method calls methods, that effectively set values of each of these instance variables to a string constant

Because of that, when adding a new service to dependency injection, we need to extend the array with the name of the new service, then also update the initialize method to also set the value it. I experimented with replacing the array with a hash, that will also contain defaults, that will be automatically assigned upon initialization. This should simplify the flow, and also reduce the size of this file.

Let me know your thoughts on that. If this makes sense, I will also make a similar update to the remaining dependencies classes.