### PR TITLE
Include `importmaps` binary and vendor stylesheets in extension gener…

### DIFF
--- a/cli/lib/spree_cli/extension.rb
+++ b/cli/lib/spree_cli/extension.rb
@@ -28,6 +28,7 @@ module SpreeCli
       empty_directory "#{file_name}/app/serializers/spree/v2/storefront"
       empty_directory "#{file_name}/app/serializers/spree/api/v2/platform"
       empty_directory "#{file_name}/vendor/javascript"
+      empty_directory "#{file_name}/vendor/stylesheets"
 
       chmod "#{file_name}/bin/rails", 0o755
 

--- a/cli/lib/spree_cli/extension.rb
+++ b/cli/lib/spree_cli/extension.rb
@@ -31,6 +31,7 @@ module SpreeCli
       empty_directory "#{file_name}/vendor/stylesheets"
 
       chmod "#{file_name}/bin/rails", 0o755
+      chmod "#{file_name}/bin/importmap", 0o755
 
       template 'extension.gemspec', "#{file_name}/#{file_name}.gemspec"
       template 'Gemfile', "#{file_name}/Gemfile"

--- a/cli/lib/spree_cli/templates/extension/app/assets/config/%file_name%_manifest.js.tt
+++ b/cli/lib/spree_cli/templates/extension/app/assets/config/%file_name%_manifest.js.tt
@@ -2,3 +2,4 @@
 //= link <%= file_name %>/application.js
 //= link_tree ../../javascript/<%= file_name %>/controllers .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../../../vendor/stylesheets .css

--- a/cli/lib/spree_cli/templates/extension/bin/importmap
+++ b/cli/lib/spree_cli/templates/extension/bin/importmap
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails'
+
+require 'importmap-rails'
+require 'importmap/commands'

--- a/cli/lib/spree_cli/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/cli/lib/spree_cli/templates/extension/lib/%file_name%/engine.rb.tt
@@ -16,6 +16,7 @@ module <%= class_name %>
     initializer '<%= file_name %>.assets' do |app|
       app.config.assets.paths << root.join('app/javascript')
       app.config.assets.paths << root.join('vendor/javascript')
+      app.config.assets.paths << root.join('vendor/stylesheets')
       app.config.assets.precompile += %w[<%= file_name %>_manifest]
     end
 


### PR DESCRIPTION
…ator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including vendor stylesheet assets in generated extensions.
  * Extensions now include a new empty vendor/stylesheets directory by default.
  * Asset pipeline configuration updated to recognize stylesheets from the vendor directory.
  * Introduced a new executable script for managing importmap functionality within extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->