### PR TITLE
Fix caching specs to work with Rails 7.1

### DIFF
--- a/api/spec/requests/spree/api/v2/caching_spec.rb
+++ b/api/spec/requests/spree/api/v2/caching_spec.rb
@@ -29,7 +29,9 @@ describe 'API v2 Caching spec', type: :request do
     end
 
     def cache_entries
-      Rails.cache.redis.keys.find_all { |k| k.start_with?(cache_namespace) }
+      Rails.cache.redis.with do |redis|
+        redis.keys.find_all { |k| k.start_with?(cache_namespace) }
+      end
     end
 
     it 'caches collection' do


### PR DESCRIPTION
Rails 7.1 deprecated an old way of accessing redis cache directly. This PR updates the reference to the new interface.