### PR TITLE
Uncomment tests in service_module_spec.rb

### DIFF
--- a/core/spec/lib/spree/service_module_spec.rb
+++ b/core/spec/lib/spree/service_module_spec.rb
@@ -174,27 +174,19 @@ describe Spree::ServiceModule do
     end
 
     it 'calls second method' do
-      skip_if_ruby_3
       expect(service).to receive(:second_method).and_call_original
       service.call(params: {})
     end
 
     it 'passes input from call to first run method' do
-      skip_if_ruby_3
       param = 'param'
       expect(service).to receive(:first_method).with(params: param).and_call_original
       service.call(params: param)
     end
 
     it 'passes empty hash if input was not provided' do
-      skip_if_ruby_3
       expect(service).to receive(:first_method).with(params: {}).and_call_original
       service.call(params: {})
-    end
-
-    # FIXME: https://github.com/rspec/rspec-mocks/issues/1306
-    def skip_if_ruby_3
-      skip 'https://github.com/rspec/rspec-mocks/issues/1306' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
     end
   end
 


### PR DESCRIPTION
Unskip tests that would not run with Ruby 3. The tests were commented due to an rspec-mocks issues wasn't fixed. Issue has been fixed and tests ran locally under Ruby 3.1.0