### PR TITLE
Remove `country_select` dependency

### DIFF
--- a/admin/app/views/spree/admin/promotion_rules/forms/_country.html.erb
+++ b/admin/app/views/spree/admin/promotion_rules/forms/_country.html.erb
@@ -1,8 +1,7 @@
 <div class="form-group">
   <%= f.label :preferred_country_iso, Spree.t(:country) %>
-  <%= f.country_select(:preferred_country_iso, 
-    { selected: f.object.preferred_country_iso }, 
-    { data: { controller: 'autocomplete-select' } 
-  }) %>
+  <%= f.select :preferred_country_iso,
+    available_countries_iso.map { |iso| [Spree.t(iso, scope: 'country_names', default: iso), iso] },
+    { selected: f.object.preferred_country_iso || current_store.default_country_iso },
+    { data: { controller: 'autocomplete-select' } } %>
 </div>
-

--- a/admin/lib/spree/admin.rb
+++ b/admin/lib/spree/admin.rb
@@ -5,7 +5,6 @@ require 'sprockets/railtie'
 
 require 'active_link_to'
 require 'chartkick'
-require 'country_select'
 require 'currency_select'
 require 'groupdate'
 require 'hightop'

--- a/admin/spree_admin.gemspec
+++ b/admin/spree_admin.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'active_link_to'
   s.add_dependency 'bootstrap', '~> 4.6', '>= 4.6.2.1'
   s.add_dependency 'chartkick', '~> 5.0'
-  s.add_dependency 'country_select', '~> 8.0'
   s.add_dependency 'currency_select'
   s.add_dependency 'dartsass-rails', '~> 0.5'
   s.add_dependency 'groupdate', '~> 6.2'


### PR DESCRIPTION
We're not using this gem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The promotion rules form now offers a localized country dropdown with an adaptive default that falls back to your store’s default country when needed.
- **Chores**
  - Removed an obsolete dependency for country selection to streamline functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->