### PR TITLE
Add basic search by property range

### DIFF
--- a/core/app/finders/spree/products/find.rb
+++ b/core/app/finders/spree/products/find.rb
@@ -182,6 +182,14 @@ module Spree
         properties.to_unsafe_hash.each do |property_filter_param, product_properties_values|
           next if property_filter_param.blank? || product_properties_values.empty?
 
+          if product_properties_values =~ /^\(.*\)$/
+            from, to = product_properties_values.tr('()', '').split(',')
+            ids = scope.unscope(:order, :includes).with_property_range(property_filter_param, from&.to_f, to&.to_f).ids
+            product_ids = index == 0 ? ids : product_ids & ids
+            index += 1
+            next
+          end
+
           values = product_properties_values.split(',').reject(&:empty?).uniq.map(&:parameterize)
 
           next if values.empty?
@@ -190,7 +198,6 @@ module Spree
           product_ids = index == 0 ? ids : product_ids & ids
           index += 1
         end
-
         products.where(id: product_ids)
       end
 

--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -140,15 +140,14 @@ module Spree
           where(property_conditions(property))
       end
 
-      # Spree::Product.with_property_range(17, 10, 40)
       add_search_scope :with_property_range do |property, from, to|
-        product_property = ProductProperty.translation_table_alias
+        table = ProductProperty.translation_table_alias
         query = joins(:properties).
           join_translation_table(Property).
           join_translation_table(ProductProperty).
           where(property_conditions(property))
-        query = query.where("#{product_property}.value::float >= ?", from) if from.present?
-        query = query.where("#{product_property}.value::float <= ?", to) if to.present?
+        query = query.where(sanitize_sql(["#{table}.value::float >= ?", from])) if from.present?
+        query = query.where(sanitize_sql(["#{table}.value::float <= ?", to])) if to.present?
         query
       end
 

--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -140,6 +140,18 @@ module Spree
           where(property_conditions(property))
       end
 
+      # Spree::Product.with_property_range(17, 10, 40)
+      add_search_scope :with_property_range do |property, from, to|
+        product_property = ProductProperty.translation_table_alias
+        query = joins(:properties).
+          join_translation_table(Property).
+          join_translation_table(ProductProperty).
+          where(property_conditions(property))
+        query = query.where("#{product_property}.value::float >= ?", from) if from.present?
+        query = query.where("#{product_property}.value::float <= ?", to) if to.present?
+        query
+      end
+
       add_search_scope :with_property_values do |property_filter_param, property_values|
         joins(product_properties: :property).
           join_translation_table(Property).

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -24,5 +24,11 @@ FactoryBot.define do
       presentation { 'Material' }
       filter_param { 'material' }
     end
+
+    trait :length do
+      name         { 'length' }
+      presentation { 'Length' }
+      filter_param { 'length' }
+    end
   end
 end

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -433,15 +433,6 @@ module Spree
         )
       end
 
-      let!(:product_4) do
-        create(
-          :product,
-          product_properties: [
-            create(:product_property, property: length, value: '120.5')
-          ]
-        )
-      end
-
       before do
         create(:product, product_properties: [create(:product_property, property: manufacturer, value: 'Jerseys')])
         create(:product, product_properties: [create(:product_property, property: material, value: '100% Cotton')])
@@ -456,10 +447,63 @@ module Spree
       end
 
       context 'when filtering by range Property' do
-        let(:properties_param) { { length: '(100,150)' } }
+        let!(:product_within_range) do
+          create(
+            :product,
+            product_properties: [
+              create(:product_property, property: length, value: '120.5')
+            ]
+          )
+        end
 
-        it 'finds Products matching any of Property values' do
-          expect(products).to contain_exactly(product_4)
+        let!(:product_below_range) do
+          create(
+            :product,
+            product_properties: [
+              create(:product_property, property: length, value: '99.9999')
+            ]
+          )
+        end
+
+        let!(:product_above_range) do
+          create(
+            :product,
+            product_properties: [
+              create(:product_property, property: length, value: '150.0001')
+            ]
+          )
+        end
+
+        context "when 'from' and 'to' values are present" do
+          let(:properties_param) { { length: '(100,150)' } }
+
+          it 'finds Products with Property in range' do
+            expect(products).to contain_exactly(product_within_range)
+          end
+        end
+
+        context "when only 'from' value is present" do
+          let(:properties_param) { { length: '(100,)' } }
+
+          it 'finds Products with Property in range' do
+            expect(products).to contain_exactly(product_within_range, product_above_range)
+          end
+        end
+
+        context "when only 'to' value is present" do
+          let(:properties_param) { { length: '(,150)' } }
+
+          it 'finds Products with Property in range' do
+            expect(products).to contain_exactly(product_below_range, product_within_range)
+          end
+        end
+
+        context "when neither 'from' and 'to' values are present" do
+          let(:properties_param) { { length: '(,)' } }
+
+          it 'finds Products with Property in range' do
+            expect(products).to contain_exactly(product_below_range, product_within_range, product_above_range)
+          end
         end
       end
 

--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -402,6 +402,7 @@ module Spree
       let(:brand) { create(:property, :brand) }
       let(:manufacturer) { create(:property, :manufacturer) }
       let(:material) { create(:property, :material) }
+      let(:length) { create(:property, :length) }
 
       let!(:product_1) do
         create(
@@ -432,6 +433,15 @@ module Spree
         )
       end
 
+      let!(:product_4) do
+        create(
+          :product,
+          product_properties: [
+            create(:product_property, property: length, value: '120.5')
+          ]
+        )
+      end
+
       before do
         create(:product, product_properties: [create(:product_property, property: manufacturer, value: 'Jerseys')])
         create(:product, product_properties: [create(:product_property, property: material, value: '100% Cotton')])
@@ -442,6 +452,14 @@ module Spree
 
         it 'finds Products matching any of Property values' do
           expect(products).to contain_exactly(product_1, product_2, product_3)
+        end
+      end
+
+      context 'when filtering by range Property' do
+        let(:properties_param) { { length: '(100,150)' } }
+
+        it 'finds Products matching any of Property values' do
+          expect(products).to contain_exactly(product_4)
         end
       end
 

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -173,6 +173,52 @@ describe 'Product scopes', type: :model do
       end
     end
 
+    context 'with_property_range' do
+      let(:name) { property.name }
+      let(:value) { '36.6' }
+
+      let(:product_property) { create(:product_property, property: property, value: value) }
+      let(:property) { create(:property, :brand) }
+
+      subject(:with_property_range) { Spree::Product.method(:with_property_range) }
+
+      it "finds by a property's name" do
+        expect(with_property_range.call(name, 0, 100).count).to eq(1)
+      end
+
+      it "cannot find by an unknown property's name" do
+        expect(with_property_range.call('fake', 0, 100).count).to eq(0)
+      end
+
+      it 'cannot find with a name outside the range (lower value)' do
+        expect(with_property_range.call(name, 40, 100).count).to eq(0)
+      end
+
+      it 'cannot find with a name outside the range (higher value)' do
+        expect(with_property_range.call(name, 0, 36).count).to eq(0)
+      end
+
+      it 'finds by a property' do
+        expect(with_property_range.call(property, 0, 100).count).to eq(1)
+      end
+
+      it 'finds by an id with a value' do
+        expect(with_property_range.call(property.id, 0, 100).count).to eq(1)
+      end
+
+      it 'cannot find with an invalid id' do
+        expect(with_property_range.call(0, 0, 100).count).to eq(0)
+      end
+
+      it 'finds by and id with value only if beginning of range is given' do
+        expect(with_property_range.call(property.id, 0, nil).count).to eq(1)
+      end
+
+      it 'finds by and id with value only if end of range is given' do
+        expect(with_property_range.call(property.id, nil, 100).count).to eq(1)
+      end
+    end
+
     context 'with_property_values' do
       subject(:with_property_values) { Spree::Product.method(:with_property_values) }
 


### PR DESCRIPTION
Allows to filter by property (float, integer) range. Pass `(range_start,range_finish)` as parameter or omit one: `(,range_finish)` or `(range_start,)`. Casts values to float and searches using `>=` and `<=`.