### PR TITLE
uppy library fix for image-editor plugin

### DIFF
--- a/admin/app/javascript/spree/admin/controllers/active_storage_upload_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/active_storage_upload_controller.js
@@ -29,7 +29,8 @@ export default class extends Controller {
     })
 
     this.uppy.use(ActiveStorageUpload, {
-      directUploadUrl: document.querySelector("meta[name='direct-upload-url']").getAttribute('content')
+      directUploadUrl: document.querySelector("meta[name='direct-upload-url']").getAttribute('content'),
+      crop: this.cropValue
     })
 
     let dashboardOptions = {}
@@ -55,16 +56,6 @@ export default class extends Controller {
 
     this.uppy.on('file-editor:complete', (updatedFile) => {
       console.log('File editing complete:', updatedFile)
-      // Remove the old file from Uppy's file list
-      this.uppy.removeFile(updatedFile.id)
-      // Add the updated file to Uppy
-      this.uppy.addFile({
-        name: updatedFile.name,
-        type: updatedFile.type,
-        data: updatedFile.data,
-        source: 'local',
-        isRemote: false
-      })
 
       this.handleUI(updatedFile)
 

--- a/admin/app/javascript/spree/admin/helpers/uppy_active_storage.js
+++ b/admin/app/javascript/spree/admin/helpers/uppy_active_storage.js
@@ -20,7 +20,8 @@ export default class ActiveStorageUpload extends BasePlugin {
       limit: 0,
       timeout: 30 * 1000,
       directUploadUrl: null,
-      headers: {}
+      headers: {},
+      crop: false
     }
 
     this.opts = Object.assign({}, defaultOptions, opts)
@@ -37,6 +38,12 @@ export default class ActiveStorageUpload extends BasePlugin {
 
   install() {
     this.uppy.addUploader(this.handleUpload)
+    this.uppy.on('file-editor:complete', (updatedFile) => {
+      this.handleUpload([updatedFile.id])
+
+      // call directly upload method after editing image
+      return this.uploadFiles([updatedFile]).then(() => null)
+    })
   }
 
   uninstall() {
@@ -46,6 +53,10 @@ export default class ActiveStorageUpload extends BasePlugin {
   handleUpload(fileIDs) {
     if (fileIDs.length === 0) {
       this.uppy.log("[ActiveStorage] No files to upload!")
+      return Promise.resolve()
+    }
+    // do not upload before editing is done
+    if (this.opts.crop) {
       return Promise.resolve()
     }
 
@@ -114,8 +125,6 @@ export default class ActiveStorageUpload extends BasePlugin {
             status: "success",
             directUploadSignedId: blob.signed_id,
           }
-
-          this.uppy.setFileState(file.id, { response })
 
           this.uppy.emit("upload-success", file, blob)
 

--- a/admin/app/javascript/spree/admin/helpers/uppy_active_storage.js
+++ b/admin/app/javascript/spree/admin/helpers/uppy_active_storage.js
@@ -15,7 +15,6 @@ export default class ActiveStorageUpload extends BasePlugin {
     this.id = opts.id || "ActiveStorageUpload"
     this.title = opts.title || "ActiveStorageUpload"
     this.type = "uploader"
-    this.onEditorComplete = this.onEditorComplete.bind(this)
 
     const defaultOptions = {
       limit: 0,
@@ -46,12 +45,12 @@ export default class ActiveStorageUpload extends BasePlugin {
     this.uppy.removeUploader(this.handleUpload)
     this.uppy.off('file-editor:complete', this.onEditorComplete)
   }
-
-  onEditorComplete (updatedFile) {
+  
+  onEditorComplete = (updatedFile) => {
     this.handleUpload([updatedFile.id])
 
     // call directly upload method after editing image
-    return this.uploadFiles([updatedFile]).then(() => null)
+    return this.uploadFiles([updatedFile])
   }
 
   handleUpload(fileIDs) {

--- a/admin/app/javascript/spree/admin/helpers/uppy_active_storage.js
+++ b/admin/app/javascript/spree/admin/helpers/uppy_active_storage.js
@@ -15,6 +15,7 @@ export default class ActiveStorageUpload extends BasePlugin {
     this.id = opts.id || "ActiveStorageUpload"
     this.title = opts.title || "ActiveStorageUpload"
     this.type = "uploader"
+    this.onEditorComplete = this.onEditorComplete.bind(this)
 
     const defaultOptions = {
       limit: 0,
@@ -38,16 +39,19 @@ export default class ActiveStorageUpload extends BasePlugin {
 
   install() {
     this.uppy.addUploader(this.handleUpload)
-    this.uppy.on('file-editor:complete', (updatedFile) => {
-      this.handleUpload([updatedFile.id])
-
-      // call directly upload method after editing image
-      return this.uploadFiles([updatedFile]).then(() => null)
-    })
+    this.uppy.on('file-editor:complete', this.onEditorComplete)
   }
 
   uninstall() {
     this.uppy.removeUploader(this.handleUpload)
+    this.uppy.off('file-editor:complete', this.onEditorComplete)
+  }
+
+  onEditorComplete (updatedFile) {
+    this.handleUpload([updatedFile.id])
+
+    // call directly upload method after editing image
+    return this.uploadFiles([updatedFile]).then(() => null)
   }
 
   handleUpload(fileIDs) {


### PR DESCRIPTION
🐛 bug description
- image-editor plugin is not working. (cropping functions etc)
- original image (not updated) is set to resource

✏️ fixes & improvements:
1. image is not being updated before editing (when editing is turned on ofc)
2. remove code that cause 'file do not exist in a state' uppy error
3. call upload method manually after finishing editing image



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for image cropping during file uploads in the admin interface.
- **Improvements**
  - Enhanced the upload workflow to handle edited files more efficiently, triggering uploads only after image editing is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->