### PR TITLE
Update weight.rb sorting

### DIFF
--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -15,7 +15,7 @@ module Spree
         private
 
         def reduce(package)
-          contents = split_package_contents_over_threshold(package).sort { |x, y| y.weight <=> x.weight }
+          contents = split_package_contents_over_threshold(package).sort_by(&:weight).reverse
           # Treat current package as one of the generated packages for convenience and add the heaviest item
           # This also prevents an additional package if no fit is possible
           package.contents.clear


### PR DESCRIPTION
sort_by is usually faster than sort. Adding reverse to get array in the desired order does not affect performance that much. 
Also leaving some benchmarks
```
require "benchmark/ips"

User  = Struct.new(:name)
ARRAY = Array.new(100) do
  User.new(sprintf "%010d", rand(1_000_000_000))
end

def fastest
  ARRAY.sort_by(&:name).reverse
end

def faster
  ARRAY.sort_by { |element| element.name }.reverse
end

def slow
  ARRAY.sort { |a, b| a.name <=> b.name }
end

Benchmark.ips do |x|
  x.report('Enumerable#sort_by (Symbol#to_proc)') { fastest }
  x.report('Enumerable#sort_by') { faster }
  x.report('Enumerable#sort')    { slow }

  x.compare!
end


Enumerable#sort_by (Symbol#to_proc)
                         47.822k (± 4.5%) i/s -    242.332k in   5.077308s
  Enumerable#sort_by     45.399k (± 5.1%) i/s -    229.914k in   5.076929s
     Enumerable#sort     17.395k (± 7.5%) i/s -     86.904k in   5.023085s

Comparison:
Enumerable#sort_by (Symbol#to_proc):    47822.0 i/s
  Enumerable#sort_by:    45399.3 i/s - same-ish: difference falls within error
     Enumerable#sort:    17395.0 i/s - 2.75x  slower
```
