### PR TITLE
Fixed updating page block / section link attributes

### DIFF
--- a/admin/app/controllers/spree/admin/page_blocks_controller.rb
+++ b/admin/app/controllers/spree/admin/page_blocks_controller.rb
@@ -47,7 +47,9 @@ module Spree
 
       def permitted_resource_params
         params.require(:page_block).permit(
-          permitted_page_block_attributes + @object.preferences.keys.map { |key| "preferred_#{key}" }
+          permitted_page_block_attributes +
+          [link_attributes: permitted_page_link_attributes + [:id]] +
+          @object.preferences.keys.map { |key| "preferred_#{key}" }
         )
       end
     end

--- a/admin/app/controllers/spree/admin/page_sections_controller.rb
+++ b/admin/app/controllers/spree/admin/page_sections_controller.rb
@@ -71,7 +71,11 @@ module Spree
       end
 
       def permitted_resource_params
-        params.require(:page_section).permit(permitted_page_section_attributes + @object.preferences.keys.map { |key| "preferred_#{key}" })
+        params.require(:page_section).permit(
+          permitted_page_section_attributes +
+          [link_attributes: permitted_page_link_attributes + [:id]] +
+          @object.preferences.keys.map { |key| "preferred_#{key}" }
+        )
       end
     end
   end

--- a/admin/spec/controllers/spree/admin/page_blocks_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/page_blocks_controller_spec.rb
@@ -83,13 +83,27 @@ RSpec.describe Spree::Admin::PageBlocksController, type: :controller do
   end
 
   describe '#update' do
-    subject { put :update, params: { id: page_block.id, page_section_id: page_section.id, page_block: { preferred_button_text_color: '#000000' } }, format: :turbo_stream }
+    subject { put :update, params: { id: page_block.id, page_section_id: page_section.id, page_block: page_block_params }, format: :turbo_stream }
 
     let(:page_block) { create(:buttons_block, section: page_section) }
     let(:page_section) { create(:featured_taxon_page_section) }
+    let(:page_block_params) { { preferred_button_text_color: '#000000' } }
 
     it 'updates the page block' do
       expect { subject }.to change { page_block.reload.preferred_button_text_color }.to('#000000')
+    end
+
+    context 'with link' do
+      let!(:page_block) { create(:buttons_block, section: page_section) }
+
+      let(:page_block_params) { { link_attributes: { id: page_block.link.id, label: 'New Label', open_in_new_tab: true } } }
+
+      it 'updates the page block' do
+        subject
+
+        expect(page_block.reload.link.label).to eq('New Label')
+        expect(page_block.reload.link.open_in_new_tab).to be_truthy
+      end
     end
   end
 

--- a/admin/spec/controllers/spree/admin/page_sections_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/page_sections_controller_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe Spree::Admin::PageSectionsController, type: :controller do
         expect(page_section.reload.position).to eq(2)
       end
     end
+
+    context 'with link' do
+      let(:page_section) { create(:image_with_text_page_section, pageable: page) }
+
+      it 'updates the page section link' do
+        put :update, params: { id: page_section.id, page_section: { link_attributes: { id: page_section.link.id, label: 'New Label', open_in_new_tab: true } } }, format: :turbo_stream
+
+        expect(page_section.reload.link.label).to eq('New Label')
+        expect(page_section.reload.link.open_in_new_tab).to be_truthy
+      end
+    end
   end
 
   describe '#destroy' do

--- a/admin/spec/controllers/spree/admin/page_sections_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/page_sections_controller_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe Spree::Admin::PageSectionsController, type: :controller do
   stub_authorization!
   render_views
 
-  let(:store) { @default_store }
+  let(:store) { create(:store) }
   let(:parent_theme) { create(:theme, store: store) }
   let(:theme) { create(:theme, :preview, parent: parent_theme) }
   let(:page) { create(:page, :preview, pageable: parent_theme) }
 
   before do
+    allow(controller).to receive(:current_store).and_return(store)
     session[:page_preview_id] = page.id
     session[:theme_preview_id] = theme.id
   end

--- a/admin/spec/controllers/spree/admin/page_sections_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/page_sections_controller_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe Spree::Admin::PageSectionsController, type: :controller do
   stub_authorization!
   render_views
 
-  let(:store) { create(:store) }
+  let(:store) { @default_store }
   let(:parent_theme) { create(:theme, store: store) }
   let(:theme) { create(:theme, :preview, parent: parent_theme) }
   let(:page) { create(:page, :preview, pageable: parent_theme) }
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
     session[:page_preview_id] = page.id
     session[:theme_preview_id] = theme.id
   end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -129,7 +129,7 @@ module Spree
 
     @@page_block_attributes = [:type, :name, :text, :position]
 
-    @@page_link_attributes = [:linkable_id, :linkable_type, :position, :label, :url]
+    @@page_link_attributes = [:linkable_id, :linkable_type, :position, :label, :url, :open_in_new_tab]
 
     @@page_section_attributes = [:type, :name, :position, :asset, :text, :description]
 

--- a/core/lib/spree/testing_support/factories/page_section_factory.rb
+++ b/core/lib/spree/testing_support/factories/page_section_factory.rb
@@ -20,5 +20,7 @@ FactoryBot.define do
     factory :newsletter_page_section, class: Spree::PageSections::Newsletter
 
     factory :video_page_section, class: Spree::PageSections::Video
+
+    factory :image_with_text_page_section, class: Spree::PageSections::ImageWithText
   end
 end


### PR DESCRIPTION
Some blocks and sections have one default link, which can be updated with block/section via nested attributes, we've missed this in permitted attributes before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for updating nested link attributes, including the ability to set links to open in a new tab, within page blocks and page sections in the admin interface.

- **Bug Fixes**
  - Improved handling of permitted parameters to ensure nested link attributes are correctly accepted and updated.

- **Tests**
  - Added and refactored tests to verify updating of nested link attributes for page blocks and page sections.

- **Chores**
  - Introduced a new factory for image-with-text page sections to support testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->