### PR TITLE
[WIP] SQL injection in Products::Find causing `undefined method distinct for nil:NilClass`

### DIFF
--- a/core/spec/finders/spree/products/find_spec.rb
+++ b/core/spec/finders/spree/products/find_spec.rb
@@ -479,6 +479,16 @@ module Spree
           it 'returns products ordered by associated taxon position' do
             expect(products).to eq [product_2, product_3, product]
           end
+
+          context 'when sort_by has SQL injection' do
+            let(:params) do
+              { store: store, sort_by: "'nvOpzp", " AND 1"=>"1 OR (<'\">iKO)),", filter: { taxons: taxonomy.root.id } }
+            end
+
+            it 'returns products ordered by associated taxon position' do
+              expect(products).to eq [product_2, product_3, product]
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Recently, an attacker attempted to inject an SQL statement via the `sort_by` param for `TaxonsController#show` on my shop. Even though the attack didn't succeeded, it produced several thousand exception reports for:

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/ed522b92-96ea-481e-8c43-f4b86526d279" />

This PR aims to make sure given scenario does not produce 500 error.