### PR TITLE
Support Rails 7.1 in Ransack

### DIFF
--- a/core/lib/ransack/context_decorator.rb
+++ b/core/lib/ransack/context_decorator.rb
@@ -1,0 +1,25 @@
+require 'ransack'
+
+module Ransack
+  module Adapters
+    module ActiveRecord
+      module ContextDecorator
+        def type_for(attr)
+          return nil unless attr && attr.valid?
+          name         = attr.arel_attribute.name.to_s
+          # Patched
+          # Original implementation
+          # table        = attr.arel_attribute.relation.table_name
+          table        = attr.arel_attribute.relation.name
+          schema_cache = self.klass.connection.schema_cache
+          unless schema_cache.send(:data_source_exists?, table)
+            raise "No table named #{table} exists."
+          end
+          attr.klass.columns.find { |column| column.name == name }.type
+        end
+      end
+    end
+  end
+end
+
+Ransack::Adapters::ActiveRecord::Context.prepend(Ransack::Adapters::ActiveRecord::ContextDecorator)

--- a/core/lib/spree_core.rb
+++ b/core/lib/spree_core.rb
@@ -1,4 +1,7 @@
 require 'friendly_id/paranoia'
 require 'mobility/plugins/store_based_fallbacks'
+if Rails::VERSION::STRING >= '7.1.0'
+  require 'ransack/context_decorator'
+end
 
 require 'spree/core'


### PR DESCRIPTION
This PR introduces a patch to Ransack to support Rails 7.1.
I've created it a while ago when testing Spree's compatibility with Rails 7.1, but I see that Ransack has just released 4.1 with an out-of-the-box support for Rails 7.1. I will later create a PR that tries upgrading Ransack to that version and will check if it works fine with Spree.