### PR TITLE
Admin: for master variants we should link to the product edit, not va…

### DIFF
--- a/admin/app/views/spree/admin/variants/_variant.html.erb
+++ b/admin/app/views/spree/admin/variants/_variant.html.erb
@@ -1,5 +1,11 @@
 <% cache variant do %>
-  <%= link_to spree.edit_admin_product_variant_path(variant.product, variant), id: spree_dom_id(variant), data: { turbo_permanent: true, turbo_frame: :_top }, class: 'd-flex align-items-center justify-content-start text-decoration-none' do %>
+  <% if variant.is_master? %>
+    <% variant_url = spree.edit_admin_product_path(variant.product) %>
+  <% else %>
+    <% variant_url = spree.edit_admin_product_variant_path(variant.product, variant) %>
+  <% end %>
+
+  <%= link_to variant_url, id: spree_dom_id(variant), data: { turbo_permanent: true, turbo_frame: :_top }, class: 'd-flex align-items-center justify-content-start text-decoration-none' do %>
     <%= render 'spree/admin/shared/product_image', object: variant %>
     <div class="ml-3">
       <strong><%= variant.name %></strong>


### PR DESCRIPTION
…riant edit page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the admin interface so that product variant links now direct users to the appropriate editing page based on the variant type.
	- Master variants now lead to a dedicated product editing page, while non-master variants continue to display the standard variant editing view, ensuring improved navigation and consistency in managing product variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->