### PR TITLE
Fix coupon codes with some chars can't be removed from cart

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -14,7 +14,7 @@ Spree::Core::Engine.add_routes do
           delete 'remove_line_item/:line_item_id', to: 'cart#remove_line_item', as: :cart_remove_line_item
           patch  :set_quantity
           patch  :apply_coupon_code
-          delete 'remove_coupon_code/:coupon_code', to: 'cart#remove_coupon_code', as: :cart_remove_coupon_code
+          delete 'remove_coupon_code/:coupon_code', to: 'cart#remove_coupon_code', as: :cart_remove_coupon_code, constraints: { coupon_code: /[^\/]+/ }
           delete 'remove_coupon_code', to: 'cart#remove_coupon_code', as: :cart_remove_coupon_code_without_code
           get :estimate_shipping_rates
           patch :associate


### PR DESCRIPTION
See: https://github.com/spree/spree_rails_frontend/issues/76