### PR TITLE
Make `ControllerHelpers::Auth#store_location` work nicely for both Cu…

### DIFF
--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -55,6 +55,10 @@ module Spree
         end
       end
 
+      def store_location_session_key
+        "#{Spree.admin_user_class.model_name.singular_route_key.to_sym}_return_to"
+      end
+
       def flash_message_for(object, event_sym)
         if object.is_a?(ActiveRecord::Relation)
           resource_desc = object.model.model_name.human.pluralize

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -43,18 +43,19 @@ module Spree
           @current_oauth_token ||= get_last_access_token.call(user) || create_access_token.call(user)
         end
 
-        def store_location
-          # disallow return to login, logout, signup pages
-          authentication_routes = [:spree_signup_path, :spree_login_path, :spree_logout_path]
-          disallowed_urls = []
-          authentication_routes.each do |route|
-            disallowed_urls << send(route) if respond_to?(route)
-          end
+        # this will work for devise out of the box
+        # for other auth systems you will need to override this method
+        def store_location(location = nil)
+          return if try_spree_current_user
 
-          disallowed_urls.map! { |url| url[/\/\w+$/] }
-          unless disallowed_urls.include?(request.fullpath)
-            session['spree_user_return_to'] = request.fullpath.gsub('//', '/')
-          end
+          location ||= request.fullpath
+          session_key = store_location_session_key
+
+          session[session_key] = location
+        end
+
+        def store_location_session_key
+          "#{Spree.user_class.model_name.singular_route_key.to_sym}_return_to"
         end
 
         # proxy method to *possible* spree_current_user method

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -74,7 +74,7 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     it 'sets session return url' do
       allow(controller).to receive_messages(request: double(fullpath: '/redirect'))
       controller.store_location
-      expect(session[:spree_user_return_to]).to eq '/redirect'
+      expect(session[:legacy_user_return_to]).to eq '/redirect'
     end
   end
 

--- a/storefront/app/controllers/spree/store_controller.rb
+++ b/storefront/app/controllers/spree/store_controller.rb
@@ -212,18 +212,6 @@ module Spree
       end
     end
 
-    # this will work for devise out of the box
-    # for other auth systems you will need to override this method
-    def store_location(location = nil)
-      return if try_spree_current_user
-      return unless defined?(store_location_for)
-      return unless defined?(Devise)
-
-      location ||= request.fullpath
-
-      store_location_for(Devise.mappings.keys.first, location)
-    end
-
     def stored_location
       return unless defined?(after_sign_in_path_for)
       return unless defined?(Devise)

--- a/storefront/spec/controllers/spree/checkout_controller_spec.rb
+++ b/storefront/spec/controllers/spree/checkout_controller_spec.rb
@@ -81,20 +81,6 @@ describe Spree::CheckoutController, type: :controller do
           get :edit, params: { token: order.token }
           expect(response).to redirect_to(spree.checkout_state_path(order.token, 'address'))
         end
-
-        context 'when Devise is installed' do
-          before do
-            allow(controller).to receive(:store_location_for)
-
-            stub_const('Devise', double(mappings: { user: nil }))
-          end
-
-          it 'saves the location so that we can redirect back after login' do
-            get :edit, params: { state: 'address', token: order.token }
-
-            expect(controller).to have_received(:store_location_for).with(:user, spree.checkout_state_path(order.token, 'address'))
-          end
-        end
       end
 
       context 'when guest checkout is not allowed' do


### PR DESCRIPTION
…stomers and Admin users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved how user return locations are stored in sessions with dynamic, flexible session key naming.
	- Simplified the logic for saving return locations, adjusting when and how redirect paths are stored after login.
	- Removed redundant location storing method from the storefront controller.
- **Tests**
	- Updated tests to align with new session key naming conventions.
	- Removed outdated tests related to Devise-specific location storing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->