### PR TITLE
storefront: fix square taxons images

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -157,6 +157,10 @@ module Spree
       sort_order == 'manual'
     end
 
+    def page_builder_image
+      square_image.presence || image
+    end
+
     def active_products_with_descendants
       @active_products_with_descendants ||= store.products.
                                             joins(:classifications).

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -783,6 +783,35 @@ describe Spree::Taxon, type: :model do
     end
   end
 
+  describe '#page_builder_image' do
+    subject(:page_builder_image) { taxon.page_builder_image }
+
+    let(:taxon) { build(:taxon, image: image, square_image: square_image) }
+
+    context 'when image and square image are not attached' do
+      let(:image) { nil }
+      let(:square_image) { nil }
+
+      it { is_expected.to_not be_attached }
+    end
+
+    context 'when only image is attached' do
+      let(:image) { file_fixture('icon_256x256.png') }
+      let(:square_image) { nil }
+
+      it { is_expected.to be_attached }
+      it { is_expected.to eq(taxon.image)}
+    end
+
+    context 'when both image and square image are attached' do
+      let(:image) { file_fixture('icon_256x256.png') }
+      let(:square_image) { file_fixture('icon_256x256.png') }
+
+      it { is_expected.to be_attached}
+      it { is_expected.to eq(taxon.square_image)}
+    end
+  end
+
   describe '#featured_sections' do
     subject { taxon.featured_sections }
 

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
@@ -47,7 +47,7 @@
           <% if section_with_image %>
             <div class='lg:col-span-5'>
               <%= link_to spree.nested_taxons_path(section.taxon), data: { turbo_frame: "_top" } do %>
-                <%= spree_image_tag(section.taxon.image, height: 500, width: 500, class: 'h-full w-full object-cover object-center', loading: :lazy) %>
+                <%= spree_image_tag(section.taxon.square_image, height: 500, width: 500, class: 'h-full w-full object-cover object-center', loading: :lazy) %>
               <% end %>
             </div>
           <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
@@ -5,7 +5,7 @@
                       when 'medium' then 'text-lg lg:text-xl font-medium'
                       when 'large' then 'text-xl lg:text-2xl font-medium'
                       end %>
-    <% if section.taxon&.image&.attached? && section.preferred_show_taxon_image %>
+    <% if section.taxon&.page_builder_image&.attached? && section.preferred_show_taxon_image %>
       <% desktop_slides_amount = 2.5 %>
       <% section_with_image = true %>
       <% arrows_on_top = false %>
@@ -47,7 +47,7 @@
           <% if section_with_image %>
             <div class='lg:col-span-5'>
               <%= link_to spree.nested_taxons_path(section.taxon), data: { turbo_frame: "_top" } do %>
-                <%= spree_image_tag(section.taxon.square_image, height: 500, width: 500, class: 'h-full w-full object-cover object-center', loading: :lazy) %>
+                <%= spree_image_tag(section.taxon.page_builder_image, height: 500, width: 500, class: 'h-full w-full object-cover object-center', loading: :lazy) %>
               <% end %>
             </div>
           <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
@@ -12,9 +12,9 @@
     <div class="gap-6 grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 xl:gap-x-8 mb-7 hidden md:grid">
       <% section.links.each do |link| %>
         <%= page_builder_link_to link, title: link.label, class: 'group block overflow-hidden', target: link.open_in_new_tab.presence && '_blank' do %>
-          <% if link.linkable.square_image&.attached? && link.linkable.square_image&.variable? %>
+          <% if link.linkable.page_builder_image&.attached? && link.linkable.page_builder_image&.variable? %>
             <div class="flex space-y-2 flex-col">
-              <%= spree_image_tag(link.linkable.square_image, height: 300, width: 300, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
+              <%= spree_image_tag(link.linkable.page_builder_image, height: 300, width: 300, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
               <span><%= link.label %></span>
             </div>
           <% else %>
@@ -47,10 +47,9 @@
           <% section.links.each do |link| %>
             <div class='swiper-slide w-[200px]'>
               <%= page_builder_link_to link, title: link.label, class: 'group block overflow-hidden', target: link.open_in_new_tab.presence && '_blank' do %>
-                <% if link.linkable.square_image&.attached? && link.linkable.square_image&.variable? %>
+                <% if link.linkable.page_builder_image.attached? %>
                   <div class="flex space-y-2 flex-col">
-                    <%= spree_image_tag(link.linkable.square_image, height: 200, width: 200, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
-                    <span><%= link.label %></span>
+                    <%= spree_image_tag(link.linkable.page_builder_image, height: 200, width: 200, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
                   </div>
                 <% else %>
                   <div class="aspect-1 w-full group-hover:bg-gray-100 bg-gray-200 flex items-center justify-center relative">

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
@@ -12,9 +12,9 @@
     <div class="gap-6 grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 xl:gap-x-8 mb-7 hidden md:grid">
       <% section.links.each do |link| %>
         <%= page_builder_link_to link, title: link.label, class: 'group block overflow-hidden', target: link.open_in_new_tab.presence && '_blank' do %>
-          <% if link.linkable.image&.attached? && link.linkable.image&.variable? %>
+          <% if link.linkable.square_image&.attached? && link.linkable.square_image&.variable? %>
             <div class="flex space-y-2 flex-col">
-              <%= spree_image_tag(link.linkable.image, height: 300, width: 300, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
+              <%= spree_image_tag(link.linkable.square_image, height: 300, width: 300, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
               <span><%= link.label %></span>
             </div>
           <% else %>
@@ -47,9 +47,9 @@
           <% section.links.each do |link| %>
             <div class='swiper-slide w-[200px]'>
               <%= page_builder_link_to link, title: link.label, class: 'group block overflow-hidden', target: link.open_in_new_tab.presence && '_blank' do %>
-                <% if link.linkable.image&.attached? && link.linkable.image&.variable? %>
+                <% if link.linkable.square_image&.attached? && link.linkable.square_image&.variable? %>
                   <div class="flex space-y-2 flex-col">
-                    <%= spree_image_tag(link.linkable.image, height: 200, width: 200, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
+                    <%= spree_image_tag(link.linkable.square_image, height: 200, width: 200, class: 'h-full w-full object-cover object-center group-hover:opacity-75 rounded-md bg-gray-200', loading: :lazy, alt: link.label) %>
                     <span><%= link.label %></span>
                   </div>
                 <% else %>


### PR DESCRIPTION
❌ current behavior:
storefront and page buider are using taxon.image cropped to square when displaying featured taxon(s) section

✅ expected behavior:
storefront and page buider should use taxon.square_image to display square images

🖊️ introduced changes:
add taxon.page_builder_image method that returns taxon.square_image and fallbacks to taxon.image

has been tested both on local builder and storefront:
- [x] `featured_taxons` 
- [ ] `featured_taxon`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced taxon image display logic to prioritize a square image when available, improving the visual presentation of featured taxons.

- **Bug Fixes**
  - Ensured that featured taxon images consistently display the most appropriate image, falling back to the default image when a square image is not attached.

- **Tests**
  - Added new tests to verify correct image selection for taxons under various attachment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->