### PR TITLE
Revert "V-3066 FIX filtering storefront products with AND instead of OR"

### DIFF
--- a/storefront/app/controllers/spree/store_controller.rb
+++ b/storefront/app/controllers/spree/store_controller.rb
@@ -126,7 +126,6 @@ module Spree
 
       filter[:taxon_ids] ||= [taxon&.id.to_s].compact
       filter[:taxons] = filter[:taxon_ids].join(',')
-      filter[:concat_taxons] = filter[:taxons] if filter[:taxon_ids].size > 1
 
       if filter.key?(:min_price) || filter.key?(:max_price)
         min_price = filter[:min_price].presence || 0

--- a/storefront/spec/controllers/spree/products_controller_spec.rb
+++ b/storefront/spec/controllers/spree/products_controller_spec.rb
@@ -16,53 +16,6 @@ describe Spree::ProductsController, type: :controller do
       expect(response).to render_template(:index)
       expect(assigns(:current_page)).to be_a(Spree::Pages::ShopAll)
     end
-
-    context 'when filtering' do
-      let(:taxon) { create(:taxon) }
-
-      context 'by one taxon' do
-        let(:product) { create(:product, stores: [store], taxons: [taxon]) }
-
-        before do
-          product
-          get :index, params: { filter: { taxon_ids: [taxon.id] } }
-        end
-
-        it 'returns one product' do
-          expect(assigns(:storefront_products).records).to eq([product])
-        end
-      end
-
-      context 'by multiple taxons' do
-        let(:taxon2) { create(:taxon) }
-
-        context 'and product is associated with both taxons' do
-          let(:product) { create(:product, stores: [store], taxons: [taxon, taxon2]) }
-
-          before do
-            product
-            get :index, params: { filter: { taxon_ids: [taxon.id, taxon2.id] } }
-          end
-
-          it 'returns the product' do
-            expect(assigns(:storefront_products).records).to eq([product])
-          end
-        end
-
-        context 'and product is associated with only one of the taxons' do
-          let(:product) { create(:product, stores: [store], taxons: [taxon]) }
-
-          before do
-            product
-            get :index, params: { filter: { taxon_ids: [taxon.id, taxon2.id] } }
-          end
-
-          it 'does not return the product' do
-            expect(assigns(:storefront_products).records).to be_empty
-          end
-        end
-      end
-    end
   end
 
   describe '#show' do


### PR DESCRIPTION
Reverts spree/spree#12631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined product filtering behavior to ensure more consistent handling when multiple categories are involved.
- **Tests**
	- Removed outdated test scenarios related to the multi-category filtering approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->