### PR TITLE
Permit `asset` param in PageBlocksController

### DIFF
--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -127,7 +127,7 @@ module Spree
 
     @@page_attributes = [:name, :slug, :meta_title, :meta_description, :meta_keywords]
 
-    @@page_block_attributes = [:type, :name, :text, :position]
+    @@page_block_attributes = [:type, :name, :text, :position, :asset]
 
     @@page_link_attributes = [:linkable_id, :linkable_type, :position, :label, :url, :open_in_new_tab]
 


### PR DESCRIPTION
- Fix PageBlocks::Image to assign submitted asset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including assets in page blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->