### PR TITLE
Checkout: skip displaying a variant as backordered if the inventory is not tracked

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -458,6 +458,7 @@ module Spree
     # @return [Array<Spree::Variant>] the backordered variants for the order
     def backordered_variants
       variants.
+        where(track_inventory: true).
         joins(:stock_items, :product).
         where(Spree::StockItem.table_name => { count_on_hand: ..0, backorderable: true })
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2016,6 +2016,7 @@ describe Spree::Order, type: :model do
     let(:order) { create(:order) }
     let(:variant) { create(:variant) }
     let(:variant_2) { create(:variant) }
+    let(:variant_3) { create(:variant, track_inventory: false) }
 
     before do
       create(:line_item, order: order, variant: variant, quantity: 1)
@@ -2023,6 +2024,9 @@ describe Spree::Order, type: :model do
 
       create(:line_item, order: order, variant: variant_2, quantity: 1)
       variant_2.stock_items.first.update(count_on_hand: 1, backorderable: true)
+
+      create(:line_item, order: order, variant: variant_3, quantity: 1)
+      variant_3.stock_items.first.update(count_on_hand: 0, backorderable: true)
     end
 
     it 'returns the backordered variants' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of backordered items by ensuring only variants that track inventory are included in backorder listings.

- **Tests**
  - Enhanced test coverage to confirm that non-inventory-tracked items are excluded from backordered variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->