### PR TITLE
Fixed saving theme preferences in page builder

### DIFF
--- a/admin/app/controllers/spree/admin/stores_controller.rb
+++ b/admin/app/controllers/spree/admin/stores_controller.rb
@@ -68,7 +68,7 @@ module Spree
       protected
 
       def permitted_store_params
-        params.require(:store).permit(permitted_store_attributes)
+        params.require(:store).permit(permitted_store_attributes + current_store.preferences.keys.map { |key| "preferred_#{key}" })
       end
 
       private

--- a/admin/app/controllers/spree/admin/themes_controller.rb
+++ b/admin/app/controllers/spree/admin/themes_controller.rb
@@ -75,7 +75,7 @@ module Spree
       end
 
       def permitted_resource_params
-        params.require(:theme).permit(permitted_theme_attributes)
+        params.require(:theme).permit(permitted_theme_attributes + @object.preferences.keys.map { |key| "preferred_#{key}" })
       end
     end
   end

--- a/admin/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -72,6 +72,10 @@ describe Spree::Admin::StoresController do
       expect(store.default_currency).to eq('GBR')
       expect(store.default_country).to eq(uk_country)
       expect(store.default_locale).to eq('pl')
+
+      expect(store.preferred_timezone).to eq('Europe/Warsaw')
+      expect(store.preferred_weight_unit).to eq('kg')
+      expect(store.preferred_unit_system).to eq('metric')
     end
 
     context 'when removing assets' do

--- a/admin/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -52,7 +52,10 @@ describe Spree::Admin::StoresController do
         name: 'New Store Name',
         default_currency: 'GBR',
         default_country_iso: 'GB',
-        default_locale: 'pl'
+        default_locale: 'pl',
+        preferred_timezone: 'Europe/Warsaw',
+        preferred_weight_unit: 'kg',
+        preferred_unit_system: 'metric'
       }
     end
 

--- a/admin/spec/controllers/spree/admin/themes_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/themes_controller_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe Spree::Admin::ThemesController, type: :controller do
     end
   end
 
+  describe 'PUT #update' do
+    it 'updates the theme' do
+      expect do
+        put :update, params: { id: theme.id, theme: { preferred_primary_color: '#0090FE', preferred_font_family: 'Inconsolata' }, format: :turbo_stream }
+      end.to change { theme.reload.preferred_primary_color }.to('#0090FE')
+        .and change { theme.reload.preferred_font_family }.to('Inconsolata')
+    end
+  end
+
   describe 'PUT #publish' do
     it 'sets the theme as default' do
       put :publish, params: { id: theme.id }, format: :turbo_stream


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for updating store and theme preferences directly through the admin interface.

- **Tests**
  - Added and updated tests to ensure preference parameters for stores and themes are correctly handled during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->