### PR TITLE
Pin Rails version to < 7.2

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_gem|
-    s.add_dependency rails_gem, '>= 6.1'
+    s.add_dependency rails_gem, '>= 6.1', '< 7.2'
   end
 
   s.add_dependency 'activemerchant', '~> 1.67'


### PR DESCRIPTION
This PR adds an explicit upper bound for Rails version.
Once Rails 7.2 is released, we'll review its breaking changes and either release a larger upgrade or a patch version that losens this lock.