### PR TITLE
Pin Rails version to < 7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
     BUNDLE_JOBS: 4
     BUNDLE_RETRY: 3
     BUNDLE_PATH: ~/spree/vendor/bundle
-    RAILS_VERSION: '~> 7.0'
+    RAILS_VERSION: '~> 7.0.0'
   working_directory: ~/spree
   docker:
     - image: &ruby_2_7_image circleci/ruby:2.7-node-browsers

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     actionpack actionview activejob activemodel activerecord
     activestorage activesupport railties
   ].each do |rails_gem|
-    s.add_dependency rails_gem, '>= 6.1'
+    s.add_dependency rails_gem, '>= 6.1', '< 7.1'
   end
 
   s.add_dependency 'activemerchant', '~> 1.67'


### PR DESCRIPTION
This PR adds an explicit upper bound for Rails version. We know that Spree 4.6 is not compatible with Rails 7.1 and requires changes from 4.7, so we should make it explicit.