### PR TITLE
Storefront - Wished Items endpoint - remove skipping authenticity tok…

### DIFF
--- a/storefront/app/controllers/spree/account/wished_items_controller.rb
+++ b/storefront/app/controllers/spree/account/wished_items_controller.rb
@@ -1,8 +1,6 @@
 module Spree
   module Account
     class WishedItemsController < BaseController
-      skip_before_action :verify_authenticity_token
-
       # POST /account/wished_items
       def create
         variant = current_store.variants.find(wished_item_params[:variant_id])


### PR DESCRIPTION
…en check

This is not needed anymore as we use https://github.com/rails/request.js which will wrap all AJAX calls with proper CSRF tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for wish list actions by enabling authenticity token verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->