### PR TITLE
Fix: Add missing email param and remove unused title param

### DIFF
--- a/storefront/app/controllers/spree/account/profile_controller.rb
+++ b/storefront/app/controllers/spree/account/profile_controller.rb
@@ -14,7 +14,7 @@ module Spree
       private
 
       def user_params
-        params.require(:user).permit(:title, :first_name, :last_name, :phone)
+        params.require(:user).permit(:first_name, :last_name, :phone, :email)
       end
     end
   end


### PR DESCRIPTION
This PR fixes an issue in `storefront/app/controllers/spree/account/profile_controller.rb`:

- Added the missing email param to ensure it is properly permitted.
- Removed the unused title param as it was not needed in the request processing.

This change ensures the controller correctly handles profile updates without missing required fields or allowing unnecessary ones.

**Why this change?**
Without the email param, users might face issues when updating their profiles. Additionally, removing the unused title param improves code clarity.

Fixes #12495 