### PR TITLE
Remove Ruby 2.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,49 +10,11 @@ defaults: &defaults
     RAILS_VERSION: '~> 7.0'
   working_directory: ~/spree
   docker:
-    - image: &ruby_2_7_image circleci/ruby:2.7-node-browsers
+    - image: &ruby_3_2_image cimg/ruby:3.2.0-browsers
     - image: &redis_image circleci/redis:6.2-alpine
 
-defaults_3_2: &defaults_3_2
-  <<: *defaults
-  docker:
-    - image: &ruby_3_2_image cimg/ruby:3.2.0-browsers
-    - image: *redis_image
-
-run_tests_2_7: &run_tests_2_7
-  <<: *defaults
-  parallelism: 3
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - spree-bundle-v10-ruby-2-7-{{ .Branch }}
-          - spree-bundle-v10-ruby-2-7
-    - run:
-        name: Add keyserver
-        command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-    - run:
-        name: Install libvips
-        command: sudo apt-get update && sudo apt-get install libvips
-    - run:
-        name: Ensure Bundle Install
-        command: |
-          bundle install
-          ./bin/build-ci.rb install
-    - run:
-        name: Run rspec in parallel
-        command: ./bin/build-ci.rb test
-    - store_artifacts:
-        path: /tmp/test-artifacts
-        destination: test-artifacts
-    - store_artifacts:
-        path: /tmp/test-results
-        destination: raw-test-output
-    - store_test_results:
-        path: /tmp/test-results
-
 run_tests_3_2: &run_tests_3_2
-  <<: *defaults_3_2
+  <<: *defaults
   parallelism: 3
   steps:
     - checkout
@@ -81,32 +43,8 @@ run_tests_3_2: &run_tests_3_2
         path: /tmp/test-results
 
 jobs:
-  bundle_ruby_2_7:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - spree-bundle-v10-ruby-2-7-{{ .Branch }}
-            - spree-bundle-v10-ruby-2-7
-      - run:
-          name: Add keyserver
-          command: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
-      - run:
-          name: Install libvips
-          command: sudo apt-get update && sudo apt-get install libvips
-      - run:
-          name: Bundle Install
-          command: |
-            bundle check || bundle install
-            ./bin/build-ci.rb install
-      - save_cache:
-          key: spree-bundle-v10-ruby-2-7-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-          paths:
-            - ~/spree/vendor/bundle
-
   bundle_ruby_3_2:
-    <<: *defaults_3_2
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
@@ -127,7 +65,7 @@ jobs:
             - ~/spree/vendor/bundle
 
   brakeman:
-    <<: *defaults_3_2
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
@@ -152,31 +90,22 @@ jobs:
           paths:
             - ~/spree/vendor/bundle
 
-  tests_ruby_2_7_rails_7_0_postgres: &tests_ruby_2_7_rails_7_0_postgres
-    <<: *run_tests_2_7
+  tests_ruby_3_2_rails_7_0_postgres: &tests_ruby_3_2_rails_7_0_postgres
+    <<: *run_tests_3_2
     environment: &postgres_environment
       <<: *environment
       DB: postgres
       DB_HOST: localhost
       DB_USERNAME: postgres
     docker:
-      - image: *ruby_2_7_image
-      - image: *redis_image
+      - image: *ruby_3_2_image
       - image: &postgres_image circleci/postgres:12-alpine
         environment:
           POSTGRES_USER: postgres
-
-  tests_ruby_3_2_rails_7_0_postgres:
-    <<: *run_tests_3_2
-    environment:
-      <<: *postgres_environment
-    docker:
-      - image: *ruby_3_2_image
-      - image: *postgres_image
       - image: *redis_image
 
-  tests_ruby_2_7_rails_6_1_postgres:
-    <<: *tests_ruby_2_7_rails_7_0_postgres
+  tests_ruby_3_2_rails_6_1_postgres:
+    <<: *tests_ruby_3_2_rails_7_0_postgres
     environment:
       <<: *postgres_environment
       RAILS_VERSION: '~> 6.1.0'
@@ -262,7 +191,6 @@ workflows:
   version: 2
   main:
     jobs:
-      - bundle_ruby_2_7
       - bundle_ruby_3_2
       - brakeman:
           requires:
@@ -270,12 +198,9 @@ workflows:
       - tests_ruby_3_2_rails_7_0_postgres:
           requires:
             - bundle_ruby_3_2
-      - tests_ruby_2_7_rails_7_0_postgres:
+      - tests_ruby_3_2_rails_6_1_postgres:
           requires:
-            - bundle_ruby_2_7
-      - tests_ruby_2_7_rails_6_1_postgres:
-          requires:
-            - bundle_ruby_2_7
+            - bundle_ruby_3_2
       - tests_ruby_3_2_rails_7_0_mysql:
           requires:
             - bundle_ruby_3_2

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,7 +15,7 @@ plugins:
         enabled: false
     config:
       file: .rubocop.yml
-    channel: "rubocop-1-10-0"
+    channel: "rubocop-1-50-3"
 exclude_patterns:
   - "**/bin/"
   - "**/script/"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   Exclude:
     - '**/sandbox/**/*'
     - '**/db/migrate/*'

--- a/api/spree_api.gemspec
+++ b/api/spree_api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => "https://github.com/spree/spree/tree/v#{s.version}",
   }
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 3.0'
 
   s.files         = `git ls-files`.split($\).reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.executables   = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/cli/lib/spree_cli/templates/extension/.rubocop.yml
+++ b/cli/lib/spree_cli/templates/extension/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   Include:
     - '**/Gemfile'
     - '**/Rakefile'

--- a/cli/lib/spree_cli/templates/extension/extension.gemspec
+++ b/cli/lib/spree_cli/templates/extension/extension.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version     = <%= class_name %>.version
   s.summary     = 'Add extension summary here'
   s.description = 'Add (optional) extension description here'
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 3.0'
 
   s.author    = 'You'
   s.email     = 'you@example.com'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
   }
 
-  s.required_ruby_version     = '>= 2.5.0'
+  s.required_ruby_version     = '>= 3.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }

--- a/emails/spree_emails.gemspec
+++ b/emails/spree_emails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
   }
 
-  s.required_ruby_version     = '>= 2.5.0'
+  s.required_ruby_version     = '>= 3.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.files        = `git ls-files`.split("\n").reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }

--- a/spree.gemspec
+++ b/spree.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/spree/spree/tree/v#{s.version}",
   }
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 3.0'
 
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'


### PR DESCRIPTION
Ruby 2.7 reached end of life, and it's holding us back from upgrading some gem dependencies. This PR removes support for Ruby 2.7 and upgrades dependencies