### PR TITLE
Handle the case when shipment's shipping method is nil when deciding whether shipment is digital

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -230,7 +230,7 @@ module Spree
     end
 
     def digital?
-      shipping_method.calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
+      shipping_method&.calculator&.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end
 
     ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)

--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -55,6 +55,7 @@
           <%= Spree.t("shipment_states.canceled") %></strong>.
         <%= Spree.t(:shipment_refunded_message) %>
       </div>
+    <% elsif shipment.shipped? && shipment.tracked? %>
     <% elsif !shipment.digital? %>
       <div class="text-sm uppercase text-center bg-neutral-100 mt-3 px-3 py-2">
         <%= Spree.t(:no_tracking_present) %>

--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -47,16 +47,13 @@
         <% end %>
       </div>
     </div>
-    <% if shipment.canceled? && shipment.shipped_at.present? %>
-      <%# No message if shipment has been shipped already %>
-    <% elsif shipment.canceled? && shipment.shipped_at.nil? %>
+    <% if shipment.canceled? && shipment.shipped_at.nil? %>
       <div class="alert-warning text-sm uppercase mt-3 px-3 py-2">
         <strong><%= Spree.t(:shipment) %>
           <%= Spree.t("shipment_states.canceled") %></strong>.
         <%= Spree.t(:shipment_refunded_message) %>
       </div>
-    <% elsif shipment.shipped? && shipment.tracked? %>
-    <% elsif !shipment.digital? %>
+    <% elsif (!shipment.tracked? || !shipment.shipped?) && !shipment.digital? %>
       <div class="text-sm uppercase text-center bg-neutral-100 mt-3 px-3 py-2">
         <%= Spree.t(:no_tracking_present) %>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the robustness of digital delivery checks by preventing potential errors when shipping methods are undefined.
  - Refined the logic for displaying messages related to shipment cancellations and tracking status.

- **New Features**
  - Enhanced the order shipment view to provide clearer information regarding shipment cancellations and tracking for non-digital shipments.
  
- **Tests**
  - Added new tests for the digital delivery functionality, ensuring accurate behavior across various shipping methods. 
  - Improved organization and clarity of existing tests related to the shipment model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->