### PR TITLE
Add `Order#use_shipping`

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -146,7 +146,8 @@ module Spree
     before_validation :ensure_currency_presence
 
     before_validation :clone_billing_address, if: :use_billing?
-    attr_accessor :use_billing
+    before_validation :clone_shipping_address, if: :use_shipping?
+    attr_accessor :use_billing, :use_shipping
 
     before_create :link_by_email
     before_update :ensure_updated_shipments, :homogenize_line_item_currencies, if: :currency_changed?
@@ -758,6 +759,10 @@ module Spree
 
     def use_billing?
       use_billing.in?([true, 'true', '1'])
+    end
+
+    def use_shipping?
+      use_shipping.in?([true, 'true', '1'])
     end
 
     def ensure_currency_presence

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -48,7 +48,7 @@ module Spree
     ]
 
     @@checkout_attributes = [
-      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing,
+      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing, :use_shipping,
       :user_id, :bill_address_id, :ship_address_id
     ]
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -15,7 +15,7 @@ describe Spree::Order, type: :model do
 
   it_behaves_like 'metadata'
 
-  describe '.scopes' do
+  describe 'Scopes' do
     let!(:user) { create(:user) }
     let!(:completed_order) { create(:order, user: user, completed_at: Time.current) }
     let!(:incompleted_order) { create(:order, user: user, completed_at: nil) }
@@ -33,6 +33,25 @@ describe Spree::Order, type: :model do
 
     describe '.not_canceled' do
       it { expect(Spree::Order.not_canceled).not_to include canceled_order }
+    end
+  end
+
+  describe 'Callbacks' do
+    let(:order) { build(:order, user: user, store: store, ship_address: ship_address) }
+    let(:ship_address) { create(:address, user: user) }
+
+    describe '#clone_shipping_address' do
+      it 'clones the shipping address when use_shipping is true' do
+        order.use_shipping = true
+        order.save!
+        expect(order.ship_address).to eq(order.bill_address)
+      end
+
+      it 'does not clone the shipping address when use_shipping is false' do
+        order.use_shipping = false
+        order.save!
+        expect(order.ship_address).not_to eq(order.bill_address)
+      end
     end
   end
 


### PR DESCRIPTION
For new checkout we request the shipping address first, and billing on the payment screen. This is more natural and modern flow used by other platforms.