### PR TITLE
V-3074 FIX taxonomies slug and taxonomy edit page

### DIFF
--- a/admin/app/controllers/spree/admin/taxonomies_controller.rb
+++ b/admin/app/controllers/spree/admin/taxonomies_controller.rb
@@ -6,6 +6,11 @@ module Spree
 
       before_action :add_breadcrumbs
 
+      def edit
+        super
+        redirect_to spree.admin_taxonomy_taxon_path(@taxonomy, @taxonomy.root.id)
+      end
+
       private
 
       def collection

--- a/admin/app/controllers/spree/admin/taxons_controller.rb
+++ b/admin/app/controllers/spree/admin/taxons_controller.rb
@@ -78,9 +78,9 @@ module Spree
 
       def set_permalink_params
         return unless params[:permalink_part]
-      
+
         params[:taxon] ||= {}
-        params[:taxon][:permalink] = [@parent_permalink.presence, params[:permalink_part]].compact.join('/')
+        params[:taxon][:permalink] = [@parent_permalink.presence, params[:permalink_part]].compact_blank.join('/')
       end
 
       def collection_url

--- a/admin/app/controllers/spree/admin/taxons_controller.rb
+++ b/admin/app/controllers/spree/admin/taxons_controller.rb
@@ -77,7 +77,10 @@ module Spree
       end
 
       def set_permalink_params
-        params[:taxon][:permalink] = "#{@parent_permalink}/" + params[:permalink_part] if params.key? 'permalink_part'
+        return unless params[:permalink_part]
+      
+        params[:taxon] ||= {}
+        params[:taxon][:permalink] = [@parent_permalink.presence, params[:permalink_part]].compact.join('/')
       end
 
       def collection_url

--- a/admin/app/views/spree/admin/taxonomies/_taxonomy.html.erb
+++ b/admin/app/views/spree/admin/taxonomies/_taxonomy.html.erb
@@ -3,7 +3,7 @@
     <%= icon('grip-vertical', class: 'rounded hover-gray p-2') %>
   </td>
   <td class="w-50 cursor-pointer py-0" data-action="click->row-link#openLink">
-    <%= link_to taxonomy.name, spree.admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link } %>
+    <%= link_to taxonomy.name, spree.admin_taxonomy_path(taxonomy), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link } %>
   </td>
   <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
     <!-- We don't want to include the root taxon -->
@@ -11,6 +11,6 @@
   </td>
   <td class="w-10 actions">
     <%= link_to_with_icon 'list-tree', Spree.t('admin.manage_taxons'), spree.admin_taxonomy_path(taxonomy), class: 'btn btn-light btn-sm' %>
-    <%= link_to_edit(taxonomy.root, url: spree.edit_admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id), class: 'btn btn-light btn-sm') if can?(:edit, taxonomy.root) %>
+    <%= link_to_edit(taxonomy, class: 'btn btn-light btn-sm') if can?(:edit, taxonomy) %>
   </td>
 </tr>

--- a/admin/app/views/spree/admin/taxonomies/_taxonomy.html.erb
+++ b/admin/app/views/spree/admin/taxonomies/_taxonomy.html.erb
@@ -3,7 +3,7 @@
     <%= icon('grip-vertical', class: 'rounded hover-gray p-2') %>
   </td>
   <td class="w-50 cursor-pointer py-0" data-action="click->row-link#openLink">
-    <%= link_to taxonomy.name, spree.admin_taxonomy_path(taxonomy), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link } %>
+    <%= link_to taxonomy.name, spree.admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link } %>
   </td>
   <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
     <!-- We don't want to include the root taxon -->
@@ -11,6 +11,6 @@
   </td>
   <td class="w-10 actions">
     <%= link_to_with_icon 'list-tree', Spree.t('admin.manage_taxons'), spree.admin_taxonomy_path(taxonomy), class: 'btn btn-light btn-sm' %>
-    <%= link_to_edit(taxonomy, class: 'btn btn-light btn-sm') if can?(:edit, taxonomy) %>
+    <%= link_to_edit(taxonomy.root, url: spree.edit_admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id), class: 'btn btn-light btn-sm') if can?(:edit, taxonomy.root) %>
   </td>
 </tr>

--- a/admin/spec/controllers/spree/admin/taxonomies_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/taxonomies_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Spree::Admin::TaxonomiesController do
+  stub_authorization!
+
+  describe '#edit' do
+    let(:taxonomy) { create(:taxonomy) }
+    let(:taxonomy_id) { taxonomy.id }
+
+    before do
+      get :edit, params: { id: taxonomy_id }
+    end
+
+    it 'redirects to taxonomy taxon path' do
+      expect(response).to redirect_to(spree.admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id))
+    end
+
+    context 'when taxonomy not found' do
+      let(:taxonomy_id) { 'not_existing' }
+
+      it 'redirects to admin taxonomies path' do
+        expect(response).to redirect_to(spree.admin_taxonomies_path)
+      end
+    end
+  end
+end

--- a/admin/spec/controllers/spree/admin/taxons_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/taxons_controller_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe Spree::Admin::TaxonsController, type: :controller do
       put :update, params: { taxonomy_id: taxonomy.id, id: taxon.id, taxon: { name: 'New Name' } }
       expect(response).to redirect_to(spree.edit_admin_taxonomy_taxon_path(taxonomy.id, taxon.id))
     end
+
+    context 'when permalink_part is present' do
+      context 'and no parent taxon' do
+        it 'sets the permalink from permalink_part param' do
+          put :update, params: { taxonomy_id: taxonomy.id, id: taxonomy.root.id, permalink_part: 'new-permalink' }
+          expect(taxonomy.root.reload.permalink).to eq('new-permalink')
+        end
+      end
+
+      context 'and parent taxon is present' do
+        it 'sets the permalink from root permalink and permalink_part param' do
+          put :update, params: { taxonomy_id: taxonomy.id, id: taxon.id, permalink_part: 'new-permalink' }
+          expect(taxon.reload.permalink).to eq("#{taxonomy.root.permalink}/new-permalink")
+        end
+      end
+    end
   end
 
   describe 'PUT #reposition' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The edit action for taxonomies now redirects to the root taxon's detailed view instead of the default edit page.

- **Bug Fixes**
  - Improved the handling and construction of permalinks for taxons, ensuring more robust and accurate updates.

- **Tests**
  - Added tests to verify correct permalink updates for taxons, both with and without parent taxons.
  - Added tests to verify redirection behavior of the taxonomy edit action for valid and invalid taxonomy IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->