### PR TITLE
Do not set locale fallbacks when store does not have default locale

### DIFF
--- a/core/app/services/spree/locales/set_fallback_locale_for_store.rb
+++ b/core/app/services/spree/locales/set_fallback_locale_for_store.rb
@@ -3,6 +3,8 @@ module Spree
     class SetFallbackLocaleForStore
       def call(store:)
         store_default_locale = store.default_locale
+        return unless store_default_locale.present?
+
         fallbacks = store.supported_locales_list.each_with_object({}) do |locale, object|
           object[locale] = [store_default_locale]
         end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved fallback locale handling to ensure the system operates reliably even when a default language setting is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->