### PR TITLE
fix: assign admin to new store

### DIFF
--- a/admin/app/controllers/spree/admin/stores_controller.rb
+++ b/admin/app/controllers/spree/admin/stores_controller.rb
@@ -24,6 +24,12 @@ module Spree
             @store.add_user(role_user.user, role_user.role)
           end
 
+          # Assigns the current user as an admin for the new store
+          Spree::Role
+            .find_by(name: Spree::Role::ADMIN_ROLE)
+            .role_users
+            .create!(user: try_spree_current_user, resource: @store)
+
           flash[:success] = flash_message_for(@store, :successfully_created)
           # redirect in view, Turbo doesn't support redirecting to a different host
         else

--- a/admin/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -42,6 +42,13 @@ describe Spree::Admin::StoresController do
       expect(new_store.default_locale).to eq('en')
       expect(new_store.users).to contain_exactly(user, user2)
     end
+
+    it 'adds the current user as an admin for the store' do
+      expect { subject }.to change(Spree::RoleUser, :count).by(1)
+
+      new_store = Spree::Store.last
+      expect(new_store.admin_users).to include(user)
+    end
   end
 
   describe 'PUT #update' do


### PR DESCRIPTION
### Description
When a new store is created from an existing one, the admin role was not being assigned to the user, which caused the user to be unable to access the store's admin interface. If the user tried to navigate to `/admin`, they were redirected to `/admin/forbidden`.

This PR addresses the issue by ensuring that the user who creates a new store is assigned the admin role for the new store.

### Solution:
- In the `create` action of `Spree::Admin::StoresController`, after creating a new store, the current user is added as an admin for the new store.
- A new test has been added in `Spree::Admin::StoresController` to confirm that the current user is granted admin access to the new store.

### Impact:
This fix ensures that the user has the proper admin role assigned and can access the `/admin` interface for the new store they have created.

### Checklist:
- [x] Ensure the user is assigned the admin role when a new store is created.
- [x] Update test to verify the new behavior.
- [x] Ensure there is no redirection to `/admin/forbidden` for the user who creates the store.
