### PR TITLE
FIX orders export

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -832,6 +832,10 @@ module Spree
 
     private
 
+    def all_line_items
+      line_items
+    end
+
     def link_by_email
       self.email = user.email if user
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -830,11 +830,11 @@ module Spree
       csv_lines
     end
 
-    private
-
     def all_line_items
       line_items
     end
+
+    private
 
     def link_by_email
       self.email = user.email if user

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2108,4 +2108,32 @@ describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe '#to_csv' do
+    subject { order.to_csv }
+
+    context 'when order has no line items' do
+      let(:order) { create(:order) }
+
+      it 'returns no csv lines' do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when order has line items' do
+      let(:order) { create(:order_with_line_items) }
+
+      let(:presenter) { Spree::CSV::OrderLineItemPresenter }
+      let(:presenter_instance) { instance_double(presenter) }
+
+      before do
+        allow(presenter).to receive(:new).and_return(presenter_instance)
+        allow(presenter_instance).to receive(:call).and_return('csv_line')
+      end
+
+      it 'returns the csv lines' do
+        expect(subject).to eq(['csv_line'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes `NameError: undefined local variable or method `all_line_items' for an instance of Spree::Order`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added tests for the order CSV export functionality, covering scenarios with and without line items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->