### PR TITLE
Add translations that are used in the spree_stripe gem

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1334,6 +1334,7 @@ en:
     order: Order
     order_adjustments: Order adjustments
     order_again: Order again
+    order_already_completed: Order already completed
     order_already_updated: The order has already been updated.
     order_approved: Order approved
     order_canceled: Order canceled
@@ -1369,7 +1370,6 @@ en:
       store_team: "%{store_name} Team"
       subtotal: 'Subtotal:'
       total: 'Order Total:'
-    order_already_completed: Order already completed
     order_not_found: We couldn't find your order. Please try that action again.
     order_number: Order %{number}
     order_processed_successfully: Your order has been processed successfully

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1369,6 +1369,7 @@ en:
       store_team: "%{store_name} Team"
       subtotal: 'Subtotal:'
       total: 'Order Total:'
+    order_already_completed: Order already completed
     order_not_found: We couldn't find your order. Please try that action again.
     order_number: Order %{number}
     order_processed_successfully: Your order has been processed successfully

--- a/storefront/config/i18n-tasks.yml
+++ b/storefront/config/i18n-tasks.yml
@@ -147,6 +147,7 @@ ignore_missing:
 ignore_unused:
 - 'spree.storefront.refund_action_not_required_message.*'
 - 'spree.storefront.refund_action_required_message.*'
+- 'spree.storefront.checkout.or_continue_below'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
         calculated_at_next_step: Calculated at next step
         continue_to_cart: Continue to cart
         continue_to_checkout: Continue to checkout
+        or_continue_below: or continue below
         delivery_method: Delivery method
         errors:
           invalid_line_items:

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -24,13 +24,13 @@ en:
         calculated_at_next_step: Calculated at next step
         continue_to_cart: Continue to cart
         continue_to_checkout: Continue to checkout
-        or_continue_below: or continue below
         delivery_method: Delivery method
         errors:
           invalid_line_items:
             one: This item will be removed from your cart because there are no delivery methods available for your address.
             other: These %{count} items will be removed from your cart because there are no delivery methods available for your address.
         gift_card_amount_applied: Gift card %{code} applied %{amount} to your order.
+        or_continue_below: or continue below
         order_already_paid: You don't need to pay anything, just click Place now button to confirm the order.
         order_success: Your order is confirmed!
         order_success_message: When your order is ready, you will receive an email confirmation.


### PR DESCRIPTION
Those translations are used in the `spree_stripe` gem, but they are very generic, so I've added them to Spree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced user feedback by introducing a notification for when an order is already completed.
  - Improved checkout guidance with an added prompt offering an alternative option to continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->