### PR TITLE
Improve `redirect_to_default_locale` method to only pass safe parameters

### DIFF
--- a/storefront/app/controllers/concerns/spree/locale_urls.rb
+++ b/storefront/app/controllers/concerns/spree/locale_urls.rb
@@ -21,7 +21,19 @@ module Spree
     def redirect_to_default_locale
       return if params[:locale].blank? || supported_locale?(params[:locale])
 
-      redirect_to url_for(request.parameters.merge(locale: nil))
+      # Only include safe parameters in the redirect
+      safe_params = {
+        controller: params[:controller],
+        action: params[:action],
+        locale: nil
+      }
+
+      # Add any additional safe parameters that should be preserved
+      %i[id format currency category_id tag].each do |param|
+        safe_params[param] = params[param] if params[param].present?
+      end
+
+      redirect_to url_for(safe_params)
     end
   end
 end

--- a/storefront/spec/controllers/concerns/spree/locale_urls_spec.rb
+++ b/storefront/spec/controllers/concerns/spree/locale_urls_spec.rb
@@ -62,7 +62,7 @@ module Spree
       context 'when locale param is present but not supported' do
         it 'redirects to URL without locale' do
           allow(controller).to receive(:supported_locale?).with('xx').and_return(false)
-          expect(controller).to receive(:url_for).with({ 'locale' => nil, 'action' => 'index', 'controller' => 'anonymous' }).and_return('/anonymous/index')
+          expect(controller).to receive(:url_for).with({ locale: nil, action: 'index', controller: 'anonymous' }).and_return('/anonymous/index')
           get :index, params: { locale: 'xx' }
           expect(response).to redirect_to('/anonymous/index')
         end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved redirect behavior to only include a limited set of safe parameters in URLs when switching locales, reducing the risk of unwanted parameters being preserved.
- **Tests**
  - Updated tests to reflect changes in how parameters are handled during locale redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->