### PR TITLE
Fix `Store.by_url` with active record encryption

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -190,7 +190,7 @@ module Spree
     #
     default_scope { order(created_at: :asc) }
     scope :by_custom_domain, ->(url) { left_joins(:custom_domains).where("#{Spree::CustomDomain.table_name}.url" => url) }
-    scope :by_url, ->(url) { where("#{table_name}.url like ?", "%#{url}%") }
+    scope :by_url, ->(url) { where(url: url).or(where("#{table_name}.url like ?", "%#{url}%")) }
 
     #
     # Delegations


### PR DESCRIPTION
where we cannot to wildcard matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved store search to return results for both exact and partial URL matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->