### PR TITLE
Use `RequestStore` to store whether webhooks are disabled

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -74,7 +74,7 @@ module Spree
       end
 
       def disable_spree_webhooks?
-        ENV['DISABLE_SPREE_WEBHOOKS'] == 'true'
+        Spree::Webhooks.disabled?
       end
 
       def webhooks_request_options

--- a/api/lib/spree/api/testing_support/matchers/webhooks.rb
+++ b/api/lib/spree/api/testing_support/matchers/webhooks.rb
@@ -61,7 +61,7 @@ RSpec::Matchers.define :emit_webhook_event do |event_to_emit|
 end
 
 def with_webhooks_enabled
-  ENV['DISABLE_SPREE_WEBHOOKS'] = nil
+  Spree::Webhooks.disabled = false
   yield
-  ENV['DISABLE_SPREE_WEBHOOKS'] = 'true'
+  Spree::Webhooks.disabled = true
 end

--- a/api/lib/spree/api/testing_support/spree_webhooks.rb
+++ b/api/lib/spree/api/testing_support/spree_webhooks.rb
@@ -1,9 +1,9 @@
 RSpec.configure do |config|
   config.before(:each, :spree_webhooks) do
-    ENV['DISABLE_SPREE_WEBHOOKS'] = nil
+    Spree::Webhooks.disabled = false
   end
 
   config.after(:each, :spree_webhooks) do
-    ENV['DISABLE_SPREE_WEBHOOKS'] = 'true'
+    Spree::Webhooks.disabled = true
   end
 end

--- a/api/spec/services/spree/webhooks_spec.rb
+++ b/api/spec/services/spree/webhooks_spec.rb
@@ -21,12 +21,12 @@ describe Spree::Webhooks do
     after { Spree::Webhooks.disabled = true }
 
     describe 'the value of spree_webhooks_disabled request variable' do
-      before { RequestStore.store[:disable_spree_webhooks] = 'some_value' }
+      before { RequestStore.store[:disable_spree_webhooks] = false }
 
       describe 'when an error is not raised' do
         it 'sets it to the original value' do
           described_class.disable_webhooks { variant.discontinue! }
-          expect(RequestStore.store[:disable_spree_webhooks]).to eq('some_value')
+          expect(RequestStore.store[:disable_spree_webhooks]).to eq(false)
         end
       end
 
@@ -36,7 +36,7 @@ describe Spree::Webhooks do
             described_class.disable_webhooks { raise StandardError }
           rescue StandardError
           end
-          expect(RequestStore.store[:disable_spree_webhooks]).to eq('some_value')
+          expect(RequestStore.store[:disable_spree_webhooks]).to eq(false)
         end
       end
     end

--- a/api/spec/services/spree/webhooks_spec.rb
+++ b/api/spec/services/spree/webhooks_spec.rb
@@ -18,15 +18,15 @@ describe Spree::Webhooks do
       allow(queue_requests).to receive(:call).with(any_args)
     end
 
-    after { ENV['DISABLE_SPREE_WEBHOOKS'] = 'true' }
+    after { Spree::Webhooks.disabled = true }
 
-    describe 'the value of DISABLE_SPREE_WEBHOOKS environment variable' do
-      before { ENV['DISABLE_SPREE_WEBHOOKS'] = 'some_value' }
+    describe 'the value of spree_webhooks_disabled request variable' do
+      before { RequestStore.store[:disable_spree_webhooks] = 'some_value' }
 
       describe 'when an error is not raised' do
         it 'sets it to the original value' do
           described_class.disable_webhooks { variant.discontinue! }
-          expect(ENV['DISABLE_SPREE_WEBHOOKS']).to eq('some_value')
+          expect(RequestStore.store[:disable_spree_webhooks]).to eq('some_value')
         end
       end
 
@@ -36,13 +36,13 @@ describe Spree::Webhooks do
             described_class.disable_webhooks { raise StandardError }
           rescue StandardError
           end
-          expect(ENV['DISABLE_SPREE_WEBHOOKS']).to eq('some_value')
+          expect(RequestStore.store[:disable_spree_webhooks]).to eq('some_value')
         end
       end
     end
 
     describe 'when webhooks are already disabled' do
-      before { ENV['DISABLE_SPREE_WEBHOOKS'] = 'true' }
+      before { Spree::Webhooks.disabled = true }
 
       it 'does not emit the event' do
         described_class.disable_webhooks { variant.discontinue! }
@@ -51,6 +51,8 @@ describe Spree::Webhooks do
     end
 
     describe 'when webhooks are enabled' do
+      before { Spree::Webhooks.disabled = false }
+
       describe 'when not using #disable_webhooks' do
         it 'emits the event' do
           expect do

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -77,7 +77,7 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::ImageHelpers
 
   config.before do
-    ENV['DISABLE_SPREE_WEBHOOKS'] = 'true'
+    Spree::Webhooks.disabled = true
 
     Rails.cache.clear
     reset_spree_preferences

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -27,6 +27,7 @@ platforms :ruby do
 end
 
 gem 'sprockets-rails', '>= 2.0.0'
+gem 'request_store', '~> 1.7.0'
 
 group :test do
   gem 'capybara'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -27,7 +27,6 @@ platforms :ruby do
 end
 
 gem 'sprockets-rails', '>= 2.0.0'
-gem 'request_store', '~> 1.7.0'
 
 group :test do
   gem 'capybara'

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -19,6 +19,7 @@ require 'ransack'
 require 'state_machines-activerecord'
 require 'active_storage_validations'
 require 'activerecord-typedstore'
+require 'request_store'
 
 # This is required because ActiveModel::Validations#invalid? conflicts with the
 # invalid state of a Payment. In the future this should be removed.

--- a/core/lib/spree/core/webhooks.rb
+++ b/core/lib/spree/core/webhooks.rb
@@ -1,13 +1,21 @@
 module Spree
   module Webhooks
     def self.disable_webhooks
-      webhooks_disabled_previously = ENV['DISABLE_SPREE_WEBHOOKS']
-      begin
-        ENV['DISABLE_SPREE_WEBHOOKS'] = 'true'
-        yield
-      ensure
-        ENV['DISABLE_SPREE_WEBHOOKS'] = webhooks_disabled_previously
-      end
+      prev_value = disabled?
+      RequestStore.store[:disable_spree_webhooks] = true
+      yield
+    ensure
+      RequestStore.store[:disable_spree_webhooks] = prev_value
+    end
+
+    def self.disabled?
+      # rubocop:disable Style/RedundantFetchBlock
+      RequestStore.fetch(:disable_spree_webhooks) { false }
+      # rubocop:enable Style/RedundantFetchBlock
+    end
+
+    def self.disabled=(value)
+      RequestStore.store[:disable_spree_webhooks] = value
     end
   end
 end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -57,5 +57,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'mobility', '~> 1.2'
   s.add_dependency 'mobility-ransack', '~> 1.2'
   s.add_dependency 'friendly_id-mobility', '~> 1.0'
-  s.add_dependency 'request_store', '~> 1.7.0'
+  s.add_dependency 'request_store', '~> 1.7'
 end

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -57,4 +57,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'mobility', '~> 1.2'
   s.add_dependency 'mobility-ransack', '~> 1.2'
   s.add_dependency 'friendly_id-mobility', '~> 1.0'
+  s.add_dependency 'request_store', '~> 1.7.0'
 end


### PR DESCRIPTION
`RequestStore` is a thread-safe storage, which is better suited than `ENV` to keep the information whether webhooks are disabled