### PR TITLE
Better way to check if account pane should be shown

### DIFF
--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -65,8 +65,22 @@ module Spree
     end
 
     def svg_country_icon(country_code)
-      country_code = :us if country_code.to_s.downcase == "en"
+      country_code = :us if country_code.to_s.downcase == 'en'
       tag.span(class: "fi fi-#{country_code.downcase}")
+    end
+
+    def show_account_pane?
+      !try_spree_current_user &&
+        (defined?(spree_login_path) && !paths_equal?(canonical_path, spree_login_path)) &&
+        (defined?(spree_signup_path) && !paths_equal?(canonical_path, spree_signup_path)) &&
+        (defined?(spree_forgot_password_path) && !paths_equal?(canonical_path, spree_forgot_password_path))
+    end
+
+    def paths_equal?(path1, path2)
+      path1 = URI.parse(path1).path.chomp('/')
+      path2 = URI.parse(path2).path.chomp('/')
+
+      path1 == path2
     end
   end
 end

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -1,8 +1,7 @@
 <% layout = section.preferred_layout %>
-<% show_account_pane = !try_spree_current_user && (defined?(spree_login_path) && canonical_path != spree_login_path) && (defined?(spree_signup_path) && canonical_path != spree_signup_path) && (defined?(spree_forgot_password_path) && canonical_path != spree_forgot_password_path) %>
 <header
   class='sticky has-[.currency-and-locale-modal:not(.hidden)]:relative top-0 z-50 has-[.currency-and-locale-modal:not(.hidden)]:z-[unset] header-<%= layout %>'
-  data-controller='header toggle-menu slideover <%= "slideover-account" if show_account_pane %>'
+  data-controller='header toggle-menu slideover <%= "slideover-account" if show_account_pane? %>'
   data-toggle-menu-class='hamburger-visible'
   data-slideover-invisible-class='translate-x-full,opacity-0'
   data-slideover-visible-class='translate-x-0,opacity-100'
@@ -106,7 +105,7 @@
 
           <!-- Desktop Account -->
           <div class='hidden lg:flex'>
-            <% if show_account_pane %>
+            <% if show_account_pane? %>
               <button
                 data-action='click->slideover-account#toggle click@window->slideover-account#hide click->toggle-menu#hide touch->toggle-menu#hide'
               >
@@ -119,7 +118,7 @@
             <% end %>
           </div>
 
-          <% if show_account_pane %>
+          <% if show_account_pane? %>
             <%= form_with url: spree.account_wishlist_path, method: :get, data: { turbo_stream: true } do %>
               <button
                 type="submit"
@@ -159,7 +158,7 @@
     </div>
   </nav>
   <%= render 'spree/shared/cart_pane', section: section %>
-  <% if show_account_pane %>
+  <% if show_account_pane? %>
     <%= render 'spree/shared/account_pane', section: section %>
   <% end %>
 

--- a/storefront/spec/helpers/spree/storefront_helper_spec.rb
+++ b/storefront/spec/helpers/spree/storefront_helper_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe Spree::StorefrontHelper, type: :helper do
+  describe '#show_account_pane?' do
+    let(:user) { create(:user) }
+
+    before do
+      allow(helper).to receive(:try_spree_current_user).and_return(current_user)
+      allow(helper).to receive(:spree_login_path).and_return('/login')
+      allow(helper).to receive(:spree_signup_path).and_return('/signup')
+      allow(helper).to receive(:spree_forgot_password_path).and_return('/forgot-password')
+      allow(helper).to receive(:canonical_path).and_return(current_path)
+    end
+
+    context 'when user is logged in' do
+      let(:current_user) { user }
+      let(:current_path) { '/some-path' }
+
+      it 'returns false' do
+        expect(helper.show_account_pane?).to be false
+      end
+    end
+
+    context 'when user is not logged in' do
+      let(:current_user) { nil }
+
+      context 'when current path is login path' do
+        let(:current_path) { '/login' }
+
+        it 'returns false' do
+          expect(helper.show_account_pane?).to be false
+        end
+
+        context 'with query parameters' do
+          before do
+            allow(helper).to receive(:spree_login_path).and_return('/login?redirect=/products')
+          end
+
+          it 'returns false when current path has different query params' do
+            allow(helper).to receive(:canonical_path).and_return('/login?return_to=/cart')
+            expect(helper.show_account_pane?).to be false
+          end
+
+          it 'returns false when current path has no query params' do
+            allow(helper).to receive(:canonical_path).and_return('/login')
+            expect(helper.show_account_pane?).to be false
+          end
+        end
+      end
+
+      context 'when current path is signup path' do
+        let(:current_path) { '/signup' }
+
+        it 'returns false' do
+          expect(helper.show_account_pane?).to be false
+        end
+
+        context 'with query parameters' do
+          before do
+            allow(helper).to receive(:spree_signup_path).and_return('/signup?redirect=/products')
+          end
+
+          it 'returns false when current path has different query params' do
+            allow(helper).to receive(:canonical_path).and_return('/signup?return_to=/cart')
+            expect(helper.show_account_pane?).to be false
+          end
+        end
+      end
+
+      context 'when current path is forgot password path' do
+        let(:current_path) { '/forgot-password' }
+
+        it 'returns false' do
+          expect(helper.show_account_pane?).to be false
+        end
+
+        context 'with query parameters' do
+          before do
+            allow(helper).to receive(:spree_forgot_password_path).and_return('/forgot-password?redirect=/products')
+          end
+
+          it 'returns false when current path has different query params' do
+            allow(helper).to receive(:canonical_path).and_return('/forgot-password?return_to=/cart')
+            expect(helper.show_account_pane?).to be false
+          end
+        end
+      end
+
+      context 'when current path is different from authentication paths' do
+        let(:current_path) { '/products' }
+
+        it 'returns true' do
+          expect(helper.show_account_pane?).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the display logic for the account section in the header, ensuring it now dynamically evaluates the user's login status and current page context for a consistent viewing experience.
- **Tests**
  - Added comprehensive tests to verify the behavior of the updated account display logic across various authentication scenarios.
- **Style**
  - Made minor formatting adjustments for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->