### PR TITLE
fix free shipping promotion

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -574,6 +574,7 @@ module Spree
     def set_shipments_cost
       shipments.each(&:update_amounts)
       updater.update_shipment_total
+      updater.update_adjustment_total
       persist_totals
     end
 

--- a/core/app/models/spree/promotion/actions/free_shipping.rb
+++ b/core/app/models/spree/promotion/actions/free_shipping.rb
@@ -13,6 +13,19 @@ module Spree
         def compute_amount(shipment)
           shipment.cost * -1
         end
+
+        # we need to persist 0 amount adjustment
+        def create_adjustment(order, adjustable, included = false)
+          amount = compute_amount(adjustable)
+
+          adjustments.new(
+            adjustable: adjustable,
+            amount: amount,
+            included: included,
+            label: label,
+            order: order
+          ).save
+        end
       end
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -113,7 +113,8 @@ describe Spree::Order, type: :model do
   context 'creates shipments cost' do
     let(:shipment) { double }
 
-    before { allow(order).to receive_messages shipments: [shipment] }
+    let(:order) { create(:order_with_line_items) }
+    let(:shipment) { order.shipments.first }
 
     it 'update and persist totals' do
       expect(shipment).to receive :update_amounts

--- a/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -32,5 +32,22 @@ describe Spree::Promotion::Actions::FreeShipping, type: :model do
       expect(promotion.credits_count).to eq(2)
       expect(order.shipment_adjustments.count).to eq(2)
     end
+
+    context 'when shipping methods are configured to be free' do
+      before do
+        order.shipments.update_all(cost: 0)
+      end
+
+      it 'can create adjustment with amount equal to 0' do
+        expect(order.shipments.count).to eq(2)
+        expect(order.shipments.first.cost).to eq(0)
+        expect(order.shipments.last.cost).to eq(0)
+        expect(action.perform(payload)).to be true
+        expect(promotion.credits_count).to eq(2)
+        expect(order.shipment_adjustments.count).to eq(2)
+        expect(order.shipment_adjustments.first.amount.to_i).to eq(0)
+        expect(order.shipment_adjustments.last.amount.to_i).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
The issue was that when we select free (by configuration) shipping method, then apply free shipping promotion, no adjustment is created (because shipping was for free already). So when we re-select shipping method with shipping rate > 0, #recalculate_adjustments method was not called & there was no adjustment to recalculate.