### PR TITLE
Add localized slugs to products and taxons API endpoints

### DIFF
--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -24,6 +24,10 @@ module Spree
           product.available?
         end
 
+        attribute :localized_slugs do |product|
+          product.localized_slugs
+        end
+
         attribute :currency do |_product, params|
           params[:currency]
         end

--- a/api/app/serializers/spree/v2/storefront/product_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/product_serializer.rb
@@ -24,10 +24,6 @@ module Spree
           product.available?
         end
 
-        attribute :localized_slugs do |product|
-          product.localized_slugs
-        end
-
         attribute :currency do |_product, params|
           params[:currency]
         end
@@ -46,6 +42,10 @@ module Spree
 
         attribute :display_compare_at_price do |product, params|
           display_compare_at_price(product, params[:currency])
+        end
+
+        attribute :localized_slugs do |product, params|
+          product.localized_slugs_for_store(params[:store])
         end
 
         has_many :variants

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -19,8 +19,8 @@ module Spree
           taxon.leaf?
         end
 
-        attribute :localized_slugs do |taxon|
-          taxon.localized_slugs
+        attribute :localized_slugs do |taxon, params|
+          taxon.localized_slugs_for_store(params[:store])
         end
 
         belongs_to :parent,   record_type: :taxon, serializer: :taxon

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -19,6 +19,10 @@ module Spree
           taxon.leaf?
         end
 
+        attribute :localized_slugs do |taxon|
+          taxon.localized_slugs
+        end
+
         belongs_to :parent,   record_type: :taxon, serializer: :taxon
         belongs_to :taxonomy, record_type: :taxonomy
 

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -995,17 +995,26 @@ describe 'API V2 Storefront Products Spec', type: :request do
     end
 
     context 'with localized_slugs' do
-      let!(:product_with_slug) { create(:product) }
+      let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
+      let(:product_with_slug) { create(:product, stores: [store2], slug: 'test_slug_en') }
       let!(:translation1) { product_with_slug.translations.create(slug: 'test_slug_pl', locale: 'pl')  }
       let!(:translation2) { product_with_slug.translations.create(slug: 'test_slug_es', locale: 'es')  }
 
+      let(:expected_result) do
+        {
+          en: 'test_slug_en',
+          pl: 'test_slug_pl',
+          es: 'test_slug_es'
+        }
+      end
+
       before do
+        allow_any_instance_of(Spree::Api::V2::Storefront::ProductsController).to receive(:current_store).and_return(store2)
         get "/api/v2/storefront/products/#{product_with_slug.id}"
       end
 
       it 'returns translated slugs' do
-        expect(json_response['data']['attributes']['localized_slugs']).to match(product_with_slug.localized_slugs)
-        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
+        expect(json_response['data']['attributes']['localized_slugs']).to match(expected_result)
       end
     end
 

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -994,6 +994,21 @@ describe 'API V2 Storefront Products Spec', type: :request do
       it_behaves_like 'returns 404 HTTP status'
     end
 
+    context 'with localized_slugs' do
+      let!(:product_with_slug) { create(:product) }
+      let!(:translation1) { product_with_slug.translations.create(slug: 'test_slug_pl', locale: 'pl')  }
+      let!(:translation2) { product_with_slug.translations.create(slug: 'test_slug_es', locale: 'es')  }
+
+      before do
+        get "/api/v2/storefront/products/#{product_with_slug.id}"
+      end
+
+      it 'returns translated slugs' do
+        expect(json_response['data']['attributes']['localized_slugs']).to match(product_with_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
+      end
+    end
+
     context 'with product image data' do
       shared_examples 'returns product image data' do
         it 'returns product image data' do

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -218,6 +218,20 @@ describe 'Taxons Spec', type: :request do
       end
     end
 
+    context 'with localized_slugs' do
+      let!(:taxon_with_slug) { create(:taxon) }
+      let!(:translations) { taxon_with_slug.translations.create([{ slug: 'test_slug_pl', locale: 'pl' }, { slug: 'test_slug_es', locale: 'es' } ])}
+
+      before do
+        get "/api/v2/storefront/taxons/#{taxon_with_slug.id}"
+      end
+
+      it 'returns translated slugs' do
+        expect(json_response['data']['attributes']['localized_slugs']).to match(taxon_with_slug.localized_slugs)
+        expect(json_response['data']['attributes']['localized_slugs']).to be_an_instance_of(ActiveSupport::HashWithIndifferentAccess)
+      end
+    end
+
     context 'with taxon image data' do
       shared_examples 'returns taxon image data' do
         it 'returns taxon image data' do

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -227,8 +227,8 @@ describe 'Taxons Spec', type: :request do
       let(:expected_slugs) do
         {
           en: 'categories/test_slug_en',
-          pl: 'test_slug_pl',
-          es: 'test_slug_es'
+          pl: 'categories/test_slug_pl',
+          es: 'categories/test_slug_es'
         }
       end
 

--- a/core/app/finders/spree/taxons/find.rb
+++ b/core/app/finders/spree/taxons/find.rb
@@ -66,9 +66,13 @@ module Spree
         return taxons unless parent_permalink?
 
         if Rails::VERSION::STRING >= '6.1'
-          taxons.joins(:parent).where(parent: { permalink: parent_permalink })
+          taxons.joins(:parent).
+            join_translation_table(Taxon, join_on_table_alias = 'parents_spree_taxons').
+            where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
         else
-          taxons.joins("INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id").where(["parent_taxon.permalink = ?", parent_permalink])
+          taxons.joins("INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id").
+            join_translation_table(Taxon, join_on_table_alias = 'parent_taxon').
+            where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
         end
       end
 

--- a/core/app/finders/spree/taxons/find.rb
+++ b/core/app/finders/spree/taxons/find.rb
@@ -67,11 +67,11 @@ module Spree
 
         if Rails::VERSION::STRING >= '6.1'
           taxons.joins(:parent).
-            join_translation_table(Taxon, join_on_table_alias = 'parents_spree_taxons').
+            join_translation_table(Taxon, 'parents_spree_taxons').
             where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
         else
           taxons.joins("INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id").
-            join_translation_table(Taxon, join_on_table_alias = 'parent_taxon').
+            join_translation_table(Taxon, 'parent_taxon').
             where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
         end
       end

--- a/core/app/models/concerns/spree/translatable_resource_scopes.rb
+++ b/core/app/models/concerns/spree/translatable_resource_scopes.rb
@@ -5,10 +5,18 @@ module Spree
     class_methods do
       # To be used when joining on the resource itself does not automatically join on its translations table
       # This method is to be used when you've already joined on the translatable table itself
-      def join_translation_table(translatable_class)
+      #
+      # If the resource table is aliased, pass the alias to `join_on_table_alias`, otherwise omit the param
+      def join_translation_table(translatable_class, join_on_table_alias = nil)
+        join_on_table_name = if join_on_table_alias.nil?
+                               translatable_class.table_name
+                             else
+                               join_on_table_alias
+                             end
         translatable_class_foreign_key = "#{translatable_class.table_name.singularize}_id"
+
         joins("LEFT OUTER JOIN #{translatable_class::Translation.table_name} #{translatable_class.translation_table_alias}
-             ON #{translatable_class.translation_table_alias}.#{translatable_class_foreign_key} = #{translatable_class.table_name}.id
+             ON #{translatable_class.translation_table_alias}.#{translatable_class_foreign_key} = #{join_on_table_name}.id
              AND #{translatable_class.translation_table_alias}.locale = '#{Mobility.locale}'")
       end
     end

--- a/core/app/models/concerns/spree/translatable_resource_slug.rb
+++ b/core/app/models/concerns/spree/translatable_resource_slug.rb
@@ -1,0 +1,17 @@
+module Spree
+  module TranslatableResourceSlug
+    extend ActiveSupport::Concern
+
+    included do
+      def localized_slugs_for_store(store)
+        localized_slugs = Hash[translations.pluck(:locale, :slug)]
+        default_locale = store.default_locale
+        supported_locales = store.supported_locales_list
+
+        supported_locales.each_with_object({}) do |locale, hash|
+          hash[locale] = localized_slugs[locale] || localized_slugs[default_locale]
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -24,6 +24,7 @@ module Spree
     include ProductScopes
     include MultiStoreResource
     include TranslatableResource
+    include TranslatableResourceSlug
     include MemoizedData
     include Metadata
     if defined?(Spree::Webhooks)
@@ -386,10 +387,6 @@ module Spree
 
     def digital?
       shipping_category&.name == I18n.t('spree.seed.shipping.categories.digital')
-    end
-
-    def localized_slugs
-      Hash[translations.pluck(:locale, :slug)]
     end
 
     private

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -388,6 +388,10 @@ module Spree
       shipping_category&.name == I18n.t('spree.seed.shipping.categories.digital')
     end
 
+    def localized_slugs
+      Hash[translations.pluck(:locale, :slug)]
+    end
+
     private
 
     def add_associations_from_prototype

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -4,6 +4,7 @@ require 'stringex'
 module Spree
   class Taxon < Spree::Base
     include TranslatableResource
+    include TranslatableResourceSlug
     include Metadata
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks
@@ -113,10 +114,6 @@ module Spree
     #  See #3390 for background.
     def child_index=(idx)
       move_to_child_with_index(parent, idx.to_i) unless new_record?
-    end
-
-    def localized_slugs
-      Hash[translations.pluck(:locale, :slug)]
     end
 
     private

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -55,8 +55,12 @@ module Spree
 
     scope :for_stores, ->(stores) { joins(:taxonomy).where(spree_taxonomies: { store_id: stores.ids }) }
 
-    TRANSLATABLE_FIELDS = %i[name description].freeze
+    TRANSLATABLE_FIELDS = %i[name description permalink].freeze
     translates(*TRANSLATABLE_FIELDS)
+
+    self::Translation.class_eval do
+      alias_attribute :slug, :permalink
+    end
 
     # indicate which filters should be used for a taxon
     # this method should be customized to your own site
@@ -109,6 +113,10 @@ module Spree
     #  See #3390 for background.
     def child_index=(idx)
       move_to_child_with_index(parent, idx.to_i) unless new_record?
+    end
+
+    def localized_slugs
+      Hash[translations.pluck(:locale, :slug)]
     end
 
     private

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -61,6 +61,17 @@ module Spree
 
     self::Translation.class_eval do
       alias_attribute :slug, :permalink
+
+      before_create :set_permalink
+
+      def set_permalink
+        parent = translated_model.parent
+        if parent.present?
+          self.permalink = [parent.permalink, (permalink.blank? ? name.to_url : permalink.split('/').last)].join('/')
+        else
+          self.permalink = name.to_url if permalink.blank?
+        end
+      end
     end
 
     # indicate which filters should be used for a taxon
@@ -82,11 +93,7 @@ module Spree
 
     # Creates permalink base for friendly_id
     def set_permalink
-      if parent.present?
-        self.permalink = [parent.permalink, (permalink.blank? ? name.to_url : permalink.split('/').last)].join('/')
-      else
-        self.permalink = name.to_url if permalink.blank?
-      end
+      translations.each(&:set_permalink)
     end
 
     def active_products

--- a/core/brakeman.ignore
+++ b/core/brakeman.ignore
@@ -49,6 +49,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "1c12fcb833b0ddffa07880acb7e604922c0d1d52de598316186241baf16551cd",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/finders/spree/taxons/find.rb",
+      "line": 75,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "taxons.joins(\"INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id\").join_translation_table(Taxon, \"parent_taxon\").where([\"#{Taxon.translation_table_alias}.permalink = ?\", parent_permalink])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Spree::Taxons::Find",
+        "method": "by_parent_permalink"
+      },
+      "user_input": "Taxon.translation_table_alias",
+      "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "1f02952550c2f54d044c9577a45e7ba7c7990c8b8a59d1dac83a96790237f507",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -141,6 +164,29 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "98607ecfb86c2d3c2567390f813861edbc42d6ffa9f482afb7c0b3464eaf6e73",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/concerns/spree/translatable_resource_scopes.rb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "joins(\"LEFT OUTER JOIN #{translatable_class::Translation.table_name} #{translatable_class.translation_table_alias}\\n             ON #{translatable_class.translation_table_alias}.#{\"#{translatable_class.table_name.singularize}_id\"} = #{(translatable_class.table_name or join_on_table_alias)}.id\\n             AND #{translatable_class.translation_table_alias}.locale = '#{Mobility.locale}'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Spree::TranslatableResourceScopes",
+        "method": "join_translation_table"
+      },
+      "user_input": "translatable_class.translation_table_alias",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "abd8e90e7a7dfbcdcd6d44fd3fb550598aee6d7a9ef2bb132ad1a18a3c50be30",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -191,7 +237,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/spree/variant.rb",
-      "line": 127,
+      "line": 126,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "joins(:product).join_translation_table(Product).where(\"LOWER(#{Product.translation_table_alias}.name) LIKE LOWER(:query)\\n               OR LOWER(sku) LIKE LOWER(:query)\", :query => (\"%#{query}%\"))",
       "render_path": null,
@@ -210,21 +256,21 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "e7aa61c87f26af5f63f00e9791954d787a559dab1eadf8926861796237bd431d",
+      "fingerprint": "ed253ae6b1b4ea3fe3d87d3652380fecab80133319b1ed041d98d163fd16b815",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/models/concerns/spree/translatable_resource_scopes.rb",
-      "line": 10,
+      "file": "app/finders/spree/taxons/find.rb",
+      "line": 71,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "joins(\"LEFT OUTER JOIN #{translatable_class::Translation.table_name} #{translatable_class.translation_table_alias}\\n             ON #{translatable_class.translation_table_alias}.#{\"#{translatable_class.table_name.singularize}_id\"} = #{translatable_class.table_name}.id\\n             AND #{translatable_class.translation_table_alias}.locale = '#{Mobility.locale}'\")",
+      "code": "taxons.joins(:parent).join_translation_table(Taxon, \"parents_spree_taxons\").where([\"#{Taxon.translation_table_alias}.permalink = ?\", parent_permalink])",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "Spree::TranslatableResourceScopes",
-        "method": "join_translation_table"
+        "class": "Spree::Taxons::Find",
+        "method": "by_parent_permalink"
       },
-      "user_input": "translatable_class.translation_table_alias",
-      "confidence": "Medium",
+      "user_input": "Taxon.translation_table_alias",
+      "confidence": "Weak",
       "cwe_id": [
         89
       ],
@@ -277,6 +323,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-02-24 11:32:53 +0100",
+  "updated": "2023-03-22 20:11:32 +0100",
   "brakeman_version": "5.4.1"
 }

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -918,4 +918,43 @@ describe Spree::Product, type: :model do
       end
     end
   end
+
+  describe '#localized_slugs_for_store' do
+    let(:store) { create(:store, default_locale: 'fr', supported_locales: 'en,pl,fr') }
+    let(:product) { create(:product, stores: [store], slug: 'test_slug_en') }
+    let!(:product_translation_fr) { product.translations.create(slug: 'test_slug_fr', locale: 'fr') }
+
+    subject { product.localized_slugs_for_store(store) }
+
+    context 'when there are slugs in locales not supported by the store' do
+      let!(:product_translation_pl) { product.translations.create(slug: 'test_slug_pl', locale: 'pl') }
+      let!(:product_translation_de) { product.translations.create(slug: 'test_slug_de', locale: 'de') }
+
+      let(:expected_slugs) do
+        {
+          'en' => 'test_slug_en',
+          'fr' => 'test_slug_fr',
+          'pl' => 'test_slug_pl'
+        }
+      end
+
+      it 'returns only slugs in locales supported by the store' do
+        expect(subject).to match(expected_slugs)
+      end
+    end
+
+    context 'when one of the supported locales does not have a translation' do
+      let(:expected_slugs) do
+        {
+          'en' => 'test_slug_en',
+          'fr' => 'test_slug_fr',
+          'pl' => 'test_slug_fr'
+        }
+      end
+
+      it "falls back to store's default locale" do
+        expect(subject).to match(expected_slugs)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -198,8 +198,8 @@ describe Spree::Taxon, type: :model do
       let(:expected_slugs) do
         {
           'en' => 'categories/test_slug_en',
-          'fr' => 'test_slug_fr',
-          'pl' => 'test_slug_pl'
+          'fr' => 'categories/test_slug_fr',
+          'pl' => 'categories/test_slug_pl'
         }
       end
 
@@ -212,8 +212,8 @@ describe Spree::Taxon, type: :model do
       let(:expected_slugs) do
         {
           'en' => 'categories/test_slug_en',
-          'fr' => 'test_slug_fr',
-          'pl' => 'test_slug_fr'
+          'fr' => 'categories/test_slug_fr',
+          'pl' => 'categories/test_slug_fr'
         }
       end
 


### PR DESCRIPTION
This PR adds a localized_slugs field to `/api/v2/storefront/products` and `/api/v2/storefront/taxons` endpoints, so that a storefront is able to redirect to the correct slug when changing locale. It also adds `permalink` to the translatable fields on a taxon, as it wasn't translatable before.