### PR TITLE
Downgrade TinyMCE to 6.x due to license change

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/plugins/_tinymce_custom.scss
+++ b/admin/app/assets/stylesheets/spree/admin/plugins/_tinymce_custom.scss
@@ -54,18 +54,18 @@
 
 /* Override TinyMCE UI font size */
 .tox-toolbar__group {
-  font-size: 13px !important; /* Change this value to your desired font size */
+  font-size: $font-size-base !important; /* Change this value to your desired font size */
 }
 .tox-mbtn__select-label {
-  font-size: 13px !important; /* Change this value to your desired font size */
+  font-size: $font-size-base !important; /* Change this value to your desired font size */
 }
 /* Override TinyMCE Content font size */
 .tox-tinymce {
-  font-size: 13px !important; /* Change this value to your desired font size */
+  font-size: $font-size-base !important; /* Change this value to your desired font size */
 }
 .tox .tox-collection__item-label, .tox-tbtn__select-label {
-  font-size: 13px !important; /* Change this value to your desired font size */
-  font-family: 'Inter';
+  font-size: $font-size-base !important; /* Change this value to your desired font size */
+  font-family: $font-family-sans-serif;
 }
 
 .tox.tox-tinymce-aux .tox-toolbar__overflow, .tox .tox-menu {

--- a/admin/app/javascript/spree/admin/helpers/tinymce.js
+++ b/admin/app/javascript/spree/admin/helpers/tinymce.js
@@ -14,7 +14,7 @@ function initializeTinmce() {
     plugins: ['image', 'table', 'code', 'link', 'lists'],
     menubar: false,
     inline_boundaries: false,
-    toolbar: 'undo redo | blocks | bold italic link forecolor backcolor | bullist numlist outdent indent | alignleft aligncenter alignright alignjustify | table | code',
+    toolbar: 'undo redo | formatselect | bold italic link forecolor backcolor | bullist numlist outdent indent | alignleft aligncenter alignright alignjustify | table | code',
     // Default styles without heading 1
     style_formats: [
       {
@@ -61,13 +61,5 @@ function initializeTinmce() {
     setup: function (ed) {
       if (document.getElementById(ed.id).hasAttribute('readonly')) ed.mode.set('readonly')
     }
-  })
-
-  tinymce.init({
-    content_style: 'table { width: 100%; }; body { font-family: Inter, sans-serif; font-size: 14px; }',
-    selector: '.spree-rte-table',
-    plugins: ['table paste code'],
-    menubar: false,
-    toolbar: 'table | code | undo redo'
   })
 }

--- a/admin/spree_admin.gemspec
+++ b/admin/spree_admin.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'turbo-rails'
   s.add_dependency 'stimulus-rails'
   s.add_dependency 'sprockets', '>= 4.0'
-  s.add_dependency 'tinymce-rails', '~> 7.0'
+  s.add_dependency 'tinymce-rails', '~> 6.8.5'
 end


### PR DESCRIPTION
TinyMCE changed license to GPL in 7.x. Probably in the future we should migrate off to TipTap or other alternative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced text editor styling by adopting flexible font configurations for improved visual consistency.
- **Refactor**
	- Streamlined the text editor setup by refining formatting options and consolidating multiple configurations.
- **Chore**
	- Updated an external dependency for better compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->