### PR TITLE
Allow users to extend spree admin importmap in their own applications

### DIFF
--- a/admin/lib/spree/admin/engine.rb
+++ b/admin/lib/spree/admin/engine.rb
@@ -29,12 +29,17 @@ module Spree
 
       initializer 'spree.admin.importmap', after: 'importmap' do |app|
         app.config.spree_admin = ActiveSupport::OrderedOptions.new
+        app.config.spree_admin.cache_sweepers = []
 
         app.config.spree_admin.importmap = Importmap::Map.new
         app.config.spree_admin.importmap.draw(root.join('config/importmap.rb'))
+      end
 
+      initializer 'spree.admin.importmap.cache_sweeper', after: 'spree.admin.importmap' do |app|
         if app.config.importmap.sweep_cache && app.config.reloading_enabled?
-          app.config.spree_admin.importmap.cache_sweeper(watches: root.join("app/javascript"))
+          app.config.spree_admin.cache_sweepers << root.join('app/javascript')
+
+          app.config.spree_admin.importmap.cache_sweeper(watches: app.config.spree_admin.cache_sweepers)
 
           ActiveSupport.on_load(:action_controller_base) do
             before_action { app.config.spree_admin.importmap.cache_sweeper.execute_if_updated }


### PR DESCRIPTION
This change will allow users to add custom JavaScript controllers to the spree admin without generating a separate importmap declaration.

[Since not all browsers support multiple importmap declarations](https://caniuse.com/mdn-html_elements_script_type_importmap_multiple_import_maps), we have to create a single importmap for spree controllers and the custom controllers that users might have


It works like this:
 
In the `config/application.rb` add your importmap:
```ruby
initializer 'my_app.admin.importmap', after: 'spree.admin.importmap' do |app|
  app.config.spree_admin.importmap.draw(app.root.join('config/admin_importmap.rb'))
end

initializer 'my_app.admin.importmap.cache_sweeper', before: 'spree.admin.importmap.cache_sweeper' do |app|
  app.config.spree_admin.cache_sweepers << app.root.join("app/javascript")
end
```

And then in `app/views/spree/admin/shared/_custom_head.html.erb` add your entry point:
```erb
<%= javascript_import_module_tag "custom-admin-entrypoint" %>
```