### PR TITLE
CHG mail image to save as png

### DIFF
--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -18,7 +18,6 @@ module Spree
       return unless image
       return unless image.variable?
       return if image.respond_to?(:attached?) && !image.attached?
-      
       url_helpers = respond_to?(:main_app) ? main_app : Rails.application.routes.url_helpers
       width = options[:width]
       height = options[:height]
@@ -77,16 +76,30 @@ module Spree
     # @option options [Integer] :height the height of the image
     def spree_image_variant_options(options = {})
       {
-        saver: {
-          strip: true,
-          quality: 75,
-          lossless: false,
-          alpha_q: 85,
-          reduction_effort: 6,
-          smart_subsample: true
-        },
+        saver: options[:format] == :png ? png_variant_options : webp_variant_options,
         format: options[:format] || :webp
       }.merge(options.except(:format))
+    end
+
+    private
+
+    def webp_variant_options
+      {
+        strip: true,
+        quality: 75,
+        lossless: false,
+        alpha_q: 85,
+        reduction_effort: 6,
+        smart_subsample: true
+      }
+    end
+
+    def png_variant_options
+      {
+        strip: true,
+        compression_level: 8,
+        interlace: true
+      }
     end
   end
 end

--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -9,7 +9,7 @@ module Spree
     # @option options [Integer] :height the height of the image
     def spree_image_tag(image, options = {})
       image_tag(
-        spree_image_url(image, { width: options[:width], height: options[:height] }),
+        spree_image_url(image, { width: options[:width], height: options[:height], format: options[:format] }),
         options
       )
     end
@@ -28,11 +28,11 @@ module Spree
 
       if width.present? && height.present?
         url_helpers.cdn_image_url(
-          image.variant(spree_image_variant_options(resize_to_fill: [width, height]))
+          image.variant(spree_image_variant_options(resize_to_fill: [width, height], format: options[:format]))
         )
       else
         url_helpers.cdn_image_url(
-          image.variant(spree_image_variant_options(resize_to_limit: [width, height]))
+          image.variant(spree_image_variant_options(resize_to_limit: [width, height], format: options[:format]))
         )
       end
     end
@@ -85,7 +85,7 @@ module Spree
           reduction_effort: 6,
           smart_subsample: true
         },
-        format: :webp
+        format: options[:format] || :webp
       }.merge(options)
     end
   end

--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -86,7 +86,7 @@ module Spree
           smart_subsample: true
         },
         format: options[:format] || :webp
-      }.merge(options)
+      }.merge(options.except(:format))
     end
   end
 end

--- a/core/app/helpers/spree/mail_helper.rb
+++ b/core/app/helpers/spree/mail_helper.rb
@@ -5,7 +5,7 @@ module Spree
 
     def variant_image_url(variant)
       image = variant.default_image
-      image.present? && image.attached? ? spree_image_url(image, width: 100, height: 100) : image_url('noimage/small.png')
+      image.present? && image.attached? ? spree_image_url(image, width: 100, height: 100, format: 'png') : image_url('noimage/small.png')
     end
 
     def name_for(order)

--- a/core/app/helpers/spree/mail_helper.rb
+++ b/core/app/helpers/spree/mail_helper.rb
@@ -5,7 +5,7 @@ module Spree
 
     def variant_image_url(variant)
       image = variant.default_image
-      image.present? && image.attached? ? spree_image_url(image, width: 100, height: 100, format: 'png') : image_url('noimage/small.png')
+      image.present? && image.attached? ? spree_image_url(image, width: 100, height: 100, format: :png) : image_url('noimage/small.png')
     end
 
     def name_for(order)

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -16,7 +16,7 @@ describe Spree::ImagesHelper, type: :helper do
 
   describe '#spree_image_tag' do
     it 'returns an image tag with the correct url' do
-      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100, format: nil }).and_return('image_url')
+      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100 }).and_return('image_url')
       expect(helper).to receive(:image_tag).with('image_url', { width: 100, height: 100 }).and_return('image_tag')
       expect(helper.spree_image_tag(image, width: 100, height: 100)).to eq('image_tag')
     end

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -16,7 +16,7 @@ describe Spree::ImagesHelper, type: :helper do
 
   describe '#spree_image_tag' do
     it 'returns an image tag with the correct url' do
-      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100 }).and_return('image_url')
+      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100, format: nil }).and_return('image_url')
       expect(helper).to receive(:image_tag).with('image_url', { width: 100, height: 100 }).and_return('image_tag')
       expect(helper.spree_image_tag(image, width: 100, height: 100)).to eq('image_tag')
     end
@@ -62,6 +62,15 @@ describe Spree::ImagesHelper, type: :helper do
         expect(image).to receive(:variant).with(hash_including(resize_to_limit: [200, nil])).and_return(variant)
         expect(Rails.application.routes.url_helpers).to receive(:cdn_image_url).and_return('cdn_url')
         expect(helper.spree_image_url(image, width: 100)).to eq('cdn_url')
+      end
+    end
+
+    context 'when format is provided' do
+      it 'returns a url with the correct format' do
+        variant = double('variant')
+        expect(image).to receive(:variant).with(hash_including(resize_to_fill: [200, 200], format: :png)).and_return(variant)
+        expect(Rails.application.routes.url_helpers).to receive(:cdn_image_url).and_return('cdn_url')
+        expect(helper.spree_image_url(image, width: 100, height: 100, format: :png)).to eq('cdn_url')
       end
     end
   end

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -16,7 +16,7 @@ describe Spree::ImagesHelper, type: :helper do
 
   describe '#spree_image_tag' do
     it 'returns an image tag with the correct url' do
-      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100 }).and_return('image_url')
+      expect(helper).to receive(:spree_image_url).with(image, { width: 100, height: 100, format: nil }).and_return('image_url')
       expect(helper).to receive(:image_tag).with('image_url', { width: 100, height: 100 }).and_return('image_tag')
       expect(helper.spree_image_tag(image, width: 100, height: 100)).to eq('image_tag')
     end

--- a/emails/spec/helpers/spree/mail_helper_spec.rb
+++ b/emails/spec/helpers/spree/mail_helper_spec.rb
@@ -27,7 +27,7 @@ module Spree
         let(:image) { create(:image) }
 
         specify 'returns proper image path' do
-          expect(subject).to eq spree_image_url(image, width: 100, height: 100)
+          expect(subject).to eq spree_image_url(image, width: 100, height: 100, format: :png)
         end
       end
     end


### PR DESCRIPTION
Gmail has problem with `webp` format photos as they are using their proxy. We need to make our mailer to send variant images as `png`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying image formats (WebP or PNG) when generating image URLs, allowing for improved image optimization and compatibility.

* **Bug Fixes**
  * Ensured that email images are always generated in PNG format for consistent rendering across email clients.

* **Tests**
  * Updated and expanded tests to verify correct handling of image format options in image URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->