### PR TITLE
Add the missing code needed when canceling quick checkout

### DIFF
--- a/core/app/services/spree/checkout/update.rb
+++ b/core/app/services/spree/checkout/update.rb
@@ -9,8 +9,16 @@ module Spree
         bill_changed = address_with_country_iso_present?(params, 'bill')
         params[:order][:ship_address_attributes] = replace_country_iso_with_id(params[:order][:ship_address_attributes]) if ship_changed
         params[:order][:bill_address_attributes] = replace_country_iso_with_id(params[:order][:bill_address_attributes]) if bill_changed
-        order.state = 'address' if (ship_changed || bill_changed) && order.has_checkout_step?('address')
-        order.state = 'delivery' if selected_shipping_rate_present?(params) && order.has_checkout_step?('delivery')
+
+        # for quick checkouts we cannot revert to previous states
+        # we already have the address and delivery steps completed
+        # however we need to update the shipping address with missing data
+        # as previously we didn't have access to first/last name and street
+        unless params[:do_not_change_state]
+          order.state = 'address' if (ship_changed || bill_changed || quick_checkout_cancelled?(params)) && order.has_checkout_step?('address')
+          order.state = 'delivery' if selected_shipping_rate_present?(params) && order.has_checkout_step?('delivery')
+        end
+
         return success(order) if order.update_from_params(params, permitted_attributes, request_env)
 
         failure(order)
@@ -30,6 +38,10 @@ module Spree
         return false unless shipments_attributes
 
         shipments_attributes.any? { |s| s.dig(:selected_shipping_rate_id) }
+      end
+
+      def quick_checkout_cancelled?(params)
+        params.dig(:order, :ship_address_id) == 'CLEAR'
       end
     end
   end

--- a/core/spec/services/spree/checkout/update_spec.rb
+++ b/core/spec/services/spree/checkout/update_spec.rb
@@ -105,6 +105,22 @@ describe Spree::Checkout::Update, type: :service do
         expect(order.state).to eq 'address'
         expect(order.ship_address.state.id).to eq state.id
       end
+
+      it 'should not set order back to address state if do_not_change_state is true' do
+        expect(order.state).not_to eq 'address'
+        order_params[:do_not_change_state] = true
+        update_service
+
+        expect(order.state).not_to eq 'address'
+      end
+
+      it 'should set order back to address state if quick checkout cancelled' do
+        expect(order.state).not_to eq 'address'
+        order_params[:order][:ship_address_id] = 'CLEAR'
+        update_service
+
+        expect(order.state).to eq 'address'
+      end
     end
 
     context 'at address state' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the checkout process to ensure that order status transitions occur only when truly necessary. The system now preserves the current order state during standard address updates unless a significant modification or quick cancellation event is detected, resulting in a more predictable and streamlined ordering experience for customers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->