### PR TITLE
add missing shipment tracking fallback in shipment view

### DIFF
--- a/admin/app/helpers/spree/admin/shipment_helper.rb
+++ b/admin/app/helpers/spree/admin/shipment_helper.rb
@@ -1,5 +1,7 @@
 module Spree::Admin
   module ShipmentHelper
+    include Spree::ShipmentHelper
+
     def can_ship?(shipment)
       can?(:update, shipment) && shipment.shippable?
     end

--- a/admin/app/views/spree/admin/orders/_shipment.html.erb
+++ b/admin/app/views/spree/admin/orders/_shipment.html.erb
@@ -65,7 +65,7 @@
           <strong><%= Spree.t(:tracking) %>: </strong>
           <% if shipment.tracked? %>
             <% if shipment.tracking_url.present? %>
-              <span><%= link_to ERB::Util.html_escape(shipment.tracking || shipment.tracking_url), ERB::Util.html_escape(shipment.tracking_url), target: '_blank', rel: "noopener noreferrer" %></span>
+              <span><%= shipment_tracking_link_to(shipment, target: '_blank', rel: 'noopener noreferrer') %></span>
             <% elsif shipment.tracking.present? %>
               <span><%= shipment.tracking %></span>
             <% end %>

--- a/admin/app/views/spree/admin/orders/_shipment.html.erb
+++ b/admin/app/views/spree/admin/orders/_shipment.html.erb
@@ -65,7 +65,7 @@
           <strong><%= Spree.t(:tracking) %>: </strong>
           <% if shipment.tracked? %>
             <% if shipment.tracking_url.present? %>
-              <span><%= link_to ERB::Util.html_escape(shipment.tracking), ERB::Util.html_escape(shipment.tracking_url), target: '_blank', rel: "noopener noreferrer" %></span>
+              <span><%= link_to ERB::Util.html_escape(shipment.tracking || shipment.tracking_url), ERB::Util.html_escape(shipment.tracking_url), target: '_blank', rel: "noopener noreferrer" %></span>
             <% elsif shipment.tracking.present? %>
               <span><%= shipment.tracking %></span>
             <% end %>

--- a/admin/app/views/spree/admin/orders/_shipment.html.erb
+++ b/admin/app/views/spree/admin/orders/_shipment.html.erb
@@ -65,7 +65,7 @@
           <strong><%= Spree.t(:tracking) %>: </strong>
           <% if shipment.tracked? %>
             <% if shipment.tracking_url.present? %>
-              <span><%= shipment_tracking_link_to(shipment, target: '_blank', rel: 'noopener noreferrer') %></span>
+              <span><%= shipment_tracking_link_to(shipment: shipment, html_options: { target: '_blank', rel: 'noopener noreferrer' }) %></span>
             <% elsif shipment.tracking.present? %>
               <span><%= shipment.tracking %></span>
             <% end %>

--- a/core/app/helpers/spree/shipment_helper.rb
+++ b/core/app/helpers/spree/shipment_helper.rb
@@ -1,7 +1,5 @@
 module Spree
   module ShipmentHelper
-    include BaseHelper
-
     def shipment_tracking_link_to(shipment:, name: nil, html_options: {})
       tracking_url = shipment.tracking_url.presence
       return '' unless tracking_url

--- a/core/app/helpers/spree/shipment_helper.rb
+++ b/core/app/helpers/spree/shipment_helper.rb
@@ -3,9 +3,12 @@ module Spree
     include BaseHelper
 
     def shipment_tracking_link_to(shipment, options = nil)
-      display_text = shipment.tracking.presence || shipment.tracking_url
+      tracking_url = shipment.tracking_url.presence
+      return '' unless tracking_url
 
-      link_to display_text, shipment.tracking_url, options
+      display_text = shipment.tracking.presence || tracking_url
+
+      link_to display_text, tracking_url, options
     end
   end
 end

--- a/core/app/helpers/spree/shipment_helper.rb
+++ b/core/app/helpers/spree/shipment_helper.rb
@@ -2,13 +2,13 @@ module Spree
   module ShipmentHelper
     include BaseHelper
 
-    def shipment_tracking_link_to(shipment, options = nil)
+    def shipment_tracking_link_to(shipment:, name: nil, html_options: {})
       tracking_url = shipment.tracking_url.presence
       return '' unless tracking_url
 
-      display_text = shipment.tracking.presence || tracking_url
+      display_text = name || shipment.tracking.presence || tracking_url
 
-      link_to display_text, tracking_url, options
+      link_to display_text, tracking_url, html_options
     end
   end
 end

--- a/core/app/helpers/spree/shipment_helper.rb
+++ b/core/app/helpers/spree/shipment_helper.rb
@@ -1,0 +1,11 @@
+module Spree
+  module ShipmentHelper
+    include BaseHelper
+
+    def shipment_tracking_link_to(shipment, options = nil)
+      display_text = shipment.tracking.presence || shipment.tracking_url
+
+      link_to display_text, shipment.tracking_url, options
+    end
+  end
+end

--- a/core/spec/helpers/shipment_helper_spec.rb
+++ b/core/spec/helpers/shipment_helper_spec.rb
@@ -4,19 +4,40 @@ module Spree
   describe ShipmentHelper, type: :helper do
     let(:shipment) { create(:shipment, tracking: tracking) }
     let(:tracking) { 'tracking' }
-    let(:tracking_url) { 'https://example.com?tracking=Abc' }
-    let(:options) { {} }
 
     before do
       allow(shipment).to receive(:tracking_url).and_return(tracking_url)
     end
 
     describe '#shipment_tracking_link_to' do
-      subject(:shipment_tracking_link_to) { helper.shipment_tracking_link_to(shipment, options) }
+      subject(:shipment_tracking_link_to) { helper.shipment_tracking_link_to(**params) }
+
+      let(:params) do
+        {
+          shipment: shipment,
+        }
+      end
+
+      let(:tracking_url) { 'https://example.com?tracking=Abc' }
 
       context 'with tracking and tracking_url' do
         it 'creates link with tracking as a name' do
           expect(shipment_tracking_link_to).to eq('<a href="https://example.com?tracking=Abc">tracking</a>')
+        end
+      end
+
+      context 'with name passed in params' do
+        let(:name) { 'overriden name' }
+
+        let(:params) do
+          {
+            shipment: shipment,
+            name: name
+          }
+        end
+
+        it 'creates link with passed value as a name' do
+          expect(shipment_tracking_link_to).to eq('<a href="https://example.com?tracking=Abc">overriden name</a>')
         end
       end
 
@@ -38,7 +59,12 @@ module Spree
       end
 
       context 'with options' do
-        let(:options) { { data: { foo: 'bar' } } }
+        let(:params) do
+          {
+            shipment: shipment,
+            html_options: { data: { foo: 'bar' } }
+          }
+        end
 
         it 'sets options for link' do
           expect(shipment_tracking_link_to).to include(' data-foo="bar"')

--- a/core/spec/helpers/shipment_helper_spec.rb
+++ b/core/spec/helpers/shipment_helper_spec.rb
@@ -27,7 +27,7 @@ module Spree
       end
 
       context 'with name passed in params' do
-        let(:name) { 'overriden name' }
+        let(:name) { 'overridden name' }
 
         let(:params) do
           {
@@ -37,7 +37,7 @@ module Spree
         end
 
         it 'creates link with passed value as a name' do
-          expect(shipment_tracking_link_to).to eq('<a href="https://example.com?tracking=Abc">overriden name</a>')
+          expect(shipment_tracking_link_to).to eq('<a href="https://example.com?tracking=Abc">overridden name</a>')
         end
       end
 

--- a/core/spec/helpers/shipment_helper_spec.rb
+++ b/core/spec/helpers/shipment_helper_spec.rb
@@ -2,31 +2,43 @@ require 'spec_helper'
 
 module Spree
   describe ShipmentHelper, type: :helper do
-    let(:shipment) { create(:shipment, external_tracking_url: tracking_url, tracking: tracking) }
+    let(:shipment) { create(:shipment, tracking: tracking) }
     let(:tracking) { 'tracking' }
-    let(:tracking_url) { 'https://example.com' }
+    let(:tracking_url) { 'https://example.com?tracking=Abc' }
     let(:options) { {} }
+
+    before do
+      allow(shipment).to receive(:tracking_url).and_return(tracking_url)
+    end
 
     describe '#shipment_tracking_link_to' do
       subject(:shipment_tracking_link_to) { helper.shipment_tracking_link_to(shipment, options) }
 
       context 'with tracking and tracking_url' do
         it 'creates link with tracking as a name' do
-          expect(shipment_tracking_link_to).to eq('<a href="https://example.com">tracking</a>')
+          expect(shipment_tracking_link_to).to eq('<a href="https://example.com?tracking=Abc">tracking</a>')
         end
       end
 
       context 'with tracking_url only' do
         let(:tracking) { nil }
         let(:tracking_url) { 'https://example.com' }
-        
+
         it 'creates a link with tracking_url as a name' do
           expect(shipment_tracking_link_to).to eq('<a href="https://example.com">https://example.com</a>')
         end
       end
 
+      context 'with no tracking_url' do
+        let(:tracking_url) { '' }
+
+        it 'returns empty string' do
+          expect(shipment_tracking_link_to).to eq('')
+        end
+      end
+
       context 'with options' do
-        let(:options) { { data: { foo: 'bar'  } } }
+        let(:options) { { data: { foo: 'bar' } } }
 
         it 'sets options for link' do
           expect(shipment_tracking_link_to).to include(' data-foo="bar"')

--- a/core/spec/helpers/shipment_helper_spec.rb
+++ b/core/spec/helpers/shipment_helper_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module Spree
+  describe ShipmentHelper, type: :helper do
+    let(:shipment) { create(:shipment, external_tracking_url: tracking_url, tracking: tracking) }
+    let(:tracking) { 'tracking' }
+    let(:tracking_url) { 'https://example.com' }
+    let(:options) { {} }
+
+    describe '#shipment_tracking_link_to' do
+      subject(:shipment_tracking_link_to) { helper.shipment_tracking_link_to(shipment, options) }
+
+      context 'with tracking and tracking_url' do
+        it 'creates link with tracking as a name' do
+          expect(shipment_tracking_link_to).to eq('<a href="https://example.com">tracking</a>')
+        end
+      end
+
+      context 'with tracking_url only' do
+        let(:tracking) { nil }
+        let(:tracking_url) { 'https://example.com' }
+        
+        it 'creates a link with tracking_url as a name' do
+          expect(shipment_tracking_link_to).to eq('<a href="https://example.com">https://example.com</a>')
+        end
+      end
+
+      context 'with options' do
+        let(:options) { { data: { foo: 'bar'  } } }
+
+        it 'sets options for link' do
+          expect(shipment_tracking_link_to).to include(' data-foo="bar"')
+        end
+      end
+    end
+  end
+end

--- a/emails/app/mailers/spree/shipment_mailer.rb
+++ b/emails/app/mailers/spree/shipment_mailer.rb
@@ -1,5 +1,7 @@
 module Spree
   class ShipmentMailer < BaseMailer
+    helper Spree::ShipmentHelper
+
     def shipped_email(shipment, resend = false)
       @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
       @order = @shipment.order

--- a/emails/app/views/spree/shipment_mailer/shipped_email.html.erb
+++ b/emails/app/views/spree/shipment_mailer/shipped_email.html.erb
@@ -26,7 +26,7 @@
 <% end %>
 <% if @shipment.tracking_url %>
   <p>
-    <%= Spree.t('shipment_mailer.shipped_email.track_link', url: link_to(@shipment.tracking_url, @shipment.tracking_url)).html_safe %>
+    <%= Spree.t('shipment_mailer.shipped_email.track_link', url: shipment_tracking_link_to(shipment: @shipment)).html_safe %>
   </p>
 <% end %>
 <p>

--- a/emails/lib/generators/spree/emails/install/templates/mailers/previews/shipment_preview.rb
+++ b/emails/lib/generators/spree/emails/install/templates/mailers/previews/shipment_preview.rb
@@ -1,4 +1,6 @@
 class ShipmentPreview < ActionMailer::Preview
+  helper Spree::ShipmentHelper
+
   def shipped_email
     Spree::ShipmentMailer.shipped_email(Spree::Shipment.shipped.first)
   end

--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -2,6 +2,7 @@ module Spree
   module StorefrontHelper
     include BaseHelper
     include Spree::ImagesHelper
+    include Spree::ShipmentHelper
     include Heroicon::Engine.helpers
 
     # Renders the storefront partials for the given section.

--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -33,10 +33,7 @@
         <% unless shipment.digital? %>
           <div class="mt-4 lg:-mt-2 lg:-mr-2">
             <% if shipment.shipped? && shipment.tracked? && shipment.tracking_url.present? %>
-              <%= link_to Spree.t(:track_items),
-              shipment.tracking_url,
-              class: "!px-3 !py-1 block btn-primary !leading-6 text-sm text-center",
-              target: :_blank %>
+              <%= shipment_tracking_link_to(shipment: shipment, name: Spree.t(:track_items), html_options { class: "!px-3 !py-1 block btn-primary !leading-6 text-sm text-center", target: :_blank }) %>
             <% else %>
               <button
                 class="

--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -33,7 +33,7 @@
         <% unless shipment.digital? %>
           <div class="mt-4 lg:-mt-2 lg:-mr-2">
             <% if shipment.shipped? && shipment.tracked? && shipment.tracking_url.present? %>
-              <%= shipment_tracking_link_to(shipment: shipment, name: Spree.t(:track_items), html_options { class: "!px-3 !py-1 block btn-primary !leading-6 text-sm text-center", target: :_blank }) %>
+              <%= shipment_tracking_link_to(shipment: shipment, name: Spree.t(:track_items), html_options: { class: "!px-3 !py-1 block btn-primary !leading-6 text-sm text-center", target: :_blank }) %>
             <% else %>
               <button
                 class="


### PR DESCRIPTION
spree admin: show shipment tracking url for shipments with tracking url with no additional tracking data

fix for failing test:

```
    context 'shipment has external tracking url' do
      before do
        shipment.external_tracking_url = 'https://track.test.com/tracking?ref=123456'
        shipment.save!
      end

      it 'shows  shipment link' do
```


```
Failures:

  1) Shipments Shipment cannot be shipped if tracking is not present  shipment has external tracking url shows  shipment link
     Failure/Error: expect(page).to have_link(shipment.tracking, href: shipment.tracking_url)
       expected to find visible link with href "https://track.test.com/tracking?ref=123456" but there were no matches. Also found "", which matched the selector but not all filters. 
     # ./spec/features/spree/admin/orders/shipments_spec.rb:70:in `block (4 levels) in <top (required)>'
     # ./spec/support/rspec_retry_config.rb:8:in `block (2 levels) in <main>'

Finished in 3 minutes 6.6 seconds (files took 6.46 seconds to load)
172 examples, 1 failure

Failed examples:

rspec ./spec/features/spree/admin/orders/shipments_spec.rb:67 # Shipments Shipment cannot be shipped if tracking is not present  shipment has external tracking url shows  shipment link
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized shipment tracking link generation using a new helper for consistent and secure links in admin, storefront, and emails.  
- **Tests**
  - Added comprehensive tests for shipment tracking link behavior across different scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->