### PR TITLE
Fixed: Do not return cancelled orders when fetching incomplete orders

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -57,7 +57,7 @@ module Spree
     end
 
     def last_incomplete_spree_order(store, options = {})
-      orders.where(store: store).incomplete.
+      orders.where(store: store).incomplete.not_canceled.
         includes(options[:includes]).
         order('created_at DESC').
         first

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -57,7 +57,7 @@ module Spree
           return unless try_spree_current_user && current_order
 
           orders_scope = try_spree_current_user.orders.
-                         incomplete.
+                         incomplete.not_canceled.
                          where.not(id: current_order.id).
                          where(store_id: current_store.id)
 
@@ -86,7 +86,7 @@ module Spree
           includes = options[:includes] ? order_includes : {}
 
           # Find any incomplete orders for the token
-          incomplete_orders = current_store.orders.incomplete.includes(includes)
+          incomplete_orders = current_store.orders.incomplete.not_canceled.includes(includes)
 
           token_order_params = current_order_params.except(:user_id)
           order = if with_adjustments

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -74,6 +74,12 @@ describe Spree::UserMethods do
       it { is_expected.to eq last_incomplete_order }
     end
 
+    context 'with incomplete canceled order' do
+      let(:canceled_order) { create(:order, user: test_user, created_at: 1.day.ago, store: current_store, state: 'canceled') }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'without an incomplete order' do
       it { is_expected.to be_nil }
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -19,6 +19,7 @@ describe Spree::Order, type: :model do
     let!(:user) { create(:user) }
     let!(:completed_order) { create(:order, user: user, completed_at: Time.current) }
     let!(:incompleted_order) { create(:order, user: user, completed_at: nil) }
+    let!(:canceled_order) { create(:order, user: user, completed_at: nil, state: 'canceled') }
 
     describe '.complete' do
       it { expect(Spree::Order.complete).to include completed_order }
@@ -28,6 +29,10 @@ describe Spree::Order, type: :model do
     describe '.incomplete' do
       it { expect(Spree::Order.incomplete).to include incompleted_order }
       it { expect(Spree::Order.incomplete).not_to include completed_order }
+    end
+
+    describe '.not_canceled' do
+      it { expect(Spree::Order.not_canceled).not_to include canceled_order }
     end
   end
 


### PR DESCRIPTION
This prevents from returning an incomplete cancelled order. Scenarios like this can happen during quick checkouts eg. apple pay