### PR TITLE
Raise RecordNotFound it no `current_store`

### DIFF
--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -18,11 +18,7 @@ module Spree
         end
 
         def store_locale
-          current_store.default_locale
-        end
-
-        def raise_record_not_found_if_store_is_not_found
-          raise ActiveRecord::RecordNotFound if current_store.nil?
+          @store_locale ||= current_store.default_locale
         end
 
         def ensure_current_store(object)
@@ -69,6 +65,10 @@ module Spree
 
         def current_store_finder
           Spree::Dependencies.current_store_finder.constantize
+        end
+
+        def raise_record_not_found_if_store_is_not_found
+          raise ActiveRecord::RecordNotFound if current_store.nil?
         end
       end
     end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -9,6 +9,8 @@ module Spree
             helper_method :current_store
             helper_method :current_price_options
           end
+
+          prepend_before_action :raise_record_not_found_if_store_is_not_found
         end
 
         def current_store
@@ -17,6 +19,10 @@ module Spree
 
         def store_locale
           current_store.default_locale
+        end
+
+        def raise_record_not_found_if_store_is_not_found
+          raise ActiveRecord::RecordNotFound if current_store.nil?
         end
 
         def ensure_current_store(object)

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -189,4 +189,16 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       end
     end
   end
+
+  describe '#raise_record_not_found_if_store_is_not_found' do
+    context 'when the store is not found' do
+      before do
+        allow(controller).to receive(:current_store).and_return(nil)
+      end
+
+      it 'raises an exception' do
+        expect { controller.send(:raise_record_not_found_if_store_is_not_found) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This won't affect single-tenant applications as we always fallback to default store, however it will be helpful for multi-tenant apps where such fallback does not happen. Rather than displaying 50x errors it will just output a 404 page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by raising an error if no store is found during request processing.

* **Tests**
  * Added tests to verify that an appropriate error is raised when no store is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->