### PR TITLE
Include `ActiveStorage::SetCurrent` module in API controllers

### DIFF
--- a/api/app/controllers/spree/api/v2/base_controller.rb
+++ b/api/app/controllers/spree/api/v2/base_controller.rb
@@ -2,6 +2,7 @@ module Spree
   module Api
     module V2
       class BaseController < ActionController::API
+        include ActiveStorage::SetCurrent
         include CanCan::ControllerAdditions
         include Spree::Core::ControllerHelpers::StrongParameters
         include Spree::Core::ControllerHelpers::Store


### PR DESCRIPTION
Include this to generate Active Storage URLs properly