### PR TITLE
Add `Spree::Account::OrdersController#load_order_details` to load order and its shipments

### DIFF
--- a/storefront/app/controllers/spree/account/orders_controller.rb
+++ b/storefront/app/controllers/spree/account/orders_controller.rb
@@ -1,16 +1,15 @@
 module Spree
   module Account
     class OrdersController < BaseController
+      before_action :load_order_details, only: :show
+
       # GET /account/orders
       def index
         @orders = orders_scope.order(created_at: :desc).page(params[:page]).per(25)
       end
 
       # GET /account/orders/:id
-      def show
-        @order = orders_scope.find_by!(number: params[:id])
-        @shipments = @order.shipments.includes(:stock_location, :address, selected_shipping_rate: :shipping_method, inventory_units: :line_item)
-      end
+      def show; end
 
       private
 
@@ -28,6 +27,11 @@ module Spree
 
       def order_finder
         Spree::Dependencies.completed_order_finder.constantize
+      end
+
+      def load_order_details
+        @order = orders_scope.find_by!(number: params[:id])
+        @shipments = @order.shipments.includes(:stock_location, :address, selected_shipping_rate: :shipping_method, inventory_units: :line_item)
       end
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of order details when viewing individual orders in the account section. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->