### PR TITLE
Enhance the display of the product properties on storefront

### DIFF
--- a/storefront/app/helpers/spree/products_helper.rb
+++ b/storefront/app/helpers/spree/products_helper.rb
@@ -213,5 +213,9 @@ module Spree
 
       Spree::ColorsPreviewStylesPresenter.new(option_type.option_values.map { |ov| { name: ov.name, filter_name: ov.name } }).to_s
     end
+
+    def default_product_properties
+      product.product_properties.joins(:property).merge(Spree::Property.available_on_front_end).sort_by_property_position
+    end
   end
 end

--- a/storefront/app/helpers/spree/products_helper.rb
+++ b/storefront/app/helpers/spree/products_helper.rb
@@ -214,7 +214,7 @@ module Spree
       Spree::ColorsPreviewStylesPresenter.new(option_type.option_values.map { |ov| { name: ov.name, filter_name: ov.name } }).to_s
     end
 
-    def default_product_properties
+    def product_properties(product)
       product.product_properties.joins(:property).merge(Spree::Property.available_on_front_end).sort_by_property_position
     end
   end

--- a/storefront/app/views/themes/default/spree/products/_details.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_details.html.erb
@@ -39,7 +39,7 @@
       </div>
     <% end %>
 
-    <% default_product_properties.each do |product_property| %>
+    <% product_properties(product).each do |product_property| %>
       <div class="product-property py-4 border-b border-default">
 
         <%= link_to "#property_#{product_property.id}", class: 'text-sm uppercase tracking-widest inline-flex w-full justify-between !border-b-transparent', data: { action: 'accordion#toggle' } do %>

--- a/storefront/app/views/themes/default/spree/products/_details.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_details.html.erb
@@ -39,7 +39,7 @@
       </div>
     <% end %>
 
-    <% product.product_properties.joins(:property).merge(Spree::Property.available_on_front_end).sort_by_property_position.each do |product_property| %>
+    <% default_product_properties.each do |product_property| %>
       <div class="product-property py-4 border-b border-default">
 
         <%= link_to "#property_#{product_property.id}", class: 'text-sm uppercase tracking-widest inline-flex w-full justify-between !border-b-transparent', data: { action: 'accordion#toggle' } do %>


### PR DESCRIPTION
In some cases I want to customize data source of the product properties, I have to override the whole `_details.html.erb`.

like this kind of data source `product.product_properties.joins(:property).custom_sort`

After this change, I just only override the method `Spree::ProductsHelper#default_product_properties`.

Or do you have any better advises?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined how product properties are retrieved and displayed on product detail pages for improved consistency.

No visible changes to the layout or property presentation for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->