### PR TITLE
Added 2 new Wishlists API endpoints: `add_items` and `remove_items` f…

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -60,6 +60,8 @@ Spree::Core::Engine.add_routes do
             post :add_item
             patch 'set_item_quantity/:item_id', to: 'wishlists#set_item_quantity', as: :set_item_quantity
             delete 'remove_item/:item_id', to: 'wishlists#remove_item', as: :remove_item
+            post :add_items
+            delete :remove_items
           end
         end
 

--- a/api/spec/requests/spree/api/v2/storefront/wishlists_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/wishlists_spec.rb
@@ -330,4 +330,275 @@ RSpec.describe Spree::Api::V2::Storefront::WishlistsController, type: :request d
       end
     end
   end
+
+  describe '#add_items' do
+    subject(:post_add_item) do
+      post "/api/v2/storefront/wishlists/#{user.wishlists.first.token}/add_items", headers: headers_bearer, params: params
+    end
+
+    let!(:variant) { create(:variant) }
+    let!(:wished_item) { nil }
+    let!(:wished_item_1) { nil }
+    let!(:wished_item_2) { nil }
+    let!(:wished_item_3) { nil }
+
+    before { post_add_item }
+
+    let(:params) do
+      {
+        wished_items: [
+          { variant_id: variant.id.to_s, quantity: 3 }
+        ]
+      }
+    end
+
+    it_behaves_like 'returns 200 HTTP status'
+
+    it 'returns wishlist in response' do
+      expect(json_response['data']['type']).to eql ('wishlist')
+      expect(json_response['data']['id']).to eql wishlist.id.to_s
+
+      expect(json_response['data']['attributes']['token']).to eq wishlist.token
+      expect(json_response['data']['attributes']['name']).to eq wishlist.name
+      expect(json_response['data']['attributes']['is_private']).to be true
+      expect(json_response['data']['attributes']['is_default']).to be false
+      expect(json_response['data']['attributes']['variant_included']).to be false
+
+      expect(json_response['data']['relationships']['wished_items']).not_to be_empty
+    end
+
+    it 'creates wished item' do
+      expect(user.wishlists.reload.first.wished_items.take.quantity).to eq 3
+    end
+
+    context 'when many variants are passed' do
+      let(:params) do
+        {
+          wished_items: [
+            { variant_id: variant.id.to_s, quantity: 1 },
+            { variant_id: variant_1.id.to_s, quantity: 2 },
+            { variant_id: variant_2.id.to_s, quantity: 3 },
+            { variant_id: variant_3.id.to_s, quantity: 4 }
+          ]
+        }
+      end
+      let(:variant_1) { create(:variant) }
+      let(:variant_2) { create(:variant) }
+      let(:variant_3) { create(:variant) }
+
+      it 'creates many wished items' do
+        expect(user.wishlists.reload.first.wished_items.count).to eq 4
+      end
+
+      context 'when some variants are already in the wishlist' do
+        let!(:wished_item_1) { create(:wished_item, wishlist: user.wishlists.first, variant: variant_1, quantity: 1) }
+        let!(:wished_item_2) { create(:wished_item, wishlist: user.wishlists.first, variant: variant_2, quantity: 1) }
+        let!(:wished_item_3) { create(:wished_item, wishlist: user.wishlists.first, variant: variant_3, quantity: 1) }
+
+        it 'updates them accordingly' do
+          expect(wished_item_1.reload.quantity).to eq 2
+          expect(wished_item_2.reload.quantity).to eq 3
+          expect(wished_item_3.reload.quantity).to eq 4
+        end
+      end
+
+      context 'when some of params is invalid' do
+        let(:params) do
+          {
+            wished_items: [
+              { variant_id: variant.id.to_s, quantity: 1 },
+              { variant_id: create(:variant).id.to_s, quantity: 0 }
+            ]
+          }
+        end
+
+        it 'does not create any wished item' do
+          expect(user.wishlists.reload.first.wished_items).to be_empty
+        end
+      end
+    end
+
+    context 'when a variant is already in the wishlist' do
+      let!(:wished_item) { create(:wished_item, wishlist: user.wishlists.first, variant: wished_variant, quantity: 2) }
+      let(:wished_variant) { create(:variant) }
+
+      context 'when quantity is passed' do
+        let(:params) do
+          {
+            wished_items: [
+              { variant_id: wished_variant.id.to_s, quantity: 3 }
+            ]
+          }
+        end
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'updates quantity' do
+          expect(wished_item.reload.quantity).to eq 3
+        end
+      end
+
+      context 'when quantity is not passed' do
+        let(:params) do
+          {
+            wished_items: [
+              { variant_id: wished_variant.id.to_s }
+            ]
+          }
+        end
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'updates quantity to 1' do
+          expect(wished_item.reload.quantity).to eq 1
+        end
+      end
+
+      context 'when passed quantity is 0' do
+        let(:params) do
+          {
+            wished_items: [
+              { variant_id: wished_variant.id.to_s, quantity: 0 }
+            ]
+          }
+        end
+
+        it_behaves_like 'returns 422 HTTP status'
+
+        it 'does not create wished item' do
+          expect(user.wishlists.reload.first.wished_items.count).to eq 1
+        end
+
+        it 'returns error message' do
+          expect(json_response['error']).to eq 'Quantity must be greater than 0'
+        end
+      end
+    end
+
+    context 'when quantity is not passed' do
+      let(:params) do
+        {
+          wished_items: [
+            { variant_id: variant.id.to_s }
+          ]
+        }
+      end
+
+      it_behaves_like 'returns 200 HTTP status'
+
+      it 'creates wished item with quantity 1' do
+        expect(user.wishlists.reload.first.wished_items.count).to eq 1
+        expect(user.wishlists.first.wished_items.take.quantity).to eq 1
+      end
+    end
+
+    context 'when variant_id is not passed' do
+      let(:params) do
+        {
+          wished_items: [
+            { quantity: 3 }
+          ]
+        }
+      end
+
+      it_behaves_like 'returns 422 HTTP status'
+
+      it 'does not create wished item' do
+        expect(user.wishlists.reload.first.wished_items).to be_empty
+      end
+
+      it 'does not create wished item' do
+        expect(user.wishlists.reload.first.wished_items).to be_empty
+      end
+    end
+
+    context 'when passed quantity is 0' do
+      let(:params) do
+        {
+          wished_items: [
+            { variant_id: variant.id.to_s, quantity: 0 }
+          ]
+        }
+      end
+
+      it_behaves_like 'returns 422 HTTP status'
+
+      it 'does not create wished item' do
+        expect(user.wishlists.reload.first.wished_items).to be_empty
+      end
+
+      it 'returns error message' do
+        expect(json_response['error']).to eq 'Quantity must be greater than 0'
+      end
+    end
+  end
+
+  describe '#remove_items' do
+    subject(:remove_items) do
+      delete "/api/v2/storefront/wishlists/#{user.wishlists.first.token}/remove_items", params: { wished_items_ids: wished_items_ids }, headers: headers_bearer
+    end
+
+    let!(:wished_item_1) { create(:wished_item, wishlist: user.wishlists.first, variant: create(:variant), quantity: 1) }
+    let!(:wished_item_2) { create(:wished_item, wishlist: user.wishlists.first, variant: create(:variant), quantity: 2) }
+    let!(:wished_item_3) { create(:wished_item, wishlist: user.wishlists.first, variant: create(:variant), quantity: 3) }
+    let!(:wished_item_4) { create(:wished_item, wishlist: user.wishlists.first, variant: create(:variant), quantity: 4) }
+
+    context 'when wished item is removed' do
+      before { remove_items }
+
+      let(:wished_items_ids) { [wished_item_2.id] }
+
+      it 'returns wishlist in response' do
+        expect(json_response['data']['type']).to eql ('wishlist')
+        expect(json_response['data']['id']).to eql wishlist.id.to_s
+
+        expect(json_response['data']['attributes']['token']).to eq wishlist.token
+        expect(json_response['data']['attributes']['name']).to eq wishlist.name
+        expect(json_response['data']['attributes']['is_private']).to be true
+        expect(json_response['data']['attributes']['is_default']).to be false
+        expect(json_response['data']['attributes']['variant_included']).to be false
+
+        expect(json_response['data']['relationships']['wished_items']).not_to be_empty
+      end
+
+      context 'when there is one wished item to remove' do
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'removes wished item' do
+          expect(wishlist.wished_items).to match_array([wished_item_1, wished_item_3, wished_item_4])
+        end
+      end
+
+      context 'when there are many wished items to remove' do
+        let(:wished_items_ids) { [wished_item_2.id, wished_item_3.id] }
+
+        it_behaves_like 'returns 200 HTTP status'
+
+        it 'removes wished items' do
+          expect(wishlist.wished_items).to match_array([wished_item_1, wished_item_4])
+        end
+      end
+    end
+
+    context 'when wished item is not removed' do
+      let(:wished_items_ids) { [wished_item_2.id] }
+
+      before do
+        allow_any_instance_of(ActiveRecord::RecordNotDestroyed).to receive_message_chain(:record, :errors, :full_messages, :to_sentence).and_return('some error')
+        allow_any_instance_of(Spree::WishedItem).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+        remove_items
+      end
+
+      it_behaves_like 'returns 422 HTTP status'
+    end
+
+    context 'user not authorised to access this action' do
+      let(:headers_bearer) { {} }
+      let(:wished_items_ids) { [wished_item_2.id] }
+
+      before { remove_items }
+
+      it_behaves_like 'returns 403 HTTP status'
+    end
+  end
 end

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -1714,6 +1714,61 @@ paths:
         name: token
         in: path
         required: true
+  '/api/v2/storefront/wishlists/{token}/add_items':
+    post:
+      summary: Add Items to Wishlist
+      description: |-
+        The Add Items to Wishlist endpoint adds variants to an existing wishlist by creating a new `wished_item` objects. A wished item in a wishlist is comparable to a line item in a cart.
+
+        Each wished item references a single variant, holds the desired quantity and returns price information determined by the variant price in current currency, and desired quantity.
+      operationId: add-item-to-wishlist
+      parameters:
+        - $ref: '#/components/parameters/Token'
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                wished_items:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      variant_id:
+                        type: string
+                        example: '1'
+                        description: The variant ID that is to be added to the wishlist.
+                      quantity:
+                        type: number
+                        example: 10
+                        description: 'Set a quantity greater than 0, or omit the quantity param if your wishlist does not support quantities. If omitted, quantity will be set to 1.'
+                    required:
+                      - variant_id
+            examples:
+              Add a variant:
+                value:
+                  wished_items:
+                    - variant_id: '1'
+                      quantity: 10
+                    - variant_id: '2'
+                      quantity: 5
+        description: |-
+          Passing a quantity value is optional for those wishlist systems that do not support quantities. In this scenario, the returned quantity value will always be `1`, allowing the add-to-cart and pricing to reflect the single representation of the wished item accurately.
+
+          If the wishlist system you are building allows for setting quantity, add the quantity attribute to the request body with an integer value greater than zero.
+      responses:
+        '200':
+          $ref: '#/components/responses/Wishlist'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '422':
+          $ref: '#/components/responses/422UnprocessableEntity'
+      security:
+        - bearerAuth: []
+      tags:
+        - Wishlists / Wished Items
   '/api/v2/storefront/wishlists/{token}/set_item_quantity/{item_id}':
     patch:
       description: This endpoint sets the wished item quantity.
@@ -1778,6 +1833,43 @@ paths:
         name: item_id
         in: path
         required: true
+  '/api/v2/storefront/wishlists/{token}/remove_items':
+    delete:
+      description: Removes wished items from a wishlist.
+      summary: Delete Items from Wishlist
+      operationId: delete-wished-variant-from-wishlist
+      parameters:
+        - $ref: '#/components/parameters/Token'
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                wished_items_ids:
+                  type: array
+                  items:
+                    type: string
+                    example: '1'
+                    description: The Wished Item ID that is to be removed from wishlist.
+            examples:
+              Remove wished items:
+                value:
+                  wished_items_ids:
+                    - '1'
+                    - '2'
+      responses:
+        '200':
+          $ref: '#/components/responses/Wishlist'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '422':
+          $ref: '#/components/responses/422UnprocessableEntity'
+      security:
+        - bearerAuth: [ ]
+      tags:
+        - Wishlists / Wished Items
   '/api/v2/storefront/digitals/{token}':
     get:
       summary: Download a Digital Asset


### PR DESCRIPTION
…or bulk operations

Developing headless storefronts we've ancountered this request many times when handling fashion websites. This is a backport from https://www.getvendo.com/