### PR TITLE
Fix required_quantity in InventoryUnit to be possible to create own InventoryUnitBuilder.

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -100,13 +100,11 @@ module Spree
     end
 
     def required_quantity
-      return @required_quantity unless @required_quantity.nil?
-
-      @required_quantity = if exchanged_unit?
-                             original_return_item.return_quantity
-                           else
-                             line_item.quantity
-                           end
+      @required_quantity ||= if exchanged_unit?
+                               original_return_item.return_quantity
+                             else
+                               quantity
+                             end
     end
 
     def exchanged_unit?


### PR DESCRIPTION
Reflecting https://github.com/spree/spree/issues/10986

Fix to be able to use own `InventoryUnitBuilder`. (For bundle products, multipacks etc.)

See `core/app/models/spree/stock/inventory_unit_builder.rb`, then it's clear we would like to return instance variable `quantity` from `Spree::InventoryUnit#required_quantity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for determining required quantity, resulting in more concise and maintainable code. No visible changes to existing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->