### PR TITLE
Fix joins for translated ransack resources

### DIFF
--- a/api/app/controllers/spree/api/v2/platform/variants_controller.rb
+++ b/api/app/controllers/spree/api/v2/platform/variants_controller.rb
@@ -12,16 +12,6 @@ module Spree
           def spree_permitted_attributes
             super + [:option_value_ids, :price, :currency]
           end
-
-          def collection
-            # if filtering on products, manually join on product translation to workaround mobility-ransack issue
-            if params.key?(:filter) && params[:filter].keys.any? { |k| k.include? 'product' }
-              @collection ||= scope.joins(:product).join_translation_table(Product).
-                              ransack(params[:filter]).result
-            else
-              super
-            end
-          end
         end
       end
     end

--- a/api/spec/requests/spree/api/v2/platform/line_items_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/line_items_spec.rb
@@ -6,7 +6,7 @@ describe 'API V2 Platform Line Items Spec' do
   let(:bearer_token) { { 'Authorization' => valid_authorization } }
 
   let!(:line_items) { create_list(:line_item, 5) }
-  
+
   describe 'line_items#index' do
     context 'with no params' do
       before { get '/api/v2/platform/line_items', headers: bearer_token }
@@ -57,6 +57,14 @@ describe 'API V2 Platform Line Items Spec' do
         it 'returns line items with price greater than or equal to the given price' do
           expect(json_response['data'].count).to eq 1
           expect(json_response['data'].first['id']).to eq line_item.id.to_s
+        end
+      end
+
+      context 'by variant name' do
+        before { get "/api/v2/platform/line_items?filter[variant_product_name_or_variant_sku_cont]=#{line_items.first.variant.name}", headers: bearer_token }
+
+        it 'returns line items with correct variant name' do
+          expect(json_response['data'].count).to eq 1
         end
       end
     end

--- a/api/spec/requests/spree/api/v2/platform/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/products_spec.rb
@@ -307,6 +307,14 @@ describe 'API V2 Platform Products Spec' do
         end
       end
     end
+
+    context 'filtering' do
+      before { get "/api/v2/platform/products?filter[name_cont]=#{in_stock_product.name}", headers: bearer_token }
+
+      it 'returns line items with correct variant name' do
+        expect(json_response['data'].count).to eq 1
+      end
+    end
   end
 
   describe 'products#show' do

--- a/api/spec/requests/spree/api/v2/platform/stock_items_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/stock_items_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'Platform API v2 Stock Items API' do
+  include_context 'Platform API v2'
+
+  let(:bearer_token) { { 'Authorization' => valid_authorization } }
+
+  let(:product_1) { create(:product, stores: [store]) }
+  let(:product_2) { create(:product, stores: [store]) }
+  let!(:stock_location_1) { create(:stock_location) }
+  let!(:stock_location_2) { create(:stock_location) }
+
+  describe 'stock_items#index' do
+    let!(:variants) { create_list(:variant, 2, product: product_1) }
+    let!(:variants) { create_list(:variant, 2, product: product_2) }
+
+    context 'filtering by stock location id' do
+      before { get "/api/v2/platform/stock_items?filter[stock_location_id_eq]=#{stock_location_1.id}", headers: bearer_token }
+
+      it 'returns stock_items with matching stock location ids' do
+        expect(json_response['data'].count).to eq 3
+        expect(json_response['data'].first).to have_type('stock_item')
+      end
+    end
+
+    context 'filtering by variant product name or sku' do
+      before { get "/api/v2/platform/stock_items?filter[variant_product_name_or_variant_sku_cont]=#{product_2.name}", headers: bearer_token }
+
+      it 'returns stock_items with matching stock location ids' do
+        expect(json_response['data'].count).to eq 2
+        expect(json_response['data'].first).to have_type('stock_item')
+      end
+    end
+  end
+end
+

--- a/api/spec/requests/spree/api/v2/platform/stock_items_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/stock_items_spec.rb
@@ -27,7 +27,8 @@ describe 'Platform API v2 Stock Items API' do
       before { get "/api/v2/platform/stock_items?filter[variant_product_name_or_variant_sku_cont]=#{product_2.name}", headers: bearer_token }
 
       it 'returns stock_items with matching stock location ids' do
-        expect(json_response['data'].count).to eq 2
+        # default variant + 2 variants for product_2, each inside two stock locations
+        expect(json_response['data'].count).to eq 6
         expect(json_response['data'].first).to have_type('stock_item')
       end
     end

--- a/api/spec/requests/spree/api/v2/platform/variants_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/variants_spec.rb
@@ -7,7 +7,7 @@ describe 'API V2 Platform Variants Spec' do
 
   let(:product) { create(:product, stores: [store]) }
   let!(:variants) { create_list(:variant, 5, product: product) }
-  
+
   describe 'variants#index' do
     context 'with no params' do
       before { get '/api/v2/platform/variants', headers: bearer_token }
@@ -41,7 +41,7 @@ describe 'API V2 Platform Variants Spec' do
         let(:product_2) { create(:product, stores: [store], name: 'Vendo T-shirt') }
         let!(:variant) { create(:variant, product: product_2) }
 
-        before { get "/api/v2/platform/variants?filter[product_name_cont]=vendo&filter[is_master_eq]=false", headers: bearer_token }
+        before { get '/api/v2/platform/variants?filter[product_name_cont]=vendo&filter[is_master_eq]=false', headers: bearer_token }
 
         it 'returns variant with a specified name' do
           expect(json_response['data'].count).to eq 1
@@ -52,7 +52,7 @@ describe 'API V2 Platform Variants Spec' do
       xcontext 'by price' do
         let!(:variant) { create(:variant, price: 100) }
 
-        before { get "/api/v2/platform/variants?filter[product_price_between]=100,200", headers: bearer_token }
+        before { get '/api/v2/platform/variants?filter[product_price_between]=100,200', headers: bearer_token }
 
         it 'returns variants with price greater than or equal to the given price' do
           expect(json_response['data'].count).to eq 1

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -3,6 +3,7 @@ class Spree::Base < ApplicationRecord
   serialize :preferences, Hash
 
   include Spree::RansackableAttributes
+  include Spree::TranslatableResourceScopes
 
   after_initialize do
     if has_attribute?(:preferences) && !preferences.nil?

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -24,7 +24,6 @@ module Spree
     include ProductScopes
     include MultiStoreResource
     include TranslatableResource
-    include TranslatableResourceScopes
     include MemoizedData
     include Metadata
     if defined?(Spree::Webhooks)

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -2,7 +2,6 @@ module Spree
   class ProductProperty < Spree::Base
     include Spree::FilterParam
     include TranslatableResource
-    include TranslatableResourceScopes
 
     TRANSLATABLE_FIELDS = %i[value filter_param].freeze
     translates(*TRANSLATABLE_FIELDS)

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -4,7 +4,6 @@ require 'stringex'
 module Spree
   class Taxon < Spree::Base
     include TranslatableResource
-    include TranslatableResourceScopes
     include Metadata
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -5,7 +5,6 @@ module Spree
 
     include MemoizedData
     include Metadata
-    include TranslatableResourceScopes
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
     end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -55,7 +55,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'active_storage_validations', '~> 0.9', '<= 0.9.5'
   s.add_dependency 'activerecord-typedstore'
   s.add_dependency 'mobility', '~> 1.2.9'
-  # Upgrade mobility-ransack version to 1.2.0 after this issue is resolved
-  s.add_dependency 'mobility-ransack', '~> 1.0.1'
+  s.add_dependency 'mobility-ransack', '~> 1.2.1'
   s.add_dependency 'friendly_id-mobility', '~> 1.0.3'
 end


### PR DESCRIPTION
We had some issues caught by spree_backend tests, where filtering by associations that were translatable, caused errors due to missing joins. I've upgraded the version of `mobility-ransack`, which fixed that issue.