### PR TITLE
Introduce `Spree::ResourceUser`

### DIFF
--- a/admin/app/helpers/spree/admin/posts_helper.rb
+++ b/admin/app/helpers/spree/admin/posts_helper.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     module PostsHelper
       def post_authors_select_options
-        current_store.admin_users.map { |user| [user.name, user.id] }
+        current_store.users.map { |user| [user.name, user.id] }
       end
     end
   end

--- a/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
       end
 
       context 'with already accepted invitation' do
-        let(:invitation) { create(:invitation, inviter: admin_user, resource: store, status: 'accepted') }
+        let(:invitation) { create(:invitation, inviter: admin_user, resource: store, status: 'accepted', invitee: create(:admin_user, :no_resource_user)) }
 
         it 'redirects to root path' do
           expect(response).to redirect_to(spree.root_path)

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -32,6 +32,8 @@ module Spree
       has_many :wished_items, through: :wishlists, source: :wished_items
       has_many :gateway_customers, class_name: 'Spree::GatewayCustomer', foreign_key: :user_id
       has_many :invitations, class_name: 'Spree::Invitation', foreign_key: :invitee_id, dependent: :destroy
+      has_many :resource_users, class_name: 'Spree::ResourceUser', foreign_key: :user_id, dependent: :destroy, as: :user
+      has_many :resources, through: :resource_users, source: :resource
       belongs_to :ship_address, class_name: 'Spree::Address', optional: true
       belongs_to :bill_address, class_name: 'Spree::Address', optional: true
 

--- a/core/app/models/spree/resource_user.rb
+++ b/core/app/models/spree/resource_user.rb
@@ -1,0 +1,43 @@
+module Spree
+  class ResourceUser < Base
+    #
+    # Associations
+    #
+    belongs_to :resource, polymorphic: true # Store, Vendor, etc
+    belongs_to :user, polymorphic: true # Spree::User, Spree::AdminUser, etc
+    belongs_to :invitation, optional: true # Spree::Invitation, if the resource_user was created from an invitation
+    has_many :invitation_roles, through: :invitation, source: :roles
+
+    #
+    # Validations
+    #
+    validates :resource_id, uniqueness: { scope: [:resource_type, :user_id, :user_type] }
+
+    #
+    # Scopes
+    #
+    scope :by_resource, ->(resource) { where(resource: resource) }
+    scope :by_user, ->(user) { where(user: user) }
+
+    #
+    # Callbacks
+    #
+    after_create :set_roles
+    after_destroy :revoke_roles
+
+    private
+
+    def set_roles
+      return if invitation.blank?
+
+      user.spree_roles = invitation_roles
+      user.save!
+    end
+
+    def revoke_roles
+      return if invitation.blank?
+
+      user.spree_roles.where(id: invitation_role_ids).destroy_all
+    end
+  end
+end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -103,6 +103,10 @@ module Spree
     has_many :posts
     has_many :post_categories
 
+    # Store Staff
+    has_many :resource_users, class_name: 'Spree::ResourceUser', as: :resource
+    has_many :users, through: :resource_users, source: :user, source_type: Spree.admin_user_class.to_s
+
     #
     # Page Builder associations
     #
@@ -348,10 +352,10 @@ module Spree
     end
 
     def admin_users
-      @admin_users ||= Spree.admin_user_class.joins(:spree_roles).where(spree_roles: { name: :admin })
-    end
+      Spree::Deprecation.warn('Store#admin_users is deprecated and will be removed in Spree 6.0. Please use Store#users instead.')
 
-    alias_method :users, :admin_users
+      users
+    end
 
     def favicon
       return unless favicon_image.attached? && favicon_image.variable?

--- a/core/app/services/spree/seeds/admin_user.rb
+++ b/core/app/services/spree/seeds/admin_user.rb
@@ -15,6 +15,10 @@ module Spree
 
           user.spree_roles << Spree::Role.find_or_create_by(name: :admin)
           user.save!
+
+          Spree::Store.all.each do |store|
+            store.resource_users.find_or_create_by!(user: user)
+          end
         end
       end
     end

--- a/core/db/migrate/20250414092155_create_spree_resource_users.rb
+++ b/core/db/migrate/20250414092155_create_spree_resource_users.rb
@@ -9,14 +9,5 @@ class CreateSpreeResourceUsers < ActiveRecord::Migration[7.2]
     end
 
     add_index :spree_resource_users, [:resource_id, :resource_type, :user_id, :user_type], unique: true
-
-    # migrate existing admin users to resource_users
-    unless Rails.env.test?
-      Spree.admin_user_class.all.each do |admin_user|
-        Spree::Store.all.each do |store|
-          store.resource_users.find_or_create_by!(user: admin_user)
-        end
-      end
-    end
   end
 end

--- a/core/db/migrate/20250414092155_create_spree_resource_users.rb
+++ b/core/db/migrate/20250414092155_create_spree_resource_users.rb
@@ -1,0 +1,22 @@
+class CreateSpreeResourceUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spree_resource_users do |t|
+      t.references :resource, null: false, polymorphic: true # Store, Vendor, etc
+      t.references :user, null: false, polymorphic: true # Spree::User, Spree::AdminUser, etc
+      t.references :invitation, null: true # Spree::Invitation, if the resource_user was created from an invitation
+
+      t.timestamps
+    end
+
+    add_index :spree_resource_users, [:resource_id, :resource_type, :user_id, :user_type], unique: true
+
+    # migrate existing admin users to resource_users
+    unless Rails.env.test?
+      Spree.admin_user_class.all.each do |admin_user|
+        Spree::Store.all.each do |store|
+          store.resource_users.find_or_create_by!(user: admin_user)
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/resource_user_factory.rb
+++ b/core/lib/spree/testing_support/factories/resource_user_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :resource_user, class: Spree::ResourceUser do
+    association :resource, factory: :store
+    association :user, factory: :admin_user
+  end
+end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -31,5 +31,22 @@ FactoryBot.define do
     last_name  { FFaker::Name.last_name }
 
     spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
+
+    trait :no_resource_user do
+      transient do
+        skip_resource_user { true }
+      end
+    end
+
+    transient do
+      skip_resource_user { false }
+    end
+
+    after(:create) do |user, evaluator|
+      unless evaluator.skip_resource_user
+        resource = Spree::Store.default
+        resource.resource_users.find_by(user: user) || create(:resource_user, user: user, resource: resource)
+      end
+    end
   end
 end

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -184,6 +184,14 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
       end
     end
   end
+
+  task migrate_admin_users_to_resource_users: :environment do |_t, _args|
+    Spree::AdminUser.all.each do |admin_user|
+      Spree::Store.all.each do |store|
+        store.resource_users.find_or_create_by!(user: admin_user)
+      end
+    end
+  end
 end
 
 namespace :core do

--- a/core/spec/models/spree/resource_user_spec.rb
+++ b/core/spec/models/spree/resource_user_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe Spree::ResourceUser, type: :model do
+  let(:resource_user) { create(:resource_user) }
+  let!(:admin_user) { create(:admin_user, :no_resource_user, spree_roles: []) }
+  let(:store) { @default_store }
+  let(:invitation) { create(:invitation, resource: store, roles: [create(:role)]) }
+
+  describe 'Callbacks' do
+    context 'after_create' do
+      it 'sets roles from invitation when invitation is present' do
+        role = create(:role)
+        invitation = create(:invitation, roles: [role])
+
+        resource_user = build(:resource_user,
+                             invitation: invitation,
+                             user: admin_user,
+                             resource: invitation.resource)
+
+        expect { resource_user.save! }.to change { admin_user.reload.spree_roles.count }.by(1)
+        expect(admin_user.spree_roles).to include(role)
+      end
+
+      it 'does not set roles when invitation is not present' do
+        resource_user = build(:resource_user, user: admin_user)
+
+        expect { resource_user.save! }.not_to change { admin_user.reload.spree_roles.count }
+      end
+    end
+
+    context 'after_destroy' do
+      it 'revokes roles from invitation when invitation is present' do
+        role = create(:role)
+        invitation = create(:invitation, roles: [role])
+
+        resource_user = create(:resource_user,
+                              invitation: invitation,
+                              user: admin_user,
+                              resource: invitation.resource)
+
+        expect(admin_user.reload.spree_roles).to include(role)
+        expect { resource_user.destroy }.to change { admin_user.reload.spree_roles.count }.by(-1)
+      end
+
+      it 'does not revoke roles when invitation is not present' do
+        role = create(:role)
+        admin_user.spree_roles << role
+        resource_user = create(:resource_user, user: admin_user)
+
+        expect { resource_user.destroy }.not_to change { admin_user.reload.spree_roles.count }
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -819,13 +819,4 @@ describe Spree::Store, type: :model, without_global_store: true do
       it { expect(store.formatted_url_or_custom_domain).to eq('http://mystore.com:3000') }
     end
   end
-
-  describe '#admin_users' do
-    let(:store) { create(:store) }
-    let(:admin_user) { create(:admin_user) }
-
-    it 'returns the admin users' do
-      expect(store.admin_users).to eq([admin_user])
-    end
-  end
 end

--- a/sample/db/samples/posts.rb
+++ b/sample/db/samples/posts.rb
@@ -4,5 +4,5 @@ store.posts.create!(
   title: 'Hello World',
   content: 'This is a test post',
   published_at: Time.current,
-  author: store.admin_users.first,
+  author: store.users.first,
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to delete admin users directly within the dashboard.
  - Improved the invitation process to ensure proper user-role linkage upon acceptance.
  - Added functionality to create resource users linked to invitations.
  - Enhanced user selection for posts to include all users associated with the store.
  - Established associations between admin users and stores for improved access management.

- **Refactor**
  - Streamlined user management by unifying admin and general user listings.
  - Updated post creation to offer a broader author selection, now drawing from all users rather than a restricted subset.

- **Chores**
  - Added a Rake task for migrating admin users to resource users across all stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->