### PR TITLE
Fix stripe api docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -262,7 +262,7 @@
                     "pages": [
                       "api-reference/storefront/stripe/return-a-stripe-payment-intent",
                       "api-reference/storefront/stripe/create-a-stripe-payment-intent",
-                      "api-reference/storefront/stripe/create-a-stripe-payment-intent-1",
+                      "api-reference/storefront/stripe/updates-stripe-payment-intent",
                       "api-reference/storefront/stripe/create-a-stripe-setup-intent"
                     ]
                   },
@@ -1132,7 +1132,7 @@
                     "pages": [
                       "api-reference/storefront/stripe/return-a-stripe-payment-intent",
                       "api-reference/storefront/stripe/create-a-stripe-payment-intent",
-                      "api-reference/storefront/stripe/create-a-stripe-payment-intent-1",
+                      "api-reference/storefront/stripe/updates-stripe-payment-intent",
                       "api-reference/storefront/stripe/create-a-stripe-setup-intent"
                     ]
                   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -263,6 +263,7 @@
                       "api-reference/storefront/stripe/return-a-stripe-payment-intent",
                       "api-reference/storefront/stripe/create-a-stripe-payment-intent",
                       "api-reference/storefront/stripe/updates-stripe-payment-intent",
+                      "api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state",
                       "api-reference/storefront/stripe/create-a-stripe-setup-intent"
                     ]
                   },
@@ -1133,6 +1134,7 @@
                       "api-reference/storefront/stripe/return-a-stripe-payment-intent",
                       "api-reference/storefront/stripe/create-a-stripe-payment-intent",
                       "api-reference/storefront/stripe/updates-stripe-payment-intent",
+                      "api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state",
                       "api-reference/storefront/stripe/create-a-stripe-setup-intent"
                     ]
                   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1129,16 +1129,6 @@
                     ]
                   },
                   {
-                    "group": "Stripe",
-                    "pages": [
-                      "api-reference/storefront/stripe/return-a-stripe-payment-intent",
-                      "api-reference/storefront/stripe/create-a-stripe-payment-intent",
-                      "api-reference/storefront/stripe/updates-stripe-payment-intent",
-                      "api-reference/storefront/stripe/mark-the-payment-intent-as-confirmed-and-move-the-order-to-the-complete-state",
-                      "api-reference/storefront/stripe/create-a-stripe-setup-intent"
-                    ]
-                  },
-                  {
                     "group": "Products",
                     "pages": [
                       "api-reference/storefront/products/list-all-products",


### PR DESCRIPTION
We were linking to the wrong document, and we were missing the documentation about the new endpoint

I've also removed the documentation about Stripe endpoints from `v4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Refreshed the Stripe API documentation with reorganized navigation.
	- Removed an outdated payment intent page and added two new pages detailing updated payment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->