### PR TITLE
Fix RAILS_VERSION parameter in the test pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
     BUNDLE_JOBS: 4
     BUNDLE_RETRY: 3
     BUNDLE_PATH: ~/spree/vendor/bundle
-    RAILS_VERSION: '~> 7.0'
+    RAILS_VERSION: '~> 7.0.0'
   working_directory: ~/spree
   docker:
     - image: &ruby_3_2_image cimg/ruby:3.2.0-browsers


### PR DESCRIPTION
The way it's currently set causes it to install 7.1 instead of 7.0, which is not the expected behavior. I've updated the version provided in the test pipeline to lock correctly to 7.0.x