### PR TITLE
Fix fetching meta attributes

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -113,8 +113,8 @@ module Spree
       meta = {}
 
       if object.is_a? ApplicationRecord
-        meta[:keywords] = object.meta_keywords if object[:meta_keywords].present?
-        meta[:description] = object.meta_description if object[:meta_description].present?
+        meta[:keywords] = object.meta_keywords if object.try(:meta_keywords).present?
+        meta[:description] = object.meta_description if object.try(:meta_description).present?
       end
 
       if meta[:description].blank? && object.is_a?(Spree::Product)


### PR DESCRIPTION
Mobility gem changes the way how translatable attributes are managed. Because of that `object[:meta_keywords]` no longer returns the value, even if it's present in the translations.

I updated this method to use the regular `.meta_keywords` and `.meta_description` methods, so that it works with Mobility.