### PR TITLE
Fix incorrect namespacing in Spree extension creation example

### DIFF
--- a/docs/developer/contributing/creating-an-extension.mdx
+++ b/docs/developer/contributing/creating-an-extension.mdx
@@ -99,7 +99,7 @@ module SpreeSimpleSales
   end
 end
 
-Spree::HomeController.prepend SpreeSimpleSalesSpree::HomeControllerDecorator
+Spree::HomeController.prepend SpreeSimpleSales::Spree::HomeControllerDecorator
 ```
 
 This will select just the products that have a variant with a `sale_price` set.


### PR DESCRIPTION
This PR corrects a code example in the "Creating a Spree Extension" documentation. The original example used `SpreeSimpleSalesSpree`, which is not properly namespaced. It has been updated to `SpreeSimpleSales::Spree` to follow Ruby conventions and ensure consistency with how Spree engines should be defined.

This change helps prevent confusion for developers following the guide and aligns the documentation with best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a namespace reference in the extension creation guide to ensure accurate module usage in code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->