### PR TITLE
bump paranoia to version 3

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 1.2'
   s.add_dependency 'money', '~> 6.13'
   s.add_dependency 'monetize', '~> 1.9'
-  s.add_dependency 'paranoia', '~> 2.4'
+  s.add_dependency 'paranoia', '~> 3.0'
   s.add_dependency 'ransack', '>= 4.1'
   s.add_dependency 'rexml'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'


### PR DESCRIPTION
Bump to version 3 as it supports rails 7.2 and backward compatible with old versions