### PR TITLE
Updated ruby installtion steps

### DIFF
--- a/docs/developer/getting-started/quickstart.mdx
+++ b/docs/developer/getting-started/quickstart.mdx
@@ -67,8 +67,10 @@ Welcome to the Spree Commerce [open-source eCommerce](https://spreecommerce.org)
 
         And now install Ruby 3.3:
 
+        Before attempting to install Ruby, check that your build environment has the necessary tools and libraries.(https://github.com/rbenv/ruby-build/wiki#suggested-build-environment)
+
         ```bash
-        rbenv init && rbenv install && rbenv global 3.3.0
+        rbenv install 3.3.0 && rbenv global 3.3.0
         ```
 
     3. Install [Docker Desktop](https://docs.docker.com/get-docker)


### PR DESCRIPTION
1. rbenv init is not required: The rbenv init cmd is automatically handled by the rbenv installation script(https://rbenv.org/install.sh)

2. Correct command to install Ruby: When using rbenv to install a specific Ruby version, the command should be rbenv install 3.3.0 (or whichever version weneed) rather than just rbenv install.

3. Included a prerequisite step to install essential tools and libraries before proceeding with Ruby installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced prerequisite guidance by advising users to verify that their build environment includes all necessary tools before installation.
	- Streamlined the installation instructions by removing redundant commands to simplify the Ruby setup process.
	- Improved overall document formatting for a clearer and more concise read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->