### PR TITLE
Fix more found incorrect namespacing in Spree extension creation example (related to #12740)

### DIFF
--- a/docs/developer/contributing/creating-an-extension.mdx
+++ b/docs/developer/contributing/creating-an-extension.mdx
@@ -93,7 +93,7 @@ module SpreeSimpleSales
   module Spree
     module HomeControllerDecorator
       def sale
-        @products = Spree::Product.joins(:variants_including_master).where('spree_variants.sale_price is not null').distinct
+        @products = ::Spree::Product.joins(:variants_including_master).where('spree_variants.sale_price is not null').distinct
       end
     end
   end
@@ -156,13 +156,13 @@ module SpreeSimpleSales
     module VariantDecorator
       def price_in(currency)
         return super unless sale_price.present?
-        Spree::Price.new(variant_id: self.id, amount: self.sale_price, currency: currency)
+        ::Spree::Price.new(variant_id: self.id, amount: self.sale_price, currency: currency)
       end
     end
   end
 end
 
-Spree::Variant.prepend SpreeSimpleSalesSpree::VariantDecorator
+Spree::Variant.prepend SpreeSimpleSales::Spree::VariantDecorator
 ```
 
 If there is a `sale_price` present on the product's master variant, we return that price. Otherwise, we call the original implementation of `price_in` using `return super`.


### PR DESCRIPTION
This PR corrects a code example in the "Creating a Spree Extension" documentation. Fixing the more found incorrect namespacing. One of them fixed in #12740.

A documentation example is updated to correct the namespace reference for a module in a code snippet ensuring the module path uses the correct separator and preventing constant lookup errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify namespace usage in extension examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->