### PR TITLE
Changing translation process of permalink and slugs in models SP-56

### DIFF
--- a/api/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -996,15 +996,15 @@ describe 'API V2 Storefront Products Spec', type: :request do
 
     context 'with localized_slugs' do
       let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
-      let(:product_with_slug) { create(:product, stores: [store2], slug: 'test_slug_en') }
-      let!(:translation1) { product_with_slug.translations.create(slug: 'test_slug_pl', locale: 'pl')  }
-      let!(:translation2) { product_with_slug.translations.create(slug: 'test_slug_es', locale: 'es')  }
+      let(:product_with_slug) { create(:product, stores: [store2], slug: 'test-slug-en') }
+      let!(:translation1) { product_with_slug.translations.create(slug: 'test-slug-pl', locale: 'pl')  }
+      let!(:translation2) { product_with_slug.translations.create(slug: 'test-slug-es', locale: 'es')  }
 
       let(:expected_result) do
         {
-          en: 'test_slug_en',
-          pl: 'test_slug_pl',
-          es: 'test_slug_es'
+          en: 'test-slug-en',
+          pl: 'test-slug-pl',
+          es: 'test-slug-es'
         }
       end
 
@@ -1021,7 +1021,7 @@ describe 'API V2 Storefront Products Spec', type: :request do
     context 'with slug fallback to default locale' do
       let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
       let!(:product_with_slug) { create(:product, stores: [store2], slug: default_locale_slug) }
-      let(:default_locale_slug) { 'test_slug_en' }
+      let(:default_locale_slug) { 'test-slug-en' }
 
       before do
         allow_any_instance_of(Spree::Api::V2::Storefront::ProductsController).to receive(:current_store).and_return(store2)
@@ -1037,8 +1037,8 @@ describe 'API V2 Storefront Products Spec', type: :request do
       let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
       let(:product_with_slug) { create(:product, stores: [store2], slug: default_locale_slug) }
       let!(:translation2) { product_with_slug.translations.create(slug: translated_slug, locale: 'es')  }
-      let(:default_locale_slug) { 'test_slug_en' }
-      let(:translated_slug) { 'test_slug_es' }
+      let(:default_locale_slug) { 'test-slug-en' }
+      let(:translated_slug) { 'test-slug-es' }
 
       before do
         allow_any_instance_of(Spree::Api::V2::Storefront::ProductsController).to receive(:current_store).and_return(store2)

--- a/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/taxons_spec.rb
@@ -226,9 +226,9 @@ describe 'Taxons Spec', type: :request do
 
       let(:expected_slugs) do
         {
-          en: 'categories/test_slug_en',
-          pl: 'categories/test_slug_pl',
-          es: 'categories/test_slug_es'
+          en: 'categories/test-slug-en',
+          pl: 'categories/test-slug-pl',
+          es: 'categories/test-slug-es'
         }
       end
 
@@ -246,7 +246,7 @@ describe 'Taxons Spec', type: :request do
       let(:store2) { create(:store, default_locale: 'en', supported_locales: 'en,pl,es') }
       let(:taxonomy) { create(:taxonomy, name: 'categories', store: store2) }
       let!(:taxon_with_slug) { create(:taxon, taxonomy: taxonomy, name: 'test slug en', permalink: default_locale_slug) }
-      let(:default_locale_slug) { 'test_slug_en' }
+      let(:default_locale_slug) { 'test-slug-en' }
 
       before do
         allow_any_instance_of(Spree::Api::V2::Storefront::TaxonsController).to receive(:current_store).and_return(store2)
@@ -264,7 +264,7 @@ describe 'Taxons Spec', type: :request do
       let!(:taxon_with_slug) { create(:taxon, taxonomy: taxonomy, permalink: default_locale_slug) }
       let!(:translations) { taxon_with_slug.translations.create([ { name: 'test slug en', permalink: translated_slug, locale: 'es' } ]) }
       let(:default_locale_slug) { 'test_slug_en' }
-      let(:translated_slug) { 'test_slug_es' }
+      let(:translated_slug) { 'test-slug-es' }
 
       before do
         allow_any_instance_of(Spree::Api::V2::Storefront::TaxonsController).to receive(:current_store).and_return(store2)

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -42,9 +42,25 @@ module Spree
     translates(*TRANSLATABLE_FIELDS)
 
     self::Translation.class_eval do
+      before_save :set_slug
       acts_as_paranoid
       # deleted translation values also need to be accessible for index views listing deleted resources
       default_scope { unscope(where: :deleted_at) }
+      def set_slug
+        self.slug = generate_slug
+      end
+
+      private
+
+      def generate_slug
+        if name.blank? && slug.blank?
+          translated_model.name.to_url
+        elsif slug.blank?
+          name.to_url
+        else
+          slug.to_url
+        end
+      end
     end
 
     friendly_id :slug_candidates, use: [:history, :mobility]

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -26,7 +26,10 @@ module Spree
 
     def duplicate_product
       product.dup.tap do |new_product|
-        product.translations.each { |t| new_product.send(:name=, "COPY OF #{t.name}", locale: t.locale) }
+        new_product.translations.each do |t|
+          t.name = "COPY OF #{t.name}"
+          t.slug = nil
+        end
         new_product.taxons = product.taxons
         new_product.stores = product.stores
         new_product.created_at = nil


### PR DESCRIPTION
Changing a way of saving translations in taxon.rb and product.rb models in order to enable the proper generation of permalinks and slugs. 
**This PR is dependable on [this](https://github.com/spree/spree_backend/pull/262) spree_backend PR**