### PR TITLE
Feature/add localized slugs to endpoint   Feature #11840

### DIFF
--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -24,8 +24,8 @@ module Spree
           product.available?
         end
 
-        attribute :translated_slugs do |product|
-          product.translated_slugs
+        attribute :localized_slugs do |product|
+          product.localized_slugs
         end
 
         attribute :currency do |_product, params|
@@ -47,9 +47,6 @@ module Spree
         attribute :display_compare_at_price do |product, params|
           display_compare_at_price(product, params[:currency])
         end
-
-
-
 
         has_many :variants
         has_many :option_types

--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -24,6 +24,10 @@ module Spree
           product.available?
         end
 
+        attribute :translated_slugs do |product|
+          product.translated_slugs
+        end
+
         attribute :currency do |_product, params|
           params[:currency]
         end
@@ -43,6 +47,9 @@ module Spree
         attribute :display_compare_at_price do |product, params|
           display_compare_at_price(product, params[:currency])
         end
+
+
+
 
         has_many :variants
         has_many :option_types

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -19,6 +19,10 @@ module Spree
           taxon.leaf?
         end
 
+        attribute :localized_slugs do |taxon|
+          taxon.localized_slugs
+        end
+
         belongs_to :parent,   record_type: :taxon, serializer: :taxon
         belongs_to :taxonomy, record_type: :taxonomy
 

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -19,9 +19,9 @@ module Spree
           taxon.leaf?
         end
 
-        # attribute :localized_slugs do |taxon|
-        #   taxon.localized_slugs
-        # end
+        attribute :localized_slugs do |taxon|
+          taxon.localized_slugs
+        end
 
         belongs_to :parent,   record_type: :taxon, serializer: :taxon
         belongs_to :taxonomy, record_type: :taxonomy

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -19,9 +19,9 @@ module Spree
           taxon.leaf?
         end
 
-        attribute :localized_slugs do |taxon|
-          taxon.localized_slugs
-        end
+        # attribute :localized_slugs do |taxon|
+        #   taxon.localized_slugs
+        # end
 
         belongs_to :parent,   record_type: :taxon, serializer: :taxon
         belongs_to :taxonomy, record_type: :taxonomy

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -994,6 +994,21 @@ describe 'API V2 Storefront Products Spec', type: :request do
       it_behaves_like 'returns 404 HTTP status'
     end
 
+    context 'with localized_slugs' do
+      # generate translations for test product
+      let!(:product_slug) { create(:product) }
+      let!(:translation1) { product_slug.translations.create(slug: "test_slug_pl", locale: "pl")  }
+      let!(:translation2) { product_slug.translations.create(slug: "test_slug_es", locale: "es")  }
+
+      before do
+        get "/api/v2/storefront/products/#{product_slug.id}"
+      end
+
+      it 'returns translated slugs' do
+        expect(json_response["data"]["attributes"]["localized_slugs"]).to match(product_slug.localized_slugs)
+      end
+    end
+
     context 'with product image data' do
       shared_examples 'returns product image data' do
         it 'returns product image data' do

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -995,17 +995,17 @@ describe 'API V2 Storefront Products Spec', type: :request do
     end
 
     context 'with localized_slugs' do
-      # generate translations for test product
       let!(:product_slug) { create(:product) }
-      let!(:translation1) { product_slug.translations.create(slug: "test_slug_pl", locale: "pl")  }
-      let!(:translation2) { product_slug.translations.create(slug: "test_slug_es", locale: "es")  }
+      let!(:translation1) { product_slug.translations.create(slug: 'test_slug_pl', locale: 'pl')  }
+      let!(:translation2) { product_slug.translations.create(slug: 'test_slug_es', locale: 'es')  }
 
       before do
         get "/api/v2/storefront/products/#{product_slug.id}"
       end
 
       it 'returns translated slugs' do
-        expect(json_response["data"]["attributes"]["localized_slugs"]).to match(product_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to match(product_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
       end
     end
 

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -995,16 +995,16 @@ describe 'API V2 Storefront Products Spec', type: :request do
     end
 
     context 'with localized_slugs' do
-      let!(:product_slug) { create(:product) }
-      let!(:translation1) { product_slug.translations.create(slug: 'test_slug_pl', locale: 'pl')  }
-      let!(:translation2) { product_slug.translations.create(slug: 'test_slug_es', locale: 'es')  }
+      let!(:product_with_slug) { create(:product) }
+      let!(:translation1) { product_with_slug.translations.create(slug: 'test_slug_pl', locale: 'pl')  }
+      let!(:translation2) { product_with_slug.translations.create(slug: 'test_slug_es', locale: 'es')  }
 
       before do
-        get "/api/v2/storefront/products/#{product_slug.id}"
+        get "/api/v2/storefront/products/#{product_with_slug.id}"
       end
 
       it 'returns translated slugs' do
-        expect(json_response['data']['attributes']['localized_slugs']).to match(product_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to match(product_with_slug.localized_slugs)
         expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
       end
     end

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -74,10 +74,6 @@ describe 'Taxons Spec', type: :request do
       it_behaves_like 'returns 200 HTTP status'
 
       it 'returns children taxons by parent' do
-        puts("/api/v2/storefront/taxons?filter[parent_permalink]=#{taxonomy.root.permalink}")
-        puts(taxonomy.root.permalink)
-        puts(taxonomy.root.permalink.class)
-        puts(json_response)
         expect(json_response['data'].size).to eq(2)
         expect(json_response['data'][0]).to have_relationship(:parent).with_data('id' => taxonomy.root.id.to_s, 'type' => 'taxon')
         expect(json_response['data'][1]).to have_relationship(:parent).with_data('id' => taxonomy.root.id.to_s, 'type' => 'taxon')
@@ -222,20 +218,20 @@ describe 'Taxons Spec', type: :request do
       end
     end
 
-    # context 'with localized_slugs' do
-    #   let!(:taxon_slug) { create(:taxon) }
-    #   let!(:translation1) { taxon_slug.translations.create(permalink: 'test_slug_pl', locale: 'pl')  }
-    #   let!(:translation2) { taxon_slug.translations.create(permalink: 'test_slug_es', locale: 'es')  }
+    context 'with localized_slugs' do
+      let!(:taxon_slug) { create(:taxon) }
+      let!(:translation1) { taxon_slug.translations.create(permalink: 'test_slug_pl', locale: 'pl')  }
+      let!(:translation2) { taxon_slug.translations.create(permalink: 'test_slug_es', locale: 'es')  }
 
-    #   before do
-    #     get "/api/v2/storefront/taxons/#{taxon_slug.id}"
-    #   end
-    #
-    #   it 'returns translated slugs' do
-    #     expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_slug.localized_slugs)
-    #     expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
-    #   end
-    # end
+      before do
+        get "/api/v2/storefront/taxons/#{taxon_slug.id}"
+      end
+
+      it 'returns translated slugs' do
+        expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
+      end
+    end
 
     context 'with taxon image data' do
       shared_examples 'returns taxon image data' do

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -219,16 +219,15 @@ describe 'Taxons Spec', type: :request do
     end
 
     context 'with localized_slugs' do
-      let!(:taxon_slug) { create(:taxon) }
-      let!(:translation1) { taxon_slug.translations.create(permalink: 'test_slug_pl', locale: 'pl')  }
-      let!(:translation2) { taxon_slug.translations.create(permalink: 'test_slug_es', locale: 'es')  }
+      let!(:taxon_with_slug) { create(:taxon) }
+      let!(:translations) { taxon_with_slug.translations.create([{ permalink: 'test_slug_pl', locale: 'pl' }, { permalink: 'test_slug_es', locale: 'es' } ])}
 
       before do
-        get "/api/v2/storefront/taxons/#{taxon_slug.id}"
+        get "/api/v2/storefront/taxons/#{taxon_with_slug.id}"
       end
 
       it 'returns translated slugs' do
-        expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_with_slug.localized_slugs)
         expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
       end
     end

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -219,17 +219,17 @@ describe 'Taxons Spec', type: :request do
     end
 
     context 'with localized_slugs' do
-      # generate translations for test taxon
       let!(:taxon_slug) { create(:taxon) }
-      let!(:translation1) { taxon_slug.translations.create(permalink: "test_slug_pl", locale: "pl")  }
-      let!(:translation2) { taxon_slug.translations.create(permalink: "test_slug_es", locale: "es")  }
+      let!(:translation1) { taxon_slug.translations.create(permalink: 'test_slug_pl', locale: 'pl')  }
+      let!(:translation2) { taxon_slug.translations.create(permalink: 'test_slug_es', locale: 'es')  }
 
       before do
         get "/api/v2/storefront/taxons/#{taxon_slug.id}"
       end
 
       it 'returns translated slugs' do
-        expect(json_response["data"]["attributes"]["localized_slugs"]).to match(taxon_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
       end
     end
 

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -218,6 +218,21 @@ describe 'Taxons Spec', type: :request do
       end
     end
 
+    context 'with localized_slugs' do
+      # generate translations for test taxon
+      let!(:taxon_slug) { create(:taxon) }
+      let!(:translation1) { taxon_slug.translations.create(permalink: "test_slug_pl", locale: "pl")  }
+      let!(:translation2) { taxon_slug.translations.create(permalink: "test_slug_es", locale: "es")  }
+
+      before do
+        get "/api/v2/storefront/taxons/#{taxon_slug.id}"
+      end
+
+      it 'returns translated slugs' do
+        expect(json_response["data"]["attributes"]["localized_slugs"]).to match(taxon_slug.localized_slugs)
+      end
+    end
+
     context 'with taxon image data' do
       shared_examples 'returns taxon image data' do
         it 'returns taxon image data' do

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -220,7 +220,7 @@ describe 'Taxons Spec', type: :request do
 
     context 'with localized_slugs' do
       let!(:taxon_with_slug) { create(:taxon) }
-      let!(:translations) { taxon_with_slug.translations.create([{ permalink: 'test_slug_pl', locale: 'pl' }, { permalink: 'test_slug_es', locale: 'es' } ])}
+      let!(:translations) { taxon_with_slug.translations.create([{ slug: 'test_slug_pl', locale: 'pl' }, { slug: 'test_slug_es', locale: 'es' } ])}
 
       before do
         get "/api/v2/storefront/taxons/#{taxon_with_slug.id}"

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -74,6 +74,10 @@ describe 'Taxons Spec', type: :request do
       it_behaves_like 'returns 200 HTTP status'
 
       it 'returns children taxons by parent' do
+        puts("/api/v2/storefront/taxons?filter[parent_permalink]=#{taxonomy.root.permalink}")
+        puts(taxonomy.root.permalink)
+        puts(taxonomy.root.permalink.class)
+        puts(json_response)
         expect(json_response['data'].size).to eq(2)
         expect(json_response['data'][0]).to have_relationship(:parent).with_data('id' => taxonomy.root.id.to_s, 'type' => 'taxon')
         expect(json_response['data'][1]).to have_relationship(:parent).with_data('id' => taxonomy.root.id.to_s, 'type' => 'taxon')
@@ -218,20 +222,20 @@ describe 'Taxons Spec', type: :request do
       end
     end
 
-    context 'with localized_slugs' do
-      let!(:taxon_slug) { create(:taxon) }
-      let!(:translation1) { taxon_slug.translations.create(permalink: 'test_slug_pl', locale: 'pl')  }
-      let!(:translation2) { taxon_slug.translations.create(permalink: 'test_slug_es', locale: 'es')  }
+    # context 'with localized_slugs' do
+    #   let!(:taxon_slug) { create(:taxon) }
+    #   let!(:translation1) { taxon_slug.translations.create(permalink: 'test_slug_pl', locale: 'pl')  }
+    #   let!(:translation2) { taxon_slug.translations.create(permalink: 'test_slug_es', locale: 'es')  }
 
-      before do
-        get "/api/v2/storefront/taxons/#{taxon_slug.id}"
-      end
-
-      it 'returns translated slugs' do
-        expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_slug.localized_slugs)
-        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
-      end
-    end
+    #   before do
+    #     get "/api/v2/storefront/taxons/#{taxon_slug.id}"
+    #   end
+    #
+    #   it 'returns translated slugs' do
+    #     expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_slug.localized_slugs)
+    #     expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
+    #   end
+    # end
 
     context 'with taxon image data' do
       shared_examples 'returns taxon image data' do

--- a/core/app/finders/spree/taxons/find.rb
+++ b/core/app/finders/spree/taxons/find.rb
@@ -66,9 +66,13 @@ module Spree
         return taxons unless parent_permalink?
 
         if Rails::VERSION::STRING >= '6.1'
-          taxons.joins(:parent).where(parent: { permalink: parent_permalink })
+          taxons.joins(:parent).
+            join_translation_table(Taxon, join_on_table_alias = 'parents_spree_taxons').
+            where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
         else
-          taxons.joins("INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id").where(["parent_taxon.permalink = ?", parent_permalink])
+          taxons.joins("INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id").
+            join_translation_table(Taxon, join_on_table_alias = 'parent_taxon').
+            where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
         end
       end
 

--- a/core/app/models/concerns/spree/translatable_resource_scopes.rb
+++ b/core/app/models/concerns/spree/translatable_resource_scopes.rb
@@ -5,10 +5,18 @@ module Spree
     class_methods do
       # To be used when joining on the resource itself does not automatically join on its translations table
       # This method is to be used when you've already joined on the translatable table itself
-      def join_translation_table(translatable_class)
+      #
+      # If the resource table is aliased, pass the alias to `join_on_table_alias`, otherwise omit the param
+      def join_translation_table(translatable_class, join_on_table_alias = nil)
+        join_on_table_name = if join_on_table_alias.nil?
+                               translatable_class.table_name
+                             else
+                               join_on_table_alias
+                             end
         translatable_class_foreign_key = "#{translatable_class.table_name.singularize}_id"
+
         joins("LEFT OUTER JOIN #{translatable_class::Translation.table_name} #{translatable_class.translation_table_alias}
-             ON #{translatable_class.translation_table_alias}.#{translatable_class_foreign_key} = #{translatable_class.table_name}.id
+             ON #{translatable_class.translation_table_alias}.#{translatable_class_foreign_key} = #{join_on_table_name}.id
              AND #{translatable_class.translation_table_alias}.locale = '#{Mobility.locale}'")
       end
     end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -387,6 +387,9 @@ module Spree
     def digital?
       shipping_category&.name == I18n.t('spree.seed.shipping.categories.digital')
     end
+    def translated_slugs
+      Hash[translations.pluck(:locale, :slug)]
+    end
 
     private
 
@@ -451,6 +454,7 @@ module Spree
     def update_slug_history
       save!
     end
+
 
     def anything_changed?
       saved_changes? || @nested_changes
@@ -574,5 +578,9 @@ module Spree
     def after_draft
       # this method is prepended in api/ to queue Webhooks requests
     end
+
+
+
+
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -387,7 +387,8 @@ module Spree
     def digital?
       shipping_category&.name == I18n.t('spree.seed.shipping.categories.digital')
     end
-    def translated_slugs
+
+    def localized_slugs
       Hash[translations.pluck(:locale, :slug)]
     end
 
@@ -454,7 +455,6 @@ module Spree
     def update_slug_history
       save!
     end
-
 
     def anything_changed?
       saved_changes? || @nested_changes
@@ -578,9 +578,5 @@ module Spree
     def after_draft
       # this method is prepended in api/ to queue Webhooks requests
     end
-
-
-
-
   end
 end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -111,9 +111,9 @@ module Spree
       move_to_child_with_index(parent, idx.to_i) unless new_record?
     end
 
-    def localized_slugs
-      Hash[translations.pluck(:locale, :permalink)]
-    end
+    # def localized_slugs
+    #   Hash[translations.pluck(:locale, :permalink)]
+    # end
 
     private
 

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -55,8 +55,12 @@ module Spree
 
     scope :for_stores, ->(stores) { joins(:taxonomy).where(spree_taxonomies: { store_id: stores.ids }) }
 
-    TRANSLATABLE_FIELDS = %i[name description].freeze
+    TRANSLATABLE_FIELDS = %i[name description permalink].freeze
     translates(*TRANSLATABLE_FIELDS)
+
+    self::Translation.class_eval do
+      alias_attribute :slug, :permalink
+    end
 
     # indicate which filters should be used for a taxon
     # this method should be customized to your own site
@@ -112,7 +116,7 @@ module Spree
     end
 
     def localized_slugs
-      Hash[translations.pluck(:locale, :permalink)]
+      Hash[translations.pluck(:locale, :slug)]
     end
 
     private

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -55,7 +55,7 @@ module Spree
 
     scope :for_stores, ->(stores) { joins(:taxonomy).where(spree_taxonomies: { store_id: stores.ids }) }
 
-    TRANSLATABLE_FIELDS = %i[name description].freeze
+    TRANSLATABLE_FIELDS = %i[name description permalink].freeze
     translates(*TRANSLATABLE_FIELDS)
 
     # indicate which filters should be used for a taxon
@@ -109,6 +109,10 @@ module Spree
     #  See #3390 for background.
     def child_index=(idx)
       move_to_child_with_index(parent, idx.to_i) unless new_record?
+    end
+
+    def localized_slugs
+      Hash[translations.pluck(:locale, :permalink)]
     end
 
     private

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -55,7 +55,7 @@ module Spree
 
     scope :for_stores, ->(stores) { joins(:taxonomy).where(spree_taxonomies: { store_id: stores.ids }) }
 
-    TRANSLATABLE_FIELDS = %i[name description permalink].freeze
+    TRANSLATABLE_FIELDS = %i[name description].freeze
     translates(*TRANSLATABLE_FIELDS)
 
     # indicate which filters should be used for a taxon
@@ -111,9 +111,9 @@ module Spree
       move_to_child_with_index(parent, idx.to_i) unless new_record?
     end
 
-    # def localized_slugs
-    #   Hash[translations.pluck(:locale, :permalink)]
-    # end
+    def localized_slugs
+      Hash[translations.pluck(:locale, :permalink)]
+    end
 
     private
 


### PR DESCRIPTION
Localized slugs field added in product and taxon endpoints. Simple tests prepared, checking response correctness. Solution required adding permalink to TRANSLATABLE_FIELDS in taxon model. 
Issue link: https://github.com/spree/spree/issues/11840