### PR TITLE
Do not show order's ship address when order does not required it

### DIFF
--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -1,15 +1,17 @@
 <li class="border border-accent mb-4">
   <div class="p-4 lg:p-6">
     <div class="flex flex-col lg:flex-row lg:gap-6 gap-4">
-      <div class="text-sm lg:w-1/2">
-        <div class="tracking-widest uppercase mb-1">
-          <%= Spree.t(:delivery_address) %>
+      <% if shipment.order.requires_ship_address? %>
+        <div class="text-sm lg:w-1/2">
+          <div class="tracking-widest uppercase mb-1">
+            <%= Spree.t(:delivery_address) %>
+          </div>
+          <div class="!leading-[1.375rem] text-neutral-800">
+            <%= render "spree/shared/address",
+            address: shipment.address || shipment.order.ship_address %>
+          </div>
         </div>
-        <div class="!leading-[1.375rem] text-neutral-800">
-          <%= render "spree/shared/address",
-          address: shipment.address || shipment.order.ship_address %>
-        </div>
-      </div>
+      <% end %>
       <div class="text-sm lg:w-1/2 lg:flex justify-between">
         <div>
           <div class="tracking-widest uppercase mb-1">

--- a/storefront/spec/controllers/spree/orders_controller_spec.rb
+++ b/storefront/spec/controllers/spree/orders_controller_spec.rb
@@ -120,6 +120,18 @@ describe Spree::OrdersController, type: :controller do
       end
     end
 
+
+    context 'when order does not require ship address' do
+      let(:digital_shipping_method) { create(:digital_shipping_method) }
+      let(:digital_product) { create(:product, shipping_category: digital_shipping_method.shipping_categories.first) }
+      let(:order) { create(:completed_order_with_totals, store: store, user: user, line_items: [create(:line_item, variant: digital_product.master)]) }
+
+      it 'renders the show template' do
+        get :show, params: { id: order.number, token: order.token }
+        expect(response).to render_template(:show)
+      end
+    end
+
     context 'when order belongs to another user' do
       let(:order) { create(:completed_order_with_totals, store: store, user: create(:user)) }
 

--- a/storefront/spec/controllers/spree/orders_controller_spec.rb
+++ b/storefront/spec/controllers/spree/orders_controller_spec.rb
@@ -124,11 +124,14 @@ describe Spree::OrdersController, type: :controller do
     context 'when order does not require ship address' do
       let(:digital_shipping_method) { create(:digital_shipping_method) }
       let(:digital_product) { create(:product, shipping_category: digital_shipping_method.shipping_categories.first) }
-      let(:order) { create(:completed_order_with_totals, store: store, user: user, line_items: [create(:line_item, variant: digital_product.master)]) }
+      let(:order) { create(:completed_order_with_totals, store: store, user: user, ship_address: nil, variants: [digital_product.default_variant]) }
 
       it 'renders the show template' do
+        expect(order.digital?).to be_truthy
+        expect(order.requires_ship_address?).to be_falsey
         get :show, params: { id: order.number, token: order.token }
         expect(response).to render_template(:show)
+        expect(response.body).not_to include(Spree.t(:delivery_address))
       end
     end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The delivery address section in the shipment display is now shown only when a shipping address is required for the order.  
* **Tests**
  * Added coverage for orders without shipping addresses, ensuring proper display for digital products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->