### PR TITLE
Storefront: add support for custom quick checkout partials

### DIFF
--- a/storefront/app/views/spree/checkout/_quick_checkout.html.erb
+++ b/storefront/app/views/spree/checkout/_quick_checkout.html.erb
@@ -1,0 +1,1 @@
+<%= render_storefront_partials(:quick_checkout_partials) %>

--- a/storefront/lib/spree/storefront/engine.rb
+++ b/storefront/lib/spree/storefront/engine.rb
@@ -10,7 +10,8 @@ module Spree
         :add_to_cart_partials,
         :remove_from_cart_partials,
         :checkout_partials,
-        :checkout_complete_partials
+        :checkout_complete_partials,
+        :quick_checkout_partials
       )
 
       initializer 'spree.storefront.configuration', before: :load_config_initializers do |_app|
@@ -43,6 +44,7 @@ module Spree
         Rails.application.config.spree_storefront.remove_from_cart_partials = []
         Rails.application.config.spree_storefront.checkout_partials = []
         Rails.application.config.spree_storefront.checkout_complete_partials = []
+        Rails.application.config.spree_storefront.quick_checkout_partials = []
       end
     end
   end


### PR DESCRIPTION
Which new gems such as `spree_stripe` can inject code