### PR TITLE
Fix translation_table_alias to be valid for locales with a dash (e.g.…

### DIFF
--- a/core/app/models/concerns/spree/translatable_resource.rb
+++ b/core/app/models/concerns/spree/translatable_resource.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def translation_table_alias
-        "#{self::Translation.table_name}_#{Mobility.locale}"
+        "#{self::Translation.table_name}_#{Mobility.locale.to_s.underscore}"
       end
     end
   end


### PR DESCRIPTION
… en-US)

At the moment, it generates an invalid query for "en-US" or "sl-SI", because - is not a valid character for a table alias (at least in psql).