### PR TITLE
Display the correct icon for Mastercard on checkout

### DIFF
--- a/storefront/app/javascript/spree/storefront/controllers/card_validation_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/card_validation_controller.js
@@ -56,6 +56,8 @@ export default class extends Controller {
   }
 
   updateCardIcon(cardType) {
+    cardType = (cardType === "mastercard" ? "master" : cardType)
+
     const iconElement = document.getElementById(`credit-card-icon-${cardType}`)
     if (iconElement) {
       this.typeContainerTarget.innerHTML = iconElement.innerHTML


### PR DESCRIPTION
- Normalize "mastercard" to "master" in icon rendering logic
- Update `updateCardIcon` to correctly handle Mastercard cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved card icon display to correctly show the "Mastercard" icon when the card type is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->