### PR TITLE
Run tests with Ruby 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,10 @@ defaults: &defaults
       type: string
     restore_cache_key_1:
       type: string
-      default: 'spree-bundle-v10-ruby-3-2-{{ .Branch }}'
+      default: 'spree-bundle-v10-ruby-3-3-{{ .Branch }}'
     restore_cache_key_2:
       type: string
-      default: spree-bundle-v10-ruby-3-2
+      default: spree-bundle-v10-ruby-3-3
     save_cache_key:
       type: string
       default: "n"
@@ -128,7 +128,7 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Merge coverage reports
-          command: 
+          command:
               bundle check || bundle install &&
               bundle exec rake coverage:report
       - run:
@@ -137,62 +137,62 @@ jobs:
       - run:
           name:  Send test coverage
           command: bash << parameters.run_file_path >>
-          
+
 
 workflows:
   version: 2
   main:
     jobs:
       - run_test:
-          name: bundle_ruby_3_2
-          ruby_image: cimg/ruby:3.2.0-browsers
+          name: bundle_ruby_3_3
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           save_cache_key: spree-bundle-v10-ruby-3-1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           run_file_path: ./bin/bundle_ruby.sh
       - run_test:
           name: brakeman
-          ruby_image: cimg/ruby:3.2.0-browsers
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           restore_cache_key_1: spree-brakeman-{{ .Branch }}
           restore_cache_key_2: spree-brakeman
           save_cache_key: spree-brakeman-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           run_file_path: ./bin/brakeman.sh
           requires:
-              - bundle_ruby_3_2
+              - bundle_ruby_3_3
       - tests_postgres:
-          name: tests_ruby_3_2_rails_7_0_postgres
+          name: tests_ruby_3_3_rails_7_0_postgres
           rails_version: '~> 7.0.0'
-          ruby_image: cimg/ruby:3.2.0-browsers
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           postgres_image: circleci/postgres:12-alpine
           store_artefacts: true
           run_file_path: ./bin/tests_database_ci.sh
           requires:
-              - bundle_ruby_3_2
+              - bundle_ruby_3_3
       - tests_postgres:
-          name: tests_ruby_3_2_rails_7_1_postgres
+          name: tests_ruby_3_3_rails_7_1_postgres
           rails_version: '~> 7.1.0'
-          ruby_image: cimg/ruby:3.2.0-browsers
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           postgres_image: circleci/postgres:12-alpine
           store_artefacts: true
           run_file_path: ./bin/tests_database_ci.sh
           requires:
-              - bundle_ruby_3_2
+              - bundle_ruby_3_3
       - tests_postgres:
-          name: tests_ruby_3_2_rails_6_1_postgres
+          name: tests_ruby_3_3_rails_6_1_postgres
           rails_version: '~> 6.1.0'
-          ruby_image: cimg/ruby:3.2.0-browsers
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           postgres_image: circleci/postgres:12-alpine
           store_artefacts: true
           run_file_path: ./bin/tests_database_ci.sh
           requires:
-              - bundle_ruby_3_2
+              - bundle_ruby_3_3
       - tests_mysql:
-          name: tests_ruby_3_2_rails_7_0_mysql
+          name: tests_ruby_3_3_rails_7_0_mysql
           rails_version: '~> 7.0.0'
-          ruby_image: cimg/ruby:3.2.0-browsers
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           mysql_image: circleci/mysql:8-ram
           store_artefacts: true
@@ -201,15 +201,15 @@ workflows:
               - persist_to_workspace:
                   root: /tmp/workspace
                   paths:
-                    - simplecov  
+                    - simplecov
           requires:
-              - bundle_ruby_3_2
+              - bundle_ruby_3_3
       - send_test_coverage:
           name: send_test_coverage
           rails_version: '~> 7.0.0'
-          ruby_image: cimg/ruby:3.2.0-browsers
+          ruby_image: cimg/ruby:3.3.0-browsers
           redis_image: circleci/redis:6.2-alpine
           run_file_path: ./bin/tests_coverage.sh
           requires:
-              - tests_ruby_3_2_rails_7_0_mysql    
+              - tests_ruby_3_3_rails_7_0_mysql
 


### PR DESCRIPTION
Ruby 3.3 was [recently released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/), so we should make sure Spree is compatible with it