### PR TITLE
Rename Taxon Conditions in admin to Rules

### DIFF
--- a/admin/app/views/spree/admin/taxons/_form.html.erb
+++ b/admin/app/views/spree/admin/taxons/_form.html.erb
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="card-body border-top pt-4 d-none" data-reveal-target="item">
-          <h6><%= Spree.t(:conditions) %></h6>
+          <h6><%= Spree.t(:rules) %></h6>
           <%= render 'spree/admin/taxons/rules_form', f: f %>
         </div>
       </div>
@@ -52,7 +52,7 @@
       <% if @taxon.automatic? %>
         <div class="card mb-4">
           <div class="card-header">
-            <h5 class="card-title"><%= Spree.t(:conditions) %></h5>
+            <h5 class="card-title"><%= Spree.t(:rules) %></h5>
           </div>
           <div class="card-body">
             <div class="alert alert-info mb-3"><%= Spree.t('admin.taxon_types.automatic_info') %></div>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -227,7 +227,7 @@ en:
       taxon_type: Taxon type
       taxon_types:
         automatic: Automatic
-        automatic_info: Automatically match products to this taxon based on the conditions you set.
+        automatic_info: Automatically add products to this taxon if they match the rules you set.
         manual: Manual
         manual_info: Curate products manually. You can add or remove them in bulk.
       upload_new_asset: Upload new asset

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -779,7 +779,6 @@ en:
     compare_at_amount: Compare at amount
     compare_at_price: Compare at price
     complete: complete
-    conditions: Conditions
     configuration: Configuration
     configurations: Configurations
     confirm: Confirm


### PR DESCRIPTION
The model is called Rule, we already have rule translation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated section and header labels from "conditions" to "rules" in the taxon form for improved clarity.
  - Revised related informational text to emphasize automatic addition of products based on matching rules.
  - Removed outdated translation for "conditions" from the English locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->