### PR TITLE
Fix `.rubocop.yml` in the spree extension template

### DIFF
--- a/cli/lib/spree_cli/templates/extension/.rubocop.yml
+++ b/cli/lib/spree_cli/templates/extension/.rubocop.yml
@@ -1,3 +1,5 @@
+plugins: rubocop-rails
+
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 3.3
@@ -9,10 +11,7 @@ AllCops:
     - 'spec/dummy/**/*'
     - 'lib/generators/**/*'
 
-Rails:
-  Enabled: true
-
-Metrics/LineLength:
+Layout/LineLength:
   Max: 150
 
 # DISABLED

--- a/cli/lib/spree_cli/templates/extension/.rubocop.yml
+++ b/cli/lib/spree_cli/templates/extension/.rubocop.yml
@@ -1,4 +1,5 @@
-plugins: rubocop-rails
+plugins:
+  - rubocop-rails
 
 AllCops:
   DisplayCopNames: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated code style configuration to explicitly include Rails support and align with current naming conventions for line length enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->