### PR TITLE
fix(Spree::Order::AddressBook): fixed same id for ship_address and bill_address

### DIFF
--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -5,15 +5,19 @@ module Spree
       extend ActiveSupport::Concern # FIXME: this module is not required to be a concern
 
       def clone_shipping_address
-        if ship_address
-          self.bill_address = ship_address
+        if ship_address && bill_address.nil?
+          self.bill_address = ship_address.clone
+        else
+          bill_address.attributes = ship_address.attributes.except('id', 'updated_at', 'created_at')
         end
         true
       end
 
       def clone_billing_address
-        if bill_address
-          self.ship_address = bill_address
+        if bill_address && ship_address.nil?
+          self.ship_address = bill_address.clone
+        else
+          ship_address.attributes = bill_address.attributes.except('id', 'updated_at', 'created_at')
         end
         true
       end


### PR DESCRIPTION
If you create a guest user inside the order and use the "Use Billing Address" checkbox, the addresses will have one id, as a result of which it will not be possible to make the addresses different from each other.