### PR TITLE
Deprecate `OrderConcern#serialized_current_order`

### DIFF
--- a/api/app/controllers/concerns/spree/api/v2/storefront/order_concern.rb
+++ b/api/app/controllers/concerns/spree/api/v2/storefront/order_concern.rb
@@ -7,7 +7,7 @@ module Spree
 
           def render_order(result)
             if result.success?
-              render_serialized_payload { serialized_current_order }
+              render_serialized_payload { serialize_resource(spree_current_order) }
             else
               render_error_payload(result.error&.value || result.value)
             end
@@ -35,6 +35,7 @@ module Spree
           end
 
           def serialized_current_order
+            Spree::Deprecation.warn('OrderConcern#serialized_current_order is deprecated and will be removed in Spree 6.0. Please use `serialize_resource(spree_current_order)` method')
             serialize_resource(spree_current_order)
           end
 

--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -54,7 +54,7 @@ module Spree
               line_item: line_item
             )
 
-            render_serialized_payload { serialized_current_order }
+            render_serialized_payload { serialize_resource(spree_current_order) }
           end
 
           def empty
@@ -63,7 +63,7 @@ module Spree
             result = empty_cart_service.call(order: spree_current_order)
 
             if result.success?
-              render_serialized_payload { serialized_current_order }
+              render_serialized_payload { serialize_resource(spree_current_order) }
             else
               render_error_payload(result.error)
             end
@@ -94,7 +94,7 @@ module Spree
           def show
             spree_authorize! :show, spree_current_order, order_token
 
-            render_serialized_payload { serialized_current_order }
+            render_serialized_payload { serialize_resource(spree_current_order) }
           end
 
           def apply_coupon_code
@@ -104,7 +104,7 @@ module Spree
             result = coupon_handler.new(spree_current_order).apply
 
             if result.error.blank?
-              render_serialized_payload { serialized_current_order }
+              render_serialized_payload { serialize_resource(spree_current_order) }
             else
               render_error_payload(result.error)
             end
@@ -120,7 +120,7 @@ module Spree
             result_errors = coupon_codes.count > 1 ? select_errors(coupon_codes) : select_error(coupon_codes)
 
             if result_errors.blank?
-              render_serialized_payload { serialized_current_order }
+              render_serialized_payload { serialize_resource(spree_current_order) }
             else
               render_error_payload(result_errors)
             end

--- a/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/checkout_controller.rb
@@ -104,10 +104,10 @@ module Spree
 
             if messages.any?
               render_serialized_payload(422) do
-                serialized_current_order.deep_merge({ meta: { messages: messages } })
+                serialize_resource(spree_current_order).deep_merge({ meta: { messages: messages } })
               end
             else
-              render_serialized_payload { serialized_current_order }
+              render_serialized_payload { serialize_resource(spree_current_order) }
             end
           end
 


### PR DESCRIPTION
This method abstracts too much, makes it harder to undersarnd what's going on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated order serialization in various storefront API endpoints to use a unified serialization method, ensuring consistency in order-related responses.
- **Chores**
  - Deprecated an older serialization method and added a deprecation warning for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->