### PR TITLE
Automatically inject theme CSS class name to body elements in storefront

### DIFF
--- a/storefront/app/views/layouts/spree/checkout.html.erb
+++ b/storefront/app/views/layouts/spree/checkout.html.erb
@@ -8,7 +8,7 @@
     <%= render 'spree/shared/head' %>
     <%= render 'spree/shared/custom_head' %>
   </head>
-  <body id="checkout-page" class="w-full bg-background text-text">
+  <body id="checkout-page" class="theme-<%= current_theme.class.name.demodulize.underscore %> w-full bg-background text-text">
     <%= render_storefront_partials(:body_start_partials) %>
     <%= current_store.storefront_custom_code_body_start&.html_safe %>
 

--- a/storefront/app/views/layouts/spree/storefront.html.erb
+++ b/storefront/app/views/layouts/spree/storefront.html.erb
@@ -6,7 +6,7 @@
     <%= render 'spree/shared/json_ld' %>
     <%= current_store.storefront_custom_code_head&.html_safe %>
   </head>
-  <body class="bg-background w-full text-text <%= current_page&.slug %>-page <% if current_theme_preview.present? %>inside-page-builder<% end %>">
+  <body class="theme-<%= current_theme.class.name.demodulize.underscore %> bg-background w-full text-text <%= current_page&.slug %>-page <% if current_theme_preview.present? %>inside-page-builder<% end %>">
     <%= render_storefront_partials(:body_start_partials) %>
     <%= current_store.storefront_custom_code_body_start&.html_safe %>
 


### PR DESCRIPTION
For easier CSS styling when using multiple themes on a single Spree instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic theme-specific classes to the checkout and storefront pages, enabling enhanced theme-based styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->