### PR TITLE
Fixed setting SSL for webhooks based on the URL and not the environment

### DIFF
--- a/api/app/services/spree/webhooks/subscribers/make_request.rb
+++ b/api/app/services/spree/webhooks/subscribers/make_request.rb
@@ -45,7 +45,7 @@ module Spree
         def http
           http = Net::HTTP.new(uri_host, uri_port)
           http.read_timeout = webhooks_timeout.to_i if custom_read_timeout?
-          http.use_ssl = true if use_ssl?
+          http.use_ssl = use_ssl?
           http
         end
 
@@ -71,7 +71,7 @@ module Spree
         end
 
         def use_ssl?
-          !(Rails.env.development? || Rails.env.test?)
+          uri.scheme == 'https'
         end
 
         def uri

--- a/api/spec/services/spree/webhooks/subscribers/make_request_spec.rb
+++ b/api/spec/services/spree/webhooks/subscribers/make_request_spec.rb
@@ -5,6 +5,8 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
   let(:url) { 'http://google.com/' }
   let(:webhook_payload_body) { { data: [{}] }.to_json }
   let(:signature) { 'some-signature-of-data' }
+  let(:uri) { URI(url) }
+  let(:http) { Net::HTTP.new(uri.host, uri.port) }
 
   describe '#execution_time' do
     subject { described_class.new(webhook_payload_body: webhook_payload_body, url: url, signature: signature).execution_time }
@@ -27,6 +29,7 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
     context 'when request raises an exception' do
       before do
         allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=).with(false)
         allow(http_double).to receive(:request) { raise Errno::ECONNREFUSED }
       end
 
@@ -42,87 +45,12 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
     before { stub_request(:post, url) }
 
     let(:headers) { { 'Content-Type' => 'application/json' } }
-    let(:http) { Net::HTTP.new(uri.host, uri.port) }
-    let(:uri) { URI(url) }
-
-    describe 'ssl usage' do
-      shared_examples 'makes the request without setting use_ssl' do
-        it 'does not set use_ssl' do
-          allow(Net::HTTP).to receive(:new).with(uri.host, uri.port).and_return(http)
-          expect(http).not_to receive(:use_ssl=)
-          subject
-        end
-
-        it 'makes a post HTTP request to the given url and webhook_payload_body' do
-          subject
-          expect(WebMock).to have_requested(:post, url).with(body: webhook_payload_body, headers: headers).once
-        end
-      end
-
-      context 'with development environment' do
-        before { allow(Rails).to receive_message_chain(:env, :development?).and_return(true) }
-
-        include_examples 'makes the request without setting use_ssl'
-      end
-
-      context 'with test environment' do
-        include_examples 'makes the request without setting use_ssl'
-      end
-
-      context 'without test and/or development environment' do
-        before do
-          allow(Rails).to receive_message_chain(:env, :development?).and_return(false)
-          allow(Rails).to receive_message_chain(:env, :test?).and_return(false)
-        end
-
-        let(:url) { 'http://google.com/' }
-
-        it 'sets use_ssl' do
-          allow(Net::HTTP).to receive(:new).and_return(http)
-          expect(http).to receive(:use_ssl=).with(true)
-          subject
-        end
-
-        it 'makes a post HTTP request to the given url and webhook_payload_body' do
-          allow(Net::HTTP).to receive(:new).and_return(http)
-          allow(http).to receive(:use_ssl=).with(true)
-          subject
-          expect(WebMock).to have_requested(:post, url).with(body: webhook_payload_body, headers: headers).once
-        end
-      end
-    end
-
-    describe 'setting read_timeout with SPREE_WEBHOOKS_TIMEOUT' do
-      context 'without SPREE_WEBHOOKS_TIMEOUT' do
-        before { ENV['SPREE_WEBHOOKS_TIMEOUT'] = nil }
-
-        it 'does not set Net::HTTP#read_timeout=' do
-          expect(http).not_to receive(:read_timeout=)
-          subject
-        end
-      end
-
-      context 'with SPREE_WEBHOOKS_TIMEOUT' do
-        before do
-          ENV['SPREE_WEBHOOKS_TIMEOUT'] = spree_webhooks_timeout.to_s
-          allow(Net::HTTP).to receive(:new).with(uri.host, uri.port).and_return(http)
-        end
-
-        after { ENV['SPREE_WEBHOOKS_TIMEOUT'] = nil }
-
-        let(:spree_webhooks_timeout) { 15 } # time in seconds
-
-        it 'sets Net::HTTP#read_timeout= to the integer value of SPREE_WEBHOOKS_TIMEOUT' do
-          expect(http).to receive(:read_timeout=).with(spree_webhooks_timeout)
-          subject
-        end
-      end
-    end
 
     describe 'rescuing from known exceptions' do
       shared_examples 'rescues from' do |exception|
         before do
           allow(Net::HTTP).to receive(:new).and_return(http_double)
+          allow(http_double).to receive(:use_ssl=).with(false)
           allow(http_double).to receive(:request) { raise exception }
         end
 
@@ -140,6 +68,7 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
       before do
         allow(Net::HTTP).to receive(:new).and_return(http_double)
         allow(http_double).to receive(:request).and_return(request_double)
+        allow(http_double).to receive(:use_ssl=).with(false)
         allow(request_double).to receive(:code).and_return('304')
       end
 
@@ -150,6 +79,20 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
 
     context 'when request status code is 2xx' do
       it { expect(subject).to eq(false) }
+    end
+  end
+
+  describe '#use_ssl?' do
+    subject { described_class.new(webhook_payload_body: webhook_payload_body, url: url, signature: signature).send(:use_ssl?) }
+
+    context 'with HTTP scheme' do
+      it { expect(subject).to eq(false) }
+    end
+
+    context 'with HTTPS scheme' do
+      let(:url) { 'https://google.com/' }
+
+      it { expect(subject).to eq(true) }
     end
   end
 
@@ -185,6 +128,7 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
     context 'when request raises an Errno::ECONNREFUSED exception' do
       before do
         allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=).with(false)
         allow(http_double).to receive(:request) { raise Errno::ECONNREFUSED }
       end
 
@@ -194,6 +138,7 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
     context 'when request raises a Net::ReadTimeout exception' do
       before do
         allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=).with(false)
         allow(http_double).to receive(:request) { raise Net::ReadTimeout }
       end
 
@@ -203,6 +148,7 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
     context 'when request raises a SocketError exception' do
       before do
         allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=).with(false)
         allow(http_double).to receive(:request) { raise SocketError }
       end
 
@@ -253,7 +199,6 @@ describe Spree::Webhooks::Subscribers::MakeRequest do
       it { expect(subject.unprocessable_uri?).to eq(true) }
     end
 
-    let(:uri) { URI(url) }
     let(:url) { 'google.com' }
 
     context 'uri with path ""' do


### PR DESCRIPTION
The previous method was very clunky and enforced non-SSL requests for all non-production environments.