### PR TITLE
Update README.md for 4.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [Spree Commerce](https://spreecommerce.org) [![Gem Version](https://badge.fury.io/rb/spree.svg)](https://badge.fury.io/rb/spree) [![Test Coverage](https://api.codeclimate.com/v1/badges/8277fc2bb0b1f777084f/test_coverage)](https://codeclimate.com/github/spree/spree/test_coverage)
 
+[![Github README - Header](https://github.com/spree/spree/assets/43988137/54768c5a-3d8f-48db-b965-f1cb96ed7f91)](https://github.com/spree/spree/releases/tag/v4.6.0)
+
 **Spree** is a headless open source e-commerce platform for global brands.
 
 * [Success Stories](https://spreecommerce.org/stories/)
@@ -23,21 +25,6 @@
 * **Fully customizable** - pick and choose parts you want to use and customize everything else (storefront, order processing, API, etc) to create unique solutions that your business requires
 * **More features available via extensions** - dozens of extensions built by community, ready for use for free!
 
-## Sponsored by
-
-<a href="https://www.getvendo.com/vendo-seller-network?utm_source=spree_github">
-  <img src="https://raw.githubusercontent.com/vendo-dev/static/main/seller-network%20-%20Edited.png" />
-</a>
-
->
-> Add Vendo sales channel to your Spree Commerce store to increase sales. 
->
-> Sell through creator-led marketplaces for free. 
->
-> We'll automatically pull and sync your products you want to sell via [Vendo](https://www.getvendo.com?utm_source=spree_github) and later send orders to your dashboard for fulfillment.
-
-👉 [Get more sales now!](https://www.getvendo.com/vendo-seller-network)
-
 ## Documentation
 
 * [Getting Started](https://dev-docs.spreecommerce.org/getting-started/installation)
@@ -52,10 +39,33 @@
 
 Spree is an open source project and we love contributions in any form - pull requests, issues, feature ideas!
 
-Please review the [Contributing Guide](https://dev-docs.spreecommerce.org/contributing/index)
+Please review the [Contributing Guide](https://dev-docs.spreecommerce.org/contributing/index) and see the list of our amazing [Contributors](https://github.com/spree/spree/graphs/contributors).
+
+## Support
+
+Get Spree support on [Slack](https://spree-commerce.slack.com/join/shared_invite/zt-ico7d35e-OeoAYXKO8XNtrZR1ZvBb5A#/shared-invite/email) or directly through a form on our [website](https://spreecommerce.org/contact/).
+
+[![GitHub README - Spree Slack](https://github.com/spree/spree/assets/43988137/d0fc8423-5f38-4514-bfb1-c26eeb752639)](https://spree-commerce.slack.com/join/shared_invite/zt-ico7d35e-OeoAYXKO8XNtrZR1ZvBb5A#/shared-invite/email)
+
+## Sponsored by
+
+### Upside
+[![Github README Sponsor Upside](https://github.com/spree/spree/assets/43988137/8b0a50a8-640e-4561-b833-2ab6de2da68d)](https://upsidelab.io/)
+
+Upside is a leading software development consultancy that specializes in helping global digital commerce brands scale their technology. Upside provides a range of end-to-end software development services, making it a one-stop shop for all digital commerce technology needs.
+
+Visit the website: [upsidelab.io](https://upsidelab.io)
+
+### Vendo
+
+[![Github README Sponsor Vendo](https://github.com/spree/spree/assets/43988137/7d0ab67c-7484-414d-bed4-156fcb00c149)](https://www.getvendo.com/)
+
+Vendo helps your eCommerce brand to sell more and effortlessly through tens of super motivated influencers only at the cost of a sales commission.
+
+While getting your brand and all the products promoted for free to millions of social media followers interested in your products, Vendo automatically pulls and syncs your products and later pushes orders to your dashboard for fulfillment. No extra work.
+
+👉 [Get more sales now!](https://www.getvendo.com/vendo-seller-network)
 
 ## License
 
 Spree is released under the [New BSD License](https://github.com/spree/spree/blob/main/license.md).
-
-[vendo]:https://getvendo.com?utm_source=spree_github


### PR DESCRIPTION
Making GitHub-hosted images clickable as links does not work for some reason. It results in:
```html
<a href="<target of the link>">
  <gh:secured-asset-reference resource_type="UserAsset" resource_id="246818192"></gh:secured-asset-reference>
</a>
```
and the image itself becoming a sibling element. It does not change after a PR is merged (tested on another repository). We can host the images in a `static` repository or somewhere else if we care about the images directing to proper websites. Or merge this and handle the links later.

The links for in the GitHub mobile app though.