### PR TITLE
Extend PaymentMethods for new admin

### DIFF
--- a/admin/app/helpers/spree/admin/payments_helper.rb
+++ b/admin/app/helpers/spree/admin/payments_helper.rb
@@ -15,6 +15,10 @@ module Spree
         image_tag "payment_icons/#{payment_method}.svg", opts
       rescue Sprockets::Rails::Helper::AssetNotFound
       end
+
+      def available_payment_methods
+        @available_payment_methods ||= Spree::PaymentMethod.providers.map(&:new).delete_if { |payment_method| !payment_method.show_in_admin? && current_store.payment_methods.pluck(:type).include?(payment_method.type) }
+      end
     end
   end
 end

--- a/api/spec/serializers/spree/api/v2/platform/payment_method_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/payment_method_serializer_spec.rb
@@ -28,9 +28,7 @@ describe Spree::Api::V2::Platform::PaymentMethodSerializer do
             created_at: resource.created_at,
             updated_at: resource.updated_at,
             preferences: {
-              dummy_key: 'PUBLICKEY123',
-              server: 'test',
-              test_mode: true
+              dummy_key: 'PUBLICKEY123'
             },
             public_metadata: {},
             private_metadata: {}

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -4,10 +4,9 @@ module Spree
 
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
-    validates :type, presence: true
+    before_validation :set_name
 
-    preference :server, :string, default: 'test'
-    preference :test_mode, :boolean, default: true
+    validates :type, presence: true, inclusion: { in: -> { Spree::PaymentMethod.providers.map(&:to_s) } }
 
     def payment_source_class
       CreditCard
@@ -76,6 +75,12 @@ module Spree
           []
         end
       end
+    end
+
+    private
+
+    def set_name
+      self.name ||= provider_class.name.demodulize.titleize
     end
   end
 end

--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -15,6 +15,10 @@ module Spree
       self.class
     end
 
+    def show_in_admin?
+      false
+    end
+
     def create_profile(payment)
       return if payment.source.has_payment_profile?
 

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -46,6 +46,10 @@ module Spree
       type.demodulize.downcase
     end
 
+    def payment_icon_name
+      method_type
+    end
+
     def self.find_with_destroyed(*args)
       unscoped { find(*args) }
     end
@@ -55,6 +59,10 @@ module Spree
     end
 
     def source_required?
+      true
+    end
+
+    def show_in_admin?
       true
     end
 

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -29,6 +29,16 @@ describe Spree::Gateway, type: :model do
     gateway.imaginary_method('foo')
   end
 
+  context 'Validations' do
+    before do
+      expect(Spree::PaymentMethod).to receive(:providers).and_return([TestGateway, Spree::Gateway::Bogus])
+    end
+
+    it 'validates the type' do
+      expect(TestGateway.new).to be_valid
+    end
+  end
+
   context 'fetching payment sources' do
     let(:store) { create(:store) }
     let(:order) { store.orders.create(user_id: 1) }

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -5,6 +5,12 @@ describe Spree::PaymentMethod, type: :model do
 
   let(:store) { create(:store) }
 
+  # register test gateways
+  before do
+    Rails.application.config.spree.payment_methods << TestGateway
+    Rails.application.config.spree.payment_methods << Spree::Gateway::Test
+  end
+
   context 'visibility scopes' do
     before do
       [nil, '', 'both', 'front_end', 'back_end'].each do |display_on|


### PR DESCRIPTION
* add ability to configure to show/hide payment method in admin
* add ability to configure payment method icon using https://github.com/activemerchant/payment_icons
* remove `server` and `test_mode` default gateway preferences - this is really ancient and doesn't match with the current payment provider behaviours, some gateways in `spree_gateway` will require an update though
* added some `type` validations so we can remove this from ad,om controllers