### PR TITLE
Add `Spree::Order#analytics_subtotal`

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -249,6 +249,10 @@ module Spree
       pre_tax_item_amount + shipments.sum(:pre_tax_amount)
     end
 
+    def analytics_subtotal
+      (item_total + line_items.sum(:promo_total)).to_f
+    end
+
     def shipping_discount
       shipment_adjustments.non_tax.eligible.sum(:amount) * - 1
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -249,6 +249,9 @@ module Spree
       pre_tax_item_amount + shipments.sum(:pre_tax_amount)
     end
 
+    # Returns the subtotal used for analytics integrations
+    # It's a sum of the item total and the promo total
+    # @return [Float]
     def analytics_subtotal
       (item_total + line_items.sum(:promo_total)).to_f
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1070,6 +1070,20 @@ describe Spree::Order, type: :model do
     end
   end
 
+  describe '#analytics_subtotal' do
+    let(:order) { create(:order_with_line_items, line_items_count: 2) }
+
+    before do
+      order.update_column(:item_total, 100)
+      order.line_items[0].update_column(:promo_total, 10)
+      order.line_items[1].update_column(:promo_total, 5)
+    end
+
+    it 'returns the subtotal used for analytics integrations' do
+      expect(order.analytics_subtotal).to eq(115)
+    end
+  end
+
   describe '#quantity' do
     # Uses a persisted record, as the quantity is retrieved via a DB count
     let(:order) { create :order_with_line_items, line_items_count: 3 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new subtotal calculation for orders that includes promotional totals from all line items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->