### PR TITLE
Update ransack version

### DIFF
--- a/api/spec/requests/spree/api/v2/platform/stock_items_spec.rb
+++ b/api/spec/requests/spree/api/v2/platform/stock_items_spec.rb
@@ -24,7 +24,7 @@ describe 'Platform API v2 Stock Items API' do
     end
 
     context 'filtering by variant product name or sku' do
-      before { get "/api/v2/platform/stock_items?filter[variant_product_name_or_variant_sku_cont]=#{product_2.name}", headers: bearer_token }
+      before { get "/api/v2/platform/stock_items?filter[variants_product_name_or_variants_sku_cont]=#{product_2.name}", headers: bearer_token }
 
       it 'returns stock_items with matching stock location ids' do
         # default variant + 2 variants for product_2, each inside two stock locations

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'money', '~> 6.13'
   s.add_dependency 'monetize', '~> 1.9'
   s.add_dependency 'paranoia', '~> 2.4'
-  s.add_dependency 'ransack', '>= 2.3', '< 3.0'
+  s.add_dependency 'ransack', '>= 3.1', '< 4.0'
   s.add_dependency 'rexml'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
   s.add_dependency 'state_machines-activemodel', '~> 0.7'


### PR DESCRIPTION
The current lock on the Ransack version blocks us from running Spree with Rails 7.1.beta - it seems like a good moment to upgrade that dependency. I did some checks and it seems to be safe for our usage of Ransack - I just needed to fix a single spec (that used incorrect scope when calling the API)