### PR TITLE
Fixed: always render validation errors when updating product

### DIFF
--- a/admin/app/controllers/spree/admin/products_controller.rb
+++ b/admin/app/controllers/spree/admin/products_controller.rb
@@ -68,10 +68,7 @@ module Spree
           # update the product again
           @product.slug = @product.slug_was if @product.slug.blank?
           invoke_callbacks(:update, :fails)
-          respond_to do |format|
-            format.html { render :edit, status: :unprocessable_entity }
-            format.turbo_stream
-          end
+          render :edit, status: :unprocessable_entity
         end
       end
 
@@ -293,10 +290,6 @@ module Spree
       end
 
       private
-
-      def update_turbo_stream_enabled?
-        true
-      end
 
       def variant_stock_includes
         [:images, { stock_items: :stock_location, option_values: :option_type }]

--- a/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -1068,6 +1068,32 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         expect(Spree::Product.find(product.id).label_list).to be_empty
       end
     end
+
+    describe 'failing to update product' do
+      let!(:existing_product) { create(:product, name: 'Existing Product', slug: 'existing-product', stores: [store]) }
+
+      let(:product_params) do
+        {
+          name: 'Existing Product',
+          slug: 'existing-product'
+        }
+      end
+
+      context 'using the same slug' do
+        before do
+          send_request
+        end
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'should render the error' do
+          expect(response.body).to include('Slug has already been taken')
+        end
+      end
+    end
   end
 
   describe 'PUT #clone' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the product update error handling by simplifying the response flow for update failures.
- **Tests**
  - Added test cases to verify that attempting to update a product with a duplicate identifier fails appropriately, ensuring the correct error message and status are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->