### PR TITLE
Do not delete stock items when track inventory is set to false

### DIFF
--- a/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -866,13 +866,14 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         create(:stock_item, count_on_hand: 20, variant: product.master)
       end
 
-      it 'removes stock items' do
+      it 'updates stock items' do
         expect(product.master.stock_items.reload.count).to be > 0
 
         send_request
 
         expect(product.reload.track_inventory).to be(false)
-        expect(product.master.stock_items.reload.count).to eq(0)
+        expect(product.master.stock_items.reload.first.backorderable).to be(true)
+        expect(product.master.stock_items.reload.first.count_on_hand).to eq(0)
       end
     end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -553,7 +553,7 @@ module Spree
       return unless track_inventory_previously_changed?
       return if track_inventory
 
-      stock_items.delete_all
+      stock_items.update_all(backorderable: true, count_on_hand: 0, updated_at: Time.current)
     end
 
     def remove_prices_from_master_variant

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -141,9 +141,13 @@ describe Spree::Variant, type: :model do
       let!(:variant) { create(:variant, product: product, track_inventory: true) }
       let!(:stock_item) { create(:stock_item, variant: variant, count_on_hand: 100) }
 
+      before do
+        stock_item.update!(backorderable: false)
+      end
+
       it 'updates stock items' do
-        expect { subject }.to change { stock_item.reload.backorderable }.from(false).to(true)
-        expect { subject }.to change { stock_item.reload.count_on_hand }.from(100).to(0)
+        expect { subject }.
+          to change { stock_item.reload.backorderable }.from(false).to(true).and change { stock_item.reload.count_on_hand }.from(110).to(0)
       end
     end
 
@@ -154,7 +158,7 @@ describe Spree::Variant, type: :model do
       let!(:stock_item) { create(:stock_item, variant: variant, count_on_hand: 100) }
 
       it 'keeps stock items' do
-        expect { subject }.to_not change(variant.stock_items, :count)
+        expect { subject }.not_to change(variant.stock_items, :count)
       end
     end
   end
@@ -621,32 +625,32 @@ describe Spree::Variant, type: :model do
   describe '#options' do
     let(:product) { create(:product, option_types: [option_type, option_type2]) }
     let(:variant) { create(:variant, product: product, option_values: [option_value, option_value2]) }
-    let!(:option_type2) { create(:option_type, name: "material") }
-    let!(:option_type) { Spree::OptionType.find_by(name: "size") || create(:option_type, name: "size") }
-    let(:option_value) { create(:option_value, name: "medium", presentation: "M", option_type: option_type) }
-    let(:option_value2) { create(:option_value, name: "wool", presentation: "Wool", option_type: option_type2) }
+    let!(:option_type2) { create(:option_type, name: 'material') }
+    let!(:option_type) { Spree::OptionType.find_by(name: 'size') || create(:option_type, name: 'size') }
+    let(:option_value) { create(:option_value, name: 'medium', presentation: 'M', option_type: option_type) }
+    let(:option_value2) { create(:option_value, name: 'wool', presentation: 'Wool', option_type: option_type2) }
 
-    it "returns an array of hashes with option type name, value, and presentation orderd by option type position" do
+    it 'returns an array of hashes with option type name, value, and presentation orderd by option type position' do
       expect(variant.options).to eq([
                                       {
-                                        name: "size",
-                                        value: "medium",
-                                        presentation: "M"
+                                        name: 'size',
+                                        value: 'medium',
+                                        presentation: 'M'
                                       },
                                       {
-                                        name: "material",
-                                        value: "wool",
-                                        presentation: "Wool"
+                                        name: 'material',
+                                        value: 'wool',
+                                        presentation: 'Wool'
                                       }
                                     ])
     end
   end
 
   describe '#options_text' do
+    subject(:options_text) { variant.options_text }
+
     let(:variant) { build :variant }
     let(:fake_presenter) { double :fake_presenter }
-
-    subject(:options_text) { variant.options_text }
 
     before do
       allow(Spree::Variants::OptionsPresenter).to receive(:new).with(variant).and_return(fake_presenter)

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -141,8 +141,9 @@ describe Spree::Variant, type: :model do
       let!(:variant) { create(:variant, product: product, track_inventory: true) }
       let!(:stock_item) { create(:stock_item, variant: variant, count_on_hand: 100) }
 
-      it 'deletes stock items' do
-        expect { subject }.to change(variant.stock_items, :count).from(2).to(0)
+      it 'updates stock items' do
+        expect { subject }.to change { stock_item.reload.backorderable }.from(false).to(true)
+        expect { subject }.to change { stock_item.reload.count_on_hand }.from(100).to(0)
       end
     end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced inventory management: When inventory tracking is disabled, stock items are now updated to display accurate details—marked as backorderable with a zero quantity on hand—ensuring consistent and reliable product availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->