### PR TITLE
Streamline and unify admin templates

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_cards.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_cards.scss
@@ -60,12 +60,11 @@
 }
 
 .card-lg {
-  @extend .mb-3;
-  @extend .bg-white;
-
+  margin-bottom: 1rem;
+  background-color: $white;
   border-radius: $border-radius-lg;
   border: 1px solid $card-border-color;
-  padding: 1rem;
+  padding: 0;
 }
 
 .card-text {

--- a/admin/app/assets/stylesheets/spree/admin/components/_main.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_main.scss
@@ -156,3 +156,10 @@ turbo-frame[loading] .spinner-border, turbo-frame[busy] .spinner-border {
     top: 0.5rem;
   }
 }
+
+.documentation-link-container {
+  font-size: $font-size-sm;
+  text-align: center;
+  margin-top: 2rem;
+  color: $gray-400;
+}

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -66,7 +66,7 @@ module Spree
           @back_path = spree.edit_admin_taxonomy_path(@resource)
         when Spree::Store
           @resource_name = @resource.name
-          @back_path = spree.edit_admin_store_path(@resource, section: "general-settings")
+          @back_path = spree.edit_admin_store_path(section: "general-settings")
         end
       end
     end

--- a/admin/app/helpers/spree/admin/navigation_helper.rb
+++ b/admin/app/helpers/spree/admin/navigation_helper.rb
@@ -128,6 +128,8 @@ module Spree
       end
 
       def button_link_to(text, url, html_options = {})
+        Spree::Deprecation.warn("button_link_to is deprecated. Use standard link_to instead.")
+
         if html_options[:method] &&
             !html_options[:method].to_s.casecmp('get').zero? &&
             !html_options[:remote]
@@ -178,7 +180,7 @@ module Spree
       def external_link_to(label, url, opts = {}, &block)
         opts[:target] ||= :blank
         opts[:rel] ||= :nofollow
-        opts[:class] ||= "d-inline-flex align-items-center text-blue"
+        opts[:class] ||= "d-inline-flex align-items-center text-blue text-decoration-none"
 
         if block_given?
           link_to url, opts, &block

--- a/admin/app/helpers/spree/admin/orders_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_helper.rb
@@ -69,25 +69,6 @@ module Spree
         end
       end
 
-      # Renders all the extension partials that may have been specified in the extensions
-      def event_links(order, events)
-        links = []
-        events.each do |event|
-          next unless order.send("can_#{event}?")
-
-          label = Spree.t(event, scope: 'admin.order.events', default: Spree.t(event))
-          links << button_link_to(
-            label.capitalize,
-            [event.to_sym, :admin, order],
-            method: :put,
-            icon: event.to_s + '.svg',
-            data: { turbo_confirm: Spree.t(:order_sure_want_to, event: label) },
-            class: 'btn-light'
-          )
-        end
-        safe_join(links, ''.html_safe)
-      end
-
       def line_item_shipment_price(line_item, quantity)
         Spree::Money.new(line_item.price * quantity, currency: line_item.currency)
       end

--- a/admin/app/views/spree/admin/coupon_codes/index.html.erb
+++ b/admin/app/views/spree/admin/coupon_codes/index.html.erb
@@ -2,8 +2,8 @@
 
 <div class="row">
   <div class="col-12 col-lg-8">
-    <div class="card-lg p-0">
-      <%= search_form_for [:admin, @promotion, @search], class: "filter-wrap border-bottom" do |f| %>
+    <div class="card-lg">
+      <%= search_form_for [:admin, @promotion, @search], class: "filter-wrap" do |f| %>
         <div class="d-flex flex-column flex-lg-row gap-2">
           <%= render 'spree/admin/shared/filters_search_bar', param: :code_eq %>
 

--- a/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
@@ -8,7 +8,7 @@
 
           <% unless entri_enabled? %>
             <th>Default</th>
-            <th class="actions"></th>
+            <th></th>
           <% end %>
         </tr>
       </thead>

--- a/admin/app/views/spree/admin/custom_domains/index.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/index.html.erb
@@ -5,7 +5,7 @@
   <%= Spree.t(:domains) %>
 <% end %>
 
-<div class="card-lg">
+<div class="card-lg p-4">
   <h5 class="mb-3">Internal URL</h5>
   <div class="row mb-4">
     <div class="col-lg-4">

--- a/admin/app/views/spree/admin/customer_returns/index.html.erb
+++ b/admin/app/views/spree/admin/customer_returns/index.html.erb
@@ -5,9 +5,9 @@
 <% content_for :page_title do %>
   <%= Spree.t(:customer_returns) %>
 <% end %>
-<div class="card-lg p-0">
+<div class="card-lg">
 
-  <%= search_form_for [:admin, @search], url: spree.admin_customer_returns_path, class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+  <%= search_form_for [:admin, @search], url: spree.admin_customer_returns_path, class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
     <%= render "spree/admin/shared/filters_search_bar",
     param: :number_cont,
     label: Spree.t(:number) %>

--- a/admin/app/views/spree/admin/dashboard/show.html.erb
+++ b/admin/app/views/spree/admin/dashboard/show.html.erb
@@ -17,7 +17,7 @@
         <%= render 'spree/admin/shared/calendar_range_picker',
           date_from_value: params[:date_from] || 1.month.ago.beginning_of_month,
           date_to_value: params[:date_to] || 1.month.ago.end_of_month,
-          css_classes: "btn btn-sm border hover-light d-inline-flex align-items-center h-100 dropdown-toggle" %>
+          css_classes: "btn btn-sm border rounded-lg hover-light d-inline-flex align-items-center h-100 dropdown-toggle" %>
       <% end %>
     </div>
     <%= render 'analytics' %>

--- a/admin/app/views/spree/admin/digital_assets/_table.html.erb
+++ b/admin/app/views/spree/admin/digital_assets/_table.html.erb
@@ -6,7 +6,7 @@
       <% end %>
       <th><%= Spree.t(:name) %></th>
       <th><%= Spree.t(:size) %></th>
-      <th class="actions"></th>
+      <th></th>
     </tr>
   </thead>
   <tbody>

--- a/admin/app/views/spree/admin/exports/index.html.erb
+++ b/admin/app/views/spree/admin/exports/index.html.erb
@@ -1,30 +1,29 @@
 <%= render 'spree/admin/shared/audit_nav' %>
 
-<% if @collection.present? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table">
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:number) %></th>
-          <th class="text-center"><%= Spree.t(:kind) %></th>
-          <th class="text-center"><%= Spree.t(:status) %></th>
-          <th><%= Spree.t(:user) %></th>
-          <th><%= Spree.t(:filename) %></th>
-          <th><%= Spree.t(:date) %></th>
-          <th><%= Spree.t(:size) %></th>
-          <th class="text-center"><%= Spree.t(:download) %></th>
-        </tr>
-      </thead>
+<div class="card-lg">
+  <% if @collection.present? %>>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:number) %></th>
+            <th class="text-center"><%= Spree.t(:kind) %></th>
+            <th class="text-center"><%= Spree.t(:status) %></th>
+            <th><%= Spree.t(:user) %></th>
+            <th><%= Spree.t(:filename) %></th>
+            <th><%= Spree.t(:date) %></th>
+            <th><%= Spree.t(:size) %></th>
+            <th class="text-center"><%= Spree.t(:download) %></th>
+          </tr>
+        </thead>
         <tbody>
-          <%= render partial: 'export', collection: @exports, cached: true %>
+          <%= render partial: 'export', collection: @collection, cached: true %>
         </tbody>
       </table>
+      <%= render 'spree/admin/shared/index_table_options', collection: @collection %>
     </div>
   </div>
 <% else %>
-  <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
-    <%= Spree.t(:no_resource_found, resource: plural_resource_name(model_class)) %>
-  </div>
+  <%= render 'spree/admin/shared/no_resource_found', new_object_url: nil %>
 <% end %>
-
-<%= render 'spree/admin/shared/index_table_options', collection: @imports, simple: true if @imports.present? %>
+</div>

--- a/admin/app/views/spree/admin/oauth_applications/index.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for(:title, Spree.t('admin.oauth_applications.list')) %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t('admin.oauth_applications.new'), new_object_url, class: "btn-primary", icon: 'plus' %>
+  <%= link_to_with_icon 'plus', Spree.t('admin.oauth_applications.new'), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::OauthApplication %>
 
 <%= content_for :page_alerts do %>
@@ -15,61 +15,60 @@
   </div>
 <% end %>
 
-<% if @oauth_applications.any? %>
-  <div class="table-responsive rounded border mt-4 bg-white">
-    <table class="table">
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th>Client ID</th>
-          <th><%= Spree.t('admin.oauth_applications.scopes') %></th>
-          <th><%= Spree.t('admin.oauth_applications.last_used') %></th>
-          <th class="actions"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @oauth_applications.each do |application| %>
-          <tr id="<%= spree_dom_id application %>">
-            <td class="w-20"><code><%= application.name %></code></td>
-            <td class="w-40">
-              <div class="input-group" data-controller="password-toggle">
-                <%= button_tag class: 'btn hover-gray px-1', data: { action: 'click->password-toggle#password' } do %>
-                  <%= icon 'eye', class: 'mr-0' %>
-                <% end %>
-                <%= password_field_tag :password, application.uid, class: 'form-control-plaintext', data: { password_toggle_target: 'unhide' }, readonly: true %>
-              </div>
-            </td>
-            <td class="w-15">
-              <% if application.scopes.include?('write') %>
-                <span class="badge badge-warning">
-                  <%= icon('pencil', class: 'mr-1') %>
-                  <%= Spree.t('admin.oauth_applications.read_and_write') %>
-                </span>
-              <% else %>
-                <span class="badge badge-light">
-                  <%= icon('eye', class: 'mr-1') %>
-                  <%= Spree.t('admin.oauth_applications.read_only') %>
-                </span>
-              <% end %>
-            </td>
-            <td class="w-15">
-              <% if application.last_used_at %>
-                <%= local_time(application.last_used_at) %>
-              <% else %>
-                <span class="text-muted"><%= Spree.t('admin.oauth_applications.never') %></span>
-              <% end %>
-            </td>
-            <td class="actions w-10">
-              <%= link_to_edit(application, no_text: true) if can? :edit, application %>
-            </td>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th>Client ID</th>
+            <th><%= Spree.t('admin.oauth_applications.scopes') %></th>
+            <th><%= Spree.t('admin.oauth_applications.last_used') %></th>
+            <th></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
-    <%= Spree.t(:no_resource_found, resource: 'API keys') %>
-    <%= link_to_with_icon('plus', Spree.t(:add_one), new_object_url, class: 'btn btn-link ml-3') if can? :create, Spree::OauthApplication %>
-  </div>
-<% end %>
+        </thead>
+        <tbody>
+          <% @collection.each do |application| %>
+            <tr id="<%= spree_dom_id application %>">
+              <td class="w-20"><code><%= application.name %></code></td>
+              <td class="w-40">
+                <div class="input-group" data-controller="password-toggle">
+                  <%= button_tag class: 'btn hover-gray px-1', data: { action: 'click->password-toggle#password' } do %>
+                    <%= icon 'eye', class: 'mr-0' %>
+                  <% end %>
+                  <%= password_field_tag :password, application.uid, class: 'form-control-plaintext', data: { password_toggle_target: 'unhide' }, readonly: true %>
+                </div>
+              </td>
+              <td class="w-15">
+                <% if application.scopes.include?('write') %>
+                  <span class="badge badge-warning">
+                    <%= icon('pencil', class: 'mr-1') %>
+                    <%= Spree.t('admin.oauth_applications.read_and_write') %>
+                  </span>
+                <% else %>
+                  <span class="badge badge-light">
+                    <%= icon('eye', class: 'mr-1') %>
+                    <%= Spree.t('admin.oauth_applications.read_only') %>
+                  </span>
+                <% end %>
+              </td>
+              <td class="w-15">
+                <% if application.last_used_at %>
+                  <%= local_time(application.last_used_at) %>
+                <% else %>
+                  <span class="text-muted"><%= Spree.t('admin.oauth_applications.never') %></span>
+                <% end %>
+              </td>
+              <td class="actions w-10">
+                <%= link_to_edit(application, no_text: true) if can? :edit, application %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found', resource_name: 'API keys' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/option_types/_filter.html.erb
+++ b/admin/app/views/spree/admin/option_types/_filter.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<%= search_form_for [:admin, @search], class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
   <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:name) %>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/option_types/index.html.erb
+++ b/admin/app/views/spree/admin/option_types/index.html.erb
@@ -3,11 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <span id="new_ot_link">
-    <%= button_link_to Spree.t(:new_option_type),
-    new_object_url,
-    { class: "btn-primary", icon: "plus", id: "new_option_type_link" } %>
-  </span>
+  <%= link_to_with_icon 'plus', Spree.t(:new_option_type), new_object_url, class: 'btn btn-primary' %>
 <% end if can?(:create, Spree::OptionType) %>
 
 <%= content_for(:page_alerts) do %>
@@ -17,12 +13,8 @@
   </div>
 <% end %>
 
-<div id="new_option_type"></div>
-
-<div class="card-lg p-0">
-
+<div class="card-lg">
   <%= render partial: "spree/admin/option_types/filter" %>
-
   <% if @option_types.any? %>
     <div class="table-responsive">
       <table class="table" id="listing_option_types">
@@ -44,7 +36,7 @@
             <th>
               <%= Spree.t(:products) %>
             </th>
-            <th class="actions"></th>
+            <th></th>
           </tr>
         </thead>
         <tbody
@@ -61,3 +53,7 @@
     <%= render "spree/admin/shared/no_resource_found" %>
   <% end %>
 </div>
+
+<p class="documentation-link-container">
+  <%= external_link_to "Learn more about options", "https://spreecommerce.org/docs/user/manage-products/product-options" %>
+</p>

--- a/admin/app/views/spree/admin/orders/_filters.html.erb
+++ b/admin/app/views/spree/admin/orders/_filters.html.erb
@@ -2,7 +2,7 @@
 
 <%= search_form_for [:admin, @vendor || @user, @search],
   url: controller_name == 'checkouts' ? spree.admin_checkouts_path : nil,
-  class: "filter-wrap border-bottom",
+  class: "filter-wrap",
   data: {
     controller: "filters reveal",
     reveal_hidden_class: "d-none",
@@ -92,12 +92,7 @@
       <%= render_admin_partials(:orders_filters_partials, f: f) %>
     </div>
 
-    <div class="form-actions">
-      <%= turbo_save_button_tag Spree.t(:filter_results) do %>
-        <%= icon("search") %>
-        <%= Spree.t(:filter_results) %>
-      <% end %>
-    </div>
+    <%= render 'spree/admin/shared/filter_submit' %>
   </div>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/orders/index.html.erb
+++ b/admin/app/views/spree/admin/orders/index.html.erb
@@ -10,7 +10,7 @@
   <%= link_to_with_icon 'plus', Spree.t(:new_order), spree.admin_orders_path, class: "btn btn-primary", data: { turbo_method: :post } if can?(:create, Spree::Order)  %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <% if params[:frame_name].present? %>
     <%= turbo_frame_tag params[:frame_name], autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
       <%= render 'spree/admin/orders/filters', frame_name: params[:frame_name] %>

--- a/admin/app/views/spree/admin/orders/return_authorizations/_form.html.erb
+++ b/admin/app/views/spree/admin/orders/return_authorizations/_form.html.erb
@@ -1,7 +1,7 @@
 <% allow_return_item_changes = !@return_authorization.customer_returned_items? %>
 
 <div data-controller="return-items">
-  <div class="table-responsive card-lg p-0 mb-4">
+  <div class="table-responsive card-lg mb-4">
     <table class="table table-condensed return-items-table">
       <thead class="text-muted">
         <tr>

--- a/admin/app/views/spree/admin/orders/return_authorizations/show.html.erb
+++ b/admin/app/views/spree/admin/orders/return_authorizations/show.html.erb
@@ -24,51 +24,53 @@ locals: {
   </div>
 <% end %>
 
-<div class="table-responsive card-lg p-0 mb-4">
-  <table class="table table-condensed return-items-table">
-    <thead class="text-muted">
-      <tr>
-        <th><%= Spree.t(:product) %></th>
-        <th><%= Spree.t(:status) %></th>
-        <th><%= Spree.t(:purchased_quantity) %></th>
-        <th><%= Spree.t(:return_quantity) %></th>
-        <th><%= Spree.t(:total) %></th>
-        <th><%= Spree.t(:refund_amount) %></th>
-        <th><%= Spree.t(:reimbursement_type) %></th>
-        <th><%= Spree.t(:exchange_for) %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @return_authorization.return_items.each do |return_item| %>
+<div class="card-lg mb-4">
+  <div class="table-responsive">
+    <table class="table table-condensed return-items-table">
+      <thead class="text-muted">
         <tr>
-          <td>
-            <div class="variant-name">
-              <%= link_to return_item.inventory_unit.variant.name,
-              spree.edit_admin_product_path(return_item.inventory_unit.variant.product) %>
-            </div>
-            <div class="variant-options"><%= return_item.inventory_unit.variant.options_text %></div>
-          </td>
-          <td><%= return_item.inventory_unit.state.humanize %></td>
-          <td class="purchased-quantity">
-            <%= return_item.line_item.quantity %>
-          </td>
-          <td><%= return_item.return_quantity %></td>
-          <td><%= return_item.pre_tax_amount %></td>
-          <td><%= return_item.display_total %></td>
-          <td><%= if return_item.preferred_reimbursement_type.present?
-              return_item.preferred_reimbursement_type.name.humanize
-            else
-              "-"
-            end %></td>
-          <td><%= if return_item.exchange_processed?
-              return_item.exchange_variant.exchange_name
-            else
-              "-"
-            end %></td>
+          <th><%= Spree.t(:product) %></th>
+          <th><%= Spree.t(:status) %></th>
+          <th><%= Spree.t(:purchased_quantity) %></th>
+          <th><%= Spree.t(:return_quantity) %></th>
+          <th><%= Spree.t(:total) %></th>
+          <th><%= Spree.t(:refund_amount) %></th>
+          <th><%= Spree.t(:reimbursement_type) %></th>
+          <th><%= Spree.t(:exchange_for) %></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% @return_authorization.return_items.each do |return_item| %>
+          <tr>
+            <td>
+              <div class="variant-name">
+                <%= link_to return_item.inventory_unit.variant.name,
+                spree.edit_admin_product_path(return_item.inventory_unit.variant.product) %>
+              </div>
+              <div class="variant-options"><%= return_item.inventory_unit.variant.options_text %></div>
+            </td>
+            <td><%= return_item.inventory_unit.state.humanize %></td>
+            <td class="purchased-quantity">
+              <%= return_item.line_item.quantity %>
+            </td>
+            <td><%= return_item.return_quantity %></td>
+            <td><%= return_item.pre_tax_amount %></td>
+            <td><%= return_item.display_total %></td>
+            <td><%= if return_item.preferred_reimbursement_type.present?
+                return_item.preferred_reimbursement_type.name.humanize
+              else
+                "-"
+              end %></td>
+            <td><%= if return_item.exchange_processed?
+                return_item.exchange_variant.exchange_name
+              else
+                "-"
+              end %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>
 
 <% if @return_authorization.reason.present? %>

--- a/admin/app/views/spree/admin/pages/_filters.html.erb
+++ b/admin/app/views/spree/admin/pages/_filters.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], url: spree.admin_pages_path , class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<%= search_form_for [:admin, @search], url: spree.admin_pages_path , class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
   <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:name) %>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/pages/index.html.erb
+++ b/admin/app/views/spree/admin/pages/index.html.erb
@@ -5,7 +5,7 @@
   <%= link_to_with_icon 'plus', Spree.t(:add_new_page), spree.new_admin_page_path, class: "btn btn-primary" if can?(:create, Spree::Page.new) %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <%= render "spree/admin/pages/filters" %>
   <% if @pages.any? %>
     <div class="table-responsive">
@@ -20,7 +20,7 @@
           <%= render collection: @pages, partial: "spree/admin/pages/page", cached: spree_base_cache_scope %>
         </tbody>
       </table>
-      <%= render partial: "spree/admin/shared/index_table_options", locals: { collection: @pages } %>
+      <%= render partial: "spree/admin/shared/index_table_options", collection: @pages %>
     </div>
   <% else %>
     <%= render 'spree/admin/shared/no_resource_found' %>

--- a/admin/app/views/spree/admin/payment_methods/index.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/index.html.erb
@@ -2,15 +2,16 @@
   <%= Spree.t(:payment_methods) %>
 <% end %>
 
-<div class="table-responsive card-lg p-0 mb-4">
-  <table class="table" id='listing_shipping_methods'>
-    <thead class="text-muted">
+<div class="card-lg">
+  <div class="table-responsive">
+    <table class="table">
+      <thead class="text-muted">
       <tr>
         <th></th>
         <th><%= Spree.t(:payment_method) %></th>
         <th><%= Spree.t(:visibility) %></th>
         <th class="text-center"><%= Spree.t(:active) %></th>
-        <th class="actions"></th>
+        <th></th>
       </tr>
     </thead>
     <tbody data-controller="sortable" data-sortable-handle-value=".move-handle" data-sortable-resource-name-value="payment_method" data-sortable-response-kind-value="turbo-stream">
@@ -21,13 +22,14 @@
 
 <% if available_payment_methods.present? && can?(:create, Spree::PaymentMethod) %>
   <h5 class="pb-2 pt-3">Available Payment Methods</h5>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_shipping_methods'>
-      <thead class="text-muted">
+  <div class="card-lg">
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
         <tr>
           <th><%= Spree.t(:name) %></th>
           <th><%= Spree.t(:description) %></th>
-          <th class="actions"></th>
+          <th></th>
         </tr>
       </thead>
       <tbody>

--- a/admin/app/views/spree/admin/post_categories/index.html.erb
+++ b/admin/app/views/spree/admin/post_categories/index.html.erb
@@ -5,7 +5,7 @@
 <%= render 'spree/admin/shared/posts_tabs' %>
 
 <% if @post_categories.any? %>
-  <div class="card-lg p-0">
+  <div class="card-lg">
     <div class="table-responsive rounded-lg">
       <table class="table">
         <thead class="text-muted">

--- a/admin/app/views/spree/admin/posts/_filters.html.erb
+++ b/admin/app/views/spree/admin/posts/_filters.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<%= search_form_for [:admin, @search], class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
   <div class="d-flex flex-column flex-lg-row gap-2">
     <%= render 'spree/admin/shared/filters_search_bar', param: :search_by_title, label: Spree.t(:title) %>
 
@@ -26,12 +26,7 @@
         </div>
       </div>
     </div>
-    <div class="form-actions">
-      <%= turbo_save_button_tag Spree.t(:filter_results) do %>
-        <%= icon("search") %>
-        <%= Spree.t(:filter_results) %>
-      <% end %>
-    </div>
+    <%= render 'spree/admin/shared/filter_submit' %>
   </div>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/posts/index.html.erb
+++ b/admin/app/views/spree/admin/posts/index.html.erb
@@ -6,7 +6,7 @@
 
 <%= render 'spree/admin/shared/posts_tabs' %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <%= render "spree/admin/posts/filters" %>
 
   <% if @posts.any? %>

--- a/admin/app/views/spree/admin/products/_empty_list.html.erb
+++ b/admin/app/views/spree/admin/products/_empty_list.html.erb
@@ -1,1 +1,0 @@
-<%= render 'spree/admin/shared/no_resource_found' %>

--- a/admin/app/views/spree/admin/products/_filters.html.erb
+++ b/admin/app/views/spree/admin/products/_filters.html.erb
@@ -1,7 +1,7 @@
 <% frame_name ||= nil %>
 
 <%= search_form_for product_list_filters_search_form_path,
-  class: "filter-wrap border-bottom",
+  class: "filter-wrap",
   data: {
     controller: "filters reveal",
     reveal_hidden_class: "d-none",
@@ -56,12 +56,7 @@
       <%= render_admin_partials(:products_filters_partials, f: f) %>
     </div>
 
-    <div class="form-actions">
-      <%= turbo_save_button_tag Spree.t(:filter_results) do %>
-        <%= icon("search") %>
-        <%= Spree.t(:filter_results) %>
-      <% end %>
-    </div>
+    <%= render 'spree/admin/shared/filter_submit' %>
   </div>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/products/_list.html.erb
+++ b/admin/app/views/spree/admin/products/_list.html.erb
@@ -46,5 +46,5 @@
     </div>
     <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>
   <% else %>
-    <%= render partial: 'spree/admin/products/empty_list' %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
   <% end %>

--- a/admin/app/views/spree/admin/products/index.html.erb
+++ b/admin/app/views/spree/admin/products/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'index_header' %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <% if params[:frame_name].present? %>
     <%= turbo_frame_tag params[:frame_name], autoscroll: true, data: { autoscroll_block: :start, autoscroll_behavior: :smooth } do %>
       <%= render 'filters', frame_name: params[:frame_name] %>
@@ -12,7 +12,7 @@
   <% end %>
 </div>
 
-<p class="text-muted small text-center py-2 px-3 mt-4 rounded-pill mx-auto d-flex-inline">
-  Learn more about 
-  <%= external_link_to 'managing products', 'https://spreecommerce.org/docs/user/manage-products', class: 'text-decoration-none' %>
+<p class="documentation-link-container">
+  Learn more about
+  <%= external_link_to 'managing products', 'https://spreecommerce.org/docs/user/manage-products' %>
 </p>

--- a/admin/app/views/spree/admin/promotions/_filters.html.erb
+++ b/admin/app/views/spree/admin/promotions/_filters.html.erb
@@ -1,0 +1,27 @@
+<%= search_form_for [:admin, @search], class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+  <div class="d-flex flex-column flex-lg-row gap-2">
+    <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:name) %>
+
+    <div class="d-flex align-items-center justify-content-between">
+      <%= render "spree/admin/promotions/table_filter_dropdown" %>
+
+      <%= render 'spree/admin/shared/filters_button' %>
+    </div>
+  </div>
+  <div data-reveal-target="item" class="d-none" id="table-filter">
+    <div class="row">
+      <div class="col-12 col-lg-6">
+        <div class="form-group">
+          <%= label_tag :q_code_or_coupon_codes_code_eq, Spree.t(:code) %>
+          <%= f.search_field :code_or_coupon_codes_code_eq, class: "form-control", data: { filters_target: :input } %>
+        </div>
+      </div>
+    </div>
+
+    <%= render 'spree/admin/shared/filter_submit' %>
+  </div>
+
+  <%= render "spree/admin/shared/filter_badge_template" %>
+
+  <div data-filters-target="badgesContainer" class="filter-badges-container"></div>
+<% end %>

--- a/admin/app/views/spree/admin/promotions/index.html.erb
+++ b/admin/app/views/spree/admin/promotions/index.html.erb
@@ -3,41 +3,13 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_promotion), new_object_url, class: "btn-primary", icon: "plus" %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_promotion), new_object_url, class: "btn btn-primary" %>
 <% end if can?(:create, Spree::Promotion) %>
 
-<div class="card-lg p-0">
-  <%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
-    <div class="d-flex flex-column flex-lg-row gap-2">
-      <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:name) %>
+<div class="card-lg">
+  <%= render 'filters' %>
 
-      <div class="d-flex align-items-center justify-content-between">
-        <%= render "spree/admin/promotions/table_filter_dropdown" %>
-
-        <%= render 'spree/admin/shared/filters_button' %>
-      </div>
-    </div>
-    <div data-reveal-target="item" class="d-none" id="table-filter">
-      <div class="row">
-        <div class="col-12 col-lg-6">
-          <div class="form-group">
-            <%= label_tag :q_code_or_coupon_codes_code_eq, Spree.t(:code) %>
-            <%= f.search_field :code_or_coupon_codes_code_eq, class: "form-control", data: { filters_target: :input } %>
-          </div>
-        </div>
-      </div>
-
-      <div class="form-actions">
-        <%= button Spree.t(:filter_results), "search" %>
-      </div>
-    </div>
-
-    <%= render "spree/admin/shared/filter_badge_template" %>
-
-    <div data-filters-target="badgesContainer" class="filter-badges-container"></div>
-  <% end %>
-
-  <% if @promotions.any? %>
+  <% if @collection.any? %>
     <div class="table-responsive">
       <table class="table">
         <thead class="text-muted">
@@ -47,15 +19,15 @@
             <th><%= Spree.t(:kind) %></th>
             <th><%= Spree.t(:usage_limit) %></th>
             <th><%= Spree.t(:status) %></th>
-            <th class="actions"></th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
-          <%= render collection: @promotions, partial: "spree/admin/promotions/promotion", cached: spree_base_cache_scope %>
+          <%= render collection: @collection, partial: "spree/admin/promotions/promotion", cached: spree_base_cache_scope %>
         </tbody>
       </table>
     </div>
-    <%= render "spree/admin/shared/index_table_options", collection: @promotions, simple: true %>
+    <%= render "spree/admin/shared/index_table_options", collection: @collection %>
   <% else %>
     <%= render "spree/admin/shared/no_resource_found" %>
   <% end %>

--- a/admin/app/views/spree/admin/properties/index.html.erb
+++ b/admin/app/views/spree/admin/properties/index.html.erb
@@ -9,22 +9,19 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_property), new_object_url, { class: "btn-primary", icon: "plus" } %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_property), new_object_url, class: "btn btn-primary" %>
 <% end if can?(:create, Spree::Property)  %>
 
-<div class="card-lg p-0">
-
-  <%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<div class="card-lg">
+  <%= search_form_for [:admin, @search], class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
     <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:name) %>
-
     <%= render "spree/admin/shared/filter_badge_template" %>
-
     <div data-filters-target="badgesContainer" class="filter-badges-container"></div>
   <% end %>
 
   <% if @properties.present? %>
     <div class="table-responsive">
-      <table class="table" id='listing_properties'>
+      <table class="table">
         <thead class="text-muted">
           <tr>
             <th class="no-border handel-head"></th>
@@ -33,7 +30,7 @@
             <th><%= Spree.t(:kind) %></th>
             <th><%= Spree.t(:products) %></th>
             <th><%= Spree.t(:visibility) %></th>
-            <th class="actions"></th>
+            <th></th>
           </tr>
         </thead>
         <tbody
@@ -45,9 +42,13 @@
           <%= render partial: "spree/admin/properties/property", collection: @collection, cached: spree_base_cache_scope %>
         </tbody>
       </table>
-      <%= render "spree/admin/shared/index_table_options", collection: @collection, simple: true %>
+      <%= render "spree/admin/shared/index_table_options", collection: @collection %>
     </div>
   <% else %>
     <%= render "spree/admin/shared/no_resource_found" %>
   <% end %>
 </div>
+
+<p class="documentation-link-container">
+  <%= external_link_to "Learn more about properties", "https://spreecommerce.org/docs/user/manage-products/product-properties" %>
+</p>

--- a/admin/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/admin/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,40 +1,42 @@
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_refund_reason), new_object_url, { icon: 'plus', id: 'admin_new_named_type', class: "btn-primary" } %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_refund_reason), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::RefundReason %>
 
 <%= render 'spree/admin/shared/returns_and_refunds_nav' %>
 
-<% if @collection.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table">
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:status) %></th>
-          <th><%= Spree.t(:mutable) %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-      <% @collection.each do |refund_reason| %>
-        <tr id="<%= spree_dom_id refund_reason %>" data-controller="row-link" class="cursor-pointer">
-          <td class="w-40 align-center" data-action="click->row-link#openLink">
-            <%= refund_reason.name %>
-          </td>
-          <td class="w-20 align-center" data-action="click->row-link#openLink">
-            <%= active_badge(refund_reason.active, label: Spree.t(refund_reason.active? ? :active : :inactive)) %>
-          </td>
-          <td class="w-10 align-center" data-action="click->row-link#openLink">
-            <%= active_badge(refund_reason.mutable) %>
-          </td>
-          <td class="actions w-10" data-action="click->row-link#openLink">
-            <%= link_to_edit(refund_reason, no_text: true, data: { row_link_target: :link }) if can? :edit, refund_reason %>
-          </td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:status) %></th>
+            <th><%= Spree.t(:mutable) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+        <% @collection.each do |refund_reason| %>
+          <tr id="<%= spree_dom_id refund_reason %>" data-controller="row-link" class="cursor-pointer">
+            <td class="w-40 align-center" data-action="click->row-link#openLink">
+              <%= refund_reason.name %>
+            </td>
+            <td class="w-20 align-center" data-action="click->row-link#openLink">
+              <%= active_badge(refund_reason.active, label: Spree.t(refund_reason.active? ? :active : :inactive)) %>
+            </td>
+            <td class="w-10 align-center" data-action="click->row-link#openLink">
+              <%= active_badge(refund_reason.mutable) %>
+            </td>
+            <td class="actions w-10" data-action="click->row-link#openLink">
+              <%= link_to_edit(refund_reason, no_text: true, data: { row_link_target: :link }) if can? :edit, refund_reason %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/admin/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,44 +1,46 @@
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_reimbursement_type), new_object_url, { :class => "btn-primary", :icon => 'plus', :id => 'admin_new_reimbursement_type' } %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_reimbursement_type), new_object_url, class: "btn btn-primary" %>
 <% end if can?(:create, Spree::ReimbursementType) %>
 
-<%= render partial: 'spree/admin/shared/returns_and_refunds_nav' %>
+<%= render 'spree/admin/shared/returns_and_refunds_nav' %>
 
-<% if @reimbursement_types.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_reimbursement_types'>
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:type) %></th>
-          <th><%= Spree.t(:status) %></th>
-          <th><%= Spree.t(:mutable) %></th>
-          <th class="actions"></th>
-        </tr>
-      </thead>
-      <tbody>
-      <% @reimbursement_types.each do |reimbursement_type| %>
-        <tr id="<%= spree_dom_id reimbursement_type %>" data-controller="row-link">
-          <td class="w-40 align-center cursor-pointer" data-action="click->row-link#openLink">
-            <%= reimbursement_type.name.humanize %>
-          </td>
-          <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
-            <code><%= reimbursement_type.type.demodulize %></code>
-          </td>
-          <td class="w-10 align-center cursor-pointer" data-action="click->row-link#openLink">
-            <%= active_badge(reimbursement_type.active, label: Spree.t(reimbursement_type.active? ? :active : :inactive)) %>
-          </td>
-          <td class="w-10 align-center cursor-pointer" data-action="click->row-link#openLink">
-            <%= active_badge(reimbursement_type.mutable) %>
-          </td>
-          <td class="actions w-10">
-            <%= link_to_edit reimbursement_type, no_text: true, data: { row_link_target: :link } if can?(:edit, reimbursement_type) %>
-          </td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:type) %></th>
+            <th><%= Spree.t(:status) %></th>
+            <th><%= Spree.t(:mutable) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @collection.each do |reimbursement_type| %>
+            <tr id="<%= spree_dom_id reimbursement_type %>" data-controller="row-link">
+              <td class="w-40 align-center cursor-pointer" data-action="click->row-link#openLink">
+                <%= reimbursement_type.name.humanize %>
+              </td>
+              <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
+                <code><%= reimbursement_type.type.demodulize %></code>
+              </td>
+              <td class="w-10 align-center cursor-pointer" data-action="click->row-link#openLink">
+                <%= active_badge(reimbursement_type.active, label: Spree.t(reimbursement_type.active? ? :active : :inactive)) %>
+              </td>
+              <td class="w-10 align-center cursor-pointer" data-action="click->row-link#openLink">
+                <%= active_badge(reimbursement_type.mutable) %>
+              </td>
+              <td class="actions w-10">
+                <%= link_to_edit reimbursement_type, no_text: true, data: { row_link_target: :link } if can?(:edit, reimbursement_type) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/reports/_report.html.erb
+++ b/admin/app/views/spree/admin/reports/_report.html.erb
@@ -1,4 +1,4 @@
-<div class="card-lg p-0">
+<div class="card-lg">
   <div class="table-responsive">
     <table class="table">
       <thead class="text-muted">

--- a/admin/app/views/spree/admin/return_authorization_reasons/index.html.erb
+++ b/admin/app/views/spree/admin/return_authorization_reasons/index.html.erb
@@ -1,45 +1,45 @@
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_rma_reason),
-  new_object_url,
-  { icon: "plus", id: "admin_new_named_type", class: "btn-primary" } %>
-  <% end if can? :create, Spree::RefundReason %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_rma_reason), new_object_url, class: "btn btn-primary" %>
+<% end if can? :create, Spree::RefundReason %>
 
-    <%= render partial: "spree/admin/shared/returns_and_refunds_nav" %>
+<%= render"spree/admin/shared/returns_and_refunds_nav" %>
 
-    <% if @collection.any? %>
-      <div class="table-responsive card-lg p-0">
-        <table class="table" id='listing_named_types'>
-          <thead class="text-muted">
-            <tr>
-              <th><%= Spree.t(:name) %></th>
-              <th><%= Spree.t(:status) %></th>
-              <th></th>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:status) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="<%= plural_resource_name(Spree::ReturnAuthorizationReason).to_s.parameterize.underscore %>">
+          <% @collection.each do |return_authorization_reason| %>
+            <tr id="<%= spree_dom_id return_authorization_reason %>" data-controller="row-link">
+              <td class="w-40 align-center cursor-pointer" data-action="click->row-link#openLink">
+                <%= return_authorization_reason.name %>
+              </td>
+              <td class="w-20 align-center cursor-pointer" data-action="click->row-link#openLink">
+                <%= active_badge(
+                  return_authorization_reason.active,
+                  label: Spree.t(return_authorization_reason.active? ? :active : :inactive),
+                ) %>
+              </td>
+              <td class="actions w-10">
+                <% if return_authorization_reason.mutable? %>
+                  <%= if can? :edit, return_authorization_reason
+                    link_to_edit(return_authorization_reason, no_text: true, data: { row_link_target: :link })
+                  end %>
+                <% end %>
+              </td>
             </tr>
-          </thead>
-          <tbody id="<%= plural_resource_name(Spree::ReturnAuthorizationReason).to_s.parameterize.underscore %>">
-            <% @collection.each do |return_authorization_reason| %>
-              <tr id="<%= spree_dom_id return_authorization_reason %>" data-controller="row-link">
-                <td class="w-40 align-center cursor-pointer" data-action="click->row-link#openLink">
-                  <%= return_authorization_reason.name %>
-                </td>
-                <td class="w-20 align-center cursor-pointer" data-action="click->row-link#openLink">
-                  <%= active_badge(
-                    return_authorization_reason.active,
-                    label: Spree.t(return_authorization_reason.active? ? :active : :inactive),
-                  ) %>
-                </td>
-                <td class="actions w-10">
-                  <% if return_authorization_reason.mutable? %>
-                    <%= if can? :edit, return_authorization_reason
-                      link_to_edit(return_authorization_reason, no_text: true, data: { row_link_target: :link })
-                    end %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    <% else %>
-      <%= render "spree/admin/shared/no_resource_found" %>
-    <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render "spree/admin/shared/no_resource_found" %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/return_authorization_reasons/index.html.erb
+++ b/admin/app/views/spree/admin/return_authorization_reasons/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_actions do %>
   <%= link_to_with_icon 'plus', Spree.t(:new_rma_reason), new_object_url, class: "btn btn-primary" %>
-<% end if can? :create, Spree::RefundReason %>
+<% end if can? :create, Spree::ReturnAuthorizationReason %>
 
 <%= render"spree/admin/shared/returns_and_refunds_nav" %>
 

--- a/admin/app/views/spree/admin/return_authorizations/_filters.html.erb
+++ b/admin/app/views/spree/admin/return_authorizations/_filters.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], url: spree.admin_return_authorizations_path, class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<%= search_form_for [:admin, @search], url: spree.admin_return_authorizations_path, class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
   <div class="d-flex flex-column flex-lg-row gap-2">
     <%= render "spree/admin/shared/filters_search_bar", param: :number_cont %>
 

--- a/admin/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/admin/app/views/spree/admin/return_authorizations/index.html.erb
@@ -2,7 +2,7 @@
   <%= Spree.t(:return_authorizations) %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <%= render "spree/admin/return_authorizations/filters" %>
   <%= render "spree/admin/return_authorizations/list" %>
 

--- a/admin/app/views/spree/admin/roles/index.html.erb
+++ b/admin/app/views/spree/admin/roles/index.html.erb
@@ -17,7 +17,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @roles.each do |role| %>
+          <% @collection.each do |role| %>
             <tr id="<%= spree_dom_id role %>">
               <td><%= role.name %></td>
               <td class="actions">

--- a/admin/app/views/spree/admin/roles/index.html.erb
+++ b/admin/app/views/spree/admin/roles/index.html.erb
@@ -3,30 +3,32 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_role), new_object_url, class: "btn-primary", icon: 'plus', id: 'admin_new_role_link' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_role), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::Role %>
 
-<% if @roles.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table">
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:role_id) %></th>
-          <th class="actions"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @roles.each do |role| %>
-          <tr id="<%= spree_dom_id role %>">
-            <td><%= role.name %></td>
-            <td class="actions">
-              <%= link_to_edit(role, no_text: true) if can? :edit, role %>
-            </td>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:role_id) %></th>
+            <th></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+        </thead>
+        <tbody>
+          <% @roles.each do |role| %>
+            <tr id="<%= spree_dom_id role %>">
+              <td><%= role.name %></td>
+              <td class="actions">
+                <%= link_to_edit(role, no_text: true) if can? :edit, role %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/shared/_filter_submit.html.erb
+++ b/admin/app/views/spree/admin/shared/_filter_submit.html.erb
@@ -1,0 +1,6 @@
+<div class="form-actions">
+  <%= turbo_save_button_tag Spree.t(:filter_results) do %>
+    <%= icon("search") %>
+    <%= Spree.t(:filter_results) %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/shared/_no_resource_found.html.erb
+++ b/admin/app/views/spree/admin/shared/_no_resource_found.html.erb
@@ -2,5 +2,5 @@
 
 <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
   <%= Spree.t(:no_resource_found, resource: resource_name) %>
-  <%= link_to_with_icon 'plus', Spree.t(:add_one), new_object_url, class: 'btn btn-light ml-3' if can?(:create, model_class) && defined?(new_object_url) %>
+  <%= link_to_with_icon 'plus', Spree.t(:add_one), new_object_url, class: 'btn btn-light ml-3' if can?(:create, model_class) && defined?(new_object_url) && new_object_url.present? %>
 </div>

--- a/admin/app/views/spree/admin/shared/_refunds.html.erb
+++ b/admin/app/views/spree/admin/shared/_refunds.html.erb
@@ -1,4 +1,4 @@
-<div class="table-responsive card-lg p-0">
+<div class="table-responsive card-lg">
   <table class="table table-condensed" id='refunds' data-order-id='<%= @order.number %>'>
     <thead class="text-muted">
       <tr data-hook="refunds_header" class="border-bottom">

--- a/admin/app/views/spree/admin/shared/sidebar/_orders_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_orders_nav.html.erb
@@ -16,7 +16,7 @@
       <% end %>
 
       <% if can?(:manage, :checkouts) %>
-        <%= nav_item(Spree.t(:draft_orders), spree.admin_checkouts_path, active: params[:controller] == 'checkouts') %>
+        <%= nav_item(Spree.t(:draft_orders), spree.admin_checkouts_path) %>
       <% end %>
 
       <%= render_admin_partials(:store_orders_nav_partials) %>

--- a/admin/app/views/spree/admin/shared/sortable_tree/_taxonomy.html.erb
+++ b/admin/app/views/spree/admin/shared/sortable_tree/_taxonomy.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="d-flex align-items-center px-3 ml-3">
-    <%= link_to_edit(taxon, url: spree.edit_admin_taxonomy_taxon_path(taxonomy, taxon.id), data: { row_link_target: :link }) %>
+    <%= link_to_edit(taxon, url: spree.edit_admin_taxonomy_taxon_path(taxonomy, taxon.id), data: { row_link_target: :link }) if can?(:edit, taxon) %>
 
     <div class="dropdown ml-2 h-100">
       <button class="btn btn-light btn-sm px-1 h-100" type="button" id="dropdownMenuButton-<%= taxon.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/admin/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/admin/app/views/spree/admin/shipping_categories/index.html.erb
@@ -3,34 +3,36 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_shipping_category), new_object_url, class: "btn-primary", icon: 'plus.svg' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_shipping_category), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::ShippingCategory %>
 
 <%= render partial: 'spree/admin/shared/shipping_nav' %>
 
-<% if @shipping_categories.any? %>
-  <div class="table-responsive border rounded bg-white shadow-xs">
-    <table class="table">
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th class="actions"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @shipping_categories.each do |shipping_category| %>
-          <tr id="<%= spree_dom_id shipping_category %>" class="cursor-pointer" data-controller="row-link">
-            <td data-action="click->row-link#openLink"><%= shipping_category.name %></td>
-            <td class="actions">
-              <span class="d-flex justify-content-end">
-                <%= link_to_edit(shipping_category, data: { row_link_target: :link }) if can? :edit, shipping_category %>
-              </span>
-            </td>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+        </thead>
+        <tbody>
+          <% @collection.each do |shipping_category| %>
+            <tr id="<%= spree_dom_id shipping_category %>" class="cursor-pointer" data-controller="row-link">
+              <td data-action="click->row-link#openLink"><%= shipping_category.name %></td>
+              <td class="actions">
+                <span class="d-flex justify-content-end">
+                  <%= link_to_edit(shipping_category, data: { row_link_target: :link }) if can? :edit, shipping_category %>
+                </span>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/shipping_methods/_actions.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/_actions.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingMethod) %>
-    <%= button_link_to Spree.t(:new_shipping_method), new_object_url, class: "btn-primary", icon: 'plus' %>
+    <%= link_to_with_icon 'plus', Spree.t(:new_shipping_method), new_object_url, class: "btn btn-primary" %>
   <% end %>
 <% end %>

--- a/admin/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/index.html.erb
@@ -11,24 +11,26 @@
   </div>
 <% end %>
 
-<% if @shipping_methods.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_shipping_methods'>
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:zone) %></th>
-          <th><%= Spree.t(:estimated_delivery_time) %></th>
-          <th><%= Spree.t(:amount) %></th>
-          <th><%= Spree.t(:visibility) %></th>
-          <th class="actions"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: 'spree/admin/shipping_methods/shipping_method', collection: @shipping_methods.includes(:zones, :calculator), as: :shipping_method %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:zone) %></th>
+            <th><%= Spree.t(:estimated_delivery_time) %></th>
+            <th><%= Spree.t(:amount) %></th>
+            <th><%= Spree.t(:visibility) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: 'spree/admin/shipping_methods/shipping_method', collection: @collection.includes(:zones, :calculator), as: :shipping_method %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/stock_items/_filters.html.erb
+++ b/admin/app/views/spree/admin/stock_items/_filters.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: { controller: "filters reveal", reveal_hidden_class: "d-none" } do |f| %>
+<%= search_form_for [:admin, @search], class: "filter-wrap", data: { controller: "filters reveal", reveal_hidden_class: "d-none" } do |f| %>
   <div class="d-flex flex-column flex-lg-row gap-2">
     <%= render 'spree/admin/shared/filters_search_bar', param: :variant_product_name_cont, label: Spree.t(:product_name) %>
 
@@ -25,12 +25,7 @@
 
     </div>
 
-    <div class="form-actions">
-      <%= turbo_save_button_tag Spree.t(:filter_results) do %>
-        <%= icon("search") %>
-        <%= Spree.t(:filter_results) %>
-      <% end %>
-    </div>
+    <%= render 'spree/admin/shared/filter_submit' %>
   </div>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/stock_items/index.html.erb
+++ b/admin/app/views/spree/admin/stock_items/index.html.erb
@@ -6,7 +6,7 @@
   <%= render "spree/admin/shared/stock_nav" %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <%= render "filters" %>
 
   <% if @stock_items.any? %>

--- a/admin/app/views/spree/admin/stock_locations/_stock_location.html.erb
+++ b/admin/app/views/spree/admin/stock_locations/_stock_location.html.erb
@@ -4,25 +4,28 @@
     <%= flag_emoji(stock_location.country_iso) %>
     <%= stock_location.country_name %>
   </td>
-  <td data-action="click->row-link#openLink"><%= active_badge(stock_location.active?) %></td>
+  <td data-action="click->row-link#openLink">
+    <%= active_badge(stock_location.active?) %>
+  </td>
   <td data-action="click->row-link#openLink"><%= active_badge(stock_location.default?) %></td>
   <td class="actions">
     <% if can? :edit, stock_location %>
       <div class="d-flex justify-content-end align-items-center">
         <div><%= link_to_edit stock_location, data: { row_link_target: 'link' } %></div>
 
-        <div class="dropdown">
-          <button class="btn btn-sm btn-light h-100" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= icon('dots', class: 'mr-0') %>
-          </button>
-
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-            <%= link_to_with_icon 'check',
-              Spree.t(:mark_as_default),
-              spree.mark_as_default_admin_stock_location_path(stock_location),
-              class: 'dropdown-item',
-              data: { turbo_method: :put } %>
-          </div>
+        <% unless stock_location.default? %>
+          <div class="dropdown">
+            <button class="btn btn-sm btn-light h-100" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <%= icon('dots', class: 'mr-0') %>
+            </button>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+              <%= link_to_with_icon 'check',
+                Spree.t(:mark_as_default),
+                spree.mark_as_default_admin_stock_location_path(stock_location),
+                class: 'dropdown-item',
+                data: { turbo_method: :put } %>
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/admin/app/views/spree/admin/stock_locations/index.html.erb
+++ b/admin/app/views/spree/admin/stock_locations/index.html.erb
@@ -2,25 +2,28 @@
   <%= Spree.t(:stock_locations) %>
 <% end %>
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_stock_location), new_object_url, class: "btn-primary", icon: 'plus' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_stock_location), new_object_url, class: "btn btn-primary" %> 
 <% end if can? :create, Spree::StockLocation %>
-<% if @stock_locations.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_tax_rates'>
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:country) %></th>
-          <th><%= Spree.t(:status) %></th>
-          <th><%= Spree.t(:default) %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: 'spree/admin/stock_locations/stock_location', collection: @stock_locations, cached: spree_base_cache_scope %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:country) %></th>
+            <th><%= Spree.t(:active) %>?</th>
+            <th><%= Spree.t(:default) %>?</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: 'spree/admin/stock_locations/stock_location', collection: @collection, cached: spree_base_cache_scope %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/stock_transfers/_filters.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/_filters.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<%= search_form_for [:admin, @search], class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
   <div class="d-flex flex-column flex-lg-row gap-2">
     <%= render 'spree/admin/shared/filters_search_bar', param: :number_cont, label: Spree.t(:number) %>
     <%= render 'spree/admin/shared/filters_button' %>

--- a/admin/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/index.html.erb
@@ -5,12 +5,12 @@
   <%= render "spree/admin/shared/stock_nav" %>
 <% end %>
 <% content_for :page_actions do %>
-  <%= if can?(:create, Spree::StockTransfer.new)
-    link_to Spree.t(:new_stock_transfer), spree.new_admin_stock_transfer_path, class: "btn btn-primary"
+  <%= if can?(:create, Spree::StockTransfer)
+    link_to_with_icon 'plus', Spree.t(:new_stock_transfer), new_object_url, class: "btn btn-primary"
   end %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <%= render "filters" %>
   <% if @stock_transfers.any? %>
     <div class="table-responsive">

--- a/admin/app/views/spree/admin/store_credit_categories/edit.html.erb
+++ b/admin/app/views/spree/admin/store_credit_categories/edit.html.erb
@@ -6,8 +6,10 @@
 <%= render 'spree/admin/shared/error_messages', target: @store_credit_category %>
 
 <%= form_for [:admin, @store_credit_category] do |f| %>
-  <fieldset>
-    <%= render 'form', f: f %>
-    <%= render 'spree/admin/shared/edit_resource_links', f: f %>
-  </fieldset>
+  <div class="card mb-4">
+    <div class="card-body">
+      <%= render 'form', f: f %>
+    </div>
+  </div>
+  <%= render 'spree/admin/shared/edit_resource_links', f: f %>
 <% end %>

--- a/admin/app/views/spree/admin/store_credit_categories/index.html.erb
+++ b/admin/app/views/spree/admin/store_credit_categories/index.html.erb
@@ -3,30 +3,34 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_store_credit_category), new_object_url, class: "btn-primary", icon: 'plus', id: 'admin_new_store_credit_category_link' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_store_credit_category), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::StoreCreditCategory %>
 
-<% if @store_credit_categories.any? %>
-<div class="table-responsive card-lg p-0">
-  <table class="table">
-    <thead class="text-muted">
-      <tr>
-        <th><%= Spree.t(:name) %></th>
-        <th class="actions"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @store_credit_categories.each do |store_credit_category| %>
-        <tr id="<%= spree_dom_id store_credit_category %>">
-          <td><%= store_credit_category.name %></td>
-          <td class="actions">
-            <%= link_to_edit(store_credit_category, no_text: true) if can? :edit, store_credit_category %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @collection.each do |store_credit_category| %>
+            <tr id="<%= spree_dom_id store_credit_category %>">
+              <td>
+                <%= store_credit_category.name %>
+              </td>
+              <td class="actions">
+                <%= link_to_edit(store_credit_category, no_text: true) if can? :edit, store_credit_category %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
 </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>

--- a/admin/app/views/spree/admin/store_credits/index.html.erb
+++ b/admin/app/views/spree/admin/store_credits/index.html.erb
@@ -5,11 +5,11 @@
   <% end %>
 
   <% content_for :page_actions do %>
-    <%= button_link_to Spree.t(:add_store_credit), spree.new_admin_user_store_credit_path(@user), class: "btn-primary", icon: 'plus' if can?(:create, Spree::StoreCredit) %>
+    <%= link_to_with_icon 'plus', Spree.t(:add_store_credit), spree.new_admin_user_store_credit_path(@user), class: "btn btn-primary" if can?(:create, Spree::StoreCredit) %>
   <% end %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <% if params[:frame_name].present? %>
     <%= turbo_frame_tag params[:frame_name], autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
       <%= render 'list' %>

--- a/admin/app/views/spree/admin/stores/form/_policies.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_policies.html.erb
@@ -8,7 +8,7 @@
   </div>
 <% end %>
 
-<div class="card-lg">
+<div class="card-lg p-4">
   <h5 class="mb-3"><%= Spree.t(:terms_of_service) %></h5>
   <div class="row">
     <div class="col-lg-4">

--- a/admin/app/views/spree/admin/tax_categories/index.html.erb
+++ b/admin/app/views/spree/admin/tax_categories/index.html.erb
@@ -3,28 +3,30 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_tax_category), new_object_url, class: "btn-primary", icon: 'plus', id: 'admin_new_tax_categories_link' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_tax_category), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::TaxCategory %>
 
-<%= render partial: 'spree/admin/shared/tax_nav' %>
+<%= render 'spree/admin/shared/tax_nav' %>
 
-<% if @tax_categories.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_tax_categories'>
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:tax_code) %></th>
-          <th><%= Spree.t(:description) %></th>
-          <th><%= Spree.t(:default) %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render collection: @tax_categories, partial: 'spree/admin/tax_categories/tax_category', cached: spree_base_cache_scope %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:tax_code) %></th>
+            <th><%= Spree.t(:description) %></th>
+            <th><%= Spree.t(:default) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render collection: @collection, partial: 'spree/admin/tax_categories/tax_category', cached: spree_base_cache_scope %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/tax_rates/index.html.erb
+++ b/admin/app/views/spree/admin/tax_rates/index.html.erb
@@ -3,30 +3,32 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_tax_rate), new_object_url, class: "btn-primary", icon: 'plus' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_tax_rate), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::TaxRate %>
 
-<%= render partial: 'spree/admin/shared/tax_nav' %>
+<%= render 'spree/admin/shared/tax_nav' %>
 
-<% if @tax_rates.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_tax_rates'>
-      <thead class="text-muted">
-        <tr data-hook="rate_header">
-          <th><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:tax_category) %></th>
-          <th><%= Spree.t(:zone) %></th>
-          <th><%= Spree.t(:amount) %></th>
-          <th><%= Spree.t(:included_in_price) %></th>
-          <th><%= Spree.t(:show_rate_in_label) %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: 'spree/admin/tax_rates/tax_rate', collection: @tax_rates, cached: spree_base_cache_scope %>
-      </tbody>
-    </table>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr data-hook="rate_header">
+            <th><%= Spree.t(:name) %></th>
+            <th><%= Spree.t(:tax_category) %></th>
+            <th><%= Spree.t(:zone) %></th>
+            <th><%= Spree.t(:amount) %></th>
+            <th><%= Spree.t(:included_in_price) %></th>
+            <th><%= Spree.t(:show_rate_in_label) %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: 'spree/admin/tax_rates/tax_rate', collection: @collection, cached: spree_base_cache_scope %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/taxonomies/index.html.erb
+++ b/admin/app/views/spree/admin/taxonomies/index.html.erb
@@ -3,11 +3,11 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_taxonomy), new_object_url, { class: "btn-primary", icon: "plus" } %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_taxonomy), new_object_url, class: "btn btn-primary" %>
 <% end if can?(:create, Spree::Taxonomy) %>
 
-<div class="card-lg p-0">
-  <%= search_form_for [:admin, @search], class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<div class="card-lg">
+  <%= search_form_for [:admin, @search], class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
     <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:name) %>
 
     <%= render "spree/admin/shared/filter_badge_template" %>
@@ -22,7 +22,7 @@
             <th class="no-border handel-head"></th>
             <th><%= Spree.t(:name) %></th>
             <th><%= Spree.t(:taxons) %></th>
-            <th class="actions"></th>
+            <th></th>
           </tr>
         </thead>
         <tbody

--- a/admin/app/views/spree/admin/taxonomies/show.html.erb
+++ b/admin/app/views/spree/admin/taxonomies/show.html.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_taxon), spree.new_admin_taxonomy_taxon_path(@taxonomy), icon: 'plus', class: 'no-wrap btn btn-primary align-self-center' %>
-<% end %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_taxon), spree.new_admin_taxonomy_taxon_path(@taxonomy), class: 'btn btn-primary' %>
+<% end if can?(:create, Spree::Taxon) %>
 
 <% content_for :page_actions_dropdown do %>
   <%= link_to_edit(@taxonomy.root, url: spree.edit_admin_taxonomy_taxon_path(@taxonomy, @taxonomy.root.id), class: 'text-left dropdown-item') %>

--- a/admin/app/views/spree/admin/themes/index.html.erb
+++ b/admin/app/views/spree/admin/themes/index.html.erb
@@ -26,7 +26,7 @@
   <% end %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <div class="table-responsive rounded-lg">
     <table class="table">
       <thead class="text-muted">
@@ -44,7 +44,7 @@
 </div>
 
 <% if available_themes.any? %>
-  <div class="card-lg p-0">
+  <div class="card-lg">
     <div class="card-header">
       <h5 class="card-title">Add a new theme</h5>
     </div>

--- a/admin/app/views/spree/admin/translations/_translations_unavailable.html.erb
+++ b/admin/app/views/spree/admin/translations/_translations_unavailable.html.erb
@@ -1,10 +1,8 @@
-<div class="container">
-  <div class="card">
-    <div class="card-body">
-      <p>To use translations, configure more than one locale for the store.</p>
-      <% if can?(:edit, current_store) %>
-        <%= button_link_to('Configure store', spree.edit_admin_store_path(current_store)) %>
-      <% end %>
-    </div>
+<div class="card">
+  <div class="card-body">
+    <p>To use translations, configure more than one locale for the store.</p>
+    <% if can?(:edit, current_store) %>
+      <%= link_to_with_icon 'settings', 'Configure store', spree.edit_admin_store_path(section: 'general-settings'), class: 'btn btn-light' %>
+    <% end %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/users/_filters.html.erb
+++ b/admin/app/views/spree/admin/users/_filters.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for [:admin, @search], url: spree.admin_users_url, class: "filter-wrap border-bottom", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
+<%= search_form_for [:admin, @search], url: spree.admin_users_url, class: "filter-wrap", data: {controller: "filters reveal", reveal_hidden_class: "d-none"} do |f| %>
   <div class="d-flex flex-column flex-lg-row gap-2">
     <%= render 'spree/admin/shared/filters_search_bar', param: :multi_search, placeholder: Spree.t('admin.users.filters.search_placeholder') %>
 
@@ -71,12 +71,7 @@
         </div>  
       </div>
     </div>
-    <div class="form-actions">
-      <%= turbo_save_button_tag Spree.t(:filter_results) do %>
-        <%= icon("search") %>
-        <%= Spree.t(:filter_results) %>
-      <% end %>
-    </div>
+    <%= render 'spree/admin/shared/filter_submit' %>
   </div>
 
   <%= render "spree/admin/shared/filter_badge_template" %>

--- a/admin/app/views/spree/admin/users/_tabs.html.erb
+++ b/admin/app/views/spree/admin/users/_tabs.html.erb
@@ -36,7 +36,7 @@
 
   <% if can?(:read, Spree::Order) %>
     <div class="tab-pane fade <%= 'show active' unless spree.respond_to?(:admin_user_visits_path) %>" id="pills-orders2" role="tabpanel" aria-labelledby="pills-orders2">
-      <div class="card-lg p-0">
+      <div class="card-lg">
         <%= turbo_frame_tag :orders_list, src: spree.admin_user_orders_path(@user, frame_name: :orders_list), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
           <%= render 'spree/admin/shared/spinner' %>
         <% end %>
@@ -44,7 +44,7 @@
     </div>
 
     <div class="tab-pane fade" id="pills-checkouts" role="tabpanel" aria-labelledby="pills-checkouts">
-      <div class="card-lg p-0">
+      <div class="card-lg">
         <%= turbo_frame_tag :orders_list, src: spree.admin_user_checkouts_path(@user, frame_name: :orders_list), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
           <%= render 'spree/admin/shared/spinner' %>
         <% end %>
@@ -54,7 +54,7 @@
 
   <% if spree.respond_to?(:admin_user_gift_cards_path) && can?(:read, Spree::GiftCard) %>
     <div class="tab-pane fade" id="pills-gift-cards" role="tabpanel" aria-labelledby="pills-gift-cards">
-      <div class="card-lg p-0">
+      <div class="card-lg">
         <%= turbo_frame_tag :gift_cards_list, src: spree.admin_user_gift_cards_path(@user, frame_name: :gift_cards_list), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
           <%= render 'spree/admin/shared/spinner' %>
         <% end %>
@@ -64,7 +64,7 @@
 
   <% if can?(:read, Spree::StoreCredit) %>
     <div class="tab-pane fade" id="pills-store-credits" role="tabpanel" aria-labelledby="pills-store-credits">
-      <div class="card-lg p-0">
+      <div class="card-lg">
         <%= turbo_frame_tag :store_credits_list, src: spree.admin_user_store_credits_path(@user, frame_name: :store_credits_list), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
           <%= render 'spree/admin/shared/spinner' %>
         <% end %>

--- a/admin/app/views/spree/admin/users/index.html.erb
+++ b/admin/app/views/spree/admin/users/index.html.erb
@@ -7,15 +7,17 @@
     <%= icon 'table-export', class: 'mr-2' %>
     <%= Spree.t(:export) %>
   <% end if can?(:export, Spree::Export) %>
+  
   <%= render 'extra_actions' %>
-  <%= button_link_to Spree.t(:create_customer), spree.new_admin_user_path, class: "btn-primary", icon: 'plus', id: 'admin_new_user_link' %>
+
+  <%= link_to_with_icon 'plus', Spree.t(:create_customer), spree.new_admin_user_path, class: "btn btn-primary" %>
 <% end if can? :create, Spree::user_class %>
 
 <% content_for :table_filter_title do %>
   <%= Spree.t(:search) %>
 <% end %>
 
-<div class="card-lg p-0">
+<div class="card-lg">
   <%= render "spree/admin/users/filters" %>
 
   <% if @users.any? %>

--- a/admin/app/views/spree/admin/variants/form/_pricing.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_pricing.html.erb
@@ -5,7 +5,7 @@
     </h5>
 
     <% if can?(:manage, Spree::Store) %>
-      <%= link_to_with_icon 'adjustments', Spree.t('admin.manage_currencies'), spree.edit_admin_store_path, class: 'btn btn-sm btn-light' %>
+      <%= link_to_with_icon 'adjustments', Spree.t('admin.manage_currencies'), spree.edit_admin_store_path(section: 'general-settings'), class: 'btn btn-sm btn-light' %>
     <% end %>
   </div>
   <div class="card-body p-0">

--- a/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
@@ -9,7 +9,7 @@
       <div class="card-body">
         <div class="row">
           <div class="form-group col-12">
-            <%= f.label :url, raw(Spree.t('admin.url') + required_span_tag) %>
+            <%= f.label :url, raw(Spree.t(:url) + required_span_tag) %>
             <%= f.text_field :url, class: 'form-control', placeholder: 'https://example.com/endpoint' %>
             <%= f.error_message_on :url %>
           </div>

--- a/admin/app/views/spree/admin/webhooks_subscribers/index.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/index.html.erb
@@ -1,26 +1,29 @@
 <%= render 'spree/admin/shared/developers_nav' %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t('admin.webhooks_subscribers.new_webhooks_subscriber'), new_object_url, class: "btn-primary", icon: 'add.svg', id: 'admin_new_webhooks_subscriber_link' %>
+  <%= link_to_with_icon 'plus', Spree.t('admin.webhooks_subscribers.new_webhooks_subscriber'), new_object_url, class: "btn btn-primary" %>
 <% end if can?(:create, Spree::Webhooks::Subscriber) %>
-<% if @webhooks_subscribers.any? %>
-  <div class="border rounded bg-white">
-    <table class="table">
-      <thead class="text-muted">
-        <tr>
-          <th><%= Spree.t('admin.url') %></th>
-          <th><%= Spree.t('admin.active') %></th>
-          <th><%= Spree.t('admin.webhooks_subscribers.subscriptions') %></th>
-          <th><%= Spree.t('admin.webhooks_subscribers.time_of_last_event') %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= render partial: 'spree/admin/webhooks_subscribers/webhooks_subscriber', collection: @webhooks_subscribers, cached: spree_base_cache_scope %>
-      </tbody>
-    </table>
-  </div>
-  <%= render 'spree/admin/shared/index_table_options', collection: @webhooks_subscribers, simple: true %>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+          <tr>
+            <th><%= Spree.t(:url) %></th>
+            <th><%= Spree.t(:active) %></th>
+            <th><%= Spree.t('admin.webhooks_subscribers.subscriptions') %></th>
+            <th><%= Spree.t('admin.webhooks_subscribers.time_of_last_event') %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: 'spree/admin/webhooks_subscribers/webhooks_subscriber', collection: @collection, cached: spree_base_cache_scope %>
+        </tbody>
+      </table>
+    </div>
+    <%= render 'spree/admin/shared/index_table_options', collection: @collection %>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/app/views/spree/admin/webhooks_subscribers/show.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/show.html.erb
@@ -5,11 +5,11 @@
 <fieldset class="card mb-4">
   <table class="table card-body pb-0">
     <tr>
-      <td><strong class="text-uppercase"><%= Spree.t('admin.url') %></strong></td>
+      <td><strong class="text-uppercase"><%= Spree.t(:url) %></strong></td>
       <td><%= external_link_to @webhooks_subscriber.url, @webhooks_subscriber.url %></td>
     </tr>
     <tr>
-      <td><strong><%= Spree.t('admin.active') %></strong></td>
+      <td><strong><%= Spree.t(:active) %></strong></td>
       <td><%= active_badge(@webhooks_subscriber.active) %></td>
     </tr>
     <tr>
@@ -45,7 +45,7 @@
         <%= render partial: 'spree/admin/webhook_events/webhook_event', collection: @events, cached: spree_base_cache_scope %>
       </tbody>
     </table>
-    <%= render 'spree/admin/shared/index_table_options', collection: @events, simple: true %>
+    <%= render 'spree/admin/shared/index_table_options', collection: @events %>
   </div>
 <% else %>
   <div class="text-center no-objects-found m-5">

--- a/admin/app/views/spree/admin/zones/index.html.erb
+++ b/admin/app/views/spree/admin/zones/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= button_link_to Spree.t(:new_zone), new_object_url, class: "btn-primary", icon: 'plus' %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_zone), new_object_url, class: "btn btn-primary" %>
 <% end if can? :create, Spree::Zone %>
 
 <% content_for :page_alerts do %>
@@ -12,34 +12,36 @@
   </div>
 <% end %>
 
-<% if @zones.any? %>
-  <div class="table-responsive card-lg p-0">
-    <table class="table" id='listing_zones'>
-      <thead class="text-muted">
-      <tr>
-        <th><%= sort_link @search,:name, Spree.t(:name), title: 'zones_order_by_name_title' %></th>
-        <th>
-          <%= sort_link @search,:description, Spree.t(:description), {}, {title: 'zones_order_by_description_title'} %>
-        </th>
-        <th><%= Spree.t(:default_tax_zone) %></th>
-        <th class="actions"></th>
-      </tr>
-      </thead>
-      <tbody>
-        <% @zones.each do |zone| %>
-          <tr id="<%= spree_dom_id zone %>" class="cursor-pointer" data-controller="row-link">
-            <td class="w-25" data-action="click->row-link#openLink"><%= zone.name %></td>
-            <td class="w-40 text-muted text-wrap" data-action="click->row-link#openLink"><%= zone.description %></td>
-            <td class="w-10" data-action="click->row-link#openLink"><%= active_badge(zone.default_tax?) %></td>
-            <td class="w-10 actions">
-              <%= link_to_edit(zone, data: { row_link_target: :link }) if can? :edit, zone %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <%= render 'spree/admin/shared/index_table_options', collection: @zones, simple: true %>
-  </div>
-<% else %>
-  <%= render 'spree/admin/shared/no_resource_found' %>
-<% end %>
+<div class="card-lg">
+  <% if @collection.any? %>
+    <div class="table-responsive">
+      <table class="table">
+        <thead class="text-muted">
+        <tr>
+          <th><%= sort_link @search,:name, Spree.t(:name) %></th>
+          <th>
+            <%= sort_link @search,:description, Spree.t(:description) %>
+          </th>
+          <th><%= Spree.t(:default_tax_zone) %></th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody>
+          <% @collection.each do |zone| %>
+            <tr id="<%= spree_dom_id zone %>" class="cursor-pointer" data-controller="row-link">
+              <td class="w-25" data-action="click->row-link#openLink"><%= zone.name %></td>
+              <td class="w-40 text-muted text-wrap" data-action="click->row-link#openLink"><%= zone.description %></td>
+              <td class="w-10" data-action="click->row-link#openLink"><%= active_badge(zone.default_tax?) %></td>
+              <td class="w-10 actions">
+                <%= link_to_edit(zone, data: { row_link_target: :link }) if can? :edit, zone %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= render 'spree/admin/shared/index_table_options', collection: @collection %>
+    </div>
+  <% else %>
+    <%= render 'spree/admin/shared/no_resource_found' %>
+  <% end %>
+</div>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -2,7 +2,6 @@
 en:
   spree:
     admin:
-      active: Active
       amount_spent: Amount spent
       audit_log: Audit Log
       avg_order_value: Avg. Order Value
@@ -231,7 +230,6 @@ en:
         manual: Manual
         manual_info: Curate products manually. You can add or remove them in bulk.
       upload_new_asset: Upload new asset
-      url: URL
       user:
         last_order_placed: Last order placed
         no_store_credit: Customer has no Store Credit available


### PR DESCRIPTION
Fix some minor issues, translations and so on

Deprecate `button_link_to`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style & Presentation**
  - Enhanced card, table, and form layouts through refined spacing and padding adjustments for a cleaner interface.
  - Updated button styles across creation and editing flows for a unified, modern look.
  - Streamlined search and filter interfaces to improve usability by removing unnecessary classes and simplifying structure.
- **Localization**
  - Adjusted displayed labels to remove outdated terminology, further simplifying the interface by deleting specific keys from the locale definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->