### PR TITLE
Fix generating slugs for translations

### DIFF
--- a/core/config/initializers/friendly_id.rb
+++ b/core/config/initializers/friendly_id.rb
@@ -1,3 +1,5 @@
+require 'friendly_id/mobility'
+
 # To learn more, check out the guide:
 # http://norman.github.io/friendly_id/file.Guide.html
 FriendlyId.defaults do |config|

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -56,5 +56,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord-typedstore'
   s.add_dependency 'mobility', '~> 1.2.9'
   s.add_dependency 'mobility-ransack', '~> 1.2.1'
-  s.add_dependency 'friendly_id-mobility', '~> 1.0.3'
+  s.add_dependency 'friendly_id-mobility', '~> 1.0.4'
 end


### PR DESCRIPTION
This PR bumps version of `friendly_id-mobility` gem, to a version that includes a fix for generating slugs.
It also adds an explicit require of the gem upon application initialization, as it doesn't get loaded automatically.