### PR TITLE
Add contact_phone and address fields to store form and translations

### DIFF
--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -33,6 +33,23 @@
 
     <div class="card mb-4">
       <div class="card-header">
+        <h5 class="card-title"><%= Spree.t(:phone) %> & <%= Spree.t(:address) %></h5>
+      </div>
+      <div class="card-body">
+        <div class="form-group">
+          <%= f.label :contact_phone %>
+          <%= f.text_field :contact_phone, class: 'form-control' %>
+        </div>
+
+        <div class="form-group">
+          <%= f.label :address %>
+          <%= f.text_area :address, class: 'form-control', data: { controller: 'textarea-autogrow' } %>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-4">
+      <div class="card-header">
         <h5 class="card-title"><%= Spree.t(:standards_and_formats) %></h5>
       </div>
       <div class="card-body">

--- a/admin/app/views/spree/admin/translations/stores/_form.html.erb
+++ b/admin/app/views/spree/admin/translations/stores/_form.html.erb
@@ -14,6 +14,8 @@
           <div class="trix-container mb-0">
             <%= rich_text_area_tag "translation[#{field}][#{translation_locale}]", resource.get_field_with_locale(translation_locale, field), { contenteditable: !readonly } %>
           </div>
+        <% when :address %>
+          <%= text_area_tag "translation[#{field}][#{translation_locale}]", resource.get_field_with_locale(translation_locale, field), class: 'form-control', readonly: readonly, data: { controller: 'textarea-autogrow'} %>
         <% else %>
           <%= text_field_tag "translation[#{field}][#{translation_locale}]", resource.get_field_with_locale(translation_locale, field), class: 'form-control', readonly: readonly %>
         <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -151,6 +151,8 @@ en:
         updated: Updated
         user: User
       spree/store:
+        address: Address
+        contact_phone: Contact Phone
         mail_from_address: Mail From Address
         meta_description: Meta Description
         meta_keywords: Meta Keywords


### PR DESCRIPTION
- Add phone and address fields to the basic store form view.
- Ensure contact_phone and address fields support translation.
- Update `en.yml` to include translations for contact_phone and address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "Phone & Address" section to the store basic form in the admin interface, allowing input of contact phone number and address with an auto-growing address field.
- **Enhancements**
  - Improved the translations form to use a multiline input for the address field.
  - Added English translations for "Address" and "Contact Phone".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->