### PR TITLE
Skip sending a reimbursement email if send_consumer_transactional_emails is set to false

### DIFF
--- a/emails/app/models/spree/reimbursement/emails.rb
+++ b/emails/app/models/spree/reimbursement/emails.rb
@@ -2,7 +2,7 @@ module Spree
   class Reimbursement < Spree.base_class
     module Emails
       def send_reimbursement_email
-        Spree::ReimbursementMailer.reimbursement_email(id).deliver_later
+        Spree::ReimbursementMailer.reimbursement_email(id).deliver_later if store.prefers_send_consumer_transactional_emails?
       end
     end
   end

--- a/emails/spec/models/spree/reimbursement_spec.rb
+++ b/emails/spec/models/spree/reimbursement_spec.rb
@@ -34,5 +34,20 @@ describe Spree::Reimbursement, type: :model do
       expect(Spree::ReimbursementMailer).to receive(:reimbursement_email).with(reimbursement.id) { double(deliver_later: true) }
       subject
     end
+
+    context 'when send_consumer_transactional_emails store setting is set to false' do
+      before do
+        store.update!(preferred_send_consumer_transactional_emails: false)
+      end
+
+      after do
+        store.update!(preferred_send_consumer_transactional_emails: true)
+      end
+
+      it 'does not trigger the reimbursement mailer to be sent' do
+        expect(Spree::ReimbursementMailer).not_to receive(:reimbursement_email)
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reimbursement emails are now sent only if the store's settings allow consumer transactional emails.

* **Tests**
  * Added tests to ensure reimbursement emails are not sent when disabled in store settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->