### PR TITLE
Page builder: ability to add more blocks to in sections

### DIFF
--- a/admin/app/views/spree/admin/page_builder/_sidebar_block.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_sidebar_block.html.erb
@@ -7,15 +7,16 @@
                                      } do %>
     <div class="d-flex align-items-center justify-content-between sidebar-block-title p-1 rounded-sm">
       <div class="d-flex align-items-center flex-fill">
-        <%= icon "#{block.icon_name}", class: 'mr-2' if block.icon_name.present? %>
-        <%= link_to block.display_name, edit_admin_page_section_block_path(block.section, block),
-                    class: 'block-edit-link flex-fill text-dark',
-                    data: {
-                      turbo_frame: :page_sidebar,
-                      action: 'click->page-builder#makeOverlayActive',
-                      page_builder_editor_id_param: "block-#{block.id}"
-                    }
-        %>
+        <%= link_to(edit_admin_page_section_block_path(block.section, block),
+          class: 'block-edit-link flex-fill text-dark',
+          data: {
+            turbo_frame: :page_sidebar,
+            action: 'click->page-builder#makeOverlayActive',
+            page_builder_editor_id_param: "block-#{block.id}"
+          }) do %>
+          <%= icon "#{block.icon_name}", class: 'mr-2' if block.icon_name.present? %>
+          <%= block.display_name %>
+        <% end %>
       </div>
       <div class="d-flex align-items-center d-none">
         <% if block.section.can_sort_blocks? %>

--- a/core/app/models/spree/page_blocks/products/buy_buttons.rb
+++ b/core/app/models/spree/page_blocks/products/buy_buttons.rb
@@ -6,6 +6,14 @@ module Spree
         BOTTOM_PADDING_DEFAULT = 20
 
         preference :text_color, :string
+
+        def icon_name
+          'shopping-cart-plus'
+        end
+
+        def display_name
+          Spree.t('page_blocks.products.buy_buttons.display_name')
+        end
       end
     end
   end

--- a/core/app/models/spree/page_blocks/products/quantity_selector.rb
+++ b/core/app/models/spree/page_blocks/products/quantity_selector.rb
@@ -6,6 +6,10 @@ module Spree
         BOTTOM_PADDING_DEFAULT = 20
 
         preference :text_color, :string
+
+        def icon_name
+          'selector'
+        end
       end
     end
   end

--- a/core/app/models/spree/page_blocks/products/variant_picker.rb
+++ b/core/app/models/spree/page_blocks/products/variant_picker.rb
@@ -3,6 +3,10 @@ module Spree
     module Products
       class VariantPicker < Spree::PageBlock
         preference :text_color, :string
+
+        def icon_name
+          'select'
+        end
       end
     end
   end

--- a/core/app/models/spree/page_sections/featured_product.rb
+++ b/core/app/models/spree/page_sections/featured_product.rb
@@ -41,6 +41,10 @@ module Spree
       def blocks_available?
         true
       end
+
+      def can_sort_blocks?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/page_sections/image_banner.rb
+++ b/core/app/models/spree/page_sections/image_banner.rb
@@ -26,7 +26,19 @@ module Spree
         ]
       end
 
+      def available_blocks_to_add
+        [
+          Spree::PageBlocks::Buttons,
+          Spree::PageBlocks::Heading,
+          Spree::PageBlocks::Text
+        ]
+      end
+
       def blocks_available?
+        true
+      end
+
+      def can_sort_blocks?
         true
       end
 

--- a/core/app/models/spree/page_sections/image_with_text.rb
+++ b/core/app/models/spree/page_sections/image_with_text.rb
@@ -27,6 +27,14 @@ module Spree
         ]
       end
 
+      def available_blocks_to_add
+        [
+          Spree::PageBlocks::Buttons,
+          Spree::PageBlocks::Heading,
+          Spree::PageBlocks::Text
+        ]
+      end
+
       def default_links
         @default_links.presence || [
           Spree::PageLink.new(
@@ -37,6 +45,10 @@ module Spree
       end
 
       def blocks_available?
+        true
+      end
+
+      def can_sort_blocks?
         true
       end
 

--- a/core/app/models/spree/page_sections/rich_text.rb
+++ b/core/app/models/spree/page_sections/rich_text.rb
@@ -8,7 +8,18 @@ module Spree
         ]
       end
 
+      def available_blocks_to_add
+        [
+          Spree::PageBlocks::Heading,
+          Spree::PageBlocks::Text
+        ]
+      end
+
       def blocks_available?
+        true
+      end
+
+      def can_sort_blocks?
         true
       end
 

--- a/core/app/models/spree/page_sections/video.rb
+++ b/core/app/models/spree/page_sections/video.rb
@@ -44,11 +44,19 @@ module Spree
         ]
       end
 
+      def available_blocks_to_add
+        [Spree::PageBlocks::Heading]
+      end
+
       def icon_name
         'movie'
       end
 
       def blocks_available?
+        true
+      end
+
+      def can_sort_blocks?
         true
       end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1455,6 +1455,9 @@ en:
     package_from: package from
     page: Page
     page_blocks:
+      products:
+        buy_buttons:
+          display_name: Add To Cart
       buttons:
         display_name: Button
       link:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1455,9 +1455,6 @@ en:
     package_from: package from
     page: Page
     page_blocks:
-      products:
-        buy_buttons:
-          display_name: Add To Cart
       buttons:
         display_name: Button
       link:
@@ -1467,6 +1464,9 @@ en:
       newsletter_form:
         button_text_default: Submit
         placeholder_default: Enter your email
+      products:
+        buy_buttons:
+          display_name: Add To Cart
     page_not_found: Sorry! Page you are looking can’t be found.
     page_sections:
       announcement_bar:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sidebar block titles now have a single clickable area that includes both the icon and display name.
  - Added icons and localized display names for product buy buttons, quantity selectors, and variant pickers in page blocks.
  - Page sections (Featured Product, Image Banner, Image With Text, Rich Text, Video) now support specifying which blocks can be added and allow block reordering.

- **Documentation**
  - Added a new translation for "Add To Cart" for product buy buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->