### PR TITLE
Stop overwriting `Rails.application.config.active_record.yaml_column_…

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -26,7 +26,7 @@ module Spree
 
       initializer 'spree.environment', before: :load_config_initializers do |app|
         app.config.spree = Environment.new(SpreeCalculators.new, Spree::Core::Configuration.new, Spree::Core::RuntimeConfiguration.new, Spree::Core::Dependencies.new)
-        app.config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal]
+        app.config.active_record.yaml_column_permitted_classes << [Symbol, BigDecimal, ActiveSupport::HashWithIndifferentAccess]
         Spree::Config = app.config.spree.preferences
         Spree::RuntimeConfig = app.config.spree.runtime_preferences
         Spree::Dependencies = app.config.spree.dependencies

--- a/sample/lib/spree_sample.rb
+++ b/sample/lib/spree_sample.rb
@@ -5,7 +5,6 @@ module SpreeSample
   class Engine < Rails::Engine
     engine_name 'spree_sample'
 
-    config.active_record.yaml_column_permitted_classes = [Symbol]
     # Needs to be here so we can access it inside the tests
     def self.load_samples
       Spree::Webhooks.disable_webhooks do


### PR DESCRIPTION
…permitted_classes`