### PR TITLE
Added `Product#default_image`, `Variant#default_image`

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -201,27 +201,21 @@ module Spree
     # we should always try to render image of the default variant
     # same as it's done on PDP
     def default_image_for_product(product)
-      if product.images.any?
-        product.images.first
-      elsif product.default_variant.images.any?
-        product.default_variant.images.first
-      elsif product.variant_images.any?
-        product.variant_images.first
-      end
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
+        `BaseHelper#default_image_for_product` is deprecated and will be removed in Spree 6.0.
+        Please use `product.default_image` instead
+      DEPRECATION
+
+      product.default_image
     end
 
     def default_image_for_product_or_variant(product_or_variant)
-      Rails.cache.fetch("spree/default-image/#{product_or_variant.cache_key_with_version}") do
-        if product_or_variant.is_a?(Spree::Product)
-          default_image_for_product(product_or_variant)
-        elsif product_or_variant.is_a?(Spree::Variant)
-          if product_or_variant.images.any?
-            product_or_variant.images.first
-          else
-            default_image_for_product(product_or_variant.product)
-          end
-        end
-      end
+      Spree::Deprecation.warn(<<-DEPRECATION, caller)
+        `BaseHelper#default_image_for_product_or_variant` is deprecated and will be removed in Spree 6.0.
+        Please use `product_or_variant.default_image` instead
+      DEPRECATION
+
+      product_or_variant.default_image
     end
 
     def base_cache_key

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -240,6 +240,35 @@ module Spree
       @default_variant_id ||= default_variant.id
     end
 
+    # Returns default Image for Product
+    # @return [Spree::Image]
+    def default_image
+      @default_image ||= if images.size.positive?
+                           images.first
+                         elsif default_variant.images.size.positive?
+                           default_variant.default_image
+                         elsif variant_images.size.positive?
+                           variant_images.first
+                         end
+    end
+    alias featured_image default_image
+
+    # Returns secondary Image for Product
+    # @return [Spree::Image]
+    def secondary_image
+      @secondary_image ||= if images.size > 1
+                             images.second
+                           elsif images.size == 1 && default_variant.images.size.positive?
+                             default_variant.images.first
+                           elsif default_variant.images.size > 1
+                             default_variant.secondary_image
+                           elsif variant_images.size > 1
+                             variant_images.second
+                           end
+    end
+
+    # Returns tax category for Product
+    # @return [Spree::TaxCategory]
     def tax_category
       @tax_category ||= super || TaxCategory.find_by(is_default: true)
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -183,6 +183,32 @@ module Spree
       !!deleted_at
     end
 
+    # Returns default Image for Variant
+    # @return [Spree::Image]
+    def default_image
+      @default_image ||= if images.size.positive?
+                           images.first
+                         else
+                           product.default_image
+                         end
+    end
+
+    # Returns secondary Image for Variant
+    # @return [Spree::Image]
+    def secondary_image
+      @secondary_image ||= if images.size > 1
+                             images.second
+                           else
+                             product.secondary_image
+                           end
+    end
+
+    # Returns additional Images for Variant
+    # @return [Array<Spree::Image>]
+    def additional_images
+      @additional_images ||= (images + product.images).uniq.find_all { |image| image.id != default_image&.id }
+    end
+
     # Returns an array of hashes with the option type name, value and presentation
     # @return [Array<Hash>]
     def options

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -55,7 +55,7 @@ describe Spree::Product, type: :model do
       end
     end
 
-    context '#duplicate' do
+    describe '#duplicate' do
       before do
         allow(product).to receive_messages taxons: [create(:taxon)], stores: [store]
       end
@@ -130,7 +130,7 @@ describe Spree::Product, type: :model do
     end
 
     context 'product has no variants' do
-      context '#destroy' do
+      describe '#destroy' do
         it 'sets deleted_at value' do
           product.destroy
           expect(product.deleted_at).not_to be_nil
@@ -144,7 +144,7 @@ describe Spree::Product, type: :model do
         create(:variant, product: product)
       end
 
-      context '#destroy' do
+      describe '#destroy' do
         it 'sets deleted_at value' do
           product.destroy
           expect(product.deleted_at).not_to be_nil
@@ -153,7 +153,7 @@ describe Spree::Product, type: :model do
       end
     end
 
-    context '#price' do
+    describe '#price' do
       # Regression test for #1173
       it 'strips non-price characters' do
         product.price = '$10'
@@ -161,7 +161,7 @@ describe Spree::Product, type: :model do
       end
     end
 
-    context '#display_price' do
+    describe '#display_price' do
       before { product.price = 10.55 }
 
       it 'shows the amount' do
@@ -181,7 +181,7 @@ describe Spree::Product, type: :model do
       end
     end
 
-    context '#available?' do
+    describe '#available?' do
       it 'is available if status is set to active' do
         product.status = 'active'
         expect(product).to be_available
@@ -193,7 +193,7 @@ describe Spree::Product, type: :model do
       end
     end
 
-    context '#can_supply?' do
+    describe '#can_supply?' do
       it 'is true' do
         expect(product.can_supply?).to be(true)
       end
@@ -490,7 +490,7 @@ describe Spree::Product, type: :model do
     end
 
     # Regression test for #4416
-    context '#possible_promotions' do
+    describe '#possible_promotions' do
       let!(:possible_promotion) { create(:promotion, advertise: true, starts_at: 1.day.ago) }
       let!(:unadvertised_promotion) { create(:promotion, advertise: false, starts_at: 1.day.ago) }
       let!(:inactive_promotion) { create(:promotion, advertise: true, starts_at: 1.day.since) }
@@ -583,7 +583,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#images' do
+  describe '#images' do
     let(:product) { create(:product, stores: [store]) }
     let(:file) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
     let(:params) { { viewable_id: product.master.id, viewable_type: 'Spree::Variant', alt: 'position 2', position: 2 } }
@@ -623,7 +623,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#total_on_hand' do
+  describe '#total_on_hand' do
     let(:product) { create(:product, stores: [store]) }
 
     it 'is infinite if track_inventory_levels is false' do
@@ -649,7 +649,7 @@ describe Spree::Product, type: :model do
   end
 
   # Regression spec for https://github.com/spree/spree/issues/5588
-  context '#validate_master when duplicate SKUs entered' do
+  describe '#validate_master when duplicate SKUs entered' do
     subject { second_product }
 
     let!(:first_product) { create(:product, sku: 'a-sku', stores: [store]) }
@@ -663,7 +663,7 @@ describe Spree::Product, type: :model do
     expect(product.master.is_master).to be true
   end
 
-  context '#discontinue!' do
+  describe '#discontinue!' do
     let(:product) { create(:product, sku: 'a-sku', stores: [store]) }
 
     it 'sets the discontinued' do
@@ -685,7 +685,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#discontinued?' do
+  describe '#discontinued?' do
     let(:product_live) { build(:product, sku: 'a-sku') }
     let(:product_discontinued) { build(:product, sku: 'a-sku', discontinue_on: Time.now - 1.day) }
 
@@ -698,7 +698,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#brand' do
+  describe '#brand' do
     let(:taxonomy) { create(:taxonomy, name: I18n.t('spree.taxonomy_brands_name')) }
     let(:product) { create(:product, taxons: [taxonomy.taxons.first], stores: [store]) }
 
@@ -707,7 +707,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#category' do
+  describe '#category' do
     let(:taxonomy) { create(:taxonomy, name: I18n.t('spree.taxonomy_categories_name')) }
     let(:product) { create(:product, taxons: [taxonomy.taxons.first], stores: [store]) }
 
@@ -716,7 +716,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#backordered?' do
+  describe '#backordered?' do
     let!(:product) { create(:product, stores: [store]) }
 
     it 'returns true when out of stock and backorderable' do
@@ -745,7 +745,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#default_variant' do
+  describe '#default_variant' do
     let(:product) { create(:product, stores: [store]) }
 
     context 'track inventory levels' do
@@ -806,7 +806,7 @@ describe Spree::Product, type: :model do
     end
   end
 
-  context '#default_variant_id' do
+  describe '#default_variant_id' do
     let(:product) { create(:product, stores: [store]) }
 
     context 'product has variants' do
@@ -854,6 +854,32 @@ describe Spree::Product, type: :model do
       let(:product) { build(:product, slug: 'My-slug') }
 
       it { expect { product.valid? }.to change(product, :slug).to('my-slug') }
+    end
+  end
+
+  describe '#default_image' do
+    let(:product) { create(:product, stores: [store]) }
+    let!(:image) { create(:image, viewable: product.master) }
+
+    it 'returns the first image for the product' do
+      expect(product.default_image).to eq(image)
+    end
+
+    context 'with variants' do
+      let!(:variant) { create(:variant, product: product) }
+      let!(:image2) { create(:image, viewable: variant) }
+
+      it 'returns the first image for the product' do
+        expect(product.default_image).to eq(image)
+      end
+
+      context 'when master has no images' do
+        let!(:image) { nil }
+
+        it 'returns the first image for the variant' do
+          expect(product.default_image).to eq(image2)
+        end
+      end
     end
   end
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -320,14 +320,14 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#cost_price=' do
+  describe '#cost_price=' do
     it 'uses LocalizedNumber.parse' do
       expect(Spree::LocalizedNumber).to receive(:parse).with('1,599.99')
       subject.cost_price = '1,599.99'
     end
   end
 
-  context '#in_stock_or_backorderable?' do
+  describe '#in_stock_or_backorderable?' do
     subject { variant.in_stock_or_backorderable? }
 
     let!(:variant) { create(:variant) }
@@ -373,34 +373,34 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#price=' do
+  describe '#price=' do
     it 'uses LocalizedNumber.parse' do
       expect(Spree::LocalizedNumber).to receive(:parse).with('1,599.99')
       subject.price = '1,599.99'
     end
   end
 
-  context '#weight=' do
+  describe '#weight=' do
     it 'uses LocalizedNumber.parse' do
       expect(Spree::LocalizedNumber).to receive(:parse).with('1,599.99')
       subject.weight = '1,599.99'
     end
   end
 
-  context '#currency' do
+  describe '#currency' do
     it 'returns the globally configured currency' do
       expect(variant.currency).to eql 'USD'
     end
   end
 
-  context '#display_amount' do
+  describe '#display_amount' do
     it 'returns a Spree::Money' do
       variant.price = 21.22
       expect(variant.display_amount.to_s).to eql '$21.22'
     end
   end
 
-  context '#cost_currency' do
+  describe '#cost_currency' do
     context 'when cost currency is nil' do
       before { variant.cost_currency = nil }
 
@@ -848,7 +848,7 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#volume' do
+  describe '#volume' do
     let(:variant_zero_width) { create(:variant, width: 0) }
     let(:variant) { create(:variant) }
 
@@ -862,7 +862,7 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#dimension' do
+  describe '#dimension' do
     let(:variant) { create(:variant) }
 
     it 'return the dimension if the dimension parameters are different of zero' do
@@ -871,7 +871,7 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#discontinue!' do
+  describe '#discontinue!' do
     let(:variant) { create(:variant) }
 
     it 'sets the discontinued' do
@@ -887,7 +887,7 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#discontinued?' do
+  describe '#discontinued?' do
     let(:variant_live) { build(:variant) }
     let(:variant_discontinued) { build(:variant, discontinue_on: Time.now - 1.day) }
 
@@ -1053,7 +1053,7 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context '#backordered?' do
+  describe '#backordered?' do
     let!(:variant) { create(:variant) }
 
     it 'returns true when out of stock and backorderable' do
@@ -1097,6 +1097,36 @@ describe Spree::Variant, type: :model do
       variant.destroy
       expect(order.reload.line_items).to be_empty
       expect(order.total).to eq(0)
+    end
+  end
+
+  describe '#default_image' do
+    let(:variant) { create(:variant) }
+    let!(:image) { create(:image, position: 1, viewable: variant) }
+
+    it 'returns the first image for the variant' do
+      expect(variant.default_image).to eq(image)
+    end
+  end
+
+  describe '#secondary_image' do
+    let(:variant) { create(:variant) }
+    let!(:image) { create(:image, position: 1, viewable: variant) }
+    let!(:image2) { create(:image, position: 2, viewable: variant) }
+
+    it 'returns the second image for the variant' do
+      expect(variant.secondary_image).to eq(image2)
+    end
+  end
+
+  describe '#additional_images' do
+    let(:variant) { create(:variant) }
+    let!(:image) { create(:image, position: 1, viewable: variant) }
+    let!(:image2) { create(:image, position: 2, viewable: variant) }
+    let!(:image3) { create(:image, position: 3, viewable: variant) }
+
+    it 'returns the additional images for the variant' do
+      expect(variant.additional_images).to eq([image2, image3])
     end
   end
 end


### PR DESCRIPTION
Deprecated `BaseHelper#default_image_for_product_or_variant` and `default_image_for_product`