### PR TITLE
Use `matches` instead of `eq` for arel query

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -96,10 +96,10 @@ module Spree
         joins(:taxonomy).
           join_translation_table(Taxonomy).
           where(
-            Taxonomy.arel_table_alias[:name].lower.eq(taxonomy_name.downcase.strip)
+            Taxonomy.arel_table_alias[:name].lower.matches(taxonomy_name.downcase.strip)
           )
       else
-        joins(:taxonomy).where(Spree::Taxonomy.arel_table[:name].lower.eq(taxonomy_name.downcase.strip))
+        joins(:taxonomy).where(Spree::Taxonomy.arel_table[:name].lower.matches(taxonomy_name.downcase.strip))
       end
     }
 


### PR DESCRIPTION
Fixes: undefined method `relation' for
<Arel::Nodes::NamedFunction:0x00007fe09a27cba8 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved taxonomy name filtering to use case-insensitive pattern matching, allowing for more flexible search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->