### PR TITLE
fix: fixed link in creating-an-extension.mdx

### DIFF
--- a/docs/developer/contributing/creating-an-extension.mdx
+++ b/docs/developer/contributing/creating-an-extension.mdx
@@ -5,7 +5,7 @@ description: Learn how to create a Spree extension.
 
 ## Overview
 
-[Spree Extensions](/customization/extensions) are a way to add new functionality to your Spree store. They are a great way to extend the functionality of Spree and add new features. You can share them with Spree community on Github so anyone can use them, contribute back and share your improvements.
+[Spree Extensions](/developer/customization/extensions) are a way to add new functionality to your Spree store. They are a great way to extend the functionality of Spree and add new features. You can share them with Spree community on Github so anyone can use them, contribute back and share your improvements.
 
 ## Getting Started
 


### PR DESCRIPTION
Fixed "Spree Extensions" link pointing to an inexistent page

Fixes https://github.com/spree/spree/issues/12759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the link to "Spree Extensions" in the Overview section for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->