### PR TITLE
set permalink when creating taxonomy. Fixes #11899

### DIFF
--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -28,7 +28,7 @@ module Spree
     private
 
     def set_root
-      self.root ||= Taxon.create!(taxonomy_id: id, name: name)
+      self.root ||= Taxon.create!(taxonomy_id: id, name: name, permalink: name.to_url)
     end
 
     def set_root_taxon_name


### PR DESCRIPTION
Fixes #11899

This happens when there is more than one language enabled. Non-default language gets an empty name and name.to_slug fails