### PR TITLE
Fixed: always make sure to load posts tag from the current store

### DIFF
--- a/admin/app/helpers/spree/admin/tags_helper.rb
+++ b/admin/app/helpers/spree/admin/tags_helper.rb
@@ -13,7 +13,7 @@ module Spree
         @post_tags_scope ||= ActsAsTaggableOn::Tag.
                              joins(:taggings).
                              where("#{ActsAsTaggableOn.taggings_table}.taggable_type = ?", 'Spree::Post').
-                             for_context(:tags)
+                             for_context(:tags).for_tenant(current_store.id)
       end
 
       def post_tags_json_array


### PR DESCRIPTION
As posts tags are tenant scoped per store already

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tag filtering to ensure only tags relevant to the current store are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->