### PR TITLE
Bump active_storate_validations version

### DIFF
--- a/core/app/models/spree/store_favicon_image.rb
+++ b/core/app/models/spree/store_favicon_image.rb
@@ -10,8 +10,17 @@ module Spree
 
     validates :attachment,
               content_type: VALID_CONTENT_TYPES,
-              dimension: { max: 256..256 },
-              aspect_ratio: :square,
               size: { less_than_or_equal_to: 1.megabyte }
+
+    validates :attachment,
+              if: :is_png?,
+              dimension: { max: 256..256 },
+              aspect_ratio: :square
+
+    private
+
+    def is_png?
+      attachment.content_type.in?('image/png')
+    end
   end
 end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'stringex'
   s.add_dependency 'validates_zipcode'
   s.add_dependency 'image_processing', '~> 1.2'
-  s.add_dependency 'active_storage_validations', '~> 0.9', '<= 0.9.5'
+  s.add_dependency 'active_storage_validations', '~> 1.1.0'
   s.add_dependency 'activerecord-typedstore'
   s.add_dependency 'mobility', '~> 1.2.9'
   s.add_dependency 'mobility-ransack', '~> 1.2.1'


### PR DESCRIPTION
Unlocked active_storate_validations gem version. Also set Active Storage variant processor to MiniMagick by default, to avoid errors related to unsupported file extentions by ruby-vips (eg. ICO files).