### PR TITLE
Implement automatic DOM IDs and CSS classes for sections/blocks/links

### DIFF
--- a/storefront/app/helpers/spree/page_helper.rb
+++ b/storefront/app/helpers/spree/page_helper.rb
@@ -17,11 +17,14 @@ module Spree
       variables[:section] = section
       variables[:loaded] = true
 
+      css_id = "section-#{section.id}"
+      css_class = "section-#{section.class.name.demodulize.underscore.dasherize}"
+
       if page_builder_enabled?
-        turbo_frame_tag("section-#{section.id}") do
+        turbo_frame_tag(css_id, class: css_class) do
           content_tag(:div,
             data: {
-              editor_id: "section-#{section.id}",
+              editor_id: css_id,
               editor_name: section.name,
               editor_link: spree.edit_admin_page_section_path(section)
             }
@@ -35,11 +38,13 @@ module Spree
 
         path = section.lazy_path(variables)
 
-        turbo_frame_tag("section-#{section.id}", src: path, loading: 'eager') do
+        turbo_frame_tag(css_id, src: path, loading: 'eager', class: css_class) do
           render('/' + section.to_partial_path, **variables)
         end
       else
-        render('/' + section.to_partial_path, **variables)
+        content_tag(:div, id: css_id, class: css_class) do
+          render('/' + section.to_partial_path, **variables)
+        end
       end
     rescue ActionView::MissingTemplate, ActionView::Template::Error => e
       raise e unless Rails.env.production?

--- a/storefront/app/helpers/spree/theme_helper.rb
+++ b/storefront/app/helpers/spree/theme_helper.rb
@@ -138,6 +138,8 @@ module Spree
           editor_parent_id: "section-#{block.section_id}",
           editor_link: spree.respond_to?(:edit_admin_page_section_block_path) ? spree.edit_admin_page_section_block_path(block.section, block) : nil
         },
+        id: "block-#{block.id}",
+        class: "block-#{block.class.name.demodulize.underscore.dasherize}",
         style: block_styles(block, allowed_styles: allowed_styles),
         width_desktop: has_width_desktop
       }.compact_blank
@@ -167,7 +169,9 @@ module Spree
                                     when :block
                                       spree.edit_admin_page_link_path(link, block_id: link.parent_id)
                                     end
-                      }
+                      },
+                      id: "link-#{link.id}",
+                      class: "link-#{link.class.name.demodulize.underscore.dasherize}"
                     }
                   else
                    {}


### PR DESCRIPTION
This will allow developers to apply custom styles per section/block/link type and give more flexibility to theme developers overall

eg. `section-announcement-bar`, `section-newsletter`, `block-nav`

![CleanShot 2025-03-21 at 09 45 51@2x](https://github.com/user-attachments/assets/78b0f02b-b60f-4ead-85a9-da5dc31a05b8)
