### PR TITLE
Added: ready to use controllers/views for admin users to be used with…

### DIFF
--- a/admin/app/controllers/spree/admin/user_passwords_controller.rb
+++ b/admin/app/controllers/spree/admin/user_passwords_controller.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Admin
+    class UserPasswordsController < defined?(Devise::PasswordsController) ? Devise::PasswordsController : Spree::Admin::BaseController
+      layout 'spree/minimal'
+
+      def create
+        self.resource = resource_class.send_reset_password_instructions(resource_params)
+        yield resource if block_given?
+
+        set_flash_message(:notice, :send_instructions) if is_navigational_format?
+        # Don't not show error message that the email was not found
+        respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
+      end
+
+      protected
+
+      def translation_scope
+        'devise.user_passwords'
+      end
+    end
+  end
+end

--- a/admin/app/controllers/spree/admin/user_sessions_controller.rb
+++ b/admin/app/controllers/spree/admin/user_sessions_controller.rb
@@ -1,8 +1,6 @@
 module Spree
   module Admin
     class UserSessionsController < defined?(Devise::SessionsController) ? Devise::SessionsController : Spree::Admin::BaseController
-      skip_before_action :verify_authenticity_token
-
       layout 'spree/minimal'
 
       # We need to overwrite this action because `return_to` url may be in a different domain

--- a/admin/app/controllers/spree/admin/user_sessions_controller.rb
+++ b/admin/app/controllers/spree/admin/user_sessions_controller.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Admin
+    class UserSessionsController < defined?(Devise::SessionsController) ? Devise::SessionsController : Spree::Admin::BaseController
+      skip_before_action :verify_authenticity_token
+
+      layout 'spree/minimal'
+
+      # We need to overwrite this action because `return_to` url may be in a different domain
+      # So we need to pass `allow_other_host` option to `redirect_to` method
+      def create
+        self.resource = warden.authenticate!(auth_options)
+        set_flash_message!(:notice, :signed_in)
+        sign_in(resource_name, resource)
+        yield resource if block_given?
+        redirect_to after_sign_in_path_for(resource), allow_other_host: true
+      end
+
+      protected
+
+      def translation_scope
+        'devise.user_sessions'
+      end
+    end
+  end
+end

--- a/admin/app/views/spree/admin/shared/devise/_links.html.erb
+++ b/admin/app/views/spree/admin/shared/devise/_links.html.erb
@@ -1,0 +1,18 @@
+<div class="mb-2 d-flex justify-content-between">
+  <div>
+    <% if defined?(devise_mapping) && devise_mapping.rememberable? && controller_name == 'user_sessions' %>
+      <div class="custom-control custom-checkbox">
+        <%= f.check_box :remember_me, class: "custom-control-input" %>
+        <%= f.label :remember_me, Spree.t(:remember_me), class: "custom-control-label" %>
+      </div>
+    <% end %>
+  </div>
+  <div class="d-flex align-items-center gap-2">
+    <% if controller_name != 'user_sessions' %>
+      <p><%= link_to Spree.t(:log_in), new_session_path(resource_name) %></p>
+    <% end %>
+    <% if defined?(devise_mapping) && devise_mapping.recoverable? && controller_name != 'user_passwords' && controller_name != 'user_registrations' %>
+      <p><%= link_to Spree.t(:forgot_password), new_password_path(resource_name) %></p>
+    <% end %>
+  </div>
+</div>

--- a/admin/app/views/spree/admin/user_passwords/edit.html.erb
+++ b/admin/app/views/spree/admin/user_passwords/edit.html.erb
@@ -15,7 +15,7 @@
     <%= f.label :password_confirmation, Spree.t(:confirm_password), required: true, class: 'form-label' %>
     <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control form-control-lg rounded-sm', min: @minimum_password_length %>
   </div>
-  <%= render 'vendo/shared/devise/links', f: f %>
+  <%= render 'spree/admin/shared/devise/links', f: f %>
   <%= turbo_save_button_tag Spree.t(:reset_password), class: 'btn btn-primary btn-lg w-100' %>
 <% end %>
 

--- a/admin/app/views/spree/admin/user_passwords/edit.html.erb
+++ b/admin/app/views/spree/admin/user_passwords/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title, Spree.t(:forgot_password)) %>
+
+<h1 class="mb-3 font-weight-light"><%= Spree.t(:change_password) %></h1>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { turbo_frame: :_top, turbo: false }) do |f| %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: resource } %>
+  <%= f.hidden_field :reset_password_token %>
+  <div class="form-group mb-3">
+    <%= f.label :password, Spree.t(:password), required: true, class: 'form-label' %>
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'form-control form-control-lg rounded-sm', min: @minimum_password_length %>
+  </div>
+  <div class="form-group mb-3">
+    <%= f.label :password_confirmation, Spree.t(:confirm_password), required: true, class: 'form-label' %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control form-control-lg rounded-sm', min: @minimum_password_length %>
+  </div>
+  <%= render 'vendo/shared/devise/links', f: f %>
+  <%= turbo_save_button_tag Spree.t(:reset_password), class: 'btn btn-primary btn-lg w-100' %>
+<% end %>
+

--- a/admin/app/views/spree/admin/user_passwords/new.html.erb
+++ b/admin/app/views/spree/admin/user_passwords/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title, Spree.t(:forgot_password)) %>
+
+<h1 class="mb-3 font-weight-light"><%= Spree.t(:forgot_password) %></h1>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), data: { turbo_frame: :_top }) do |f| %>
+  <div class="form-group mb-3">
+    <%= f.label :email, Spree.t(:email), required: true, class: 'form-label' %>
+    <%= f.email_field :email, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: 'steve@apple.com', data: { enable_button_target: :input }, autocomplete: :email, autofocus: true %>
+  </div>
+  <%= render 'vendo/shared/devise/links', f: f %>
+  <%= turbo_save_button_tag Spree.t(:reset_password), class: 'btn btn-primary btn-lg w-100' %>
+<% end %>
+

--- a/admin/app/views/spree/admin/user_passwords/new.html.erb
+++ b/admin/app/views/spree/admin/user_passwords/new.html.erb
@@ -6,7 +6,7 @@
     <%= f.label :email, Spree.t(:email), required: true, class: 'form-label' %>
     <%= f.email_field :email, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: 'steve@apple.com', data: { enable_button_target: :input }, autocomplete: :email, autofocus: true %>
   </div>
-  <%= render 'vendo/shared/devise/links', f: f %>
+  <%= render 'spree/admin/shared/devise/links', f: f %>
   <%= turbo_save_button_tag Spree.t(:reset_password), class: 'btn btn-primary btn-lg w-100' %>
 <% end %>
 

--- a/admin/app/views/spree/admin/user_sessions/new.html.erb
+++ b/admin/app/views/spree/admin/user_sessions/new.html.erb
@@ -10,7 +10,7 @@
     <%= f.label :password, Spree.t(:password), required: true, class: 'form-label' %>
     <%= f.password_field :password, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: '********', autocomplete: 'current-password' %>
   </div>
-  <%= render 'vendo/shared/devise/links', f: f %>
+  <%= render 'spree/admin/shared/devise/links', f: f %>
   <%= turbo_save_button_tag Spree.t(:sign_in), class: 'btn btn-primary btn-lg w-100' %>
 <% end %>
 

--- a/admin/app/views/spree/admin/user_sessions/new.html.erb
+++ b/admin/app/views/spree/admin/user_sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, Spree.t(:sign_in)) %>
+<% content_for(:title, Spree.t(:login)) %>
 
 <h1 class="mb-3 font-weight-light">Welcome back</h1>
 <%= form_for resource, as: resource_name, url: session_path(resource_name), data: { controller: 'enable-button', turbo: false } do |f| %>
@@ -11,6 +11,6 @@
     <%= f.password_field :password, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: '********', autocomplete: 'current-password' %>
   </div>
   <%= render 'spree/admin/shared/devise/links', f: f %>
-  <%= turbo_save_button_tag Spree.t(:sign_in), class: 'btn btn-primary btn-lg w-100' %>
+  <%= turbo_save_button_tag Spree.t(:login), class: 'btn btn-primary btn-lg w-100' %>
 <% end %>
 

--- a/admin/app/views/spree/admin/user_sessions/new.html.erb
+++ b/admin/app/views/spree/admin/user_sessions/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for(:title, Spree.t(:sign_in)) %>
+
+<h1 class="mb-3 font-weight-light">Welcome back</h1>
+<%= form_for resource, as: resource_name, url: session_path(resource_name), data: { controller: 'enable-button', turbo: false } do |f| %>
+  <div class="form-group mb-3">
+    <%= f.label :email, Spree.t(:email), required: true, class: 'form-label' %>
+    <%= f.email_field :email, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: 'steve@getvendo.com', data: { enable_button_target: :input }, autocomplete: :email, autofocus: true %>
+  </div>
+  <div class="form-group mb-3">
+    <%= f.label :password, Spree.t(:password), required: true, class: 'form-label' %>
+    <%= f.password_field :password, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: '********', autocomplete: 'current-password' %>
+  </div>
+  <%= render 'vendo/shared/devise/links', f: f %>
+  <%= turbo_save_button_tag Spree.t(:sign_in), class: 'btn btn-primary btn-lg w-100' %>
+<% end %>
+


### PR DESCRIPTION
… Devise or custom auth

can be added as simply as adding new devise configuration for routes

```ruby
devise_for(
  Spree.admin_user_class.model_name.singular_route_key,
  class_name: Spree.admin_user_class.to_s,
  controllers: { sessions: 'spree/admin/user_sessions', passwords: 'spree/admin/user_passwords' },
  skip: :registrations,
  path: :admin_user,
  router_name: :spree
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated admin interfaces for user sign-in and password reset, including new pages for logging in, requesting password resets, and setting a new password.
  - Added user-friendly forms with validation, localized labels, and styled buttons for improved usability.
  - Included helpful links for login, password recovery, and "remember me" options within the admin authentication views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->