### PR TITLE
fix(Spree::Order::AddressBook): fixed same id for ship_address and bill_address

### DIFF
--- a/core/app/models/spree/order/address_book.rb
+++ b/core/app/models/spree/order/address_book.rb
@@ -6,14 +6,14 @@ module Spree
 
       def clone_shipping_address
         if ship_address
-          self.bill_address = ship_address
+          self.bill_address = ship_address.clone
         end
         true
       end
 
       def clone_billing_address
         if bill_address
-          self.ship_address = bill_address
+          self.ship_address = bill_address.clone
         end
         true
       end


### PR DESCRIPTION
If you create a guest user inside the order and use the "Use Billing Address" checkbox, the addresses will have one id, as a result of which it will not be possible to make the addresses different from each other.