### PR TITLE
Added `LineItem#item_weight` and `Shipment#item_weight`

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -48,7 +48,7 @@ module Spree
 
     after_create :update_tax_charge
 
-    delegate :name, :description, :sku, :should_track_inventory?, :product, :options_text, :slug, :product_id, to: :variant
+    delegate :name, :description, :sku, :should_track_inventory?, :product, :options_text, :slug, :product_id, :dimensions_unit, :weight_unit, to: :variant
     delegate :brand, :category, to: :product
     delegate :tax_zone, to: :order
     delegate :digital?, to: :variant
@@ -116,6 +116,13 @@ module Spree
 
     def final_amount
       amount + adjustment_total
+    end
+
+    # Returns the weight of the line item
+    #
+    # @return [BigDecimal]
+    def item_weight
+      variant.weight * quantity
     end
 
     alias total final_amount

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -649,7 +649,7 @@ module Spree
     #
     # @return [BigDecimal] the total weight of the inventory units in the order
     def total_weight
-      @total_weight ||= line_items.joins(:variant).includes(:variant).map { |li| li.variant.weight * li.quantity }.sum
+      @total_weight ||= line_items.joins(:variant).includes(:variant).map(&:item_weight).sum
     end
 
     # Returns line items that have no shipping rates

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -221,8 +221,18 @@ module Spree
       inventory_units.where(line_item_id: line_item.id, variant_id: line_item.variant_id || variant.id)
     end
 
+    # Returns the cost of the shipment
+    #
+    # @return [BigDecimal]
     def item_cost
       manifest.map { |m| (m.line_item.price + (m.line_item.adjustment_total / m.line_item.quantity)) * m.quantity }.sum
+    end
+
+    # Returns the weight of the shipment
+    #
+    # @return [BigDecimal]
+    def item_weight
+      manifest.map(&:item_weight).sum
     end
 
     def line_items

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -232,7 +232,14 @@ module Spree
     #
     # @return [BigDecimal]
     def item_weight
-      manifest.map(&:item_weight).sum
+      manifest.map { |m| m.line_item.item_weight }.sum
+    end
+
+    # Returns the weight unit of the shipment
+    #
+    # @return [String]
+    def weight_unit
+      manifest.first.line_item.weight_unit
     end
 
     def line_items

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -536,4 +536,31 @@ describe Spree::LineItem, type: :model do
       expect(line_item.display_compare_at_amount.to_s).to eq('$30.00')
     end
   end
+
+  describe '#item_weight' do
+    let(:variant) { create(:variant, weight: 10) }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the weight for the line item' do
+      expect(line_item.item_weight).to eq(20)
+    end
+  end
+
+  describe '#dimensions_unit' do
+    let(:variant) { create(:variant, dimensions_unit: 'cm') }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the dimension unit for the line item' do
+      expect(line_item.dimensions_unit).to eq('cm')
+    end
+  end
+
+  describe '#weight_unit' do
+    let(:variant) { create(:variant, weight_unit: 'kg') }
+    let(:line_item) { build(:line_item, variant: variant, quantity: 2) }
+
+    it 'returns the weight unit for the line item' do
+      expect(line_item.weight_unit).to eq('kg')
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -205,8 +205,21 @@ describe Spree::Shipment, type: :model do
 
   describe '#item_weight' do
     it 'equals line items weight' do
-      shipment = create(:shipment, order: create(:order_with_line_item_quantity, line_items_quantity: 2))
-      expect(shipment.item_weight).to eq(22.0)
+      order = create(:order)
+      variant = create(:variant, weight: 10)
+      line_item = create(:line_item, order: order, variant: variant, quantity: 2)
+      shipment = create(:shipment, order: order)
+      expect(shipment.item_weight).to eq(20.0)
+    end
+  end
+
+  describe '#weight_unit' do
+    it 'equals line items weight unit' do
+      order = create(:order)
+      variant = create(:variant, weight: 10, weight_unit: 'kg')
+      line_item = create(:line_item, order: order, variant: variant, quantity: 2)
+      shipment = create(:shipment, order: order)
+      expect(shipment.weight_unit).to eq('kg')
     end
   end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -203,6 +203,13 @@ describe Spree::Shipment, type: :model do
     end
   end
 
+  describe '#item_weight' do
+    it 'equals line items weight' do
+      shipment = create(:shipment, order: create(:order_with_line_item_quantity, line_items_quantity: 2))
+      expect(shipment.item_weight).to eq(22.0)
+    end
+  end
+
   it '#discounted_cost' do
     shipment = create(:shipment)
     shipment.cost = 10


### PR DESCRIPTION
Also `LineItem#dimensions_unit` and `LineItem#weight_unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to view the total weight of individual line items and shipments.
  - Line items now display their dimensions and weight units.

- **Bug Fixes**
  - Improved accuracy and consistency in calculating total order and shipment weights.

- **Tests**
  - Added tests to verify correct calculation of item and shipment weights, as well as the display of dimension and weight units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->