### PR TITLE
Fix link to variant when product for that variant is deleted

### DIFF
--- a/admin/app/controllers/spree/admin/products_controller.rb
+++ b/admin/app/controllers/spree/admin/products_controller.rb
@@ -152,7 +152,7 @@ module Spree
       protected
 
       def find_resource
-        current_store.products.accessible_by(current_ability, :manage).with_deleted.friendly.find(params[:id])
+        current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
       end
 
       def load_data

--- a/admin/app/views/spree/admin/variants/_variant.html.erb
+++ b/admin/app/views/spree/admin/variants/_variant.html.erb
@@ -1,7 +1,5 @@
 <% cache variant do %>
-  <% if variant.product.deleted? %>
-    <% variant_url = "" %>
-  <% elsif variant.is_master? %>
+  <% if variant.is_master? || variant.product.deleted? %>
     <% variant_url = spree.edit_admin_product_path(variant.product) %>
   <% else %>
     <% variant_url = spree.edit_admin_product_variant_path(variant.product, variant) %>
@@ -14,11 +12,6 @@
       <% if variant.options_text.present? %>
         <p class="text-muted my-1 font-size-sm">
           <%= variant.options_text %>
-        </p>
-      <% end %>
-      <% if variant.product.deleted? %>
-        <p class="text-muted my-1 font-size-sm">
-          (<%= Spree.t("admin.products.deleted") %>)
         </p>
       <% end %>
     </div>

--- a/admin/app/views/spree/admin/variants/_variant.html.erb
+++ b/admin/app/views/spree/admin/variants/_variant.html.erb
@@ -1,17 +1,24 @@
 <% cache variant do %>
-  <% if variant.is_master? %>
+  <% if variant.product.deleted? %>
+    <% variant_url = "" %>
+  <% elsif variant.is_master? %>
     <% variant_url = spree.edit_admin_product_path(variant.product) %>
   <% else %>
     <% variant_url = spree.edit_admin_product_variant_path(variant.product, variant) %>
   <% end %>
 
   <%= link_to variant_url, id: spree_dom_id(variant), data: { turbo_permanent: true, turbo_frame: :_top }, class: 'd-flex align-items-center justify-content-start text-decoration-none' do %>
-    <%= render 'spree/admin/shared/product_image', object: variant %>
+    <%= render "spree/admin/shared/product_image", object: variant %>
     <div class="ml-3">
       <strong><%= variant.name %></strong>
       <% if variant.options_text.present? %>
         <p class="text-muted my-1 font-size-sm">
           <%= variant.options_text %>
+        </p>
+      <% end %>
+      <% if variant.product.deleted? %>
+        <p class="text-muted my-1 font-size-sm">
+          (<%= Spree.t("admin.products.deleted") %>)
         </p>
       <% end %>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated variant links so that variants of deleted products now direct to the product edit page instead of the variant edit page.
- **Style**
  - Minor update to the syntax of partial render calls for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->