### PR TITLE
Add `Spree::Invitation#accept` ability for users

### DIFF
--- a/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
@@ -226,12 +226,11 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
   end
 
   describe 'PUT #accept' do
-    stub_authorization!
-
     let(:invitation) { create(:invitation, inviter: admin_user, invitee: another_user, resource: store) }
     let(:another_user) { create(:user) }
 
     before do
+      allow(controller).to receive(:current_ability).and_return(Spree::Dependencies.ability_class.constantize.new(another_user))
       allow(controller).to receive(:try_spree_current_user).and_return(another_user)
       put :accept, params: { id: invitation.id }
     end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -57,7 +57,7 @@ module Spree
       alias_action :create, :update, :destroy, to: :modify
     end
 
-    def apply_admin_permissions(user, options)
+    def apply_admin_permissions(_user, _options)
       can :manage, :all
       cannot :cancel, Spree::Order
       can :cancel, Spree::Order, &:allow_cancel?
@@ -65,7 +65,7 @@ module Spree
       cannot [:edit, :update], Spree::ReimbursementType, mutable: false
     end
 
-    def apply_user_permissions(user, options)
+    def apply_user_permissions(user, _options)
       can :read, ::Spree::Country
       can :read, ::Spree::OptionType
       can :read, ::Spree::OptionValue
@@ -96,6 +96,7 @@ module Spree
       can [:create, :update, :destroy], ::Spree::WishedItem do |wished_item|
         wished_item.wishlist.user == user
       end
+      can :accept, Spree::Invitation, invitee_id: [user.id, nil], status: 'pending', expires_at: Time.current..
     end
 
     def protect_admin_role

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -96,7 +96,7 @@ module Spree
       can [:create, :update, :destroy], ::Spree::WishedItem do |wished_item|
         wished_item.wishlist.user == user
       end
-      can :accept, Spree::Invitation, invitee_id: [user.id, nil], status: 'pending'
+      can :accept, Spree::Invitation, invitee_id: [user.id, nil], invitee_type: user.class.name, status: 'pending'
     end
 
     def protect_admin_role

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -96,7 +96,7 @@ module Spree
       can [:create, :update, :destroy], ::Spree::WishedItem do |wished_item|
         wished_item.wishlist.user == user
       end
-      can :accept, Spree::Invitation, invitee_id: [user.id, nil], status: 'pending', expires_at: Time.current..
+      can :accept, Spree::Invitation, invitee_id: [user.id, nil], status: 'pending'
     end
 
     def protect_admin_role

--- a/core/app/models/spree/invitation.rb
+++ b/core/app/models/spree/invitation.rb
@@ -38,6 +38,7 @@ module Spree
     #
     state_machine initial: :pending, attribute: :status do
       state :accepted do
+        validate :accept_invitation_within_time_limit
         validates :invitee, presence: true
       end
 
@@ -141,6 +142,12 @@ module Spree
       return if invitee.present?
 
       self.invitee = Spree.admin_user_class.find_by(email: email)
+    end
+
+    def accept_invitation_within_time_limit
+      if Time.current > expires_at
+        errors.add(:base, 'Invitation expired')
+      end
     end
   end
 end

--- a/core/spec/models/spree/invitation_spec.rb
+++ b/core/spec/models/spree/invitation_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe Spree::Invitation, type: :model do
       end
     end
 
+    context 'when invitation is accepted after expiration' do
+      it 'is invalid' do
+        invitation.expires_at = 1.day.ago
+        expect(invitation.accept).to be_falsey
+
+        expect(invitation.accepted_at).not_to be_present
+        expect(invitation.status).to eq('pending')
+        expect(invitation.errors[:base]).to include('Invitation expired')
+      end
+    end
+
     context 'when invitee already exists in the store' do
       it 'is invalid' do
         create(:admin_user, email: 'existing@example.com')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now only accept invitations if they have not expired; expired invitations cannot be accepted and will display an error message.

- **Bug Fixes**
  - Improved permission rules to ensure only eligible users can accept pending invitations addressed to them or unassigned.

- **Tests**
  - Added tests to verify that expired invitations cannot be accepted and display the appropriate error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->