### PR TITLE
Remove `Capybara.app_host` from `spec_helper`

### DIFF
--- a/storefront/spec/spec_helper.rb
+++ b/storefront/spec/spec_helper.rb
@@ -97,7 +97,6 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
-  Capybara.app_host = 'http://app.' + Spree.root_domain
   Capybara.server_port = 3000
   Capybara.test_id = 'data-test-id'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test configuration by removing the explicit base URL setting for Capybara in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->