### PR TITLE
Performance fix: added memoization of `Taxon#cached_self_and_descenda…

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -22,7 +22,7 @@ module Spree
       include Spree::Webhooks::HasWebhooks
     end
 
-    MEMOIZED_METHODS = [:cached_self_and_descendants_ids]
+    MEMOIZED_METHODS = %w[cached_self_and_descendants_ids].freeze
 
     #
     # Magic methods

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -17,9 +17,12 @@ module Spree
     include Spree::TranslatableResource
     include Spree::TranslatableResourceSlug
     include Spree::Metadata
+    include Spree::MemoizedData
     if defined?(Spree::Webhooks::HasWebhooks)
       include Spree::Webhooks::HasWebhooks
     end
+
+    MEMOIZED_METHODS = [:cached_self_and_descendants_ids]
 
     #
     # Magic methods
@@ -368,7 +371,7 @@ module Spree
     end
 
     def cached_self_and_descendants_ids
-      Rails.cache.fetch("#{cache_key_with_version}/descendant-ids") do
+      @cached_self_and_descendants_ids ||= Rails.cache.fetch("#{cache_key_with_version}/descendant-ids") do
         self_and_descendants.ids
       end
     end


### PR DESCRIPTION
…nts_ids`

to avoid calling cache store every time we access this method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved the efficiency of retrieving taxon descendant IDs, resulting in faster navigation and filtering within category trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->