### PR TITLE
Skip args sanitizing for :for_template_promotion_id scope

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -56,6 +56,9 @@ module Spree
 
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id', 'promotion_batch_id', 'code']
     self.whitelisted_ransackable_scopes = ['for_template_promotion_id']
+    def self.ransackable_scopes_skip_sanitize_args
+      [:for_template_promotion_id]
+    end
 
     def self.with_coupon_code(coupon_code)
       where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase).


### PR DESCRIPTION
The fix is related to [this issue](https://github.com/activerecord-hackery/ransack/issues/1232).

Ransack scope functions by default convert values that are included in those sets to pertinent boolean values:
```ruby
    TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE'].to_set
    FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE'].to_set
```
This is undesirable since integer 1 is correct value for `:for_template_promotion_id` and should be treated as such.

Setting `self.ransackable_scopes_skip_sanitize_args` prevents this conversion. It affects only `true/false` values conversion.