### PR TITLE
Proper way of using `Spree.user_class` in association for CreditCard

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -12,7 +12,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :payment_method
-    belongs_to :user, class_name: "::#{Spree.user_class}", foreign_key: 'user_id', optional: true
+    belongs_to :user, class_name: Spree.user_class.to_s, foreign_key: 'user_id', optional: true
     belongs_to :gateway_customer, class_name: 'Spree::GatewayCustomer', optional: true
 
     has_many :payments, as: :source


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified internal logic for associating user accounts with payment functionality, maintaining all existing behaviors for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->