### PR TITLE
Export `SPREE_STOREFRONT_PATH` ENV variable so we can later use it in…

### DIFF
--- a/storefront/lib/generators/spree/storefront/install/templates/tailwind.config.js
+++ b/storefront/lib/generators/spree/storefront/install/templates/tailwind.config.js
@@ -2,8 +2,17 @@ const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
   content: [
+    'public/*.html',
+    'app/helpers/**/*.rb',
+    'app/javascript/**/*.js',
     'app/views/spree/**/*.erb',
     'app/views/devise/**/*.erb',
+    'app/views/themes/**/*.erb',
+    process.env.SPREE_STOREFRONT_PATH + '/app/helpers/**/*.rb',
+    process.env.SPREE_STOREFRONT_PATH + '/app/javascript/**/*.js',
+    process.env.SPREE_STOREFRONT_PATH + '/app/views/themes/**/*.erb',
+    process.env.SPREE_STOREFRONT_PATH + '/app/views/spree/**/*.erb',
+    process.env.SPREE_STOREFRONT_PATH + '/app/views/devise/**/*.erb'
   ],
   plugins: [
     require('@tailwindcss/typography'),

--- a/storefront/lib/spree/storefront/engine.rb
+++ b/storefront/lib/spree/storefront/engine.rb
@@ -30,6 +30,11 @@ module Spree
         app.config.importmap.cache_sweepers << root.join('app/javascript')
       end
 
+      # we need to set the path to the storefront so that tailwind can find the views
+      initializer 'spree.storefront.tailwind_views_path' do
+        ENV['SPREE_STOREFRONT_PATH'] = root.to_s
+      end
+
       config.after_initialize do
         Rails.application.config.spree_storefront.head_partials = []
         Rails.application.config.spree_storefront.body_start_partials = []


### PR DESCRIPTION
… Tailwind config