### PR TITLE
Force to user `admin_user` in path for admin user rest

### DIFF
--- a/admin/app/views/spree/admin/user_passwords/edit.html.erb
+++ b/admin/app/views/spree/admin/user_passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, Spree.t(:forgot_password)) %>
 
 <h1 class="mb-3 font-weight-light"><%= Spree.t(:change_password) %></h1>
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { turbo_frame: :_top, turbo: false }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(:admin_user), html: { method: :put }, data: { turbo_frame: :_top, turbo: false }) do |f| %>
   <%= render partial: 'spree/admin/shared/error_messages', locals: { target: resource } %>
   <%= f.hidden_field :reset_password_token %>
   <div class="form-group mb-3">

--- a/admin/app/views/spree/admin/user_passwords/new.html.erb
+++ b/admin/app/views/spree/admin/user_passwords/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, Spree.t(:forgot_password)) %>
 
 <h1 class="mb-3 font-weight-light"><%= Spree.t(:forgot_password) %></h1>
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), data: { turbo_frame: :_top }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(:admin_user), data: { turbo_frame: :_top }) do |f| %>
   <div class="form-group mb-3">
     <%= f.label :email, Spree.t(:email), required: true, class: 'form-label' %>
     <%= f.email_field :email, required: true, class: 'form-control form-control-lg rounded-sm', placeholder: 'steve@apple.com', data: { enable_button_target: :input }, autocomplete: :email, autofocus: true %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of password reset forms for admin users by ensuring submissions are always directed to the correct admin user password path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->