### PR TITLE
fix the typo of japan flag name

### DIFF
--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -65,6 +65,7 @@ module Spree
 
     def svg_country_icon(country_code)
       country_code = :us if country_code.to_s.downcase == 'en'
+      country_code = :jp if country_code.to_s.downcase == 'ja'
       tag.span(class: "fi fi-#{country_code.downcase}")
     end
 


### PR DESCRIPTION
the code try to show the icon via https://esm.sh/flag-icons@7.3.2/flags/4x3/ja.svg

the correct link is https://esm.sh/flag-icons@7.3.2/flags/4x3/jp.svg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved country icon display by correctly mapping the "ja" country code to show the Japanese flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->