### PR TITLE
Add option to exclude quick checkout addresses from the addresses api

### DIFF
--- a/core/app/finders/spree/addresses/find.rb
+++ b/core/app/finders/spree/addresses/find.rb
@@ -1,6 +1,27 @@
 module Spree
   module Addresses
     class Find < ::Spree::BaseFinder
+      def initialize(scope:, params:)
+        super
+        @exclude_quick_checkout = params.dig(:filter, :exclude_quick_checkout)
+      end
+
+      def execute
+        addresses = scope
+        exclude_quick_checkout(addresses)
+      end
+
+      private
+
+      def exclude_quick_checkout?
+        @exclude_quick_checkout.present?
+      end
+
+      def exclude_quick_checkout(addresses)
+        return addresses unless exclude_quick_checkout?
+
+        addresses.not_quick_checkout
+      end
     end
   end
 end

--- a/core/spec/finders/spree/addresses/find_spec.rb
+++ b/core/spec/finders/spree/addresses/find_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Spree::Addresses::Find do
+  let!(:user) { create(:user) }
+  let!(:address1) { create(:address, user: user) }
+  let!(:address2) { create(:address, user: user) }
+  let!(:address3) { create(:address, user: user, quick_checkout: true) }
+  let!(:address4) { create(:address, user: user, quick_checkout: true) }
+
+  describe '#execute' do
+    let(:scope) { Spree::Address.where(user: user) }
+
+    context 'without any filter parameters' do
+      let(:params) { {} }
+
+      it 'returns all addresses without filtering' do
+        result = described_class.new(
+          scope: scope,
+          params: params
+        ).execute
+
+        expect(result).to include(address1)
+        expect(result).to include(address2)
+        expect(result).to include(address3)
+        expect(result).to include(address4)
+      end
+    end
+
+    context 'with exclude_quick_checkout filter set to truthy value' do
+      let(:params) { { filter: { exclude_quick_checkout: '1' } } }
+
+      it 'returns only non-quick-checkout addresses' do
+        result = described_class.new(
+          scope: scope,
+          params: params
+        ).execute
+
+        expect(result).to include(address1)
+        expect(result).to include(address2)
+        expect(result).not_to include(address3)
+        expect(result).not_to include(address4)
+      end
+    end
+
+    context 'with exclude_quick_checkout filter set to falsey value' do
+      let(:params) { { filter: { exclude_quick_checkout: nil } } }
+
+      it 'returns all addresses without filtering' do
+        result = described_class.new(
+          scope: scope,
+          params: params
+        ).execute
+
+        expect(result).to include(address1)
+        expect(result).to include(address2)
+        expect(result).to include(address3)
+        expect(result).to include(address4)
+      end
+    end
+  end
+end

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -149,6 +149,12 @@ paths:
         - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/SparseFieldsAddress'
+        - in: query
+          name: 'filter[exclude_quick_checkout]'
+          schema:
+            type: boolean
+          example: true
+          description: 'Exclude addresses that were created during quick checkout'
       tags:
         - Account / Address
     post:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced addresses filter, allowing users to exclude addresses created during quick checkout.
- **Tests**
	- Added comprehensive tests to verify the new filtering behavior under different conditions.
- **Documentation**
	- Updated the API documentation to include a new boolean query parameter for filtering addresses by quick checkout status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->