### PR TITLE
Align promotion rule eligibility error message with currency of the order.

### DIFF
--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -36,12 +36,12 @@ module Spree
         private
 
         def formatted_amount_min
-          Spree::Money.new(preferred_amount_min).to_s
+          Spree::Money.new(preferred_amount_min, currency: order.currency).to_s
         end
 
         def formatted_amount_max
           if preferred_amount_max.present?
-            Spree::Money.new(preferred_amount_max).to_s
+            Spree::Money.new(preferred_amount_max, currency: order.currency).to_s
           else
             Spree.t('no_maximum')
           end

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -27,19 +27,19 @@ module Spree
             upper_limit_condition = true
           end
 
-          eligibility_errors.add(:base, ineligible_message_max) unless upper_limit_condition
-          eligibility_errors.add(:base, ineligible_message_min) unless lower_limit_condition
+          eligibility_errors.add(:base, ineligible_message_max(order)) unless upper_limit_condition
+          eligibility_errors.add(:base, ineligible_message_min(order)) unless lower_limit_condition
 
           eligibility_errors.empty?
         end
 
         private
 
-        def formatted_amount_min
+        def formatted_amount_min(order)
           Spree::Money.new(preferred_amount_min, currency: order.currency).to_s
         end
 
-        def formatted_amount_max
+        def formatted_amount_max(order)
           if preferred_amount_max.present?
             Spree::Money.new(preferred_amount_max, currency: order.currency).to_s
           else
@@ -47,19 +47,19 @@ module Spree
           end
         end
 
-        def ineligible_message_max
+        def ineligible_message_max(order)
           if preferred_operator_max == 'lt'
-            eligibility_error_message(:item_total_more_than_or_equal, amount: formatted_amount_max)
+            eligibility_error_message(:item_total_more_than_or_equal, amount: formatted_amount_max(order))
           else
-            eligibility_error_message(:item_total_more_than, amount: formatted_amount_max)
+            eligibility_error_message(:item_total_more_than, amount: formatted_amount_max(order))
           end
         end
 
-        def ineligible_message_min
+        def ineligible_message_min(order)
           if preferred_operator_min == 'gte'
-            eligibility_error_message(:item_total_less_than, amount: formatted_amount_min)
+            eligibility_error_message(:item_total_less_than, amount: formatted_amount_min(order))
           else
-            eligibility_error_message(:item_total_less_than_or_equal, amount: formatted_amount_min)
+            eligibility_error_message(:item_total_less_than_or_equal, amount: formatted_amount_min(order))
           end
         end
       end

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Promotion::Rules::ItemTotal, type: :model do
   let!(:store) { @default_store }
   let(:rule) { Spree::Promotion::Rules::ItemTotal.new }
-  let(:order) { double(:order) }
+  let(:order) { build(:order, store: store) }
 
   before do
     rule.preferred_amount_min = 50


### PR DESCRIPTION
Currency on error message
<img width="629" alt="Screenshot 2025-05-20 at 18 09 07" src="https://github.com/user-attachments/assets/29ceb85b-a1a9-4282-a240-2ec3e761bacd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display of monetary amounts to correctly reflect the order's currency throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->