### PR TITLE
Fix `default_url_options` when store does not have `default_locale`

### DIFF
--- a/admin/app/views/spree/admin/stores/new.html.erb
+++ b/admin/app/views/spree/admin/stores/new.html.erb
@@ -25,6 +25,11 @@
                   </div>
 
                   <div class="form-group">
+                    <%= f.label :default_locale, Spree.t(:locale) %>
+                    <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, current_store.default_locale || I18n.locale), { }, { data: { controller: 'autocomplete-select', enable_button_target: 'input', action: 'store-form#updateCurrency' } } %>
+                  </div>
+
+                  <div class="form-group">
                     <%= f.label :default_currency, Spree.t(:currency) %>
                     <%= f.currency_select :default_currency, preferred_currencies, {}, { data: { controller: 'autocomplete-select', enable_button_target: 'input', store_form_target: 'currency' } } %>
                   </div>

--- a/admin/app/views/spree/admin/stores/new.html.erb
+++ b/admin/app/views/spree/admin/stores/new.html.erb
@@ -25,7 +25,7 @@
                   </div>
 
                   <div class="form-group">
-                    <%= f.label :default_locale, Spree.t(:locale) %>
+                    <%= f.label :default_locale %>
                     <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, current_store.default_locale || I18n.locale), { }, { data: { controller: 'autocomplete-select', enable_button_target: 'input', action: 'store-form#updateCurrency' } } %>
                   </div>
 

--- a/admin/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -18,7 +18,8 @@ describe Spree::Admin::StoresController do
       {
         name: 'New UK Store',
         default_currency: 'GBR',
-        default_country_iso: 'GB'
+        default_country_iso: 'GB',
+        default_locale: 'en'
       }
     end
 
@@ -31,6 +32,7 @@ describe Spree::Admin::StoresController do
       expect(store.name).to eq('New UK Store')
       expect(store.default_currency).to eq('GBR')
       expect(store.default_country).to eq(uk_country)
+      expect(store.default_locale).to eq('en')
     end
   end
 
@@ -41,7 +43,8 @@ describe Spree::Admin::StoresController do
       {
         name: 'New Store Name',
         default_currency: 'GBR',
-        default_country_iso: 'GB'
+        default_country_iso: 'GB',
+        default_locale: 'pl'
       }
     end
 
@@ -57,6 +60,7 @@ describe Spree::Admin::StoresController do
       expect(store.reload.name).to eq('New Store Name')
       expect(store.default_currency).to eq('GBR')
       expect(store.default_country).to eq(uk_country)
+      expect(store.default_locale).to eq('pl')
     end
 
     context 'when removing assets' do

--- a/storefront/app/controllers/concerns/spree/locale_urls.rb
+++ b/storefront/app/controllers/concerns/spree/locale_urls.rb
@@ -9,7 +9,11 @@ module Spree
     private
 
     def default_url_options
-      locale = current_locale == current_store.default_locale ? nil : current_locale
+      locale = if current_store.default_locale.nil? || current_locale == current_store.default_locale
+                 nil
+               else
+                 current_locale
+               end
 
       super.merge(locale: locale, currency: currency_param)
     end

--- a/storefront/spec/controllers/concerns/spree/locale_urls_spec.rb
+++ b/storefront/spec/controllers/concerns/spree/locale_urls_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+module Spree
+  RSpec.describe LocaleUrls, type: :controller do
+    controller(ActionController::Base) do
+      include Spree::LocaleUrls
+      include Spree::Core::ControllerHelpers::Locale
+
+      def index
+        render plain: 'index'
+      end
+    end
+
+    before do
+      allow(controller).to receive(:current_store).and_return(@default_store)
+      allow(controller).to receive(:current_locale).and_return('en')
+      allow(controller).to receive(:currency_param).and_return(nil)
+      allow(controller).to receive(:supported_locales).and_return(['en', 'fr', 'es'])
+    end
+
+    describe '#default_url_options' do
+      context 'when current locale is the same as default store locale' do
+        before do
+          allow(controller).to receive(:current_locale).and_return('en')
+          @default_store.update(default_locale: 'en')
+        end
+
+        it 'does not include locale in URL options' do
+          expect(controller.send(:default_url_options)[:locale]).to be_nil
+        end
+      end
+
+      context 'when current locale is different from default store locale' do
+        before do
+          allow(controller).to receive(:current_locale).and_return('fr')
+          @default_store.update(default_locale: 'en')
+        end
+
+        it 'includes locale in URL options' do
+          expect(controller.send(:default_url_options)[:locale]).to eq('fr')
+        end
+      end
+
+      context 'when default_locale is nil' do
+        before do
+          allow(controller).to receive(:current_locale).and_return('fr')
+          @default_store.update(default_locale: nil)
+        end
+
+        it 'does not include locale in URL options' do
+          expect(controller.send(:default_url_options)[:locale]).to be_nil
+        end
+      end
+
+      it 'includes currency in URL options' do
+        allow(controller).to receive(:currency_param).and_return('USD')
+        expect(controller.send(:default_url_options)[:currency]).to eq('USD')
+      end
+    end
+
+    describe '#redirect_to_default_locale' do
+      context 'when locale param is present but not supported' do
+        it 'redirects to URL without locale' do
+          allow(controller).to receive(:supported_locale?).with('xx').and_return(false)
+          expect(controller).to receive(:url_for).with({ 'locale' => nil, 'action' => 'index', 'controller' => 'anonymous' }).and_return('/anonymous/index')
+          get :index, params: { locale: 'xx' }
+          expect(response).to redirect_to('/anonymous/index')
+        end
+      end
+
+      context 'when locale param is blank' do
+        it 'does not redirect' do
+          get :index
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context 'when locale param is supported' do
+        it 'does not redirect' do
+          allow(controller).to receive(:supported_locale?).with('fr').and_return(true)
+          get :index, params: { locale: 'fr' }
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new form group in the admin interface for creating a store, allowing the selection of a default locale.
  
- **Refactor**
  - Updated locale handling for URL generation. Now, URLs omit the language parameter when using the default setting, providing a cleaner and more intuitive navigation experience.

- **Tests**
  - Added a comprehensive test suite to ensure correct locale behavior and redirection, validating that users are seamlessly directed even when unsupported or blank language selections are made.
  - Enhanced tests for store creation and updates to validate the new `default_locale` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->