### PR TITLE
spree fix for images in admin store builder and storefront

### DIFF
--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -18,10 +18,10 @@ module Spree
       width = options[:width]
       height = options[:height]
 
-      width = width * 2 if width.present?
-      height = height * 2 if height.present?
+      width *= 2 if width.present?
+      height *= 2 if height.present?
 
-      return unless image.attached?
+      return if image.respond_to?(:attached?) && !image.attached?
       return unless image.variable?
 
       if width.present? && height.present?
@@ -51,17 +51,18 @@ module Spree
       return unless height
       return if height.zero?
 
-      w, h = width.to_f, height.to_f
+      w = width.to_f
+      h = height.to_f
 
       # Always return width / height, flipping if needed
-      if h > w
-        ratio = h / w
-      elsif h < w
-        ratio = w / h
-      else
-        # h == w, square image
-        ratio = 1.0
-      end
+      ratio = if h > w
+                h / w
+              elsif h < w
+                w / h
+              else
+                # h == w, square image
+                1.0
+              end
 
       ratio.round(3)
     end

--- a/core/lib/spree/testing_support/factories/post_factory.rb
+++ b/core/lib/spree/testing_support/factories/post_factory.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     published_at { Time.current }
     author { create(:admin_user) }
     store { Spree::Store.default || create(:store) }
+
+    trait :with_image do
+      image { Rack::Test::UploadedFile.new(Spree::Core::Engine.root.join('spec/fixtures/thinking-cat.jpg'), 'image/jpeg') }
+    end
   end
 end

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -23,6 +23,10 @@ describe Spree::ImagesHelper, type: :helper do
   end
 
   describe '#spree_image_url' do
+    it 'supports blob' do
+      expect(helper.spree_image_url(image.blob)).to eq(helper.spree_image_url(image))
+    end
+
     context 'when image is not attached' do
       before do
         allow(image).to receive(:attached?).and_return(false)
@@ -35,8 +39,7 @@ describe Spree::ImagesHelper, type: :helper do
 
     context 'when image is not variable' do
       before do
-        allow(image).to receive(:attached?).and_return(true)
-        allow(image).to receive(:variable?).and_return(false)
+        allow(image).to receive_messages(attached?: true, variable?: false)
       end
 
       it 'returns nil' do
@@ -82,8 +85,7 @@ describe Spree::ImagesHelper, type: :helper do
 
     context 'when aspect_ratio is present in metadata' do
       before do
-        allow(attachment).to receive(:analyzed?).and_return(true)
-        allow(attachment).to receive(:metadata).and_return({ 'aspect_ratio' => 1.5 })
+        allow(attachment).to receive_messages(analyzed?: true, metadata: { 'aspect_ratio' => 1.5 })
       end
 
       it 'returns the aspect ratio' do
@@ -93,8 +95,7 @@ describe Spree::ImagesHelper, type: :helper do
 
     context 'when calculating aspect ratio from dimensions' do
       before do
-        allow(attachment).to receive(:analyzed?).and_return(true)
-        allow(attachment).to receive(:metadata).and_return({ 'width' => width, 'height' => height })
+        allow(attachment).to receive_messages(analyzed?: true, metadata: { 'width' => width, 'height' => height })
       end
 
       context 'when height is greater than width' do

--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -1,6 +1,7 @@
 module Spree
   module StorefrontHelper
     include BaseHelper
+    include Spree::ImagesHelper
     include Heroicon::Engine.helpers
 
     # Renders the storefront partials for the given section.
@@ -71,9 +72,9 @@ module Spree
 
     def show_account_pane?
       !try_spree_current_user &&
-        (defined?(spree_login_path) && !paths_equal?(canonical_path, spree_login_path)) &&
-        (defined?(spree_signup_path) && !paths_equal?(canonical_path, spree_signup_path)) &&
-        (defined?(spree_forgot_password_path) && !paths_equal?(canonical_path, spree_forgot_password_path))
+        defined?(spree_login_path) && !paths_equal?(canonical_path, spree_login_path) &&
+        defined?(spree_signup_path) && !paths_equal?(canonical_path, spree_signup_path) &&
+        defined?(spree_forgot_password_path) && !paths_equal?(canonical_path, spree_forgot_password_path)
     end
 
     def paths_equal?(path1, path2)

--- a/storefront/spec/features/post_details_page_spec.rb
+++ b/storefront/spec/features/post_details_page_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-RSpec.describe 'Post details page', type: :feature, js: true do
+RSpec.describe 'Post details page', :js, type: :feature do
   describe 'JSON-LD data' do
     let(:store) { Spree::Store.default }
     let!(:post) do
       create(
-        :post,
+        :post, :with_image,
         post_category: post_category,
         tag_list: tags,
         title: 'New products on sale!',
@@ -27,11 +27,11 @@ RSpec.describe 'Post details page', type: :feature, js: true do
       let(:post_category) { create(:post_category, title: 'Articles') }
 
       it 'renders BlogPosting JSON-LD' do
-        expect(json_ld).to eq(
+        expect(json_ld).to match(
           '@context' => 'https://schema.org',
           '@type' => 'BlogPosting',
           'headline' => 'New products on sale!',
-          'image' => [],
+          'image' => array_including(kind_of(String)),
           'datePublished' => post.published_at.iso8601,
           'dateModified' => post.updated_at.iso8601,
           'author' => [
@@ -44,7 +44,7 @@ RSpec.describe 'Post details page', type: :feature, js: true do
       end
 
       it 'renders BreadcrumbList JSON-LD with a link to category page' do
-        expect(json_ld_breadcrumbs).to eq(
+        expect(json_ld_breadcrumbs).to match(
           {
             '@context' => 'https://schema.org',
             '@type' => 'BreadcrumbList',
@@ -82,11 +82,11 @@ RSpec.describe 'Post details page', type: :feature, js: true do
       let(:post_category) { nil }
 
       it 'renders JSON-LD' do
-        expect(json_ld).to eq(
+        expect(json_ld).to match(
           '@context' => 'https://schema.org',
           '@type' => 'BlogPosting',
           'headline' => 'New products on sale!',
-          'image' => [],
+          'image' => array_including(kind_of(String)),
           'datePublished' => post.published_at.iso8601,
           'dateModified' => post.updated_at.iso8601,
           'author' => [


### PR DESCRIPTION
- support blobs in spree_image_tag (500 when adding image via store builder) 
- includes spree image helpers for storefront (500 when displaying blog post images and more) - update post add feature specs to use post with image
- rubocop -A for updated files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved code readability and robustness in image helper methods without changing functionality.
  - Enhanced test setup style for helper specs.

- **New Features**
  - Added support for posts to include images in tests via a new trait.

- **Tests**
  - Updated feature tests to validate JSON-LD image data for posts with images.
  - Relaxed JSON-LD assertions for more flexible test validation.

- **Chores**
  - Included image helper methods in storefront helpers for broader availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->