### PR TITLE
Set `auto_capture` on by default

### DIFF
--- a/core/lib/spree/core/configuration.rb
+++ b/core/lib/spree/core/configuration.rb
@@ -33,7 +33,7 @@ module Spree
       preference :always_include_confirm_step, :boolean, default: false # Ensures confirmation step is always in checkout_progress bar, but does not force a confirm step if your payment methods do not support it.
       preference :always_put_site_name_in_title, :boolean, deprecated: true
       preference :always_use_translations, :boolean, default: false
-      preference :auto_capture, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
+      preference :auto_capture, :boolean, default: true # automatically capture the credit card (as opposed to just authorize and capture later)
       preference :auto_capture_on_dispatch, :boolean, default: false # Captures payment for each shipment in Shipment#after_ship callback, and makes Shipment.ready when payment authorized.
       preference :binary_inventory_cache, :boolean, default: false, deprecated: true # only invalidate product cache when a stock item changes whether it is in_stock
       preference :checkout_zone, :string, default: nil, deprecated: true # replace with the name of a zone if you would like to limit the countries

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -26,11 +26,13 @@ describe 'exchanges:charge_unreturned_items' do
       Spree::Shipment.last.ship!
       return_item_1.receive!
       Timecop.travel travel_time
+      Spree::Config[:auto_capture] = false
     end
 
     after do
       Timecop.return
       Spree::Config[:expedited_exchanges] = @original_expedited_exchanges_pref
+      Spree::Config[:auto_capture] = true
     end
 
     context 'fewer than the config allowed days have passed' do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -981,12 +981,12 @@ describe Spree::Payment, type: :model do
   context 'state changes' do
     it 'are logged to the database' do
       expect(payment.state_changes).to be_empty
-      expect(payment.process!).to be true
+      expect(payment.process!).to be_a(Spree::PaymentCaptureEvent)
       expect(payment.state_changes.count).to eq(2)
       changes = payment.state_changes.map { |change| { change.previous_state => change.next_state } }
       expect(changes).to match_array([
                                        { 'checkout' => 'processing' },
-                                       { 'processing' => 'pending' }
+                                       { 'processing' => 'completed' }
                                      ])
     end
   end


### PR DESCRIPTION
Most modern payment gateways have auto capture on by default. To no configure customers using Spree we should follow their lead and have this on by default.

Also for non credit card payments (BNPL) require this to be always on.