### PR TITLE
Add setup files for e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ vendor/bundle
 */vendor/bundle
 .ignore
 TODO
+node_modules
+package-lock.json

--- a/cucumber.conf.js
+++ b/cucumber.conf.js
@@ -1,0 +1,25 @@
+const { Before, BeforeAll, AfterAll, After, setDefaultTimeout } = require("@cucumber/cucumber");
+const { chromium } = require("playwright");
+
+setDefaultTimeout(60000)
+
+BeforeAll(async function () {
+  global.browser = await chromium.launch({
+      headless: false,
+      slowMo: 1000,
+  });
+});
+
+AfterAll(async function () {
+   await global.browser.close();
+});
+
+Before(async function () {
+  global.context = await global.browser.newContext();
+  global.page = await global.context.newPage();
+});
+
+After(async function () {
+  await global.page.close();
+  await global.context.close();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "spree-fork",
+  "version": "1.0.0",
+  "description": "<p align=\"center\">   <a href=\"https://spreecommerce.org\">     <img alt=\"Spree Commerce - an open source eCommerce platform\" src=\"https://github.com/spree/spree/assets/12614496/ff5372a4-e906-458e-83b6-7927ba0629c1\">   </a>",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "lib": "lib"
+  },
+  "scripts": {
+    "test:e2e": "cucumber-js --require cucumber.conf.js --require tests/stepDefinitions/**/*.js --format @cucumber/pretty-formatter"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@cucumber/cucumber": "^7.3.1",
+    "@cucumber/pretty-formatter": "^1.0.1",
+    "@playwright/test": "^1.49.1",
+    "playwright": "^1.49.1"
+  }
+}


### PR DESCRIPTION
## Description

This PR adds setup files for end-to-end (E2E) testing using Playwright and Cucumber which facilitates Behavior-Driven Development (BDD) practices. With this setup, we can define test scenarios in Gherkin language, ensuring comprehensive coverage of our application's behavior.

## Related Issue
Issue: https://github.com/spree/spree/issues/12235

## Motivation and Context
The repository lacks end-to-end (E2E) testing. This means there are no automated tests in place to validate the application's functionality from end to end. As a result, there is a higher risk of undetected bugs and it becomes challenging to ensure the overall reliability and robustness of the application.