### PR TITLE
Fix delivery range formatting for shipping methods

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -93,7 +93,7 @@ module Spree
       if estimated_transit_business_days_min == estimated_transit_business_days_max
         estimated_transit_business_days_min.to_s
       else
-        "#{estimated_transit_business_days_min}-#{estimated_transit_business_days_max}"
+        [estimated_transit_business_days_min, estimated_transit_business_days_max].compact.join("-")
       end
     end
 

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -183,6 +183,20 @@ describe Spree::ShippingMethod, type: :model do
 
       it { expect(shipping_method.delivery_range).to eq('1') }
     end
+
+    context "when only one transit day value is set" do
+      context "when only minimum day is set" do
+        let(:shipping_method) { build(:shipping_method, estimated_transit_business_days_min: 1) }
+
+        it { expect(shipping_method.delivery_range).to eq('1') }
+      end
+
+      context "when only maximum day is set" do
+        let(:shipping_method) { build(:shipping_method, estimated_transit_business_days_max: 2) }
+
+        it { expect(shipping_method.delivery_range).to eq('2') }
+      end
+    end
   end
 
   describe '#display_estimated_price' do


### PR DESCRIPTION
- Update `delivery_range` to handle cases with only one transit day set.
- Replace string interpolation with `compact.join` for cleaner output.
- Add specs to cover cases with only min or max transit days provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of shipping delivery ranges to avoid showing "nil" when only one value is available.

- **Tests**
  - Added test cases to ensure correct display of delivery ranges when only minimum or maximum delivery days are set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->