### PR TITLE
Fix issues with Stock Transfers in admin

### DIFF
--- a/admin/app/views/active_storage/_upload_form.html.erb
+++ b/admin/app/views/active_storage/_upload_form.html.erb
@@ -13,7 +13,7 @@
       data-active-storage-upload-auto-submit-value="<%= auto_submit %>"
       data-active-storage-upload-field-name-value="<%= form.object_name %>[<%= field_name %>]"
       data-active-storage-upload-allowed-file-types-value="<%= Rails.application.config.active_storage.web_image_content_types %>"
-      class="d-flex flex-column w-100 position-relative">
+      class="d-flex flex-column justify-content-center w-100 position-relative">
     <div class="mb-3 rounded-lg overflow-hidden thumb-preview cursor-pointer bg-light"
          data-action="click->active-storage-upload#open"
     >

--- a/admin/app/views/spree/admin/shared/_error_messages.html.erb
+++ b/admin/app/views/spree/admin/shared/_error_messages.html.erb
@@ -1,12 +1,22 @@
-<% if target && target.errors.any? %>
+<% only_for ||= [] %>
+
+<% if target && target.errors.any? && (only_for.empty? || (target.errors.to_hash.keys & only_for).any?) %>
   <div class="alert alert-danger">
     <p>
       <strong><%= Spree.t(:errors_prohibited_this_record_from_being_saved, count: target.errors.size) %>:</strong><br>
     </p>
     <ul class="list-unstyled mb-0">
-     <% target.errors.full_messages.each do |msg| %>
-       <li><%= msg %></li>
-     <% end %>
+      <% if only_for.any? %>
+        <% only_for.each do |attribute_name| %>
+          <% target.errors.full_messages_for(attribute_name).each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        <% end %>
+      <% else %>
+        <% target.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      <% end %>
     </ul>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/stock_transfers/_destination_movement_form.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/_destination_movement_form.html.erb
@@ -1,8 +1,10 @@
 <% variant_id = f.object.variant&.id || 'VARIANT_ID' %>
+<% location_id ||= 'DESTINATION_ID' %>
+
 <div class="d-flex align-items-center justify-content-between nested-form-wrapper" data-new-record="true">
   <%= f.hidden_field :variant_id, value: variant_id %>
   <%= f.hidden_field :stock_item_id %>
-  <%= f.hidden_field :originator_id, data: { stock_transfer_target: "destinationInput" }, value: f.object.originator_id || 'DESTINATION_ID' %>
+  <%= f.hidden_field :location_id, data: { stock_transfer_target: "destinationInput" }, value: location_id %>
   <div class="d-flex align-items-center gap-2">
     <% if f.object.variant.present? %>
       <%= render 'spree/admin/shared/product_image', object: f.object.variant %>
@@ -12,12 +14,13 @@
     <div class="d-flex flex-column align-items-start justify-content-center">
       <% if f.object.variant.present? %>
         <%= f.object.variant.name %>
-        <span class="text-muted">
-          <%= "(#{f.object.variant.options_text})" if f.object.variant.options_text.present? %>
-        </span>
         <% if f.object.variant.sku.present? %>
           <span class="text-muted"><strong><%= Spree.t(:sku) %>:</strong> <%= f.object.variant.sku %></span>
         <% end %>
+
+        <span class="text-muted">
+          <%= "(#{f.object.variant.options_text})" if f.object.variant.options_text.present? %>
+        </span>
       <% else %>
         VARIANT_INFO
       <% end %>

--- a/admin/app/views/spree/admin/stock_transfers/_new_variant_modal.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/_new_variant_modal.html.erb
@@ -11,8 +11,8 @@
           <%= form.hidden_field :param_name, value: 'stock_transfer' %>
           <%= form.hidden_field :all, value: true %>
           <%= form.hidden_field :eligible, value: true %>
-          <%= form.hidden_field :omit_ids, value: params[:variants]&.keys&.join(','), data: { stock_transfer_target: :newVariantOmitIds } %>
-          <%= form.hidden_field :stock_location_id, value: params.dig(:stock_transfer, :source_location_id), data: {stock_transfer_target: :newVariantStockLocationId} %>
+          <%= form.hidden_field :omit_ids, value: @variant_omit_ids&.join(',').presence, data: { stock_transfer_target: :newVariantOmitIds } %>
+          <%= form.hidden_field :stock_location_id, value: params.dig(:stock_transfer, :source_location_id), data: { stock_transfer_target: :newVariantStockLocationId } %>
         <% end %>
       </div>
       <div class="modal-body p-0" style="min-height: 200px">

--- a/admin/app/views/spree/admin/stock_transfers/_source_movement_form.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/_source_movement_form.html.erb
@@ -1,6 +1,8 @@
+<% location_id ||= 'SOURCE_ID' %>
+
 <div data-source-movement>
   <%= f.hidden_field :variant_id, value: f.object.variant&.id || 'VARIANT_ID' %>
   <%= f.hidden_field :stock_item_id, value: f.object.stock_item_id %>
-  <%= f.hidden_field :originator_id, data: { stock_transfer_target: "sourceInput" }, value: f.object.originator_id || 'SOURCE_ID' %>
+  <%= f.hidden_field :location_id, data: { stock_transfer_target: "sourceInput" }, value: location_id %>
   <%= f.hidden_field :quantity, value: f.object.quantity.zero? ? -1 : f.object.quantity, data: { source_quantity: true } %>
 </div>

--- a/admin/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/new.html.erb
@@ -2,9 +2,13 @@
   <%= page_header_back_button spree.admin_stock_transfers_path %>
   <%= Spree.t(:new_stock_transfer) %>
 <% end %>
+
 <% content_for :title do %>
   <%= Spree.t(:new_stock_transfer) %>
 <% end %>
+
+<%= render partial: 'spree/admin/shared/error_messages', locals: { target: @stock_transfer, only_for: %i[base source_location destination_location] } %>
+
 <div data-controller="stock-transfer">
   <%= render 'spree/admin/stock_transfers/new_variant_modal' %>
   <%= form_with model: [:admin, @stock_transfer] do |f| %>
@@ -15,11 +19,25 @@
         <div class="row">
           <div class="form-group col-12 col-lg-6">
             <%= f.label :source_location_id, Spree.t(:origin), class: 'form-label' %>
-            <%= tom_select_tag "stock_transfer[source_location_id]", empty_option: Spree.t(:none), options: stock_locations, active_option: @stock_transfer.source_location_id, select_data: {action: 'stock-transfer#updateSourceLocation'} %>
+            <%= tom_select_tag "stock_transfer[source_location_id]",
+              empty_option: Spree.t(:none),
+              options: stock_locations,
+              active_option: @stock_transfer.source_location_id,
+              select_data: {
+                stock_transfer_target: :sourceLocationId,
+                action: 'stock-transfer#updateSourceLocation'
+              } %>
           </div>
           <div class="form-group col-12 col-lg-6">
             <%= f.label :destination_location_id, Spree.t(:destination), class: 'form-label' %>
-            <%= tom_select_tag "stock_transfer[destination_location_id]", options: stock_locations, required: true, active_option: @stock_transfer.destination_location_id, select_data: {action: 'stock-transfer#updateDestinationLocation'} %>
+            <%= tom_select_tag "stock_transfer[destination_location_id]",
+              options: stock_locations,
+              required: true,
+              active_option: @stock_transfer.destination_location_id,
+              select_data: {
+                stock_transfer_target: :destinationLocationId,
+                action: 'stock-transfer#updateDestinationLocation'
+              } %>
           </div>
         </div>
         <div class="form-group">
@@ -34,9 +52,11 @@
           <%= Spree.t(:products) %>
         </h5>
         <span data-toggle="modal" data-target="#stock_transfer_modal">
-          <%= button_tag type: 'button', class: 'btn btn-light btn-sm' do %>
-            <%= icon("plus", class: "icon icon-plus") %>
-            <%= Spree.t(:add_products) %>
+          <%= button_tag type: 'button', class: 'btn btn-light btn-sm', disabled: @stock_transfer.destination_location_id.blank?, data: { stock_transfer_target: :newVariantAddButton } do %>
+            <%= content_tag(:span, class: 'with-tip', title: Spree.t('admin.stock_transfers.add_products_tip'), data: { toggle: 'tooltip', placement: 'top' }) do %>
+              <%= icon('plus', class: 'icon icon-plus') %>
+              <%= Spree.t(:add_products) %>
+            <% end %>
           <% end %>
         </span>
       </div>
@@ -51,9 +71,9 @@
               </div>
             <% end %>
             <% if smf.object.quantity < 0 %>
-              <%= render 'spree/admin/stock_transfers/source_movement_form', f: smf %>
+              <%= render 'spree/admin/stock_transfers/source_movement_form', f: smf, location_id: f.object.source_location_id %>
             <% else %>
-              <%= render 'spree/admin/stock_transfers/destination_movement_form', f: smf %>
+              <%= render 'spree/admin/stock_transfers/destination_movement_form', f: smf, location_id: f.object.destination_location_id %>
             <% end %>
           <% end %>
           <div data-stock-transfer-target="target"></div>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -223,6 +223,8 @@ en:
         you_have_no_menus: You have no Menus, click the Add New Menu button to create your first Menu.
         this_link_takes_you_to_your_stores_home_page: This link takes you to your stores home page.
       settings: Settings
+      stock_transfers:
+        add_products_tip: You need to select a destination location first
       utilities:
         preview: Preview
       webhooks_subscribers:

--- a/admin/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Spree::Admin::StockTransfersController, type: :controller do
         post :create, params: { stock_transfer: { source_location_id: source_location.id, destination_location_id: destination_location.id } }
 
         expect(response).to render_template(:new)
-        expect(flash[:error]).to eq(Spree.t('stock_transfer.errors.must_have_variant'))
         expect(response.status).to eq(422)
+        expect(assigns(:object).errors).to contain_exactly(Spree.t('stock_transfer.errors.must_have_variant'))
       end
     end
 
@@ -32,8 +32,8 @@ RSpec.describe Spree::Admin::StockTransfersController, type: :controller do
             source_location_id: source_location.id,
             destination_location_id: destination_location.id,
             stock_movements_attributes: {
-              '0' => { variant_id: variant.id, quantity: -10, originator_id: source_location.id },
-              '1' => { variant_id: variant.id, quantity: 10, originator_id: destination_location.id }
+              '0' => { variant_id: variant.id, quantity: -10, location_id: source_location.id },
+              '1' => { variant_id: variant.id, quantity: 10, location_id: destination_location.id }
             }
           }
         }
@@ -46,14 +46,14 @@ RSpec.describe Spree::Admin::StockTransfersController, type: :controller do
       end
     end
 
-    context 'when originator_id is null' do
+    context 'when location_id is null' do
       it 'creates a stock transfer to destination and redirects to the stock transfer path' do
         post :create, params: {
           stock_transfer: {
             source_location_id: source_location.id,
             destination_location_id: destination_location.id,
             stock_movements_attributes: {
-              '0' => { variant_id: variant.id, quantity: 10, originator_id: destination_location.id }
+              '0' => { variant_id: variant.id, quantity: 10, location_id: destination_location.id }
             }
           }
         }

--- a/api/spec/serializers/spree/api/v2/platform/stock_transfer_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/stock_transfer_serializer_spec.rb
@@ -6,13 +6,13 @@ describe Spree::Api::V2::Platform::StockTransferSerializer do
   include_context 'API v2 serializers params'
 
   let(:destination_location) { create(:stock_location) }
-  let(:resource) { create(type, destination_location: destination_location, source_location: source_location) }
+  let(:resource) { create(type, destination_location: destination_location, source_location: source_location, stock_movements: [stock_movement]) }
   let(:source_location) { create(:stock_location) }
   let(:stock_item) { stock_location.stock_items.order(:id).first }
   let(:stock_location) { create(:stock_location_with_items) }
   let(:type) { :stock_transfer }
 
-  let!(:stock_movement) { create(:stock_movement, stock_item: stock_item, originator: resource) }
+  let(:stock_movement) { build(:stock_movement, stock_item: stock_item) }
 
   it do
     expect(subject).to eq(

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -89,8 +89,8 @@ module Spree
       stock_item(variant).try(:backorderable?)
     end
 
-    def restock(variant, quantity, originator = nil)
-      move(variant, quantity, originator)
+    def restock(variant, quantity, originator = nil, persist: true)
+      move(variant, quantity, originator, persist: persist)
     end
 
     def restock_backordered(variant, quantity, _originator = nil)
@@ -101,13 +101,18 @@ module Spree
       )
     end
 
-    def unstock(variant, quantity, originator = nil)
-      move(variant, -quantity, originator)
+    def unstock(variant, quantity, originator = nil, persist: true)
+      move(variant, -quantity, originator, persist: persist)
     end
 
-    def move(variant, quantity, originator = nil)
-      stock_item_or_create(variant).stock_movements.create!(quantity: quantity,
-                                                            originator: originator)
+    def move(variant, quantity, originator = nil, persist: true)
+      stock_item = stock_item_or_create(variant)
+
+      if persist
+        stock_item.stock_movements.create!(quantity: quantity, originator: originator)
+      else
+        originator.stock_movements << stock_item.stock_movements.build(quantity: quantity)
+      end
     end
 
     def fill_status(variant, quantity)

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -23,7 +23,7 @@ module Spree
 
     scope :recent, -> { order(created_at: :desc) }
 
-    delegate :variant, to: :stock_item, allow_nil: true
+    delegate :variant, :variant_id, to: :stock_item, allow_nil: true
     delegate :product, to: :variant
 
     self.whitelisted_ransackable_attributes = ['quantity']

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -44,8 +44,8 @@ module Spree
 
       transaction do
         variants.each_pair do |variant, quantity|
-          source_location&.unstock(variant, quantity, self)
-          destination_location.restock(variant, quantity, self)
+          source_location&.unstock(variant, quantity, self, persist: false)
+          destination_location.restock(variant, quantity, self, persist: false)
 
           self.source_location = source_location
           self.destination_location = destination_location

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -11,7 +11,7 @@ module Spree
     has_many :stock_movements, as: :originator
     accepts_nested_attributes_for :stock_movements, reject_if: proc { |attributes|
       attributes[:quantity] = attributes[:quantity].to_i
-      attributes[:quantity].blank? || attributes[:quantity].zero? || attributes[:stock_item_id].blank? || attributes[:originator_id].blank?
+      attributes[:quantity].blank? || attributes[:quantity].zero? || attributes[:stock_item_id].blank?
     }
 
     belongs_to :source_location, class_name: 'StockLocation', optional: true
@@ -20,6 +20,7 @@ module Spree
     self.whitelisted_ransackable_attributes = %w[reference source_location_id destination_location_id number]
 
     validate :source_location_is_not_destination_location
+    validate :stock_movements_not_empty
     validates :destination_location, presence: true
 
     def source_movements
@@ -72,6 +73,10 @@ module Spree
       return if source_location_id != destination_location_id
 
       errors.add(:source_location, Spree.t('stock_transfer.errors.same_location'))
+    end
+
+    def stock_movements_not_empty
+      errors.add(:base, Spree.t('stock_transfer.errors.must_have_variant')) if stock_movements.empty?
     end
 
     def variants_available_in_source_location?(source_location, variants)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -521,6 +521,7 @@ en:
     add_one: Add One
     add_option_value: Add Option Value
     add_product: Add Product
+    add_products: Add Products
     add_product_properties: Add Product Properties
     add_rule_of_type: Add rule of type
     add_state: Add State
@@ -1637,7 +1638,7 @@ en:
     stock_transfer_name: Stock Transfer
     stock_transfer:
       errors:
-        must_have_variant: You must add at least one variant.
+        must_have_variant: You must add at least one variant
         variants_unavailable: "Some variants are not available on %{stock}"
         same_location: "cannot be the same as the destination location"
     stock_transfers: Stock Transfers

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -2,6 +2,9 @@ FactoryBot.define do
   factory :stock_transfer, class: Spree::StockTransfer do
     association :source_location, factory: :stock_location
     association :destination_location, factory: :stock_location
+
+    stock_movements { [build(:stock_movement)] }
+
     number {}
     reference {}
     type {}

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -169,13 +169,13 @@ module Spree
 
     it 'restocks a variant with a positive stock movement' do
       originator = double
-      expect(subject).to receive(:move).with(variant, 5, originator)
+      expect(subject).to receive(:move).with(variant, 5, originator, persist: true)
       subject.restock(variant, 5, originator)
     end
 
     it 'unstocks a variant with a negative stock movement' do
       originator = double
-      expect(subject).to receive(:move).with(variant, -5, originator)
+      expect(subject).to receive(:move).with(variant, -5, originator, persist: true)
       subject.unstock(variant, 5, originator)
     end
 

--- a/core/spec/models/spree/stock_transfer_spec.rb
+++ b/core/spec/models/spree/stock_transfer_spec.rb
@@ -2,7 +2,14 @@ require 'spec_helper'
 
 module Spree
   describe StockTransfer, type: :model do
-    subject { described_class.create(reference: 'PO123', source_location: source_location, destination_location: destination_location) }
+    let(:stock_transfer) do
+      create(
+        :stock_transfer,
+        reference: 'PO123',
+        source_location: source_location,
+        destination_location: destination_location
+      )
+    end
 
     let(:destination_location) { create(:stock_location_with_items) }
     let(:source_location) { create(:stock_location_with_items) }
@@ -12,73 +19,104 @@ module Spree
     it_behaves_like 'metadata'
 
     describe '#reference' do
-      subject { super().reference }
+      subject { stock_transfer.reference }
 
       it { is_expected.to eq 'PO123' }
     end
 
     describe '#to_param' do
-      subject { super().to_param }
+      subject { stock_transfer.to_param }
 
       it { is_expected.to match(/T\d+/) }
     end
 
     describe '#transfer' do
-      it 'transfers variants between 2 locations' do
-        variants = { variant => 5 }
+      subject { stock_transfer.transfer(source_location, destination_location, variants) }
 
-        subject.transfer(source_location, destination_location, variants)
+      let(:stock_transfer) do
+        build(
+          :stock_transfer,
+          reference: 'PO123',
+          source_location: nil,
+          destination_location: nil,
+          stock_movements: []
+        )
+      end
+
+      let(:variants) { { variant => 5 } }
+
+      it 'transfers variants between 2 locations' do
+        subject
 
         expect(source_location.count_on_hand(variant)).to eq 5
         expect(destination_location.count_on_hand(variant)).to eq 5
 
-        expect(subject.source_location).to eq source_location
-        expect(subject.destination_location).to eq destination_location
+        expect(stock_transfer.source_location).to eq source_location
+        expect(stock_transfer.destination_location).to eq destination_location
 
-        expect(subject.source_movements.first.quantity).to eq(-5)
-        expect(subject.destination_movements.first.quantity).to eq 5
+        expect(stock_transfer.source_movements.first.quantity).to eq(-5)
+        expect(stock_transfer.destination_movements.first.quantity).to eq 5
       end
 
       context 'when variants are not available in the source location' do
+        let(:variants) { { variant => 5, other_variant => 5 } }
         let(:other_variant) { create(:variant) }
 
         it 'does not transfer the variants' do
-          expect(subject.transfer(source_location, destination_location, { variant => 5, other_variant => 5 })).to be false
-          expect(subject.errors[:base]).to include(Spree.t('stock_transfer.errors.variants_unavailable'))
+          expect(subject).to be false
+          expect(stock_transfer.errors[:base]).to include(Spree.t('stock_transfer.errors.variants_unavailable'))
         end
       end
 
       context 'when variants are empty' do
+        let(:variants) { {} }
+
         it 'does not transfer the variants' do
-          expect(subject.transfer(source_location, destination_location, {})).to be false
-          expect(subject.errors[:base]).to include(Spree.t('stock_transfer.errors.must_have_variant'))
+          expect(subject).to be false
+          expect(stock_transfer.errors[:base]).to include(Spree.t('stock_transfer.errors.must_have_variant'))
         end
       end
 
       context 'when variants are nil' do
+        let(:variants) { nil }
+
         it 'does not transfer the variants' do
-          expect(subject.transfer(source_location, destination_location, nil)).to be false
-          expect(subject.errors[:base]).to include(Spree.t('stock_transfer.errors.must_have_variant'))
+          expect(subject).to be false
+          expect(stock_transfer.errors[:base]).to include(Spree.t('stock_transfer.errors.must_have_variant'))
         end
       end
     end
 
-    it 'receive new inventory (from a vendor)' do
-      variants = { variant => 5 }
+    describe '#receive' do
+      subject { stock_transfer.receive(destination_location, { variant => 5 }) }
 
-      subject.receive(destination_location, variants)
+      let(:stock_transfer) do
+        build(
+          :stock_transfer,
+          reference: 'PO123',
+          source_location: nil,
+          destination_location: nil,
+          stock_movements: []
+        )
+      end
 
-      expect(destination_location.count_on_hand(variant)).to eq 5
+      it 'receives new inventory (from a vendor)' do
+        subject
 
-      expect(subject.source_location).to be_nil
-      expect(subject.destination_location).to eq destination_location
+        expect(destination_location.count_on_hand(variant)).to eq 5
+
+        expect(stock_transfer.source_location).to be_nil
+        expect(stock_transfer.destination_location).to eq destination_location
+      end
     end
 
     describe '#validations' do
       it 'checks if source location and destination location are the same' do
-        expect(described_class.new(source_location: source_location, destination_location: source_location)).to be_invalid
-        expect(described_class.new(source_location: source_location, destination_location: destination_location)).to be_valid
-        expect(described_class.new(destination_location: destination_location)).to be_valid
+        stock_movements = [build(:stock_movement)]
+
+        expect(described_class.new(source_location: source_location, destination_location: source_location, stock_movements: stock_movements)).to be_invalid
+        expect(described_class.new(source_location: source_location, destination_location: destination_location, stock_movements: stock_movements)).to be_valid
+        expect(described_class.new(destination_location: destination_location, stock_movements: stock_movements)).to be_valid
       end
     end
   end


### PR DESCRIPTION
Fixes:
* Product Variant reappears in the search after failing to create a Stock Transfer
* Broken validation (moved some to the `Spree::StockTransfer` model)
* Product Variants can be added to the Stock Transfer with no destination Stock Location