### PR TITLE
Introduce `spree_image_tag` and `spree_image_url` methods

### DIFF
--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -42,10 +42,10 @@ module Spree
         options[:class] ||= 'avatar'
 
         if user.respond_to?(:avatar) && user.avatar.attached? && user.avatar.variable?
-          image_tag(
-            main_app.cdn_image_url(
-              user.avatar.variant(spree_image_variant_options(resize_to_fill: [options[:width] * 2, options[:height] * 2]))
-            ),
+          spree_image_tag(
+            user.avatar,
+            width: options[:width],
+            height: options[:height],
             class: options[:class],
             style: "width: #{options[:width]}px; height: #{options[:height]}px;"
           )

--- a/admin/app/helpers/spree/admin/stores_helper.rb
+++ b/admin/app/helpers/spree/admin/stores_helper.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     module StoresHelper
+      include Spree::ImagesHelper
+
       def available_stores
         @available_stores ||= Spree::Store.accessible_by(current_ability)
       end
@@ -18,31 +20,9 @@ module Spree
 
         Rails.cache.fetch(["#{store.cache_key_with_version}/admin_icon", opts.to_param]) do
           if store.logo&.attached? && store.logo&.variable?
-            image_tag(
-              main_app.cdn_image_url(
-                store.logo.variant(
-                  spree_image_variant_options(
-                    resize_to_fill: [opts[:width] * 2, opts[:height] * 2]
-                  )
-                )
-              ),
-              class: opts[:class],
-              width: opts[:width],
-              height: opts[:height]
-            )
+            spree_image_tag(store.logo, class: opts[:class], width: opts[:width], height: opts[:height])
           elsif store.favicon_image&.attached? && store.favicon_image&.variable?
-            image_tag(
-              main_app.cdn_image_url(
-                store.favicon_image.variant(
-                  spree_image_variant_options(
-                    resize_to_fill: [opts[:width] * 2, opts[:height] * 2]
-                  )
-                )
-              ),
-              class: opts[:class],
-              width: opts[:width],
-              height: opts[:height]
-            )
+            spree_image_tag(store.favicon_image, class: opts[:class], width: opts[:width], height: opts[:height])
           else
             first_letter_icon(store.name, opts)
           end
@@ -65,16 +45,7 @@ module Spree
         opts.merge!(options)
 
         if store.is_a?(Spree::Store) && store.logo&.attached? && store.logo&.variable?
-          image_tag(
-            main_app.cdn_image_url(
-              store.logo.variant(
-                spree_image_variant_options(
-                  resize_to_fill: [opts[:width] * 2, opts[:height] * 2]
-                )
-              )
-            ),
-            opts
-          )
+          spree_image_tag(store.logo, class: opts[:class], width: opts[:width], height: opts[:height])
         else
           initials = store.name.split.map(&:first).join.upcase
           content_tag(:div, initials, class: "avatar rounded with-tip bg-light",

--- a/admin/app/views/active_storage/_upload_form.html.erb
+++ b/admin/app/views/active_storage/_upload_form.html.erb
@@ -18,14 +18,10 @@
          data-action="click->active-storage-upload#open"
     >
       <% if form.object.send(field_name).attached? && form.object.send(field_name).variable? %>
-        <%= image_tag(
-          main_app.cdn_image_url(
-            form.object.send(field_name).variant(
-              spree_image_variant_options(
-                resize_to_fill: [width, (crop ? height : nil)]
-              )
-            )
-          ),
+        <%= spree_image_tag(
+          form.object.send(field_name),
+          width: width,
+          height: height,
           class: 'img-fluid rounded-lg',
           data: { active_storage_upload_target: 'thumb' },
           loading: :lazy

--- a/admin/app/views/spree/admin/posts/_post.html.erb
+++ b/admin/app/views/spree/admin/posts/_post.html.erb
@@ -3,17 +3,7 @@
     <%= link_to spree.edit_admin_post_path(post), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark gap-3', data: { row_link_target: :link, 'turbo-frame': '_top' } do %>
       <% if post.image.attached? && post.image.variable? %>
         <div class="admin-product-image-container">
-          <%= image_tag(
-                main_app.cdn_image_url(
-                  post.image.variant(
-                    spree_image_variant_options(resize_to_fill: [200, 130])
-                  )
-                ),
-                class: 'img-fluid',
-                loading: :lazy,
-                width: 100,
-                height: 65
-          ) %>
+          <%= spree_image_tag(post.image, width: 100, height: 65, class: 'img-fluid', loading: :lazy) %>
         </div>
       <% else %>
         <%= render 'spree/admin/shared/no_image', width: 100, height: 65 %>

--- a/admin/app/views/spree/admin/shared/_product_image.html.erb
+++ b/admin/app/views/spree/admin/shared/_product_image.html.erb
@@ -5,16 +5,7 @@
 <% if image.present? && image.attached? && image.variable? %>
   <% alt ||= image.alt || object.name %>
   <div class="admin-product-image-container">
-    <%= image_tag(
-          main_app.cdn_image_url(
-            image.variant(
-              spree_image_variant_options(resize_to_fill: [width * 2, height * 2])
-            )
-          ),
-          width: width,
-          height: height,
-          alt: alt
-    ) %>
+    <%= spree_image_tag(image, width: width, height: height, alt: alt) %>
   </div>
 <% else %>
   <%= render 'spree/admin/shared/no_image', width: width, height: height %>

--- a/admin/app/views/spree/admin/shared/sortable_tree/_taxonomy.html.erb
+++ b/admin/app/views/spree/admin/shared/sortable_tree/_taxonomy.html.erb
@@ -10,29 +10,9 @@
   <div class="flex-grow-1 cursor-pointer" data-action="click->row-link#openLink">
     <div class="d-flex align-items-center overflow-hidden w-100 <% if taxon.square_image&.attached? || taxon.image&.attached? %>py-2<% else %>py-3<% end %>">
       <% if taxon.square_image&.attached? && taxon.square_image.variable? %>
-        <%= image_tag(
-              main_app.cdn_image_url(
-                taxon.square_image.variant(
-                  spree_image_variant_options(resize_to_fill: [96, 96])
-                )
-              ),
-              class: 'rounded mr-3',
-              width: 48,
-              height: 48,
-              loading: :lazy
-        ) %>
+        <%= spree_image_tag(taxon.square_image, class: 'rounded mr-3', width: 48, height: 48, loading: :lazy) %>
       <% elsif taxon.image&.attached? && taxon.image.variable? %>
-        <%= image_tag(
-              main_app.cdn_image_url(
-                taxon.image.variant(
-                  spree_image_variant_options(resize_to_fill: [96, 96])
-                )
-              ),
-              class: 'rounded mr-3',
-              width: 48,
-              height: 48,
-              loading: :lazy
-        ) %>
+        <%= spree_image_tag(taxon.image, class: 'rounded mr-3', width: 48, height: 48, loading: :lazy) %>
       <% end %>
       <div class="overflow-hidden">
         <%= taxon.name %>

--- a/admin/app/views/spree/admin/themes/_theme_preview_image.html.erb
+++ b/admin/app/views/spree/admin/themes/_theme_preview_image.html.erb
@@ -2,16 +2,7 @@
 <% height ||= 72 %>
 
 <% if theme.screenshot.attached? && theme.screenshot.variable? %>
-  <%= image_tag(
-        main_app.cdn_image_url(
-          theme.screenshot.variant(
-            spree_image_variant_options(resize_to_fill: [width * 2, height * 2])
-          )
-        ),
-        class: 'img-thumbnail',
-        style: "width: #{width}px; height: #{height}px",
-        loading: :lazy
-  ) %>
+  <%= spree_image_tag(theme.screenshot, width: width, height: height, class: 'img-thumbnail', style: "width: #{width}px; height: #{height}px", loading: :lazy) %>
 <% elsif theme.class.preview_image_url.present? %>
   <%= image_tag(
   theme.class.preview_image_url,

--- a/admin/app/views/spree/admin/variants/form/_media_asset.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_media_asset.html.erb
@@ -9,13 +9,7 @@
 
   <div data-toggle="modal" data-target="#modal-lg">
     <%= link_to spree.edit_admin_asset_path(asset), data: { turbo_frame: 'dialog_modal_lg' } do %>
-      <%= image_tag(
-            main_app.cdn_image_url(
-              asset.attachment.variant(spree_image_variant_options(resize_to_fill: [400, 400]))
-            ),
-            alt: asset.alt,
-            class: 'w-100 d-block h-100 position-absolute'
-          ) %>
+      <%= spree_image_tag(asset.attachment, width: 200, height: 200, alt: asset.alt, class: 'w-100 d-block h-100 position-absolute') %>
     <% end %>
   </div>
 </div>

--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -1,6 +1,77 @@
 module Spree
   module ImagesHelper
+    # render an image tag with a spree image variant
+    # it also automatically scales the width and height by 2x to look great on retina screens
+    #
+    # @param image [ActiveStorage::Attachment] the image to render
+    # @param options [Hash] options for the image tag
+    # @option options [Integer] :width the width of the image
+    # @option options [Integer] :height the height of the image
+    def spree_image_tag(image, options = {})
+      image_tag(
+        spree_image_url(image, { width: options[:width], height: options[:height] }),
+        options
+      )
+    end
+
+    def spree_image_url(image, options = {})
+      width = options[:width]
+      height = options[:height]
+
+      width = width * 2 if width.present?
+      height = height * 2 if height.present?
+
+      return unless image.attached?
+      return unless image.variable?
+
+      if width.present? && height.present?
+        main_app.cdn_image_url(
+          image.variant(spree_image_variant_options(resize_to_fill: [width, height]))
+        )
+      else
+        main_app.cdn_image_url(
+          image.variant(spree_image_variant_options(resize_to_limit: [width, height]))
+        )
+      end
+    end
+
+    def spree_asset_aspect_ratio(attachment)
+      return unless attachment.present?
+      return unless attachment.analyzed?
+
+      metadata = attachment.metadata
+      aspect_ratio = metadata['aspect_ratio'].presence
+
+      return aspect_ratio if aspect_ratio
+
+      width = metadata['width']&.to_f
+      return unless width
+
+      height = metadata['height']&.to_f
+      return unless height
+      return if height.zero?
+
+      w, h = width.to_f, height.to_f
+
+      # Always return width / height, flipping if needed
+      if h > w
+        ratio = h / w
+      elsif h < w
+        ratio = w / h
+      else
+        # h == w, square image
+        ratio = 1.0
+      end
+
+      ratio.round(3)
+    end
+
     # convert images to webp with some sane optimization defaults
+    # it also automatically scales the width and height by 2x to look great on retina screens
+    #
+    # @param options [Hash] options for the image variant
+    # @option options [Integer] :width the width of the image
+    # @option options [Integer] :height the height of the image
     def spree_image_variant_options(options = {})
       {
         saver: {

--- a/core/app/views/active_storage/blobs/_blob.html.erb
+++ b/core/app/views/active_storage/blobs/_blob.html.erb
@@ -1,12 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag main_app.cdn_image_url(
-      blob.variant(
-        spree_image_variant_options(
-          resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]
-        )
-      )
-    ) %>
+    <%= spree_image_tag(blob, width: local_assigns[:in_gallery] ? 400 : 512, height: local_assigns[:in_gallery] ? 300 : 400) %>
   <% end %>
 
   <figcaption class="attachment__caption">

--- a/core/app/views/spree/shared/_mailer_logo.html.erb
+++ b/core/app/views/spree/shared/_mailer_logo.html.erb
@@ -5,7 +5,7 @@
 <%= link_to current_store.url_or_custom_domain, id: 'site-logo', style: "text-decoration: none;" do %>
   <span style="display: none;"><%= current_store.name %></span>
   <% if logo.present? && logo.attached? && logo.variable? %>
-    <% aspect_ratio = as_aspect_ratio(logo) %>
+    <% aspect_ratio = spree_asset_aspect_ratio(logo) %>
     <% logo_style = "aspect-ratio: #{aspect_ratio};" %>
 
     <% if aspect_ratio.to_f > 10 %>

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe Spree::ImagesHelper, type: :helper do
+  let(:store) { @default_store }
+  let(:product) { create(:product, stores: [store]) }
+  let(:image) do
+    product_image = create(:image, viewable: product)
+    product_image.attachment.attach(
+      io: File.open(Spree::Core::Engine.root.join('spec', 'fixtures', 'thinking-cat.jpg')),
+      filename: 'thinking-cat.jpg',
+      content_type: 'image/jpeg'
+    )
+    product_image
+  end
+  let(:attachment) { image.attachment }
+
+  describe '#spree_image_tag' do
+    it 'returns an image tag with the correct url' do
+      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100 }).and_return('image_url')
+      expect(helper).to receive(:image_tag).with('image_url', { width: 100, height: 100 }).and_return('image_tag')
+      expect(helper.spree_image_tag(image, width: 100, height: 100)).to eq('image_tag')
+    end
+  end
+
+  describe '#spree_image_url' do
+    context 'when image is not attached' do
+      before do
+        allow(image).to receive(:attached?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(helper.spree_image_url(image)).to be_nil
+      end
+    end
+
+    context 'when image is not variable' do
+      before do
+        allow(image).to receive(:attached?).and_return(true)
+        allow(image).to receive(:variable?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(helper.spree_image_url(image)).to be_nil
+      end
+    end
+
+    context 'when width and height are present' do
+      it 'returns a url with resize_to_fill' do
+        variant = double('variant')
+        expect(image).to receive(:variant).with(hash_including(resize_to_fill: [200, 200])).and_return(variant)
+        expect(helper).to receive(:main_app).and_return(double('main_app', cdn_image_url: 'cdn_url'))
+        expect(helper.spree_image_url(image, width: 100, height: 100)).to eq('cdn_url')
+      end
+    end
+
+    context 'when only width is present' do
+      it 'returns a url with resize_to_limit' do
+        variant = double('variant')
+        expect(image).to receive(:variant).with(hash_including(resize_to_limit: [200, nil])).and_return(variant)
+        expect(helper).to receive(:main_app).and_return(double('main_app', cdn_image_url: 'cdn_url'))
+        expect(helper.spree_image_url(image, width: 100)).to eq('cdn_url')
+      end
+    end
+  end
+
+  describe '#spree_asset_aspect_ratio' do
+    context 'when attachment is not present' do
+      it 'returns nil' do
+        expect(helper.spree_asset_aspect_ratio(nil)).to be_nil
+      end
+    end
+
+    context 'when attachment is not analyzed' do
+      before do
+        allow(attachment).to receive(:analyzed?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(helper.spree_asset_aspect_ratio(attachment)).to be_nil
+      end
+    end
+
+    context 'when aspect_ratio is present in metadata' do
+      before do
+        allow(attachment).to receive(:analyzed?).and_return(true)
+        allow(attachment).to receive(:metadata).and_return({ 'aspect_ratio' => 1.5 })
+      end
+
+      it 'returns the aspect ratio' do
+        expect(helper.spree_asset_aspect_ratio(attachment)).to eq(1.5)
+      end
+    end
+
+    context 'when calculating aspect ratio from dimensions' do
+      before do
+        allow(attachment).to receive(:analyzed?).and_return(true)
+        allow(attachment).to receive(:metadata).and_return({ 'width' => width, 'height' => height })
+      end
+
+      context 'when height is greater than width' do
+        let(:width) { 100 }
+        let(:height) { 200 }
+
+        it 'returns the correct ratio' do
+          expect(helper.spree_asset_aspect_ratio(attachment)).to eq(2.0)
+        end
+      end
+
+      context 'when width is greater than height' do
+        let(:width) { 200 }
+        let(:height) { 100 }
+
+        it 'returns the correct ratio' do
+          expect(helper.spree_asset_aspect_ratio(attachment)).to eq(2.0)
+        end
+      end
+
+      context 'when width equals height' do
+        let(:width) { 100 }
+        let(:height) { 100 }
+
+        it 'returns 1.0' do
+          expect(helper.spree_asset_aspect_ratio(attachment)).to eq(1.0)
+        end
+      end
+    end
+  end
+end

--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -47,21 +47,8 @@ module Spree
     end
 
     def as_aspect_ratio(attachment)
-      return unless attachment.present?
-      return unless attachment.analyzed?
-
-      metadata = attachment.metadata
-      aspect_ratio = metadata['aspect_ratio'].presence
-
-      return aspect_ratio if aspect_ratio
-
-      width = metadata['width']&.to_f
-      return unless width
-
-      height = metadata['height']&.to_f
-      return unless height
-
-      width / height
+      Spree::Deprecation.warn('as_aspect_ratio is deprecated. Please use spree_asset_aspect_ratio instead.')
+      spree_asset_aspect_ratio(attachment)
     end
 
     def svg_country_icon(country_code)

--- a/storefront/app/views/spree/checkout/_line_item.html.erb
+++ b/storefront/app/views/spree/checkout/_line_item.html.erb
@@ -5,7 +5,7 @@
     </span>
     <% image = line_item.variant.default_image %>
     <% if image.present? && image.attached? && image.variable? %>
-      <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [128, 128]))), class: 'rounded border border-default bg-transparent object-cover object-center', loading: :lazy, width: 60, height: 60 %>
+      <%= spree_image_tag(image, class: 'rounded border border-default bg-transparent object-cover object-center', loading: :lazy, width: 60, height: 60) %>
     <% end %>
   </div>
   <div class="flex-1 pr-3 text-sm">

--- a/storefront/app/views/spree/shared/_head.html.erb
+++ b/storefront/app/views/spree/shared/_head.html.erb
@@ -6,7 +6,7 @@
 
 <% cache current_store do %>
   <% if current_store.favicon_image.attached? && current_store.favicon_image.variable? %>
-    <link rel="icon" href="<%= main_app.cdn_image_url(current_store.favicon_image.variant(spree_image_variant_options(resize_to_fill: [256, 256]))) %>">
+    <link rel="icon" href="<%= spree_image_url(current_store.favicon_image, width: 256, height: 256) %>">
   <% end %>
 <% end %>
 

--- a/storefront/app/views/themes/default/spree/orders/_line_item.html.erb
+++ b/storefront/app/views/themes/default/spree/orders/_line_item.html.erb
@@ -5,7 +5,7 @@
         <% image = line_item.variant.default_image %>
         <% if image.present? && image.attached? && image.variable? %>
           <%= link_to spree_storefront_resource_url(line_item.product), data: { 'turbo-frame': '_top' } do %>
-            <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fit: [256, 256]))), width: 128, height: 128, class: 'object-cover', loading: :lazy %>
+            <%= spree_image_tag(image, width: 128, height: 128, class: 'object-cover', loading: :lazy) %>
           <% end %>
         <% end %>
       </div>

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
@@ -47,7 +47,7 @@
           <% if section_with_image %>
             <div class='lg:col-span-5'>
               <%= link_to spree.nested_taxons_path(section.taxon), data: { turbo_frame: "_top" } do %>
-                <%= image_tag main_app.cdn_image_url(section.taxon.image.variant(spree_image_variant_options(resize_to_fill: [1000, 1000]))), height: 500, width: 500, class: 'h-full w-full object-cover object-center', loading: :lazy %>
+                <%= spree_image_tag(section.taxon.image, height: 500, width: 500, class: 'h-full w-full object-cover object-center', loading: :lazy) %>
               <% end %>
             </div>
           <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
@@ -14,7 +14,7 @@
         <%= page_builder_link_to link, title: link.label, class: 'group block overflow-hidden', target: link.open_in_new_tab.presence && '_blank' do %>
           <% if link.linkable.image&.attached? && link.linkable.image&.variable? %>
             <div class="flex space-y-2 flex-col">
-              <%= image_tag main_app.cdn_image_url(link.linkable.image.variant(spree_image_variant_options(resize_to_fill: [600, 600]))), height: 300, width: 300, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label %>
+              <%= spree_image_tag(link.linkable.image, height: 300, width: 300, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
               <span><%= link.label %></span>
             </div>
           <% else %>
@@ -49,7 +49,7 @@
               <%= page_builder_link_to link, title: link.label, class: 'group block overflow-hidden', target: link.open_in_new_tab.presence && '_blank' do %>
                 <% if link.linkable.image&.attached? && link.linkable.image&.variable? %>
                   <div class="flex space-y-2 flex-col">
-                    <%= image_tag main_app.cdn_image_url(link.linkable.image.variant(spree_image_variant_options(resize_to_fill: [400, 400]))), height: 200, width: 200, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label %>
+                    <%= spree_image_tag(link.linkable.image, height: 200, width: 200, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
                     <span><%= link.label %></span>
                   </div>
                 <% else %>

--- a/storefront/app/views/themes/default/spree/page_sections/_image_banner.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_image_banner.html.erb
@@ -3,13 +3,13 @@
     <div class="w-full absolute left-0 image-banner--image-wrapper" style="height: <%= section.preferred_height %>px; opacity: <%= section.preferred_overlay_transparency %>%;">
       <% if section.image.attached? && section.image.variable? %>
         <picture>
-          <source media="(max-width: 640px)" srcset="<%= main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [640, nil]))) %>">
-          <source media="(max-width: 750px)" srcset="<%= main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [750, nil]))) %>">
-          <source media="(max-width: 828px)" srcset="<%= main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [828, nil]))) %>">
-          <source media="(max-width: 1080px)" srcset="<%= main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [1080, nil]))) %>">
-          <source media="(max-width: 1200px)" srcset="<%= main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [1200, nil]))) %>">
-          <source media="(min-width: 1201px)" srcset="<%= main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [2000, nil]))) %>">
-          <%= image_tag main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_limit: [2000, nil]))), class: "w-full h-full object-cover", loading: "lazy" %>
+          <source media="(max-width: 640px)" srcset="<%= spree_image_url(section.image, width: 320, height: nil) %>">
+          <source media="(max-width: 750px)" srcset="<%= spree_image_url(section.image, width: 375, height: nil) %>">
+          <source media="(max-width: 828px)" srcset="<%= spree_image_url(section.image, width: 414, height: nil) %>">
+          <source media="(max-width: 1080px)" srcset="<%= spree_image_url(section.image, width: 540, height: nil) %>">
+          <source media="(max-width: 1200px)" srcset="<%= spree_image_url(section.image, width: 620, height: nil) %>">
+          <source media="(min-width: 1201px)" srcset="<%= spree_image_url(section.image, width: 1000, height: nil) %>">
+          <%= spree_image_tag(section.image, width: 1000, class: "w-full h-full object-cover", loading: "lazy") %>
         </picture>
       <% end %>
     </div>

--- a/storefront/app/views/themes/default/spree/page_sections/_image_with_text.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_image_with_text.html.erb
@@ -5,12 +5,12 @@
         <div class="lg:col-span-6 aspect-[6/7] <%= 'lg:col-start-7 lg:order-1' if section.preferred_desktop_image_alignment == 'right' %> image-with-text--image-wrapper">
           <%= page_builder_link_to(section.link, title: section.link&.label,  target: (section.link&.open_in_new_tab ? '_blank' : nil)) do %>
             <% if section.image.present? %>
-              <%= image_tag main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_fill: [2000, nil]))),
+              <%= image_tag spree_image_url(section.image, width: 1000, height: nil),
                 class: "w-full h-full object-cover",
                 loading: :lazy,
                 sizes: "(max-width: 1024px) 100vw, 50vw",
                 srcset: [640, 750, 828, 1080, 1200, 2000].map { |width|
-                  "#{main_app.cdn_image_url(section.image.variant(spree_image_variant_options(resize_to_fill: [width, nil])))} #{width}w"
+                  "#{spree_image_url(section.image, width: width / 2, height: nil)} #{width}w"
                 }.join(', ')
               %>
             <% else %>

--- a/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
@@ -5,7 +5,7 @@
     <img
       class="w-full h-full absolute top-0 object-cover z-0"
       style="opacity: <%= section.preferred_overlay_transparency %>%"
-      src="<%= main_app.cdn_image_url(img.variant(spree_image_variant_options(resize_to_limit: [2000, nil]))) %>" />
+      src="<%= spree_image_url(img, width: 2000, height: nil) %>" />
   <% end %>
   <div class="w-full page-container flex flex-col text-center py-5 px-5 z-10">
     <% section.blocks.includes(:rich_text_text).each do |block| %>
@@ -37,8 +37,8 @@
         <% when 'Spree::PageBlocks::Image' %>
           <div <%= block_attributes(block) %> class="flex justify-center w-full">
             <% if block.image.attached? && block.image.variable? %>
-              <% image_style = "aspect-ratio: #{as_aspect_ratio(block.image)}; --desktop-height: #{block.preferred_height}px; --mobile-height: #{block.preferred_mobile_height}px;" %>
-              <%= image_tag main_app.cdn_image_url(block.image.variant(spree_image_variant_options(resize_to_fill: [1000, 1000]))), height: block.preferred_height, width: block.preferred_width, class: "custom-desktop-height custom-mobile-height", style: image_style %>
+              <% image_style = "aspect-ratio: #{spree_asset_aspect_ratio(block.image)}; --desktop-height: #{block.preferred_height}px; --mobile-height: #{block.preferred_mobile_height}px;" %>
+              <%= image_tag spree_image_url(block.image, width: 1000, height: 1000), height: block.preferred_height, width: block.preferred_width, class: "custom-desktop-height custom-mobile-height", style: image_style %>
             <% end %>
           </div>
       <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_post_details.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_post_details.html.erb
@@ -2,7 +2,7 @@
   <div class="page-container">
     <div class="flex flex-col max-w-3xl m-auto mt-16 first:mt-0">
       <% if post.image.attached? && post.image.variable? %>
-        <%= image_tag main_app.cdn_image_url(post.image.variant(spree_image_variant_options(resize_to_fit: [nil, 800]))), height: 400, class: 'h-full w-full object-cover object-center', loading: :lazy, alt: post.title %>
+        <%= spree_image_tag(post.image, height: 400, class: 'h-full w-full object-cover object-center', loading: :lazy, alt: post.title) %>
       <% end %>
 
       <h1 class="uppercase text-2xl font-medium mt-4"><%= post.title %></h1>

--- a/storefront/app/views/themes/default/spree/page_sections/_taxon_banner.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_taxon_banner.html.erb
@@ -7,12 +7,18 @@
       <div class="lg:gap-6 lg:grid lg:grid-cols-12">
         <% if taxon.image.present? %>
           <div class="flex lg:col-span-7 lg:col-start-6 lg:order-1 lg:items-center lg:justify-end">
-            <% aspect_ratio_style = "aspect-ratio: #{as_aspect_ratio(taxon.image)};" %>
-            <%= image_tag main_app.cdn_image_url(taxon.image.variant(spree_image_variant_options(resize_to_limit: [720, 720]))), alt: taxon.name, class: 'w-full lg:max-h-[280px] h-full lg:w-auto mb-6', style: aspect_ratio_style, loading: :lazy %>
+            <% aspect_ratio_style = "aspect-ratio: #{spree_asset_aspect_ratio(taxon.image)};" %>
+            <%= spree_image_tag(taxon.image, width: 500, height: 280, alt: taxon.name, class: 'w-full lg:h-[280px] h-full lg:w-auto mb-6', style: aspect_ratio_style, loading: :lazy) %>
           </div>
         <% end %>
         <div class="lg:col-span-5 flex flex-col justify-center items-start gap-1">
-          <div class="text-xs lg:text-sm tracking-widest" style="<%= section_heading_styles(section) %>"><%= taxon.taxonomy.name.singularize %></div>
+          <div class="text-xs lg:text-sm tracking-widest" style="<%= section_heading_styles(section) %>">
+            <% if taxon.root? || taxon.parent.root? %>
+              <%= taxon.taxonomy.name.singularize %>
+            <% else%>
+              <%= link_to taxon.parent.name, spree.nested_taxons_path(taxon.parent) %>
+            <% end %>
+          </div>
           <h1 class="self-stretch text-2xl lg:text-3xl font-medium" style="<%= section_heading_styles(section) %>"><%= taxon.name %></h1>
           <% description_text = taxon.description.to_plain_text %>
           <div

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -28,7 +28,7 @@
                 <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
                   <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
                     <%= link_to spree_storefront_resource_url(block.featured_taxon), class: "flex flex-col col-start-4" do %>
-                      <%= image_tag main_app.cdn_image_url(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [700, 700]))), class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name %>
+                      <%= spree_image_tag(block.featured_taxon.image, width: 360, height: 360, class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name) %>
                       <span class="py-3 px-2 bg-accent block uppercase text-sm tracking-widest font-semibold header--mega-nav-featured-taxon-title"><%= Spree.t(:explore_taxon, taxon_name: block.featured_taxon.name) %></span>
                     <% end %>
                   <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -24,7 +24,7 @@
                       <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
                         <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
                           <%= link_to spree_storefront_resource_url(block.featured_taxon), class: "flex w-full pt-4" do %>
-                            <%= image_tag main_app.cdn_image_url(block.featured_taxon.image.variant(spree_image_variant_options(resize_to_fill: [280, 280]))), class: 'h-auto aspect-1 w-2/5 max-w-[140px]', loading: :lazy, alt: block.featured_taxon.name %>
+                            <%= spree_image_tag(block.featured_taxon.image, width: 140, height: 140, class: 'h-auto aspect-1 w-2/5 max-w-[140px]', loading: :lazy, alt: block.featured_taxon.name) %>
                             <span class="bg-accent w-full flex items-center justify-center header--mega-nav-featured-taxon-title text-sm tracking-widest font-semibold uppercase">
                               <%= Spree.t(:explore_taxon, taxon_name: block.featured_taxon.name) %>
                             </span>

--- a/storefront/app/views/themes/default/spree/posts/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/posts/_json_ld.html.erb
@@ -3,7 +3,7 @@
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": "<%= post.title %>",
-    "image": <%= post.image.attached? ? [main_app.cdn_image_url(post.image.variant(spree_image_variant_options(resize_to_limit: [1200, 675])))].to_json.html_safe : [].to_json.html_safe %>,
+    "image": <%= post.image.attached? ? [spree_image_url(post.image, width: 1200, height: 675)].to_json.html_safe : [].to_json.html_safe %>,
     "datePublished": "<%= post.published_at&.iso8601 %>",
     "dateModified": "<%= post.updated_at&.iso8601 %>",
     "author": [

--- a/storefront/app/views/themes/default/spree/posts/_post.html.erb
+++ b/storefront/app/views/themes/default/spree/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <%= link_to spree.post_path(post), class: 'block hover:opacity-70 transition-opacity' do %>
     <div class="h-[200px] w-full bg-gray-100">
       <% if post.image.attached? && post.image.variable? %>
-        <%= image_tag main_app.cdn_image_url(post.image.variant(spree_image_variant_options(resize_to_fit: [nil, 800]))), height: 400, class: 'h-full w-full object-cover object-center', loading: :lazy, alt: post.title %>
+        <%= spree_image_tag(post.image, width: 400, height: 200, class: 'h-full w-full object-cover object-center', loading: :lazy, alt: post.title) %>
       <% end %>
     </div>
 

--- a/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
@@ -12,24 +12,16 @@
       <% object_class = 'object-contain object-top' %>
     <% end %>
 
-    <% image_variant_options = spree_image_variant_options(resize_and_pad: [width * 2, height * 2, { alpha: true }]) %>
-
     <% image_hover_class = object.secondary_image.present? && object.secondary_image.attached? ? 
          "w-full group-hover:opacity-0 transition-opacity duration-500 z-10 relative h-full bg-background product-card !max-h-full #{object_class}" :
          "w-full h-full !max-h-full #{object_class}" %>
 
-    <%= image_tag main_app.cdn_image_url(object.default_image.variant(image_variant_options)),
-          loading: :lazy,
-          alt: object.default_image.alt,
-          class: image_hover_class %>
+    <%= spree_image_tag(object.default_image, width: width, height: height, loading: :lazy, alt: object.default_image.alt, class: image_hover_class) %>
 
     <% if object.secondary_image.present? && object.secondary_image.attached? %>
       <% secondary_image_class = "w-full absolute top-0 left-0 opacity-100 h-full !max-h-full #{object_class}" %>
 
-      <%= image_tag main_app.cdn_image_url(object.secondary_image.variant(image_variant_options)),
-            loading: :lazy,
-            alt: object.secondary_image.alt,
-            class: secondary_image_class %>
+      <%= spree_image_tag(object.secondary_image, width: width, height: height, loading: :lazy, alt: object.secondary_image.alt, class: secondary_image_class) %>
     <% end %>
   </figure>
 <% else %>

--- a/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
@@ -7,7 +7,7 @@
     "url": <%= spree.product_url(product).to_json.html_safe %>,
   <% if product.featured_image %>
     "image": [
-      <%= main_app.cdn_image_url(product.featured_image.variant(spree_image_variant_options(resize_to_limit: [1260, 1260]))).to_json.html_safe %>
+      <%= spree_image_url(product.featured_image, width: 630, height: 630).to_json.html_safe %>
     ],
   <% end %>
   <% if product.description.present? %>

--- a/storefront/app/views/themes/default/spree/products/_media_gallery.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_media_gallery.html.erb
@@ -21,7 +21,7 @@
                     class="relative aspect-1 w-full block "
                     id="thumb-desktop-product-image-<%= image.id %>"
                     data-turbo-permanent>
-                    <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [200, 200]))), alt: image_alt(image), class: 'w-full h-full' %>
+                    <%= spree_image_tag(image, width: 100, height: 100, alt: image_alt(image), class: 'w-full h-full') %>
                   </div>
                 </div>
               <% end %>
@@ -39,11 +39,11 @@
                   class="product-image relative w-full aspect-1"
                   id="main-desktop-product-image-<%= image.id %>"
                   data-turbo-permanent>
-                  <%= link_to main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [2000, 2000]))), data: { pswp_width: "2000", pswp_height: "2000" } do %>
+                  <%= link_to spree_image_url(image, width: 1000, height: 1000), data: { pswp_width: "2000", pswp_height: "2000" } do %>
                     <div class="zoom-icon hidden absolute bottom-2 right-2 p-4 bg-background rounded-full opacity-75 hover:opacity-100">
                       <%= render 'spree/shared/icons/zoom' %>
                     </div>
-                    <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [2000, 2000]))), alt: image_alt(image), class: 'w-full h-full' %>
+                    <%= spree_image_tag(image, width: 1000, height: 1000, alt: image_alt(image), class: 'w-full h-full') %>
                   <% end %>
                 </div>
               </div>
@@ -70,11 +70,11 @@
         <div class="swiper-wrapper">
           <% images.each do |image| %>
             <div class="swiper-slide aspect-1" id="swiper-slide-<%= image.id %>">
-              <%= link_to main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [2000, 2000]))), class: "absolute top-2 right-2 p-2 bg-background rounded-full opacity-75 hover:opacity-100", data: { pswp_width: "2000", pswp_height: "2000" } do %>
+              <%= link_to spree_image_url(image, width: 2000, height: 2000), class: "absolute top-2 right-2 p-2 bg-background rounded-full opacity-75 hover:opacity-100", data: { pswp_width: "2000", pswp_height: "2000" } do %>
                 <%= render 'spree/shared/icons/zoom' %>
               <% end %>
               <%= render 'spree/products/label', product: product, mobile_pdp: true %>
-              <%= image_tag main_app.cdn_image_url(image.variant(spree_image_variant_options(resize_to_fill: [720, 720]))), alt: image_alt(image), class: 'h-full w-full object-cover object-center', style: 'min-height: 358px' %>
+              <%= spree_image_tag(image, width: 360, height: 360, alt: image_alt(image), class: 'h-full w-full object-cover object-center', style: 'min-height: 358px') %>
             </div>
           <% end %>
         </div>

--- a/storefront/app/views/themes/default/spree/shared/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_json_ld.html.erb
@@ -6,7 +6,7 @@
       "url": <%= current_store.formatted_url_or_custom_domain.to_json.html_safe %>,
       "sameAs": <%= current_store.social_links.to_json.html_safe %>,
     <% if current_store.logo && current_store.logo&.attached? && current_store.logo&.variable? %>
-      "logo": <%= main_app.cdn_image_url(current_store.logo.variant(spree_image_variant_options(resize_to_fill: [500, 500]))).to_json.html_safe %>,
+      "logo": <%= spree_image_url(current_store.logo, width: 250, height: 250).to_json.html_safe %>,
     <% end %>
       "name": <%= current_store.name.to_json.html_safe %>,
       "email": <%= current_store.customer_support_email.to_json.html_safe %>

--- a/storefront/app/views/themes/default/spree/shared/_logo.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_logo.html.erb
@@ -5,7 +5,7 @@
 <%= link_to spree.root_path, id: 'site-logo' do %>
   <span class='sr-only'><%= current_store.name %></span>
   <% if logo.present? && logo.attached? && logo.variable? %>
-    <% aspect_ratio = as_aspect_ratio(logo) %>
+    <% aspect_ratio = spree_asset_aspect_ratio(logo) %>
     <% logo_style = "aspect-ratio: #{aspect_ratio};" %>
 
     <% if aspect_ratio.to_f > 10 %>

--- a/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
@@ -22,7 +22,7 @@
 <meta property="og:description" content="<%= h(og_description) %>">
 
 <% if page_image.present? && page_image.attached? && page_image.variable? %>
-  <% image_url = spree_image_url(page_image, width: 600, height: 315) %>
+  <% image_url = spree_image_url(page_image, width: 1200, height: 630) %>
 
   <meta property="og:image" content="<%= image_url %>">
   <meta property="og:image:secure_url" content="<%= image_url %>">

--- a/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
@@ -22,7 +22,7 @@
 <meta property="og:description" content="<%= h(og_description) %>">
 
 <% if page_image.present? && page_image.attached? && page_image.variable? %>
-  <% image_url = main_app.cdn_image_url(page_image.variant(spree_image_variant_options(resize_to_fill: [1200, 630]))) %>
+  <% image_url = spree_image_url(page_image, width: 600, height: 315) %>
 
   <meta property="og:image" content="<%= image_url %>">
   <meta property="og:image:secure_url" content="<%= image_url %>">

--- a/storefront/app/views/themes/default/spree/shared/_order_line_item.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_line_item.html.erb
@@ -6,11 +6,7 @@
       <% image = line_item.variant.default_image %>
       <% if image.present? && image.attached? && image.variable? %>
         <%= link_to spree_storefront_resource_url(line_item.product, relative: true) do %>
-          <%= image_tag main_app.cdn_image_url(
-            image.variant(spree_image_variant_options(resize_to_fit: [256, 256])),
-          ),
-          width: 128,
-          loaging: :lazy %>
+          <%= spree_image_tag(image, width: 128, height: 128, loading: :lazy) %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
To simplify storefront templates, DRY up our helpers/views and centralize images generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified image handling and responsive display across admin and storefront views, ensuring consistent rendering of avatars, logos, products, and other media.
	- Optimized URL generation, resizing behavior, and aspect ratio calculations for improved load performance and visual consistency.
- **Tests**
	- Introduced comprehensive tests to verify the new image rendering and aspect ratio functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->