### PR TITLE
V-3053 FIX disabled payment methods on storefront

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
@@ -91,7 +91,7 @@ module Spree
           end
 
           def payment_methods
-            render_serialized_payload { serialize_payment_methods(spree_current_order.available_payment_methods) }
+            render_serialized_payload { serialize_payment_methods(spree_current_order.collect_frontend_payment_methods) }
           end
 
           def validate_order_for_payment

--- a/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/checkout_spec.rb
@@ -586,7 +586,7 @@ describe 'API V2 Storefront Checkout Spec', type: :request do
   describe 'checkout#payment_methods' do
     let(:execute) { get '/api/v2/storefront/checkout/payment_methods', headers: headers }
     let!(:payment_method) { create(:credit_card_payment_method, stores: [store]) }
-    let(:payment_methods) { order.available_payment_methods }
+    let(:payment_methods) { order.collect_frontend_payment_methods }
 
     shared_examples 'returns a list of available payment methods' do
       before { execute }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -84,7 +84,7 @@ module Spree
     self.whitelisted_ransackable_scopes = %w[refunded partially_refunded multi_search]
 
     attr_reader :coupon_code
-    attr_accessor :temporary_address, :temporary_credit_card, :use_billing, :use_shipping
+    attr_accessor :temporary_address, :temporary_credit_card
 
     attribute :state_machine_resumed, :boolean
 
@@ -151,6 +151,7 @@ module Spree
 
     before_validation :clone_billing_address, if: :use_billing?
     before_validation :clone_shipping_address, if: :use_shipping?
+    attr_accessor :use_billing, :use_shipping
 
     before_create :link_by_email
     before_update :ensure_updated_shipments, :homogenize_line_item_currencies, if: :currency_changed?
@@ -195,8 +196,8 @@ module Spree
       joins(:refunds).group(:id).having("sum(#{Spree::Refund.table_name}.amount) = #{Spree::Order.table_name}.total")
     }
     scope :partially_refunded, lambda {
-                                 joins(:refunds).group(:id).having("sum(#{Spree::Refund.table_name}.amount) < #{Spree::Order.table_name}.total")
-                               }
+                                joins(:refunds).group(:id).having("sum(#{Spree::Refund.table_name}.amount) < #{Spree::Order.table_name}.total")
+                              }
     scope :with_deleted_bill_address, -> { joins(:bill_address).where.not(Address.table_name => { deleted_at: nil }) }
     scope :with_deleted_ship_address, -> { joins(:ship_address).where.not(Address.table_name => { deleted_at: nil }) }
 
@@ -503,7 +504,7 @@ module Spree
     end
 
     def available_payment_methods(store = nil)
-      Spree::Deprecation.warn('`Order#validate_payments_attributes` is deprecated and will be removed in Spree 6. Use `collect_frontend_payment_methods` instead.')
+      Spree::Deprecation.warn('`Order#available_payment_methods` is deprecated and will be removed in Spree 6. Use `collect_frontend_payment_methods` instead.')
       if store.present?
         Spree::Deprecation.warn('The `store` parameter is deprecated and will be removed in Spree 5. Order is already associated with Store')
       end
@@ -843,7 +844,7 @@ module Spree
           errors.add(:base, Spree.t(:items_cannot_be_shipped))
         end
 
-        false
+        return false
       end
     end
 

--- a/core/app/services/spree/payments/create.rb
+++ b/core/app/services/spree/payments/create.rb
@@ -14,7 +14,7 @@ module Spree
       protected
 
       def prepare_payment_attributes(order:, params:)
-        payment_method = order.available_payment_methods.find { |pm| pm.id.to_s == params[:payment_method_id]&.to_s }
+        payment_method = order.collect_frontend_payment_methods.find { |pm| pm.id.to_s == params[:payment_method_id]&.to_s }
 
         payment_attributes = {
           amount: params[:amount] || order.order_total_after_store_credit,

--- a/storefront/app/helpers/spree/checkout_helper.rb
+++ b/storefront/app/helpers/spree/checkout_helper.rb
@@ -29,7 +29,7 @@ module Spree
     end
 
     def checkout_available_payment_methods
-      @checkout_available_payment_methods ||= @order.available_payment_methods.reject(&:store_credit?)
+      @checkout_available_payment_methods ||= @order.collect_frontend_payment_methods.reject(&:store_credit?)
     end
 
     def checkout_started?


### PR DESCRIPTION
1. Deleted deprecated methods
2. Renamed `collect_payment_methods` to `collect_frontend_payment_methods` which is similar to `collect_backend_payment_methods`
3. Replaced Spree::Order `available_payment_methods` to  due to unnecessary name collision with Spree::Admin::PaymentHelper method
4. Added active scope to `collect_frontend_payment_methods` to fix task issue

After refactor all payment methods views seems to work properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to collect frontend-specific payment methods for a more relevant checkout experience.

- **Bug Fixes**
  - Updated the checkout process to ensure only applicable payment options are displayed, enhancing user experience.

- **Tests**
  - Adjusted test scenarios to validate the new payment method filtering and ensure a seamless checkout process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->