### PR TITLE
Optimize performance of loading translations

### DIFF
--- a/api/app/controllers/concerns/spree/api/v2/product_list_includes.rb
+++ b/api/app/controllers/concerns/spree/api/v2/product_list_includes.rb
@@ -8,7 +8,8 @@ module Spree
             option_types: [],
             variant_images: [],
             master: product_variant_includes,
-            variants: product_variant_includes
+            variants: product_variant_includes,
+            translations: []
           }
         end
 

--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -30,13 +30,14 @@ module Spree
           end
 
           def scope_includes
-            node_includes = %i[icon parent taxonomy]
+            node_includes = %i[icon parent taxonomy translations]
 
             {
               parent: node_includes,
               children: node_includes,
               taxonomy: [root: node_includes],
-              icon: [attachment_attachment: :blob]
+              icon: [attachment_attachment: :blob],
+              translations: []
             }
           end
 

--- a/core/app/finders/spree/option_values/find_available.rb
+++ b/core/app/finders/spree/option_values/find_available.rb
@@ -9,7 +9,7 @@ module Spree
       end
 
       def execute
-        find_available(scope, products_scope).select(select_args).order(order_args)
+        find_available(scope, products_scope).includes(:translations).select(select_args).order(order_args)
       end
 
       private

--- a/core/app/finders/spree/product_properties/find_available.rb
+++ b/core/app/finders/spree/product_properties/find_available.rb
@@ -9,7 +9,7 @@ module Spree
       end
 
       def execute
-        find_available(scope, products_scope)
+        find_available(scope, products_scope).includes(:translations)
       end
 
       private


### PR DESCRIPTION
Similar to https://github.com/spree/spree_backend/pull/237 , but related to spree_api.

This PR resolves n + 1 queries issue in the following endpoints
- /api/v2/storefront/products - before that, it triggered an additional query for every product in the list, to pull localized name, description etc. We also display `localized_slugs` field, which requires translations in all locales.
- /api/v2/storefront/taxons - similar to the one above
- /api/v2/storefront/products - the list of available filters for the given query triggered n + 1 queries when pulling product properties and option types/values. This is now fixed.
