### PR TITLE
Disallow creation of `Spree::Price` records with empty values

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -14,10 +14,17 @@ module Spree
     before_validation :ensure_currency
     before_save :remove_compare_at_amount_if_equals_amount
 
-    validates :amount, allow_nil: -> { Spree::RuntimeConfig.allow_empty_price_amount }, numericality: {
+    # legacy behavior
+    validates :amount, allow_nil: true, numericality: {
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: MAXIMUM_AMOUNT
-    }
+    }, if: -> { Spree::RuntimeConfig.allow_empty_price_amount }
+
+    # new behavior
+    validates :amount, allow_nil: false, numericality: {
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: MAXIMUM_AMOUNT
+    }, unless: -> { Spree::RuntimeConfig.allow_empty_price_amount }
 
     validates :compare_at_amount, allow_nil: true, numericality: {
       greater_than_or_equal_to: 0,

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -14,7 +14,7 @@ module Spree
     before_validation :ensure_currency
     before_save :remove_compare_at_amount_if_equals_amount
 
-    validates :amount, allow_nil: true, numericality: {
+    validates :amount, allow_nil: -> { Spree::RuntimeConfig.allow_empty_price_amount }, numericality: {
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: MAXIMUM_AMOUNT
     }

--- a/core/lib/spree/core/runtime_configuration.rb
+++ b/core/lib/spree/core/runtime_configuration.rb
@@ -4,6 +4,7 @@ module Spree
   module Core
     class RuntimeConfiguration < Preferences::RuntimeConfiguration
       preference :always_use_translations, :boolean, default: false
+      preference :allow_empty_price_amount, :boolean, default: false
     end
   end
 end

--- a/core/spec/models/spree/order/currency_updater_spec.rb
+++ b/core/spec/models/spree/order/currency_updater_spec.rb
@@ -24,7 +24,10 @@ describe Spree::Order, type: :model do
         end
 
         context 'when there is a price with nil amount' do
-          let!(:euro_price) { create(:price, variant: line_item.variant, amount: nil, currency: 'EUR') }
+          let!(:euro_price) do
+            allow(Spree::RuntimeConfig).to receive(:allow_empty_price_amount).and_return(true)
+            create(:price, variant: line_item.variant, amount: nil, currency: 'EUR')
+          end
 
           it 'destroys the line item when we switch to that price\'s currency' do
             expect { line_item.order.update!(currency: 'EUR') }.to change(Spree::LineItem, :count).by(-1)

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -91,7 +91,7 @@ describe Spree::Price, type: :model do
           allow(Spree::RuntimeConfig).to receive(:allow_empty_price_amount).and_return(true)
         end
 
-        it { binding.pry; is_expected.to be_valid }
+        it { is_expected.to be_valid }
       end
 
       context 'new behavior' do

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -86,7 +86,17 @@ describe Spree::Price, type: :model do
     context 'when the amount is nil' do
       let(:amount) { nil }
 
-      it { is_expected.to be_valid }
+      context 'legacy behavior' do
+        before do
+          allow(Spree::RuntimeConfig).to receive(:allow_empty_price_amount).and_return(true)
+        end
+
+        it { binding.pry; is_expected.to be_valid }
+      end
+
+      context 'new behavior' do
+        it { is_expected.not_to be_valid }
+      end
     end
 
     context 'when the amount is less than 0' do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -176,6 +176,10 @@ describe Spree::Variant, type: :model do
         end
 
         context 'when price do not have amount' do
+          before do
+            allow(Spree::RuntimeConfig).to receive(:allow_empty_price_amount).and_return(true)
+          end
+
           let!(:price_1) { create(:price, currency: currency, variant: variant, amount: nil) }
 
           it { expect(Spree::Variant.for_currency_and_available_price_amount(currency)).not_to include(variant) }
@@ -192,6 +196,10 @@ describe Spree::Variant, type: :model do
         end
 
         context 'when price do not have amount' do
+          before do
+            allow(Spree::RuntimeConfig).to receive(:allow_empty_price_amount).and_return(true)
+          end
+
           let!(:price_1) { create(:price, currency: unavailable_currency, variant: variant, amount: nil) }
 
           it { expect(Spree::Variant.for_currency_and_available_price_amount(currency)).not_to include(variant) }

--- a/core/spec/services/spree/cart/add_item_spec.rb
+++ b/core/spec/services/spree/cart/add_item_spec.rb
@@ -236,6 +236,7 @@ module Spree
       let(:call_service) { subject.call(order: order, variant: variant, quantity: 1) }
 
       before do
+        allow(Spree::RuntimeConfig).to receive(:allow_empty_price_amount).and_return(true)
         variant.prices.first.update(amount: nil)
       end
 


### PR DESCRIPTION
To preserve current behaviour in your `config/initializers/spree.rb` file add

```ruby
Spree::RuntimeConfig[: allow_empty_price_amount] = true
```