### PR TITLE
Added breadcrumb navigation to admin dashboard

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_buttons.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_buttons.scss
@@ -62,27 +62,15 @@ button[disabled]        .show-when-enabled { display: none; }
   }
 }
 
-.btn-hover {
-  &:hover, &:focus {
-    text-decoration: none;
-    background-color: $gray-50;
-  }
-}
 .hover-light {
   &:hover, &:focus {
-    background-color: $gray-25;
+    background-color: $dropdown-link-hover-bg;
     text-decoration: none;
   }
 }
 .hover-gray {
   &:hover, &:focus {
     background-color: $gray-100;
-    text-decoration: none;
-  }
-}
-.hover-gray-50 {
-  &:hover, &:focus {
-    background-color: $gray-50;
     text-decoration: none;
   }
 }

--- a/admin/app/assets/stylesheets/spree/admin/components/_dropdowns.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_dropdowns.scss
@@ -82,7 +82,7 @@
   }
   .dropdown-item.active {
     font-weight: 600 !important;
-    background-color: $gray-50 !important;
+    background-color: $dropdown-link-hover-bg !important;
   }
   .button_to {
     width: 100%;

--- a/admin/app/assets/stylesheets/spree/admin/components/_main.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_main.scss
@@ -1,24 +1,75 @@
-turbo-frame[loading] .spinner-border, turbo-frame[busy] .spinner-border {
-  display: block !important;
-}
-
 .sort-handle {
   cursor: grab;
 }
 
-.no-wrap {
-  white-space: nowrap;
-}
-
 #page-header {
-  height: 74px;
+  height: 60px;
   display: flex;
   align-items: center;
 }
 
 .page-header-title {
   font-size: 1.25rem;
-  font-weight: 700;
+}
+
+#header {
+  height: $header-height;
+  background-color: $body-bg;
+}
+
+.store-dropdown {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  background-color: $sidebar-bg;
+  width: $sidebar-width;
+  border-right: 1px solid $border-color;
+  height: $header-height;
+}
+
+.store-dropdown-button {
+  background-color: $sidebar-bg;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: left;
+  gap: 0.5rem;
+
+  &:hover {
+    background-color: $gray-50;
+  }
+}
+
+.store-chooser {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  margin: 0.25rem;
+  border: 1px solid $border-color;
+  border-radius: $border-radius-lg;
+
+  .store-chooser-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: $border-radius;
+    padding: 0.25rem;
+    text-wrap: nowrap;
+
+    &:hover {
+      text-decoration: none;
+      background-color: $dropdown-link-hover-bg;
+    }
+
+    &.active {
+      cursor: not-allowed;
+      background-color: $action;
+    }
+  }
 }
 
 #main-sidebar {
@@ -26,28 +77,18 @@ turbo-frame[loading] .spinner-border, turbo-frame[busy] .spinner-border {
   flex-direction: column;
   gap: 0.5rem;
   width: $sidebar-width;
-  background-color: $gray-25;
-  border-right: 1px solid $gray-100;
+  background-color: $sidebar-bg;
+  border-right: 1px solid $border-color;
   height: 100vh;
   overflow-y: auto;
   overflow-x: hidden;
   position: fixed;
-  top: 0;
+  top: $header-height;
   color: $gray-700;
-  padding-top: 0.5rem;
+  padding-top: 0.8rem;
 
   @media (max-width: 992px) {
     display: none;
-  }
-
-  .store-dropdown {
-    border-bottom: 1px solid $border-color;
-    padding-bottom: 0.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding-right: 0.5rem;
-    background-color: $gray-25;
   }
 
   .nav {
@@ -142,6 +183,7 @@ turbo-frame[loading] .spinner-border, turbo-frame[busy] .spinner-border {
 }
 
 #content {
+  padding-top: 0.5rem;
   @media (min-width: 992px) {
     margin-left: $sidebar-width + 1px;
   }

--- a/admin/app/assets/stylesheets/spree/admin/global/_variables.scss
+++ b/admin/app/assets/stylesheets/spree/admin/global/_variables.scss
@@ -2,7 +2,7 @@
 
 $gray-25: #F9F9F9;
 $gray-50: #F3F3F3;
-$gray-100: #E4E4E4 !default;
+$gray-100: #E6E6E6 !default;
 $gray-200: #D5D5D5 !default;
 $gray-300: #B3B3B3 !default;
 $gray-400: #999999 !default;
@@ -148,8 +148,7 @@ $display4-weight:             400 !default;
 
 $dropdown-border-width:  0px !default;
 $dropdown-border-radius: $border-radius-lg !default;
-$dropdown-link-hover-bg: $blue !default;
-$dropdown-link-hover-color: $white !default;
+$dropdown-link-hover-bg: $gray-50 !default;
 $dropdown-box-shadow:    rgba(209, 217, 224, 0.8) 0px 0px 0px 1px, rgba(37, 41, 46, 0.04) 0px 6px 12px -3px, rgba(37, 41, 46, 0.12) 0px 6px 18px 0px !default;
 $dropdown-padding-x:    0.25rem !default;
 $dropdown-padding-y:    0.25rem !default;
@@ -199,3 +198,4 @@ $list-group-item-padding-x:         1rem !default;
 
 $header-height: 52px !default;
 $sidebar-width: 220px !default;
+$sidebar-bg: $gray-25 !default;

--- a/admin/app/assets/stylesheets/spree/admin/shared/_base.scss
+++ b/admin/app/assets/stylesheets/spree/admin/shared/_base.scss
@@ -479,6 +479,9 @@ turbo-frame[busy] #turbo-spinner {
     height: 2rem;
   }
 }
+turbo-frame[loading] .spinner-border, turbo-frame[busy] .spinner-border {
+  display: block !important;
+}
 
 .fill-primary {
   & > * {
@@ -675,7 +678,7 @@ div.uppy-Root {
 }
 
 .tooltip-inner {
-  border: 1px solid $gray-100;
+  border: 1px solid $border-color;
   box-shadow: $box-shadow-xs;
 }
 
@@ -693,16 +696,20 @@ div.uppy-Root {
 .breadcrumb {
   gap: 0.5rem;
   align-items: center;
-  color: $gray-600;
+  color: $gray-500;
+  font-size: $font-size-sm;
   
+  i {
+    opacity: 0.5;
+  }
+
   li {
     a {
-      color: $gray-600;
+      color: $gray-500;
       text-decoration: none;
 
       &:hover {
         color: $primary;
-        text-decoration: none;
       }
     }
   }

--- a/admin/app/assets/stylesheets/spree/admin/shared/_forms.scss
+++ b/admin/app/assets/stylesheets/spree/admin/shared/_forms.scss
@@ -34,7 +34,7 @@ label {
     @extend .shadow-none;
     @extend .text-muted;
     background-color: $gray-50 !important;
-    border: 1px solid $gray-100 !important;
+    border: 1px solid $border-color !important;
     cursor: not-allowed;
   }
 }

--- a/admin/app/assets/stylesheets/spree/admin/views/_page_builder.scss
+++ b/admin/app/assets/stylesheets/spree/admin/views/_page_builder.scss
@@ -16,7 +16,7 @@
   }
 
   .nav-pills {
-    border: 1px solid $gray-100;
+    border: 1px solid $border-color;
     border-radius: $border-radius;
     background-color: $gray-50;
     padding: 0.1rem;
@@ -29,7 +29,7 @@
 
       &.active {
         background-color: $white;
-        border: 1px solid $gray-100;
+        border: 1px solid $border-color;
       }
     }
   }

--- a/admin/app/controllers/concerns/spree/admin/breadcrumb_concern.rb
+++ b/admin/app/controllers/concerns/spree/admin/breadcrumb_concern.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Admin
+    module BreadcrumbConcern
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :breadcrumb_icon
+        before_action :add_breadcrumb_icon_instance_var
+      end
+
+      class_methods do
+        def add_breadcrumb_icon(icon_name)
+          self.breadcrumb_icon = icon_name
+        end
+      end
+
+      def add_breadcrumb_icon_instance_var
+        @breadcrumb_icon = self.class.breadcrumb_icon
+      end
+    end
+  end
+end

--- a/admin/app/controllers/concerns/spree/admin/products_breadcrumb_concern.rb
+++ b/admin/app/controllers/concerns/spree/admin/products_breadcrumb_concern.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Admin
+    module ProductsBreadcrumbConcern
+      extend ActiveSupport::Concern
+
+      included do
+        add_breadcrumb_icon 'box'
+        add_breadcrumb Spree.t(:products), :admin_products_path
+
+        before_action :add_breadcrumb_for_product, only: [:edit, :update]
+      end
+
+      private
+
+      def add_breadcrumb_for_product
+        return unless @product.present?
+        return if @product.new_record?
+        add_breadcrumb @product.name, spree.edit_admin_product_path(@product)
+      end
+    end
+  end
+end

--- a/admin/app/controllers/concerns/spree/admin/promotions_breadcrumb_concern.rb
+++ b/admin/app/controllers/concerns/spree/admin/promotions_breadcrumb_concern.rb
@@ -1,0 +1,23 @@
+module Spree
+  module Admin
+    module PromotionsBreadcrumbConcern
+      extend ActiveSupport::Concern
+
+      included do
+        add_breadcrumb_icon 'discount'
+        add_breadcrumb Spree.t(:promotions), :admin_promotions_path
+
+        before_action :add_breadcrumb_for_promotion
+      end
+
+      private
+
+      def add_breadcrumb_for_promotion
+        return unless @promotion.present?
+        return if @promotion.new_record?
+
+        add_breadcrumb @promotion.name, spree.admin_promotion_path(@promotion)
+      end
+    end
+  end
+end

--- a/admin/app/controllers/concerns/spree/admin/storefront_breadcrumb_concern.rb
+++ b/admin/app/controllers/concerns/spree/admin/storefront_breadcrumb_concern.rb
@@ -1,0 +1,12 @@
+module Spree
+  module Admin
+    module StorefrontBreadcrumbConcern
+      extend ActiveSupport::Concern
+
+      included do
+        add_breadcrumb_icon 'building-store'
+        add_breadcrumb Spree.t('admin.storefront'), :admin_themes_path
+      end
+    end
+  end
+end

--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class BaseController < Spree::BaseController
+      include Spree::Admin::BreadcrumbConcern
+
       layout :choose_layout
 
       helper 'spree/base'

--- a/admin/app/controllers/spree/admin/checkouts_controller.rb
+++ b/admin/app/controllers/spree/admin/checkouts_controller.rb
@@ -5,6 +5,10 @@ module Spree
 
       before_action :load_user, only: [:index]
 
+      add_breadcrumb Spree.t(:orders), :admin_orders_path
+      add_breadcrumb Spree.t(:draft_orders), :admin_checkouts_path
+      add_breadcrumb_icon 'inbox'
+
       def index
         params[:q] ||= {}
         params[:q][:s] ||= 'created_at desc'

--- a/admin/app/controllers/spree/admin/coupon_codes_controller.rb
+++ b/admin/app/controllers/spree/admin/coupon_codes_controller.rb
@@ -3,6 +3,8 @@ module Spree
     class CouponCodesController < ResourceController
       belongs_to 'spree/promotion', find_by: :id
 
+      include PromotionsBreadcrumbConcern
+
       def collection
         return @collection if @collection.present?
 

--- a/admin/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/admin/app/controllers/spree/admin/customer_returns_controller.rb
@@ -1,6 +1,9 @@
 module Spree
   module Admin
     class CustomerReturnsController < ResourceController
+      add_breadcrumb_icon 'receipt-refund'
+      add_breadcrumb Spree.t(:returns), :admin_customer_returns_path
+
       def index; end
 
       private

--- a/admin/app/controllers/spree/admin/dashboard_controller.rb
+++ b/admin/app/controllers/spree/admin/dashboard_controller.rb
@@ -7,9 +7,15 @@ module Spree
       before_action :load_vendor
       before_action :clear_return_to, only: %i[show]
 
-      def show; end
+      def show
+        @breadcrumb_icon = 'home'
+        add_breadcrumb Spree.t(:home), spree.admin_dashboard_path
+      end
 
-      def getting_started; end
+      def getting_started
+        @breadcrumb_icon = 'map'
+        add_breadcrumb Spree.t(:getting_started), spree.admin_getting_started_path
+      end
 
       def analytics
         @orders_scope = current_store.orders.complete.where(currency: params[:analytics_currency])

--- a/admin/app/controllers/spree/admin/dashboard_controller.rb
+++ b/admin/app/controllers/spree/admin/dashboard_controller.rb
@@ -14,7 +14,7 @@ module Spree
 
       def getting_started
         @breadcrumb_icon = 'map'
-        add_breadcrumb Spree.t(:getting_started), spree.admin_getting_started_path
+        add_breadcrumb Spree.t('admin.getting_started'), spree.admin_getting_started_path
       end
 
       def analytics

--- a/admin/app/controllers/spree/admin/digital_assets_controller.rb
+++ b/admin/app/controllers/spree/admin/digital_assets_controller.rb
@@ -3,6 +3,10 @@ module Spree
     class DigitalAssetsController < ResourceController
       belongs_to 'spree/product', find_by: :slug
 
+      include ProductsBreadcrumbConcern
+
+      before_action :add_breadcrumbs
+
       private
 
       def model_class
@@ -39,6 +43,10 @@ module Spree
 
       def permitted_resource_params
         params.require(:digital_asset).permit(permitted_digital_attributes)
+      end
+
+      def add_breadcrumbs
+        add_breadcrumb Spree.t(:digital_assets), spree.admin_product_digital_assets_path(@product)
       end
     end
   end

--- a/admin/app/controllers/spree/admin/option_types_controller.rb
+++ b/admin/app/controllers/spree/admin/option_types_controller.rb
@@ -3,6 +3,11 @@ module Spree
     class OptionTypesController < ResourceController
       before_action :setup_new_option_value, only: :edit
 
+      include ProductsBreadcrumbConcern
+      add_breadcrumb Spree.t(:options), :admin_option_types_path
+
+      before_action :add_breadcrumbs
+
       private
 
       def collection
@@ -17,6 +22,12 @@ module Spree
 
       def setup_new_option_value
         @option_type.option_values.build if @option_type.option_values.empty?
+      end
+
+      def add_breadcrumbs
+        if @option_type.present? && @option_type.persisted?
+          add_breadcrumb @option_type.presentation, spree.edit_admin_option_type_path(@option_type)
+        end
       end
     end
   end

--- a/admin/app/controllers/spree/admin/orders_controller.rb
+++ b/admin/app/controllers/spree/admin/orders_controller.rb
@@ -11,10 +11,21 @@ module Spree
 
       helper_method :model_class
 
+      add_breadcrumb Spree.t(:orders), :admin_orders_path
+      add_breadcrumb_icon 'inbox'
+
       def create
         @order = Spree::Order.create(created_by: try_spree_current_user, store: current_store)
 
         redirect_to spree.edit_admin_order_path(@order)
+      end
+
+      def edit
+        unless @order.completed?
+          add_breadcrumb Spree.t(:draft_orders), :admin_checkouts_path
+        end
+
+        add_breadcrumb @order.number, spree.edit_admin_order_path(@order)
       end
 
       def index

--- a/admin/app/controllers/spree/admin/pages_controller.rb
+++ b/admin/app/controllers/spree/admin/pages_controller.rb
@@ -6,6 +6,9 @@ module Spree
       destroy.after :remove_preview_from_session
       create.after :remove_preview_from_session
 
+      include StorefrontBreadcrumbConcern
+      add_breadcrumb Spree.t(:pages), :admin_pages_path
+
       private
 
       def remove_preview_from_session

--- a/admin/app/controllers/spree/admin/post_categories_controller.rb
+++ b/admin/app/controllers/spree/admin/post_categories_controller.rb
@@ -1,6 +1,9 @@
 module Spree
   module Admin
     class PostCategoriesController < ResourceController
+      include StorefrontBreadcrumbConcern
+      add_breadcrumb Spree.t(:posts), :admin_posts_path
+      add_breadcrumb Spree.t(:categories), :admin_post_categories_path
     end
   end
 end

--- a/admin/app/controllers/spree/admin/posts_controller.rb
+++ b/admin/app/controllers/spree/admin/posts_controller.rb
@@ -3,6 +3,11 @@ module Spree
     class PostsController < ResourceController
       before_action :load_post_categories
 
+      include StorefrontBreadcrumbConcern
+      add_breadcrumb Spree.t(:posts), :admin_posts_path
+
+      before_action :add_breadcrumb_for_post, only: [:edit, :update]
+
       def select_options
         render json: current_store.posts.published.to_tom_select_json
       end
@@ -23,6 +28,12 @@ module Spree
 
       def load_post_categories
         @post_categories = current_store.post_categories.accessible_by(current_ability).order(:title)
+      end
+
+      def add_breadcrumb_for_post
+        return unless @post.present?
+
+        add_breadcrumb @post.title, spree.edit_admin_post_path(@post)
       end
     end
   end

--- a/admin/app/controllers/spree/admin/products_controller.rb
+++ b/admin/app/controllers/spree/admin/products_controller.rb
@@ -4,6 +4,7 @@ module Spree
       include Spree::Admin::StockLocationsHelper
       include Spree::Admin::BulkOperationsConcern
       include Spree::Admin::SessionAssetsHelper
+      include Spree::Admin::ProductsBreadcrumbConcern
 
       helper 'spree/admin/products'
       helper 'spree/admin/taxons'

--- a/admin/app/controllers/spree/admin/promotions_controller.rb
+++ b/admin/app/controllers/spree/admin/promotions_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class PromotionsController < ResourceController
+      include PromotionsBreadcrumbConcern
+
       before_action :load_form_data, except: :index
 
       # POST /admin/promotions/:id/clone

--- a/admin/app/controllers/spree/admin/properties_controller.rb
+++ b/admin/app/controllers/spree/admin/properties_controller.rb
@@ -1,6 +1,11 @@
 module Spree
   module Admin
     class PropertiesController < ResourceController
+      include ProductsBreadcrumbConcern
+      add_breadcrumb Spree.t(:properties), :admin_properties_path
+
+      before_action :add_breadcrumbs
+
       protected
 
       def update_turbo_stream_enabled?
@@ -17,6 +22,12 @@ module Spree
         @search = @collection.ransack(params[:q])
         @collection = @search.result.
                       page(params[:page])
+      end
+
+      def add_breadcrumbs
+        if @property.present? && @property.persisted?
+          add_breadcrumb @property.presentation, spree.edit_admin_property_path(@property)
+        end
       end
     end
   end

--- a/admin/app/controllers/spree/admin/reports_controller.rb
+++ b/admin/app/controllers/spree/admin/reports_controller.rb
@@ -3,6 +3,9 @@ module Spree
     class ReportsController < ResourceController
       include ActiveStorage::SetCurrent
 
+      add_breadcrumb_icon 'chart-bar'
+      add_breadcrumb Spree.t(:reports), :admin_reports_path
+
       before_action :set_user, only: [:new, :create]
 
       def show

--- a/admin/app/controllers/spree/admin/stock_items_controller.rb
+++ b/admin/app/controllers/spree/admin/stock_items_controller.rb
@@ -1,6 +1,10 @@
 module Spree
   module Admin
     class StockItemsController < ResourceController
+      include ProductsBreadcrumbConcern
+
+      before_action :add_breadcrumbs
+
       private
 
       def update_turbo_stream_enabled?
@@ -19,6 +23,11 @@ module Spree
                        includes(:stock_location, [variant: [product: [variants: [:images], master: [:images]], images: []]]).
                        page(params[:page]).
                        per(params[:per_page])
+      end
+
+      def add_breadcrumbs
+        add_breadcrumb Spree.t(:stock), spree.admin_stock_items_path
+        add_breadcrumb Spree.t(:stock_items), spree.admin_stock_items_path
       end
     end
   end

--- a/admin/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/admin/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -3,7 +3,11 @@ module Spree
     class StockTransfersController < ResourceController
       before_action :prepare_params, only: :create
 
+      include ProductsBreadcrumbConcern
+
       create.fails :load_variant_omit_ids
+
+      before_action :add_breadcrumbs
 
       private
 
@@ -42,6 +46,15 @@ module Spree
 
       def load_variant_omit_ids
         @variant_omit_ids = @stock_transfer.stock_movements.map(&:variant_id)
+      end
+
+      def add_breadcrumbs
+        add_breadcrumb Spree.t(:stock), spree.admin_stock_items_path
+        add_breadcrumb Spree.t(:stock_transfers), spree.admin_stock_transfers_path
+
+        if @stock_transfer.present? && @stock_transfer.persisted?
+          add_breadcrumb @stock_transfer.number, spree.admin_stock_transfer_path(@stock_transfer)
+        end
       end
     end
   end

--- a/admin/app/controllers/spree/admin/store_credits_controller.rb
+++ b/admin/app/controllers/spree/admin/store_credits_controller.rb
@@ -73,6 +73,10 @@ module Spree
           flash[:error] = Spree.t(:user_not_found)
           redirect_to spree.admin_path
         end
+
+        @breadcrumb_icon = 'users'
+        add_breadcrumb Spree.t(:customers), :admin_users_path
+        add_breadcrumb @user.name, spree.admin_user_path(@user)
       end
 
       def load_store_credit

--- a/admin/app/controllers/spree/admin/storefront_controller.rb
+++ b/admin/app/controllers/spree/admin/storefront_controller.rb
@@ -1,6 +1,9 @@
 module Spree
   module Admin
     class StorefrontController < BaseController
+      include StorefrontBreadcrumbConcern
+      add_breadcrumb Spree.t(:settings), :edit_admin_storefront_path
+
       def edit
         @store = current_store
       end

--- a/admin/app/controllers/spree/admin/taxonomies_controller.rb
+++ b/admin/app/controllers/spree/admin/taxonomies_controller.rb
@@ -1,6 +1,11 @@
 module Spree
   module Admin
     class TaxonomiesController < ResourceController
+      include ProductsBreadcrumbConcern
+      add_breadcrumb Spree.t(:taxonomies), :admin_taxonomies_path
+
+      before_action :add_breadcrumbs
+
       private
 
       def collection
@@ -15,6 +20,12 @@ module Spree
 
       def location_after_save
         spree.admin_taxonomy_path(@taxonomy)
+      end
+
+      def add_breadcrumbs
+        if @taxonomy.present? && @taxonomy.persisted?
+          add_breadcrumb @taxonomy.name, spree.admin_taxonomy_path(@taxonomy)
+        end
       end
     end
   end

--- a/admin/app/controllers/spree/admin/taxons_controller.rb
+++ b/admin/app/controllers/spree/admin/taxons_controller.rb
@@ -15,6 +15,12 @@ module Spree
 
       before_action :load_form_data, only: [:new, :create, :edit, :update]
 
+      add_breadcrumb Spree.t(:products), :admin_products_path
+      add_breadcrumb Spree.t(:taxonomies), :admin_taxonomies_path
+
+      add_breadcrumb_icon 'package'
+      before_action :add_breadcrumb_taxonomy
+
       def show
         redirect_to location_after_save
       end
@@ -91,6 +97,16 @@ module Spree
 
         @rule_match_policies = Spree::TaxonRule::MATCH_POLICIES.map do |policy|
           [Spree.t("admin.taxon_rules.match_policies.#{policy}"), policy]
+        end
+      end
+
+      def add_breadcrumb_taxonomy
+        return unless @taxonomy.present?
+
+        add_breadcrumb @taxonomy.name, collection_url
+
+        if @object.present? && @object.persisted?
+          add_breadcrumb @object.name, spree.edit_admin_taxonomy_taxon_path(@taxonomy, @object.id)
         end
       end
     end

--- a/admin/app/controllers/spree/admin/themes_controller.rb
+++ b/admin/app/controllers/spree/admin/themes_controller.rb
@@ -3,6 +3,9 @@ module Spree
     class ThemesController < ResourceController
       layout :choose_layout
 
+      include StorefrontBreadcrumbConcern
+      add_breadcrumb Spree.t(:themes), :admin_themes_path
+
       def edit
         @theme_preview = params[:theme_preview_id].present? ? @theme.previews.find(params[:theme_preview_id]) : @theme.create_preview
         @page = if params[:page_id].present?

--- a/admin/app/controllers/spree/admin/users_controller.rb
+++ b/admin/app/controllers/spree/admin/users_controller.rb
@@ -10,7 +10,12 @@ module Spree
       before_action :load_last_order_data, only: :show
       before_action :remove_empty_params, only: :update
 
-      def show; end
+      add_breadcrumb_icon 'users'
+      add_breadcrumb Spree.t(:customers), :admin_users_path
+
+      def show
+        add_breadcrumb @user.name, spree.admin_user_path(@user)
+      end
 
       def create
         @user = Spree.user_class.new(user_params)

--- a/admin/app/controllers/spree/admin/variants_controller.rb
+++ b/admin/app/controllers/spree/admin/variants_controller.rb
@@ -3,9 +3,12 @@ module Spree
     class VariantsController < ResourceController
       include StockLocationsHelper
 
+      include ProductsBreadcrumbConcern
+
       belongs_to 'spree/product', find_by: :slug
       before_action :load_data, only: [:edit, :update]
       before_action :strip_attributes, only: [:update]
+      before_action :add_breadcrumbs
 
       edit_action.before :build_prices
       edit_action.before :build_stock_items
@@ -84,6 +87,12 @@ module Spree
       def strip_attributes
         params[:variant].delete(:prices_attributes) unless can?(:manage, @variant.prices.first)
         params[:variant].delete(:stock_items_attributes) unless can?(:manage, @variant.stock_items.first)
+      end
+
+      def add_breadcrumbs
+        if @variant.present? && @variant.persisted?
+          add_breadcrumb @variant.human_name, spree.edit_admin_product_variant_path(@product, @variant)
+        end
       end
     end
   end

--- a/admin/app/helpers/spree/admin/navigation_helper.rb
+++ b/admin/app/helpers/spree/admin/navigation_helper.rb
@@ -268,6 +268,14 @@ module Spree
         css ||= 'text-muted'
         content_tag :small, icon('info-square-rounded', class: css), data: { placement: placement }, class: "with-tip #{css}", title: text
       end
+
+      def render_breadcrumb_icon
+        if settings_active?
+          icon('settings')
+        elsif @breadcrumb_icon
+          icon(@breadcrumb_icon)
+        end
+      end
     end
   end
 end

--- a/admin/app/helpers/spree/admin/stores_helper.rb
+++ b/admin/app/helpers/spree/admin/stores_helper.rb
@@ -4,7 +4,7 @@ module Spree
       include Spree::ImagesHelper
 
       def available_stores
-        @available_stores ||= Spree::Store.accessible_by(current_ability)
+        @available_stores ||= Spree::Store.accessible_by(current_ability).includes(:logo_attachment, :favicon_image_attachment, :default_custom_domain)
       end
 
       DEFAULT_ICON_SIZE = 40

--- a/admin/app/views/spree/admin/digital_assets/index.html.erb
+++ b/admin/app/views/spree/admin/digital_assets/index.html.erb
@@ -1,6 +1,5 @@
 <% content_for :page_title do %>
   <%= page_header_back_button spree.admin_product_path(@product) %>
-  <span class="mr-3"><%= @product.name %></span>
   <span><%= Spree.t("digital_assets") %></span>
 <% end %>
 

--- a/admin/app/views/spree/admin/option_types/edit.html.erb
+++ b/admin/app/views/spree/admin/option_types/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>
   <%= page_header_back_button spree.admin_option_types_url %>
-  <%= @option_type.name %>
+  <%= @option_type.presentation %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @option_type } %>

--- a/admin/app/views/spree/admin/promotions/_sidebar.html.erb
+++ b/admin/app/views/spree/admin/promotions/_sidebar.html.erb
@@ -49,6 +49,24 @@
 
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <span class="text-muted">
+            <%= Spree.t(:created_at) %>
+          </span>
+          <span>
+            <%= local_time(@promotion.created_at, format: :long) %>
+          </span>
+        </li>
+
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span class="text-muted">
+            <%= Spree.t(:updated_at) %>
+          </span>
+          <span>
+            <%= local_time(@promotion.updated_at, format: :long) %>
+          </span>
+        </li>
+
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <span class="text-muted">
             <%= Spree.t(:kind) %>
           </span>
           <span class="badge badge-light">

--- a/admin/app/views/spree/admin/properties/edit.html.erb
+++ b/admin/app/views/spree/admin/properties/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>
   <%= page_header_back_button admin_properties_url %>
-  <%= @property.name %>
+  <%= @property.presentation %>
 <% end %>
 
 

--- a/admin/app/views/spree/admin/shared/_breadcrumbs.html.erb
+++ b/admin/app/views/spree/admin/shared/_breadcrumbs.html.erb
@@ -1,0 +1,12 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <%= render_breadcrumb_icon %>
+    <% if settings_active? %>
+      <li>
+        <%= active_link_to Spree.t(:settings), spree.edit_admin_store_path %>
+      </li>
+    <% end %>
+
+    <%= render_breadcrumbs tag: :li, separator: icon('slash', class: 'text-muted font-size-sm') %>
+  </ol>
+</nav>

--- a/admin/app/views/spree/admin/shared/_header.html.erb
+++ b/admin/app/views/spree/admin/shared/_header.html.erb
@@ -2,26 +2,27 @@
 
 <%= render 'spree/admin/shared/offcanvas_nav' %>
 
-<header id="header" data-turbo-permanent>
-  <nav class="navbar navbar-expand-lg py-2 px-lg-5 d-lg-none">
-    <button type="button" class="btn d-flex align-items-center p-0 h-100 pull-bs-canvas-left d-lg-none text-white text-decoration-none">
-      <%= icon('menu-2', height: 32, class: 'm-0 h-100') %>
+<header id="header" class="sticky-top">
+  <nav class="navbar navbar-expand-lg border-bottom p-0 d-flex align-items-center pr-3">
+    <button type="button" class="btn btn-light pull-bs-canvas-left d-lg-none px-2 ml-3 text-decoration-none">
+      <%= icon('menu-2', class: 'mr-0') %>
     </button>
 
-    <div class="navbar-collapse d-none d-lg-flex">
-      <%= form_with url: spree.admin_search_admin_path, method: :post, class: 'd-none' do |form| %>
-        <div class="w-50 d-lg-flex align-items-center pr-2">
-          <%= icon('search', class: 'text-muted') %>
-          <%= text_field_tag :search, params[:search], class: 'px-3 py-2 bg-transparent w-100 outline-none border-0', placeholder: 'Search...', oninput: "this.form.requestSubmit()" %>
-        </div>
-      <% end if spree.respond_to?(:admin_search_admin_path) && defined?(current_store) && current_store %>
-    </div>
-
-    <%= link_to spree.admin_dashboard_path, class: 'navbar-brand d-flex d-lg-none h-100 align-items-center mx-0 text-white' do %>
-      <%= current_store.name %>
+    <% if settings_active? %>
+      <div class="store-dropdown p-2">
+        <%= active_link_to_with_icon('arrow-back-up', Spree.t('admin.back_to_dashboard'), spree.admin_dashboard_path, class: 'btn store-dropdown-button w-100 justify-content-start mr-1') %>
+      </div>
+    <% else %>
+      <% if defined?(current_vendor) && current_vendor.present? %>
+        <%= render 'spree/admin/shared/sidebar/vendor_dropdown' %>
+      <% else %>
+        <%= render 'spree/admin/shared/sidebar/store_dropdown' %>
+      <% end %>
     <% end %>
 
-    <div class="text-right d-flex justify-content-end p-0" id="header-user-account" data-turbo-permanent>
+    <%= render 'spree/admin/shared/breadcrumbs' %>
+
+    <div class="ml-auto d-flex align-items-center">
       <%= render 'spree/admin/shared/user_dropdown' %>
     </div>
   </nav>

--- a/admin/app/views/spree/admin/shared/_new_item_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/_new_item_dropdown.html.erb
@@ -1,0 +1,32 @@
+<div class="dropdown">
+  <button type="button" class="btn btn-sm btn-light shadow-xs px-1" data-toggle="dropdown" aria-expanded="false">
+    <%= icon 'plus', class: 'mr-0' %>
+  </button>
+  <div class="dropdown-menu">
+    <%= link_to_with_icon 'shopping-bag-plus', Spree.t(:new_order), spree.admin_orders_path, class: "dropdown-item", data: { turbo_method: :post } if can?(:manage, Spree::Order)  %>
+
+    <%= link_to spree.new_admin_product_path, class: 'dropdown-item' do %>
+      <%= icon 'cube-plus' %>
+      <%= Spree.t(:new_product) %>
+    <% end if can?(:create, Spree::Product) %>
+    <%= link_to spree.new_admin_user_path, class: 'dropdown-item' do %>
+      <%= icon 'user-plus' %>
+      <%= Spree.t(:new_customer) %>
+    <% end if can?(:manage, Spree.user_class) %>
+
+    <%= link_to spree.new_admin_promotion_path, class: 'dropdown-item' do %>
+      <%= icon 'discount' %>
+      <%= Spree.t(:new_promotion) %>
+    <% end if can?(:create, Spree::Promotion) %>
+
+    <%= invite_vendor_button(class: 'dropdown-item') if defined?(invite_vendor_button) %>
+
+    <% if can?(:create, Spree::Store) %>
+      <div class="dropdown-divider"></div>
+
+      <span data-toggle="modal" data-target="#modal-lg">
+        <%= link_to_with_icon 'building-store', Spree.t(:new_store), spree.new_admin_store_path, class: 'dropdown-item', data: { turbo_frame: 'dialog_modal_lg' } %>
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/admin/app/views/spree/admin/shared/_no_resource_found.html.erb
+++ b/admin/app/views/spree/admin/shared/_no_resource_found.html.erb
@@ -1,6 +1,9 @@
 <% resource_name ||= model_class.name.demodulize.underscore.humanize %>
 
-<div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
-  <%= Spree.t(:no_resource_found, resource: resource_name) %>
-  <%= link_to_with_icon 'plus', Spree.t(:add_one), new_object_url, class: 'btn btn-light ml-3', data: { 'turbo-frame': '_top' } if can?(:create, model_class) && defined?(new_object_url) && new_object_url.present? %>
+<div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center flex-column">
+  <%= icon 'map-search', class: 'mb-3 opacity-50', style: 'font-size: 2rem;' %>
+  <p>
+    <%= Spree.t(:no_resource_found, resource: resource_name) %>
+  </p>
+  <%= link_to_with_icon 'plus', Spree.t(:add_one), new_object_url, class: 'btn btn-link btn-sm ml-3', data: { 'turbo-frame': '_top' } if can?(:create, model_class) && defined?(new_object_url) && new_object_url.present? %>
 </div>

--- a/admin/app/views/spree/admin/shared/_offcanvas_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/_offcanvas_nav.html.erb
@@ -1,19 +1,6 @@
 <!-- Left off-canvas sidebar -->
-<div class="bs-canvas bs-canvas-left position-fixed bg-black h-100">
+<div class="bs-canvas bs-canvas-left position-fixed h-100 bg-light border-right">
   <div class="bs-canvas-content px-2">
-    <div class="d-flex align-items-center font-weight-bold py-3 bg-black text-white border-bottom border-black sticky-top justify-content-between">
-      <div class="d-flex align-items-center">
-        <% if defined?(current_store) && current_store&.present? %>
-          <%= store_admin_icon(current_store, width: 36, height: 36) %>
-          <span class="ml-3 font-size-lg">
-            <%= truncate(current_store.name, length: 15) %>
-          </span>
-        <% end %>
-      </div>
-      <button class="btn py-0 bs-canvas-close text-white">
-        <%= icon('x', height: 18, class: 'mr-0') %>
-      </button>
-    </div>
     <% if try_spree_current_user.present? %>
       <% if defined?(current_vendor) && current_vendor.present? %>
         <%= render 'spree/admin/shared/sidebar/vendor_nav' %>

--- a/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
@@ -1,9 +1,12 @@
 <% if try_spree_current_user.present? %>
-  <div class="dropdown py-2 bg-gray-25 border-top" id="<%= dom_id(try_spree_current_user, 'account-dropdown') %>" data-turbo-permanent>
+  <div class="dropdown" id="<%= dom_id(try_spree_current_user, 'account-dropdown') %>" data-turbo-permanent>
     <button type="button"
           class="btn d-flex align-items-center justify-content-between text-left w-100 pr-0"
           data-toggle="dropdown" aria-expanded="false" id="accountNav">
-      <div class="d-flex align-items-center">
+      <%= render_avatar(try_spree_current_user, width: 32, height: 32) %>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right" style="min-width: 250px;">
+      <div class="d-flex align-items-center p-2 bg-gray-25 rounded-lg">
         <%= render_avatar(try_spree_current_user, width: 34, height: 34) %>
         <span class="d-none d-lg-inline ml-lg-2">
           <% if try_spree_current_user.name.present? %>
@@ -14,20 +17,25 @@
           <% end %>
         </span>
       </div>
-      <%= icon('dots-vertical', class: 'ml-auto text-muted') %>
-    </button>
-    <div class="dropdown-menu dropdown-menu-right w-100 mb-1 mt-1 mt-lg-0">
+
+      <%= render_admin_partials(:user_dropdown_partials) %>
+
       <% if can?(:update, try_spree_current_user) %>
+        <h6 class="dropdown-header mt-2">
+          <%= Spree.t('admin.account') %>
+        </h6>
         <%= link_to_with_icon 'user-scan', Spree.t('admin.edit_profile'), spree.edit_admin_profile_path, class: 'dropdown-item' %>
       <% end %>
 
       <% if can?(:manage, current_store) %>
-        <%= link_to_with_icon 'book', 'Help center', 'https://spreecommerce.org/docs/user', class: 'dropdown-item', target: '_blank' %>
-        <%= link_to_with_icon 'message-circle', 'Contact us', 'https://spreecommerce.org/contact/', class: 'dropdown-item', target: '_blank' %>
-        <div class="dropdown-divider"></div>
+        <h6 class="dropdown-header mt-2">
+          <%= Spree.t('admin.support') %>
+        </h6>
+        <%= external_link_to 'Help center', 'https://spreecommerce.org/docs/user', class: 'dropdown-item justify-content-between', target: '_blank' %>
+        <%= external_link_to 'Contact us', 'https://spreecommerce.org/contact/', class: 'dropdown-item justify-content-between', target: '_blank' %>
       <% end %>
 
-      <%= render_admin_partials(:user_dropdown_partials) %>
+      <div class="dropdown-divider"></div>
 
       <%= button_to spree_admin_logout_path, class: 'dropdown-item mb-0', method: :delete do %>
         <%= icon('logout', class: "icon icon-logout")  %>

--- a/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
@@ -22,17 +22,17 @@
 
       <% if can?(:update, try_spree_current_user) %>
         <h6 class="dropdown-header mt-2">
-          <%= Spree.t('admin.account') %>
+          <%= Spree.t(:account) %>
         </h6>
         <%= link_to_with_icon 'user-scan', Spree.t('admin.edit_profile'), spree.edit_admin_profile_path, class: 'dropdown-item' %>
       <% end %>
 
       <% if can?(:manage, current_store) %>
         <h6 class="dropdown-header mt-2">
-          <%= Spree.t('admin.support') %>
+          <%= Spree.t(:support) %>
         </h6>
-        <%= external_link_to 'Help center', 'https://spreecommerce.org/docs/user', class: 'dropdown-item justify-content-between', target: '_blank' %>
-        <%= external_link_to 'Contact us', 'https://spreecommerce.org/contact/', class: 'dropdown-item justify-content-between', target: '_blank' %>
+        <%= external_link_to Spree.t(:help_center), 'https://spreecommerce.org/docs/user', class: 'dropdown-item justify-content-between', target: '_blank' %>
+        <%= external_link_to Spree.t(:contact_us), 'https://spreecommerce.org/contact/', class: 'dropdown-item justify-content-between', target: '_blank' %>
       <% end %>
 
       <div class="dropdown-divider"></div>

--- a/admin/app/views/spree/admin/shared/sidebar/_products_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_products_nav.html.erb
@@ -1,6 +1,6 @@
 <% products_active =  %w[products external_categories taxons taxonomies option_types option_values properties stock_items stock_transfers].include?(controller_name) || request.path.include?('products') %>
 <% if can?(:manage, Spree::Product) %>
-  <%= nav_item(Spree.t(:products), spree.admin_products_path, icon: 'box-seam', active: products_active) %>
+  <%= nav_item(Spree.t(:products), spree.admin_products_path, icon: 'package', active: products_active) %>
   <% if products_active %>
     <ul class="ml-4 pl-1 mb-2 nav-submenu mt-1">
       <% if can?(:manage, Spree::StockItem) || can?(:manage, Spree::StockTransfer) %>

--- a/admin/app/views/spree/admin/shared/sidebar/_promotions_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_promotions_nav.html.erb
@@ -1,0 +1,17 @@
+<% if can?(:manage, Spree::Promotion) %>
+  <% discounts_active = %w[promotions gift_cards gift_card_batches coupon_codes].include?(controller_name) && @user.nil? %>
+  <li class="nav-item">
+    <%= active_link_to spree.admin_promotions_path, class: 'nav-link', active: discounts_active do %>
+      <%= icon 'discount' %>
+      <%= Spree.t(:promotions) %>
+    <% end %>
+
+    <% if discounts_active && defined?(Spree::GiftCard) && spree.respond_to?(:admin_gift_cards_path) && can?(:manage, Spree::GiftCard) %>
+      <ul class="ml-4 pl-1 mb-2 nav-submenu mt-1">
+        <li class="nav-item">
+          <%= active_link_to Spree.t(:gift_cards), spree.admin_gift_cards_path, class: 'nav-link', active: %w[gift_cards gift_card_batches].include?(controller_name) %>
+        </li>
+      </ul>
+    <% end %>
+  </li>
+<% end %>

--- a/admin/app/views/spree/admin/shared/sidebar/_store_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_dropdown.html.erb
@@ -1,46 +1,11 @@
-<% if available_stores.count > 1 %>
-  <div class="modal fade" id="switch-store-modal" tabindex="-1" role="dialog" aria-labelledby="switchStoreModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <%= modal_header(icon('switch-horizontal', class: 'mr-2') + Spree.t(:switch_store)) %>
-        <div class="modal-body">
-          <div class="list-group">
-            <% available_stores.each do |store| %>
-              <% if store.id != current_store.id %>
-                <%= link_to spree.admin_dashboard_url(host: store.url), class: 'list-group-item hover-light d-flex text-dark w-100 align-items-center text-primary' do %>
-                  <%= store_admin_icon(current_store, height: 32, width: 32) %>
-                  <span class="ml-3">
-                    <%= store.name %>
-                  </span>
-                <% end %>
-              <% else %>
-                <div class="list-group-item d-flex text-dark w-100 align-items-center cursor-disabled active">
-                  <%= store_admin_icon(current_store, height: 32, width: 32) %>
-                  <span class="ml-3">
-                    <%= store.name %>
-                  </span>
-
-                  <%= icon('check', class: 'ml-auto') %>
-                </div>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
-
-<div class="store-dropdown sticky-top" id="store-menu" data-turbo-permanent>
+<div class="store-dropdown" id="store-menu" data-turbo-permanent>
   <div class="dropdown">
-    <button type="button" class="btn d-flex align-items-center justify-content-between text-left dropdown-toggle d-flex align-items-center gap-2"
+    <button type="button" class="btn store-dropdown-button dropdown-toggle"
             data-toggle="dropdown" aria-expanded="false">
       <%= store_admin_icon(current_store, height: 32, width: 32) %>
-      <span class="d-none d-lg-block">
-        <%= truncate(current_store.name, length: 10) %>
-      </span>
+      <%= truncate(current_store.name, length: 10) %>
     </button>
-    <div class="dropdown-menu">
+    <div class="dropdown-menu ml-2">
       <%= link_to current_store.formatted_url_or_custom_domain, class: 'dropdown-item', target: '_blank' do %>
         <%= icon 'eye' %>
         <%= Spree.t(:view_store) %>
@@ -52,45 +17,38 @@
 
       <% if available_stores.count > 1 %>
         <div class="dropdown-divider"></div>
-        <%= link_to "#", class: 'dropdown-item mb-0', data: { toggle: 'modal', target: '#switch-store-modal' } do %>
-          <%= icon 'switch-horizontal' %>
+        <h6 class="dropdown-header">
           <%= Spree.t(:switch_store) %>
-        <% end %>
+        </h6>
+        <div class="store-chooser">
+          <% available_stores.each do |store| %>
+            <% if store.id == current_store.id %>
+              <div class="store-chooser-item active">
+                <%= store_admin_icon(store, height: 32, width: 32) %>
+                <span class="d-flex flex-column mr-2">
+                  <%= store.name %>
+                  <small class="text-muted">
+                    <%= store.url_or_custom_domain %>
+                  </small>
+                </span>
+                <%= icon('check', class: 'ml-auto') %>
+              </div>
+            <% else %>
+              <%= link_to spree.admin_dashboard_url(host: store.url), class: 'store-chooser-item' do %>
+                <%= store_admin_icon(store, height: 32, width: 32) %>
+                <span class="d-flex flex-column">
+                  <%= store.name %>
+                  <small class="text-muted">
+                    <%= store.url_or_custom_domain %>
+                  </small>
+                </span>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>
 
-  <div class="dropdown">
-    <button type="button" class="btn btn-sm btn-light shadow-xs" data-toggle="dropdown" aria-expanded="false">
-      <%= icon 'plus', class: 'mr-0' %>
-    </button>
-    <div class="dropdown-menu">
-      <%= link_to_with_icon 'shopping-bag-plus', Spree.t(:new_order), spree.admin_orders_path, class: "dropdown-item", data: { turbo_method: :post } if can?(:manage, Spree::Order)  %>
-
-      <%= link_to spree.new_admin_product_path, class: 'dropdown-item' do %>
-        <%= icon 'cube-plus' %>
-        <%= Spree.t(:new_product) %>
-      <% end if can?(:create, Spree::Product) %>
-      <%= link_to spree.new_admin_user_path, class: 'dropdown-item' do %>
-        <%= icon 'user-plus' %>
-        <%= Spree.t(:new_customer) %>
-      <% end if can?(:manage, Spree.user_class) %>
-
-      <%= link_to spree.new_admin_promotion_path, class: 'dropdown-item' do %>
-        <%= icon 'discount' %>
-        <%= Spree.t(:new_promotion) %>
-      <% end if can?(:create, Spree::Promotion) %>
-
-      <%= invite_vendor_button(class: 'dropdown-item') if defined?(invite_vendor_button) %>
-
-      <% if can?(:create, Spree::Store) %>
-        <div class="dropdown-divider"></div>
-
-        <span data-toggle="modal" data-target="#modal-lg">
-          <%= link_to_with_icon 'building-store', Spree.t(:new_store), spree.new_admin_store_path, class: 'dropdown-item', data: { turbo_frame: 'dialog_modal_lg' } %>
-        </span>
-      <% end %>
-    </div>
-  </div>
+  <%= render 'spree/admin/shared/new_item_dropdown' %>
 </div>
-

--- a/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
@@ -1,9 +1,5 @@
 <% if settings_active? %>
   <ul class="nav flex-column">
-    <li class="nav-item mb-1 py-2 border-bottom border-bottom-dashed">
-      <%= active_link_to_with_icon('arrow-back-up', Spree.t('admin.back_to_dashboard'), spree.admin_dashboard_path, class: 'nav-link') %>
-    </li>
-
     <% if can?(:manage, current_store) %>
       <%= nav_item(Spree.t(:store_details), spree.edit_admin_store_path(section: 'general-settings'), icon: 'building-store', active: params[:section] == 'general-settings') %>
     <% end %>
@@ -68,8 +64,6 @@
     <%= render_admin_partials(:store_settings_nav_partials) %>
   </ul>
 <% else %>
-  <%= render 'spree/admin/shared/sidebar/store_dropdown' %>
-
   <ul class="nav flex-column">
     <% unless current_store.setup_completed? %>
       <li class="nav-item">
@@ -105,23 +99,7 @@
       </li>
     <% end %>
 
-    <% if can?(:manage, Spree::Promotion) %>
-      <% discounts_active = %w[promotions gift_cards gift_card_batches coupon_codes].include?(controller_name) %>
-      <li class="nav-item">
-        <%= active_link_to spree.admin_promotions_path, class: 'nav-link', active: discounts_active do %>
-          <%= icon 'discount' %>
-          <%= Spree.t(:promotions) %>
-        <% end %>
-
-        <% if discounts_active && defined?(Spree::GiftCard) && spree.respond_to?(:admin_gift_cards_path) && can?(:manage, Spree::GiftCard) %>
-          <ul class="ml-4 pl-1 mb-2 nav-submenu mt-1">
-            <li class="nav-item">
-              <%= active_link_to Spree.t(:gift_cards), spree.admin_gift_cards_path, class: 'nav-link', active: %w[gift_cards gift_card_batches].include?(controller_name) %>
-            </li>
-          </ul>
-        <% end %>
-      </li>
-    <% end %>
+    <%= render 'spree/admin/shared/sidebar/promotions_nav' %>
 
     <% if can?(:manage, Spree::Report) %>
       <li class="nav-item">

--- a/admin/app/views/spree/admin/users/_user.html.erb
+++ b/admin/app/views/spree/admin/users/_user.html.erb
@@ -2,7 +2,7 @@
   <td class="pr-0 w-5">
     <%= bulk_operations_checkbox(user) %>
   </td>
-  <td class='w-50 no-wrap py-0 pl-1 pr-0'>
+  <td class='w-50 text-nowrap py-0 pl-1 pr-0'>
     <%= render 'spree/admin/shared/user', user: user %>
   </td>
   <td class="cursor-pointer" data-action="click->row-link#openLink">
@@ -12,7 +12,7 @@
     <%= customer_location_flag(user) %>
     <%= customer_location(user) %>
   </td>
-  <td class='w-10 no-wrap cursor-pointer' data-action="click->row-link#openLink"><%= user.completed_orders_for_store(current_store).count %></td>
-  <td class='w-10 no-wrap cursor-pointer' data-action="click->row-link#openLink"><%= user.display_amount_spent_in(current_currency) %></td>
-  <td class='w-10 no-wrap cursor-pointer' data-action="click->row-link#openLink"><%= local_time(user.created_at) %></td>
+  <td class='w-10 text-nowrap cursor-pointer' data-action="click->row-link#openLink"><%= user.completed_orders_for_store(current_store).count %></td>
+  <td class='w-10 text-nowrap cursor-pointer' data-action="click->row-link#openLink"><%= user.display_amount_spent_in(current_currency) %></td>
+  <td class='w-10 text-nowrap cursor-pointer' data-action="click->row-link#openLink"><%= local_time(user.created_at) %></td>
 </tr>

--- a/admin/lib/spree/admin.rb
+++ b/admin/lib/spree/admin.rb
@@ -4,6 +4,7 @@ require 'spree_api'
 require 'sprockets/railtie'
 
 require 'active_link_to'
+require 'breadcrumbs_on_rails'
 require 'chartkick'
 require 'currency_select'
 require 'groupdate'

--- a/admin/spree_admin.gemspec
+++ b/admin/spree_admin.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'active_link_to'
   s.add_dependency 'bootstrap', '~> 4.6', '>= 4.6.2.1'
+  s.add_dependency 'breadcrumbs_on_rails', '~> 4.1'
   s.add_dependency 'chartkick', '~> 5.0'
   s.add_dependency 'currency_select'
   s.add_dependency 'dartsass-rails', '~> 0.5'


### PR DESCRIPTION
As we have a lot of nested resources this will improve the UX

![CleanShot 2025-04-27 at 20 56 37@2x](https://github.com/user-attachments/assets/a068c2d3-08bd-44c1-adf8-90cad675cac4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced breadcrumb navigation throughout the admin interface for improved context and navigation, including breadcrumb icons and hierarchical links for resources like products, promotions, storefront, and users.
  - Added a new dropdown menu for quick creation of orders, products, customers, promotions, and stores.
  - Implemented a new sidebar navigation for promotions and gift cards.

- **Enhancements**
  - Redesigned the admin header and sidebar for a cleaner layout, improved dropdowns, and more accessible navigation.
  - Updated store switching to an inline dropdown list for faster access.
  - Updated user dropdown menu with improved structure and grouping.
  - Refined "no resource found" messaging with clearer layout and iconography.
  - Added creation and update timestamps to the promotion details sidebar.
  - Changed edit page titles to display user-facing labels instead of internal names for option types and properties.

- **Style**
  - Unified and updated color variables and background styles across admin components for consistency.
  - Improved breadcrumb, form, and navigation styling for better clarity and accessibility.
  - Updated icons in navigation and sidebar for visual consistency.

- **Chores**
  - Added the `breadcrumbs_on_rails` gem as a new dependency to support breadcrumb navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->