### PR TITLE
Handle `GiftCard#expires_at` properly, also better messages on checko…

### DIFF
--- a/core/app/models/spree/gift_card.rb
+++ b/core/app/models/spree/gift_card.rb
@@ -46,7 +46,7 @@ module Spree
     # Scopes
     #
     scope :active, -> { where(state: [:active, :partially_redeemed]).where(expires_at: [nil,  Date.tomorrow..]) }
-    scope :expired, -> { where(state: :active).where(expires_at: ..Time.current) }
+    scope :expired, -> { where(state: :active).where(expires_at: ..Date.current) }
     scope :redeemed, -> { where(state: [:redeemed]) }
     scope :partially_redeemed, -> { where(state: [:partially_redeemed]) }
 

--- a/core/app/models/spree/gift_card.rb
+++ b/core/app/models/spree/gift_card.rb
@@ -23,18 +23,12 @@ module Spree
     end
 
     #
-    # Attributes
-    #
-    attribute :skip_expires_at_validation, :boolean, default: false
-
-    #
     # Validations
     #
     validates :code, presence: true, uniqueness: { scope: :store_id }
     validates :store, :currency, presence: true
     validates :amount, presence: true, numericality: { greater_than: 0 }
     validates :amount_used, :amount_authorized, presence: true, numericality: { greater_than_or_equal_to: 0 }
-    validates :expires_at, comparison: { greater_than: Date.current + 1.day }, allow_nil: true, unless: :skip_expires_at_validation
 
     #
     # Associations
@@ -51,9 +45,10 @@ module Spree
     #
     # Scopes
     #
-    scope :active, -> { where(state: [:active, :partially_redeemed]).where(expires_at: [nil, Time.current..]) }
+    scope :active, -> { where(state: [:active, :partially_redeemed]).where(expires_at: [nil,  Date.tomorrow..]) }
     scope :expired, -> { where(state: :active).where(expires_at: ..Time.current) }
     scope :redeemed, -> { where(state: [:redeemed]) }
+    scope :partially_redeemed, -> { where(state: [:partially_redeemed]) }
 
     #
     # Ransack
@@ -115,7 +110,7 @@ module Spree
     # Checks if the gift card is expired
     # @return [Boolean]
     def expired?
-      !redeemed? && expires_at.present? && expires_at < Time.current
+      !redeemed? && expires_at.present? && expires_at <= Date.current
     end
 
     # Checks if the gift card is active, i.e. not expired and not redeemed

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -12,6 +12,15 @@ module Spree
 
       def apply
         if load_gift_card_code
+
+          if @gift_card.expired?
+            set_error_code :gift_card_expired
+            return self
+          elsif @gift_card.redeemed?
+            set_error_code :gift_card_already_redeemed
+            return self
+          end
+
           result = order.apply_gift_card(@gift_card)
 
           if result.success?
@@ -207,7 +216,7 @@ module Spree
       def load_gift_card_code
         return unless order.coupon_code.present?
 
-        @gift_card = order.store.gift_cards.active.find_by(code: order.coupon_code.downcase)
+        @gift_card = order.store.gift_cards.find_by(code: order.coupon_code.downcase)
       end
     end
   end

--- a/core/app/services/spree/gift_cards/remove.rb
+++ b/core/app/services/spree/gift_cards/remove.rb
@@ -18,7 +18,6 @@ module Spree
 
           gift_card.with_lock do
             gift_card.amount_used -= payment_total
-            gift_card.skip_expires_at_validation = true
             gift_card.save!
           end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1095,8 +1095,10 @@ en:
     generate_code: Generate coupon code
     get_back_to_the: Get back to the
     gift_card: Gift Card
+    gift_card_already_redeemed: The Gift Card has already been redeemed.
     gift_card_applied: The Gift Card was successfully applied to your order!
     gift_card_batch: Gift Card Batch
+    gift_card_expired: The Gift Card has expired.
     gift_card_removed: The Gift Card was successfully removed from your order
     gift_card_using_store_credit_error: You can't apply the Gift Card after you applied the store credit.
     gift_cards: Gift Cards

--- a/core/lib/spree/testing_support/factories/gift_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/gift_card_factory.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
 
     trait :expired do
       expires_at { 1.day.ago }
-      skip_expires_at_validation { true }
     end
   end
 end

--- a/core/spec/models/spree/gift_card_spec.rb
+++ b/core/spec/models/spree/gift_card_spec.rb
@@ -20,9 +20,40 @@ RSpec.describe Spree::GiftCard, type: :model do
     end
   end
 
+  describe 'Scopes' do
+    let(:active_gift_card) { create(:gift_card, state: :active) }
+    let(:redeemed_gift_card) { create(:gift_card, state: :redeemed) }
+    let(:partially_redeemed_gift_card) { create(:gift_card, state: :partially_redeemed) }
+    let(:expired_gift_card) { create(:gift_card, expires_at: Date.current, state: :active) }
+
+    describe '#active' do
+      it 'returns active gift cards' do
+        expect(described_class.active).to contain_exactly(active_gift_card)
+      end
+    end
+
+    describe '#expired' do
+      it 'returns expired gift cards' do
+        expect(described_class.expired).to contain_exactly(expired_gift_card)
+      end
+    end
+
+    describe '#redeemed' do
+      it 'returns redeemed gift cards' do
+        expect(described_class.redeemed).to contain_exactly(redeemed_gift_card)
+      end
+    end
+
+    describe '#partially_redeemed' do
+      it 'returns partially redeemed gift cards' do
+        expect(described_class.partially_redeemed).to contain_exactly(partially_redeemed_gift_card)
+      end
+    end
+  end
+
   describe '#active?' do
     context 'when expired' do
-      let(:gift_card) { build(:gift_card, expires_at: 1.day.ago, state: :active) }
+      let(:gift_card) { build(:gift_card, expires_at: Date.current, state: :active) }
 
       it 'returns false' do
         expect(gift_card.active?).to be(false)

--- a/core/spec/models/spree/promotion_handler/coupon_with_gift_card_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_with_gift_card_spec.rb
@@ -43,6 +43,34 @@ describe Spree::PromotionHandler::Coupon, type: :model do
           expect(order.total_applied_store_credit).to eq(0)
         end
       end
+
+      context 'when gift card is expired' do
+        let(:gift_card) { create(:gift_card, :expired) }
+
+        it 'returns error code' do
+          order.coupon_code = gift_card.code
+          handler = described_class.new(order)
+          handler.apply
+
+          expect(order.reload.gift_card).to eq(nil)
+          expect(order.total_applied_store_credit).to eq(0)
+          expect(handler.status_code).to eq(:gift_card_expired)
+        end
+      end
+
+      context 'when gift card is already redeemed' do
+        let(:gift_card) { create(:gift_card, :redeemed) }
+
+        it 'returns error code' do
+          order.coupon_code = gift_card.code
+          handler = described_class.new(order)
+          handler.apply
+
+          expect(order.reload.gift_card).to eq(nil)
+          expect(order.total_applied_store_credit).to eq(0)
+          expect(handler.status_code).to eq(:gift_card_already_redeemed)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
…ut if expired/redeemed card is applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new error messages for expired and already redeemed gift cards.
  * Introduced a filter to view partially redeemed gift cards.

* **Bug Fixes**
  * Improved validation when applying gift cards, preventing use of expired or already redeemed cards.
  * Updated gift card expiration handling to consider full days rather than exact times.

* **Tests**
  * Expanded test coverage for gift card states, including new scenarios for expired and redeemed cards, and added tests for new and updated gift card filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->