### PR TITLE
feature: skip confirmation for automatically created users

### DIFF
--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -44,6 +44,7 @@ module Spree
         user.accepts_email_marketing = accepts_email_marketing.to_b if user.respond_to?(:accepts_email_marketing)
         user.password = password if user.respond_to?(:password)
         user.password_confirmation = password if user.respond_to?(:password_confirmation)
+        user.skip_confirmation! if user.respond_to?(:skip_confirmation!)
 
         user.save
 


### PR DESCRIPTION
### Description
This PR updates the user creation process to skip email confirmation when the user model includes Devise's `confirmable` module.

When we automatically create user accounts, we are the ones initiating the account creation. Therefore, it makes sense to skip the confirmation step, as we already trust the context in which the account is being created.

### What changed
Added a call to `user.skip_confirmation!` (if the method is available) when creating users via `Spree::Orders::CreateUserAccount`.

### Why this matters
Avoiding the confirmation email improves user experience and prevents confusion, especially when users are not expecting to receive a confirmation email for an account they didn't manually register.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User accounts created during the order process will now have email confirmation automatically skipped, allowing immediate access after account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->