### PR TITLE
Remove unused alias_attribute raising deprecation message

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -109,8 +109,6 @@ module Spree
 
     after_commit :clear_cache
 
-    alias_attribute :contact_email, :customer_support_email
-
     def self.current(url = nil)
       Spree::Deprecation.warn(<<-DEPRECATION, caller)
         `Spree::Store.current` is deprecated and will be removed in Spree 5.0


### PR DESCRIPTION
I noticed a bunch of deprecation warnings come up when upgrading to `4.7`

<img width="1434" alt="Screenshot 2023-12-19 at 18 18 13" src="https://github.com/spree/spree/assets/6045239/1db08663-0ce7-43ee-acfc-2af141bb3760">

`contact_email` [was removed in a commit in 2021](https://github.com/spree/spree/commit/ac1830677c81f96694fc5c60df8d17d5a12afc5f) and was aliased at the time, I guess for backwards compatibility on existing stores (because I couldn't find any references to it on other spree gems).

This PR removes this alias since it will stop working in the next Rails minor/major release.