### PR TITLE
Data Feed handling improvements

### DIFF
--- a/api/app/controllers/spree/api/v2/data_feeds/google_controller.rb
+++ b/api/app/controllers/spree/api/v2/data_feeds/google_controller.rb
@@ -10,7 +10,7 @@ module Spree
           private
 
           def settings
-            @settings ||= Spree::DataFeed.find_by!(store: current_store, slug: params[:slug], provider: 'google', active: true)
+            @settings ||= Spree::DataFeed::Google.find_by!(store: current_store, slug: params[:slug], active: true)
           end
 
           def data_feeds_google_rss_service

--- a/api/spec/requests/spree/api/v2/platform/data_feeds/google_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/data_feeds/google_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'Data Feeds API Google Feed', type: :request do
+  subject { get '/api/v2/data_feeds/google/test-feed.rss' }
+
+  context 'when a feed with given permalink does not exist' do
+    before { subject }
+
+    it_behaves_like 'returns 404 HTTP status'
+  end
+
+  context 'when there is a feed with a given slug' do
+    before do
+     create(:google_data_feed, store: Spree::Store.default, slug: 'test-feed', active: active)
+     subject
+   end
+
+    context 'when the feed is active' do
+      let(:active) { true }
+
+      it_behaves_like 'returns 200 HTTP status'
+    end
+
+    context 'when the feed is not active' do
+      let(:active) { false }
+
+      it_behaves_like 'returns 404 HTTP status'
+    end
+  end
+end

--- a/core/app/models/spree/data_feed.rb
+++ b/core/app/models/spree/data_feed.rb
@@ -9,12 +9,11 @@ module Spree
     with_options presence: true do
       validates :store
       validates :name, uniqueness: true
-      validates :provider
       validates :slug, uniqueness: { scope: :store_id }
     end
 
     def formatted_url
-      "#{store.formatted_url}/api/v2/data_feeds/#{provider}/#{slug}.rss"
+      "#{store.formatted_url}/api/v2/data_feeds/#{self.class.provider_name}/#{slug}.rss"
     end
 
     private
@@ -22,6 +21,20 @@ module Spree
     def generate_slug
       new_slug = slug.blank? ? SecureRandom.uuid : slug.parameterize
       write_attribute(:slug, new_slug)
+    end
+
+    class << self
+      def label
+        raise NotImplementedError
+      end
+
+      def provider_name
+        raise NotImplementedError
+      end
+
+      def available_types
+        Rails.application.config.spree.data_feed_types
+      end
     end
   end
 end

--- a/core/app/models/spree/data_feed/google.rb
+++ b/core/app/models/spree/data_feed/google.rb
@@ -1,0 +1,15 @@
+require_dependency 'spree/data_feed'
+
+module Spree
+  class DataFeed::Google < DataFeed
+    class << self
+      def label
+        'Google Merchant Center Feed'
+      end
+
+      def provider_name
+        'google'
+      end
+    end
+  end
+end

--- a/core/db/migrate/20230512094803_rename_data_feeds_column_provider_to_type.rb
+++ b/core/db/migrate/20230512094803_rename_data_feeds_column_provider_to_type.rb
@@ -1,0 +1,5 @@
+class RenameDataFeedsColumnProviderToType < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :spree_data_feeds, :provider, :type
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -11,7 +11,8 @@ module Spree
                                :adjusters,
                                :stock_splitters,
                                :promotions,
-                               :line_item_comparison_hooks)
+                               :line_item_comparison_hooks,
+                               :data_feed_types)
       SpreeCalculators = Struct.new(:shipping_methods, :tax_rates, :promotion_actions_create_adjustments, :promotion_actions_create_item_adjustments)
       PromoEnvironment = Struct.new(:rules, :actions)
       isolate_namespace Spree
@@ -121,6 +122,10 @@ module Spree
           Promotion::Actions::CreateItemAdjustments,
           Promotion::Actions::CreateLineItems,
           Promotion::Actions::FreeShipping
+        ]
+
+        Rails.application.config.spree.data_feed_types = [
+          Spree::DataFeed::Google
         ]
       end
 

--- a/core/lib/spree/testing_support/factories/google_data_feed_factory.rb
+++ b/core/lib/spree/testing_support/factories/google_data_feed_factory.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
-  factory :data_feed, class: Spree::DataFeed do
+  factory :google_data_feed, class: Spree::DataFeed::Google do
     id             { 1 }
     active         { true }
     store          { create(:store) }
-    provider       { 'google' }
     name           { 'test' }
   end
 end

--- a/core/spec/models/spree/data_feed/google_spec.rb
+++ b/core/spec/models/spree/data_feed/google_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Spree::DataFeed::Google, type: :model do
+  let(:store) { create(:store, url: 'http://store.test') }
+
+  describe '#create' do
+    context 'when slug is not provided' do
+      let(:data_feed) { create(:google_data_feed, store: store, slug: nil) }
+
+      it 'generates slug automatically' do
+        expect(data_feed.slug).not_to be_empty
+      end
+    end
+
+    context 'when slug is provided' do
+      let(:data_feed) { create(:google_data_feed, store: store, slug: 'test-slug') }
+
+      it 'uses the slug provided' do
+        expect(data_feed.slug).to eq('test-slug')
+      end
+    end
+  end
+
+  describe '#formatted_url' do
+    let(:data_feed) { create(:google_data_feed, store: store, slug: 'test-feed') }
+    let(:expected_url) { 'http://store.test/api/v2/data_feeds/google/test-feed.rss' }
+
+    it 'returns full url to the data feed' do
+      expect(data_feed.formatted_url).to eq(expected_url)
+    end
+  end
+
+  describe '.label' do
+    subject { Spree::DataFeed::Google.label }
+
+    it 'returns a descriptive label' do
+      expect(subject).to eq('Google Merchant Center Feed')
+    end
+  end
+end

--- a/core/spec/services/spree/data_feeds/google/rss_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/rss_spec.rb
@@ -5,10 +5,10 @@ module Spree
     subject { described_class.new }
 
     let(:store) { create(:store) }
-    let(:setting) { create(:data_feed, store: store) }
+    let(:data_feed) { create(:google_data_feed, store: store) }
     let(:product) { create(:product, stores: [store]) }
     let!(:variant) { create(:with_image_variant, product: product) }
-    let(:result) { subject.call(setting) }
+    let(:result) { subject.call(data_feed) }
 
     context 'store header is generated correctly' do
       before do

--- a/sample/db/samples/data_feeds.rb
+++ b/sample/db/samples/data_feeds.rb
@@ -1,7 +1,6 @@
 # settings for default store
-Spree::DataFeed.create!(
+Spree::DataFeed::Google.create!(
   store: Spree::Store.default,
-  name: 'Default Google Data Feed',
-  provider: 'google'
+  name: 'Default Google Data Feed'
 )
 


### PR DESCRIPTION
This PR changes handling multiple Data Feed providers to a way that's similar to how we do that with Calculators (using STI to represent multiple types). It also introduces a new configuration variable that allows to enable custom data feeds (to display them in e.g. the admin panel).

 