### PR TITLE
Add `foreign_key` name for user's `gateway_customers` association

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -30,7 +30,7 @@ module Spree
       has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: :user_id, dependent: :destroy
       has_many :wishlists, class_name: 'Spree::Wishlist', foreign_key: :user_id, dependent: :destroy
       has_many :wished_items, through: :wishlists, source: :wished_items
-      has_many :gateway_customers, class_name: 'Spree::GatewayCustomer'
+      has_many :gateway_customers, class_name: 'Spree::GatewayCustomer', foreign_key: :user_id
       belongs_to :ship_address, class_name: 'Spree::Address', optional: true
       belongs_to :bill_address, class_name: 'Spree::Address', optional: true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted user data linkage to ensure accurate and consistent associations with related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->