### PR TITLE
V-3041 ADD data test id to add address button

### DIFF
--- a/storefront/app/views/themes/default/spree/account/addresses/_new_address_modal.html.erb
+++ b/storefront/app/views/themes/default/spree/account/addresses/_new_address_modal.html.erb
@@ -32,7 +32,7 @@
     <div class="border-t border-default px-8 py-4 flex justify-end gap-8 shrink-0">
       <%= button_tag Spree.t(:cancel), class: 'uppercase text-sm font-semibold', data: { action: 'click->modal#close' } %>
       <%= hidden_field_tag :from_modal, "true" %>
-      <%= f.submit Spree.t(:add), class: 'btn-primary w-48' %>
+      <%= f.submit Spree.t(:add), class: 'btn-primary w-48', data: { test_id: 'add-address-button' } %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a data attribute to the "Add Address" button in the new address modal to support improved testing and automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->