### PR TITLE
Fixed: when creating new store, add to staff admins the current user

### DIFF
--- a/admin/app/controllers/spree/admin/stores_controller.rb
+++ b/admin/app/controllers/spree/admin/stores_controller.rb
@@ -19,6 +19,9 @@ module Spree
         @store.mail_from_address = current_store.mail_from_address
 
         if @store.save
+          @store.users << try_spree_current_user
+          @store.save!
+
           flash[:success] = flash_message_for(@store, :successfully_created)
           # redirect in view, Turbo doesn't support redirecting to a different host
         else

--- a/admin/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -5,10 +5,12 @@ describe Spree::Admin::StoresController do
   render_views
 
   let(:store) { create(:store) }
+  let(:user) { create(:admin_user) }
   let!(:uk_country) { create(:country, iso: 'GB', iso3: 'GBR', name: 'United Kingdom') }
 
   before do
     allow(controller).to receive(:current_store).and_return(store)
+    allow(controller).to receive(:try_spree_current_user).and_return(user)
   end
 
   describe 'POST #create' do
@@ -28,11 +30,18 @@ describe Spree::Admin::StoresController do
 
       expect(flash[:success]).to match('has been successfully created')
 
-      store = Spree::Store.last
-      expect(store.name).to eq('New UK Store')
-      expect(store.default_currency).to eq('GBR')
-      expect(store.default_country).to eq(uk_country)
-      expect(store.default_locale).to eq('en')
+      new_store = Spree::Store.last
+      expect(new_store.name).to eq('New UK Store')
+      expect(new_store.default_currency).to eq('GBR')
+      expect(new_store.default_country).to eq(uk_country)
+      expect(new_store.default_locale).to eq('en')
+    end
+
+    it 'adds the current user to the store' do
+      expect { subject }.to change(Spree::ResourceUser, :count).by(1)
+
+      new_store = Spree::Store.last
+      expect(new_store.users).to include(user)
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New store creations automatically link to the admin user who created them, streamlining management.
  - Enhanced error handling during store setup improves reliability by promptly identifying issues during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->