### PR TITLE
Bulk promo codes improvements

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -30,6 +30,7 @@ module Spree
     has_many :stores, class_name: 'Spree::Store', through: :store_promotions
 
     has_many :promotion_batches, foreign_key: 'template_promotion_id'
+    has_many :promotions_from_template, through: :promotion_batches, class_name: 'Spree::Promotion', source: :promotions
 
     accepts_nested_attributes_for :promotion_actions, :promotion_rules
 
@@ -51,8 +52,10 @@ module Spree
       SQL
     }
     scope :templates, -> { where(template: true) }
+    scope :for_template_promotion_id, ->(id) { joins(:promotion_batch).where(promotion_batch: { template_promotion_id: id }) }
 
-    self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id', 'code']
+    self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id', 'promotion_batch_id', 'code']
+    self.whitelisted_ransackable_scopes = ['for_template_promotion_id']
 
     def self.with_coupon_code(coupon_code)
       where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase).

--- a/core/app/models/spree/promotion_handler/promotion_batch_duplicator.rb
+++ b/core/app/models/spree/promotion_handler/promotion_batch_duplicator.rb
@@ -14,6 +14,7 @@ module Spree
         new_promotion.path = "#{@promotion.path}_#{@code}"
         new_promotion.code = @code
         new_promotion.stores = @promotion.stores
+        new_promotion.template = false
 
         ActiveRecord::Base.transaction do
           new_promotion.save

--- a/core/app/services/spree/promotion_batches/generate_code.rb
+++ b/core/app/services/spree/promotion_batches/generate_code.rb
@@ -8,7 +8,7 @@ module Spree
       def call(random_characters:, prefix: nil, suffix: nil)
         [
           prefix,
-          @random.hex(random_characters),
+          @random.hex(random_characters).upcase,
           suffix
         ].join('')
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1743,8 +1743,7 @@ en:
     taxonomy_tree_error: The requested change has not been accepted and the tree has been returned to its previous state, please try again.
     taxonomy_tree_instruction: ! '* Right click (or double tap on iOS device) a child in the tree to access the menu for adding, deleting or sorting a child.'
     taxons: Taxons
-    template_not_found: Template promotion - not found! Assign a template before populating a batch.
-    template_promotion_already_assigned: Template promotion has already been assigned!
+    template_promotions: Template Promotions
     test: Test
     test_mailer:
       test_email:

--- a/core/spec/models/spree/promotion_handler/promotion_batch_duplicator_spec.rb
+++ b/core/spec/models/spree/promotion_handler/promotion_batch_duplicator_spec.rb
@@ -18,6 +18,7 @@ describe Spree::PromotionHandler::PromotionBatchDuplicator do
            code: 'test1',
            advertise: true,
            path: 'test1',
+           template: true,
            promotion_category: promo_category,
            stores: [store, store_2])
   end
@@ -31,7 +32,7 @@ describe Spree::PromotionHandler::PromotionBatchDuplicator do
     let(:promotion_batch) { create(:promotion_batch) }
 
     context 'model fields' do
-      let(:excluded_fields) { ['code', 'path', 'id', 'created_at', 'updated_at', 'deleted_at', 'promotion_batch_id', 'usage_limit'] }
+      let(:excluded_fields) { ['code', 'path', 'id', 'created_at', 'updated_at', 'deleted_at', 'promotion_batch_id', 'usage_limit', 'template'] }
 
       context "when code is provided" do
         subject { described_class.new(promotion, promotion_batch.id, code: provided_code) }
@@ -56,6 +57,10 @@ describe Spree::PromotionHandler::PromotionBatchDuplicator do
 
       it 'associates the duplicated promotion with a batch' do
         expect(new_promotion.promotion_batch_id).to match promotion_batch.id
+      end
+
+      it 'returns a duplicate promotion with template set to false' do
+        expect(new_promotion.template?).to be_falsey
       end
     end
 

--- a/core/spec/services/spree/promotion_batches/generate_code_spec.rb
+++ b/core/spec/services/spree/promotion_batches/generate_code_spec.rb
@@ -10,11 +10,11 @@ module Spree
     let(:suffix) { nil }
 
     before do
-      allow(random_double).to receive(:hex).with(random_characters).and_return('CODE')
+      allow(random_double).to receive(:hex).with(random_characters).and_return('code')
     end
 
     context 'when no prefix or suffix is set' do
-      it 'returns randomly generated code' do
+      it 'returns randomly generated code in uppercase' do
         expect(subject).to eq('CODE')
       end
     end


### PR DESCRIPTION
- Use uppercase letters when generating promo codes
- Clone template promotion without template flag
- Add additional scopes and translation keys