### PR TITLE
fix: correct landing_page field name in dashboard analytics

### DIFF
--- a/admin/app/controllers/spree/admin/dashboard_controller.rb
+++ b/admin/app/controllers/spree/admin/dashboard_controller.rb
@@ -139,7 +139,7 @@ module Spree
                                                             default_value: 0)
                   end
 
-        @top_landing_pages = @visits_scope.where.not(landing_page_title: [nil, '']).top(:landing_page_title, 10)
+        @top_landing_pages = @visits_scope.where.not(landing_page: [nil, '']).top(:landing_page, 10)
         @top_referrers = @visits_scope.where.not(referring_domain: current_store.custom_domains.pluck(:url) << current_store.url).top(
           :referring_domain, 10
         )


### PR DESCRIPTION
### Summary
While upgrading the app to Spree v5, I encountered the following error on the admin dashboard:

```sh
ActiveRecord::StatementInvalid in Spree::Admin::DashboardController#analytics

PG::UndefinedColumn: ERROR: column "landing_page_title" does not exist
LINE 1: SELECT COUNT(*) AS "count_all", "landing_page_title" AS "lan...
```
### Investigation
The error originates from a query in Spree::Admin::DashboardController that references a column named `landing_page_title`.

However, upon checking the Ahoy migration generator template, I confirmed that no such column exists. The correct column is `landing_page`.

Even in the historical versions of the Ahoy migration template ([source code link](https://github.com/ankane/ahoy/blob/d20699cac07d9a29174b2ba2107fef9428349076/lib/generators/ahoy/templates/active_record_migration.rb.tt#L18)), there has never been a `landing_page_title` column.

### Fix
Updated the query to use the correct column: landing_page.
This fix ensures compatibility with the default Ahoy schema.
It resolves the error and restores functionality to the admin analytics dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of top landing pages in analytics by updating the filtering and aggregation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->