### PR TITLE
Update paranoia to v3.0 to support Rails 7.2 update

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 1.2'
   s.add_dependency 'money', '~> 6.13'
   s.add_dependency 'monetize', '~> 1.9'
-  s.add_dependency 'paranoia', '~> 2.4', '< 3.1'
+  s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '>= 4.1'
   s.add_dependency 'rexml'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 1.2'
   s.add_dependency 'money', '~> 6.13'
   s.add_dependency 'monetize', '~> 1.9'
-  s.add_dependency 'paranoia', '~> 2.4'
+  s.add_dependency 'paranoia', '~> 2.4', '< 3.1'
   s.add_dependency 'ransack', '>= 4.1'
   s.add_dependency 'rexml'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'


### PR DESCRIPTION
Update paranoia v3.0.0 to support Rails 7.2 version