### PR TITLE
fix: undefined method 'last' for nil

### DIFF
--- a/admin/app/views/spree/admin/preferences/_password_field.html.erb
+++ b/admin/app/views/spree/admin/preferences/_password_field.html.erb
@@ -3,7 +3,7 @@
     <div data-replace-target="from">
       <div readonly class="form-control d-flex align-items-center justify-content-between pr-1">
         <span class="text-muted">
-          ...<%= form.object.send(field).last(4) %>
+          ...<%= form.object.send(field)&.last(4) %>
         </span>
         <button class="btn btn-sm btn-light" type="button" data-action="click->replace#replace">
           <%= icon 'edit', class: 'mr-2' %>


### PR DESCRIPTION
I enabled a PaymentMethod without `preference`.

```ruby
module Spree
  class PaymentMethod::Alipay < ::Spree::PaymentMethod
  end
end
```

Then I want to add some preferences for this PaymentMethod.

```ruby
module Spree
  class PaymentMethod::Alipay < ::Spree::PaymentMethod
      preference :publishable_key, :password
      preference :secret_key, :password
  end
end
```

I got some errors when I edit the PaymentMethod at admin panel from this file `admin/app/views/spree/admin/preferences/_password_field.html.erb`

```html
<span class="text-muted">
    ...<%= form.object.send(field)&.last(4) %>
</span>
```

It seems that the added preferences is nil for enabled PaymentMethod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty or missing password fields to prevent errors when displaying preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->