### PR TITLE
Update serialize to work with Rails 7.1

### DIFF
--- a/core/app/models/concerns/spree/metadata.rb
+++ b/core/app/models/concerns/spree/metadata.rb
@@ -5,8 +5,13 @@ module Spree
     included do
       attribute :public_metadata, default: {}
       attribute :private_metadata, default: {}
-      serialize :public_metadata, HashSerializer
-      serialize :private_metadata, HashSerializer
+      if Rails::VERSION::STRING >= '7.1.0'
+        serialize :public_metadata, coder: HashSerializer
+        serialize :private_metadata, coder: HashSerializer
+      else
+        serialize :public_metadata, HashSerializer
+        serialize :private_metadata, HashSerializer
+      end
     end
 
     # https://nandovieira.com/using-postgresql-and-jsonb-with-ruby-on-rails

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -10,7 +10,11 @@ module Spree
       include Spree::Security::Addresses
     end
 
-    serialize :preferences, Hash, default: {}
+    if Rails::VERSION::STRING >= '7.1.0'
+      serialize :preferences, type: Hash, coder: YAML, default: {}
+    else
+      serialize :preferences, Hash, default: {}
+    end
 
     NO_ZIPCODE_ISO_CODES ||= [
       'AO', 'AG', 'AW', 'BS', 'BZ', 'BJ', 'BM', 'BO', 'BW', 'BF', 'BI', 'CM', 'CF', 'KM', 'CG',

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -1,6 +1,10 @@
 class Spree::Base < ApplicationRecord
   include Spree::Preferences::Preferable
-  serialize :preferences, Hash
+  if Rails::VERSION::STRING >= '7.1.0'
+    serialize :preferences, type: Hash, coder: YAML
+  else
+    serialize :preferences, Hash
+  end
 
   include Spree::RansackableAttributes
   include Spree::TranslatableResourceScopes

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -1,5 +1,9 @@
 class Spree::Preference < Spree::Base
-  serialize :value
+  if Rails::VERSION::STRING >= '7.1.0'
+    serialize :value, coder: YAML
+  else
+    serialize :value
+  end
 
   validates :key, presence: true,
                   uniqueness: { case_sensitive: false, allow_blank: true, scope: spree_base_uniqueness_scope }

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -62,7 +62,11 @@ module Spree
     scope :exchange_required, -> { eager_load(:exchange_inventory_units).where(spree_inventory_units: { original_return_item_id: nil }).distinct }
     scope :resellable, -> { where resellable: true }
 
-    serialize :acceptance_status_errors
+    if Rails::VERSION::STRING >= '7.1.0'
+      serialize :acceptance_status_errors, coder: YAML
+    else
+      serialize :acceptance_status_errors
+    end
 
     delegate :eligible_for_return?, :requires_manual_intervention?, to: :validator
     delegate :variant, to: :inventory_unit


### PR DESCRIPTION
Rails 7.1 made a breaking change to how `serialize :attribute` works - it now requires an explicit `coder` attribute (not supported previously via a named param), and also permits a `type` param.

I've updated the implementation to work with both approaches