### PR TITLE
Split checkout views into more granular level partials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
       PROJECTS: admin
   test_storefront_postgres:
     <<: *test
+    parallelism: 2
     environment:
       <<: *environment
       PROJECTS: storefront
@@ -141,6 +142,7 @@ jobs:
       PROJECTS: admin
   test_storefront_mysql:
     <<: *test_mysql
+    parallelism: 2
     environment:
       <<: *mysql_environment
       PROJECTS: storefront

--- a/core/lib/spree/testing_support/factories/page_section_factory.rb
+++ b/core/lib/spree/testing_support/factories/page_section_factory.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :page_section, class: Spree::PageSection do
     pageable { Spree::Page.find_by!(name: 'Homepage') }
-    pageable_type { 'Spree::Page' }
 
     trait :without_links do
       do_not_create_links { true }

--- a/storefront/app/views/spree/checkout/_address.html.erb
+++ b/storefront/app/views/spree/checkout/_address.html.erb
@@ -13,7 +13,7 @@
           </h5>
           <ul class="select_address list-group mb-5 border mt-3 rounded-md border-default">
             <% user_available_addresses.each_with_index do |address, idx| %>
-              <%= render 'spree/checkout/address_list_item', address: address, idx: idx, order: @order %>
+              <%= render 'spree/checkout/address_list_item', address: address, idx: idx, order: @order, address_type: address_type, address_name: address_name %>
             <% end %>
             <li class="list-group-item p-0 m-0">
               <div class="custom-control custom-radio px-5 py-4 flex items-center">

--- a/storefront/app/views/spree/checkout/_address.html.erb
+++ b/storefront/app/views/spree/checkout/_address.html.erb
@@ -13,20 +13,7 @@
           </h5>
           <ul class="select_address list-group mb-5 border mt-3 rounded-md border-default">
             <% user_available_addresses.each_with_index do |address, idx| %>
-              <li class="p-0 m-0 border-b border-default" id="<%= [address_type, dom_id(address)].join('_') %>">
-                <% checked = (address.id == @order.ship_address_id || (!@order.ship_address_id && idx == 0)) %>
-                <div class="custom-control custom-radio px-5 py-4 flex items-center">
-                  <%= radio_button_tag "order_#{address_name}_id", address.id, checked, class: 'custom-control-input radio-input mt-1 mr-5', data: { action: 'checkout-address-book#select' } %>
-                  <label class="custom-control-label d-block select-none cursor-pointer max-w-[calc(100%-58px)]" for="<%= "order_#{address_name}_id_#{address.id}" %>">
-                    <%= turbo_frame_tag dom_id(address) do %>
-                      <%= render 'spree/shared/address', address: address %>
-                      <div class="address-book-actions mt-3 <% unless checked %>hidden<% end %>">
-                        <%= link_to Spree.t(:edit), spree.edit_address_path(address, checkout: @order.token), class: 'text-dark' %>
-                      </div>
-                    <% end %>
-                  </label>
-                </div>
-              </li>
+              <%= render 'spree/checkout/address_list_item', address: address, idx: idx, order: @order %>
             <% end %>
             <li class="list-group-item p-0 m-0">
               <div class="custom-control custom-radio px-5 py-4 flex items-center">
@@ -58,7 +45,7 @@
 
     <%= form_for @order, url: spree.update_checkout_path(@order.token, @order.state), html: { id: "checkout_form_#{@order.state}" } do |form| %>
       <div>
-        <%= form.hidden_field :state_lock_version %>
+        <%= render 'spree/checkout/order_lock_version', order: @order %>
         <%= form.hidden_field :ship_address_id, data: { 'checkout-address-book-target': 'addressId' } %>
       </div>
 
@@ -77,9 +64,8 @@
   </div>
 <% else %>
   <%= form_for @order, url: spree.update_checkout_path(@order.token, @order.state), html: { id: "checkout_form_#{@order.state}" } do |form| %>
+    <%= render 'spree/checkout/order_lock_version', order: @order %>
     <div class="mb-5">
-      <%= form.hidden_field :state_lock_version %>
-
       <% if !try_spree_current_user || try_spree_current_user.email.blank? %>
         <div class="grid grid-cols-1 lg:grid-cols-2 mb-3 font-body">
           <h5 class="font-body">

--- a/storefront/app/views/spree/checkout/_address_list_item.html.erb
+++ b/storefront/app/views/spree/checkout/_address_list_item.html.erb
@@ -1,0 +1,14 @@
+<li class="p-0 m-0 border-b border-default" id="<%= [address_type, dom_id(address)].join('_') %>">
+  <% checked = (address.id == @order.ship_address_id || (!@order.ship_address_id && idx == 0)) %>
+  <div class="custom-control custom-radio px-5 py-4 flex items-center">
+    <%= radio_button_tag "order_#{address_name}_id", address.id, checked, class: 'custom-control-input radio-input mt-1 mr-5', data: { action: 'checkout-address-book#select' } %>
+    <label class="custom-control-label d-block select-none cursor-pointer max-w-[calc(100%-58px)]" for="<%= "order_#{address_name}_id_#{address.id}" %>">
+      <%= turbo_frame_tag dom_id(address) do %>
+        <%= render 'spree/shared/address', address: address %>
+        <div class="address-book-actions mt-3 <% unless checked %>hidden<% end %>">
+          <%= link_to Spree.t(:edit), spree.edit_address_path(address, checkout: @order.token), class: 'text-dark' %>
+        </div>
+      <% end %>
+    </label>
+  </div>
+</li>

--- a/storefront/app/views/spree/checkout/_delivery.html.erb
+++ b/storefront/app/views/spree/checkout/_delivery.html.erb
@@ -1,19 +1,8 @@
 <%= form_for @order, url: spree.update_checkout_path(@order.token, @order.state), data: { controller: 'checkout-delivery' } do |form| %>
   <div class="mb-5">
-    <%= turbo_frame_tag :checkout_lock_version do %>
-      <%= hidden_field_tag 'order[state_lock_version]', @order.state_lock_version %>
-    <% end %>
+    <%= render 'spree/checkout/order_lock_version', order: @order %>
     <div id="shipping-method">
-      <% if @order.backordered_variants.any? %>
-        <div class="alert rounded border border-default text-sm p-5 mb-6">
-          <%= Spree.t("storefront.checkout.backorder_notice") %>
-          <ul class="list-disc list-inside flex-col flex space-y-1 mt-2">
-            <% @order.backordered_variants.each do |variant| %>
-              <li><%= variant.name %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
+      <%= render 'spree/checkout/delivery_backorder_notice', order: @order %>
 
       <div id="methods">
         <%= form.fields_for :shipments do |ship_form| %>
@@ -27,28 +16,7 @@
             </h5>
             <ul class="rounded-md list-group mb-4 border border-default border-b-0 text-sm border-default" data-checkout-delivery-target="shippingList">
               <% ship_form.object.shipping_rates.includes(:shipping_method, :tax_rate).each do |rate| %>
-                <li class="list-group-item p-0 m-0 border-b delivery-list-item border-default" data-checkout-delivery-target="shippingRate">
-                  <div class="custom-control custom-radio flex items-center px-5 py-4">
-                    <%= ship_form.radio_button :selected_shipping_rate_id,
-                      rate.id,
-                      class: 'custom-control-input radio-input',
-                      id: "shipping-rate-#{rate.id}",
-                      data: {
-                        action: 'click->checkout-delivery#update',
-                        cost: rate.display_cost,
-                        tax: rate.display_tax_amount
-                      } %>
-                    <label class="select-none cursor-pointer px-2 word-break w-full" for="<%= "shipping-rate-#{rate.id}" %>">
-                      <%= rate.name %>
-                      <% if rate.delivery_range %>
-                        <span class="text-gray-600 text-xs ml-3"><%= rate.display_delivery_range %></span>
-                      <% end %>
-                    </label>
-                    <span class="text-right">
-                      <%= rate.cost <= 0 ? Spree.t(:free) : rate.display_cost %>
-                    </span>
-                  </div>
-                </li>
+                <%= render 'spree/checkout/delivery_shipping_rate', ship_form: ship_form, rate: rate %>
               <% end %>
             </ul>
           </div>

--- a/storefront/app/views/spree/checkout/_delivery_backorder_notice.html.erb
+++ b/storefront/app/views/spree/checkout/_delivery_backorder_notice.html.erb
@@ -1,0 +1,10 @@
+<% if order.backordered_variants.any? %>
+  <div class="alert rounded border border-default text-sm p-5 mb-6">
+    <%= Spree.t("storefront.checkout.backorder_notice") %>
+    <ul class="list-disc list-inside flex-col flex space-y-1 mt-2">
+      <% order.backordered_variants.each do |variant| %>
+        <li><%= variant.name %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/storefront/app/views/spree/checkout/_delivery_shipping_rate.html.erb
+++ b/storefront/app/views/spree/checkout/_delivery_shipping_rate.html.erb
@@ -1,0 +1,22 @@
+<li class="list-group-item p-0 m-0 border-b delivery-list-item border-default" data-checkout-delivery-target="shippingRate" id="<%= spree_dom_id(rate) %>">
+  <div class="custom-control custom-radio flex items-center px-5 py-4">
+    <%= ship_form.radio_button :selected_shipping_rate_id,
+      rate.id,
+      class: 'custom-control-input radio-input',
+      id: "shipping-rate-#{rate.id}",
+      data: {
+        action: 'click->checkout-delivery#update',
+        cost: rate.display_cost,
+        tax: rate.display_tax_amount
+      } %>
+    <label class="select-none cursor-pointer px-2 word-break w-full" for="<%= "shipping-rate-#{rate.id}" %>">
+      <%= rate.name %>
+      <% if rate.delivery_range %>
+        <span class="text-gray-600 text-xs ml-3"><%= rate.display_delivery_range %></span>
+      <% end %>
+    </label>
+    <span class="text-right">
+      <%= rate.cost <= 0 ? Spree.t(:free) : rate.display_cost %>
+    </span>
+  </div>
+</li>

--- a/storefront/app/views/spree/checkout/_order_lock_version.html.erb
+++ b/storefront/app/views/spree/checkout/_order_lock_version.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag :checkout_lock_version do %>
+  <%= hidden_field_tag 'order[state_lock_version]', order.state_lock_version %>
+<% end %>

--- a/storefront/app/views/spree/checkout/_payment.html.erb
+++ b/storefront/app/views/spree/checkout/_payment.html.erb
@@ -1,5 +1,5 @@
 <%= form_for @order, url: spree.update_checkout_path(@order.token, @order.state), html: { id: "checkout_form_#{@order.state}" } do |form| %>
-  <%= form.hidden_field :state_lock_version %>
+  <%= render 'spree/checkout/order_lock_version', order: @order %>
 
   <% if @order.respond_to?(:gift_card) %>
     <%= turbo_frame_tag :gift_card_code_field do %>

--- a/storefront/app/views/spree/checkout/update.turbo_stream.erb
+++ b/storefront/app/views/spree/checkout/update.turbo_stream.erb
@@ -2,9 +2,7 @@
   <%= render 'summary', order: @order %>
 <% end %>
 <%= turbo_stream.replace :checkout_lock_version do %>
-  <%= turbo_frame_tag :checkout_lock_version do %>
-    <%= hidden_field_tag 'order[state_lock_version]', @order.state_lock_version %>
-  <% end %>
+  <%= render 'spree/checkout/order_lock_version', order: @order %>
 <% end %>
 <%= turbo_stream.update 'summary-order-total' do %>
   <%= @order.display_total.to_html %>


### PR DESCRIPTION
for easier customization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated complex and repeated checkout markup into reusable partials for improved clarity and maintainability. This includes address selection, shipping rate options, backorder notices, and order lock version fields.
* **New Features**
  * Added clear, styled alerts for backordered items in the checkout process.
  * Enhanced address and shipping rate selection interfaces with improved layout and interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->