### PR TITLE
Add default locale fallbacks for permalinks

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/products_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/products_controller.rb
@@ -16,7 +16,7 @@ module Spree
           end
 
           def resource
-            @resource ||= scope.find_by(slug: params[:id]) || scope.find(params[:id])
+            @resource ||= find_with_fallback_default_locale { scope.find_by(slug: params[:id]) } || scope.find(params[:id])
           end
 
           def collection_sorter

--- a/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/taxons_controller.rb
@@ -22,7 +22,7 @@ module Spree
           end
 
           def resource
-            @resource ||= scope.find_by(permalink: params[:id]) || scope.find(params[:id])
+            @resource ||= find_with_fallback_default_locale { scope.find_by(permalink: params[:id]) } || scope.find(params[:id])
           end
 
           def model_class

--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -1018,6 +1018,38 @@ describe 'API V2 Storefront Products Spec', type: :request do
       end
     end
 
+    context 'with slug fallback to default locale' do
+      let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
+      let!(:product_with_slug) { create(:product, stores: [store2], slug: default_locale_slug) }
+      let(:default_locale_slug) { 'test_slug_en' }
+
+      before do
+        allow_any_instance_of(Spree::Api::V2::Storefront::ProductsController).to receive(:current_store).and_return(store2)
+        get "/api/v2/storefront/products/#{default_locale_slug}?locale=pl"
+      end
+
+      it 'finds the product' do
+        expect(json_response['data']['id']).to eq(product_with_slug.id.to_s)
+      end
+    end
+
+    context 'with slug in translated locale' do
+      let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
+      let(:product_with_slug) { create(:product, stores: [store2], slug: default_locale_slug) }
+      let!(:translation2) { product_with_slug.translations.create(slug: translated_slug, locale: 'es')  }
+      let(:default_locale_slug) { 'test_slug_en' }
+      let(:translated_slug) { 'test_slug_es' }
+
+      before do
+        allow_any_instance_of(Spree::Api::V2::Storefront::ProductsController).to receive(:current_store).and_return(store2)
+        get "/api/v2/storefront/products/#{translated_slug}?locale=es"
+      end
+
+      it 'finds the product' do
+        expect(json_response['data']['id']).to eq(product_with_slug.id.to_s)
+      end
+    end
+
     context 'with product image data' do
       shared_examples 'returns product image data' do
         it 'returns product image data' do

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -82,6 +82,10 @@ RSpec.configure do |config|
 
     country = create(:country, name: 'United States of America', iso_name: 'UNITED STATES', iso: 'US', iso3: 'USA', states_required: true)
     create(:store, default: true, default_country: country, default_currency: 'USD')
+
+    # Request specs to paths with ?locale=xx don't reset the locale afterwards
+    # Some tests assume that the current locale is :en, so we ensure it here
+    I18n.locale = :en
   end
 
   config.order = :random

--- a/core/lib/spree/core/controller_helpers/locale.rb
+++ b/core/lib/spree/core/controller_helpers/locale.rb
@@ -68,6 +68,16 @@ module Spree
 
           I18n.locale.to_s
         end
+
+        def find_with_fallback_default_locale(&block)
+          result = begin
+            block.call
+          rescue ActiveRecord::RecordNotFound => _e
+            nil
+          end
+
+          result || Mobility.with_locale(current_store.default_locale) { block.call }
+        end
       end
     end
   end


### PR DESCRIPTION
Mobility doesn't support fallbacks when querying with .friendly or .where, so by default if a translation is not available, a product or taxon won't be accessible. 
I've added a method supporting fallbacks to Spree::Store's default locale.