### PR TITLE
Fixed: show delete button for order pages if order is draft

### DIFF
--- a/admin/app/controllers/spree/admin/orders_controller.rb
+++ b/admin/app/controllers/spree/admin/orders_controller.rb
@@ -10,7 +10,7 @@ module Spree
       before_action :load_order_items, only: :edit
       before_action :load_user, only: [:index]
 
-      helper_method :model_class
+      helper_method :model_class, :object_url
 
       # POST /admin/orders
       def create
@@ -107,6 +107,11 @@ module Spree
 
       def model_class
         Spree::Order
+      end
+
+      # needed to show the delete button in the content header
+      def object_url
+        spree.admin_order_path(@order)
       end
     end
   end

--- a/admin/app/views/spree/admin/shared/sortable_tree/_taxonomy.html.erb
+++ b/admin/app/views/spree/admin/shared/sortable_tree/_taxonomy.html.erb
@@ -26,7 +26,7 @@
     <% end %>
   </div>
 
-  <div class="d-flex align-items-center px-3 ml-3">
+  <div class="d-flex align-items-center px-3 ml-3 gap-2">
     <%= link_to_edit(taxon, url: spree.edit_admin_taxonomy_taxon_path(taxonomy, taxon.id), data: { row_link_target: :link }) if can?(:edit, taxon) %>
 
     <div class="dropdown h-100">

--- a/admin/spec/features/spree/admin/orders/destroy_order_spec.rb
+++ b/admin/spec/features/spree/admin/orders/destroy_order_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'Destroy Order Spec', type: :feature, js: true do
+  stub_authorization!
+
+  let(:store) { Spree::Store.default }
+  let(:order) { create(:order, store: store) }
+
+  context 'draft order' do
+    it 'can be destroyed' do
+      visit spree.edit_admin_order_path(order)
+      within('#page_actions_dropdown') do
+        click_on 'more-actions-link'
+        accept_confirm do
+          click_on 'Delete'
+        end
+      end
+
+      expect(page).to have_content('Order has been successfully removed!')
+      expect(Spree::Order.count).to eq 0
+    end
+  end
+
+  context 'completed order' do
+    let(:order) { create(:shipped_order, store: store) }
+
+    it 'cannot be destroyed' do
+      visit spree.edit_admin_order_path(order)
+      within('#page_actions_dropdown') do
+        expect(page).not_to have_content('Delete')
+      end
+    end
+  end
+end

--- a/admin/spec/features/spree/admin/orders/edit_order_spec.rb
+++ b/admin/spec/features/spree/admin/orders/edit_order_spec.rb
@@ -1,0 +1,168 @@
+require 'spec_helper'
+
+describe 'Edit Order Spec', type: :feature do
+  stub_authorization!
+
+  let(:store) { Spree::Store.default }
+  let(:customer) { create(:user) }
+  let(:admin_user) { create(:admin_user) }
+  let!(:order) do
+    create(
+      :order,
+       user: customer,
+       ship_address: create(:address, user: customer),
+       bill_address: create(:address, user: customer)
+    )
+  end
+
+  before do
+    visit spree.edit_admin_order_path(order)
+  end
+
+  describe 'order ready to ship', js: true do
+    let!(:order) do
+      create(:order_ready_to_ship, user: customer, ship_address: create(:address, user: customer), bill_address: create(:address, user: customer))
+    end
+
+    it 'can change shipping address' do
+      within('#customer-edit-dropdown') do
+        click_on 'dropdown-toggle'
+        click_on Spree.t('admin.edit_shipping_address')
+      end
+
+      fill_in_address
+      click_on 'Update'
+      wait_for_turbo
+
+      expect(page).to have_content('successfully updated')
+      expect(page).to have_content('John 99')
+      expect(page).to have_content('Bethesda')
+
+      expect(order.reload.ship_address.firstname).to eq('John 99')
+      expect(order.ship_address.lastname).to eq('Doe')
+      expect(order.ship_address.address1).to eq('100 first lane')
+      expect(order.ship_address.address2).to eq('#101')
+      expect(order.ship_address.city).to eq('Bethesda')
+      expect(order.ship_address.zipcode).to eq('20170')
+      expect(order.ship_address.country.name).to eq(store.default_country.name)
+      expect(order.ship_address.state.name).to eq(store.default_country.states.first.name)
+      expect(order.ship_address.phone).to eq('123-456-7890')
+    end
+
+    it 'can select existing shipping address' do
+      address_to_select = order.user.addresses.first
+      expect(order.ship_address).not_to eq(address_to_select)
+
+      within('#customer-edit-dropdown') do
+        click_on 'dropdown-toggle'
+        click_on Spree.t('admin.edit_shipping_address')
+      end
+      wait_for_turbo
+
+      tom_select address_to_select.to_s.gsub('<br/>', ", "), from: Spree.t(:existing_address)
+      wait_for_turbo
+
+      expect(page).to have_content('successfully updated')
+      expect(page).to have_content(address_to_select.firstname)
+      expect(page).to have_content(address_to_select.city)
+
+      expect(order.reload.ship_address).to eq(address_to_select)
+    end
+  end
+
+  context 'when order is not shipped', js: true do
+    it 'can change shipping address' do
+      within('#customer-edit-dropdown') do
+        click_on 'dropdown-toggle'
+        click_on Spree.t('admin.edit_shipping_address')
+      end
+      wait_for_turbo
+
+      fill_in_address
+      click_on 'Update'
+
+      expect(page).to have_content('successfully updated')
+      expect(page).to have_content('John 99')
+      expect(page).to have_content('Bethesda')
+
+      expect(order.reload.ship_address.firstname).to eq('John 99')
+      expect(order.ship_address.lastname).to eq('Doe')
+      expect(order.ship_address.address1).to eq('100 first lane')
+      expect(order.ship_address.address2).to eq('#101')
+      expect(order.ship_address.city).to eq('Bethesda')
+      expect(order.ship_address.zipcode).to eq('20170')
+      expect(order.ship_address.country.name).to eq(store.default_country.name)
+      expect(order.ship_address.state.name).to eq(store.default_country.states.first.name)
+      expect(order.ship_address.phone).to eq('123-456-7890')
+    end
+
+    it 'can select existing shipping address' do
+      address_to_select = order.user.addresses.first
+      expect(order.ship_address).not_to eq(address_to_select)
+
+      within('#customer-edit-dropdown') do
+        click_on 'dropdown-toggle'
+        click_on Spree.t('admin.edit_shipping_address')
+      end
+      wait_for_turbo
+
+      tom_select address_to_select.to_s.gsub('<br/>', ", "), from: Spree.t(:existing_address)
+      wait_for_turbo
+
+      expect(page).to have_content('successfully updated')
+      expect(page).to have_content(address_to_select.firstname)
+      expect(page).to have_content(address_to_select.city)
+
+      expect(order.reload.ship_address).to eq(address_to_select)
+    end
+
+    context 'when updating to an existing shipping address' do
+      let!(:existing_address) do
+        create(
+          :address,
+          user: customer,
+          first_name: 'John 99',
+          last_name: 'Doe',
+          address1: '100 first lane',
+          address2: '#101',
+          city: 'Bethesda',
+          zipcode: '20170',
+          state: store.default_country.states.first,
+          country: store.default_country,
+          phone: '123-456-7890'
+        )
+      end
+
+      it 'switches the shipping address to the existing address' do
+        within('#customer-edit-dropdown') do
+          click_on 'dropdown-toggle'
+          click_on Spree.t('admin.edit_shipping_address')
+        end
+        wait_for_turbo
+
+        fill_in_address
+        click_on 'Update'
+
+        expect(page).to have_content('successfully updated')
+        expect(page).to have_content('John 99')
+        expect(page).to have_content('Bethesda')
+
+        expect(order.reload.ship_address).to eq(existing_address)
+      end
+    end
+  end
+
+  def fill_in_address
+    fill_in 'address_firstname',       with: 'John 99'
+    fill_in 'address_lastname',        with: 'Doe'
+    fill_in 'address_address1',        with: ''
+    fill_in 'address_address1',        with: '100 first lane'
+    fill_in 'address_address2',        with: ''
+    fill_in 'address_address2',        with: '#101'
+    select store.default_country.name, from: 'address_country_id' if store.countries_available_for_checkout.count > 1
+    fill_in 'address_city',            with: 'Bethesda'
+    fill_in 'address_zipcode',         with: '20170'
+    select store.default_country.states.first.name, from: 'address_state_id'
+    fill_in 'address_phone', with: '123-456-7890'
+  end
+end

--- a/core/lib/spree/testing_support/capybara_config.rb
+++ b/core/lib/spree/testing_support/capybara_config.rb
@@ -10,6 +10,7 @@ Capybara.configure do |config|
   config.match = :smart
   config.ignore_hidden_elements = true
 end
+Capybara.test_id = 'data-test-id'
 
 if ENV['WEBDRIVER'] == 'accessible'
   require 'capybara/accessible'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete draft orders from the admin interface, with appropriate success messaging and removal from the order list.
  * Improved editing of shipping addresses for orders in the admin panel, including updating via form or selecting from saved addresses.
* **Bug Fixes**
  * Ensured completed (shipped) orders cannot be deleted from the admin interface.
* **Style**
  * Updated admin UI spacing for taxon actions to improve visual consistency.
* **Tests**
  * Introduced feature tests covering order deletion and shipping address editing workflows in the admin interface.
* **Chores**
  * Added a custom test identifier attribute for Capybara to improve test targeting and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->