### PR TITLE
fix: add two words connector on checkout agreement text

### DIFF
--- a/storefront/app/views/spree/checkout/_payment_methods.html.erb
+++ b/storefront/app/views/spree/checkout/_payment_methods.html.erb
@@ -56,8 +56,8 @@
 
   <p class="text-xs mt-2 mb-4">
     <%= Spree.t('storefront.checkout.by_placing_this_order_you_agree_to') %>
-    <%= link_to Spree.t(:terms_of_service), policy_path('terms_of_service'), target: :_blank, class: 'text-primary' %> and
-    <%= link_to Spree.t(:privacy_policy), policy_path('privacy_policy'), target: :_blank, class: 'text-primary' %>
+    <%= link_to Spree.t(:terms_of_service), policy_path('terms_of_service'), target: :_blank, class: 'text-primary' %><%= I18n.t('support.array.two_words_connector') %>
+    <%= link_to Spree.t(:privacy_policy), policy_path('privacy_policy'), target: :_blank, class: 'text-primary' %>.
   </p>
 
   <div class="flex justify-end w-full">

--- a/storefront/config/i18n-tasks.yml
+++ b/storefront/config/i18n-tasks.yml
@@ -138,7 +138,8 @@ search:
 #   #   Keep in mind the context of all the strings for a more accurate translation.
 
 ## Do not consider these keys missing:
-# ignore_missing:
+ignore_missing:
+  - 'support.array.{last_word_connector,two_words_connector,words_connector}' # rails_i18n default support locales
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
 


### PR DESCRIPTION
### Description
Fixes the checkout agreement text by using the proper two-word connector for better readability and localization.

### Solution
Replaces the hardcoded `and` with `I18n.t('support.array.two_words_connector')` to ensure correct formatting across languages.

### QA Testing
- Check the checkout page agreement text.
- Verify the correct connector appears between "Terms of Service" and "Privacy Policy."
- Ensure proper localization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - The legal agreement text in the payment section has been updated for improved clarity and readability. The language now features a refined connector and enhanced punctuation that deliver a more polished, grammatically precise presentation. These enhancements help ensure users receive clear and easily understandable legal information during checkout.
- **Chores**
  - Activated the `ignore_missing` key in the configuration, enhancing support for array formatting in translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->