### PR TITLE
Added `LineItem#display_compare_at_amount` to remove business logic f…

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -95,7 +95,7 @@ module Spree
     end
 
     def compare_at_amount
-      variant.compare_at_amount_in(currency) * quantity
+      (variant.compare_at_amount_in(currency) || 0) * quantity
     end
 
     alias subtotal amount

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -85,13 +85,17 @@ module Spree
     extend DisplayMoney
     money_methods :amount, :subtotal, :discounted_amount, :final_amount, :total, :price,
                   :adjustment_total, :additional_tax_total, :promo_total, :included_tax_total,
-                  :pre_tax_amount, :shipping_cost, :tax_total
+                  :pre_tax_amount, :shipping_cost, :tax_total, :compare_at_amount
 
     alias single_money display_price
     alias single_display_amount display_price
 
     def amount
       price * quantity
+    end
+
+    def compare_at_amount
+      variant.compare_at_amount_in(currency) * quantity
     end
 
     alias subtotal amount

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -508,6 +508,24 @@ describe Spree::LineItem, type: :model do
     it 'returns the compare at amount for the line item' do
       expect(line_item.compare_at_amount).to eq(30)
     end
+
+    context 'when compare_at_price is nil' do
+      let(:variant)     { create(:variant, compare_at_price: nil) }
+
+      it 'returns zero' do
+        expect(line_item.compare_at_amount).to eq(0)
+        expect(line_item.display_compare_at_amount.to_s).to eq('$0.00')
+      end
+    end
+
+    context 'when compare_at_price is zero' do
+      let(:variant)   { create(:variant, compare_at_price: 0) }
+
+      it 'returns zero' do
+        expect(line_item.compare_at_amount).to eq(0)
+        expect(line_item.display_compare_at_amount.to_s).to eq('$0.00')
+      end
+    end
   end
 
   describe '#display_compare_at_amount' do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -482,4 +482,40 @@ describe Spree::LineItem, type: :model do
       end
     end
   end
+
+  describe '#amount' do
+    let(:variant) { create(:variant, price: 10) }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the amount for the line item' do
+      expect(line_item.amount).to eq(20)
+    end
+  end
+
+  describe '#display_amount' do
+    let(:variant) { create(:variant, price: 10) }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the amount for the line item' do
+      expect(line_item.display_amount.to_s).to eq('$20.00')
+    end
+  end
+
+  describe '#compare_at_amount' do
+    let(:variant) { create(:variant, compare_at_price: 15) }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the compare at amount for the line item' do
+      expect(line_item.compare_at_amount).to eq(30)
+    end
+  end
+
+  describe '#display_compare_at_amount' do
+    let(:variant) { create(:variant, compare_at_price: 15) }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the compare at amount for the line item' do
+      expect(line_item.display_compare_at_amount.to_s).to eq('$30.00')
+    end
+  end
 end

--- a/storefront/app/views/spree/checkout/_line_item.html.erb
+++ b/storefront/app/views/spree/checkout/_line_item.html.erb
@@ -15,7 +15,7 @@
   <div class="font-semibold text-sm text-right shrink-0">
     <% if should_display_compare_at_price?(line_item.variant) %>
       <span class="line-through text-red-500">
-        <%= Spree::Money.new(line_item.variant.compare_at_amount_in(line_item.currency) * line_item.quantity, currency: line_item.currency) %>
+        <%= line_item.display_compare_at_amount %>
       </span>
       <br />
     <% end %>


### PR DESCRIPTION
…rom views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "compare at" amount display for line items, showing the total compare-at price based on quantity and currency.

- **Bug Fixes**
  - Improved consistency in how compare-at prices are displayed in the checkout by centralizing the logic.

- **Tests**
  - Added tests to ensure accurate calculation and display of line item amounts and compare-at amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->