### PR TITLE
If exists, automatically load `application.js` on the storefront

### DIFF
--- a/storefront/app/views/spree/shared/_head.html.erb
+++ b/storefront/app/views/spree/shared/_head.html.erb
@@ -14,7 +14,11 @@
 <%= render 'spree/shared/css_variables' %>
 <%= render 'spree/shared/fonts' %>
 
-<%= javascript_importmap_tags 'application-spree-storefront' %>
+<%= javascript_importmap_tags "application-spree-storefront" %>
+<% if Rails.application.importmap.packages["application"].present? %>
+  <%= javascript_import_module_tag "application" %>
+<% end %>
+
 <%= javascript_tag "wishedVariantIds = #{(current_wishlist&.variant_ids&.map(&:to_s) || []).to_json.html_safe};" %>
 
 <%= stylesheet_link_tag "tailwind", defer: true, data: { turbo_track: 'reload' } %>


### PR DESCRIPTION
This will allow users to start adding their own JavaScript code to the storefront without having to add a new custom head partial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved JavaScript module loading to automatically include an additional script when certain packages are present, enhancing compatibility with different storefront configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->