### PR TITLE
Upgrade has_secure_token to work with Rails 7.1

### DIFF
--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -5,7 +5,12 @@ module Spree
         include Spree::VendorConcern
       end
 
-      has_secure_token :secret_key
+      if Rails::VERSION::STRING >= '7.1.0'
+        has_secure_token :secret_key, on: :save
+      else
+        has_secure_token :secret_key
+      end
+
 
       has_many :events, inverse_of: :subscriber
 

--- a/core/app/models/spree/digital_link.rb
+++ b/core/app/models/spree/digital_link.rb
@@ -1,6 +1,10 @@
 module Spree
   class DigitalLink < Spree::Base
-    has_secure_token
+    if Rails::VERSION::STRING >= '7.1.0'
+      has_secure_token on: :save
+    else
+      has_secure_token
+    end
 
     if defined?(Spree::Webhooks)
       include Spree::Webhooks::HasWebhooks

--- a/core/app/models/spree/wishlist.rb
+++ b/core/app/models/spree/wishlist.rb
@@ -5,7 +5,11 @@ module Spree
       include Spree::Webhooks::HasWebhooks
     end
 
-    has_secure_token
+    if Rails::VERSION::STRING >= '7.1.0'
+      has_secure_token on: :save
+    else
+      has_secure_token
+    end
 
     belongs_to :user, class_name: "::#{Spree.user_class}", touch: true
     belongs_to :store, class_name: 'Spree::Store'


### PR DESCRIPTION
Rails 7.1 changed the default behavior of `has_secure_token`, so we need to specify the moment when the token is generated manually. This PR introduces this change.