### PR TITLE
Added missing `selected_locale` for admin users table

### DIFF
--- a/core/db/migrate/20250508060800_add_selected_locale_to_spree_admin_users.rb
+++ b/core/db/migrate/20250508060800_add_selected_locale_to_spree_admin_users.rb
@@ -1,0 +1,8 @@
+class AddSelectedLocaleToSpreeAdminUsers < ActiveRecord::Migration[7.2]
+  def change
+    if Spree.admin_user_class.present?
+      users_table_name = Spree.admin_user_class.table_name
+      add_column users_table_name, :selected_locale, :string unless column_exists?(users_table_name, :selected_locale)
+    end
+  end
+end


### PR DESCRIPTION
If it's different than users table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for storing a selected locale preference for admin users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->