### PR TITLE
Remove duplicated `has_payment_profile?` from `PaymentSource`

### DIFF
--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -20,12 +20,6 @@ module Spree
     #
     delegate :profile_id, to: :gateway_customer, prefix: true, allow_nil: true
 
-    # Returns true if the payment source has a payment profile.
-    # @return [Boolean]
-    def has_payment_profile?
-      gateway_customer&.profile_id&.present? || gateway_payment_profile_id.present?
-    end
-
     # Returns the gateway customer for the user.
     # @return [Spree::GatewayCustomer]
     def gateway_customer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an obsolete method related to payment profiles from the payment source functionality. No visible impact on user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->