### PR TITLE
fix_admin_views_for_i18n

### DIFF
--- a/admin/app/views/spree/admin/admin_users/_audit_log.html.erb
+++ b/admin/app/views/spree/admin/admin_users/_audit_log.html.erb
@@ -1,5 +1,5 @@
 <div class="text-muted text-center py-5">
-  <p>Audit log is part of the Spree Enterprise offering.</p>
+  <p><%= Spree.t(:audit_log_help) %></p>
 
-  <%= external_link_to 'Upgrade to Spree Enterprise', 'https://spreecommerce.org/pricing', class: 'btn btn-primary' %>
+  <%= external_link_to Spree.t(:upgrade_to_spree_enterprise), 'https://spreecommerce.org/pricing', class: 'btn btn-primary' %>
 </div>

--- a/admin/app/views/spree/admin/admin_users/_form.html.erb
+++ b/admin/app/views/spree/admin/admin_users/_form.html.erb
@@ -1,12 +1,12 @@
 <div class="form-group">
-  <%= f.label :email %>
+  <%= f.label :email, Spree.t(:email) %>
   <%= f.email_field :email, class: 'form-control', required: true, autofocus: true %>
 </div>
 <div class="form-group">
-  <%= f.label :first_name %>
+  <%= f.label :first_name, Spree.t(:first_name) %>
   <%= f.text_field :first_name, class: 'form-control', required: true %>
 </div>
 <div class="form-group">
-  <%= f.label :last_name %>
+  <%= f.label :last_name, Spree.t(:last_name) %>
   <%= f.text_field :last_name, class: 'form-control', required: true %>
 </div>

--- a/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
@@ -4,10 +4,10 @@
       <thead>
         <tr>
           <th><%= Spree.t(:name) %></th>
-          <th>Active?</th>
+          <th><%= Spree.t(:active) %></th>
 
           <% unless entri_enabled? %>
-            <th>Default</th>
+            <th><%= Spree.t(:default) %></th>
             <th></th>
           <% end %>
         </tr>
@@ -19,6 +19,6 @@
   </div>
 <% else %>
   <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
-    You don't have any custom domains set yet.
+    <%= Spree.t(:no_custom_domains) %>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/custom_domains/_form.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_form.html.erb
@@ -11,8 +11,8 @@
 
     <div class="custom-control custom-checkbox">
       <%= f.check_box :default, class: 'custom-control-input' %>
-      <%= f.label :default, class: 'custom-control-label font-weight-semibold' %>
-      <p class="form-text mb-0">We will use this domain in emails to customers.</p>
+      <%= f.label :default, Spree.t(:default), class: 'custom-control-label font-weight-semibold' %>
+      <p class="form-text mb-0"><%= Spree.t(:default_custom_domains_help) %></p>
       <%= f.error_message_on :default %>
     </div>
   </div>

--- a/admin/app/views/spree/admin/custom_domains/index.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/index.html.erb
@@ -6,11 +6,11 @@
 <% end %>
 
 <div class="card-lg p-4">
-  <h5 class="mb-3">Internal URL</h5>
+  <h5 class="mb-3"><%= Spree.t(:internal_url) %></h5>
   <div class="row mb-4">
     <div class="col-lg-4">
       <p class="text-muted">
-        This is your internal URL.
+        <%= Spree.t(:internal_url_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -26,11 +26,11 @@
     </div>
   </div>
   <hr class="my-5" />
-  <h5>Custom domains</h5>
+  <h5><%= Spree.t(:custom_domains) %></h5>
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Connect your domain or subdomain to your store.
+        <%= Spree.t(:custom_domains_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">

--- a/admin/app/views/spree/admin/dashboard/_setup_progress.html.erb
+++ b/admin/app/views/spree/admin/dashboard/_setup_progress.html.erb
@@ -1,14 +1,14 @@
 <div class="mb-3 card rounded-lg" id="setup_progress">
   <div class="card-body">
     <div class="mb-3">
-      Your overall setup progress
+      <%= Spree.t(:your_overall_setup_progress) %>
       <span class="float-right badge badge-<%= current_store.setup_completed? ? 'success' : 'info' %>">
         <% if current_store.setup_completed? %>
           <%= icon('check', class: 'text-success') %>
         <% end %>
 
         <span>
-          <strong><%= current_store.setup_tasks_done %></strong> of <%= current_store.setup_tasks_total %> steps done
+          <strong><%= current_store.setup_tasks_done %></strong> of <%= current_store.setup_tasks_total %> <%= Spree.t(:steps_done) %>
         </span>
       </span>
     </div>

--- a/admin/app/views/spree/admin/dashboard/_store_preview.html.erb
+++ b/admin/app/views/spree/admin/dashboard/_store_preview.html.erb
@@ -32,7 +32,7 @@
     </div>
     <% unless current_store.default_custom_domain&.active? %>
       <div class="card-footer border-top p-2">
-        <%= link_to_with_icon 'world-www', 'Connect your own domain', spree.admin_custom_domains_path, class: 'btn btn-link w-100 py-2' %>
+        <%= link_to_with_icon 'world-www', Spree.t(:connect_your_own_domain), spree.admin_custom_domains_path, class: 'btn btn-link w-100 py-2' %>
       </div>
     <% end %>
   </div>

--- a/admin/app/views/spree/admin/dashboard/analytics.html.erb
+++ b/admin/app/views/spree/admin/dashboard/analytics.html.erb
@@ -11,7 +11,7 @@
         <div class="col-6 col-lg-4 pr-2">
           <div class="analytics-card-tab active" data-tabs-target="tab" data-action="click->tabs#change">
             <div class="d-flex justify-content-center flex-column mb-3 mb-lg-0">
-              <span class="font-size-sm text-muted">Total Sales</span>
+              <span class="font-size-sm text-muted"><%= Spree.t(:total_sales) %></span>
               <span class="font-size-lg text-dark font-weight-bold mt-1">
                 <%= @sales_total %>
               </span>
@@ -25,7 +25,7 @@
         <div class="col-6 col-lg-2 pl-0 pr-2">
           <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#change">
             <div class="d-flex justify-content-center flex-column mb-3 mb-lg-0">
-              <span class="font-size-sm text-muted">Avg. Order Value</span>
+              <span class="font-size-sm text-muted"><%= Spree.t(:avg_order_value) %></span>
               <span class="font-size-lg text-dark font-weight-bold mt-1 me-3"><%= @orders_average %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @orders_average_growth_rate %>
@@ -37,7 +37,7 @@
         <div class="col-6 col-lg-2 pl-0 pr-2">
           <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#change">
             <div class="d-flex justify-content-center flex-column mb-3 mb-lg-0">
-              <span class="font-size-sm text-muted">Total Orders</span>
+              <span class="font-size-sm text-muted"><%= Spree.t(:total_orders) %></span>
               <span class="font-size-lg text-dark font-weight-bold mt-1 me-3"><%= @orders_total  %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @orders_growth_rate %>
@@ -49,7 +49,7 @@
           <div class="col-6 col-lg-2 pl-0 pr-2">
             <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#change">
               <div class="d-flex justify-content-center flex-column">
-                <span class="font-size-sm text-muted">Visits</span>
+                <span class="font-size-sm text-muted"><%= Spree.t(:visits) %></span>
                 <span class="font-size-lg text-dark font-weight-bold mt-1 me-3"><%= @visits_total %></span>
                 <div>
                   <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @visits_growth_rate %>
@@ -63,7 +63,7 @@
           <div class="col-6 col-lg-2 pl-0">
             <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#change">
               <div class="d-flex justify-content-center flex-column">
-                <span class="font-size-sm text-muted">Sign-ups</span>
+                <span class="font-size-sm text-muted"><%= Spree.t(:sign_ups) %></span>
                 <span class="font-size-lg text-dark font-weight-bold mt-1 me-3"><%= @audience_total %></span>
                 <div>
                   <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @audience_growth_rate %>

--- a/admin/app/views/spree/admin/dashboard/setup_tasks/_add_products.html.erb
+++ b/admin/app/views/spree/admin/dashboard/setup_tasks/_add_products.html.erb
@@ -1,17 +1,7 @@
 <% if done %>
-  <p>
-    Good job, you've added products to your store!
-  </p>
-  <p>
-    Remember you can always add more!
-  </p>
+  <%= Spree.t('admin.store_setup_tasks.products.done').html_safe %>
 <% else %>
-  <p>
-    Add products to your store, either your own or invite 3rd party vendors to sell together.
-  </p>
-  <p>
-    You can also import products in bulk from a CSV or Excel file.
-  </p>
+  <%= Spree.t('admin.store_setup_tasks.products.copy').html_safe %>
 <% end %>
 
 <div class="d-flex gap-3">

--- a/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
+++ b/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
@@ -1,12 +1,10 @@
 <%= turbo_frame_tag :set_customer_support_email, class: 'w-100' do %>
   <div class="alert alert-info">
-    We need your customer support email to display on your storefront.
-    This email will work as a contact point for your customers to reach out to you for any queries or support.
+    <%= Spree.t('admin.store_setup_tasks.customer_support_email.info').html_safe %>
   </div>
-
   <% if done %>
     <p>
-      Your customer support email is <strong><%= current_store.customer_support_email %>.</strong>
+      <%= Spree.t('admin.store_setup_tasks.customer_support_email.done', email: current_store.customer_support_email).html_safe %>
     </p>
     <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_emails_admin_store_path, class: 'btn btn-light' %>
   <% else %>

--- a/admin/app/views/spree/admin/gift_cards/_table_filter_dropdown.html.erb
+++ b/admin/app/views/spree/admin/gift_cards/_table_filter_dropdown.html.erb
@@ -1,6 +1,6 @@
 <div class="dropdown">
   <button class="btn btn-light dropdown-toggle" type="button" data-toggle="dropdown" data-display="static" data-flip="false" aria-expanded="false">
-    <span class="text-muted font-weight-normal">Show:</span>
+    <span class="text-muted font-weight-normal"><%= Spree.t(:show) %>:</span>
     <%= gift_cards_filter_dropdown_value %>
   </button>
   <div class="dropdown-menu w-100" style="min-width: 200px">

--- a/admin/app/views/spree/admin/invitations/_invitation.html.erb
+++ b/admin/app/views/spree/admin/invitations/_invitation.html.erb
@@ -21,7 +21,7 @@
       <span class="badge badge-warning"><%= Spree.t(:expired) %></span>
     <% else %>
       <span class="badge badge-light"><%= Spree.t(:pending) %></span>
-      <p class="text-muted font-size-sm mb-0 mt-2 pl-1">Expires at: <%= local_time(invitation.expires_at) %></p>
+      <p class="text-muted font-size-sm mb-0 mt-2 pl-1"><%= Spree.t(:expires_at) %>: <%= local_time(invitation.expires_at) %></p>
     <% end %>
   </td>
   <td class="w-10">

--- a/admin/app/views/spree/admin/invitations/new.html.erb
+++ b/admin/app/views/spree/admin/invitations/new.html.erb
@@ -17,7 +17,7 @@
           </div>
         <% end %>
         <div class="form-group">
-          <%= f.label :expires_at %>
+          <%= f.label :expires_at, Spree.t(:expires_at) %>
           <%= f.date_field :expires_at, class: 'form-control', required: true, data: { 'enable-button-target': 'input' } %>
         </div>
       </div>

--- a/admin/app/views/spree/admin/oauth_applications/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/oauth_applications/create.turbo_stream.erb
@@ -29,13 +29,13 @@
             </div>
           </div>
           <div class="alert alert-warning mt-3">
-            This is your application's secret token, copy it now and keep it safe. It won't be shown again.
+            <%= Spree.t('admin.oauth_applications.warning') %>
           </div>
         </div>
       </div>
     </div>
     <div class="card-footer">
-      <%= link_to 'Back to list', spree.admin_oauth_applications_url, class: 'btn btn-light' %>
+      <%= link_to Spree.t(:back_to_list), spree.admin_oauth_applications_url, class: 'btn btn-light' %>
     </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/oauth_applications/index.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/index.html.erb
@@ -9,8 +9,7 @@
 <%= content_for :page_alerts do %>
   <div class="alert alert-info mb-3">
     <p>
-      Here you can manage API keys to access the <%= link_to 'Platform API', 'https://spreecommerce.org/docs/api-reference/platform/authentication', target: '_blank' %>.
-      For headless storefronts you don't need an API key, please use the <%= link_to 'Storefront API', 'https://spreecommerce.org/docs/api-reference/storefront/authentication', target: '_blank' %>.
+      <%= Spree.t('admin.oauth_applications.info').html_safe %>
     </p>
   </div>
 <% end %>
@@ -22,7 +21,7 @@
         <thead>
           <tr>
             <th><%= Spree.t(:name) %></th>
-            <th>Client ID</th>
+            <th><%= Spree.t('admin.oauth_applications.client_id') %></th>
             <th><%= Spree.t('admin.oauth_applications.scopes') %></th>
             <th><%= Spree.t('admin.oauth_applications.last_used') %></th>
             <th></th>

--- a/admin/app/views/spree/admin/option_types/_form.html.erb
+++ b/admin/app/views/spree/admin/option_types/_form.html.erb
@@ -10,7 +10,7 @@
             <%= f.text_field :presentation, class: "form-control", required: true, autofocus: f.object.new_record?, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName' } %>
             <%= f.error_message_on :presentation %>
             <p class="text-muted form-text mt-2 mb-0">
-              This is used to display the option type on the storefront.
+              <%= Spree.t(:presentation_help).html_safe %>
             </p>
           </div>
         </div>
@@ -21,7 +21,7 @@
             <%= f.text_field :name, class: "form-control", data: { slug_form_target: :url } %>
             <%= f.error_message_on :name %>
             <p class="text-muted form-text mt-2 mb-0">
-              This is used internally to identify the option type. <strong>It must be unique.</strong>
+              <%= Spree.t(:internal_name_help).html_safe %>
             </p>
           </div>
         </div>

--- a/admin/app/views/spree/admin/option_types/index.html.erb
+++ b/admin/app/views/spree/admin/option_types/index.html.erb
@@ -8,8 +8,7 @@
 
 <%= content_for(:page_alerts) do %>
   <div class="alert alert-info">
-    Options are used to group certain attributes. For example, you can create an option named "shirt size" and then
-    create an option value named "small" and "medium" for this option.
+    <%= Spree.t(:option_types_info) %>
   </div>
 <% end %>
 
@@ -24,11 +23,11 @@
             <th><%= Spree.t(:internal_name) %></th>
             <th>
               <%= Spree.t(:presentation) %>
-              <%= help_bubble("How this option is presented to customers") %>
+              <%= help_bubble(Spree.t(:presentation_help)) %>
             </th>
             <th>
               <%= Spree.t(:filterable) %>
-              <%= help_bubble("Whether this option can be used in product filters") %>
+              <%= help_bubble(Spree.t(:filterable_help)) %>
             </th>
             <th>
               <%= Spree.t(:option_values) %>
@@ -55,5 +54,5 @@
 </div>
 
 <p class="documentation-link-container">
-  <%= external_link_to "Learn more about options", "https://spreecommerce.org/docs/user/manage-products/product-options" %>
+  <%= external_link_to Spree.t(:learn_more_about_options), "https://spreecommerce.org/docs/user/manage-products/product-options" %>
 </p>

--- a/admin/app/views/spree/admin/orders/_customer_summary.html.erb
+++ b/admin/app/views/spree/admin/orders/_customer_summary.html.erb
@@ -11,7 +11,7 @@
     <span class="text-muted">
       <%= order.full_name %>
     </span>
-    <%= help_bubble('This order was placed by a guest customer') %>
+    <%= help_bubble(Spree.t(:order_by_guest_customer)) %>
   <% else %>
     <span class="text-muted">
       <%= Spree.t(:not_available) %>

--- a/admin/app/views/spree/admin/orders/_user_overview.html.erb
+++ b/admin/app/views/spree/admin/orders/_user_overview.html.erb
@@ -2,12 +2,9 @@
   <div class="alert alert-info mt-2 mb-0">
     <div>
       <h6 class="font-weight-bold">
-        <%= icon('magic') %> Assistant
+        <%= icon('magic') %> <%= Spree.t(:assistant) %> 
       </h6>
-      This is a repeat customer that has spent a total of
-      <strong><%= Spree::Money.new(@order.user.orders.complete.sum(:total)) %></strong> across
-      <strong><%= @order.user.orders.complete.count %> orders</strong>, averaging
-      <strong><%= Spree::Money.new(@order.user.orders.complete.average(:total)) %></strong> per order.
+      <%= Spree.t(:assistant_info, total: Spree::Money.new(@order.user.orders.complete.sum(:total)), count: @order.user.orders.complete.count, average: Spree::Money.new(@order.user.orders.complete.average(:total))).html_safe %>
     </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/_form.html.erb
@@ -31,7 +31,7 @@
           <%= label_tag :payment_method_name, Spree.t(:name) %>
           <%= text_field :payment_method, :name, class: 'form-control' %>
           <span class="text-muted form-text mt-2">
-            This name will be used to identify the payment method on the storefront
+            <%= Spree.t(:payment_method_name_help) %>
           </span>
 
           <%= error_message_on :payment_method, :name %>

--- a/admin/app/views/spree/admin/payment_methods/descriptions/_store_credit.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/descriptions/_store_credit.html.erb
@@ -1,1 +1,1 @@
-Allow customers to use store credit for payment. Issue store credit to customers from the admin.
+<%= Spree.t('store_credit.description') %>

--- a/admin/app/views/spree/admin/payment_methods/index.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/index.html.erb
@@ -22,7 +22,7 @@
 </div>
 
 <% if available_payment_methods.present? && can?(:create, Spree::PaymentMethod) %>
-  <h6 class="pb-2 pt-3">Available Payment Methods</h6>
+  <h6 class="pb-2 pt-3"><%= Spree.t(:available_payment_methods) %></h6>
   <div class="card-lg">
     <div class="table-responsive">
       <table class="table">

--- a/admin/app/views/spree/admin/posts/_form.html.erb
+++ b/admin/app/views/spree/admin/posts/_form.html.erb
@@ -24,7 +24,7 @@
 
         <div class="form-group mb-0">
           <%= f.label :excerpt, Spree.t(:excerpt) %>
-          <%= help_bubble('Add a summary of the post') %>
+          <%= help_bubble(Spree.t(:excerpt_help)) %>
 
           <div class="trix-container mb-0">
             <%= f.rich_text_area :excerpt, class: 'overflow-auto', style: 'height: 100px', data: { seo_form_target: 'sourceExcerptInput' } %>
@@ -76,6 +76,6 @@
           description: @post.content,
           slug: @post.slug,
           slug_path: 'posts',
-          placeholder: 'Add a title and content to see how this post might appear in a search engine listing' %>
+          placeholder: Spree.t('admin.posts.seo_placeholder') %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/products/index.html.erb
+++ b/admin/app/views/spree/admin/products/index.html.erb
@@ -13,6 +13,5 @@
 </div>
 
 <p class="documentation-link-container">
-  Learn more about
-  <%= external_link_to 'managing products', 'https://spreecommerce.org/docs/user/manage-products' %>
+  <%= external_link_to Spree.t(:learn_more_about_managing_products), 'https://spreecommerce.org/docs/user/manage-products' %>
 </p>

--- a/admin/app/views/spree/admin/profile/edit.html.erb
+++ b/admin/app/views/spree/admin/profile/edit.html.erb
@@ -11,20 +11,20 @@
         </div>
         <div class="card-body">
           <div class="form-group mb-4">
-            <%= f.label :email, class: 'form-label' %>
+            <%= f.label :email, Spree.t(:email), class: 'form-label' %>
             <%= f.email_field :email, class: 'form-control', required: true %>
           </div>
           <div class="form-group mb-4">
-            <%= f.label :first_name, class: 'form-label' %>
+            <%= f.label :first_name, Spree.t(:first_name), class: 'form-label' %>
             <%= f.text_field :first_name, class: 'form-control', required: true %>
           </div>
           <div class="form-group mb-4">
-            <%= f.label :last_name, class: 'form-label' %>
+            <%= f.label :last_name, Spree.t(:last_name), class: 'form-label' %>
             <%= f.text_field :last_name, class: 'form-control', required: true %>
           </div>
           <div class="form-group mb-0">
             <div>
-              <%= f.label :avatar, class: 'form-label' %>
+              <%= f.label :avatar, Spree.t(:avatar), class: 'form-label' %>
             </div>
             <%= render 'active_storage/upload_form', form: f, field_name: :avatar, crop: true %>
           </div>
@@ -41,7 +41,7 @@
           <% if @user.respond_to?(:deliver_invitation_accepted_email) %>
             <div class="custom-control custom-switch mb-3">
               <%= f.check_box :deliver_invitation_accepted_email, class: 'custom-control-input' %>
-              <%= f.label :deliver_invitation_accepted_email, 'Someone accepted your team invitation', class: 'custom-control-label' %>
+              <%= f.label :deliver_invitation_accepted_email, Spree.t(:deliver_invitation_accepted_email), class: 'custom-control-label' %>
             </div>
           <% end %>
 

--- a/admin/app/views/spree/admin/promotion_rules/forms/_item_total.html.erb
+++ b/admin/app/views/spree/admin/promotion_rules/forms/_item_total.html.erb
@@ -20,7 +20,7 @@
     <%= f.number_field :preferred_amount_max, class: 'form-control' %>
 
     <span class="form-text text-muted mt-2">
-      Leave this field blank to not limit the maximum amount.
+      <%= Spree.t('item_total_rule.blank_maximum_amount_help') %>
     </span>
   </div>
 </div>

--- a/admin/app/views/spree/admin/promotions/_form.html.erb
+++ b/admin/app/views/spree/admin/promotions/_form.html.erb
@@ -14,7 +14,7 @@
           <%= f.text_field :name, class: 'form-control', required: true, autofocus: true %>
           <%= f.error_message_on :name %>
           <span class="form-text text-muted mt-2">
-            Customers will see this in their cart and at checkout.
+            <%= Spree.t(:promotion_name_help) %>
           </span>
         </div>
       </div>

--- a/admin/app/views/spree/admin/promotions/edit.html.erb
+++ b/admin/app/views/spree/admin/promotions/edit.html.erb
@@ -15,14 +15,14 @@
           <%= f.text_field :name, class: 'form-control', required: true, autofocus: true %>
           <%= f.error_message_on :name %>
           <span class="form-text text-muted mt-2">
-            Customers will see this in their cart and at checkout.
+            <%= Spree.t(:promotion_name_help) %>
           </span>
         </div>
 
         <% if @promotion.coupon_code? && !@promotion.multi_codes? %>
           <div class="form-group">   
             <%= f.label :code %>
-            <%= f.text_field :code, class: 'form-control text-uppercase', placeholder: 'Your coupon code' %>
+            <%= f.text_field :code, class: 'form-control text-uppercase', placeholder: Spree.t(:your_coupon_code) %>
           </div>
         <% end %>
       </div>

--- a/admin/app/views/spree/admin/promotions/form/_kind.html.erb
+++ b/admin/app/views/spree/admin/promotions/form/_kind.html.erb
@@ -6,9 +6,9 @@
     <div class="d-flex align-items-start custom-control custom-radio">
       <%= f.radio_button :multi_codes, false, data: { toggle: :collapse, target: '#single-code' }, class: 'custom-control-input' %>
       <%= f.label :multi_codes_false, class: 'custom-control-label' do %>
-        One code for all customers
+        <%= Spree.t(:one_code_for_all_customers) %>
         <span class="form-text text-muted font-weight-normal mr-1">
-          You can limit the number of times this code can be used.
+          <%= Spree.t(:one_code_for_all_customers_help) %>
         </span>
       <% end %>
     </div>
@@ -19,25 +19,25 @@
     <div class="mt-2 d-flex align-items-start custom-control custom-radio">
       <%= f.radio_button :multi_codes, true, data: { toggle: :collapse, target: '#multi-codes' }, class: 'custom-control-input' %>
       <%= f.label :multi_codes_true, class: 'custom-control-label' do %>
-        Generate unique codes
+        <%= Spree.t(:generate_unique_codes) %>
         <span class="form-text text-muted font-weight-normal mr-1">
-          These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
+          <%= Spree.t(:generate_unique_codes_help) %>
         </span>
       <% end %>
     </div>
     <div id="multi-codes" class="ml-3 mt-2 row collapse <% if @promotion.multi_codes? %>show<% end %>" data-parent="#coupon-code">
       <div class="col-6">
-        <%= f.text_field :code_prefix, class: 'form-control text-uppercase', placeholder: 'Coupon Prefix (optional)' %>
+        <%= f.text_field :code_prefix, class: 'form-control text-uppercase', placeholder: Spree.t(:code_prefix_placeholder) %>
         <span class="form-text text-muted">
-          eg. <strong>ABC</strong>
+          <%= Spree.t(:code_prefix_help).html_safe %>
         </span>
       </div>
       <div class="col-6">
         <% minimum_number_of_codes = @promotion.persisted? && @promotion.coupon_codes.count.positive? ? @promotion.coupon_codes.count : 1 %>
         <% maximum_number_of_codes = ENV.fetch('PROMOTION_MAX_NUMBER_OF_CODES', 5000) %>
-        <%= f.number_field :number_of_codes, class: 'form-control', placeholder: 'Number of codes', min: minimum_number_of_codes, max: maximum_number_of_codes, step: 1 %>
+        <%= f.number_field :number_of_codes, class: 'form-control', placeholder: Spree.t(:number_of_codes), min: minimum_number_of_codes, max: maximum_number_of_codes, step: 1 %>
         <span class="form-text text-muted">
-          How many codes you want to generate.
+          <%= Spree.t(:number_of_codes_help) %>
           <% if @promotion.persisted? %>
             To add more codes just increase this number
           <% end %>
@@ -52,6 +52,6 @@
   <%= f.label :kind_automatic, Spree.t(:automatic_promotion), class: 'custom-control-label' %>
 
   <p class="form-text text-muted mt-2 mb-0">
-    This promotion will be automatically applied to all eligible orders.
+    <%= Spree.t(:automatic_promotion_help) %>
   </p>
 </div>

--- a/admin/app/views/spree/admin/promotions/form/_settings.html.erb
+++ b/admin/app/views/spree/admin/promotions/form/_settings.html.erb
@@ -3,7 +3,7 @@
     <%= f.label :usage_limit, Spree.t('limit_usage_to') %>
     <%= f.number_field :usage_limit, min: 0, step: 1, class: 'form-control' %>
     <span class="form-text text-muted mt-2">
-      Leave this field blank for unlimited usage.
+      <%= Spree.t(:limit_usage_to_help) %>
     </span>
   </div>
 <% end %>
@@ -19,6 +19,6 @@
   <%= f.datetime_field :expires_at, class: 'form-control' %>
   <%= f.error_message_on :expires_at %>
   <span class="form-text text-muted mt-2">
-    Leave this field blank for no expiration.
+    <%= Spree.t(:expires_at_help) %>
   </span>
 </div>

--- a/admin/app/views/spree/admin/promotions/new.html.erb
+++ b/admin/app/views/spree/admin/promotions/new.html.erb
@@ -5,7 +5,7 @@
 <%= form_for :promotion, url: collection_url do |f| %>
   <%= render 'form', f: f %>
   <p class="alert alert-info text-center mt-3">
-    In the next step you will be able to add actions and rules to your promotion
+    <%= Spree.t(:new_promotion_info) %>
   </p>
   <%= render 'spree/admin/shared/new_resource_links' %>
 <% end %>

--- a/admin/app/views/spree/admin/properties/index.html.erb
+++ b/admin/app/views/spree/admin/properties/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for(:page_alerts) do %>
   <div class="alert alert-info">
-    Properties allow you to enrich your Product information.
+    <%= Spree.t(:properties_info) %>
   </div>
 <% end %>
 
@@ -50,5 +50,5 @@
 </div>
 
 <p class="documentation-link-container">
-  <%= external_link_to "Learn more about properties", "https://spreecommerce.org/docs/user/manage-products/product-properties" %>
+  <%= external_link_to Spree.t(:learn_more_about_properties), "https://spreecommerce.org/docs/user/manage-products/product-properties" %>
 </p>

--- a/admin/app/views/spree/admin/shared/_content_header.html.erb
+++ b/admin/app/views/spree/admin/shared/_content_header.html.erb
@@ -14,7 +14,7 @@
     <div id="page_actions" class="ml-auto page-actions d-flex align-items-center gap-2">
       <% if action_name == 'index' && defined?(model_class) && model_class && Spree::Export.available_models.include?(model_class) && can?(:create, Spree::Export) %>
         <span data-toggle="modal" data-target="#modal">
-          <%= link_to spree.new_admin_export_path(export: { search_params: params[:q]&.to_json, type: Spree::Export.type_for_model(model_class) }), class: 'btn btn-light bg-transparent with-tip', title: 'Download records as CSV file', data: { turbo_frame: :dialog_modal } do %>
+          <%= link_to spree.new_admin_export_path(export: { search_params: params[:q]&.to_json, type: Spree::Export.type_for_model(model_class) }), class: 'btn btn-light bg-transparent with-tip', title: Spree.t(:download_records_as_csv_file), data: { turbo_frame: :dialog_modal } do %>
             <%= icon 'table-export', class: 'mr-0 mr-lg-2' %>
             <span class="d-none d-lg-inline"><%= Spree.t(:export) %></span>
           <% end %>
@@ -46,7 +46,7 @@
                   <%= hidden_field_tag :record_number, record.number, data: { clipboard_target: 'source' } %>
                   <button data-action="clipboard#copy" class="text-left dropdown-item">
                     <%= icon 'copy' %>
-                    <%= 'Copy number' %>
+                    <%= Spree.t(:copy_number) %>
                   </button>
                 </div>
               <% end %>

--- a/admin/app/views/spree/admin/shared/_seo.html.erb
+++ b/admin/app/views/spree/admin/shared/_seo.html.erb
@@ -1,7 +1,7 @@
 <div class="card mb-4 seo-form">
   <div class="card-header d-flex justify-content-between">
     <h5 class="card-title"><%= Spree.t(:search_engine_listing) %></h5>
-    <button class="btn btn-light btn-sm ml-auto" data-action="click->seo-form#toggleInputs" type="button">Edit</button>
+    <button class="btn btn-light btn-sm ml-auto" data-action="click->seo-form#toggleInputs" type="button"><%= Spree.t(:edit) %></button>
   </div>
   <div class="card-body d-flex flex-column">
     <div class="seo__preview <% if title.blank? && description.blank? %>d-none<% else %>d-flex flex-column<% end %>" data-seo-form-target="preview">

--- a/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
@@ -9,14 +9,14 @@
         </div>
 
         <p class="form-text text-muted small mt-2">
-          This will be displayed to customers.
+          <%= Spree.t(:shipping_method_name_help) %>
         </p>
       </div>
 
       <div class="col-lg-6">
         <div class="form-group">
           <%= f.label :display_on %>
-          <%= f.select :display_on, display_on_options, {}, { class: 'custom-select custom-select' } %>
+          <%= f.select :display_on, display_on_options, {}, { class: 'custom-select' } %>
           <%= f.error_message_on :display_on %>
         </div>
       </div>
@@ -31,7 +31,7 @@
         </div>
 
         <p class="form-text text-muted small mt-2">
-          This will be displayed to admins.
+          <%= Spree.t(:shipping_method_internal_name_help) %>
         </p>
       </div>
 

--- a/admin/app/views/spree/admin/shipping_methods/form/_estimated_transit_business_days.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_estimated_transit_business_days.html.erb
@@ -6,8 +6,7 @@
   </div>
   <div class="card-body">
     <div class="alert alert-info">
-      This is the estimated number of business days it will take for the package to arrive at the customer's address.
-      It will be displayed on the checkout page.
+      <%= Spree.t(:estimated_transit_business_days_help) %>
     </div>
     <div class="row">
       <div class="col">

--- a/admin/app/views/spree/admin/shipping_methods/form/_tracking_url.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_tracking_url.html.erb
@@ -12,7 +12,7 @@
 
     <p class="form-text text-muted small mt-2">
       <code>:tracking</code>
-      <span>will be replaced with the tracking number.</span>
+      <span><%= Spree.t(:tracking_url_help) %></span>
     </p>
   </div>
 </div>

--- a/admin/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/index.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Shipping methods are options that the customer sees when they reach the checkout, they are the carriers and services used to send your products.
+    <%= Spree.t(:shipping_methods_info) %>
   </div>
 <% end %>
 

--- a/admin/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/admin/app/views/spree/admin/stock_transfers/new.html.erb
@@ -18,7 +18,7 @@
       <div class="card-body" >
         <div class="row">
           <div class="form-group col-12 col-lg-6">
-            <%= f.label :source_location_id, Spree.t(:origin), class: 'form-label' %>
+            <%= f.label :source_location_id, Spree.t(:source), class: 'form-label' %>
             <%= tom_select_tag "stock_transfer[source_location_id]",
               empty_option: Spree.t(:none),
               options: stock_locations,
@@ -41,7 +41,7 @@
           </div>
         </div>
         <div class="form-group">
-          <%= f.label :reference, class: 'form-label' %>
+          <%= f.label :reference, Spree.t(:reference), class: 'form-label' %>
           <%= f.text_field :reference, class: 'form-control' %>
         </div>
       </div>

--- a/admin/app/views/spree/admin/storefront/edit.html.erb
+++ b/admin/app/views/spree/admin/storefront/edit.html.erb
@@ -27,7 +27,7 @@
             <%= f.text_field :name, class: 'form-control' %>
           </div>
           <div class="form-group">
-            <%= f.label :meta_description, 'Search description' %>
+            <%= f.label :meta_description, Spree.t(:search_description) %>
             <%= f.text_area :meta_description, class: 'form-control', style: 'min-height: 5em', data: { controller: 'textarea-autogrow'} %>
           </div>
           <div class="custom-control custom-checkbox mb-2">
@@ -35,7 +35,7 @@
             <%= f.label :preferred_index_in_search_engines, Spree.t(:index_in_search_engines), class: 'custom-control-label' %>
           </div>
           <p class="text-muted small pl-4 mb-0">
-            Checking this box will allow your site to appear in search engines.
+            <%= Spree.t(:index_in_search_engines_help) %>
           </p>
         </div>
       </div>
@@ -52,7 +52,7 @@
             <%= f.label :preferred_password_protected, Spree.t(:password_protected), class: 'custom-control-label' %>
           </div>
           <p class="text-muted small pl-4">
-            Checking this box will put your storefront behind a password.
+            <%= Spree.t(:password_protected_help) %>
           </p>
           
           <div class="form-group <%= @store.prefers_password_protected? ? '' : 'd-none' %>" data-reveal-target="item">
@@ -97,16 +97,16 @@
         <div class="card-body">
           <div class="form-group">
             <%= f.label :favicon_image do %>
-              Favicon image
-              <%= help_bubble("A favicon is a small image that appears in the tab of your web browser when you visit a website. It is usually a tiny square or rectangle with a unique design or logo that represents the website") %>
+              <%= Spree.t(:favicon_image) %>
+              <%= help_bubble(Spree.t(:favicon_image_info)) %>
             <% end %>
             <%= render 'active_storage/upload_form', form: f, field_name: :favicon_image, width: 120, height: 120, crop: true %>
           </div>
 
           <div class="form-group mb-0">
             <%= f.label :social_image do %>
-              Preview image
-              <%= help_bubble("This image will be used when your store is shared on social media or in search engines.") %>
+              <%= Spree.t(:preview_image) %>
+              <%= help_bubble(Spree.t(:preview_image_info)) %>
             <% end %>
             <%= render 'active_storage/upload_form', form: f, field_name: :social_image, width: 1200, height: 630, crop: true %>
           </div>
@@ -121,7 +121,7 @@
         </div>
         <div class="card-body">
           <div class="alert alert-info">
-            Social links will be displayed in the footer of your store
+            <%= Spree.t(:social_media_info) %>
           </div>
           <% Spree::Store::SUPPORTED_SOCIAL_NETWORKS.each do |social| %>
             <div class="form-group">

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -24,7 +24,7 @@
         <div class="form-group mb-0">
           <%= f.label :logo do %>
             <%= Spree.t(:logo) %>
-            <%= help_bubble("Used in the admin dashboard") %>
+            <%= help_bubble(Spree.t(:logo_help)) %>
           <% end %>
           <%= render 'active_storage/upload_form', form: f, field_name: :logo, width: 240, height: 240, crop: true %>
         </div>

--- a/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -6,15 +6,13 @@
   <div class="col-lg-6">
     <div class="card mb-4">
       <div class="card-header">
-        <h5 class="card-title">Logo for emails</h5>
+        <h5 class="card-title"><%= Spree.t('admin.logo_for_emails') %></h5>
       </div>
       <div class="card-body">
-        <p class="text-muted">This logo is included in all email notifications such as order confirmation</p>
+        <p class="text-muted"><%= Spree.t('admin.logo_for_emails_help') %></p>
         <%= render 'active_storage/upload_form', form: f, field_name: :mailer_logo, width: 204, height: 104 %>
         <p class="form-text text-muted mb-0 mt-2">
-          We recommend images with a transparent background.
-          <br />
-          Only JPEG and PNG formats are supported.
+          <%= Spree.t('admin.logo_for_emails_recommend').html_safe %>
         </p>
       </div>
     </div>
@@ -23,11 +21,11 @@
   <div class="col-lg-6">
     <div class="card mb-4">
       <div class="card-header">
-        <h5 class="card-title">Email addresses</h5>
+        <h5 class="card-title"><%= Spree.t('admin.store_form.email_addresses') %></h5>
       </div>
       <div class="card-body">
         <p class="text-muted">
-          Please provide the email address that will be used as the sender of all emails sent from your store.
+          <%= Spree.t('admin.store_form.email_addresses_help') %>
         </p>
 
         <div class="form-group">

--- a/admin/app/views/spree/admin/stores/form/_policies.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_policies.html.erb
@@ -4,7 +4,7 @@
 
 <%= content_for :page_alerts do %>
   <div class="alert alert-info mb-3">
-    Policies will be automatically added to footer of your store and will be available to customers during checkout.
+    <%= Spree.t(:policies_info) %>
   </div>
 <% end %>
 
@@ -13,7 +13,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Customers will need to accept these terms of service during signup.
+        <%= Spree.t(:terms_of_service_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -27,7 +27,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Customers will need to accept these privacy policy during signup.
+        <%= Spree.t(:privacy_policy_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -42,7 +42,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Please provide your customers with a clear and transparent returns policy.
+        <%= Spree.t(:returns_policy_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -56,7 +56,7 @@
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Please provide your customers with a clear and transparent shipping policy.
+        <%= Spree.t(:shipping_policy_help) %>
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
@@ -68,11 +68,11 @@
 
   <% if current_store.respond_to?(:partners_terms_of_service) %>
     <hr class="my-5">
-    <h5 class="mb-3">Vendors <%= Spree.t(:terms_of_service) %></h5>
+    <h5 class="mb-3"><%= Spree.t(:vendors_terms_of_service) %></h5>
     <div class="row" id="partners-terms">
       <div class="col-lg-4">
         <p class="text-muted">
-          Vendors you invite will need to accept these terms of service during their onboarding process.
+          <%= Spree.t(:vendors_terms_of_service_help) %>
         </p>
       </div>
       <div class="col-lg-7 offset-lg-1">

--- a/admin/app/views/spree/admin/taxons/_form.html.erb
+++ b/admin/app/views/spree/admin/taxons/_form.html.erb
@@ -108,7 +108,7 @@
       <div class="card-body">
         <%= f.label :square_image, Spree.t(:square_image) %>
         <p class="text-muted form-text">
-          Used for the featured image on the homepage.
+          <%= Spree.t(:square_image_help) %>
         </p>
         <%= render 'active_storage/upload_form', form: f, field_name: :square_image, width: 400, height: 400, crop: true %>
         <%= f.error_message_on :square_image %>
@@ -143,6 +143,6 @@
           slug_attribute_name: :permalink_part,
           slug: @permalink_part,
           slug_path: ['t', @parent_permalink.presence].compact.join('/'),
-          placeholder: 'Add a title and description to see how this taxon might appear in a search engine listing' %>
+          placeholder: Spree.t('admin.taxons.seo_placeholder') %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/taxons/_rule_form.html.erb
+++ b/admin/app/views/spree/admin/taxons/_rule_form.html.erb
@@ -15,7 +15,7 @@
     <%= render "spree/admin/taxons/rule_forms/#{rf.object.type.demodulize.underscore}", rule_form: rf %>
   </div>
   <div class="col-lg-1 mb-3 d-flex align-items-center justify-content-center">
-    <button type="button" data-action="nested-form#remove" class="btn btn-sm btn-danger px-2 with-tip" title="Remove condition">
+    <button type="button" data-action="nested-form#remove" class="btn btn-sm btn-danger px-2 with-tip" title=<%= Spree.t(:remove_condition) %>>
       <%= icon('x', class: 'mr-0') %>
       <span class="d-lg-none"><%= Spree.t(:remove_condition) %></span>
     </button>

--- a/admin/app/views/spree/admin/themes/index.html.erb
+++ b/admin/app/views/spree/admin/themes/index.html.erb
@@ -8,9 +8,7 @@
 
 <%= content_for :page_alerts do %>
   <div class="alert alert-info">
-    If you wan't to make changes to theme but don't want to go live with them,
-    you can make a copy of the theme and make changes to the copy. And later promote that copy
-    to the live theme.
+    <%= Spree.t(:themes_info) %>
   </div>
   <br />
 
@@ -18,9 +16,9 @@
     <div class="alert alert-info d-inline-flex align-items-center py-2 pr-2">
       <div class="d-flex align-items-center">
         <span>
-          You don't have domain connected to your store
+          <%= Spree.t(:no_domain_connected) %>
         </span>
-        <%= link_to 'Connect your own domain', spree.admin_custom_domains_path, class: 'btn btn-link ml-3' %>
+        <%= link_to Spree.t(:connect_your_own_domain), spree.admin_custom_domains_path, class: 'btn btn-link ml-3' %>
       </div>
     </div>
   <% end %>

--- a/admin/app/views/spree/admin/users/_filters.html.erb
+++ b/admin/app/views/spree/admin/users/_filters.html.erb
@@ -49,9 +49,9 @@
     <div class="row">
       <div class="col-lg-3">
         <div class="form-group">
-          <%= f.label :accepts_email_marketing_eq, "Accepts email marketing" %>
+          <%= f.label :accepts_email_marketing_eq, Spree.t(:accepts_email_marketing) %>
           <%= f.select :accepts_email_marketing_eq,
-                   options_for_select([["Yes", true], ["No", false]], params[:q][:accepts_email_marketing_eq]),
+                   options_for_select([[Spree.t(:say_yes), true], [Spree.t(:say_no), false]], params[:q][:accepts_email_marketing_eq]),
                    { include_blank: true },
                    { class: "custom-select", data: { filters_target: :input } } %>
         </div>

--- a/admin/app/views/spree/admin/users/_lifetime_stats.html.erb
+++ b/admin/app/views/spree/admin/users/_lifetime_stats.html.erb
@@ -21,7 +21,7 @@
 
       <div class="col-lg-4">
         <div class="d-flex justify-content-center flex-column mb-3 mb-lg-0">
-          <span class="text-muted"><%= Spree.t('admin.avg_order_value') %></span>
+          <span class="text-muted"><%= Spree.t(:avg_order_value) %></span>
           <span class="font-size-lg text-dark font-weight-bold mt-1 me-3">
             <%= @user.display_average_order_value %>
           </span>

--- a/admin/app/views/spree/admin/variants/form/_dimensions.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_dimensions.html.erb
@@ -1,19 +1,19 @@
 <div class="row">
   <div class="col-lg-6">
     <div class="form-group mb-3">
-      <%= f.label :width %>
+      <%= f.label :width, Spree.t(:width) %>
       <%= f.text_field :width, value: number_with_precision(f.object.width, precision: 2), class: 'form-control' %>
     </div>
 
     <div class="form-group mb-3">
-      <%= f.label :height %>
+      <%= f.label :height, Spree.t(:height) %>
       <%= f.text_field :height, value: number_with_precision(f.object.height, precision: 2), class: 'form-control' %>
     </div>
   </div>
 
   <div class="col-lg-6">
     <div class="form-group mb-3">
-      <%= f.label :depth %>
+      <%= f.label :depth, Spree.t(:depth) %>
       <%= f.text_field :depth, value: number_with_precision(f.object.depth, precision: 2), class: 'form-control' %>
     </div>
 
@@ -25,7 +25,7 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :weight %>
+  <%= f.label :weight, Spree.t(:weight) %>
   <div class="form-control d-flex align-items-center py-0 focus-border focus-shadow">
     <%= f.text_field :weight, value: number_with_precision(f.object.weight, precision: 2), class: 'form-control-plaintext pl-0' %>
     <%= f.select :weight_unit, options_for_select(weight_units(current_store), f.object.weight_unit), { include_blank: false }, { class: 'form-control-plaintext w-auto border-left' } %>

--- a/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
@@ -16,7 +16,7 @@
           <div class="form-group col-3">
             <div class="custom-control custom-switch">
               <%= f.check_box :active, class: 'custom-control-input' %>
-              <%= f.label :active, class: 'custom-control-label' %>
+              <%= f.label :active, Spree.t(:active), class: 'custom-control-label' %>
             </div>
           </div>
         </div>

--- a/admin/app/views/spree/admin/zones/index.html.erb
+++ b/admin/app/views/spree/admin/zones/index.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Zones are geographical groupings, they represent collections of either states or countries.
+    <%= Spree.t(:zones_info) %>
   </div>
 <% end %>
 

--- a/admin/app/views/spree/admin/zones/new.html.erb
+++ b/admin/app/views/spree/admin/zones/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %>
   <%= page_header_back_button spree.admin_zones_url %>
-  <%= Spree.t(:new_market) %>
+  <%= Spree.t(:new_zone) %>
 <% end %>
 
 <%= form_for [:admin, @zone], data: {controller: 'auto-submit'} do |zone_form| %>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -91,6 +91,9 @@ en:
       integrations:
         invalid_integration_type: This integration is not allowed
         page_subtitle: Connect your store to third-party services to enhance customer experience.
+      logo_for_emails: Logo for emails
+      logo_for_emails_help: This logo is included in all email notifications such as order confirmation.
+      logo_for_emails_recommend: We recommend images with a transparent background.<br>Only JPEG and PNG formats are supported.
       manage_currencies: Manage Currencies
       manage_properties: Manage Properties
       manage_stock_locations: Manage Stock Locations
@@ -103,6 +106,8 @@ en:
       notifications: Notifications
       num_orders: No. of Orders
       oauth_applications:
+        client_id: Client ID
+        info: Here you can manage API keys to access the <a href='https://spreecommerce.org/docs/api-reference/platform/authentication' target='_blank' class='alert-link'>Platform API</a>. For headless storefronts you don't need an API key, please use the <a href='https://spreecommerce.org/docs/api-reference/storefront/authentication' target='_blank' class='alert-link'>Storefront API</a>.
         last_used: Last used
         list: API keys
         never: Never
@@ -110,6 +115,7 @@ en:
         read_and_write: Read & Write
         read_only: Read Only
         scopes: Scopes
+        warning: This is your application's secret token, copy it now and keep it safe. It won't be shown again.
       order:
         events:
           approve: Approve
@@ -165,6 +171,8 @@ en:
         vertical_alignment: Vertical alignment
         youtube_video_url: Youtube video URL
       personal_details: Personal Details
+      posts:
+        seo_placeholder: Add a title and content to see how this post might appear in a search engine listing
       products:
         active: Active
         all_statuses: All statuses
@@ -211,16 +219,25 @@ en:
           description: It shows the company field on the address form in the My Account section and on the checkout address step.
           label: Display the company address field
         customer_support_email_help: This email is visible to your Store visitors in the Footer section
+        email_addresses: Email addresses
+        email_addresses_help: Please provide the email address that will be used as the sender of all emails sent from your store.
         new_order_notifications_email_help: If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to
       store_setup_tasks:
         add_billing_address: Add billing address
         add_products: Add products
+        customer_support_email:
+          info: We need your customer support email to display on your storefront.<br>This email will work as a contact point for your customers to reach out to you for any queries or support.
+          done: Your customer support email is <strong>%{email}</strong>.
         payment_methods:
           copy: In order to collect payments, please setup at least one online payment provider.
           done: You're all set! You can always manage your Payment Methods on <a href="%{link}" data-turbo-frame="_top">this</a> page.
           setup: Setup Payment Methods
           title: Please setup Payment Methods for your store
+        products:
+          copy:  <p>Add products to your store, either your own or invite 3rd party vendors to sell together.</p><p>You can also import products in bulk from a CSV or Excel file.</p>
+          done: <p>Good job, you've added products to your store!</p><p>Remember you can always add more!</p>
         set_customer_support_email: Set customer support email
+        setup_payment_method: Setup payment method
         setup_taxes_collection: Setup taxes collection
         taxes:
           copy: In order to collect taxes, please setup your tax rates.
@@ -240,6 +257,7 @@ en:
           is_not_equal_to: is not equal to
         on_sale: On sale
         products_must_match: 'Products must match:'
+        sale: On Sale
         tag: Product tag
       taxon_type: Taxon type
       taxon_types:
@@ -247,6 +265,8 @@ en:
         automatic_info: Automatically add products to this taxon if they match the rules you set.
         manual: Manual
         manual_info: Curate products manually. You can add or remove them in bulk.
+      taxons:
+        seo_placeholder: Add a title and description to see how this taxon might appear in a search engine listing
       upload_new_asset: Upload new asset
       user:
         last_order_placed: Last order placed

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -122,6 +122,8 @@ en:
         event_name: Event Name
         expires_at: Expires At
         generate_code: Generate coupon code
+        match_policy_all: Match policy all
+        match_policy_any: Match policy any
         name: Name
         path: Path
         promotion_category: Promotion Category
@@ -141,6 +143,8 @@ en:
         name: Name
       spree/shipment:
         number: Number
+      spree/shipping_method:
+        display_on: Display On
       spree/state:
         abbr: Abbreviation
         name: Name
@@ -152,6 +156,8 @@ en:
         type: Type
         updated: Updated
         user: User
+      spree/stock_location:
+        active: Active
       spree/store:
         address: Address
         contact_phone: Contact Phone
@@ -172,6 +178,7 @@ en:
         name: Name
       spree/tax_category:
         description: Description
+        is_default: Is default
         name: Name
       spree/tax_rate:
         amount: Rate
@@ -181,6 +188,7 @@ en:
         name: Name
         permalink: Permalink
         position: Position
+        sort_order: Sort order
       spree/taxonomy:
         name: Name
       spree/user:
@@ -340,6 +348,9 @@ en:
       spree/credit_card:
         one: Credit Card
         other: Credit Cards
+      spree/custom_domain:
+        one: Custom domain
+        other: Custom domains
       spree/customer_return:
         one: Customer Return
         other: Customer Returns
@@ -385,6 +396,12 @@ en:
       spree/payment_method:
         one: Payment Method
         other: Payment Methods
+      spree/post:
+        one:  Post
+        other: Posts
+      spree/post_category:
+        one:  Post Category
+        other: Post Categories
       spree/price:
         one: Price
         other: Prices
@@ -672,6 +689,8 @@ en:
     alt_text: Alternative Text
     alternative_phone: Alternative Phone
     amount: Amount
+    amount_min: Amount Min
+    amount_max: Amount Max
     analytics: Analytics
     and: and
     api_keys: API keys
@@ -683,25 +702,34 @@ en:
     approver: Approver
     are_you_sure: Are you sure?
     are_you_sure_delete: Are you sure you want to delete this record?
+    assets: Assets
+    assistant: Assistant
+    assistant_info: This is a repeat customer that has spent a total of <strong>%{total}</strong> across <strong>%{count} orders</strong>, averaging <strong>%{average}</strong> per order.
     associated_adjustment_closed: The associated adjustment is closed, and will not be recalculated. Do you want to open it?
     at_symbol: "@"
     attachments: Attachments
     audit_log: Audit Log
+    audit_log_help: Audit log is part of the Spree Enterprise offering.
     author: Author
     authorization_failure: Authorization Failure
     authorized: Authorized
     auto_capture: Auto Capture
     automatic_promotion: Automatic
+    automatic_promotion_help: This promotion will be automatically applied to all eligible orders.
     automatic_taxon_names:
       new_arrivals: New arrivals
       on_sale: On sale
     availability: availability
     available: Available
     available_on: Available On
+    available_payment_methods: Available Payment Methods
+    avatar: Avatar
     average_order_value: Average Order Value
+    avg_order_value: Avg. Order Value
     avs_response: AVS Response
     back: Back
     back_end: Backend
+    back_to_list: Back To List
     back_to_payment: Back To Payment
     back_to_resource_list: Back To %{resource} List
     back_to_rma_reason_list: Back To RMA Reason List
@@ -775,6 +803,9 @@ en:
     categories: Categories
     categorization: Categorization
     category: Category
+    category_lvl0: Category Lvl0
+    category_lvl1: Category Lvl1
+    category_lvl2: Category Lvl2
     change: Change
     change_password: Change password
     changes_published: Changes published!
@@ -799,6 +830,8 @@ en:
     close_all_adjustments: Close All Adjustments
     close_sidebar: Close sidebar
     code: Code
+    code_prefix_help: eg. <strong>ABC</strong>
+    code_prefix_placeholder: Coupon Prefix (optional)
     colors: Colors
     company: Company
     compare_at_amount: Compare at amount
@@ -809,6 +842,7 @@ en:
     confirm: Confirm
     confirm_delete: Confirm Deletion
     confirm_password: Password Confirmation
+    connect_your_own_domain: Connect your own domain
     contact: Contact
     contact_information: Contact information
     contact_phone: Contact phone
@@ -823,6 +857,7 @@ en:
     copy: Copy
     copy_id: Copy ID
     copy_link: Copy link
+    copy_number: Copy number
     cost_currency: Cost Currency
     cost_price: Cost Price
     could_not_create_customer_return: Could not create customer return
@@ -831,6 +866,7 @@ en:
     countries: Countries
     country: Country
     country_based: Country Based
+    country_iso: Country ISO
     country_name: Name
     country_names:
       CA: Canada
@@ -875,6 +911,8 @@ en:
     current: Current
     current_password: Current password
     custom_code: Custom code
+    custom_domains: Custom domains
+    custom_domains_help: Connect your domain or subdomain to your store.
     custom_font_code: Custom font code
     customer: Customer
     customer_details: Customer Details
@@ -899,6 +937,7 @@ en:
     default_country: Default Country
     default_country_cannot_be_deleted: Default country cannot be deleted
     default_currency: Default currency
+    default_custom_domains_help: We will use this domain in emails to customers.
     default_locale: Default locale
     default_post_categories:
       articles: Articles
@@ -916,6 +955,7 @@ en:
     delete_from_taxon: Delete From Taxon
     delete_selected: Delete selected
     deleted: Deleted
+    deliver_invitation_accepted_email: Someone accepted your team invitation
     delivery: Delivery
     delivery_address: Delivery Address
     delivery_information: Delivery Information
@@ -932,6 +972,8 @@ en:
     digital_assets: Digital assets
     digital_assets_help: Digital assets are files that can be downloaded by customers after purchase.
     digital_link_unauthorized: You are not authorized to access this asset
+    digital_links: Digital Links
+    digitals: Digitals
     dimension_units:
       centimeter: Centimeter (cm)
       foot: Foot (ft)
@@ -955,6 +997,7 @@ en:
     done: Done
     dont_have_account: No account?
     download: Download
+    download_records_as_csv_file: Download records as CSV file
     draft: Draft
     draft_mode: Draft Mode
     draft_orders: Draft Orders
@@ -1014,6 +1057,7 @@ en:
       other: "%{count} errors prohibited this record from being saved"
     estimated_delivery_time: Estimated delivery time
     estimated_transit_business_days: Estimated transit business days
+    estimated_transit_business_days_help: This is the estimated number of business days it will take for the package to arrive at the customer's address. It will be displayed on the checkout page.
     event: Event
     events:
       spree:
@@ -1031,6 +1075,7 @@ en:
     exceptions:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
     excerpt: Excerpt
+    excerpt_help: Add a summary of the post
     exchange_for: Exchange for
     excl: excl.
     existing_address: Existing address
@@ -1040,6 +1085,7 @@ en:
     expiration_date: Expiration Date
     expired: Expired
     expires_at: Expires at
+    expires_at_help: Leave this field blank for no expiration.
     explore_taxon: Explore taxon
     export: Export
     export_mailer:
@@ -1053,6 +1099,8 @@ en:
     facebook: Facebook
     failed_payment_attempts: Failed Payment Attempts
     favicon: Favicon
+    favicon_image: Favicon image
+    favicon_image_info: A favicon is a small image that appears in the tab of your web browser when you visit a website. It is usually a tiny square or rectangle with a unique design or logo that represents the website
     favicon_upload_info: 'File format: PNG or ICO. File resolution: up to 256x256. File size: up to 1MB'
     featured_image: Featured image
     featured_taxon: Featured taxon
@@ -1062,6 +1110,7 @@ en:
     filter: Filter
     filter_results: Filter Results
     filterable: Filterable
+    filterable_help: Whether this option can be used in product filters
     filtered_records: Filtered records
     finalize: Finalize
     finalized: Finalized
@@ -1093,6 +1142,8 @@ en:
     general_information: General information
     general_settings: General Settings
     generate_code: Generate coupon code
+    generate_unique_codes: Generate unique codes
+    generate_unique_codes_help: These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
     get_back_to_the: Get back to the
     gift_card: Gift Card
     gift_card_applied: The Gift Card was successfully applied to your order!
@@ -1148,6 +1199,7 @@ en:
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
     incomplete: Incomplete
     index_in_search_engines: Index in search engines
+    index_in_search_engines_help: Checking this box will allow your site to appear in search engines.
     info_number_of_skus_not_shown:
       one: and one other
       other: and %{count} others
@@ -1161,6 +1213,9 @@ en:
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
+    internal_name_help: This is used internally to identify the option type. <strong>It must be unique.</strong>
+    internal_url: Internal URL
+    internal_url_help: This is your internal URL.
     internationalization: Internationalization
     invalid_credit_card: Invalid credit card.
     invalid_exchange_variant: Invalid exchange variant.
@@ -1184,6 +1239,7 @@ en:
         subject: Invitation to join %{resource_name}
       thanks: Thank you,
     invitation_resent: Invitation resent!
+    inventory_units: Inventory Units
     invitations: Invitations
     invited_by: Invited by
     is_not_available_to_shipment_address: is not available to shipment address
@@ -1200,6 +1256,7 @@ en:
         gte: greater than or equal to
         lt: less than
         lte: less than or equal to
+      blank_maximum_amount_help: Leave this field blank to not limit the maximum amount.
     items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
     items_in_rmas: Items in Return Authorizations
     items_reimbursed: Items reimbursed
@@ -1211,8 +1268,12 @@ en:
     last_name_begins_with: Last Name Begins With
     lastname: Last Name
     learn_more: Learn More
+    learn_more_about_managing_products: Learn more about managing products
+    learn_more_about_options: Learn more about options
+    learn_more_about_properties: Learn more about properties
     lifetime_stats: Lifetime Stats
     limit_usage_to: Limit usage to
+    limit_usage_to_help: Leave this field blank for unlimited usage.
     line_item: Line Item
     line_item_adjustments: Line item adjustments
     line_items: Line items
@@ -1234,6 +1295,7 @@ en:
     login_failed: Login authentication failed.
     login_name: Login
     logo: Logo
+    logo_help: Used in the admin dashboard
     logout: Logout
     logs: Logs
     look_for_similar_items: Look for similar items
@@ -1252,6 +1314,7 @@ en:
     match_choices:
       all: All
       none: None
+    match_policy: Match Policy
     max: Max
     max_items: Max Items
     media: Media
@@ -1312,6 +1375,7 @@ en:
     new_product: New Product
     new_promotion: New Promotion
     new_promotion_category: New Promotion Category
+    new_promotion_info: In the next step you will be able to add actions and rules to your promotion
     new_property: New Property
     new_prototype: New Prototype
     new_refund: New Refund
@@ -1347,6 +1411,8 @@ en:
     no_billing_address_available: No billing address available
     no_cc_type: N/A
     no_country: No country set
+    no_custom_domains: You don't have any custom domains set yet.
+    no_domain_connected: You don't have domain connected to your store
     no_email_provided: No email provided
     no_limits_zone: No Limits
     no_payment_found: No payment found
@@ -1389,17 +1455,24 @@ en:
     notify_me_when_available: Notify me when available
     num_orders: "# Orders"
     number: Number
+    number_of_codes: Number of Codes
+    number_of_codes_help: How many codes you want to generate.
+    one_code_for_all_customers: One code for all customers
+    one_code_for_all_customers_help: You can limit the number of times this code can be used.
     ok: OK
     on_hand: On Hand
     only_active_products_can_be_added_to_cart: Draft and archived products cannot be added to cart, please mark the product as active before.
     only_left: Only %{count} left
     open: Open
     open_all_adjustments: Open All Adjustments
+    operator_min: Operator Min
+    operator_max: Operator Max
     option_name: Option name
     option_type: Option Type
     option_type_filterable_info: When an option type is set to Filterable, your storefront visitors are presented with the option to filter a taxon of products based on the option type. A typical example of this would be to filter clothing by size and color.<br><br><b>Please Note:</b> Filters will only be visible in the storefront taxons that contain products with this option type set.
     option_type_placeholder: Choose an option type
     option_types: Option Types
+    option_types_info: Options are used to group certain attributes. For example, you can create an option named "shirt size" and then create an option value named "small" and "medium" for this option.
     option_value: Option Value
     option_values: Option Values
     optional: Optional
@@ -1413,6 +1486,7 @@ en:
     order_already_completed: Order already completed
     order_already_updated: The order has already been updated.
     order_approved: Order approved
+    order_by_guest_customer: This order was placed by a guest customer
     order_canceled: Order canceled
     order_details: Order Details
     order_email_resent: Order Email Resent
@@ -1536,16 +1610,19 @@ en:
       truncate: "&hellip;"
     password: Password
     password_protected: Password protected
+    password_protected_help: Checking this box will put your storefront behind a password.
     paste: Paste
     path: Path
     pay: Pay
     payment: Payment
     payment_amount: Payment amount
     payment_attempts: failed attempts
+    payment_capture_events: Payment Capture Events
     payment_could_not_be_created: Payment could not be created.
     payment_identifier: Payment Identifier
     payment_information: Payment Information
     payment_method: Payment Method
+    payment_method_name_help: This name will be used to identify the payment method on the storefront
     payment_method_not_supported: That payment method is unsupported. Please choose another one.
     payment_methods: Payment Methods
     payment_processing_failed: Payment could not be processed, please check the details you entered
@@ -1585,6 +1662,7 @@ en:
     please_define_payment_methods: Please define some payment methods first.
     please_enter_reasonable_quantity: Please enter a reasonable quantity.
     policies: Policies
+    policies_info: Policies will be automatically added to footer of your store and will be available to customers during checkout.
     populate_get_error: Something went wrong. Please try adding the item again.
     post_categories: Post categories
     posts: Posts
@@ -1594,7 +1672,10 @@ en:
     pre_tax_total: Pre-Tax Total
     preferred_reimbursement_type: Preferred Reimbursement Type
     presentation: Presentation
+    presentation_help: How this option is presented to customers
     preview: Preview
+    preview_image: Preview Image
+    preview_image_info: This image will be used when your store is shared on social media or in search engines.
     preview_product: Preview Product
     preview_taxon: Preview Taxon
     previous: Previous
@@ -1605,6 +1686,7 @@ en:
     prices: Prices
     pricing: Pricing
     privacy_policy: Privacy Policy
+    privacy_policy_help: Customers will need to accept these privacy policy during signup.
     process: Process
     processing: Processing
     product: Product
@@ -1635,6 +1717,7 @@ en:
       price_high_to_low: Price (high-low)
       price_low_to_high: Price (low-high)
       relevance: Relevance
+    promo_total: Promo Total
     promotion: Promotion
     promotion_action: Promotion Action
     promotion_action_types:
@@ -1659,6 +1742,7 @@ en:
         all: Match all of these rules
         any: Match any of these rules
     promotion_label: Promotion (%{name})
+    promotion_name_help: Customers will see this in their cart and at checkout.
     promotion_not_cloned: 'Promotion has not been cloned. Reason: %{error}'
     promotion_rule: Promotion Rule
     promotion_rule_types:
@@ -1697,6 +1781,7 @@ en:
     promotions: Promotions
     propagate_all_variants: Propagate all variants
     properties: Properties
+    properties_info: Properties allow you to enrich your Product information.
     property: Property
     prototype: Prototype
     prototypes: Prototypes
@@ -1800,6 +1885,7 @@ en:
     returned: Returned
     returns: Returns
     returns_policy: Returns Policy
+    returns_policy_help: Please provide your customers with a clear and transparent returns policy.
     review: Review
     risk: Risk
     risk_analysis: Risk Analysis
@@ -1827,6 +1913,7 @@ en:
     search: Search
     search_all: Search all
     search_by: 'Search by:'
+    search_description: Search description
     search_engine_listing: Search engine listing
     search_order_number: Order Number
     search_results: Search results for '%{keywords}'
@@ -1893,6 +1980,7 @@ en:
       ready: Ready
       shipped: Shipped
     shipment_successfully_shipped: Shipment successfully shipped
+    shipment_total: Shipment Total
     shipment_transfer_error: There was an error transferring variants
     shipment_transfer_success: Variants successfully transferred
     shipments: Shipments
@@ -1907,9 +1995,13 @@ en:
     shipping_flexible_rate: Flexible Rate per package item
     shipping_instructions: Shipping Instructions
     shipping_method: Shipping Method
+    shipping_method_name_help: This will be displayed to customers.
+    shipping_method_internal_name_help: This will be displayed to admins.
     shipping_methods: Shipping Methods
+    shipping_methods_info: Shipping methods are options that the customer sees when they reach the checkout, they are the carriers and services used to send your products.
     shipping_not_available: Shipping not available
     shipping_policy: Shipping Policy
+    shipping_policy_help: Please provide your customers with a clear and transparent shipping policy.
     shipping_price_sack: Price sack
     shipping_rates:
       display_price:
@@ -1939,6 +2031,7 @@ en:
     sign_in_with_provider: Sign in with %{provider}
     sign_out: Sign out
     sign_up: Sign Up
+    sign_ups: Sign-ups
     site_name: Site name
     size: Size
     sku: SKU
@@ -1946,6 +2039,7 @@ en:
     slug: Slug
     social: Social
     social_media: Social media
+    social_media_info: Social links will be displayed in the footer of your store
     sold_out: Sold out
     something_went_wrong: Something went wrong
     sort_by: Sort by
@@ -1954,6 +2048,7 @@ en:
     split: Split
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     square_image: Square image
+    square_image_help: Used for the featured image on the homepage.
     ssl:
       change_protocol: Please switch to using HTTP (rather than HTTPS) and retry this request.
     standards_and_formats: Standards and formats
@@ -2001,6 +2096,7 @@ en:
     states: States
     states_required: States Required
     status: Status
+    steps_done: steps done
     stock: Stock
     stock_items: Stock Items
     stock_location: Stock Location
@@ -2029,6 +2125,7 @@ en:
       available_amount: You have <strong>%{amount}</strong> in Store Credit available!
       captured: Used
       credit: Credit
+      description: Allow customers to use store credit for payment. Issue store credit to customers from the admin.
       eligible: Eligible
       errors:
         cannot_change_used_store_credit: You cannot change a store credit that has already been used
@@ -2059,6 +2156,7 @@ en:
       unable_to_create: Unable to create store.
       unable_to_delete: Unable to delete store.
       unable_to_update: Unable to update store.
+    store_favicon_images: Store Favicon Images
     store_form:
       checkout_zone_help: Selecting zone will limit to which Countries or States products are shipped. For more information <a href='https://guides.spreecommerce.org/user/configuration/configuring_geography.html#zones' target='_blank' class='alert-link'>please see documentation</a>
       code_help: Store unique identifier, which is an abbreviated version of the store’s name (used as the layout directory name, and also helpful for separating templates by store)
@@ -2070,6 +2168,8 @@ en:
       new_order_notifications_email_help: If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to
       seo_robots: Please check <a href='https://developers.google.com/search/reference/robots_meta_tag' target='_blank'>this page for more help</a>
       social_help: If you want to link to your social accounts in the footer part of your website please fill below fields
+    store_logos: Store Logos
+    store_mailer_logos: Store Mailer Logos
     store_name: Store name
     store_name_help: This is the name of your store. It will be displayed in the header and in the footer.
     store_not_set_as_default: Couldn't set store %{store} as a default store
@@ -2102,9 +2202,11 @@ en:
     tax_included: Tax (incl.)
     tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
+    tax_total: Tax Total
     taxes: Taxes
     taxon: Taxon
     taxon_edit: Edit Taxon
+    taxon_images: Taxon Images
     taxon_missing_alt: Category banner description
     taxon_placeholder: Add a Taxon
     taxon_rule:
@@ -2122,6 +2224,7 @@ en:
     taxonomy_tree_instruction: "* Right click (or double tap on iOS device) a child in the tree to access the menu for adding, deleting or sorting a child."
     taxons: Taxons
     terms_of_service: Terms of Service
+    terms_of_service_help: Customers will need to accept these terms of service during signup.
     test: Test
     test_mailer:
       test_email:
@@ -2149,6 +2252,7 @@ en:
       success_color: Success color
       text_color: Text color
     themes: Themes
+    themes_info: If you wan't to make changes to theme but don't want to go live with them, you can make a copy of the theme and make changes to the copy. And later promote that copy to the live theme.
     there_are_no_items_for_this_order: There are no items for this order
     there_were_problems_with_the_following_fields: There were problems with the following fields
     this_order_has_already_received_a_refund: This order has already received a refund
@@ -2165,6 +2269,7 @@ en:
     toggle_menu: Toggle menu
     top_suggestions: Top suggestions
     total: Total
+    total_orders: Total Orders
     total_per_item: Total per item
     total_pre_tax_refund: Total Pre-Tax Refund
     total_price: Total price
@@ -2175,6 +2280,7 @@ en:
     tracking: Tracking
     tracking_number: Tracking Number
     tracking_url: Tracking URL
+    tracking_url_help: will be replaced with the tracking number.
     tracking_url_placeholder: e.g. http://quickship.com/package?num=:tracking
     transaction_id: Transaction ID
     transaction_id_help: This is the ID of the transaction that was created in the 3rd party payment gateway.
@@ -2209,6 +2315,7 @@ en:
     update_shipping_address: Update shipping address
     updated_at: Updated at
     updating: Updating
+    upgrade_to_spree_enterprise: Upgrade to Spree Enterprise
     upload_image: Upload image
     url: URL
     usage_limit: Usage Limit
@@ -2241,6 +2348,8 @@ en:
     variants_count: Variants count
     vendor: Vendor
     vendors: Vendors
+    vendors_terms_of_service: Vendors Terms of Service
+    vendors_terms_of_service_help: Vendors you invite will need to accept these terms of service during their onboarding process.
     version: Version
     view: View
     view_all: View all
@@ -2253,6 +2362,7 @@ en:
     we_are_busy_updating: We're updating the %{store_name} homepage.
     we_are_busy_updating_page: We're busy updating this page.
     we_will_be_back: We will be back.
+    weeks_online: Weeks online
     webhooks: Webhooks
     weight: Weight
     weight_unit: Weight unit
@@ -2265,17 +2375,22 @@ en:
     what_is_a_cvv: What is a (CVV) Credit Card Code?
     what_is_this: What's This?
     width: Width
+    wished_items: Wished Items
     wishlist: Wishlist
+    wishlists: Wishlists
     without_taxon: Without taxon
     year: Year
     you_have_no_orders_yet: You have no orders yet
+    your_coupon_code: Your coupon code
     your_cart_is_empty: Your cart is empty
     your_order_is_empty_add_product: Your order is empty, please search for and add a product above
+    your_overall_setup_progress: Your overall setup progress
     zip: Zip
     zipcode: Zip Code
     zipcode_required: Zip Code Required
     zone: Zone
     zones: Zones
+    zones_info: Zones are geographical groupings, they represent collections of either states or countries.
   views:
     pagination:
       truncate: Truncate


### PR DESCRIPTION
Replace the hard-coded English text with translation keys in the admin views.
Updated English locale files with new translation keys.

Some examples of images are as follows:

admin_home:
![home](https://github.com/user-attachments/assets/42a3babc-ff60-4af2-8007-6ca7f751fa92)

order:
![orders](https://github.com/user-attachments/assets/adf09bb9-c709-470d-9f49-60724b2eae4b)

product:
![product](https://github.com/user-attachments/assets/5aa0ef8d-af99-4aae-a927-3460f9e94fca)

user:
![user](https://github.com/user-attachments/assets/6f5dd49d-9c72-4462-a3bc-d90a8f1c1db8)

custom_domain:
![custom_domain](https://github.com/user-attachments/assets/52e835f3-03bd-4659-b6c1-46f9ccd3b8fb)

admin_storefront:
![storefront](https://github.com/user-attachments/assets/617579aa-ac30-4e6a-9b78-f51396f915ec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All user-facing text in the admin interface now supports localization, enabling dynamic translation based on the selected language.

* **Style**
  * Replaced hardcoded English text in admin views with translation keys for headings, labels, help texts, tooltips, placeholders, and button labels.

* **Documentation**
  * Expanded English locale files with new translation keys for admin UI elements, help texts, and informational messages to support internationalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->