### PR TITLE
Add documentation about the new spree_stripe api endpoint

### DIFF
--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -1625,7 +1625,7 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
   "/api/v2/storefront/stripe/payment_intents/{id}/confirm":
-    post:
+    patch:
       summary: Mark the payment intent as confirmed, and move the order to the complete state
       description: This endpoint is used to complete the order with succeeded payment intent. First it will check if the payment intent has `status` `succeeded`, if yes, then it will move the order to the complete state.
       tags:

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -1573,6 +1573,7 @@ paths:
           $ref: '#/components/responses/422UnprocessableEntity'
       security:
         - orderToken: []
+  "/api/v2/storefront/stripe/payment_intents/{id}":
     get:
       summary: Return a Stripe Payment Intent
       description: 'Returns the Payment Intent information'
@@ -1623,6 +1624,24 @@ paths:
           $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
+  "/api/v2/storefront/stripe/payment_intents/{id}/confirm":
+    post:
+      summary: Mark the payment intent as confirmed, and move the order to the complete state
+      description: This endpoint is used to complete the order with succeeded payment intent. First it will check if the payment intent has `status` `succeeded`, if yes, then it will move the order to the complete state.
+      tags:
+        - Stripe
+      operationId: confirm-stripe-payment-intent
+      security:
+        - orderToken: []
+      responses:
+        '200':
+          $ref: '#/components/responses/StripePaymentIntent'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '422':
+          $ref: '#/components/responses/422UnprocessableEntity'
   /api/v2/storefront/stripe/setup_intents:
     post:
       summary: Create a Stripe Setup Intent

--- a/docs/api-reference/storefront/stripe/create-a-stripe-payment-intent-1.mdx
+++ b/docs/api-reference/storefront/stripe/create-a-stripe-payment-intent-1.mdx
@@ -1,4 +1,4 @@
 ---
-openapi: patch /api/v2/storefront/stripe/payment_intents
+openapi: patch /api/v2/storefront/stripe/payment_intents/{id}
 version: v5
 ---

--- a/docs/api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state.mdx
+++ b/docs/api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /api/v2/storefront/stripe/payment_intents/{id}/confirm
+version: v5
 ---

--- a/docs/api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state.mdx
+++ b/docs/api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/v2/storefront/stripe/payment_intents/{id}/confirm
+---

--- a/docs/api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state.mdx
+++ b/docs/api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state.mdx
@@ -1,4 +1,4 @@
 ---
-openapi: post /api/v2/storefront/stripe/payment_intents/{id}/confirm
+openapi: patch /api/v2/storefront/stripe/payment_intents/{id}/confirm
 version: v5
 ---

--- a/docs/api-reference/storefront/stripe/return-a-stripe-payment-intent.mdx
+++ b/docs/api-reference/storefront/stripe/return-a-stripe-payment-intent.mdx
@@ -1,4 +1,4 @@
 ---
-openapi: get /api/v2/storefront/stripe/payment_intents
+openapi: get /api/v2/storefront/stripe/payment_intents/{id}
 version: v5
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a GET endpoint to fetch details for a specific Stripe Payment Intent.
  - Added a PATCH endpoint to confirm a payment intent, finalizing the related order.

- **Documentation**
  - Updated the API specifications to reflect resource-level operations for creating, retrieving, and confirming Stripe Payment Intents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->