### PR TITLE
Add runtime configuration class

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -141,3 +141,4 @@ require 'spree/core/controller_helpers/currency'
 
 require 'spree/core/preferences/store'
 require 'spree/core/preferences/scoped_store'
+require 'spree/core/preferences/runtime_configuration'

--- a/core/lib/spree/core/preferences/runtime_configuration.rb
+++ b/core/lib/spree/core/preferences/runtime_configuration.rb
@@ -1,0 +1,43 @@
+module Spree
+  module Preferences
+    class RuntimeConfiguration
+      def initialize
+        self.class.defaults.each do |key, value|
+          self[key] = value
+        end
+      end
+
+      def configure
+        yield(self) if block_given?
+      end
+
+      def get(preference)
+        send(preference)
+      end
+
+      alias [] get
+
+      def set(preference, value)
+        send("#{preference}=", value)
+      end
+
+      alias []= set
+
+      class << self
+        def preference(name, _type, default: nil, deprecated: false)
+          defaults[name] = default
+          deprecations[name] = deprecated
+          attr_accessor name
+        end
+
+        def defaults
+          @defaults ||= {}
+        end
+
+        def deprecations
+          @deprecations ||= {}
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/preferences/runtime_configuration_spec.rb
+++ b/core/spec/models/spree/preferences/runtime_configuration_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Spree::Preferences::RuntimeConfiguration, type: :model do
+  let(:test_class) do
+    Class.new(Spree::Preferences::RuntimeConfiguration) do
+      preference :admin_path, :string, default: '/admin'
+      preference :page_size, :integer
+    end
+  end
+
+  subject { test_class.new }
+
+  describe '#get' do
+    it 'returns default value if present' do
+      expect(subject.get(:admin_path)).to eq('/admin')
+    end
+
+    it 'returns nil if not present' do
+      expect(subject.get(:page_size)).to be_nil
+    end
+
+    it 'returns value via an attribute accessor' do
+      expect(subject.admin_path).to eq('/admin')
+    end
+
+    it 'returns value via a hash accessor' do
+      expect(subject[:admin_path]).to eq('/admin')
+    end
+  end
+
+  describe '#set' do
+    it 'overrides the default value' do
+      subject.set(:admin_path, '/secret_admin')
+      expect(subject.get(:admin_path)).to eq('/secret_admin')
+    end
+
+    it 'sets value if not set previously' do
+      subject.set(:page_size, 10)
+      expect(subject.get(:page_size)).to eq(10)
+    end
+
+    it 'sets the value via an attribute accessor' do
+      subject.page_size = 10
+      expect(subject.get(:page_size)).to eq(10)
+    end
+
+    it 'sets value via a hash accessor' do
+      subject[:page_size] = 10
+      expect(subject.get(:page_size)).to eq(10)
+    end
+  end
+end


### PR DESCRIPTION
Currently, `Spree::Config`, `Spree::Backend::Config` etc. use `Spree::Preferences::Configuration` class as a base. The problem with `Spree::Preferences::Configuration` is that it persists every preference in the database, so that they can be e.g. changed via the UI in the admin panel. 

This causes some major issues with the initialization process. As an example, `Spree::Backend` defines a preference called `admin_path` that's used to define the root for its routes. The value needs to be known at boot time, and cannot be dynamically changed. Similar case with `Spree::Auth::Devise`, where certain Devise features are enabled at boot time, based on configuration.

Because of that, we should introduce an additional type of Configuration - RuntimeConfiguration, that's not persisted and that should be only defined in an initializer. This will allow to run the configuration step before after_initialize, and will work regardless of whether the database connection is ready.

This PR implements a draft of such solution that could be later reused in other gems and extensions.