### PR TITLE
Skip sending a shipment email if send_consumer_transactional_emails is set to false

### DIFF
--- a/emails/app/models/spree/shipment/emails.rb
+++ b/emails/app/models/spree/shipment/emails.rb
@@ -2,7 +2,7 @@ module Spree
   class Shipment < Spree.base_class
     module Emails
       def send_shipped_email
-        ShipmentMailer.shipped_email(@shipment.id).deliver_later
+        ShipmentMailer.shipped_email(@shipment.id).deliver_later if @shipment.store.prefers_send_consumer_transactional_emails?
       end
     end
   end

--- a/emails/spec/models/spree/reimbursement_spec.rb
+++ b/emails/spec/models/spree/reimbursement_spec.rb
@@ -37,11 +37,7 @@ describe Spree::Reimbursement, type: :model do
 
     context 'when send_consumer_transactional_emails store setting is set to false' do
       before do
-        store.update!(preferred_send_consumer_transactional_emails: false)
-      end
-
-      after do
-        store.update!(preferred_send_consumer_transactional_emails: true)
+        allow_any_instance_of(Spree::Store).to receive(:prefers_send_consumer_transactional_emails?).and_return(false)
       end
 
       it 'does not trigger the reimbursement mailer to be sent' do

--- a/emails/spec/models/spree/shipment_spec.rb
+++ b/emails/spec/models/spree/shipment_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Spree::Shipment, type: :model do
-  let(:store) { @default_store }
   let(:order) { create(:order) }
   let(:shipping_method) { create(:shipping_method, name: 'UPS') }
   let(:shipment) { create(:shipment, cost: 1, state: 'pending', stock_location: create(:stock_location), order: order) }
@@ -39,11 +38,7 @@ describe Spree::Shipment, type: :model do
 
       context 'when send_consumer_transactional_emails store setting is set to false' do
         before do
-          store.update!(preferred_send_consumer_transactional_emails: false)
-        end
-
-        after do
-          store.update!(preferred_send_consumer_transactional_emails: true)
+          allow(shipment.store).to receive(:prefers_send_consumer_transactional_emails?).and_return(false)
         end
 
         it 'does not trigger the shipment mailer to be sent' do

--- a/emails/spec/models/spree/shipment_spec.rb
+++ b/emails/spec/models/spree/shipment_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Spree::Shipment, type: :model do
+  let(:store) { @default_store }
   let(:order) { create(:order) }
   let(:shipping_method) { create(:shipping_method, name: 'UPS') }
   let(:shipment) { create(:shipment, cost: 1, state: 'pending', stock_location: create(:stock_location), order: order) }
@@ -34,6 +35,21 @@ describe Spree::Shipment, type: :model do
 
         shipment.ship!
         expect(shipment_id).to eq(shipment.id)
+      end
+
+      context 'when send_consumer_transactional_emails store setting is set to false' do
+        before do
+          store.update!(preferred_send_consumer_transactional_emails: false)
+        end
+
+        after do
+          store.update!(preferred_send_consumer_transactional_emails: true)
+        end
+
+        it 'does not trigger the shipment mailer to be sent' do
+          expect(Spree::ShipmentMailer).not_to receive(:shipped_email)
+          shipment.ship!
+        end
       end
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shipment emails are now only sent if the store's email preference is enabled, allowing for more control over transactional email notifications.

* **Tests**
  * Added tests to verify that shipment emails are not sent when the store's email preference is disabled.
  * Improved test setup by stubbing store email preferences without modifying the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->