### PR TITLE
Require mobility 1.3

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'validates_zipcode'
   s.add_dependency 'image_processing', '~> 1.2'
   s.add_dependency 'active_storage_validations', '1.3.0'
-  s.add_dependency 'mobility', '~> 1.2'
+  s.add_dependency 'mobility', '~> 1.3', '>= 1.3.2'
   s.add_dependency 'mobility-ransack', '~> 1.2'
   s.add_dependency 'mobility-actiontext', '~> 1.1'
   s.add_dependency 'friendly_id-mobility', '~> 1.0'


### PR DESCRIPTION
Fixes numerous issues on Rails 8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the minimum required version of the mobility library to 1.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->