### PR TITLE
Remove `spree_api` dependency from `storefront`

### DIFF
--- a/storefront/lib/spree/storefront.rb
+++ b/storefront/lib/spree/storefront.rb
@@ -1,5 +1,4 @@
 require 'spree_core'
-require 'spree_api'
 
 require 'sprockets/railtie'
 

--- a/storefront/spree_storefront.gemspec
+++ b/storefront/spree_storefront.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.files        = Dir['{app,config,lib}/**/*', 'LICENSE.md', 'Rakefile'].reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'
 
-  s.add_dependency 'spree_api', ">= #{s.version}"
   s.add_dependency 'spree_core', ">= #{s.version}"
 
   s.add_dependency 'active_link_to'


### PR DESCRIPTION
We don't intereact/depend on API in Storefront at all