### PR TITLE
Set Order Token cookie with `httponly` flag

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -26,6 +26,7 @@ module Spree
         end
 
         def set_token
+          Spree::Deprecation.warn('set_token is deprecated and will be removed in Spree 5.2. Please use create_token_cookie(token) instead.')
           cookies.permanent.signed[:token] ||= cookies.signed[:guest_token]
           cookies.permanent.signed[:token] ||= {
             value: generate_token,

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -118,7 +118,8 @@ module Spree
             value: token,
             expires: 90.days.from_now,
             secure: Rails.configuration.force_ssl || Rails.application.config.ssl_options[:secure_cookies],
-            domain: current_store.url_or_custom_domain
+            domain: current_store.url_or_custom_domain,
+            httponly: true
           }
         end
 


### PR DESCRIPTION
To increase security, to protect the cookie from malicious client-side JavaScript code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation Notices**
  - Added a deprecation warning for the use of `set_token`, advising users to switch to `create_token_cookie(token)` before Spree 5.2.

- **Security Improvements**
  - Enhanced order token cookie security by making it HTTP-only, preventing client-side scripts from accessing the token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->