### PR TITLE
Fixed: brought back `track inventory` checkbox in variant form,

### DIFF
--- a/admin/app/views/spree/admin/variants/form/_inventory.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_inventory.html.erb
@@ -4,8 +4,18 @@
       <%= Spree.t(:inventory) %>
     </h5>
   </div>
-  <div class="card-body p-0">
-    <table class="table">
+  <div class="card-body p-0" data-controller="reveal" data-reveal-hidden-class="d-none">
+    <div class="custom-control custom-checkbox mb-4 m-3">
+      <%= f.check_box :track_inventory,
+            class: 'custom-control-input',
+            data: {
+              action: 'change->reveal#toggle'
+            }
+          %>
+      <%= f.label :track_inventory, Spree.t(:track_quantity), class: 'custom-control-label' %>
+    </div>
+
+    <table class="table <%= 'd-none' unless f.object.track_inventory? %>" data-reveal-target="item">
       <thead>
         <tr>
           <th><%= Spree.t(:stock_location) %></th>

--- a/admin/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -232,15 +232,16 @@ RSpec.describe Spree::Admin::VariantsController, type: :controller do
         {
           id: variant.id,
           product_id: product.slug,
-          variant: { track_inventory: false }
+          variant: { track_inventory: '0' }
         }
       end
 
       it 'sets the track inventory to false' do
+        expect(variant.track_inventory).to eq(true)
         put :update, params: variant_params
-        expect(variant.reload.track_inventory?).to eq(false)
+        variant.reload
+        expect(variant.track_inventory).to eq(false)
         expect(variant.stock_items.first.count_on_hand).to eq(0)
-        expect(variant.stock_items.first.backorderable).to eq(false)
       end
     end
   end

--- a/admin/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -226,6 +226,23 @@ RSpec.describe Spree::Admin::VariantsController, type: :controller do
         expect(variant.stock_items.last.backorderable).to eq(true)
       end
     end
+
+    context 'disabling track inventory' do
+      let(:variant_params) do
+        {
+          id: variant.id,
+          product_id: product.slug,
+          variant: { track_inventory: false }
+        }
+      end
+
+      it 'sets the track inventory to false' do
+        put :update, params: variant_params
+        expect(variant.reload.track_inventory?).to eq(false)
+        expect(variant.stock_items.first.count_on_hand).to eq(0)
+        expect(variant.stock_items.first.backorderable).to eq(false)
+      end
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -251,7 +251,7 @@ module Spree
       delegate method_name, :"#{method_name}=", to: :default_variant
     end
 
-    delegate :display_amount, :display_price, :has_default_price?,
+    delegate :display_amount, :display_price, :has_default_price?, :track_inventory?,
              :display_compare_at_price, :images, to: :default_variant
 
     delegate :name, to: :brand, prefix: true, allow_nil: true

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -74,7 +74,7 @@ module Spree
     after_create :set_master_out_of_stock, unless: :is_master?
     after_commit :clear_line_items_cache, on: :update
 
-    after_create :create_default_stock_item, unless: :track_inventory?
+    after_save :create_default_stock_item, unless: :track_inventory?
     after_update_commit :handle_track_inventory_change
 
     after_commit :remove_prices_from_master_variant, on: [:create, :update], unless: :is_master?

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -566,6 +566,18 @@ describe Spree::Product, type: :model do
         expect(product.variants.length).to eq(27)
       end
     end
+
+    context 'when track inventory is disabled' do
+      let(:product) { build(:product, track_inventory: false, stores: [store]) }
+
+      it 'creates a default stock item' do
+        product.save
+        expect(product.master.track_inventory?).to eq(false)
+        expect(product.master.stock_items.count).to eq(1)
+        expect(product.master.stock_items.first.count_on_hand).to eq(0)
+        expect(product.master.stock_items.first.backorderable).to eq(false)
+      end
+    end
   end
 
   describe '#images' do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -131,7 +131,7 @@ describe Spree::Variant, type: :model do
       end
     end
 
-    describe 'create_default_stock_item' do
+    describe '#create_default_stock_item' do
       let(:new_variant) { product.variants.create(track_inventory: track_inventory, is_master: true) }
 
       context 'when not tracking inventory' do
@@ -176,6 +176,19 @@ describe Spree::Variant, type: :model do
         it 'does not create a default stock item' do
           new_variant
           expect(new_variant.reload.stock_items.count).to eq(0)
+        end
+      end
+
+      context 'existing variant' do
+        let(:variant) { create(:variant, product: product, track_inventory: true) }
+
+        # clear out previous stock items
+        before do
+          variant.stock_items.delete_all
+        end
+
+        it 'creates a default stock item' do
+          expect { variant.update!(track_inventory: false) }.to change(variant.stock_items, :count).by(1)
         end
       end
     end

--- a/storefront/spec/features/checkout_steps_spec.rb
+++ b/storefront/spec/features/checkout_steps_spec.rb
@@ -378,6 +378,31 @@ describe 'Checkout steps (address and delivery)' do
         end
       end
     end
+
+    context 'when all items have track inventory disabled' do
+      before do
+        login_as(user, scope: :user)
+        order.variants.each do |variant|
+          variant.stock_items.delete_all
+        end
+        order.variants.each do |variant|
+          variant.update(track_inventory: false)
+        end
+      end
+
+      it 'still allows to checkout' do
+        visit "/checkout/#{order.token}"
+        choose "order_ship_address_id_#{user.shipping_address.id}"
+        click_on 'Save and Continue'
+
+        expect(page).to have_content('Delivery')
+        expect(page).to have_content(Spree::ShippingMethod.first.name)
+
+        page.find("input[data-cost='$10.00']").click
+
+        expect(page).to have_content('Payment')
+      end
+    end
   end
 
   describe 'payment step', js: true do


### PR DESCRIPTION
+ making sure we always have default stock item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option in the admin inventory form to toggle inventory tracking for variants, dynamically showing or hiding inventory details based on selection.

* **Bug Fixes**
  * Ensured that disabling inventory tracking resets stock quantities and backorder status appropriately for variants and products.

* **Tests**
  * Added comprehensive tests verifying behavior when inventory tracking is disabled, including variant updates, product creation, and checkout flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->