### PR TITLE
Cast `say_no` and `say_yes` translations to string, since they can be parsed to bool

### DIFF
--- a/admin/app/helpers/spree/admin/navigation_helper.rb
+++ b/admin/app/helpers/spree/admin/navigation_helper.rb
@@ -190,7 +190,7 @@ module Spree
       # @return [String] the badge with the icon
       def active_badge(condition, options = {})
         label = options[:label]
-        label ||= condition ? Spree.t(:say_yes) : Spree.t(:say_no)
+        label ||= condition ? Spree.t(:say_yes).to_s : Spree.t(:say_no).to_s
         label = icon('check') + label if condition
 
         css_class = condition ? 'badge-active' : 'badge-inactive'

--- a/admin/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/_form.html.erb
@@ -55,7 +55,7 @@
         </div>
         <div class="form-group">
           <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>
-          <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {class: 'custom-select'}) %>
+          <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes).to_s, true], [Spree.t(:say_no).to_s, false]], {}, {class: 'custom-select'}) %>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of option labels in the payment method form to ensure correct display of "yes" and "no" choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->