### PR TITLE
Stop stubbing `find_by` for admin users

### DIFF
--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -43,7 +43,6 @@ module Spree
           let(:admin_user) { create(:admin_user) }
 
           before do
-            allow(Spree.admin_user_class).to receive(:find_by).and_return(admin_user)
             if defined?(Spree::Admin::BaseController)
               allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(admin_user)
             end


### PR DESCRIPTION
This can lead to edge cases when you have more user roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal authorization stubbing for admin user in testing support to streamline behavior. No changes to public interfaces or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->