### PR TITLE
Fixed Spree CDN on localhost

### DIFF
--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -2,6 +2,10 @@
 # see: https://github.com/rails/rails/issues/34872
 Rails.application.routes.draw do
   direct :cdn_image do |model, options|
+    host = Spree.cdn_host || Rails.application.routes.default_url_options[:host] || 'localhost'
+    port = Rails.application.routes.default_url_options[:port]
+    port ||= 3000 if Rails.env.development?
+
     if model.blob.service_name == 'cloudinary' && defined?(Cloudinary)
       if model.class.method_defined?(:has_mvariation)
         Cloudinary::Utils.cloudinary_url(model.blob.key,
@@ -17,10 +21,7 @@ Rails.application.routes.draw do
         :rails_service_blob_proxy,
         model.signed_id,
         model.filename,
-        options.merge(
-          host: Spree.cdn_host || Rails.application.routes.default_url_options[:host],
-          port: Rails.application.routes.default_url_options[:port]
-        )
+        options.merge(host: host, port: port)
       )
     else
       signed_blob_id = model.blob.signed_id
@@ -32,10 +33,7 @@ Rails.application.routes.draw do
         signed_blob_id,
         variation_key,
         filename,
-        options.merge(
-          host: Spree.cdn_host || Rails.application.routes.default_url_options[:host],
-          port: Rails.application.routes.default_url_options[:port]
-        )
+        options.merge(host: host, port: port)
       )
     end
   end


### PR DESCRIPTION
Fallbacks to localhost:3000 to serve images via Spree CDN