### PR TITLE
Enhance storefront devise integration with dedicated controllers

### DIFF
--- a/core/lib/generators/spree/authentication/devise/devise_generator.rb
+++ b/core/lib/generators/spree/authentication/devise/devise_generator.rb
@@ -33,6 +33,8 @@ module Spree
     include Spree::UserPaymentSource
             RUBY
           end
+          gsub_file user_class_file, "< ApplicationRecord", "< Spree.base_class"
+
           say "Successfully added Spree user modules into #{user_class_file}"
         else
           say "Could not locate user model file at #{user_class_file}. Please add these lines manually:", :red
@@ -42,13 +44,14 @@ module Spree
             include Spree::UserMethods
             include Spree::UserPaymentSource
           RUBY
+
+          say "Please replace < ApplicationRecord with < Spree.base_class in #{user_class_file}"
         end
 
         append_file 'config/initializers/spree.rb' do
           %Q{
             if defined?(Devise) && Devise.respond_to?(:parent_controller)
-              Devise.parent_controller = "Spree::StoreController"
-              Devise.parent_mailer = "Spree::BaseMailer"
+              Devise.parent_controller = "Spree::BaseController"
             end\n}
         end
       end

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -78,6 +78,11 @@ module Spree
     def install_storefront
       if @install_storefront && Spree::Core::Engine.frontend_available?
         generate 'spree:storefront:install'
+
+        # generate devise controllers if authentication is devise
+        if @authentication == 'devise'
+          generate 'spree:storefront:devise'
+        end
       end
     end
 

--- a/storefront/app/controllers/concerns/spree/storefront/devise_concern.rb
+++ b/storefront/app/controllers/concerns/spree/storefront/devise_concern.rb
@@ -1,0 +1,42 @@
+# This concern is used to include the necessary methods and helpers for the Devise controllers
+# It is used to avoid repeating the same code in each controller
+module Spree
+  module Storefront
+    module DeviseConcern
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :title
+        helper_method :stored_location
+        layout 'spree/storefront'
+
+        include Spree::Core::ControllerHelpers::Order
+        include Spree::LocaleUrls
+        include Spree::ThemeConcern
+        include Spree::IntegrationsHelper if defined?(Spree::IntegrationsHelper)
+
+        helper 'spree/wishlist'
+        helper 'spree/currency'
+        helper 'spree/locale'
+        helper 'spree/storefront_locale'
+        helper 'spree/integrations' if defined?(Spree::IntegrationsHelper)
+      end
+
+      def stored_location
+        return unless defined?(after_sign_in_path_for)
+        return unless defined?(store_location_for)
+        return unless defined?(Devise)
+
+        path = after_sign_in_path_for(Devise.mappings.keys.first)
+
+        store_location_for(Devise.mappings.keys.first, path)
+
+        path
+      end
+
+      def password_path(_resource_or_scope = nil)
+        send("#{Spree.user_class.model_name.singular_route_key}_password_path")
+      end
+    end
+  end
+end

--- a/storefront/lib/generators/spree/storefront/devise/devise_generator.rb
+++ b/storefront/lib/generators/spree/storefront/devise/devise_generator.rb
@@ -1,0 +1,47 @@
+require 'rails/generators'
+
+module Spree
+  module Storefront
+    module Generators
+      class DeviseGenerator < Rails::Generators::Base
+        desc 'Installs Spree Storefront Devise controllers'
+
+        def self.source_paths
+          [
+            File.expand_path('templates', __dir__),
+            File.expand_path('../templates', "../#{__FILE__}"),
+            File.expand_path('../templates', "../../#{__FILE__}")
+          ]
+        end
+
+        def install
+          template 'user_sessions_controller.rb', 'app/controllers/spree/user_sessions_controller.rb'
+          template 'user_registrations_controller.rb', 'app/controllers/spree/user_registrations_controller.rb'
+          template 'user_passwords_controller.rb', 'app/controllers/spree/user_passwords_controller.rb'
+
+          # add devise routes
+          insert_into_file 'config/routes.rb', after: "Rails.application.routes.draw do\n" do
+            <<-ROUTES.strip_heredoc.indent!(2)
+              Spree::Core::Engine.add_routes do
+                # Storefront routes
+                scope '(:locale)', locale: /\#{Spree.available_locales.join('|')\}/, defaults: { locale: nil } do
+                  devise_for(
+                    Spree.user_class.model_name.singular_route_key,
+                    class_name: Spree.user_class.to_s,
+                    path: :user,
+                    controllers: {
+                      sessions: 'spree/user_sessions',
+                      passwords: 'spree/user_passwords',
+                      registrations: 'spree/user_registrations'
+                    },
+                    router_name: :spree
+                  )
+                end
+              end
+            ROUTES
+          end
+        end
+      end
+    end
+  end
+end

--- a/storefront/lib/generators/spree/storefront/devise/templates/user_passwords_controller.rb
+++ b/storefront/lib/generators/spree/storefront/devise/templates/user_passwords_controller.rb
@@ -1,0 +1,17 @@
+module Spree
+  class UserPasswordsController < ::Devise::PasswordsController
+    include Spree::Storefront::DeviseConcern
+
+    protected
+
+    def translation_scope
+      'devise.user_passwords'
+    end
+
+    private
+
+    def title
+      Spree.t(:forgot_password)
+    end
+  end
+end

--- a/storefront/lib/generators/spree/storefront/devise/templates/user_registrations_controller.rb
+++ b/storefront/lib/generators/spree/storefront/devise/templates/user_registrations_controller.rb
@@ -1,0 +1,17 @@
+module Spree
+  class UserRegistrationsController < ::Devise::RegistrationsController
+    include Spree::Storefront::DeviseConcern
+
+    protected
+
+    def translation_scope
+      'devise.user_registrations'
+    end
+
+    private
+
+    def title
+      Spree.t(:sign_up)
+    end
+  end
+end

--- a/storefront/lib/generators/spree/storefront/devise/templates/user_sessions_controller.rb
+++ b/storefront/lib/generators/spree/storefront/devise/templates/user_sessions_controller.rb
@@ -1,0 +1,17 @@
+module Spree
+  class UserSessionsController < ::Devise::SessionsController
+    include Spree::Storefront::DeviseConcern
+
+    protected
+
+    def translation_scope
+      'devise.user_sessions'
+    end
+
+    private
+
+    def title
+      Spree.t(:login)
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced custom Devise controllers for user sessions, registrations, and password resets in the storefront, providing improved localization and tailored page titles.
  - Added a shared concern to centralize Devise-related logic and helpers for storefront controllers.
  - Enhanced the installation process to automatically generate and configure Devise controllers and routes for the storefront when Devise authentication is selected.

- **Chores**
  - Updated Devise configuration to use a new parent controller and removed unnecessary mailer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->