### PR TITLE
Add missing background to mobile nav

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -1,7 +1,7 @@
-<div class="mt-4 border-default border-t overflow-x-hidden h-full w-screen overflow-y-hidden">
+<div class="bg-background mt-4 border-default border-t overflow-x-hidden h-full w-screen overflow-y-hidden">
   <div class="h-full flex transform has-[.currency-and-locale-modal:not(.hidden)]:transform-none relative transition-transform duration-300" data-controller="mobile-nav">
     <div class="w-screen shrink-0 flex flex-col h-full flex-grow-0">
-      <div class="bg-background flex-grow overflow-y-scroll">
+      <div class="flex-grow overflow-y-scroll">
         <% if section.blocks.any? %>
           <% section.blocks.each do |block| %>
             <% presenter = Spree::MegaNavPresenter.new(block) %>


### PR DESCRIPTION
Previous modifications were not applied to the secondary menu background