### PR TITLE
`Spree.available_locales` should only return locales with translation…

### DIFF
--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -17,15 +17,12 @@ module Spree
     end
 
     def available_locales
-      locales_from_i18n = I18n.available_locales
-      locales =
-        if defined?(SpreeI18n)
-          (SpreeI18n::Locale.all << :en).map(&:to_sym)
-        else
-          [Rails.application.config.i18n.default_locale, I18n.locale, :en]
-        end
+      locales = defined?(SpreeI18n) ? SpreeI18n::Locale.all.map(&:to_sym) : []
+      locales << :en
+      locales << I18n.locale
+      locales << Rails.application.config.i18n.default_locale
 
-      (locales + locales_from_i18n).uniq.compact
+      locales.uniq.compact
     end
 
     alias t translate

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -28,9 +28,8 @@ describe 'i18n' do
 
       it 'returns all locales from the SpreeI18n' do
         locales = Spree.available_locales
-        expected_locales = [:en, :de, :nl, :ar, :az, :bg, :ca, :cs, :da, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :"pt-BR", :ro, :ru, :sk, :sv, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
 
-        expect(locales).to match_array(expected_locales)
+        expect(locales).to contain_exactly(:en, :de, :nl)
       end
 
       it 'returns an array with the string "en" removed' do
@@ -41,12 +40,10 @@ describe 'i18n' do
     end
 
     context 'when SpreeI18n is not defined' do
-      it 'returns just default locales' do
+      it 'returns just default locale' do
         locales = Spree.available_locales
 
-        expected_locales = [:en, :ar, :az, :bg, :ca, :cs, :da, :de, :el, :es, :fa, :fi, :fr, :hu, :id, :it, :ja, :nl, :"pt-BR", :ro, :ru, :sv, :sk, :tr, :"zh-CN", :"zh-TW", :pl, :uk, :vi]
-
-        expect(locales).to match_array(expected_locales)
+        expect(locales).to contain_exactly(:en)
       end
     end
   end


### PR DESCRIPTION
…s provided by `spree_i18n` gem