### PR TITLE
Add `importmap-rails` gem for all development environments of all gems

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -54,6 +54,7 @@ group :test, :development do
 end
 
 group :development do
+  gem 'importmap-rails'
   # gem 'github_fast_changelog'
   gem 'solargraph'
   gem 'ruby-lsp'


### PR DESCRIPTION
So we can use importmap CLI utility for core and other non-UI gems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the internal development toolset to streamline the build process. While you won’t see any direct changes in functionality, these improvements contribute to a more efficient development cycle and help maintain long-term stability in the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->