### PR TITLE
fix/Use keyword argument when passing a class to `serialize`

### DIFF
--- a/core/app/models/concerns/spree/metadata.rb
+++ b/core/app/models/concerns/spree/metadata.rb
@@ -5,8 +5,8 @@ module Spree
     included do
       attribute :public_metadata, default: {}
       attribute :private_metadata, default: {}
-      serialize :public_metadata, HashSerializer
-      serialize :private_metadata, HashSerializer
+      serialize :public_metadata, type: HashSerializer
+      serialize :private_metadata, type: HashSerializer
     end
 
     # https://nandovieira.com/using-postgresql-and-jsonb-with-ruby-on-rails

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -10,7 +10,7 @@ module Spree
       include Spree::Security::Addresses
     end
 
-    serialize :preferences, Hash, default: {}
+    serialize :preferences, type: Hash, default: {}
 
     NO_ZIPCODE_ISO_CODES ||= [
       'AO', 'AG', 'AW', 'BS', 'BZ', 'BJ', 'BM', 'BO', 'BW', 'BF', 'BI', 'CM', 'CF', 'KM', 'CG',

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -1,6 +1,6 @@
 class Spree::Base < ApplicationRecord
   include Spree::Preferences::Preferable
-  serialize :preferences, coder: Hash
+  serialize :preferences, type: Hash
 
   include Spree::RansackableAttributes
   include Spree::TranslatableResourceScopes

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -1,6 +1,6 @@
 class Spree::Base < ApplicationRecord
   include Spree::Preferences::Preferable
-  serialize :preferences, Hash
+  serialize :preferences, coder: Hash
 
   include Spree::RansackableAttributes
   include Spree::TranslatableResourceScopes


### PR DESCRIPTION
### **What?**
Adhere to newer way of invocating `serialize`.

### **Why?**
In Rails 7.2 it'll be deprecated.
[source](https://github.com/rails/rails/blob/v7.1.0.beta1/activerecord/lib/active_record/attribute_methods/serialization.rb#L183C14-L183C14)

### **How?**
Pass serialization class as a keyword argument.

It also has been suggested how to do it in the error message:

```
Please pass the class as a keyword argument:

  serialize :preferences, type: Hash
  ```
