### PR TITLE
Bring back Tax Category dropdown to product form

### DIFF
--- a/admin/app/views/spree/admin/products/_form.html.erb
+++ b/admin/app/views/spree/admin/products/_form.html.erb
@@ -7,13 +7,14 @@
     <% end unless @product.has_variants? %>
     <%= render 'spree/admin/products/form/variants', f: f %>
     <%= render 'spree/admin/products/form/inventory', f: f unless @product.has_variants? %>
-    <%= render 'spree/admin/products/form/shipping', f: f %>
     <%= render 'spree/admin/products/form/properties', f: f %>
     <%= render_admin_partials(:product_form_partials, f: f, product: @product) %>
   </div>
   <div class="col-md-4">
     <%= render 'spree/admin/products/form/status', f: f %>
     <%= render 'spree/admin/products/form/categorization', f: f %>
+    <%= render 'spree/admin/products/form/shipping', f: f %>
+    <%= render 'spree/admin/products/form/tax', f: f %>
     <%= render 'spree/admin/products/form/stores', f: f if available_stores.count > 1 %>
     <%= render_admin_partials(:product_form_sidebar_partials, f: f, product: @product) %>
 

--- a/admin/app/views/spree/admin/products/form/_tax.html.erb
+++ b/admin/app/views/spree/admin/products/form/_tax.html.erb
@@ -1,0 +1,12 @@
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:tax) %></h5>
+  </div>
+  <div class="card-body">
+    <div class="form-group">
+      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
+      <%= f.select(:tax_category_id, @tax_categories.pluck(:name, :id), { include_blank: false }, { class: 'custom-select' }) %>
+      <%= f.error_message_on :tax_category %>
+    </div>
+  </div>
+</div>

--- a/admin/app/views/spree/admin/variants/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_basic.html.erb
@@ -5,22 +5,22 @@
     </h5>
   </div>
   <div class="card-body">
-    <div class="form-group" data-hook="sku">
+    <div class="form-group">
       <%= f.label :sku, Spree.t(:sku) %>
       <%= f.text_field :sku, class: 'form-control' %>
     </div>
 
-    <div class="form-group" data-hook="sku">
+    <div class="form-group">
       <%= f.label :barcode, Spree.t(:barcode) %>
       <%= f.text_field :barcode, class: 'form-control' %>
     </div>
 
-    <div class="form-group" data-hook="tax_category">
+    <div class="form-group">
       <%= f.label :tax_category_id, Spree.t(:tax_category) %>
       <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { data: { controller: 'autocomplete-select' } }) %>
     </div>
 
-    <div class="form-group" data-hook="discontinue_on">
+    <div class="form-group">
       <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
       <%= f.error_message_on :discontinue_on %>
       <%= f.date_field :discontinue_on, class: 'form-control' %>

--- a/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
     let(:other_stock_location) { create(:stock_location) }
 
     let(:shipping_category) { create(:shipping_category, name: 'Default') }
+    let(:tax_category) { create(:tax_category, name: 'Clothing') }
 
     context 'without variants' do
       let(:product_params) do
@@ -168,7 +169,8 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
           depth: 10,
           dimensions_unit: 'cm',
           weight_unit: 'kg',
-          shipping_category_id: shipping_category.id
+          shipping_category_id: shipping_category.id,
+          tax_category_id: tax_category.id
         }
       end
 
@@ -185,6 +187,9 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         expect(product.dimensions_unit).to eq 'cm'
         expect(product.weight_unit).to eq 'kg'
         expect(product.stores).to eq [store]
+
+        expect(product.shipping_category).to eq shipping_category
+        expect(product.tax_category).to eq tax_category
       end
 
       context 'with multi-currency pricing' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a tax category selection section to the product form sidebar for easier assignment of tax categories.
- **Refactor**
  - Reorganized the product form layout by moving the shipping section and introducing the new tax section in the sidebar.
- **Style**
  - Removed certain HTML data attributes from the variant form for cleaner markup.
- **Tests**
  - Updated product creation tests to include and verify tax category assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->