### PR TITLE
Fixed `Admin::ProductsHelper#media_form_assets` method

### DIFF
--- a/admin/app/helpers/spree/admin/products_helper.rb
+++ b/admin/app/helpers/spree/admin/products_helper.rb
@@ -34,6 +34,8 @@ module Spree
           variant.images
         elsif session_uploaded_assets.any?
           Spree::Image.accessible_by(current_ability, :manage).where(id: session_uploaded_assets)
+        else
+          []
         end
       end
 

--- a/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -3,11 +3,20 @@ require 'spec_helper'
 RSpec.describe Spree::Admin::ProductsController, type: :controller do
   stub_authorization!
 
+  render_views
+
   let(:user) { create(:admin_user) }
   let(:store) { @default_store }
 
   before do
     allow(controller).to receive(:current_ability).and_call_original
+  end
+
+  describe '#GET #new' do
+    it 'renders the new template' do
+      get :new
+      expect(response).to render_template(:new)
+    end
   end
 
   describe 'GET #index' do
@@ -452,6 +461,24 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
           product = Spree::Product.last
           expect(product.stores).to eq [store]
         end
+      end
+    end
+  end
+
+  describe '#GET #edit' do
+    let!(:product) { create(:product, stores: [store], status: 'active') }
+
+    it 'renders the edit template' do
+      get :edit, params: { id: product.to_param }
+      expect(response).to render_template(:edit)
+    end
+
+    context 'with variants' do
+      let!(:variant) { create(:variant, product: product) }
+
+      it 'renders the edit template' do
+        get :edit, params: { id: product.to_param }
+        expect(response).to render_template(:edit)
       end
     end
   end

--- a/admin/spec/helpers/spree/admin/products_helper_spec.rb
+++ b/admin/spec/helpers/spree/admin/products_helper_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe Spree::Admin::ProductsHelper do
+  let(:user) { create(:admin_user) }
+
+  before do
+    allow(helper).to receive(:current_ability).and_return(Spree::Ability.new(user))
+  end
+
   describe '#available_status' do
     context 'when product is active' do
       let(:product) { build(:product, status: :active) }
@@ -39,6 +45,37 @@ describe Spree::Admin::ProductsHelper do
 
       it 'returns the correct status' do
         expect(available_status(product)).to eq('Deleted')
+      end
+    end
+  end
+
+  describe '#media_form_assets' do
+    context 'when variant is persisted' do
+      let(:variant) { build(:variant) }
+
+      it 'returns the correct assets' do
+        expect(helper.media_form_assets(variant)).to eq(variant.images)
+      end
+    end
+
+    context 'when variant is not persisted' do
+      let(:variant) { build(:variant, id: nil) }
+
+      it 'returns an empty array' do
+        expect(helper.media_form_assets(variant)).to eq([])
+      end
+    end
+
+    context 'when there are session uploaded assets' do
+      let(:variant) { build(:variant, id: nil) }
+      let(:session_uploaded_assets) { [create(:image)] }
+
+      before do
+        allow(helper).to receive(:session_uploaded_assets).and_return(session_uploaded_assets)
+      end
+
+      it 'returns the correct assets' do
+        expect(helper.media_form_assets(variant)).to eq(session_uploaded_assets)
       end
     end
   end


### PR DESCRIPTION
To always return an empty array and not break the new product screen plus added some more tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved media asset handling to consistently deliver an empty list when no images are available, preventing unexpected behavior.
- **Tests**
	- Expanded coverage for product creation and editing flows to ensure correct page rendering under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->