### PR TITLE
Add ability to customize the quantity picker Stimulus controller

### DIFF
--- a/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
@@ -1,3 +1,5 @@
+import { Controller } from "@hotwired/stimulus"
+
 export default class extends Controller {
   static targets = [ 'quantity', 'increase', 'decrease' ]
 

--- a/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
@@ -1,43 +1,47 @@
-import { Controller } from "@hotwired/stimulus"
-
 export default class extends Controller {
   static targets = [ 'quantity', 'increase', 'decrease' ]
 
+  static values = {
+    min: { type: Number, default: 1 },
+    max: { type: Number, default: 9999 },
+    disableClass: { type: String, default: 'opacity-50 cursor-not-allowed' }
+  }
+
   connect() {
-    if (this.quantity <= 1) this.disableButton(this.decreaseTarget)
+    if (this.quantity <= this.minValue) this.disableButton(this.decreaseTarget)
   }
 
   get quantity() {
-    return parseInt(this.quantityTarget.value) || 1
+    return parseInt(this.quantityTarget.value) || this.minValue
   }
 
   get maxQuantity() {
-    return parseInt(this.quantityTarget.max) || 9999
+    return parseInt(this.quantityTarget.max) || this.maxValue
   }
 
   set quantity(value) {
-    this.quantityTarget.value = parseInt(value) || 1
+    this.quantityTarget.value = parseInt(value) || this.minValue
   }
 
   increase() {
     if (this.quantity < this.maxQuantity) this.quantity = this.quantity + 1
-    if (this.quantity > 1) this.enableButton(this.decreaseTarget)
+    if (this.quantity > this.minValue) this.enableButton(this.decreaseTarget)
     if (this.quantity == this.maxQuantity && this.increaseTarget.type != 'submit') this.disableButton(this.increaseTarget)
   }
 
   decrease() {
-    if (this.quantity > 1) this.quantity = this.quantity - 1
-    if (this.quantity == 1 && this.decreaseTarget.type != 'submit') this.disableButton(this.decreaseTarget)
+    if (this.quantity > this.minValue) this.quantity = this.quantity - 1
+    if (this.quantity == this.minValue && this.decreaseTarget.type != 'submit') this.disableButton(this.decreaseTarget)
     if (this.quantity < this.maxQuantity) this.enableButton(this.increaseTarget)
   }
 
   disableButton(button) {
     button.setAttribute('disabled', 'disabled')
-    button.classList.add('opacity-50', 'cursor-not-allowed')
+    this.disableClassValue.split(' ').forEach(className => button.classList.add(className))
   }
 
   enableButton(button) {
     button.removeAttribute('disabled')
-    button.classList.remove('opacity-50', 'cursor-not-allowed')
+    this.disableClassValue.split(' ').forEach(className => button.classList.remove(className))
   }
 }

--- a/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = [ 'quantity', 'increase', 'decrease' ]
 
   static values = {
-    min: { type: Number, default: 0 },
+    min: { type: Number, default: 1 },
     max: { type: Number, default: 9999 }
   }
 

--- a/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/quantity_picker_controller.js
@@ -4,10 +4,11 @@ export default class extends Controller {
   static targets = [ 'quantity', 'increase', 'decrease' ]
 
   static values = {
-    min: { type: Number, default: 1 },
-    max: { type: Number, default: 9999 },
-    disableClass: { type: String, default: 'opacity-50 cursor-not-allowed' }
+    min: { type: Number, default: 0 },
+    max: { type: Number, default: 9999 }
   }
+
+  static classes = ['disabled']
 
   connect() {
     if (this.quantity <= this.minValue) this.disableButton(this.decreaseTarget)
@@ -39,11 +40,11 @@ export default class extends Controller {
 
   disableButton(button) {
     button.setAttribute('disabled', 'disabled')
-    this.disableClassValue.split(' ').forEach(className => button.classList.add(className))
+    button.classList.add(...this.disabledClasses)
   }
 
   enableButton(button) {
     button.removeAttribute('disabled')
-    this.disableClassValue.split(' ').forEach(className => button.classList.remove(className))
+    button.classList.remove(...this.disabledClasses)
   }
 }

--- a/storefront/app/views/themes/default/spree/orders/_line_item_quantity.html.erb
+++ b/storefront/app/views/themes/default/spree/orders/_line_item_quantity.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center">
   <%= form_for line_item, url: spree.line_item_url(line_item, order_token: line_item.order.token), data: { controller: 'turbo-stream-form' } do |item_form| %>
-    <div class="quantity-picker" data-controller="quantity-picker">
+    <div class="quantity-picker" data-controller="quantity-picker" data-quantity-picker-disabled-class="opacity-50 cursor-not-allowed">
       <!-- this is a dummy button to work with turbo frame forms when hitting ENTER -->
       <%= button_tag render('spree/shared/icons/minus'), type: 'submit', class: 'hidden' %>
       <%= quantity_modifier_button_tag render('spree/shared/icons/minus'), type: 'submit', action: 'decrease', class: 'quantity-decrease-button' %>


### PR DESCRIPTION
eg. allow line items with 0 quantity, customize the CSS classes for disabled elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quantity picker now supports configurable minimum and maximum values, as well as customizable styles for disabled buttons.

- **Refactor**
  - Improved consistency and flexibility by centralizing quantity limits and disabled button styles into configurable options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->