### PR TITLE
Add missing translations

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1751,6 +1751,7 @@ en:
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To
+    translations: Translations
     tree: Tree
     type: Type
     type_to_search: Type to search

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1572,6 +1572,7 @@ en:
     starting_from: Starts at
     state: State
     state_based: State Based
+    state_changes: State Changes
     states: States
     state_machine_states:
       accepted: Accepted


### PR DESCRIPTION
### **What?**
Add missing translations

### **Why?**
In order not to introduce elaborate and unnecessary translation handlers in spree_backend.
See: [spree_backend#274](https://github.com/spree/spree_backend/pull/274/commits/5e923d8cd5da428652ea16fe5de0e358d3f63122)

### **How?**
Add missing translations