### PR TITLE
Allow `spree_role_users.resource` to be null to ease the migration fr…

### DIFF
--- a/core/db/migrate/20250418174652_add_resource_to_spree_role_users.rb
+++ b/core/db/migrate/20250418174652_add_resource_to_spree_role_users.rb
@@ -1,6 +1,6 @@
 class AddResourceToSpreeRoleUsers < ActiveRecord::Migration[7.2]
   def change
-    add_reference :spree_role_users, :resource, polymorphic: true, null: false
+    add_reference :spree_role_users, :resource, polymorphic: true, null: true
     add_reference :spree_role_users, :invitation, null: true
 
     add_index :spree_role_users, [:resource_id, :resource_type, :user_id, :user_type, :role_id], unique: true


### PR DESCRIPTION
…om the old user role system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated database to allow the resource field in user roles to be optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->