### PR TITLE
Specific importmap for Spree Admin

### DIFF
--- a/admin/app/views/spree/admin/shared/_head.html.erb
+++ b/admin/app/views/spree/admin/shared/_head.html.erb
@@ -43,7 +43,7 @@
 <%= tinymce_assets %>
 <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.1.12/dist/trix.css">
 
-<%= javascript_importmap_tags 'application-spree-admin' %>
+<%= javascript_importmap_tags 'application-spree-admin', importmap: Rails.application.config.spree_admin.importmap %>
 
 <%= yield :head %>
 

--- a/admin/config/importmap.rb
+++ b/admin/config/importmap.rb
@@ -1,5 +1,9 @@
 pin 'application-spree-admin', to: 'spree/admin/application.js', preload: false
 
+pin "@hotwired/turbo-rails", to: "turbo.min.js"
+pin "@hotwired/stimulus", to: "stimulus.min.js"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+
 pin '@rails/actioncable', to: 'actioncable.esm.js', preload: ['application-spree-admin']
 pin '@rails/activestorage', to: 'activestorage.esm.js', preload: ['application-spree-admin']
 pin '@rails/actiontext', to: '@rails--actiontext@7.2.201.js', preload: ['application-spree-admin']
@@ -135,3 +139,5 @@ pin_all_from Spree::Admin::Engine.root.join('app/javascript/spree/admin/helpers'
              under: 'spree/admin/helpers',
              to: 'spree/admin/helpers',
              preload: ['application-spree-admin']
+
+draw Spree::Core::Engine.root.join('config/importmap.rb')

--- a/admin/lib/spree/admin/engine.rb
+++ b/admin/lib/spree/admin/engine.rb
@@ -29,6 +29,7 @@ module Spree
 
       initializer 'spree.admin.importmap', after: 'importmap' do |app|
         app.config.spree_admin = ActiveSupport::OrderedOptions.new
+
         app.config.spree_admin.importmap = Importmap::Map.new
         app.config.spree_admin.importmap.draw(root.join('config/importmap.rb'))
 


### PR DESCRIPTION
Before the `importmap` for `spree_admin` would be drawn directly into the application importmap. Since `spree_admin` contains a complete application it creates the possibility of conflicts.

Instead create its own instance of an Importmap and use that.