### PR TITLE
Quick checkout: do not require shipping address for fully digital ord…

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -325,7 +325,14 @@ module Spree
     # Either fully digital or not digital at all
     # @return [Boolean]
     def quick_checkout_available?
-      payment_required? && shipments.count <= 1 && (digital? || !some_digital?)
+      payment_required? && shipments.count <= 1 && (digital? || !some_digital? || !delivery_required?)
+    end
+
+    # Check if quick checkout requires an address collection
+    # If the order is digital or not delivery required, then we don't need to collect an address
+    # @return [Boolean]
+    def quick_checkout_require_address?
+      !digital? && delivery_required?
     end
 
     # Returns the relevant zone (if any) to be used for taxation purposes.

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2137,7 +2137,7 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe '#quick_checkout_available?' do
+  context 'quick checkout' do
     let(:digital_shipping_method) { create(:digital_shipping_method) }
     let(:digital_product) { create(:product, shipping_category: digital_shipping_method.shipping_categories.first) }
     let(:digital_variant) { create(:variant, product: digital_product, digitals: [create(:digital)]) }
@@ -2145,47 +2145,86 @@ describe Spree::Order, type: :model do
     let(:physical_line_item) { create(:line_item, quantity: 1, order: order) }
     let(:order) { create(:order) }
 
-    it 'returns true if the order is fully digital' do
-      digital_line_item
-      order.update_totals
+    describe '#quick_checkout?' do
+      it 'returns false if the order has no shipping address' do
+        expect(order.quick_checkout?).to be false
+      end
 
-      expect(order.quick_checkout_available?).to be true
+      it 'returns false if the order has a shipping address but it is not a quick checkout address' do
+        order.shipping_address = create(:address)
+        expect(order.quick_checkout?).to be false
+      end
+
+      it 'returns true if the order has a quick checkout shipping address' do
+        order.shipping_address = create(:address, quick_checkout: true)
+        expect(order.quick_checkout?).to be true
+      end
     end
 
-    it 'returns true if the order has no digital products at all' do
-      physical_line_item
-      order.update_totals
+    describe '#quick_checkout_available?' do
+      it 'returns true if the order is fully digital' do
+        digital_line_item
+        order.update_totals
 
-      expect(order.quick_checkout_available?).to be true
+        expect(order.quick_checkout_available?).to be true
+      end
+
+      it 'returns true if the order has no digital products at all' do
+        physical_line_item
+        order.update_totals
+
+        expect(order.quick_checkout_available?).to be true
+      end
+
+      it 'returns false if the order has physical products and some digital products' do
+        physical_line_item
+        digital_line_item
+        order.update_totals
+
+        expect(order.quick_checkout_available?).to be false
+      end
+
+      it 'returns false if order has many shipments' do
+        physical_line_item
+        digital_line_item
+        order.update_totals
+        order.create_proposed_shipments
+
+        expect(order.shipments.count).to eq(2)
+
+        expect(order.quick_checkout_available?).to be false
+      end
+
+      it 'returns false if order does not require payment' do
+        physical_line_item.update(price: 0)
+        order.update_totals
+
+        expect(order.total).to eq(0)
+        expect(order.payment_required?).to be false
+
+        expect(order.quick_checkout_available?).to be false
+      end
     end
 
-    it 'returns false if the order has physical products and some digital products' do
-      physical_line_item
-      digital_line_item
-      order.update_totals
+    describe '#quick_checkout_require_address?' do
+      let(:order) { create(:order) }
 
-      expect(order.quick_checkout_available?).to be false
-    end
+      it 'returns true if the order is not digital and delivery is required' do
+        expect(order.quick_checkout_require_address?).to be true
+      end
 
-    it 'returns false if order has many shipments' do
-      physical_line_item
-      digital_line_item
-      order.update_totals
-      order.create_proposed_shipments
+      it 'returns false if the order is digital' do
+        digital_line_item
+        order.update_totals
 
-      expect(order.shipments.count).to eq(2)
+        expect(order.quick_checkout_require_address?).to be false
+      end
 
-      expect(order.quick_checkout_available?).to be false
-    end
+      it 'returns false if the order does not require delivery' do
+        allow(order).to receive(:delivery_required?).and_return(false)
 
-    it 'returns false if order does not require payment' do
-      physical_line_item.update(price: 0)
-      order.update_totals
-
-      expect(order.total).to eq(0)
-      expect(order.payment_required?).to be false
-
-      expect(order.quick_checkout_available?).to be false
+        expect(order.quick_checkout_require_address?).to be false
+      end
     end
   end
 end

--- a/storefront/spec/controllers/spree/checkout_controller_spec.rb
+++ b/storefront/spec/controllers/spree/checkout_controller_spec.rb
@@ -1295,7 +1295,7 @@ describe Spree::CheckoutController, type: :controller do
       expect(response).to redirect_to spree.checkout_path(order.token)
 
       expect(order.reload.payments.count).to eq(1)
-      expect(order.payments.first).to be_invalid
+      expect(order.payments.first.state).to eq('invalid')
       expect(order.payments.first.source).to eq(store_credit)
       expect(order.payments.first.payment_method).to eq(payment_method)
       expect(order.payments.first.amount).to eq(12.34)


### PR DESCRIPTION
…ers or if delivery is not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quick checkout is now available for orders that do not require delivery, in addition to previous scenarios.
  - Address collection during quick checkout is only required if the order is not digital and delivery is needed.

- **Tests**
  - Improved and expanded test coverage for quick checkout scenarios, including address requirements and order types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->