### PR TITLE
Fix image urls in the products export

### DIFF
--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -15,21 +15,22 @@ module Spree
     end
 
     def spree_image_url(image, options = {})
+      url_helpers = respond_to?(:main_app) ? main_app : Rails.application.routes.url_helpers
       width = options[:width]
       height = options[:height]
 
       width = width * 2 if width.present?
       height = height * 2 if height.present?
 
-      return unless image.attached?
-      return unless image.variable?
+      return unless image&.attached?
+      return unless image&.variable?
 
       if width.present? && height.present?
-        main_app.cdn_image_url(
+        url_helpers.cdn_image_url(
           image.variant(spree_image_variant_options(resize_to_fill: [width, height]))
         )
       else
-        main_app.cdn_image_url(
+        url_helpers.cdn_image_url(
           image.variant(spree_image_variant_options(resize_to_limit: [width, height]))
         )
       end

--- a/core/app/presenters/spree/csv/product_variant_presenter.rb
+++ b/core/app/presenters/spree/csv/product_variant_presenter.rb
@@ -1,6 +1,8 @@
 module Spree
   module CSV
     class ProductVariantPresenter
+      include Spree::ImagesHelper
+
       CSV_HEADERS = [
         'product_id',
         'sku',
@@ -99,9 +101,9 @@ module Spree
           variant.backorderable?,
           variant.tax_category&.name,
           variant.digital?,
-          variant.images[0]&.original_url,
-          variant.images[1]&.original_url,
-          variant.images[2]&.original_url,
+          spree_image_url(variant.images[0], image_url_options),
+          spree_image_url(variant.images[1], image_url_options),
+          spree_image_url(variant.images[2], image_url_options),
           index.positive? ? option_type(0)&.presentation : nil,
           index.positive? ? option_value(option_type(0)) : nil,
           index.positive? ? option_type(1)&.presentation : nil,
@@ -124,6 +126,15 @@ module Spree
 
       def option_value(option_type)
         variant.option_values.find { |ov| ov.option_type == option_type }&.presentation
+      end
+
+      private
+
+      def image_url_options
+        {
+          width: 1000,
+          height: 1000
+        }
       end
     end
   end

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     opts = options.slice(:protocol, :host, :port)
     opts[:host] = Spree.cdn_host if Spree.cdn_host.present?
     opts[:host] ||= Rails.application.routes.default_url_options[:host]
+    opts[:host] ||= Spree::Store.current.url_or_custom_domain if Spree::Store.current.present?
 
     opts[:only_path] = true if opts[:host].blank?
 

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -48,7 +48,7 @@ describe Spree::ImagesHelper, type: :helper do
       it 'returns a url with resize_to_fill' do
         variant = double('variant')
         expect(image).to receive(:variant).with(hash_including(resize_to_fill: [200, 200])).and_return(variant)
-        expect(helper).to receive(:main_app).and_return(double('main_app', cdn_image_url: 'cdn_url'))
+        expect(Rails.application.routes.url_helpers).to receive(:cdn_image_url).and_return('cdn_url')
         expect(helper.spree_image_url(image, width: 100, height: 100)).to eq('cdn_url')
       end
     end
@@ -57,7 +57,7 @@ describe Spree::ImagesHelper, type: :helper do
       it 'returns a url with resize_to_limit' do
         variant = double('variant')
         expect(image).to receive(:variant).with(hash_including(resize_to_limit: [200, nil])).and_return(variant)
-        expect(helper).to receive(:main_app).and_return(double('main_app', cdn_image_url: 'cdn_url'))
+        expect(Rails.application.routes.url_helpers).to receive(:cdn_image_url).and_return('cdn_url')
         expect(helper.spree_image_url(image, width: 100)).to eq('cdn_url')
       end
     end

--- a/core/spec/presenters/spree/csv/product_variant_presenter_spec.rb
+++ b/core/spec/presenters/spree/csv/product_variant_presenter_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Spree::CSV::ProductVariantPresenter do
       expect(subject[26]).to eq variant.backorderable?
       expect(subject[27]).to eq variant.tax_category&.name
       expect(subject[28]).to eq variant.digital?
-      expect(subject[29]).to eq variant.images[0].original_url
-      expect(subject[30]).to eq variant.images[1].original_url
-      expect(subject[31]).to eq variant.images[2].original_url
+      expect(subject[29]).to end_with(variant.images[0].filename.to_s)
+      expect(subject[30]).to end_with(variant.images[1].filename.to_s)
+      expect(subject[31]).to end_with(variant.images[2].filename.to_s)
       expect(subject[32]).to eq nil
       expect(subject[33]).to eq nil
       expect(subject[34]).to eq nil
@@ -82,6 +82,44 @@ RSpec.describe Spree::CSV::ProductVariantPresenter do
         expect(subject[35]).to eq 'Small'
         expect(subject[36]).to eq nil
         expect(subject[37]).to eq nil
+      end
+    end
+
+    describe 'images host' do
+      context 'when default host is set' do
+        before do
+          allow(Rails.application.routes).to receive(:default_url_options).and_return({ host: 'test.host' })
+        end
+
+        it 'returns images with default host' do
+          expect(subject[29]).to start_with('http://test.host')
+          expect(subject[30]).to start_with('http://test.host')
+          expect(subject[31]).to start_with('http://test.host')
+        end
+      end
+
+      context 'when there is no default host' do
+        before do
+          allow(Rails.application.routes).to receive(:default_url_options).and_return({})
+        end
+
+        it 'returns images with the store url' do
+          expect(subject[29]).to start_with("http://#{store.url}")
+          expect(subject[30]).to start_with("http://#{store.url}")
+          expect(subject[31]).to start_with("http://#{store.url}")
+        end
+
+        context 'when custom domain is set' do
+          let!(:custom_domain) { create(:custom_domain, store: store, url: 'custom.domain') }
+
+          before { store.reload }
+
+          it 'returns images with the custom domain' do
+            expect(subject[29]).to start_with('http://custom.domain')
+            expect(subject[30]).to start_with('http://custom.domain')
+            expect(subject[31]).to start_with('http://custom.domain')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of image URLs in CSV exports to ensure correct host is used based on store and environment configuration.
  - Resolved potential errors when images are missing or not attached.

- **Tests**
  - Enhanced test coverage to verify image URLs use the correct host in various scenarios, including default, store, and custom domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->