### PR TITLE
Fixed setting proper from/reply-to headers for the invitation mailer

### DIFF
--- a/core/app/mailers/spree/invitation_mailer.rb
+++ b/core/app/mailers/spree/invitation_mailer.rb
@@ -4,6 +4,8 @@ module Spree
     def invitation_email(invitation)
       @invitation = invitation
       mail(to: invitation.email,
+           from: from_address,
+           reply_to: reply_to_address,
            subject: Spree.t('invitation_mailer.invitation_email.subject',
                             resource_name: invitation.resource&.name))
     end
@@ -12,6 +14,8 @@ module Spree
     def invitation_accepted(invitation)
       @invitation = invitation
       mail(to: invitation.inviter.email,
+           from: from_address,
+           reply_to: reply_to_address,
            subject: Spree.t('invitation_mailer.invitation_accepted.subject',
                             invitee_name: invitation.invitee&.name,
                             resource_name: invitation.resource&.name))

--- a/core/app/views/spree/invitation_mailer/invitation_email.html.erb
+++ b/core/app/views/spree/invitation_mailer/invitation_email.html.erb
@@ -10,7 +10,7 @@
 
 <% if spree.respond_to?(:admin_invitation_url) %>
   <p>
-    <%= link_to Spree.t('invitation_mailer.invitation_email.link_text'), spree.admin_invitation_url(@invitation, token: @invitation.token, host: @current_store.formatted_url) %>
+    <%= link_to Spree.t('invitation_mailer.invitation_email.link_text'), spree.admin_invitation_url(@invitation, token: @invitation.token, host: @invitation.store.formatted_url) %>
   </p>
 <% end %>
 

--- a/core/spec/mailers/spree/invitation_mailer_spec.rb
+++ b/core/spec/mailers/spree/invitation_mailer_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Spree::InvitationMailer, type: :mailer do
       expect(mail.to).to eq([invitation.email])
     end
 
+    it 'sends from the store mail from address' do
+      expect(mail.from).to eq([store.mail_from_address])
+    end
+
+    it 'sets reply-to as the store mail from address' do
+      expect(mail.reply_to).to eq([store.mail_from_address])
+    end
+
     it 'includes the invitation link in the body' do
       expect(mail.body.encoded).to include("http://test.com/admin/invitations/#{invitation.id}?token=#{invitation.token}")
     end
@@ -49,6 +57,14 @@ RSpec.describe Spree::InvitationMailer, type: :mailer do
 
     it 'sends to the correct recipient' do
       expect(mail.to).to eq([inviter.email])
+    end
+
+    it 'sends from the store mail from address' do
+      expect(mail.from).to eq([store.mail_from_address])
+    end
+
+    it 'sets reply-to as the store mail from address' do
+      expect(mail.reply_to).to eq([store.mail_from_address])
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invitation emails now correctly use the store associated with the invitation for generating links.
  - Emails sent for invitations now explicitly set the sender and reply-to addresses to the store’s configured email.

- **Tests**
  - Added tests to verify that invitation emails use the correct sender and reply-to addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->