### PR TITLE
Ability to disable admin updater widget via config

### DIFF
--- a/admin/app/views/spree/admin/dashboard/_updater.html.erb
+++ b/admin/app/views/spree/admin/dashboard/_updater.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:manage, current_store) && spree_update_available? %>
+<% if Spree::Admin::RuntimeConfig.admin_updater_enabled && can?(:manage, current_store) && spree_update_available? %>
   <div class="alert alert-info">
     <div>
       <p class="mb-1">There's a newer version of Spree available.</p>

--- a/admin/lib/spree/admin/runtime_configuration.rb
+++ b/admin/lib/spree/admin/runtime_configuration.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class RuntimeConfiguration < ::Spree::Preferences::RuntimeConfiguration
       preference :admin_path, :string, default: '/admin'
-      preference :admin_show_version, :boolean, default: true
+      preference :admin_updater_enabled, :boolean, default: true
     end
   end
 end


### PR DESCRIPTION
```ruby
Spree::Admin::RuntimeConfig.admin_updater_enabled = false
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The admin updater alert now appears only when the administrator has proper permissions, an update is available, and a new configuration option is enabled.
	- A previous version display setting has been replaced with this new updater control, offering improved management of alert notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->