### PR TITLE
show delete button for uploaded active storage images

### DIFF
--- a/admin/app/views/active_storage/_upload_form.html.erb
+++ b/admin/app/views/active_storage/_upload_form.html.erb
@@ -2,7 +2,7 @@
 <% height ||= 300 %>
 <% crop ||= false unless defined?(crop) %>
 <% auto_submit ||= false %>
-<% can_delete ||= true unless defined?(can_delete) %>
+<% show_delete_button = defined?(can_delete) ? can_delete : true %>
 <% css ||= '' %>
 
 <% if field_name && form %>
@@ -48,7 +48,7 @@
         <%= Spree.t('actions.select_file') %>
       </button>
 
-      <% if can_delete %>
+      <% if show_delete_button %>
         <button type="button" class="btn btn-danger ml-auto" data-action="active-storage-upload#remove" data-turbo-confirm="<%= Spree.t(:are_you_sure) %>">
           <%= icon('trash') %>
 


### PR DESCRIPTION
❌ current behavior
some uploaded images could not be deleted. for example there is no possibility to unset uploaded images from taxons

✅ expected behavior
delete button should be visible by default, visibility of delete button should be controlled by partial variable can_delete in `views/active_storage/_upload_form.html.erb`

<img width="445" alt="Zrzut ekranu 2025-06-12 o 14 06 50" src="https://github.com/user-attachments/assets/d4b4a7b3-3059-4f92-af87-a79fd043210d" />



🐛 the issue
`<% can_delete ||= true unless defined?(can_delete) %>` this is always defined because when checking defined? the variable is already defined




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the logic controlling the visibility of the delete button in the upload form to improve clarity and consistency. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->