### PR TITLE
Redirect a guest to sign up page when trying to enter checkout

### DIFF
--- a/storefront/app/controllers/spree/checkout_controller.rb
+++ b/storefront/app/controllers/spree/checkout_controller.rb
@@ -4,10 +4,6 @@ module Spree
     include Spree::CheckoutHelper
     include Spree::CheckoutAnalyticsHelper
 
-    before_action unless: -> { current_store.prefers_guest_checkout? } do
-      require_user(redirect_path: spree_signup_path)
-    end
-
     before_action :load_order
     before_action :remove_out_of_stock_items, only: [:edit, :update]
 
@@ -194,6 +190,8 @@ module Spree
             redirect_to spree_login_path
           end
         end
+      elsif !current_store.prefers_guest_checkout?
+        require_user(redirect_path: spree_signup_path)
       end
 
       # completed orders shouldn't be updated anymore

--- a/storefront/app/controllers/spree/checkout_controller.rb
+++ b/storefront/app/controllers/spree/checkout_controller.rb
@@ -4,7 +4,10 @@ module Spree
     include Spree::CheckoutHelper
     include Spree::CheckoutAnalyticsHelper
 
-    before_action :require_user, unless: -> { current_store.prefers_guest_checkout? }
+    before_action unless: -> { current_store.prefers_guest_checkout? } do
+      require_user(redirect_path: spree_signup_path)
+    end
+
     before_action :load_order
     before_action :remove_out_of_stock_items, only: [:edit, :update]
 

--- a/storefront/app/controllers/spree/store_controller.rb
+++ b/storefront/app/controllers/spree/store_controller.rb
@@ -204,13 +204,13 @@ module Spree
       redirect_back(fallback_location: default)
     end
 
-    def require_user(return_to = nil)
+    def require_user(return_to: nil, redirect_path: nil)
       return if try_spree_current_user
 
       store_location(return_to)
 
       respond_to do |format|
-        format.html { redirect_to spree_login_path }
+        format.html { redirect_to redirect_path || spree_login_path }
         format.turbo_stream { render turbo_stream: turbo_stream.slideover_open('slideover-account', 'account-pane') }
       end
     end

--- a/storefront/spec/controllers/spree/checkout_controller_spec.rb
+++ b/storefront/spec/controllers/spree/checkout_controller_spec.rb
@@ -16,10 +16,13 @@ describe Spree::CheckoutController, type: :controller do
   let(:accept_marketing) { true }
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive_messages try_spree_current_user: user
-    allow(controller).to receive_messages spree_current_user: user
-    allow(controller).to receive(:spree_login_path).and_return('/login')
+    allow(controller).to receive_messages(
+      current_store: store,
+      try_spree_current_user: user,
+      spree_current_user: user,
+      spree_signup_path: '/signup',
+      spree_login_path: '/login'
+    )
   end
 
   describe '#edit' do
@@ -115,9 +118,9 @@ describe Spree::CheckoutController, type: :controller do
       context 'when guest checkout is not allowed' do
         let(:allow_guest_checkout) { false }
 
-        it 'redirects to the login page' do
+        it 'redirects to the sign up page' do
           get :edit, params: { token: order.token }
-          expect(response).to redirect_to('/login')
+          expect(response).to redirect_to('/signup')
         end
       end
     end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Users attempting checkout without being logged in are now redirected to the sign up page instead of the login page when guest checkout is not allowed.

- **Tests**
  - Updated tests to verify redirection to the sign up page during checkout when guest checkout is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->