### PR TITLE
Fix documentation about the payment_intent update endpoint

### DIFF
--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -1590,8 +1590,8 @@ paths:
       security:
         - orderToken: []
     patch:
-      summary: Create a Stripe Payment Intent
-      description: Create a Stripe Payment Intent using provided payment method. It creates a Stripe customer if not exists.
+      summary: Updates Stripe Payment Intent
+      description: Updates the payment intent with new `amount` and `payment_method_id`
       tags:
         - Stripe
       operationId: update-stripe-payment-intent
@@ -1612,9 +1612,6 @@ paths:
                     stripe_payment_method_id:
                       type: string
                       description: A new Stripe Payment Method ID
-                    off_session:
-                      type: boolean
-                      description: If the payment is off-session (eq. payment method from setup intent)
               required:
                 - payment_intent
       responses:

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -1591,7 +1591,7 @@ paths:
         - orderToken: []
     patch:
       summary: Updates Stripe Payment Intent
-      description: Updates the payment intent with new `amount` and `payment_method_id`
+      description: Updates the payment intent with new `amount` and `stripe_payment_method_id`
       tags:
         - Stripe
       operationId: update-stripe-payment-intent

--- a/docs/api-reference/storefront/stripe/updates-stripe-payment-intent.mdx
+++ b/docs/api-reference/storefront/stripe/updates-stripe-payment-intent.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: patch /api/v2/storefront/stripe/payment_intents/{id}
+version: v5
 ---

--- a/docs/api-reference/storefront/stripe/updates-stripe-payment-intent.mdx
+++ b/docs/api-reference/storefront/stripe/updates-stripe-payment-intent.mdx
@@ -1,4 +1,3 @@
 ---
 openapi: patch /api/v2/storefront/stripe/payment_intents/{id}
-version: v5
 ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to clarify the PATCH `/api/v2/storefront/stripe/payment_intents/{id}` endpoint, changing its description to "Updates Stripe Payment Intent".
  - Removed the `off_session` parameter from the request body, simplifying the update process to include only `amount` and `stripe_payment_method_id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->