### PR TITLE
Move ActiveStorage code into `Spree::Asset`

### DIFF
--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -8,5 +8,13 @@ module Spree
 
     belongs_to :viewable, polymorphic: true, touch: true
     acts_as_list scope: [:viewable_id, :viewable_type]
+
+    if Spree.public_storage_service_name
+      has_one_attached :attachment, service: Spree.public_storage_service_name
+    else
+      has_one_attached :attachment
+    end
+
+    default_scope { includes(attachment_attachment: :blob) }
   end
 end

--- a/core/app/models/spree/cms_section_image.rb
+++ b/core/app/models/spree/cms_section_image.rb
@@ -1,11 +1,5 @@
 module Spree
   class CmsSectionImage < Asset
-    if Spree.public_storage_service_name
-      has_one_attached :attachment, service: Spree.public_storage_service_name
-    else
-      has_one_attached :attachment
-    end
-
     IMAGE_COUNT = ['one', 'two', 'three']
     IMAGE_TYPES = ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'].freeze
     IMAGE_SIZE = ['sm', 'md', 'lg', 'xl']

--- a/core/app/models/spree/icon.rb
+++ b/core/app/models/spree/icon.rb
@@ -1,11 +1,5 @@
 module Spree
   class Icon < Spree::Asset
-    if Spree.public_storage_service_name
-      has_one_attached :attachment, service: Spree.public_storage_service_name
-    else
-      has_one_attached :attachment
-    end
-
     ICON_TYPES = %i[png jpg jpeg gif svg]
 
     validates :attachment, attached: true, content_type: ICON_TYPES

--- a/core/app/models/spree/image/configuration/active_storage.rb
+++ b/core/app/models/spree/image/configuration/active_storage.rb
@@ -5,15 +5,7 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          if Spree.public_storage_service_name
-            has_one_attached :attachment, service: Spree.public_storage_service_name
-          else
-            has_one_attached :attachment
-          end
-
           validates :attachment, attached: true, content_type: /\Aimage\/.*\z/
-
-          default_scope { includes(attachment_attachment: :blob) }
 
           def self.styles
             @styles ||= {

--- a/core/app/models/spree/store_favicon_image.rb
+++ b/core/app/models/spree/store_favicon_image.rb
@@ -1,11 +1,5 @@
 module Spree
   class StoreFaviconImage < Asset
-    if Spree.public_storage_service_name
-      has_one_attached :attachment, service: Spree.public_storage_service_name
-    else
-      has_one_attached :attachment
-    end
-
     VALID_CONTENT_TYPES = ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon'].freeze
 
     validates :attachment,

--- a/core/app/models/spree/store_logo.rb
+++ b/core/app/models/spree/store_logo.rb
@@ -1,9 +1,4 @@
 module Spree
   class StoreLogo < Asset
-    if Spree.public_storage_service_name
-      has_one_attached :attachment, service: Spree.public_storage_service_name
-    else
-      has_one_attached :attachment
-    end
   end
 end

--- a/core/app/models/spree/store_mailer_logo.rb
+++ b/core/app/models/spree/store_mailer_logo.rb
@@ -1,11 +1,5 @@
 module Spree
   class StoreMailerLogo < Asset
-    if Spree.public_storage_service_name
-      has_one_attached :attachment, service: Spree.public_storage_service_name
-    else
-      has_one_attached :attachment
-    end
-
     VALID_CONTENT_TYPES = ['image/png', 'image/jpg', 'image/jpeg'].freeze
 
     validates :attachment, content_type: VALID_CONTENT_TYPES

--- a/core/app/models/spree/taxon_image/configuration/active_storage.rb
+++ b/core/app/models/spree/taxon_image/configuration/active_storage.rb
@@ -5,12 +5,6 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          if Spree.public_storage_service_name
-            has_one_attached :attachment, service: Spree.public_storage_service_name
-          else
-            has_one_attached :attachment
-          end
-
           validates :attachment, content_type: /\Aimage\/.*\z/
 
           default_scope { includes(attachment_attachment: :blob) }


### PR DESCRIPTION
We only use Active Storage for a while, and it's just code duplication. Also any `Spree::Asset` should have access to `attachment`