### PR TITLE
fix: allow guest checkout when order is created by logged in user

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -369,13 +369,7 @@ module Spree
     def disassociate_user!
       nullified_attributes = ASSOCIATED_USER_ATTRIBUTES.index_with(nil)
 
-      self.assign_attributes(nullified_attributes)
-
-      changes = slice(*ASSOCIATED_USER_ATTRIBUTES)
-
-      ActiveRecord::Base.connected_to(role: :writing) do
-        self.class.unscoped.where(id: self).update_all(changes)
-      end
+      update!(nullified_attributes)
     end
 
     def quantity_of(variant, options = {})

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -91,6 +91,8 @@ module Spree
     acts_as_taggable_on :tags
     acts_as_taggable_tenant :store_id
 
+    ASSOCIATED_USER_ATTRIBUTES = [:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id]
+
     belongs_to :user, class_name: "::#{Spree.user_class}", optional: true, autosave: true
     belongs_to :created_by, class_name: "::#{Spree.admin_user_class}", optional: true
     belongs_to :approver, class_name: "::#{Spree.admin_user_class}", optional: true
@@ -355,10 +357,22 @@ module Spree
       self.bill_address ||= user.bill_address
       self.ship_address ||= user.ship_address
 
-      changes = slice(:user_id, :email, :created_by_id, :bill_address_id, :ship_address_id)
+      changes = slice(*ASSOCIATED_USER_ATTRIBUTES)
 
       # immediately persist the changes we just made, but don't use save
       # since we might have an invalid address associated
+      ActiveRecord::Base.connected_to(role: :writing) do
+        self.class.unscoped.where(id: self).update_all(changes)
+      end
+    end
+
+    def disassociate_user!
+      nullified_attributes = ASSOCIATED_USER_ATTRIBUTES.index_with(nil)
+
+      self.assign_attributes(nullified_attributes)
+
+      changes = slice(*ASSOCIATED_USER_ATTRIBUTES)
+
       ActiveRecord::Base.connected_to(role: :writing) do
         self.class.unscoped.where(id: self).update_all(changes)
       end

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -7,7 +7,7 @@ module Spree
       @order = order
     end
 
-    def merge!(other_order, user = nil)
+    def merge!(other_order, user = nil, discard_merged: true)
       other_order.line_items.each do |other_order_line_item|
         next unless other_order_line_item.currency == order.currency
 
@@ -16,12 +16,14 @@ module Spree
       end
 
       set_user(user)
-      clear_addresses(other_order)
+      clear_addresses(other_order) if discard_merged
       persist_merge
 
-      # So that the destroy doesn't take out line items which may have been re-assigned
-      other_order.line_items.reload
-      other_order.destroy
+      if discard_merged
+        # So that the destroy doesn't take out line items which may have been re-assigned
+        other_order.line_items.reload
+        other_order.destroy
+      end
     end
 
     # Compare the line item of the other order with mine.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -795,6 +795,7 @@ en:
     continue_as_guest: Continue as a guest
     continue_selling_when_out_of_stock: Continue selling when out of stock
     continue_shopping: Continue shopping
+    continue_without_logging_in: Continue without logging in
     copy: Copy
     copy_id: Copy ID
     copy_link: Copy link

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -14,6 +14,19 @@ module Spree
       expect { order_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    context 'when `discard_merged` is false' do
+      it 'keeps the other order' do
+        subject.merge!(order_2, discard_merged: false)
+        expect { order_2.reload }.not_to raise_error
+      end
+
+      it 'does not change the other order' do
+        expect {
+          subject.merge!(order_2, discard_merged: false)
+        }.not_to change(order_2, :attributes)
+      end
+    end
+
     it 'persist the merge' do
       expect(subject).to receive(:persist_merge)
       subject.merge!(order_2)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -838,6 +838,28 @@ describe Spree::Order, type: :model do
     end
   end
 
+  describe '#disassociate_user!' do
+    let(:order) { create(:order_with_line_items) }
+    let(:expected_order_attributes) {
+      {
+        user: nil,
+        user_id: nil,
+        email: nil,
+        created_by: nil,
+        created_by_id: nil,
+        bill_address: nil,
+        bill_address_id: nil,
+        ship_address: nil,
+        ship_address_id: nil
+      }
+    }
+
+    it 'disassociates a user from an order' do
+      order.disassociate_user!
+      expect(order).to have_attributes(expected_order_attributes)
+    end
+  end
+
   describe '#can_ship?' do
     let(:order) { Spree::Order.create }
 

--- a/storefront/app/controllers/spree/checkout_controller.rb
+++ b/storefront/app/controllers/spree/checkout_controller.rb
@@ -192,14 +192,14 @@ module Spree
                        .orders
                        .create!(current_order_params.except(:token, :user_id))
                        .tap do |order|
-              order.merge!(@order)
+              order.merge!(@order, discard_merged: false)
               order.disassociate_user!
             end
 
             reset_session
             cookies.permanent.signed[:token] = @order.token
 
-            redirect_to spree.cart_path(order_token: @order.token)
+            redirect_to spree.checkout_path(@order.token)
           else
             store_location
             redirect_to spree_login_path

--- a/storefront/app/controllers/spree/store_controller.rb
+++ b/storefront/app/controllers/spree/store_controller.rb
@@ -30,6 +30,8 @@ module Spree
                   :storefront_products_scope, :storefront_products,
                   :default_products_sort, :default_products_finder_params
 
+    helper_method :stored_location
+
     before_action :redirect_to_default_locale
     before_action :render_404_if_store_not_exists
     rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_authenticity_token
@@ -217,6 +219,13 @@ module Spree
       location ||= request.fullpath
 
       store_location_for(Devise.mappings.keys.first, location)
+    end
+
+    def stored_location
+      return unless defined?(after_sign_in_path_for)
+      return unless defined?(Devise)
+
+      after_sign_in_path_for(Devise.mappings.keys.first)
     end
 
     def redirect_to_cart

--- a/storefront/app/views/devise/sessions/new.html.erb
+++ b/storefront/app/views/devise/sessions/new.html.erb
@@ -23,7 +23,7 @@
     <%= render "devise/shared/links" %>
 
     <% if current_order.present? &&
-          current_store.prefers_guest_checkout? &&
+          current_store&.prefers_guest_checkout? &&
           stored_location&.include?(spree.checkout_path(current_order.token))
     %>
       <div class="relative my-5 flex items-center">

--- a/storefront/app/views/devise/sessions/new.html.erb
+++ b/storefront/app/views/devise/sessions/new.html.erb
@@ -21,5 +21,21 @@
       </div>
     <% end %>
     <%= render "devise/shared/links" %>
+
+    <% if current_order.present? &&
+          current_store.prefers_guest_checkout? &&
+          stored_location&.include?(spree.checkout_path(current_order.token))
+    %>
+      <div class="relative my-5 flex items-center">
+        <div class="flex-grow border-t border-gray-200"></div>
+        <span class="mx-4 text-sm text-gray-500 uppercase"><%= Spree.t(:or) %></span>
+        <div class="flex-grow border-t border-gray-200"></div>
+      </div>
+
+      <div class="flex flex-col items-center gap-4">
+        <p class="text-sm text-gray-600"><%= Spree.t(:continue_without_logging_in) %></p>
+        <%= link_to Spree.t(:continue_as_guest), spree.checkout_path(current_order.token, guest: true), class: 'btn btn-secondary w-full max-w-sm', data: { turbo: false } %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/storefront/spec/controllers/spree/checkout_controller_spec.rb
+++ b/storefront/spec/controllers/spree/checkout_controller_spec.rb
@@ -130,6 +130,20 @@ describe Spree::CheckoutController, type: :controller do
             get :edit, params: { token: order.token }
             expect(response).to redirect_to('/login')
           end
+
+          context 'when guest checkout is allowed' do
+            let(:allow_guest_checkout) { true }
+
+            it 'creates a new order and allows access to the checkout' do
+              expect {
+                get :edit, params: { token: order.token, guest: true }
+              }.to change(Spree::Order, :count).by(1)
+
+              new_order = Spree::Order.last
+
+              expect(response).to redirect_to(spree.checkout_path(new_order.token))
+            end
+          end
         end
 
         context 'when user is logged in' do


### PR DESCRIPTION
### Problem:

Previously, when a **logged-in user** created an order and then logged out, the order token remained stored in `cookies.permanent.signed[:token]`.

This led to the following issue:

- If a **new user** visited the store and added items to their cart, they would still be tied to the previous order (via the persisted token).
- During checkout, they would hit the logic:

```
elsif try_spree_current_user.nil? && !@order.completed?
  store_location
  redirect_to spree_login_path
end
```

This would force the new user to log in, even if they never had an account before, an counterintuitive and confusing experience.

And if the user then logged in with a different account, they would hit this logic:

```
if try_spree_current_user.present? && @order.user_id != try_spree_current_user.id
  clear_order_token
  flash[:error] = 'You cannot access this checkout'
  redirect_to_cart
end
```
...resulting in the message: **You cannot access this checkout**.

Some stores require login for checkout, which makes this less of a problem.

However, for stores where the preference `guest_checkout` is enabled (`preference :guest_checkout, :boolean, default: true`), customers were still being forced to log in, even though they were supposed to be able to check out as guests.

### Solution
This PR introduces a guest checkout option on the login page when the order belongs to a previous user but `guest_checkout` is enabled.

A new link is displayed:

```
<p class="text-sm text-gray-600"><%= Spree.t(:continue_without_logging_in) %></p>
<%= link_to Spree.t(:continue_as_guest), spree.checkout_path(current_order.token, guest: true), class: 'btn btn-secondary w-full max-w-sm', data: { turbo: false } %>
```
Clicking this link:

- Resets the session.
- Creates a new order based on the previous one, but disassociates it from the original user using a new `disassociate_user!` method in the `Spree::Order` model.
- Allows the current visitor to proceed with checkout as a guest.

### Customer Impact

#### Before
New customers were unexpectedly forced to log in and blocked from completing their order if the token belonged to another user.

#### After
Customers can now proceed with guest checkout, even if the previous order was created by a logged-in user.

### QA Test Guidelines

1. Log in as a user and add items to the cart.
2. Log out, ensuring the cart token remains in cookies.
3. As a new (unauthenticated) visitor, add new items to the cart and go to checkout.
4. Confirm that you're redirected to the login page.
5. On the login page, verify the "Continue as guest" option is displayed.
6. Click "Continue as guest".

#### Confirm:
- A new order is created (based on previous cart contents if any)
- You're redirected to the cart or checkout
- You are able to proceed without logging in
- No association with the previous user remains

#### Also test:

- Guest checkout is not offered when guest_checkout preference is disabled.
- Existing users can still log in and complete checkout as usual.

### Screenshots & Visual Aids

1. Login screen with new guest checkout option:

<img src="https://github.com/user-attachments/assets/b861d1b6-7d44-4a33-aff1-807bb7e87ca1" width="400" />
