### PR TITLE
Do not require shipping address for digital delivery

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -860,6 +860,10 @@ module Spree
       line_items
     end
 
+    def requires_ship_address?
+      !digital?
+    end
+
     private
 
     def link_by_email

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -433,7 +433,7 @@ module Spree
     end
 
     def can_get_rates?
-      return true if order.ship_address.nil? && order.digital?
+      return true if order.requires_ship_address?
 
       order.ship_address&.valid?
     end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -433,6 +433,8 @@ module Spree
     end
 
     def can_get_rates?
+      return true if order.ship_address.nil? && order.digital?
+
       order.ship_address&.valid?
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -433,7 +433,7 @@ module Spree
     end
 
     def can_get_rates?
-      return true if order.requires_ship_address?
+      return true unless order.requires_ship_address?
 
       order.ship_address&.valid?
     end

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -48,7 +48,7 @@ module Spree
     end
 
     def include?(address)
-      return true if digital?
+      return true unless requires_zone_check?
       return false unless address
 
       zones.includes(:zone_members).any? do |zone|

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -56,8 +56,8 @@ module Spree
       end
     end
 
-    def digital?
-      calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
+    def requires_zone_check?
+      !calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end
 
     def build_tracking_url(tracking)

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -48,11 +48,16 @@ module Spree
     end
 
     def include?(address)
+      return true if digital?
       return false unless address
 
       zones.includes(zone_members: :zoneable).any? do |zone|
         zone.include?(address)
       end
+    end
+
+    def digital?
+      calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end
 
     def build_tracking_url(tracking)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -325,6 +325,37 @@ describe Spree::Shipment, type: :model do
     end
   end
 
+  describe '#can_get_rates?' do
+    let(:digital_shipping_method) { create(:digital_shipping_method) }
+    let(:digital_product) { create(:product, shipping_category: digital_shipping_method.shipping_categories.first) }
+    let(:digital_line_item) { create(:line_item, variant: create(:variant, product: digital_product)) }
+
+    it 'returns true if order is digital and it does not have a ship address' do
+      order.ship_address = nil
+      order.line_items = [digital_line_item]
+      expect(order.digital?).to eq(true)
+      expect(shipment.send(:can_get_rates?)).to be_truthy
+    end
+
+    it 'returns false if order is not digital and it does not have a ship address' do
+      order.ship_address = nil
+      expect(order.digital?).to eq(false)
+      expect(shipment.send(:can_get_rates?)).to be_falsey
+    end
+
+    it 'returns false when order\'s ship address is not valid' do
+      order.ship_address = build(:address, address1: nil)
+      expect(order.digital?).to eq(false)
+      expect(shipment.send(:can_get_rates?)).to be_falsey
+    end
+
+    it 'returns true when order\'s ship address is valid' do
+      order.ship_address = build(:address)
+      expect(order.digital?).to eq(false)
+      expect(shipment.send(:can_get_rates?)).to be_truthy
+    end
+  end
+
   context 'shipping_rates' do
     let(:shipment) { create(:shipment) }
     let(:shipping_method1) { create(:shipping_method) }

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -35,14 +35,14 @@ describe Spree::ShippingMethod, type: :model do
     end
   end
 
-  describe '#digital?' do
-    it 'returns false if the shipping method is not digital' do
-      expect(shipping_method.digital?).to be_falsey
+  describe '#requires_zone_check?' do
+    it 'returns true if the shipping method is not digital' do
+      expect(shipping_method.requires_zone_check?).to be_truthy
     end
 
-    it 'returns true if the shipping method is digital' do
+    it 'returns false if the shipping method is digital' do
       shipping_method = create(:digital_shipping_method)
-      expect(shipping_method.digital?).to be_truthy
+      expect(shipping_method.requires_zone_check?).to be_falsey
     end
   end
 

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -35,6 +35,17 @@ describe Spree::ShippingMethod, type: :model do
     end
   end
 
+  describe '#digital?' do
+    it 'returns false if the shipping method is not digital' do
+      expect(shipping_method.digital?).to be_falsey
+    end
+
+    it 'returns true if the shipping method is digital' do
+      shipping_method = create(:digital_shipping_method)
+      expect(shipping_method.digital?).to be_truthy
+    end
+  end
+
   context 'calculators' do
     it "rejects calculators that don't inherit from Spree::ShippingCalculator" do
       allow(Spree::ShippingMethod).to receive_message_chain(:spree_calculators, :shipping_methods).and_return([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for digital orders by allowing shipping rate retrieval even when no shipping address is present.
  * Added direct recognition of digital shipping methods, enabling them to bypass standard address checks.
  * Added a method to determine if an order requires a shipping address.

* **Tests**
  * Introduced new tests to verify digital order handling and digital shipping method detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->