### PR TITLE
V-3074 FIX restore taxonomies edit page

### DIFF
--- a/admin/app/controllers/spree/admin/taxonomies_controller.rb
+++ b/admin/app/controllers/spree/admin/taxonomies_controller.rb
@@ -6,11 +6,6 @@ module Spree
 
       before_action :add_breadcrumbs
 
-      def edit
-        super
-        redirect_to spree.admin_taxonomy_taxon_path(@taxonomy, @taxonomy.root.id)
-      end
-
       private
 
       def collection

--- a/admin/spec/controllers/spree/admin/taxonomies_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/taxonomies_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Spree::Admin::TaxonomiesController do
   stub_authorization!
+  render_views
 
   describe '#edit' do
     let(:taxonomy) { create(:taxonomy) }
@@ -10,7 +11,7 @@ describe Spree::Admin::TaxonomiesController do
       get :edit, params: { id: taxonomy.id }
     end
 
-    it 'redirects to taxonomy edit path' do
+    it 'renders edit taxonomy view' do
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:edit)
     end

--- a/admin/spec/controllers/spree/admin/taxonomies_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/taxonomies_controller_spec.rb
@@ -5,22 +5,14 @@ describe Spree::Admin::TaxonomiesController do
 
   describe '#edit' do
     let(:taxonomy) { create(:taxonomy) }
-    let(:taxonomy_id) { taxonomy.id }
 
     before do
-      get :edit, params: { id: taxonomy_id }
+      get :edit, params: { id: taxonomy.id }
     end
 
-    it 'redirects to taxonomy taxon path' do
-      expect(response).to redirect_to(spree.admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id))
-    end
-
-    context 'when taxonomy not found' do
-      let(:taxonomy_id) { 'not_existing' }
-
-      it 'redirects to admin taxonomies path' do
-        expect(response).to redirect_to(spree.admin_taxonomies_path)
-      end
+    it 'redirects to taxonomy edit path' do
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:edit)
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the taxonomy editing experience in the admin area to display the standard edit page instead of redirecting to the root taxon.
- **Tests**
  - Adjusted tests to verify that editing a taxonomy now shows the edit page as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->