### PR TITLE
Remove outdated Rails version checks

### DIFF
--- a/api/lib/spree/api/testing_support/serializers.rb
+++ b/api/lib/spree/api/testing_support/serializers.rb
@@ -5,21 +5,11 @@ module Spree
 end
 
 shared_examples 'an ActiveJob serializable hash' do
-  context 'Rails < 6', if: Rails::VERSION::MAJOR < 6 do
-    it 'can not be serialized by ActiveJob' do
-      expect { Spree::TestArgumentsJob.perform_later(subject) }.to(
-        raise_error(ActiveJob::SerializationError, 'Unsupported argument type: Symbol')
-      )
-    end
-  end
-
-  context 'Rails >= 6', if: Rails::VERSION::MAJOR >= 6 do
-    it 'can be serialized by ActiveJob' do
-      # It should fail if subject contains any custom instance (e.g Spree::Money)
-      expect { Spree::TestArgumentsJob.perform_later(subject) }.not_to raise_error
-      expect { Spree::TestArgumentsJob.perform_later(subject.merge(price: Spree::Money.new(0))) }.to(
-        raise_error(ActiveJob::SerializationError)
-      )
-    end
+  it 'can be serialized by ActiveJob' do
+    # It should fail if subject contains any custom instance (e.g Spree::Money)
+    expect { Spree::TestArgumentsJob.perform_later(subject) }.not_to raise_error
+    expect { Spree::TestArgumentsJob.perform_later(subject.merge(price: Spree::Money.new(0))) }.to(
+      raise_error(ActiveJob::SerializationError)
+    )
   end
 end

--- a/core/app/finders/spree/taxons/find.rb
+++ b/core/app/finders/spree/taxons/find.rb
@@ -65,15 +65,9 @@ module Spree
       def by_parent_permalink(taxons)
         return taxons unless parent_permalink?
 
-        if Rails::VERSION::STRING >= '6.1'
-          taxons.joins(:parent).
-            join_translation_table(Taxon, 'parents_spree_taxons').
-            where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
-        else
-          taxons.joins("INNER JOIN #{Spree::Taxon.table_name} AS parent_taxon ON parent_taxon.id = #{Spree::Taxon.table_name}.parent_id").
-            join_translation_table(Taxon, 'parent_taxon').
-            where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
-        end
+        taxons.joins(:parent).
+          join_translation_table(Taxon, 'parents_spree_taxons').
+          where(["#{Taxon.translation_table_alias}.permalink = ?", parent_permalink])
       end
 
       def by_taxonomy(taxons)

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -174,10 +174,6 @@ module Spree
       Spree::Core::Engine.frontend_available?
     end
 
-    def rails_5?
-      Rails::VERSION::STRING < '6.0'
-    end
-
     def spree_storefront_resource_url(resource, options = {})
       if defined?(locale_param) && locale_param.present?
         options.merge!(locale: locale_param)

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -10,9 +10,7 @@ module Spree
       include Spree::Security::Addresses
     end
 
-    if Rails::VERSION::STRING >= '6.1'
-      serialize :preferences, Hash, default: {}
-    end
+    serialize :preferences, Hash, default: {}
 
     NO_ZIPCODE_ISO_CODES ||= [
       'AO', 'AG', 'AW', 'BS', 'BZ', 'BJ', 'BM', 'BO', 'BW', 'BF', 'BI', 'CM', 'CF', 'KM', 'CG',

--- a/core/app/models/spree/cms/sections/image_gallery.rb
+++ b/core/app/models/spree/cms/sections/image_gallery.rb
@@ -3,11 +3,7 @@ module Spree::Cms::Sections
     after_initialize :default_values
     validate :reset_multiple_link_attributes
 
-    LINKED_RESOURCE_TYPE = if Rails::VERSION::STRING < '6.0'
-                             ['Spree::Taxon'].freeze
-                           else
-                             ['Spree::Taxon', 'Spree::Product'].freeze
-                           end
+    LINKED_RESOURCE_TYPE = ['Spree::Taxon', 'Spree::Product'].freeze
 
     LAYOUT_OPTIONS = ['Default', 'Reversed'].freeze
     LABEL_OPTIONS = ['Show', 'Hide'].freeze
@@ -71,8 +67,6 @@ module Spree::Cms::Sections
     private
 
     def reset_multiple_link_attributes
-      return if Rails::VERSION::STRING < '6.0'
-
       if link_type_one_changed?
         return if link_type_one_was.nil?
 

--- a/core/app/models/spree/cms/sections/side_by_side_images.rb
+++ b/core/app/models/spree/cms/sections/side_by_side_images.rb
@@ -3,11 +3,7 @@ module Spree::Cms::Sections
     after_initialize :default_values
     validate :reset_multiple_link_attributes
 
-    LINKED_RESOURCE_TYPE = if Rails::VERSION::STRING < '6.0'
-                             ['Spree::Taxon'].freeze
-                           else
-                             ['Spree::Taxon', 'Spree::Product'].freeze
-                           end
+    LINKED_RESOURCE_TYPE = ['Spree::Taxon', 'Spree::Product'].freeze
 
     store :content, accessors: [:link_type_one, :link_one, :title_one, :subtitle_one,
                                 :link_type_two, :link_two, :title_two, :subtitle_two], coder: JSON
@@ -49,8 +45,6 @@ module Spree::Cms::Sections
     private
 
     def reset_multiple_link_attributes
-      return if Rails::VERSION::STRING < '6.0'
-
       if link_type_one_changed?
         return if link_type_one_was.nil?
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -222,18 +222,10 @@ module Spree
 
     def validate_source
       if source && !source.valid?
-        if Rails::VERSION::STRING >= '6.1'
-          source.errors.map { |error| { field: error.attribute, message: error&.message } }.each do |err|
-            next if err[:field].blank? || err[:message].blank?
+        source.errors.map { |error| { field: error.attribute, message: error&.message } }.each do |err|
+          next if err[:field].blank? || err[:message].blank?
 
-            add_source_error(err[:field], err[:message])
-          end
-        else
-          source.errors.messages.each do |field, error|
-            next if field.blank? || error.empty?
-
-            add_source_error(field, error.first)
-          end
+          add_source_error(err[:field], err[:message])
         end
       end
       !errors.present?

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -507,18 +507,10 @@ module Spree
       # We call master.default_price here to ensure price is initialized.
       # Required to avoid Variant#check_price validation failing on create.
       unless master.default_price && master.valid?
-        if Rails::VERSION::STRING >= '6.1'
-          master.errors.map { |error| { field: error.attribute, message: error&.message } }.each do |err|
-            next if err[:field].blank? || err[:message].blank?
+        master.errors.map { |error| { field: error.attribute, message: error&.message } }.each do |err|
+          next if err[:field].blank? || err[:message].blank?
 
-            errors.add(err[:field], err[:message])
-          end
-        else
-          master.errors.messages.each do |field, error|
-            next if field.blank? || error.empty?
-
-            errors.add(field, error.first)
-          end
+          errors.add(err[:field], err[:message])
         end
       end
     end

--- a/core/app/services/spree/seeds/countries.rb
+++ b/core/app/services/spree/seeds/countries.rb
@@ -9,34 +9,19 @@ module Spree
 
       def call
         ApplicationRecord.transaction do
-          if Rails::VERSION::MAJOR >= 6
-            new_countries = Carmen::Country.all.map do |country|
-              # Skip the creation of some territories, uninhabited islands and the Antarctic.
-              next if EXCLUDED_COUNTRIES.include?(country.alpha_2_code)
+          new_countries = Carmen::Country.all.map do |country|
+            # Skip the creation of some territories, uninhabited islands and the Antarctic.
+            next if EXCLUDED_COUNTRIES.include?(country.alpha_2_code)
 
-              Hash[
-                'name': country.name,
-                'iso3': country.alpha_3_code,
-                'iso': country.alpha_2_code,
-                'iso_name': country.name.upcase,
-                'numcode': country.numeric_code,
-              ]
-            end.compact.uniq
-            Spree::Country.insert_all(new_countries)
-          else
-            Carmen::Country.all.each do |country|
-              # Skip the creation of some territories, uninhabited islands and the Antarctic.
-              next if EXCLUDED_COUNTRIES.include?(country.alpha_2_code)
-
-              Spree::Country.where(
-                name: country.name,
-                iso3: country.alpha_3_code,
-                iso: country.alpha_2_code,
-                iso_name: country.name.upcase,
-                numcode: country.numeric_code
-              ).first_or_create!
-            end
-          end
+            Hash[
+              'name': country.name,
+              'iso3': country.alpha_3_code,
+              'iso': country.alpha_2_code,
+              'iso_name': country.name.upcase,
+              'numcode': country.numeric_code,
+            ]
+          end.compact.uniq
+          Spree::Country.insert_all(new_countries)
 
           # Find countries that do not use postal codes (by iso) and set 'zipcode_required' to false for them.
           Spree::Country.where(iso: Spree::Address::NO_ZIPCODE_ISO_CODES).update_all(zipcode_required: false)

--- a/core/app/services/spree/seeds/states.rb
+++ b/core/app/services/spree/seeds/states.rb
@@ -49,23 +49,14 @@ module Spree
       end
 
       def province_level(country, subregion)
-        if Rails::VERSION::MAJOR >= 6
-          new_states = subregion.subregions.map do |province|
-            Hash[
-              name: province.name,
-              abbr: province.code,
-              country_id: country.id
-            ]
-          end.compact.uniq
-          Spree::State.insert_all(new_states)
-        else
-          subregion.subregions.each do |province|
-            country.states.where(
-              name: province.name,
-              abbr: province.code
-            ).first_or_create!
-          end
-        end
+        new_states = subregion.subregions.map do |province|
+          Hash[
+            name: province.name,
+            abbr: province.code,
+            country_id: country.id
+          ]
+        end.compact.uniq
+        Spree::State.insert_all(new_states)
       end
     end
   end

--- a/core/app/services/spree/stock_locations/stock_items/create.rb
+++ b/core/app/services/spree/stock_locations/stock_items/create.rb
@@ -5,24 +5,18 @@ module Spree
         prepend Spree::ServiceModule::Base
 
         def call(stock_location:, variants_scope: Spree::Variant)
-          if Rails::VERSION::MAJOR >= 6
-            prepared_stock_items = variants_scope.ids.map do |variant_id|
-              Hash[
-                'stock_location_id', stock_location.id,
-                'variant_id', variant_id,
-                'backorderable', stock_location.backorderable_default,
-                'created_at', Time.current,
-                'updated_at', Time.current
-              ]
-            end
-            if prepared_stock_items.any?
-              stock_location.stock_items.insert_all(prepared_stock_items)
-              variants_scope.touch_all
-            end
-          else
-            variants_scope.find_each do |variant|
-              stock_location.propagate_variant(variant)
-            end
+          prepared_stock_items = variants_scope.ids.map do |variant_id|
+            Hash[
+              'stock_location_id', stock_location.id,
+              'variant_id', variant_id,
+              'backorderable', stock_location.backorderable_default,
+              'created_at', Time.current,
+              'updated_at', Time.current
+            ]
+          end
+          if prepared_stock_items.any?
+            stock_location.stock_items.insert_all(prepared_stock_items)
+            variants_scope.touch_all
           end
         end
       end

--- a/core/config/initializers/rails61_fixes.rb
+++ b/core/config/initializers/rails61_fixes.rb
@@ -1,3 +1,1 @@
-if Rails::VERSION::STRING >= '6.1'
-  ActiveRecord::Base.has_many_inversing = false
-end
+ActiveRecord::Base.has_many_inversing = false

--- a/core/spec/models/spree/cms/sections/image_gallery_spec.rb
+++ b/core/spec/models/spree/cms/sections/image_gallery_spec.rb
@@ -58,46 +58,44 @@ describe Spree::Cms::Sections::ImageGallery, type: :model do
     end
   end
 
-  if Rails::VERSION::STRING >= '6.0'
-    context 'when changing the link types for links one two and three' do
-      let!(:image_gallery_section) { create(:cms_image_gallery_section, cms_page: homepage) }
+  context 'when changing the link types for links one two and three' do
+    let!(:image_gallery_section) { create(:cms_image_gallery_section, cms_page: homepage) }
 
-      before do
-        section = Spree::CmsSection.find(image_gallery_section.id)
+    before do
+      section = Spree::CmsSection.find(image_gallery_section.id)
 
-        section.content[:link_type_one] = 'Spree::Product'
-        section.content[:link_type_two] = 'Spree::Product'
-        section.content[:link_type_three] = 'Spree::Product'
+      section.content[:link_type_one] = 'Spree::Product'
+      section.content[:link_type_two] = 'Spree::Product'
+      section.content[:link_type_three] = 'Spree::Product'
 
-        section.content[:link_one] = 'Shirt 1'
-        section.content[:link_two] = 'Shirt 2'
-        section.content[:link_three] = 'Shirt 3'
+      section.content[:link_one] = 'Shirt 1'
+      section.content[:link_two] = 'Shirt 2'
+      section.content[:link_three] = 'Shirt 3'
 
-        section.save!
-        section.reload
-      end
+      section.save!
+      section.reload
+    end
 
-      it 'link_one, link_two and save the initial values' do
-        section = Spree::CmsSection.find(image_gallery_section.id)
+    it 'link_one, link_two and save the initial values' do
+      section = Spree::CmsSection.find(image_gallery_section.id)
 
-        expect(section.link_one).to eql 'Shirt 1'
-        expect(section.link_two).to eql 'Shirt 2'
-        expect(section.link_three).to eql 'Shirt 3'
-      end
+      expect(section.link_one).to eql 'Shirt 1'
+      expect(section.link_two).to eql 'Shirt 2'
+      expect(section.link_three).to eql 'Shirt 3'
+    end
 
-      it 'link_one, link_two and link_three are reset to nil' do
-        section = Spree::CmsSection.find(image_gallery_section.id)
+    it 'link_one, link_two and link_three are reset to nil' do
+      section = Spree::CmsSection.find(image_gallery_section.id)
 
-        section.content[:link_type_one] = 'Spree::Taxon'
-        section.content[:link_type_two] = 'Spree::Taxon'
-        section.content[:link_type_three] = 'Spree::Taxon'
-        section.save!
-        section.reload
+      section.content[:link_type_one] = 'Spree::Taxon'
+      section.content[:link_type_two] = 'Spree::Taxon'
+      section.content[:link_type_three] = 'Spree::Taxon'
+      section.save!
+      section.reload
 
-        expect(section.link_one).to be nil
-        expect(section.link_two).to be nil
-        expect(section.link_three).to be nil
-      end
+      expect(section.link_one).to be nil
+      expect(section.link_two).to be nil
+      expect(section.link_three).to be nil
     end
   end
 end

--- a/core/spec/models/spree/cms/sections/side_by_side_images_spec.rb
+++ b/core/spec/models/spree/cms/sections/side_by_side_images_spec.rb
@@ -46,41 +46,39 @@ describe Spree::Cms::Sections::SideBySideImages, type: :model do
     end
   end
 
-  if Rails::VERSION::STRING >= '6.0'
-    context 'when changing the link types for links one and two' do
-      let!(:side_by_side_images_section) { create(:cms_side_by_side_images_section, cms_page: homepage) }
+  context 'when changing the link types for links one and two' do
+    let!(:side_by_side_images_section) { create(:cms_side_by_side_images_section, cms_page: homepage) }
 
-      before do
-        section = Spree::CmsSection.find(side_by_side_images_section.id)
+    before do
+      section = Spree::CmsSection.find(side_by_side_images_section.id)
 
-        section.content[:link_type_one] = 'Spree::Product'
-        section.content[:link_type_two] = 'Spree::Product'
+      section.content[:link_type_one] = 'Spree::Product'
+      section.content[:link_type_two] = 'Spree::Product'
 
-        section.content[:link_one] = 'Shirt 1'
-        section.content[:link_two] = 'Shirt 2'
+      section.content[:link_one] = 'Shirt 1'
+      section.content[:link_two] = 'Shirt 2'
 
-        section.save!
-        section.reload
-      end
+      section.save!
+      section.reload
+    end
 
-      it 'link_one and link_two save the values correctly' do
-        section = Spree::CmsSection.find(side_by_side_images_section.id)
+    it 'link_one and link_two save the values correctly' do
+      section = Spree::CmsSection.find(side_by_side_images_section.id)
 
-        expect(section.link_one).to eql 'Shirt 1'
-        expect(section.link_two).to eql 'Shirt 2'
-      end
+      expect(section.link_one).to eql 'Shirt 1'
+      expect(section.link_two).to eql 'Shirt 2'
+    end
 
-      it 'link_one and link_two are reset to nil when type is changed' do
-        section = Spree::CmsSection.find(side_by_side_images_section.id)
+    it 'link_one and link_two are reset to nil when type is changed' do
+      section = Spree::CmsSection.find(side_by_side_images_section.id)
 
-        section.content[:link_type_one] = 'Spree::Taxon'
-        section.content[:link_type_two] = 'Spree::Taxon'
-        section.save!
-        section.reload
+      section.content[:link_type_one] = 'Spree::Taxon'
+      section.content[:link_type_two] = 'Spree::Taxon'
+      section.save!
+      section.reload
 
-        expect(section.link_one).to be nil
-        expect(section.link_two).to be nil
-      end
+      expect(section.link_one).to be nil
+      expect(section.link_two).to be nil
     end
   end
 end

--- a/core/spec/services/spree/stock_locations/stock_items/create_spec.rb
+++ b/core/spec/services/spree/stock_locations/stock_items/create_spec.rb
@@ -10,91 +10,70 @@ module Spree
     let(:stock_location_class) { stock_location.class }
 
     describe '#call' do
-      context 'Rails < 6', if: Rails::VERSION::MAJOR < 6 do
-        context 'with variants to propagate' do
-          before { stock_location.stock_items.delete_all }
+      let(:time_current) { Time.local(1990) }
 
-          it 'propagates the variants' do
-            expect { result }.to change { stock_location.stock_items.count }.from(0).to(4)
+      context 'with prepared stock items' do
+        context 'with stock items in the db' do
+          before { Spree::StockItem.find(Spree::StockItem.ids.sample).delete }
+
+          it 'inserts stock items without duplicates' do
+            total_stock_items = Spree::StockItem.count
+            expect { result }.to change {
+              stock_location.stock_items.count
+            }.from(total_stock_items).to(total_stock_items + 1)
           end
         end
 
-        context 'without variants to propagate' do
-          before { Variant.destroy_all }
+        context 'without stock items in the db' do
+          before do
+            # Delete all stock_location.stock_items to start counting from 0.
+            stock_location.stock_items.unscope(:where).delete_all
+          end
 
-          it 'does not propagate stock location variants' do
-            expect(stock_location).not_to receive(:propagate_variant)
+          let(:created_stock_item) { stock_location.stock_items.order(:id).last }
+          let(:created_stock_item_attrs) do
+            created_stock_item.attributes.values_at(
+              'stock_location_id', 'variant_id', 'backorderable', 'created_at', 'updated_at'
+            )
+          end
+
+          it 'inserts the stock location stock items' do
+            expect { result }.to change { stock_location.stock_items.count }.from(0).to(4)
+          end
+
+          it 'sets the stock location data necessary for the inserted stock items' do
+            Timecop.freeze(time_current) do
+              result
+              expect(created_stock_item_attrs).to(
+                eq([
+                     stock_location.id,
+                     unrelated_variant.id,
+                     stock_location.backorderable_default,
+                     time_current,
+                     time_current
+                   ])
+              )
+            end
+          end
+
+          it 'invalidates the Variant cache' do
+            expect(Spree::Variant).to receive(:touch_all).once
             result
           end
         end
       end
 
-      context 'Rails >= 6', if: Rails::VERSION::MAJOR >= 6 do
-        let(:time_current) { Time.local(1990) }
+      context 'without prepared stock items' do
+        before { Spree::Variant.destroy_all }
 
-        context 'with prepared stock items' do
-          context 'with stock items in the db' do
-            before { Spree::StockItem.find(Spree::StockItem.ids.sample).delete }
-
-            it 'inserts stock items without duplicates' do
-              total_stock_items = Spree::StockItem.count
-              expect { result }.to change {
-                stock_location.stock_items.count
-              }.from(total_stock_items).to(total_stock_items + 1)
-            end
-          end
-
-          context 'without stock items in the db' do
-            before do
-              # Delete all stock_location.stock_items to start counting from 0.
-              stock_location.stock_items.unscope(:where).delete_all
-            end
-
-            let(:created_stock_item) { stock_location.stock_items.order(:id).last }
-            let(:created_stock_item_attrs) do
-              created_stock_item.attributes.values_at(
-                'stock_location_id', 'variant_id', 'backorderable', 'created_at', 'updated_at'
-              )
-            end
-
-            it 'inserts the stock location stock items' do
-              expect { result }.to change { stock_location.stock_items.count }.from(0).to(4)
-            end
-
-            it 'sets the stock location data necessary for the inserted stock items' do
-              Timecop.freeze(time_current) do
-                result
-                expect(created_stock_item_attrs).to(
-                  eq([
-                       stock_location.id,
-                       unrelated_variant.id,
-                       stock_location.backorderable_default,
-                       time_current,
-                       time_current
-                     ])
-                )
-              end
-            end
-
-            it 'invalidates the Variant cache' do
-              expect(Spree::Variant).to receive(:touch_all).once
-              result
-            end
-          end
+        it 'does not insert stock items' do
+          expect(stock_location.stock_items).not_to receive(:insert_all)
+          result
         end
 
-        context 'without prepared stock items' do
-          before { Spree::Variant.destroy_all }
-
-          it 'does not insert stock items' do
-            expect(stock_location.stock_items).not_to receive(:insert_all)
-            result
-          end
-
-          it 'does not invalidates the Variant cache' do
-            expect(Spree::Variant).not_to receive(:touch_all)
-            result
-          end
+        it 'does not invalidates the Variant cache' do
+          expect(Spree::Variant).not_to receive(:touch_all)
+          result
         end
       end
     end


### PR DESCRIPTION
Some time ago we've dropped support for Rails < 6.1. 
There are still multiple checks in the codebase, that execute different logic for older version of Rails, or enable certain features only for Rails 6.1 and higher. We're safe to remove them now, as we can expect the users to be on at least Rails 6.1