### PR TITLE
Use `Spree.base_class` as the class that Invitations inherits from

### DIFF
--- a/core/app/models/spree/invitation.rb
+++ b/core/app/models/spree/invitation.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Invitation < Base
+  class Invitation < Spree.base_class
     has_secure_token
     acts_as_paranoid
 

--- a/core/app/models/spree/invitation_role.rb
+++ b/core/app/models/spree/invitation_role.rb
@@ -1,5 +1,5 @@
 module Spree
-  class InvitationRole < Base
+  class InvitationRole < Spree.base_class
     belongs_to :invitation, class_name: 'Spree::Invitation'
     belongs_to :role, class_name: 'Spree::Role'
   end

--- a/core/app/models/spree/resource_user.rb
+++ b/core/app/models/spree/resource_user.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ResourceUser < Base
+  class ResourceUser < Spree.base_class
     #
     # Associations
     #


### PR DESCRIPTION
Making sure that in multi tenant installations these are isolated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the underlying structure for handling invitations, roles, and user resources to improve overall system consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->