### PR TITLE
Don't restrict loading admin users to the current resource

### DIFF
--- a/admin/app/controllers/spree/admin/admin_users_controller.rb
+++ b/admin/app/controllers/spree/admin/admin_users_controller.rb
@@ -83,7 +83,7 @@ module Spree
       end
 
       def load_admin_user
-        @admin_user = scope.find(params[:id])
+        @admin_user = Spree.admin_user_class.accessible_by(current_ability).find(params[:id])
       end
 
       # for self signup flow, we use the minimal layout


### PR DESCRIPTION
That way, store owners can preview/update vendor users, etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved admin user lookup to ensure broader and more consistent access to admin user accounts while maintaining proper authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->