### PR TITLE
Fix Addresses queue name

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -104,7 +104,7 @@ module Spree
       coupon_codes: :default,
       webhooks: :default,
       themes: :default,
-      addresses: :addresses
+      addresses: :default
     )
   end
 


### PR DESCRIPTION
By default, it should be just `:default` as this queue works with most Active Job adapters by... default (d'oh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized the internal queue configuration to align processing across the system, ensuring consistent and reliable handling of tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->