### PR TITLE
Improve performance of filtering products by property

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -186,7 +186,7 @@ module Spree
 
           next if values.empty?
 
-          ids = products.with_property_values(property_filter_param, values).ids
+          ids = scope.unscope(:order, :includes).with_property_values(property_filter_param, values).ids
           product_ids = index == 0 ? ids : product_ids & ids
           index += 1
         end


### PR DESCRIPTION
Previously it used all joins/includes to fetch these IDs which are not required. Products with lots of variants would cause significant performance issues