### PR TITLE
Fixed Storefront products list N+1 when loading product brand name

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -595,7 +595,11 @@ module Spree
                      join_translation_table(Taxonomy).
                      find_by(Taxonomy.translation_table_alias => { name: Spree.t(:taxonomy_brands_name) })
                  else
-                   taxons.joins(:taxonomy).find_by(Taxonomy.table_name => { name: Spree.t(:taxonomy_brands_name) })
+                   if taxons.loaded?
+                     taxons.find { |taxon| taxon.taxonomy.name == Spree.t(:taxonomy_brands_name) }
+                   else
+                     taxons.joins(:taxonomy).find_by(Taxonomy.table_name => { name: Spree.t(:taxonomy_brands_name) })
+                   end
                  end
     end
 
@@ -606,7 +610,11 @@ module Spree
                         order(depth: :desc).
                         find_by(Taxonomy.translation_table_alias => { name: Spree.t(:taxonomy_categories_name) })
                     else
-                      taxons.joins(:taxonomy).order(depth: :desc).find_by(Taxonomy.table_name => { name: Spree.t(:taxonomy_categories_name) })
+                      if taxons.loaded?
+                        taxons.find { |taxon| taxon.taxonomy.name == Spree.t(:taxonomy_categories_name) }
+                      else
+                        taxons.joins(:taxonomy).order(depth: :desc).find_by(Taxonomy.table_name => { name: Spree.t(:taxonomy_categories_name) })
+                      end
                     end
     end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance when retrieving product brand and category, resulting in faster page loads in some scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->