### PR TITLE
Revert "clone address instead of using same objects to stop overwriti…

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -307,8 +307,8 @@ module Spree
       # we need to check if user is of admin user class to avoid mismatch type error
       # in a scenario where we have separate classes for admin and regular users
       self.created_by   ||= user if user.is_a?(Spree.admin_user_class)
-      self.bill_address ||= user.bill_address.try(:clone)
-      self.ship_address ||= user.ship_address.try(:clone)
+      self.bill_address ||= user.bill_address
+      self.ship_address ||= user.ship_address
 
       changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -672,9 +672,11 @@ describe Spree::Order, type: :model do
       expect(order.created_by).to eql(created_by)
       expect(order.created_by_id).to eql(created_by.id)
 
-      expect(order.bill_address == bill_address).to be(true) if order.bill_address
+      expect(order.bill_address).to eql(bill_address)
+      expect(order.bill_address_id).to eql(bill_address.id)
 
-      expect(order.ship_address == ship_address).to be(true) if order.ship_address
+      expect(order.ship_address).to eql(ship_address)
+      expect(order.ship_address_id).to eql(ship_address.id)
     end
 
     shared_examples_for '#associate_user!' do |persisted = false|

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -673,10 +673,10 @@ describe Spree::Order, type: :model do
       expect(order.created_by_id).to eql(created_by.id)
 
       expect(order.bill_address).to eql(bill_address)
-      expect(order.bill_address_id).to eql(bill_address.id)
+      expect(order.bill_address_id).to eql(bill_address&.id)
 
       expect(order.ship_address).to eql(ship_address)
-      expect(order.ship_address_id).to eql(ship_address.id)
+      expect(order.ship_address_id).to eql(ship_address&.id)
     end
 
     shared_examples_for '#associate_user!' do |persisted = false|
@@ -731,7 +731,7 @@ describe Spree::Order, type: :model do
     end
 
     context 'when the user is not persisted' do
-      let(:user) { build(:user) }
+      let(:user) { build(:user_with_addreses) }
 
       it 'does not persist the user' do
         expect { order.associate_user!(user) }.


### PR DESCRIPTION
…ng them"

This reverts commit db4cbdfd8e2b437d764f74c5022c6f8b504ce241.

We don't need this behavior as we've introduced a cloning mechanism to address here: https://github.com/spree/spree/commit/0b0b39048f2edc5eb461c8ad7adcddda96aa38d8