### PR TITLE
Fix to preserve theme name plural in generator

### DIFF
--- a/storefront/lib/generators/spree/storefront/theme/theme_generator.rb
+++ b/storefront/lib/generators/spree/storefront/theme/theme_generator.rb
@@ -28,7 +28,7 @@ module Spree
 
         no_tasks do
           def class_name
-            name.classify
+            name.camelize
           end
 
           def file_name


### PR DESCRIPTION
When generating a new theme using spree:storefront:theme generator, the theme class name was incorrectly singularized by the classify method. For example, 'Dolaris' would become 'Dolari'. This commit changes the method from classify to camelize to preserve the original theme name format while still maintaining proper class name casing.

This ensures theme names like 'Dolaris' remain unchanged while still converting names like 'my_theme' to 'MyTheme' properly.