### PR TITLE
improve-admin-general-settings-views-i18n

### DIFF
--- a/admin/app/views/active_storage/_upload_form.html.erb
+++ b/admin/app/views/active_storage/_upload_form.html.erb
@@ -36,7 +36,7 @@
 
         <% if crop %>
           <span class="text-muted ml-2 text-center small mt-2">
-            Recommended size: <%= width %>x<%= height %>px
+            <%= Spree.t('admin.recommended_size') %>: <%= width %>x<%= height %>px
           </span>
         <% end %>
       </div>

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          This is the name of your store. It will be displayed in the header and in the footer.
+          <%= Spree.t(:store_name_help) %>
         </p>
         <div class="form-group">
           <%= f.label :name, Spree.t(:name) %>
@@ -37,12 +37,12 @@
       </div>
       <div class="card-body">
         <div class="form-group">
-          <%= f.label :contact_phone %>
+          <%= f.label :contact_phone, Spree.t(:contact_phone) %>
           <%= f.text_field :contact_phone, class: 'form-control' %>
         </div>
 
         <div class="form-group">
-          <%= f.label :address %>
+          <%= f.label :address, Spree.t(:address) %>
           <%= f.text_area :address, class: 'form-control', data: { controller: 'textarea-autogrow' } %>
         </div>
       </div>
@@ -54,7 +54,7 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          Set the timezone, default unit system and weight unit for your store.
+          <%= Spree.t(:standards_and_formats_help) %>
         </p>
         <div class="form-group mb-3">
           <%= label_tag :preferred_timezone, raw(Spree.t(:timezone) + required_span_tag) %>
@@ -65,14 +65,14 @@
             <%= label_tag :preferred_unit_system, raw(Spree.t(:unit_system) + required_span_tag) %>
             <%= select_tag 'store[preferred_unit_system]', options_for_select(unit_systems, @store.preferred_unit_system), {class: 'custom-select', data: {unit_system_target: "body", action: "change->unit-system#unitSystemHandler"}} %>
             <p class="text-muted form-text mt-2 mb-0">
-              This will be used as the default unit system for your store. You can override this on a per-product basis.
+              <%= Spree.t(:unit_system_help) %>
             </p>
           </div>
           <div class="form-group">
             <%= label_tag :preferred_weight_unit, raw(Spree.t(:weight_unit) + required_span_tag) %>
             <%= select_tag 'store[preferred_weight_unit]', options_for_select(weight_units(@store), @store.preferred_weight_unit), {class: 'custom-select', data: {unit_system_target: "weightUnit"}} %>
             <p class="text-muted form-text mt-2 mb-0">
-              This will be used as the default weight unit for your store. You can override this on a per-product basis.
+              <%= Spree.t(:weight_unit_help) %>
             </p>
           </div>
         </div>
@@ -87,10 +87,10 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          This determines which vendors you can connect with and what customers see on your store.
+          <%= Spree.t(:currency_and_country_help) %>
         </p>
         <div class="form-group">
-          <%= f.label :default_currency %>
+          <%= f.label :default_currency, Spree.t(:default_currency) %>
           <%= f.currency_select :default_currency, preferred_currencies, {}, data: { controller: 'autocomplete-select' } %>
           <%= f.error_message_on :default_currency %>
         </div>
@@ -112,14 +112,14 @@
           <%= f.label :checkout_zone_id, Spree.t(:shipping_zone) %>
           <%= f.select :checkout_zone_id, options_for_select(@zones, @store.checkout_zone_id), { }, { data: { controller: 'autocomplete-select' } } %>
           <small class="form-text text-muted mt-2">
-            Zone will limit to which Countries or States products are shipped.
+            <%= Spree.t(:shipping_zone_help) %>
             <%= link_to Spree.t('admin.manage_zones'), spree.admin_zones_path %>
           </small>
           <%= f.error_message_on :checkout_zone_id %>
         </div>
 
         <div class="form-group">
-          <%= f.label :default_locale %>
+          <%= f.label :default_locale, Spree.t(:default_locale) %>
           <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), {}, { data: { controller: 'autocomplete-select' } } %>
           <%= f.error_message_on :default_locale %>
         </div>
@@ -139,8 +139,7 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          Digital assets are files that can be downloaded by customers after
-          purchase.
+          <%= Spree.t(:digital_assets_help) %>
         </p>
         <div class="custom-control custom-checkbox mb-3">
           <%= f.check_box :preferred_limit_digital_download_days,

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
           choose_stores: Choose which stores this product should be available in
         variants:
           option_types_link: To add more option types please go to <a href="%{link}">Option Types</a>
+      recommended_size: Recommended size
       report_created: Your report is being generated. You will receive an email with a download link when it is ready!
       reset_digital_link_download_limits: Reset download limits
       response_code: Response Code

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -863,6 +863,7 @@ en:
     credits: Credits
     currencies: Currencies
     currency: Currency
+    currency_and_country_help: This determines which vendors you can connect with and what customers see on your store.
     currency_settings: Currency Settings
     current: Current
     current_password: Current password
@@ -892,6 +893,7 @@ en:
     default_country: Default Country
     default_country_cannot_be_deleted: Default country cannot be deleted
     default_currency: Default currency
+    default_locale: Default locale
     default_post_categories:
       articles: Articles
       news: News
@@ -922,6 +924,7 @@ en:
     digital:
       digital_delivery: Digital Delivery
     digital_assets: Digital assets
+    digital_assets_help: Digital assets are files that can be downloaded by customers after purchase.
     digital_link_unauthorized: You are not authorized to access this asset
     dimension_units:
       centimeter: Centimeter (cm)
@@ -1903,6 +1906,7 @@ en:
         including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
     shipping_total: Shipping total
     shipping_zone: Shipping Zone
+    shipping_zone_help: Zone will limit to which Countries or States products are shipped.
     shop_all: Shop All
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart
@@ -1942,6 +1946,7 @@ en:
     ssl:
       change_protocol: Please switch to using HTTP (rather than HTTPS) and retry this request.
     standards_and_formats: Standards and formats
+    standards_and_formats_help: Set the timezone, default unit system and weight unit for your store.
     start: Start
     start_typing_to_search_for_products: Start typing to search for products
     start_typing_to_search_for_variants: Start typing to search for variants
@@ -2056,6 +2061,7 @@ en:
       seo_robots: Please check <a href='https://developers.google.com/search/reference/robots_meta_tag' target='_blank'>this page for more help</a>
       social_help: If you want to link to your social accounts in the footer part of your website please fill below fields
     store_name: Store name
+    store_name_help: This is the name of your store. It will be displayed in the header and in the footer.
     store_not_set_as_default: Couldn't set store %{store} as a default store
     store_set_as_default: Store %{store} is now a default store
     store_set_default_button: Set as default
@@ -2178,6 +2184,7 @@ en:
     under_price: Under %{price}
     unit: Unit
     unit_system: Unit system
+    unit_system_help: This will be used as the default unit system for your store. You can override this on a per-product basis.
     unit_systems:
       imperial_system: Imperial system
       metric: metric
@@ -2239,6 +2246,7 @@ en:
     webhooks: Webhooks
     weight: Weight
     weight_unit: Weight unit
+    weight_unit_help: This will be used as the default weight unit for your store. You can override this on a per-product basis.
     weight_units:
       gram: Gram (g)
       kilogram: Kilogram (kg)


### PR DESCRIPTION
Some texts on the administrator page cannot be internationalized. The view of the general settings of the backend administrator has been improved.
![2025-06-23_230609](https://github.com/user-attachments/assets/cc479add-578d-45ed-9f30-e5c682817007)

![2025-06-23_230705](https://github.com/user-attachments/assets/e9b2e9a5-36d5-468e-a54b-b5708f9eda7b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved localization support for store administration forms and image upload recommendations, replacing hardcoded English text with translation keys.
  - Added new help text entries to enhance guidance for store configuration options.

- **Documentation**
  - Updated English locale files with new translation keys and help messages for improved clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->