### PR TITLE
fix: store cc type in snake_case format

### DIFF
--- a/storefront/app/javascript/spree/storefront/controllers/card_validation_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/card_validation_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
   validateCard(event) {
     let value = event.target.value.replace(/\D/g, '')
     const validation = valid.number(value)
-    
+
     // Format the card number with spaces
     if (validation.card) {
       const gaps = validation.card.gaps
@@ -44,10 +44,10 @@ export default class extends Controller {
     if (validation.card) {
       // Update CVV validation length based on card type
       this.cvvTarget.setAttribute('maxlength', validation.card.code.size)
-      
+
       // Update card type field and icon
       const cardType = validation.card.type
-      this.ccTypeTarget.value = cardType
+      this.ccTypeTarget.value = cardType.replace(/-/g, '_')
       this.updateCardIcon(cardType)
     } else {
       this.ccTypeTarget.value = ''
@@ -66,12 +66,12 @@ export default class extends Controller {
 
   validateExpiry(event) {
     let input = event.target.value.replace(/\D/g, '').substring(0, 6)
-    
+
     // Format as MM/YYYY
     if (input.length > 2) {
       input = input.substring(0, 2) + '/' + input.substring(2)
     }
-    
+
     // Validate month
     const monthValue = parseInt(input.substring(0, 2))
     if (monthValue > 12) {
@@ -82,7 +82,7 @@ export default class extends Controller {
 
     const [month, year] = input.split('/')
     const validation = valid.expirationDate({ month, year })
-    
+
     if (validation.isPotentiallyValid) {
       event.target.classList.remove('invalid')
     } else {
@@ -93,11 +93,11 @@ export default class extends Controller {
   validateCVV(event) {
     const cvv = event.target.value
     const validation = valid.cvv(cvv)
-    
+
     if (validation.isPotentiallyValid) {
       event.target.classList.remove('invalid')
     } else {
       event.target.classList.add('invalid')
     }
   }
-} 
+}


### PR DESCRIPTION
### Description
Currently, in the codebase, the `card_validation_controller.js` utilizes the `card-validator` library (`import valid from "card-validator"`), which in turn relies on the `credit-card-type` library (https://github.com/braintree/credit-card-type) to determine the card type.

The issue is that the card type information retrieved from this library is being sent to the backend when saving a `CreditCard`, but the `ccType` is formatted with dashes (`-`) instead of underscores (`_`).

![image](https://github.com/user-attachments/assets/97d134a4-f816-43c5-bcb8-adf40ad212c3)

For compatibility with the `active_merchant` gem, I propose converting the `ccType` to snake_case. The `active_merchant` gem verifies supported card types using the following logic:

```
def self.supports?(card_type)
  supported_cardtypes.include?(card_type.to_sym)
end
````

All `supported_cardtypes` from the gem follow the snake_case format:

![image](https://github.com/user-attachments/assets/1145d143-71f7-438b-b435-5919e2a963a5)

Since the current format is incompatible for card types with multiple words, the payment state is being invalidated in the code:

```
if payment_method.supports?(source) || token_based?
  yield
else
  invalidate!
  raise Core::GatewayError, Spree.t(:payment_method_not_supported)
end
```

### Solution
This PR ensures that `ccType` is converted from dash-case to snake_case before being sent to the backend. This change maintains compatibility with `active_merchant` and prevents payment state validation errors.