### PR TITLE
Use dedicated deprecation class

### DIFF
--- a/api/app/controllers/concerns/spree/api/v2/storefront/order_concern.rb
+++ b/api/app/controllers/concerns/spree/api/v2/storefront/order_concern.rb
@@ -39,7 +39,7 @@ module Spree
           end
 
           def serialize_order(order)
-            ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            Spree::Deprecation.warn(<<-DEPRECATION, caller)
               `OrderConcern#serialize_order` is deprecated and will be removed in Spree 5.0.
               Please use `serializer_resource` method
             DEPRECATION

--- a/core/app/finders/spree/countries/find.rb
+++ b/core/app/finders/spree/countries/find.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def call
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           Spree::Countries::Find.new.call is deprecated and will be removed in Spree 5.0.
           Please use Spree::Countries::Find.new.execute instead
         DEPRECATION

--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -5,7 +5,7 @@ module Spree
         @scope = scope
 
         if current_currency.present?
-          ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+          Spree::Deprecation.warn(<<-DEPRECATION, caller)
             `current_currency` param is deprecated and will be removed in Spree 5.
             Please pass `:currency` in `params` hash instead.
           DEPRECATION

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -55,7 +55,7 @@ module Spree
     end
 
     def logo(image_path = nil, options = {})
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `BaseHelper#logo` is deprecated and will be removed in Spree 5.0.
         Please use `FrontendHelper#logo` instead
       DEPRECATION

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -76,7 +76,7 @@ module Spree
 
     # will return a human readable string
     def available_status(product)
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Spree::ProductsHelper#available_status` method from spree/core is deprecated and will be removed.
         Please use `Spree::Admin::ProductsHelper#available_status` from spree_backend instead.
       DEPRECATION
@@ -140,7 +140,7 @@ module Spree
     end
 
     def related_products
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         ProductsHelper#related_products is deprecated and will be removed in Spree 5.0.
         Please use ProductsHelper#relations from now on.
       DEPRECATION

--- a/core/app/models/concerns/spree/user_roles.rb
+++ b/core/app/models/concerns/spree/user_roles.rb
@@ -14,19 +14,19 @@ module Spree
       end
 
       def self.admin
-        ActiveSupport::Deprecation.warn('`User#admin` is deprecated and will be removed in Spree 5. Please use `User#spree_admin`')
+        Spree::Deprecation.warn('`User#admin` is deprecated and will be removed in Spree 5. Please use `User#spree_admin`')
 
         spree_admin
       end
 
       def self.admin_created?
-        ActiveSupport::Deprecation.warn('`User#admin_created?` is deprecated and will be removed in Spree 5. Please use `User#spree_admin_created?`')
+        Spree::Deprecation.warn('`User#admin_created?` is deprecated and will be removed in Spree 5. Please use `User#spree_admin_created?`')
 
         spree_admin_created?
       end
 
       def admin?
-        ActiveSupport::Deprecation.warn('`User#admin?` is deprecated and will be removed in Spree 5. Please use `User#spree_admin?`')
+        Spree::Deprecation.warn('`User#admin?` is deprecated and will be removed in Spree 5. Please use `User#spree_admin?`')
 
         spree_admin?
       end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -69,7 +69,7 @@ module Spree
     self.whitelisted_ransackable_associations = %w[country state user]
 
     def self.build_default
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Address#build_default` is deprecated and will be removed in Spree 5.0.
         Please use standard rails `Address.new(country: current_store.default_country)`
       DEPRECATION
@@ -77,7 +77,7 @@ module Spree
     end
 
     def self.default(user = nil, kind = 'bill')
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Address#default` is deprecated and will be removed in Spree 5.0.
       DEPRECATION
       if user && user_address = user.public_send(:"#{kind}_address")

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -19,7 +19,7 @@ module Spree
     validates :name, :iso_name, :iso, :iso3, presence: true, uniqueness: { case_sensitive: false, scope: spree_base_uniqueness_scope }
 
     def self.default(store = nil)
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Country#default` is deprecated and will be removed in Spree 5.0.
         Please use `current_store.default_country` instead
       DEPRECATION
@@ -49,7 +49,7 @@ module Spree
     private
 
     def ensure_not_default
-      ActiveSupport::Deprecation.warn('Country#ensure_not_default is deprecated and will be removed in Spree v5')
+      Spree::Deprecation.warn('Country#ensure_not_default is deprecated and will be removed in Spree v5')
 
       if id.eql?(Spree::Config[:default_country_id])
         errors.add(:base, Spree.t(:default_country_cannot_be_deleted))

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -415,7 +415,7 @@ module Spree
 
     def available_payment_methods(store = nil)
       if store.present?
-        ActiveSupport::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
+        Spree::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
       end
 
       @available_payment_methods ||= collect_payment_methods(store)
@@ -449,7 +449,7 @@ module Spree
     end
 
     def empty!
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Order#empty!` is deprecated and will be removed in Spree 5.0.
         Please use `Spree::Cart::Empty.call(order: order)` instead.
       DEPRECATION
@@ -647,7 +647,7 @@ module Spree
     end
 
     def validate_payments_attributes(attributes)
-      ActiveSupport::Deprecation.warn('`Order#validate_payments_attributes` is deprecated and will be removed in Spree 5')
+      Spree::Deprecation.warn('`Order#validate_payments_attributes` is deprecated and will be removed in Spree 5')
 
       # Ensure the payment methods specified are allowed for this user
       payment_method_ids = available_payment_methods.map(&:id).map(&:to_s)
@@ -745,7 +745,7 @@ module Spree
 
     def collect_payment_methods(store = nil)
       if store.present?
-        ActiveSupport::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
+        Spree::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
       end
       store ||= self.store
 

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -33,7 +33,7 @@ module Spree
     delegate :name, :presentation, to: :property, prefix: true, allow_nil: true
 
     def property_name=(name)
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `ProductProperty#property_name=` is deprecated and will be removed in Spree 5.0.
       DEPRECATION
       if name.present?

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -112,7 +112,7 @@ module Spree
     alias_attribute :contact_email, :customer_support_email
 
     def self.current(url = nil)
-      ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Spree::Store.current` is deprecated and will be removed in Spree 5.0
         Please use `Spree::Stores::FindCurrent.new(url: "https://example.com").execute` instead
       DEPRECATION
@@ -194,7 +194,7 @@ module Spree
     end
 
     def checkout_zone_or_default
-      ActiveSupport::Deprecation.warn('Store#checkout_zone_or_default is deprecated and will be removed in Spree 5')
+      Spree::Deprecation.warn('Store#checkout_zone_or_default is deprecated and will be removed in Spree 5')
 
       @checkout_zone_or_default ||= checkout_zone || Spree::Zone.default_checkout_zone
     end

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -74,7 +74,7 @@ module Spree
     end
 
     def self.default_checkout_zone
-      ActiveSupport::Deprecation.warn('Spree::Zone.default_checkout_zone is deprecated and will be removed in Spree 5')
+      Spree::Deprecation.warn('Spree::Zone.default_checkout_zone is deprecated and will be removed in Spree 5')
 
       first
     end

--- a/core/app/validators/db_maximum_length_validator.rb
+++ b/core/app/validators/db_maximum_length_validator.rb
@@ -2,7 +2,7 @@
 # Validates a field based on the maximum length of the underlying DB field, if there is one.
 class DbMaximumLengthValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+    Spree::Deprecation.warn(<<-DEPRECATION, caller)
       `DbMaximumLengthValidator` is deprecated and will be removed in Spree 5.0.
       Please remove any `db_maximum_length: true` validations from your codebase
     DEPRECATION

--- a/core/lib/spree/core/configuration.rb
+++ b/core/lib/spree/core/configuration.rb
@@ -76,7 +76,7 @@ module Spree
 
       # searcher_class allows spree extension writers to provide their own Search class
       def searcher_class
-        ActiveSupport::Deprecation.warn('`Spree::Config.searcher_class` is deprecated and will be removed in Spree v5, please use `Spree.searcher_class` instead.')
+        Spree::Deprecation.warn('`Spree::Config.searcher_class` is deprecated and will be removed in Spree v5, please use `Spree.searcher_class` instead.')
         @searcher_class ||= Spree.searcher_class
       end
 

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -75,7 +75,7 @@ module Spree
         # Override this method in your controllers if you want to have special behavior in case the user is not authorized
         # to access the requested action.  For example, a popup window might simply close itself.
         def redirect_unauthorized_access
-          ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+          Spree::Deprecation.warn(<<-DEPRECATION, caller)
             Core::ControllerHelpers#redirect_unauthorized_access is deprecated and will be removed in Spree 5.0.
             This method is implemented differently for Storefront and Admin
           DEPRECATION

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -17,7 +17,7 @@ module Spree
           attr_writer :title
 
           def title
-            ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            Spree::Deprecation.warn(<<-DEPRECATION, caller)
               ControllerHelpers::Common is deprecated and will be removed in Spree 5.0.
             DEPRECATION
             title_string = @title.present? ? @title : accurate_title
@@ -33,7 +33,7 @@ module Spree
           end
 
           def default_title
-            ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            Spree::Deprecation.warn(<<-DEPRECATION, caller)
               ControllerHelpers::Common is deprecated and will be removed in Spree 5.0.
             DEPRECATION
             current_store.name
@@ -41,7 +41,7 @@ module Spree
 
           # this is a hook for subclasses to provide title
           def accurate_title
-            ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            Spree::Deprecation.warn(<<-DEPRECATION, caller)
               ControllerHelpers::Common is deprecated and will be removed in Spree 5.0.
             DEPRECATION
             current_store.seo_title
@@ -50,7 +50,7 @@ module Spree
           private
 
           def set_user_language
-            ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            Spree::Deprecation.warn(<<-DEPRECATION, caller)
               ControllerHelpers::Common#set_user_language is deprecated and will be removed in Spree 5.0.
               Please use `before_action :set_locale` instead
             DEPRECATION
@@ -65,7 +65,7 @@ module Spree
           # Default layout is: +app/views/spree/layouts/spree_application+
           #
           def get_layout
-            ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+            Spree::Deprecation.warn(<<-DEPRECATION, caller)
               ControllerHelpers::Common is deprecated and will be removed in Spree 5.0.
             DEPRECATION
             return unless defined?(Spree::Frontend)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -27,6 +27,7 @@ module Spree
         app.config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal]
         Spree::Config = app.config.spree.preferences
         Spree::Dependencies = app.config.spree.dependencies
+        Spree::Deprecation = ActiveSupport::Deprecation.new
       end
 
       initializer 'spree.register.calculators', before: :after_initialize do |app|

--- a/core/lib/spree/core/preferences/preferable_class_methods.rb
+++ b/core/lib/spree/core/preferences/preferable_class_methods.rb
@@ -19,7 +19,7 @@ module Spree::Preferences
         value = convert_preference_value(value, type)
         preferences[name] = value
 
-        ActiveSupport::Deprecation.warn("`#{name}` is deprecated. #{deprecated}") if deprecated
+        Spree::Deprecation.warn("`#{name}` is deprecated. #{deprecated}") if deprecated
 
         # If this is an activerecord object, we need to inform
         # ActiveRecord::Dirty that this value has changed, since this is an

--- a/core/lib/spree/testing_support/controller_requests.rb
+++ b/core/lib/spree/testing_support/controller_requests.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def spree_get(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_get is deprecated and will be removed in Spree 5.0.
           Please use get, params: {}
         DEPRECATION
@@ -17,7 +17,7 @@ module Spree
 
       # Executes a request simulating POST HTTP method and set/volley the response
       def spree_post(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_post is deprecated and will be removed in Spree 5.0.
           Please use post, params: {}
         DEPRECATION
@@ -26,7 +26,7 @@ module Spree
 
       # Executes a request simulating PUT HTTP method and set/volley the response
       def spree_put(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_put is deprecated and will be removed in Spree 5.0.
           Please use put, params: {}
         DEPRECATION
@@ -35,7 +35,7 @@ module Spree
 
       # # Executes a request simulating PATCH HTTP method and set/volley the response
       def spree_patch(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_patch is deprecated and will be removed in Spree 5.0.
           Please use patch, params: {}
         DEPRECATION
@@ -44,7 +44,7 @@ module Spree
 
       # Executes a request simulating DELETE HTTP method and set/volley the response
       def spree_delete(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_delete is deprecated and will be removed in Spree 5.0.
           Please use delete, params: {}
         DEPRECATION
@@ -52,35 +52,35 @@ module Spree
       end
 
       def spree_xhr_get(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_xhr_get is deprecated and will be removed in Spree 5.0.
         DEPRECATION
         process_spree_xhr_action(action, parameters, session, flash, :get)
       end
 
       def spree_xhr_post(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_xhr_post is deprecated and will be removed in Spree 5.0.
         DEPRECATION
         process_spree_xhr_action(action, parameters, session, flash, :post)
       end
 
       def spree_xhr_put(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_xhr_put is deprecated and will be removed in Spree 5.0.
         DEPRECATION
         process_spree_xhr_action(action, parameters, session, flash, :put)
       end
 
       def spree_xhr_patch(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_xhr_patch is deprecated and will be removed in Spree 5.0.
         DEPRECATION
         process_spree_xhr_action(action, parameters, session, flash, :patch)
       end
 
       def spree_xhr_delete(action, parameters = nil, session = nil, flash = nil)
-        ActiveSupport::Deprecation.warn(<<-DEPRECATION, caller)
+        Spree::Deprecation.warn(<<-DEPRECATION, caller)
           ControllerRequests#spree_xhr_delete is deprecated and will be removed in Spree 5.0.
         DEPRECATION
         process_spree_xhr_action(action, parameters, session, flash, :delete)


### PR DESCRIPTION
Rails 7.1 added a deprecation notice against using `ActiveSupport::Deprecation.warn` - instead we should use our own instance of deprecator. This PR creates a deprecator that can be shared by Spree gems.