### PR TITLE
Fix address form

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -80,7 +80,7 @@ module Spree
     end
 
     delegate :name, :iso3, :iso, :iso_name, to: :country, prefix: true
-    delegate :abbr, to: :state, prefix: true, allow_nil: true
+    delegate :abbr, :name, to: :state, prefix: true, allow_nil: true
 
     alias_attribute :postal_code, :zipcode
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -80,7 +80,7 @@ module Spree
     end
 
     delegate :name, :iso3, :iso, :iso_name, to: :country, prefix: true
-    delegate :abbr, :name, to: :state, prefix: true, allow_nil: true
+    delegate :abbr, to: :state, prefix: true, allow_nil: true
 
     alias_attribute :postal_code, :zipcode
 

--- a/storefront/app/views/spree/checkout/_address.html.erb
+++ b/storefront/app/views/spree/checkout/_address.html.erb
@@ -134,7 +134,7 @@
                 address_name: address_name,
                 address_form: address_form,
                 address_type: address_type,
-                address: Spree::Address.new(country: current_store.default_country, user: try_spree_current_user),
+                address: address_form.object.persisted? ? address_form.object : Spree::Address.new(country: current_store.default_country, user: try_spree_current_user),
                 form: form
               } %>
             </div>


### PR DESCRIPTION
This fixes changing country state to first one from select after moving back to address checkout step after saving one. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the checkout address form to correctly use existing saved addresses when editing, rather than always initializing a new address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->