### PR TITLE
Fixed: storefront products infinite scroll

### DIFF
--- a/storefront/app/views/spree/shared/_load_more_products.turbo_stream.erb
+++ b/storefront/app/views/spree/shared/_load_more_products.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "next_page" do %>
-  <%= render 'spree/products/show_more_button' %>
+  <%= render 'spree/products/show_more_button' if storefront_products.any? %>
 <% end %>
 
 <%= turbo_stream.append "products" do %>


### PR DESCRIPTION
For Kanimari we also need to check if there are any records at all, as `last_page?` will return false when total_pages = 0