### PR TITLE
Directly use Mobility's locale normalization method

### DIFF
--- a/core/app/models/concerns/spree/translatable_resource.rb
+++ b/core/app/models/concerns/spree/translatable_resource.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def translation_table_alias
-        "#{self::Translation.table_name}_#{Mobility.locale.to_s.underscore}"
+        "#{self::Translation.table_name}_#{Mobility.normalize_locale(Mobility.locale)}"
       end
     end
   end


### PR DESCRIPTION
@rafalcymerys sorry for the quick update, but this should be better and more compatible, as used by mobility:
https://github.com/shioyama/mobility/blob/master/lib/mobility/backends/table.rb#L126

I would prefer to even use the `table_alias` method directly but I haven't found a nice way of getting to the backend class, so this is the next best thing.