### PR TITLE
fix: line item partial UI issues

### DIFF
--- a/storefront/app/views/spree/checkout/_line_item.html.erb
+++ b/storefront/app/views/spree/checkout/_line_item.html.erb
@@ -1,20 +1,18 @@
-<div class="flex justify-between items-center">
-  <div class="flex items-center">
-    <div class="mr-5 w-[64px] h-[64px] relative rounded bg-accent-100">
-      <span class="rounded-full text-xs text-center font-bold pl-[0.5px] py-1 w-6 text-sidebar-text bg-background absolute -right-2 -top-3">
-        <%= line_item.quantity %>
-      </span>
-      <% image = line_item.variant.default_image %>
-      <% if image.present? && image.attached? && image.variable? %>
-        <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [128, 128]))), class: 'rounded border border-default bg-transparent object-cover object-center', loading: :lazy, width: 64, height: 64 %>
-      <% end %>
-    </div>
-    <div class="col-6 col-md-8 pr-3 text-sm">
-      <p class="font-bold word-break"><%= line_item.name %></p>
-      <p class="text-xs"><%= line_item.options_text %></p>
-    </div>
+<div class="flex justify-between items-center pt-3">
+  <div class="mr-5 w-[60px] h-[60px] relative rounded bg-accent-100 shrink-0">
+    <span class="rounded-full text-xs text-center font-bold pl-[0.5px] py-1 w-6 text-sidebar-text bg-background absolute -right-2 -top-3">
+      <%= line_item.quantity %>
+    </span>
+    <% image = line_item.variant.default_image %>
+    <% if image.present? && image.attached? && image.variable? %>
+      <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [128, 128]))), class: 'rounded border border-default bg-transparent object-cover object-center', loading: :lazy, width: 60, height: 60 %>
+    <% end %>
   </div>
-  <div class="font-semibold text-sm text-right">
+  <div class="flex-1 pr-3 text-sm">
+    <p class="font-bold word-break"><%= line_item.name %></p>
+    <p class="text-xs"><%= line_item.options_text %></p>
+  </div>
+  <div class="font-semibold text-sm text-right shrink-0">
     <% if should_display_compare_at_price?(line_item.variant) %>
       <span class="line-through text-red-500">
         <%= Spree::Money.new(line_item.variant.compare_at_amount_in(line_item.currency) * line_item.quantity, currency: line_item.currency) %>


### PR DESCRIPTION
### Description  
Previously, product images and long product names could cause misalignment in the checkout line item layout. This update improves the structure to ensure consistent alignment and responsiveness.

### Solution  
- Refactored `_line_item.html.erb` for better alignment and responsiveness.  
- Adjusted image size (`64x64` → `60x60`) and applied `shrink-0` to maintain proportions.  
- Used `flex-1` to prevent long product names from breaking the layout.  
- Ensured price remains properly aligned with `shrink-0`. 

### Customer Impact  
- Customers will now see properly aligned product images in the checkout.  

### QA Testing Guidelines  
1. Go to the checkout page and verify that product images are correctly aligned.  
2. Ensure the image does not overflow or shift when resizing the screen.  
3. Test with products that have and do not have images.  
4. Confirm that the fix applies across different screen sizes (mobile, tablet, desktop).

### Screenshots/Visual Aids:

The layout breaks when the product name is too long...

**Before:**
![image](https://github.com/user-attachments/assets/2a7b09e4-5191-406f-8bef-d46973e7a5f6)

**After:**
![image](https://github.com/user-attachments/assets/b5e03f68-3e2a-403f-8916-4a3fecc84bd1)