### PR TITLE
Fix/admin settings views i18n

### DIFF
--- a/admin/app/helpers/spree/admin/turbo_helper.rb
+++ b/admin/app/helpers/spree/admin/turbo_helper.rb
@@ -27,7 +27,7 @@ module Spree
         opts[:class] ||= 'btn btn-primary text-center'
         opts[:class] << ' d-flex align-items-center justify-content-center' if opts[:class].exclude?('d-block') && opts[:class].exclude?('d-flex')
 
-        opts['data-turbo-submits-with'] ||= "#{content_tag(:span, '', class: 'spinner-border spinner-border-sm mr-2', role: 'status')}Saving..."
+        opts['data-turbo-submits-with'] ||= "#{content_tag(:span, '', class: 'spinner-border spinner-border-sm mr-2', role: 'status')}#{Spree.t(:saving)}"
         opts['data-enable-button-target'] = 'button'
 
         if block_given?

--- a/admin/app/views/active_storage/_upload_form.html.erb
+++ b/admin/app/views/active_storage/_upload_form.html.erb
@@ -36,7 +36,7 @@
 
         <% if crop %>
           <span class="text-muted ml-2 text-center small mt-2">
-            Recommended size: <%= width %>x<%= height %>px
+            <%= Spree.t('admin.recommended_size') %>: <%= width %>x<%= height %>px
           </span>
         <% end %>
       </div>

--- a/admin/app/views/spree/admin/admin_users/_form.html.erb
+++ b/admin/app/views/spree/admin/admin_users/_form.html.erb
@@ -1,12 +1,12 @@
 <div class="form-group">
-  <%= f.label :email %>
+  <%= f.label :email, Spree.t(:email) %>
   <%= f.email_field :email, class: 'form-control', required: true, autofocus: true %>
 </div>
 <div class="form-group">
-  <%= f.label :first_name %>
+  <%= f.label :first_name, Spree.t(:first_name) %>
   <%= f.text_field :first_name, class: 'form-control', required: true %>
 </div>
 <div class="form-group">
-  <%= f.label :last_name %>
+  <%= f.label :last_name, Spree.t(:last_name) %>
   <%= f.text_field :last_name, class: 'form-control', required: true %>
 </div>

--- a/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
@@ -4,10 +4,10 @@
       <thead>
         <tr>
           <th><%= Spree.t(:name) %></th>
-          <th>Active?</th>
+          <th><%= Spree.t(:active) %>?</th>
 
           <% unless entri_enabled? %>
-            <th>Default</th>
+            <th><%= Spree.t(:default) %></th>
             <th></th>
           <% end %>
         </tr>
@@ -19,6 +19,6 @@
   </div>
 <% else %>
   <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
-    You don't have any custom domains set yet.
+    <%= Spree.t(:no_custom_domains) %>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/custom_domains/_form.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_form.html.erb
@@ -11,8 +11,8 @@
 
     <div class="custom-control custom-checkbox">
       <%= f.check_box :default, class: 'custom-control-input' %>
-      <%= f.label :default, class: 'custom-control-label font-weight-semibold' %>
-      <p class="form-text mb-0">We will use this domain in emails to customers.</p>
+      <%= f.label :default, Spree.t(:default), class: 'custom-control-label font-weight-semibold' %>
+      <p class="form-text mb-0"><%= Spree.t(:default_custom_domain_help) %></p>
       <%= f.error_message_on :default %>
     </div>
   </div>

--- a/admin/app/views/spree/admin/custom_domains/index.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/index.html.erb
@@ -6,11 +6,11 @@
 <% end %>
 
 <div class="card-lg p-4">
-  <h5 class="mb-3">Internal URL</h5>
+  <h5 class="mb-3"><%= Spree.t(:internal_url) %></h5>
   <div class="row mb-4">
     <div class="col-lg-4">
       <p class="text-muted">
-        This is your internal URL.
+        <%= Spree.t(:internal_url_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -26,11 +26,11 @@
     </div>
   </div>
   <hr class="my-5" />
-  <h5>Custom domains</h5>
+  <h5><%= Spree.t(:custom_domains) %></h5>
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Connect your domain or subdomain to your store.
+        <%= Spree.t(:custom_domains_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">

--- a/admin/app/views/spree/admin/invitations/new.html.erb
+++ b/admin/app/views/spree/admin/invitations/new.html.erb
@@ -17,7 +17,7 @@
           </div>
         <% end %>
         <div class="form-group">
-          <%= f.label :expires_at %>
+          <%= f.label :expires_at, Spree.t(:expires_at) %>
           <%= f.date_field :expires_at, class: 'form-control', required: true, data: { 'enable-button-target': 'input' } %>
         </div>
       </div>

--- a/admin/app/views/spree/admin/oauth_applications/_form.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :scopes, raw(Spree.t(:scopes) + required_span_tag) %>
-  <%= f.select :scopes, [['Read Only', 'admin read'], ['Read & Write', 'admin write']], { selected: @oauth_application.scopes.to_s }, { class: 'custom-select' } %>
+  <%= f.label :scopes, raw(Spree.t('admin.oauth_applications.scopes') + required_span_tag) %>
+  <%= f.select :scopes, [[Spree.t('admin.oauth_applications.read_only'), 'admin read'], [Spree.t('admin.oauth_applications.read_and_write'), 'admin write']], { selected: @oauth_application.scopes.to_s }, { class: 'custom-select' } %>
   <%= f.error_message_on :scopes %>
 </div>

--- a/admin/app/views/spree/admin/oauth_applications/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/oauth_applications/create.turbo_stream.erb
@@ -3,7 +3,7 @@
     <div class="card-body">
       <div data-controller="clipboard" class="mb-3">
         <div class="form-group">
-          <%= label_tag :client_id, 'Client ID' %>
+          <%= label_tag :client_id, Spree.t(:client_id) %>
           <div class="input-group">
             <%= text_area_tag :client_id, @object.uid, class: 'form-control', rows: 1, data: { clipboard_target: 'source', action: 'clipboard#copy' }, readonly: true %>
             <div class="input-append">
@@ -18,7 +18,7 @@
 
       <div data-controller="clipboard" class="mb-3">
         <div class="form-group">
-          <%= label_tag :client_secret, 'Client Secret' %>
+          <%= label_tag :client_secret, Spree.t(:client_secret) %>
           <div class="input-group">
             <%= text_area_tag :client_secret, @object.plaintext_secret, class: 'form-control', rows: 1, data: { clipboard_target: 'source', action: 'clipboard#copy' }, readonly: true %>
             <div class="input-append">
@@ -29,13 +29,13 @@
             </div>
           </div>
           <div class="alert alert-warning mt-3">
-            This is your application's secret token, copy it now and keep it safe. It won't be shown again.
+           <%= Spree.t('admin.oauth_applications.warning') %>
           </div>
         </div>
       </div>
     </div>
     <div class="card-footer">
-      <%= link_to 'Back to list', spree.admin_oauth_applications_url, class: 'btn btn-light' %>
+      <%= link_to Spree.t(:back_to_list), spree.admin_oauth_applications_url, class: 'btn btn-light' %>
     </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/oauth_applications/index.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/index.html.erb
@@ -9,8 +9,7 @@
 <%= content_for :page_alerts do %>
   <div class="alert alert-info mb-3">
     <p>
-      Here you can manage API keys to access the <%= link_to 'Platform API', 'https://spreecommerce.org/docs/api-reference/platform/authentication', target: '_blank' %>.
-      For headless storefronts you don't need an API key, please use the <%= link_to 'Storefront API', 'https://spreecommerce.org/docs/api-reference/storefront/authentication', target: '_blank' %>.
+      <%= Spree.t('admin.oauth_applications.info').html_safe %>
     </p>
   </div>
 <% end %>
@@ -22,7 +21,7 @@
         <thead>
           <tr>
             <th><%= Spree.t(:name) %></th>
-            <th>Client ID</th>
+            <th><%= Spree.t(:client_id) %></th>
             <th><%= Spree.t('admin.oauth_applications.scopes') %></th>
             <th><%= Spree.t('admin.oauth_applications.last_used') %></th>
             <th></th>
@@ -69,6 +68,6 @@
       </table>
     </div>
   <% else %>
-    <%= render 'spree/admin/shared/no_resource_found', resource_name: 'API keys' %>
+    <%= render 'spree/admin/shared/no_resource_found', resource_name: Spree.t(:api_keys) %>
   <% end %>
 </div>

--- a/admin/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/_form.html.erb
@@ -31,7 +31,7 @@
           <%= label_tag :payment_method_name, Spree.t(:name) %>
           <%= text_field :payment_method, :name, class: 'form-control' %>
           <span class="text-muted form-text mt-2">
-            This name will be used to identify the payment method on the storefront
+            <%= Spree.t(:payment_method_name_help) %>
           </span>
 
           <%= error_message_on :payment_method, :name %>

--- a/admin/app/views/spree/admin/payment_methods/index.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/index.html.erb
@@ -22,7 +22,7 @@
 </div>
 
 <% if available_payment_methods.present? && can?(:create, Spree::PaymentMethod) %>
-  <h6 class="pb-2 pt-3">Available Payment Methods</h6>
+  <h6 class="pb-2 pt-3"><%= Spree.t(:available_payment_methods) %></h6>
   <div class="card-lg">
     <div class="table-responsive">
       <table class="table">

--- a/admin/app/views/spree/admin/profile/edit.html.erb
+++ b/admin/app/views/spree/admin/profile/edit.html.erb
@@ -11,20 +11,20 @@
         </div>
         <div class="card-body">
           <div class="form-group mb-4">
-            <%= f.label :email, class: 'form-label' %>
+            <%= f.label :email, Spree.t(:email), class: 'form-label' %>
             <%= f.email_field :email, class: 'form-control', required: true %>
           </div>
           <div class="form-group mb-4">
-            <%= f.label :first_name, class: 'form-label' %>
+            <%= f.label :first_name, Spree.t(:first_name), class: 'form-label' %>
             <%= f.text_field :first_name, class: 'form-control', required: true %>
           </div>
           <div class="form-group mb-4">
-            <%= f.label :last_name, class: 'form-label' %>
+            <%= f.label :last_name, Spree.t(:last_name), class: 'form-label' %>
             <%= f.text_field :last_name, class: 'form-control', required: true %>
           </div>
           <div class="form-group mb-0">
             <div>
-              <%= f.label :avatar, class: 'form-label' %>
+              <%= f.label :avatar, Spree.t(:avatar), class: 'form-label' %>
             </div>
             <%= render 'active_storage/upload_form', form: f, field_name: :avatar, crop: true %>
           </div>

--- a/admin/app/views/spree/admin/shared/_no_resource_found.html.erb
+++ b/admin/app/views/spree/admin/shared/_no_resource_found.html.erb
@@ -1,9 +1,9 @@
-<% resource_name ||= model_class.name.demodulize.underscore.humanize %>
+<% resource_name ||= Spree.t("#{model_class.name.demodulize.underscore}") %>
 
 <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center flex-column">
   <%= icon 'map-search', class: 'mb-3 opacity-50', style: 'font-size: 2rem;' %>
   <p>
-    <%= Spree.t(:no_resource_found, resource: resource_name) %>
+    <%= Spree.t(:no_resource_found, resource: resource_name).html_safe %>
   </p>
   <%= link_to_with_icon 'plus', Spree.t(:add_one), new_object_url, class: 'btn btn-link btn-sm ml-3', data: { 'turbo-frame': '_top' } if can?(:create, model_class) && defined?(new_object_url) && new_object_url.present? %>
 </div>

--- a/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
@@ -9,13 +9,13 @@
         </div>
 
         <p class="form-text text-muted small mt-2">
-          This will be displayed to customers.
+          <%= Spree.t(:shipping_method_name_help) %>
         </p>
       </div>
 
       <div class="col-lg-6">
         <div class="form-group">
-          <%= f.label :display_on %>
+          <%= f.label :display_on, Spree.t(:display_on) %>
           <%= f.select :display_on, display_on_options, {}, { class: 'custom-select custom-select' } %>
           <%= f.error_message_on :display_on %>
         </div>
@@ -31,7 +31,7 @@
         </div>
 
         <p class="form-text text-muted small mt-2">
-          This will be displayed to admins.
+          <%= Spree.t(:shipping_method_internal_name_help) %>
         </p>
       </div>
 

--- a/admin/app/views/spree/admin/shipping_methods/form/_estimated_transit_business_days.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_estimated_transit_business_days.html.erb
@@ -6,8 +6,7 @@
   </div>
   <div class="card-body">
     <div class="alert alert-info">
-      This is the estimated number of business days it will take for the package to arrive at the customer's address.
-      It will be displayed on the checkout page.
+      <%= Spree.t(:estimated_transit_business_days_help) %>
     </div>
     <div class="row">
       <div class="col">

--- a/admin/app/views/spree/admin/shipping_methods/form/_tracking_url.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_tracking_url.html.erb
@@ -12,7 +12,7 @@
 
     <p class="form-text text-muted small mt-2">
       <code>:tracking</code>
-      <span>will be replaced with the tracking number.</span>
+      <span><%= Spree.t(:tracking_url_help) %></span>
     </p>
   </div>
 </div>

--- a/admin/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/index.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Shipping methods are options that the customer sees when they reach the checkout, they are the carriers and services used to send your products.
+    <%= Spree.t(:shipping_methods_info) %>
   </div>
 <% end %>
 

--- a/admin/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/admin/app/views/spree/admin/stock_locations/_form.html.erb
@@ -18,7 +18,7 @@
       <div class="form-group">
         <div class="custom-control custom-checkbox">
           <%= f.check_box :active, class: 'custom-control-input' %>
-          <%= f.label :active, class: 'custom-control-label' %>
+          <%= f.label :active, Spree.t(:active), class: 'custom-control-label' %>
         </div>
       </div>
     <% end %>

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          This is the name of your store. It will be displayed in the header and in the footer.
+          <%= Spree.t(:store_name_help) %>
         </p>
         <div class="form-group">
           <%= f.label :name, Spree.t(:name) %>
@@ -37,12 +37,12 @@
       </div>
       <div class="card-body">
         <div class="form-group">
-          <%= f.label :contact_phone %>
+          <%= f.label :contact_phone, Spree.t(:contact_phone) %>
           <%= f.text_field :contact_phone, class: 'form-control' %>
         </div>
 
         <div class="form-group">
-          <%= f.label :address %>
+          <%= f.label :address, Spree.t(:address) %>
           <%= f.text_area :address, class: 'form-control', data: { controller: 'textarea-autogrow' } %>
         </div>
       </div>
@@ -54,7 +54,7 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          Set the timezone, default unit system and weight unit for your store.
+          <%= Spree.t(:standards_and_formats_help) %>
         </p>
         <div class="form-group mb-3">
           <%= label_tag :preferred_timezone, raw(Spree.t(:timezone) + required_span_tag) %>
@@ -65,14 +65,14 @@
             <%= label_tag :preferred_unit_system, raw(Spree.t(:unit_system) + required_span_tag) %>
             <%= select_tag 'store[preferred_unit_system]', options_for_select(unit_systems, @store.preferred_unit_system), {class: 'custom-select', data: {unit_system_target: "body", action: "change->unit-system#unitSystemHandler"}} %>
             <p class="text-muted form-text mt-2 mb-0">
-              This will be used as the default unit system for your store. You can override this on a per-product basis.
+              <%= Spree.t(:unit_system_help) %>
             </p>
           </div>
           <div class="form-group">
             <%= label_tag :preferred_weight_unit, raw(Spree.t(:weight_unit) + required_span_tag) %>
             <%= select_tag 'store[preferred_weight_unit]', options_for_select(weight_units(@store), @store.preferred_weight_unit), {class: 'custom-select', data: {unit_system_target: "weightUnit"}} %>
             <p class="text-muted form-text mt-2 mb-0">
-              This will be used as the default weight unit for your store. You can override this on a per-product basis.
+              <%= Spree.t(:weight_unit_help) %>
             </p>
           </div>
         </div>
@@ -87,10 +87,10 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          This determines which vendors you can connect with and what customers see on your store.
+          <%= Spree.t(:currency_and_country_help) %>
         </p>
         <div class="form-group">
-          <%= f.label :default_currency %>
+          <%= f.label :default_currency, Spree.t(:default_currency) %>
           <%= f.currency_select :default_currency, preferred_currencies, {}, data: { controller: 'autocomplete-select' } %>
           <%= f.error_message_on :default_currency %>
         </div>
@@ -112,14 +112,14 @@
           <%= f.label :checkout_zone_id, Spree.t(:shipping_zone) %>
           <%= f.select :checkout_zone_id, options_for_select(@zones, @store.checkout_zone_id), { }, { data: { controller: 'autocomplete-select' } } %>
           <small class="form-text text-muted mt-2">
-            Zone will limit to which Countries or States products are shipped.
+            <%= Spree.t(:shipping_zone_help) %>
             <%= link_to Spree.t('admin.manage_zones'), spree.admin_zones_path %>
           </small>
           <%= f.error_message_on :checkout_zone_id %>
         </div>
 
         <div class="form-group">
-          <%= f.label :default_locale %>
+          <%= f.label :default_locale, Spree.t(:default_locale) %>
           <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), {}, { data: { controller: 'autocomplete-select' } } %>
           <%= f.error_message_on :default_locale %>
         </div>
@@ -139,8 +139,7 @@
       </div>
       <div class="card-body">
         <p class="text-muted">
-          Digital assets are files that can be downloaded by customers after
-          purchase.
+          <%= Spree.t(:digital_assets_help) %>
         </p>
         <div class="custom-control custom-checkbox mb-3">
           <%= f.check_box :preferred_limit_digital_download_days,

--- a/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -6,15 +6,13 @@
   <div class="col-lg-6">
     <div class="card mb-4">
       <div class="card-header">
-        <h5 class="card-title">Logo for emails</h5>
+        <h5 class="card-title"><%= Spree.t('admin.logo_for_emails') %></h5>
       </div>
       <div class="card-body">
-        <p class="text-muted">This logo is included in all email notifications such as order confirmation</p>
+        <p class="text-muted"><%= Spree.t('admin.logo_for_emails_help') %></p>
         <%= render 'active_storage/upload_form', form: f, field_name: :mailer_logo, width: 204, height: 104 %>
         <p class="form-text text-muted mb-0 mt-2">
-          We recommend images with a transparent background.
-          <br />
-          Only JPEG and PNG formats are supported.
+          <%= Spree.t('admin.logo_for_emails_recommend').html_safe %>
         </p>
       </div>
     </div>
@@ -23,11 +21,11 @@
   <div class="col-lg-6">
     <div class="card mb-4">
       <div class="card-header">
-        <h5 class="card-title">Email addresses</h5>
+        <h5 class="card-title"><%= Spree.t('admin.store_form.email_addresses') %></h5>
       </div>
       <div class="card-body">
         <p class="text-muted">
-          Please provide the email address that will be used as the sender of all emails sent from your store.
+          <%= Spree.t('admin.store_form.email_addresses_help') %>
         </p>
 
         <div class="form-group">

--- a/admin/app/views/spree/admin/stores/form/_policies.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_policies.html.erb
@@ -4,7 +4,7 @@
 
 <%= content_for :page_alerts do %>
   <div class="alert alert-info mb-3">
-    Policies will be automatically added to footer of your store and will be available to customers during checkout.
+    <%= Spree.t(:policies_info) %>
   </div>
 <% end %>
 
@@ -13,7 +13,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Customers will need to accept these terms of service during signup.
+        <%= Spree.t(:terms_of_service_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -27,7 +27,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Customers will need to accept these privacy policy during signup.
+        <%= Spree.t(:privacy_policy_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -42,7 +42,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Please provide your customers with a clear and transparent returns policy.
+       <%= Spree.t(:returns_policy_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -56,7 +56,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Please provide your customers with a clear and transparent shipping policy.
+        <%= Spree.t(:shipping_policy_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">

--- a/admin/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/admin/app/views/spree/admin/tax_categories/_form.html.erb
@@ -19,7 +19,7 @@
 
     <div class="custom-control custom-checkbox">
       <%= f.check_box :is_default, class: 'custom-control-input' %>
-      <%= f.label :is_default, class: 'custom-control-label' %>
+      <%= f.label :is_default, Spree.t(:is_default), class: 'custom-control-label' %>
     </div>
   </div>
 </div>

--- a/admin/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/admin/app/views/spree/admin/tax_rates/_form.html.erb
@@ -34,14 +34,14 @@
     <div class="form-group">
       <div class="custom-control custom-checkbox">
         <%= f.check_box :included_in_price, class: 'custom-control-input' %>
-        <%= f.label :included_in_price, class: 'custom-control-label' %>
+        <%= f.label :included_in_price, Spree.t(:included_in_price), class: 'custom-control-label' %>
       </div>
     </div>
 
     <div class="form-group">
       <div class="custom-control custom-checkbox">
         <%= f.check_box :show_rate_in_label, class: 'custom-control-input' %>
-        <%= f.label :show_rate_in_label, class: 'custom-control-label' %>
+        <%= f.label :show_rate_in_label, Spree.t(:show_rate_in_label), class: 'custom-control-label' %>
       </div>
     </div>
   </div>

--- a/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
@@ -16,7 +16,7 @@
           <div class="form-group col-3">
             <div class="custom-control custom-switch">
               <%= f.check_box :active, class: 'custom-control-input' %>
-              <%= f.label :active, class: 'custom-control-label' %>
+              <%= f.label :active, Spree.t(:active), class: 'custom-control-label' %>
             </div>
           </div>
         </div>

--- a/admin/app/views/spree/admin/zones/index.html.erb
+++ b/admin/app/views/spree/admin/zones/index.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Zones are geographical groupings, they represent collections of either states or countries.
+    <%= Spree.t(:zones_info) %>
   </div>
 <% end %>
 

--- a/admin/app/views/spree/admin/zones/new.html.erb
+++ b/admin/app/views/spree/admin/zones/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>
   <%= page_header_back_button spree.admin_zones_url %>
-  <%= Spree.t(:new_market) %>
+  <%= Spree.t(:new_zone) %>
 <% end %>
 
 <%= form_for [:admin, @zone], data: {controller: 'auto-submit'} do |zone_form| %>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
           choose_stores: Choose which stores this product should be available in
         variants:
           option_types_link: To add more option types please go to <a href="%{link}">Option Types</a>
+      recommended_size: Recommended size
       report_created: Your report is being generated. You will receive an email with a download link when it is ready!
       reset_digital_link_download_limits: Reset download limits
       response_code: Response Code

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -80,6 +80,9 @@ en:
       integrations:
         invalid_integration_type: This integration is not allowed
         page_subtitle: Connect your store to third-party services to enhance customer experience.
+      logo_for_emails: Logo for emails
+      logo_for_emails_help: This logo is included in all email notifications such as order confirmation.
+      logo_for_emails_recommend: We recommend images with a transparent background.<br>Only JPEG and PNG formats are supported.
       manage_currencies: Manage Currencies
       manage_properties: Manage Properties
       manage_stock_locations: Manage Stock Locations
@@ -92,6 +95,7 @@ en:
       notifications: Notifications
       num_orders: No. of Orders
       oauth_applications:
+        info: Here you can manage API keys to access the <a href='https://spreecommerce.org/docs/api-reference/platform/authentication' target='_blank' class='alert-link'>Platform API</a>. For headless storefronts you don't need an API key, please use the <a href='https://spreecommerce.org/docs/api-reference/storefront/authentication' target='_blank' class='alert-link'>Storefront API</a>.
         last_used: Last used
         list: API keys
         never: Never
@@ -99,6 +103,7 @@ en:
         read_and_write: Read & Write
         read_only: Read Only
         scopes: Scopes
+        warning:  This is your application's secret token, copy it now and keep it safe. It won't be shown again.
       order:
         events:
           approve: Approve
@@ -201,6 +206,8 @@ en:
           description: It shows the company field on the address form in the My Account section and on the checkout address step.
           label: Display the company address field
         customer_support_email_help: This email is visible to your Store visitors in the Footer section
+        email_addresses: Email addresses
+        email_addresses_help: Please provide the email address that will be used as the sender of all emails sent from your store.
         new_order_notifications_email_help: If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to
       store_setup_tasks:
         add_billing_address: Add billing address

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -333,6 +333,9 @@ en:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
+      spree/custom_domain:
+        one: Custom Domain
+        other: Custom Domains
       spree/customer_return:
         one: Customer Return
         other: Customer Returns
@@ -351,6 +354,9 @@ en:
       spree/line_item:
         one: Line Item
         other: Line Items
+      spree/oauth_application:
+        one: Oauth Application
+        other: Oauth Applications
       spree/option_type:
         one: Option Type
         other: Option Types
@@ -674,6 +680,7 @@ en:
     approver: Approver
     are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
+    assets: Assets
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
     at_symbol: "@"
     attachments: Attachments
@@ -689,10 +696,13 @@ en:
     availability: availability
     available: Available
     available_on: Available On
+    available_payment_methods: Available Payment Methods
+    avatar: Avatar
     average_order_value: Average Order Value
     avs_response: AVS Response
     back: Back
     back_end: Backend
+    back_to_list: Back to list
     back_to_payment: Back To Payment
     back_to_resource_list: Back To %{resource} List
     back_to_rma_reason_list: Back To RMA Reason List
@@ -785,6 +795,8 @@ en:
     clear_cache_ok: Cache was flushed
     clear_cache_warning: Clearing cache will temporarily reduce the performance of your store.
     click_and_drag_on_the_products_to_sort_them: Click and drag on the products to sort them.
+    client_id: Client ID
+    client_secret: Client Secret
     clone: Clone
     close: Close
     close_all_adjustments: Close All Adjustments
@@ -869,6 +881,8 @@ en:
     current_password: Current password
     current_promotion_usage: 'current usage: %{count}'
     custom_code: Custom code
+    custom_domains: Custom domains
+    custom_domains_help: Connect your domain or subdomain to your store.
     custom_font_code: Custom font code
     customer: Customer
     customer_details: Customer Details
@@ -893,6 +907,7 @@ en:
     default_country: Default Country
     default_country_cannot_be_deleted: Default country cannot be deleted
     default_currency: Default currency
+    default_custom_domain_help: We will use this domain in emails to customers.
     default_locale: Default locale
     default_post_categories:
       articles: Articles
@@ -926,6 +941,7 @@ en:
     digital_assets: Digital assets
     digital_assets_help: Digital assets are files that can be downloaded by customers after purchase.
     digital_link_unauthorized: You are not authorized to access this asset
+    digitals: Digitals
     dimension_units:
       centimeter: Centimeter (cm)
       foot: Foot (ft)
@@ -952,6 +968,8 @@ en:
     draft: Draft
     draft_mode: Draft Mode
     draft_orders: Draft orders
+    dummy_key: Dummy Key
+    dummy_secret_key: Dummy Secret Key
     duplicate: Duplicate
     duplicating: Duplicating
     edit: Edit
@@ -1008,6 +1026,7 @@ en:
       other: "%{count} errors prohibited this record from being saved"
     estimated_delivery_time: Estimated delivery time
     estimated_transit_business_days: Estimated transit business days
+    estimated_transit_business_days_help: This is the estimated number of business days it will take for the package to arrive at the customer's address. It will be displayed on the checkout page.
     event: Event
     events:
       spree:
@@ -1151,6 +1170,8 @@ en:
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
+    internal_url: Internal URL
+    internal_url_help: This is your internal URL.
     internationalization: Internationalization
     invalid_credit_card: Invalid credit card.
     invalid_exchange_variant: Invalid exchange variant.
@@ -1174,8 +1195,10 @@ en:
         subject: Invitation to join %{resource_name}
       thanks: Thank you,
     invitation_resent: Invitation resent!
+    inventory_units: Inventory Units
     invitations: Invitations
     invited_by: Invited by
+    is_default: Is Default
     is_not_available_to_shipment_address: is not available to shipment address
     iso: ISO Alpha-2
     iso3: ISO Alpha-3
@@ -1237,6 +1260,7 @@ en:
     manage_variants: Manage Variants
     manual_intervention_required: Manual intervention required
     mark_as_default: Mark as default
+    marked_as_default: Marked as default
     master: Master
     master_price: Master Price
     master_sku: Master SKU
@@ -1245,6 +1269,8 @@ en:
       none: None
     max: Max
     max_items: Max Items
+    maximum_item_total: Maximum Item Total
+    maximum_weight: Maximum Weight
     media: Media
     memo: Memo
     meta_description: Meta Description
@@ -1253,9 +1279,11 @@ en:
     metadata: Metadata
     min: Min
     minimal_amount: Minimal Amount
+    minimum_item_total: Minimum Item Total
     minimum_password_length:
       one: "(%{count} character minimum)"
       other: "(%{count} characters minimum)"
+    minimum_weight: Minimum Weight
     missing_return_authorization: Missing Return Authorization for %{item_name}.
     month: Month
     more: More
@@ -1337,6 +1365,7 @@ en:
     no_billing_address_available: No billing address available
     no_cc_type: N/A
     no_country: No country set
+    no_custom_domains: You don't have any custom domains set yet.
     no_email_provided: No email provided
     no_limits_zone: No Limits
     no_payment_found: No payment found
@@ -1532,10 +1561,12 @@ en:
     payment: Payment
     payment_amount: Payment amount
     payment_attempts: failed attempts
+    payment_capture_events: Payment Capture Events
     payment_could_not_be_created: Payment could not be created.
     payment_identifier: Payment Identifier
     payment_information: Payment Information
     payment_method: Payment Method
+    payment_method_name_help: This name will be used to identify the payment method on the storefront
     payment_method_not_supported: That payment method is unsupported. Please choose another one.
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
@@ -1575,6 +1606,7 @@ en:
     please_define_payment_methods: Please define some payment methods first.
     please_enter_reasonable_quantity: Please enter a reasonable quantity.
     policies: Policies
+    policies_info: Policies will be automatically added to footer of your store and will be available to customers during checkout.
     populate_get_error: Something went wrong. Please try adding the item again.
     post_categories: Post categories
     posts: Posts
@@ -1595,6 +1627,7 @@ en:
     prices: Prices
     pricing: Pricing
     privacy_policy: Privacy Policy
+    privacy_policy_help: Customers will need to accept these privacy policy during signup.
     process: Process
     processing: Processing
     product: Product
@@ -1692,6 +1725,7 @@ en:
     prototypes: Prototypes
     provider: Provider
     provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
+    publishable_key: Publishable Key
     published_at: Published at
     purchased_quantity: Purchased Quantity
     qty: Qty
@@ -1789,6 +1823,7 @@ en:
     returned: Returned
     returns: Returns
     returns_policy: Returns Policy
+    returns_policy_help: Please provide your customers with a clear and transparent returns policy.
     review: Review
     risk: Risk
     risk_analysis: Risk Analysis
@@ -1821,6 +1856,7 @@ en:
     search_results: Search results for '%{keywords}'
     search_results_for: Search results for %{query}
     searching: Searching
+    secret_key: Secret Key
     secure_connection_type: Secure Connection Type
     security: Security
     security_settings: Security Settings
@@ -1896,9 +1932,13 @@ en:
     shipping_flexible_rate: Flexible Rate per package item
     shipping_instructions: Shipping Instructions
     shipping_method: Shipping Method
+    shipping_method_name_help: This will be displayed to customers.
+    shipping_method_internal_name_help: This will be displayed to admins.
     shipping_methods: Shipping Methods
+    shipping_methods_info: Shipping methods are options that the customer sees when they reach the checkout, they are the carriers and services used to send your products.
     shipping_not_available: Shipping not available
     shipping_policy: Shipping Policy
+    shipping_policy_help: Please provide your customers with a clear and transparent shipping policy.
     shipping_price_sack: Price sack
     shipping_rates:
       display_price:
@@ -2049,6 +2089,7 @@ en:
       unable_to_create: Unable to create store.
       unable_to_delete: Unable to delete store.
       unable_to_update: Unable to update store.
+    store_favicon_images: Store Favicon Images
     store_form:
       checkout_zone_help: Selecting zone will limit to which Countries or States products are shipped. For more information <a href='https://guides.spreecommerce.org/user/configuration/configuring_geography.html#zones' target='_blank' class='alert-link'>please see documentation</a>
       code_help: Store unique identifier, which is an abbreviated version of the store’s name (used as the layout directory name, and also helpful for separating templates by store)
@@ -2060,14 +2101,17 @@ en:
       new_order_notifications_email_help: If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to
       seo_robots: Please check <a href='https://developers.google.com/search/reference/robots_meta_tag' target='_blank'>this page for more help</a>
       social_help: If you want to link to your social accounts in the footer part of your website please fill below fields
+    store_logos: Store Logos
     store_name: Store name
     store_name_help: This is the name of your store. It will be displayed in the header and in the footer.
+    store_mailer_logos: Store Mailer Logos
     store_not_set_as_default: Couldn't set store %{store} as a default store
     store_set_as_default: Store %{store} is now a default store
     store_set_default_button: Set as default
     stores: Stores
     street_address: Street Address
     street_address_2: Street Address (cont'd)
+    subscriber: Subscriber
     subscribed: Subscribed
     subtotal: Subtotal
     subtract: Subtract
@@ -2091,10 +2135,12 @@ en:
     tax_code: Tax Code
     tax_included: Tax (incl.)
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
+    tax_rate: Tax Rate
     tax_rates: Tax Rates
     taxes: Taxes
     taxon: Taxon
     taxon_edit: Edit Taxon
+    taxon_images: Taxon Images
     taxon_missing_alt: Category banner description
     taxon_placeholder: Add a Taxon
     taxon_rule:
@@ -2112,6 +2158,7 @@ en:
     taxonomy_tree_instruction: "* Right click (or double tap on iOS device) a child in the tree to access the menu for adding, deleting or sorting a child."
     taxons: Taxons
     terms_of_service: Terms of Service
+    terms_of_service_help: Customers will need to accept these terms of service during signup.
     test: Test
     test_mailer:
       test_email:
@@ -2165,6 +2212,7 @@ en:
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
+    tracking_url_help: will be replaced with the tracking number.
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
     transaction_id: Transaction ID
     transaction_id_help: This is the ID of the transaction that was created in the 3rd party payment gateway.
@@ -2255,7 +2303,9 @@ en:
     what_is_a_cvv: What is a (CVV) Credit Card Code?
     what_is_this: What's This?
     width: Width
+    wished_items: Wished Items
     wishlist: Wishlist
+    wishlists: Wishlists
     without_taxon: Without taxon
     year: Year
     you_have_no_orders_yet: You have no orders yet
@@ -2266,6 +2316,7 @@ en:
     zipcode_required: Zip Code Required
     zone: Zone
     zones: Zones
+    zones_info: Zones are geographical groupings, they represent collections of either states or countries.
   views:
     pagination:
       truncate: Truncate

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -863,6 +863,7 @@ en:
     credits: Credits
     currencies: Currencies
     currency: Currency
+    currency_and_country_help: This determines which vendors you can connect with and what customers see on your store.
     currency_settings: Currency Settings
     current: Current
     current_password: Current password
@@ -892,6 +893,7 @@ en:
     default_country: Default Country
     default_country_cannot_be_deleted: Default country cannot be deleted
     default_currency: Default currency
+    default_locale: Default locale
     default_post_categories:
       articles: Articles
       news: News
@@ -922,6 +924,7 @@ en:
     digital:
       digital_delivery: Digital Delivery
     digital_assets: Digital assets
+    digital_assets_help: Digital assets are files that can be downloaded by customers after purchase.
     digital_link_unauthorized: You are not authorized to access this asset
     dimension_units:
       centimeter: Centimeter (cm)
@@ -1903,6 +1906,7 @@ en:
         including_tax: "%{price} (incl. %{tax_amount} %{tax_rate_name})"
     shipping_total: Shipping total
     shipping_zone: Shipping Zone
+    shipping_zone_help: Zone will limit to which Countries or States products are shipped.
     shop_all: Shop All
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart
@@ -1942,6 +1946,7 @@ en:
     ssl:
       change_protocol: Please switch to using HTTP (rather than HTTPS) and retry this request.
     standards_and_formats: Standards and formats
+    standards_and_formats_help: Set the timezone, default unit system and weight unit for your store.
     start: Start
     start_typing_to_search_for_products: Start typing to search for products
     start_typing_to_search_for_variants: Start typing to search for variants
@@ -2056,6 +2061,7 @@ en:
       seo_robots: Please check <a href='https://developers.google.com/search/reference/robots_meta_tag' target='_blank'>this page for more help</a>
       social_help: If you want to link to your social accounts in the footer part of your website please fill below fields
     store_name: Store name
+    store_name_help: This is the name of your store. It will be displayed in the header and in the footer.
     store_not_set_as_default: Couldn't set store %{store} as a default store
     store_set_as_default: Store %{store} is now a default store
     store_set_default_button: Set as default
@@ -2178,6 +2184,7 @@ en:
     under_price: Under %{price}
     unit: Unit
     unit_system: Unit system
+    unit_system_help: This will be used as the default unit system for your store. You can override this on a per-product basis.
     unit_systems:
       imperial_system: Imperial system
       metric: metric
@@ -2239,6 +2246,7 @@ en:
     webhooks: Webhooks
     weight: Weight
     weight_unit: Weight unit
+    weight_unit_help: This will be used as the default weight unit for your store. You can override this on a per-product basis.
     weight_units:
       gram: Gram (g)
       kilogram: Kilogram (kg)


### PR DESCRIPTION
Replace the hard-coded English text with translation keys in the dashboard settings.
Updated English locale files with new translation keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive internationalization support throughout the admin interface by replacing hardcoded English text with localized translations for labels, help texts, headings, and messages.
  - Expanded the set of available English translations for various admin and storefront UI elements, including new resource names, help texts, and user guidance.

- **Style**
  - Improved consistency and clarity of user-facing text by standardizing label and message rendering with translation helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->