### PR TITLE
Fixed: don't raise 404 when no store on root domain

### DIFF
--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -68,7 +68,13 @@ module Spree
         end
 
         def raise_record_not_found_if_store_is_not_found
+          return if skip_store_lookup?
+
           raise ActiveRecord::RecordNotFound if current_store.nil?
+        end
+
+        def skip_store_lookup?
+          Spree.root_domain.present? && Spree.root_domain.include?(request.env['SERVER_NAME'])
         end
       end
     end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -191,6 +191,8 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
   end
 
   describe '#raise_record_not_found_if_store_is_not_found' do
+    let(:store) { create :store }
+
     context 'when the store is not found' do
       before do
         allow(controller).to receive(:current_store).and_return(nil)
@@ -198,6 +200,27 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
 
       it 'raises an exception' do
         expect { controller.send(:raise_record_not_found_if_store_is_not_found) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'with root_domain set' do
+      before do
+        allow(Spree).to receive(:root_domain).and_return('example.com')
+        controller.request.env['SERVER_NAME'] = 'example.com'
+      end
+
+      it 'does not raise an exception' do
+        expect { controller.send(:raise_record_not_found_if_store_is_not_found) }.not_to raise_error
+      end
+    end
+
+    context 'when store is found' do
+      before do
+        allow(controller).to receive(:current_store).and_return(store)
+      end
+
+      it 'does not raise an exception' do
+        expect { controller.send(:raise_record_not_found_if_store_is_not_found) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of store lookup errors to prevent unnecessary errors when the request matches the configured root domain.

* **Tests**
  * Added new test cases to verify correct behavior when the root domain is set and when a valid store exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->