### PR TITLE
Allow to use custom page blocks defined in section

### DIFF
--- a/admin/app/controllers/spree/admin/page_blocks_controller.rb
+++ b/admin/app/controllers/spree/admin/page_blocks_controller.rb
@@ -26,14 +26,22 @@ module Spree
       end
 
       def create
-        allowed_types = Rails.application.config.spree.page_blocks.map(&:to_s)
         page_block_type = params.dig(:page_block, :type)
 
-        if allowed_types.include?(page_block_type) && page_block_type.safe_constantize.present?
+        if allowed_types.map(&:to_s).include?(page_block_type) && page_block_type.safe_constantize.present?
           @page_block = page_block_type.constantize.new
           @page_block.section = @page_section
           @page_block.save!
         end
+      end
+
+      private
+
+      def allowed_types
+        [
+          *Rails.application.config.spree.page_blocks,
+          *parent&.available_blocks_to_add
+        ].uniq.sort_by(&:name)
       end
     end
   end

--- a/admin/spec/controllers/spree/admin/page_blocks_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/page_blocks_controller_spec.rb
@@ -68,4 +68,42 @@ RSpec.describe Spree::Admin::PageBlocksController, type: :controller do
       end
     end
   end
+
+  describe '#allowed_types' do
+    subject { controller.send(:allowed_types) }
+
+    let(:page_section) { create(:featured_taxon_page_section) }
+
+    before do
+      allow(controller).to receive(:parent).and_return(page_section)
+    end
+
+    it 'returns the section allowed types' do
+      expect(subject).to include(
+        Spree::PageBlocks::Buttons,
+        Spree::PageBlocks::Image,
+        Spree::PageBlocks::Text
+      )
+    end
+
+    context 'with custom page section class' do
+      class CustomPageBlock < Spree::PageBlock
+        def self.name
+          'Spree::PageBlocks::Custom'
+        end
+      end
+
+      class CustomPageSection < Spree::PageSections::FeaturedTaxon
+        def available_blocks_to_add
+          [CustomPageBlock]
+        end
+      end
+
+      let(:page_section) { CustomPageSection.new }
+
+      it 'returns the section allowed types' do
+        expect(subject).to include(CustomPageBlock)
+      end
+    end
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation when creating new page blocks to ensure only allowed types can be added, including support for custom blocks defined by the parent section.

- **Tests**
	- Added tests to verify that only valid page block types are permitted, including custom and standard block types, ensuring correct behavior for different page sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->