### PR TITLE
Product variants form - add autocomplete for option values

### DIFF
--- a/admin/app/controllers/spree/admin/option_values_controller.rb
+++ b/admin/app/controllers/spree/admin/option_values_controller.rb
@@ -3,6 +3,10 @@ module Spree
     class OptionValuesController < ResourceController
       belongs_to 'spree/option_type', find_by: :id
 
+      def select_options
+        render json: @option_type.option_values.to_tom_select_json
+      end
+
       private
 
       def update_turbo_stream_enabled?

--- a/admin/app/controllers/spree/admin/products_controller.rb
+++ b/admin/app/controllers/spree/admin/products_controller.rb
@@ -167,20 +167,25 @@ module Spree
         return unless @product.has_variants?
 
         @product_options = {}
+        @product_available_options = {}
 
         @product.
           option_values.
           joins(option_type: :product_option_types).
+          includes(option_type: :option_values).
           merge(@product.product_option_types).
           reorder('spree_product_option_types.position').
           uniq.group_by(&:option_type).each_with_index do |option, index|
-          option_type, option_values = option
-          @product_options[option_type.id.to_s] = {
-            name: option_type.presentation,
-            position: index + 1,
-            values: option_values.pluck(:presentation).uniq
-          }
-        end
+            option_type, option_values = option
+
+            @product_options[option_type.id.to_s] = {
+              name: option_type.presentation,
+              position: index + 1,
+              values: option_values.pluck(:presentation).uniq
+            }
+
+            @product_available_options[option_type.id.to_s] = option_type.option_values.to_tom_select_json
+          end
 
         @product_stock = {}
         @product.stock_items.includes(:variant).each do |stock_item|

--- a/admin/app/helpers/tom_select_helper.rb
+++ b/admin/app/helpers/tom_select_helper.rb
@@ -4,9 +4,9 @@ module TomSelectHelper
   #
   # @param [String] name
   # @param [Hash] options
-  def tom_select_tag(name, options = { multiple: false, url: nil, active_option: nil, class: 'w-100', create: false, select_data: {} })
+  def tom_select_tag(name, options = { template: false, multiple: false, url: nil, active_option: nil, class: 'w-100', create: false, select_data: {} })
     stimulus_options = options[:data] || {}
-    stimulus_options[:controller] = 'select'
+    stimulus_options[:controller] = 'select' unless options[:template].present?
     stimulus_options['select-active-option-value'] = options[:active_option].as_json if options[:active_option]
     stimulus_options['select-empty-option-value'] = options[:empty_option] if options[:empty_option]
     stimulus_options['select-options-value'] = options[:options].as_json if options[:options]

--- a/admin/app/javascript/spree/admin/application.js
+++ b/admin/app/javascript/spree/admin/application.js
@@ -58,6 +58,7 @@ import FiltersController from 'spree/admin/controllers/filters_controller'
 import FontPickerController from 'spree/admin/controllers/font_picker_controller'
 import MediaFormController from 'spree/admin/controllers/media_form_controller'
 import MultiInputController from 'spree/admin/controllers/multi_input_controller'
+import MultiTomSelectController from 'spree/admin/controllers/multi_tom_select_controller'
 import OrderBillingAddressController from 'spree/admin/controllers/order_billing_address_controller'
 import PageBuilderController from 'spree/admin/controllers/page_builder_controller'
 import PasswordToggle from 'spree/admin/controllers/password_toggle_controller'
@@ -103,6 +104,7 @@ application.register('filters', FiltersController)
 application.register('font-picker', FontPickerController)
 application.register('media-form', MediaFormController)
 application.register('multi-input', MultiInputController)
+application.register('multi-tom-select', MultiTomSelectController)
 application.register('nested-form', RailsNestedForm)
 application.register('notification', Notification)
 application.register('order-billing-address', OrderBillingAddressController)

--- a/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
@@ -13,11 +13,7 @@ export default class extends Controller {
     this.element.values = this.values.bind(this)
     this.element.setValues = this.setValues.bind(this)
 
-    this.lastSelect = this.selectTargets[this.selectTargets.length - 1].querySelector('select')
-
-    if (this.preloadedValuesValue.length > 0) {
-      this.setValues(this.preloadedValuesValue)
-    }
+    this.setValues(this.preloadedValuesValue)
   }
 
   reset() {
@@ -35,7 +31,7 @@ export default class extends Controller {
       }
     })
 
-    this.lastSelect = this.selectTargets[0]
+    this.lastSelect = this.selectTargets[0]?.querySelector('select')
   }
 
   values() {
@@ -45,22 +41,9 @@ export default class extends Controller {
       .filter((text) => text?.length > 0)
   }
 
-  setValues(values) {
+  setValues() {
     this.reset()
-
-    values.forEach((value, i) => {
-      if (i > 0) this.addSelect()
-
-      const select = this.selectTargets[i].querySelector('select')
-      const tomSelect = select.tomselect
-
-      if (tomSelect) {
-        tomSelect.clear()
-        tomSelect.clearOptions()
-        tomSelect.addOptions(this.preloadedOptionsValue)
-        tomSelect.addItem(value)
-      }
-    })
+    this.preloadedValuesValue.forEach((value) => this.addSelect(value))
   }
 
   handleSelect(event) {
@@ -91,13 +74,23 @@ export default class extends Controller {
     }
   }
 
-  addSelect() {
+  addSelect(value = null) {
     const newTomSelectTag = this.selectTemplateTarget.cloneNode(true)
+
+    if (value) {
+      newTomSelectTag.setAttribute('data-select-options-value', JSON.stringify(this.preloadedOptionsValue))
+      newTomSelectTag.setAttribute('data-select-active-option-value', value.id)
+    }
+
     newTomSelectTag.setAttribute('data-multi-tom-select-target', 'select')
     newTomSelectTag.setAttribute('data-controller', 'select')
 
-    const lastSelect = this.selectTargets[this.selectTargets.length - 1]
-    lastSelect.insertAdjacentElement('afterend', newTomSelectTag)
+    if (this.hasSelectTargets) {
+      const lastSelect = this.selectTargets[this.selectTargets.length - 1]
+      lastSelect.insertAdjacentElement('afterend', newTomSelectTag)
+    } else {
+      this.element.insertAdjacentElement('beforeend', newTomSelectTag)
+    }
 
     this.lastSelect = newTomSelectTag.querySelector('select')
   }

--- a/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
@@ -1,0 +1,104 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['selectTemplate', 'select']
+
+  static values = {
+    preloadedValues: { type: Array, default: [] },
+    preloadedOptions: { type: Array, default: [] }
+  }
+
+  connect() {
+    this.element.reset = this.reset.bind(this)
+    this.element.values = this.values.bind(this)
+    this.element.setValues = this.setValues.bind(this)
+
+    this.lastSelect = this.selectTargets[this.selectTargets.length - 1].querySelector('select')
+
+    if (this.preloadedValuesValue.length > 0) {
+      this.setValues(this.preloadedValuesValue)
+    }
+  }
+
+  reset() {
+    this.selectTargets.forEach((container, i) => {
+      if (i > 0) {
+        container.remove()
+      } else {
+        const select = container.querySelector('select')
+        const tomSelect = select.tomselect
+
+        if (tomSelect) {
+          tomSelect.clear()
+          tomSelect.clearOptions()
+        }
+      }
+    })
+
+    this.lastSelect = this.selectTargets[0]
+  }
+
+  values() {
+    return this.selectTargets
+      .map((selectTarget) => selectTarget.querySelector('select'))
+      .map((select) => select.options[select.selectedIndex].text)
+      .filter((text) => text?.length > 0)
+  }
+
+  setValues(values) {
+    this.reset()
+
+    values.forEach((value, i) => {
+      if (i > 0) this.addSelect()
+
+      const select = this.selectTargets[i].querySelector('select')
+      const tomSelect = select.tomselect
+
+      if (tomSelect) {
+        tomSelect.clear()
+        tomSelect.clearOptions()
+        tomSelect.addOptions(this.preloadedOptionsValue)
+        tomSelect.addItem(value)
+      }
+    })
+  }
+
+  handleSelect(event) {
+    const ts = event.target.tomselect
+
+    if (ts && ts.getValue().length > 0 && (this.lastSelect === event.target || this.selectTargets.length === 1)) {
+      this.addSelect()
+    }
+  }
+
+  handleKeyDown(event) {
+    const ts = this.tomSelects.get(event.target)
+    if (event.key === 'Backspace' && (!ts || ts.getValue().length === 0) && this.selectTargets.length > 1) {
+      const inputContainer = event.target.closest('[data-multi-tom-select-target="select"]')
+      this.removeSelect(inputContainer)
+    }
+  }
+
+  removeSelect(container) {
+    if (this.selectTargets.length > 1) {
+      const input = container.querySelector('input, select')
+      const ts = this.tomSelects.get(input)
+      if (ts) {
+        ts.destroy()
+        this.tomSelects.delete(input)
+      }
+      container.remove()
+    }
+  }
+
+  addSelect() {
+    const newTomSelectTag = this.selectTemplateTarget.cloneNode(true)
+    newTomSelectTag.setAttribute('data-multi-tom-select-target', 'select')
+    newTomSelectTag.setAttribute('data-controller', 'select')
+
+    const lastSelect = this.selectTargets[this.selectTargets.length - 1]
+    lastSelect.insertAdjacentElement('afterend', newTomSelectTag)
+
+    this.lastSelect = newTomSelectTag.querySelector('select')
+  }
+}

--- a/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
@@ -16,22 +16,11 @@ export default class extends Controller {
     this.setValues(this.preloadedValuesValue)
   }
 
-  reset() {
-    this.selectTargets.forEach((container, i) => {
-      if (i > 0) {
-        container.remove()
-      } else {
-        const select = container.querySelector('select')
-        const tomSelect = select.tomselect
+  reset(addBlankSelect = true) {
+    this.selectTargets.forEach((container) => container.remove())
 
-        if (tomSelect) {
-          tomSelect.clear()
-          tomSelect.clearOptions()
-        }
-      }
-    })
-
-    this.lastSelect = this.selectTargets[0]?.querySelector('select')
+    if (addBlankSelect)
+      this.addSelect()
   }
 
   values() {
@@ -42,8 +31,11 @@ export default class extends Controller {
   }
 
   setValues() {
-    this.reset()
+    this.reset(false)
     this.preloadedValuesValue.forEach((value) => this.addSelect(value))
+
+    if (this.selectTargets.length === this.preloadedValuesValue.length)
+      this.addSelect()
   }
 
   handleSelect(event) {
@@ -51,12 +43,7 @@ export default class extends Controller {
 
     if (ts && ts.getValue().length > 0 && (this.lastSelect === event.target || this.selectTargets.length === 1)) {
       this.addSelect()
-    }
-  }
-
-  handleKeyDown(event) {
-    const ts = this.tomSelects.get(event.target)
-    if (event.key === 'Backspace' && (!ts || ts.getValue().length === 0) && this.selectTargets.length > 1) {
+    } else if (ts && ts.getValue().length === 0 && this.selectTargets.length > 1) {
       const inputContainer = event.target.closest('[data-multi-tom-select-target="select"]')
       this.removeSelect(inputContainer)
     }
@@ -64,12 +51,8 @@ export default class extends Controller {
 
   removeSelect(container) {
     if (this.selectTargets.length > 1) {
-      const input = container.querySelector('input, select')
-      const ts = this.tomSelects.get(input)
-      if (ts) {
-        ts.destroy()
-        this.tomSelects.delete(input)
-      }
+      const select = container.querySelector('select')
+      select.tomselect?.destroy()
       container.remove()
     }
   }
@@ -77,10 +60,10 @@ export default class extends Controller {
   addSelect(value = null) {
     const newTomSelectTag = this.selectTemplateTarget.cloneNode(true)
 
-    if (value) {
-      newTomSelectTag.setAttribute('data-select-options-value', JSON.stringify(this.preloadedOptionsValue))
+    newTomSelectTag.setAttribute('data-select-options-value', JSON.stringify(this.preloadedOptionsValue))
+
+    if (value)
       newTomSelectTag.setAttribute('data-select-active-option-value', value.id)
-    }
 
     newTomSelectTag.setAttribute('data-multi-tom-select-target', 'select')
     newTomSelectTag.setAttribute('data-controller', 'select')

--- a/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -244,7 +244,7 @@ export default class extends CheckboxSelectAll {
         label.textContent = label.dataset.noOptionsText
       }
     }
-    this.refreshTomSelect()
+    this.refreshOptionNameSelect()
     this.variantsValue = this.generateVariants(value)
 
     // We want to clear the ignoredVariants when the options change
@@ -836,6 +836,7 @@ export default class extends CheckboxSelectAll {
     event.preventDefault()
     this.newOptionFormTarget.classList.remove('d-none')
     this.newOptionButtonTarget.classList.add('d-none')
+    this.refreshOptionNameSelect()
   }
 
   optionTemplate(name, values, id, color = false) {
@@ -928,24 +929,34 @@ export default class extends CheckboxSelectAll {
     return templates
   }
 
-  refreshTomSelect() {
+  refreshOptionNameSelect() {
     const alreadySelectedOptions = Object.keys(this.optionsValue).filter((k) => this.optionsValue[k] !== null)
 
     Array.from(this.newOptionNameInputTarget.options).forEach((option) => {
-      const tomselectOption = this.newOptionNameInputTarget.tomselect?.getOption(option.value)
+      const tomSelect = this.newOptionNameInputTarget.tomselect
+      if (!tomSelect) return
+
+      const tomselectOption = tomSelect.getOption(option.value)
       if (!tomselectOption) return
+
       const alreadySelected = alreadySelectedOptions.includes(option.value)
       tomselectOption.ariaDisabled = alreadySelected
+
       if (alreadySelected) {
         tomselectOption.removeAttribute('data-selectable')
       } else {
         tomselectOption.setAttribute('data-selectable', '')
       }
+
       tomselectOption.disabled = alreadySelected
     })
 
-    this.newOptionNameInputTarget.tomselect?.sync()
-    this.newOptionNameInputTarget.tomselect?.refreshOptions()
+    const optionNameTomSelect = this.newOptionNameInputTarget.tomselect
+
+    if (optionNameTomSelect) {
+      optionNameTomSelect.sync()
+      optionNameTomSelect.refreshOptions(false)
+    }
   }
 
   generateVariants(optionsValue) {

--- a/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -714,7 +714,11 @@ export default class extends CheckboxSelectAll {
 
       if (response.ok) {
         this.currentOptionValues = await response.json
-        this.newOptionValuesSelectTargets.forEach((select) => this.replaceSelectOptions(select))
+
+        const optionsCreatorContainer = targetInput.closest('.options-creator__option')
+        const newOptionValuesSelects = optionsCreatorContainer.querySelectorAll('[data-variants-form-target="newOptionValuesSelect"]')
+
+        newOptionValuesSelects.forEach((select) => this.replaceSelectOptions(select))
       }
     }
   }

--- a/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -27,6 +27,7 @@ export default class extends CheckboxSelectAll {
   static values = {
     productId: String,
     options: Object,
+    availableOptions: Object,
     variants: Array,
     stock: Object,
     prices: Object,
@@ -703,8 +704,7 @@ export default class extends CheckboxSelectAll {
     }
   }
 
-  // After selecting an option name (eg. "Color"), we fetch the option values for that option name
-  // and dispatch a custom event to select tag to update the options
+  // After selecting an option name (eg. "Color"), we fetch the option values for that option name and update the tom select options
   async handleSelectedOptionName(event) {
     const targetInput = event.target
     const optionNameId = targetInput.value
@@ -771,8 +771,9 @@ export default class extends CheckboxSelectAll {
     const option = this.optionsContainerTarget.querySelector(`#option-${optionId}`)
 
     const { name, values } = this.optionsValue[optionId]
+    const availableOptions = this.availableOptionsValue[optionId]
 
-    const form = this.optionFormTemplate(name, values, optionId)
+    const form = this.optionFormTemplate(name, values, optionId, availableOptions)
 
     option.replaceWith(form)
   }
@@ -795,7 +796,7 @@ export default class extends CheckboxSelectAll {
     let position = this.optionsValue[optionId].position
     let newOptionsPositions = {}
 
-    const optionValues = option.querySelector('[data-slot="optionValuesInput"]').values()
+    const optionValues = option.querySelector('[data-slot="optionValuesSelectContainer"]').values()
 
     if (optionValues.length === 0) {
       return
@@ -865,7 +866,7 @@ export default class extends CheckboxSelectAll {
     this.refreshParentInputs()
   }
 
-  optionFormTemplate(optionName, optionValues, id) {
+  optionFormTemplate(optionName, optionValues, id, availableOptions) {
     const template = this.optionFormTemplateTarget.content.cloneNode(true)
 
     const optionNameSelect = template.querySelector('select[name="option_name"]')
@@ -887,8 +888,16 @@ export default class extends CheckboxSelectAll {
       optionNameSelect.appendChild(newOption)
     }
 
-    const optionValuesInput = template.querySelector('[data-slot="optionValuesInput"]')
-    optionValuesInput.dataset.multiInputPreloadedValuesValue = JSON.stringify(optionValues)
+    const optionValuesSelectContainer = template.querySelector('[data-slot="optionValuesSelectContainer"]')
+    const tomSelectOptionValues = optionValues.map((optionValue) => {
+      return {
+        id: availableOptions.find((availableOption) => availableOption.name === optionValue).id,
+        name: optionValue
+      }
+    })
+
+    optionValuesSelectContainer.setAttribute('data-multi-tom-select-preloaded-options-value', JSON.stringify(availableOptions))
+    optionValuesSelectContainer.setAttribute('data-multi-tom-select-preloaded-values-value', JSON.stringify(tomSelectOptionValues))
 
     template.querySelectorAll('[data-variants-form-option-id-param]').forEach((el) => {
       el.dataset.variantsFormOptionIdParam = id

--- a/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -68,16 +68,35 @@
               </div>
               <div class="form-group">
                 <span class="label"><%= Spree.t(:option_values) %></span>
-                <!-- TODO add multi-input: <div data-controller="multi-input" class="values-inputs" data-variants-form-target="newOptionValuesInput">-->
-                <div class="values-inputs" data-variants-form-target="newOptionValuesInput">
-                  <div class="values-inputs__input" data-multi-input-target="input">
+                <div data-controller="multi-tom-select" class="values-inputs" data-variants-form-target="newOptionValuesSelectContainer">
+                  <%= tom_select_tag "new_option_values[]",
+                    preloaded_options: @option_values,
+                    multiple: false,
+                    create: true,
+                    include_blank: true,
+                    template: true,
+                    class: 'w-100 mb-1',
+                    data: {
+                      multi_tom_select_target: "selectTemplate"
+                    },
+                    select_data: {
+                      variants_form_target: "newOptionValuesSelect",
+                      action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
+                    } %>
+
+                  <div class="values-inputs__input">
                     <%= tom_select_tag "new_option_values[]",
                       preloaded_options: @option_values,
                       multiple: false,
                       create: true,
                       include_blank: true,
+                      class: 'w-100 mb-1',
+                      data: {
+                        multi_tom_select_target: "select"
+                      },
                       select_data: {
-                        variants_form_target: "newOptionValuesSelect"
+                        variants_form_target: "newOptionValuesSelect",
+                        action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
                       } %>
                   </div>
                 </div>

--- a/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -80,7 +80,7 @@
                     },
                     select_data: {
                       variants_form_target: "newOptionValuesSelect",
-                      action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
+                      action: "multi-tom-select#handleSelect keydown.enter->variants-form#handleNewOption:prevent"
                     } %>
 
                   <%= tom_select_tag "new_option_values[]",
@@ -92,7 +92,7 @@
                     },
                     select_data: {
                       variants_form_target: "newOptionValuesSelect",
-                      action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
+                      action: "multi-tom-select#handleSelect keydown.enter->variants-form#handleNewOption:prevent"
                     } %>
                 </div>
               </div>

--- a/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -15,6 +15,7 @@
         data-variants-form-current-stock-location-id-value="<%= default_stock_location_for_product(@product).id %>"
         data-variants-form-stock-locations-value="<%= available_stock_locations_for_product(@product).ids.map(&:to_s).to_json %>"
         <% if @product_options.present? %> data-variants-form-options-value="<%= @product_options.to_json %>" <% end %>
+        <% if @product_available_options.present? %> data-variants-form-available-options-value="<%= @product_available_options.to_json %>" <% end %>
         <% if @product_stock.present? %> data-variants-form-stock-value="<%= @product_stock.to_json %>" <% end %>
         <% if @product_prices.present? %> data-variants-form-prices-value="<%= @product_prices.to_json %>" <% end %>
         <% if @product_variant_ids.present? %> data-variants-form-variant-ids-value="<%= @product_variant_ids.to_json %>" <% end %>
@@ -70,12 +71,10 @@
                 <span class="label"><%= Spree.t(:option_values) %></span>
                 <div data-controller="multi-tom-select" class="values-inputs" data-variants-form-target="newOptionValuesSelectContainer">
                   <%= tom_select_tag "new_option_values[]",
-                    preloaded_options: @option_values,
+                    template: true,
                     multiple: false,
                     create: true,
                     include_blank: true,
-                    template: true,
-                    class: 'w-100 mb-1',
                     data: {
                       multi_tom_select_target: "selectTemplate"
                     },
@@ -84,21 +83,17 @@
                       action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
                     } %>
 
-                  <div class="values-inputs__input">
-                    <%= tom_select_tag "new_option_values[]",
-                      preloaded_options: @option_values,
-                      multiple: false,
-                      create: true,
-                      include_blank: true,
-                      class: 'w-100 mb-1',
-                      data: {
-                        multi_tom_select_target: "select"
-                      },
-                      select_data: {
-                        variants_form_target: "newOptionValuesSelect",
-                        action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
-                      } %>
-                  </div>
+                  <%= tom_select_tag "new_option_values[]",
+                    multiple: false,
+                    create: true,
+                    include_blank: true,
+                    data: {
+                      multi_tom_select_target: "select"
+                    },
+                    select_data: {
+                      variants_form_target: "newOptionValuesSelect",
+                      action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
+                    } %>
                 </div>
               </div>
               <div class="d-flex justify-content-between">

--- a/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -59,7 +59,7 @@
                   include_blank: true,
                   select_data: {
                     variants_form_target: "newOptionNameInput",
-                    action: "variants-form#handleSelectedOptionName"
+                    action: "variants-form#handleSelectedOptionName tomSelectInitialized->variants-form#refreshOptionNameSelect"
                   } %>
                 <% if can?(:manage, Spree::OptionType) %>
                   <p class="form-text text-muted mt-2">

--- a/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -51,7 +51,15 @@
             <div class="w-100">
               <div class="form-group">
                 <label class="label" for="new_option_name"><%= Spree.t(:option_name) %></label>
-                <%= tom_select_tag :new_option_name, multiple: false, create: true, preloaded_options: option_types_for_select, include_blank: true, select_data: {variants_form_target: "newOptionNameInput"} %>
+                <%= tom_select_tag :new_option_name,
+                  multiple: false,
+                  create: true,
+                  preloaded_options: option_types_for_select,
+                  include_blank: true,
+                  select_data: {
+                    variants_form_target: "newOptionNameInput",
+                    action: "variants-form#handleSelectedOptionName"
+                  } %>
                 <% if can?(:manage, Spree::OptionType) %>
                   <p class="form-text text-muted mt-2">
                     <%= Spree.t('admin.products.variants.option_types_link', link: spree.admin_option_types_path).html_safe %>
@@ -60,9 +68,17 @@
               </div>
               <div class="form-group">
                 <span class="label"><%= Spree.t(:option_values) %></span>
-                <div data-controller="multi-input" class="values-inputs" data-variants-form-target="newOptionValuesInput">
+                <!-- TODO add multi-input: <div data-controller="multi-input" class="values-inputs" data-variants-form-target="newOptionValuesInput">-->
+                <div class="values-inputs" data-variants-form-target="newOptionValuesInput">
                   <div class="values-inputs__input" data-multi-input-target="input">
-                    <input class="form-control" name="new_option_values[]" data-action="multi-input#handleInput keydown->multi-input#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent">
+                    <%= tom_select_tag "new_option_values[]",
+                      preloaded_options: @option_values,
+                      multiple: false,
+                      create: true,
+                      include_blank: true,
+                      select_data: {
+                        variants_form_target: "newOptionValuesSelect"
+                      } %>
                   </div>
                 </div>
               </div>

--- a/admin/app/views/spree/admin/products/form/variants/_option_template.html.erb
+++ b/admin/app/views/spree/admin/products/form/variants/_option_template.html.erb
@@ -28,10 +28,19 @@
       </div>
       <div class="form-group">
         <span class="label"><%= Spree.t(:option_values) %></span>
-        <div data-controller="multi-input" class="values-inputs" data-slot="optionValuesInput">
-          <div class="values-inputs__input" data-multi-input-target="input">
-            <input class="form-control" data-variants-form-option-id-param="" name="new_option_values[]" data-action="multi-input#handleInput keydown->multi-input#handleKeyDown keydown.enter->variants-form#saveOption:prevent">
-          </div>
+        <div data-controller="multi-tom-select" class="values-inputs" data-variants-form-target="newOptionValuesSelectContainer" data-slot="optionValuesSelectContainer">
+          <%= tom_select_tag "new_option_values[]",
+            template: true,
+            multiple: false,
+            create: true,
+            include_blank: true,
+            data: {
+              multi_tom_select_target: "selectTemplate"
+            },
+            select_data: {
+              variants_form_target: "newOptionValuesSelect",
+              action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
+            } %>
         </div>
       </div>
       <div class="d-flex justify-content-between">

--- a/admin/app/views/spree/admin/products/form/variants/_option_template.html.erb
+++ b/admin/app/views/spree/admin/products/form/variants/_option_template.html.erb
@@ -24,7 +24,14 @@
     <div class="w-100">
       <div class="form-group">
         <label class="label" for="option_name"><%= Spree.t(:option_name) %></label>
-        <%= tom_select_tag :option_name, multiple: false, create: true, preloaded_options: option_types_for_select, include_blank: true %>
+        <%= tom_select_tag :option_name,
+          multiple: false,
+          create: true,
+          preloaded_options: option_types_for_select,
+          include_blank: true,
+          select_data: {
+            action: "variants-form#handleSelectedOptionName tomSelectInitialized->variants-form#refreshOptionNameSelect"
+          } %>
       </div>
       <div class="form-group">
         <span class="label"><%= Spree.t(:option_values) %></span>

--- a/admin/app/views/spree/admin/products/form/variants/_option_template.html.erb
+++ b/admin/app/views/spree/admin/products/form/variants/_option_template.html.erb
@@ -39,7 +39,7 @@
             },
             select_data: {
               variants_form_target: "newOptionValuesSelect",
-              action: "multi-tom-select#handleSelect keydown->multi-tom-select#handleKeyDown keydown.enter->variants-form#handleNewOption:prevent"
+              action: "multi-tom-select#handleSelect keydown.enter->variants-form#handleNewOption:prevent"
             } %>
         </div>
       </div>

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -3,7 +3,11 @@ Spree::Core::Engine.add_routes do
     # product catalog
     resources :properties, except: :show
     resources :option_types, except: :show do
-      resources :option_values, only: [:update]
+      resources :option_values, only: [:update] do
+        collection do
+          get :select_options
+        end
+      end
     end
     resources :products do
       collection do

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -62,10 +62,10 @@ module Spree
     delegate :name, :presentation, to: :option_type, prefix: true, allow_nil: true
 
     def self.to_tom_select_json
-      all.map do |option_value|
+      all.pluck(:id, :presentation).map do |id, presentation|
         {
-          id: option_value.id,
-          name: option_value.presentation
+          id: id,
+          name: presentation
         }
       end
     end

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -61,6 +61,15 @@ module Spree
 
     delegate :name, :presentation, to: :option_type, prefix: true, allow_nil: true
 
+    def self.to_tom_select_json
+      all.map do |option_value|
+        {
+          id: option_value.id,
+          name: option_value.presentation
+        }
+      end
+    end
+
     private
 
     def touch_all_variants

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1359,7 +1359,7 @@ en:
         message: Please click the button below to pay for your order.
         message_copy_link: 'If the button doesn''t work please copy and paste the following link to your browser:'
         pay_for_order: Pay for order
-        subject: "Payment link for order #%{number}"
+        subject: 'Payment link for order #%{number}'
       store_owner_notification_email:
         heading: New Order Received
         instructions: You have received a new order.


### PR DESCRIPTION
- [x] Add working tom_select for new option values (+ duplicating selects)
- [x] Fix editing variants with autocomplete
- [x] Fix an issue with duplicating selects when editing options
- [x] Fix a bug with the form where it allows to pick existing option names, eg. "Color" on editing the product (we grey this out when adding a new product)
- [x] Fix an issue with editing current option names - you're able to pick an already existing option name

https://github.com/user-attachments/assets/8c5701c0-67d0-4fb8-839d-3e1924446d8a
