### PR TITLE
Redirect to sign up form instead of login page before entering checkout

### DIFF
--- a/storefront/app/controllers/spree/checkout_controller.rb
+++ b/storefront/app/controllers/spree/checkout_controller.rb
@@ -188,7 +188,7 @@ module Spree
             redirect_to spree.checkout_path(@order.token)
           else
             store_location
-            redirect_to spree_login_path
+            redirect_to spree_signup_path
           end
         end
       end

--- a/storefront/app/controllers/spree/store_controller.rb
+++ b/storefront/app/controllers/spree/store_controller.rb
@@ -208,7 +208,7 @@ module Spree
       store_location(return_to)
 
       respond_to do |format|
-        format.html { redirect_to spree_login_path }
+        format.html { redirect_to spree_signup_path }
         format.turbo_stream { render turbo_stream: turbo_stream.slideover_open('slideover-account', 'account-pane') }
       end
     end

--- a/storefront/spec/controllers/spree/account/addresses_controller_spec.rb
+++ b/storefront/spec/controllers/spree/account/addresses_controller_spec.rb
@@ -8,8 +8,11 @@ describe Spree::Account::AddressesController, type: :controller do
   render_views
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive(:spree_login_path).and_return('/login')
+    allow(controller).to receive_messages(
+      current_store: store,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#index' do
@@ -35,8 +38,9 @@ describe Spree::Account::AddressesController, type: :controller do
     end
 
     context 'when user is not logged in' do
-      it 'redirects to login page' do
+      it 'redirects to sign up page' do
         expect(subject).to have_http_status(302)
+        expect(response).to redirect_to('/signup')
       end
     end
   end

--- a/storefront/spec/controllers/spree/account/orders_controller_spec.rb
+++ b/storefront/spec/controllers/spree/account/orders_controller_spec.rb
@@ -8,8 +8,11 @@ describe Spree::Account::OrdersController, type: :controller do
   render_views
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive(:spree_login_path).and_return('/login')
+    allow(controller).to receive_messages(
+      current_store: store,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#index' do
@@ -76,8 +79,9 @@ describe Spree::Account::OrdersController, type: :controller do
     end
 
     context 'when user is not logged in' do
-      it 'redirects to login page' do
+      it 'redirects to sign up page' do
         expect(subject).to have_http_status(302)
+        expect(response).to redirect_to('/signup')
       end
     end
   end

--- a/storefront/spec/controllers/spree/account/store_credits_controller_spec.rb
+++ b/storefront/spec/controllers/spree/account/store_credits_controller_spec.rb
@@ -9,8 +9,11 @@ describe Spree::Account::StoreCreditsController, type: :controller do
   render_views
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive(:spree_login_path).and_return('/login')
+    allow(controller).to receive_messages(
+      current_store: store,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#index' do
@@ -35,8 +38,9 @@ describe Spree::Account::StoreCreditsController, type: :controller do
     end
 
     context 'when user is not logged in' do
-      it 'redirects to login page' do
+      it 'redirects to sign up page' do
         expect(subject).to have_http_status(302)
+        expect(response).to redirect_to('/signup')
       end
     end
   end

--- a/storefront/spec/controllers/spree/account/wished_items_controller_spec.rb
+++ b/storefront/spec/controllers/spree/account/wished_items_controller_spec.rb
@@ -10,10 +10,13 @@ describe Spree::Account::WishedItemsController, type: :controller do
   render_views
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive(:spree_login_path).and_return('/login')
-    allow(controller).to receive_messages try_spree_current_user: user
-    allow(controller).to receive(:current_wishlist).and_return(wishlist)
+    allow(controller).to receive_messages(
+      current_store: store,
+      try_spree_current_user: user,
+      current_wishlist: wishlist,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#create' do
@@ -72,8 +75,9 @@ describe Spree::Account::WishedItemsController, type: :controller do
         allow(controller).to receive(:try_spree_current_user).and_return(nil)
       end
 
-      it 'redirects to login page' do
+      it 'redirects to sign up page' do
         expect(subject).to have_http_status(302)
+        expect(response).to redirect_to('/signup')
       end
     end
 

--- a/storefront/spec/controllers/spree/checkout_controller_spec.rb
+++ b/storefront/spec/controllers/spree/checkout_controller_spec.rb
@@ -16,10 +16,13 @@ describe Spree::CheckoutController, type: :controller do
   let(:accept_marketing) { true }
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive_messages try_spree_current_user: user
-    allow(controller).to receive_messages spree_current_user: user
-    allow(controller).to receive(:spree_login_path).and_return('/login')
+    allow(controller).to receive_messages(
+      current_store: store,
+      try_spree_current_user: user,
+      spree_current_user: user,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#edit' do
@@ -117,7 +120,7 @@ describe Spree::CheckoutController, type: :controller do
 
         it 'redirects to the login page' do
           get :edit, params: { token: order.token }
-          expect(response).to redirect_to('/login')
+          expect(response).to redirect_to('/signup')
         end
       end
     end
@@ -155,9 +158,9 @@ describe Spree::CheckoutController, type: :controller do
         context 'when user is not logged in' do
           let(:user) { nil }
 
-          it 'redirects to login page' do
+          it 'redirects to sign up page' do
             get :edit, params: { token: order.token }
-            expect(response).to redirect_to('/login')
+            expect(response).to redirect_to('/signup')
           end
 
           context 'when guest checkout is allowed' do

--- a/storefront/spec/controllers/spree/wishlists_controller_spec.rb
+++ b/storefront/spec/controllers/spree/wishlists_controller_spec.rb
@@ -10,8 +10,11 @@ describe Spree::WishlistsController, type: :controller do
   render_views
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive(:spree_login_path).and_return('/login')
+    allow(controller).to receive_messages(
+      current_store: store,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#show' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated redirection for unauthenticated users to go to the signup page instead of the login page during checkout and when accessing protected content.

- **Tests**
	- Adjusted tests to verify redirection to the signup page for unauthenticated users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->