### PR TITLE
API: fixed Taxon's `header_url` to always use CDN when generating ima…

### DIFF
--- a/api/app/helpers/spree/api/v2/store_media_serializer_images_concern.rb
+++ b/api/app/helpers/spree/api/v2/store_media_serializer_images_concern.rb
@@ -9,7 +9,6 @@ module Spree
             attachment = store.send(attribute_name)
             return unless attachment.attached?
 
-            url_helpers = Rails.application.routes.url_helpers
             url_helpers.cdn_image_url(attachment)
           end
 

--- a/api/app/serializers/spree/api/v2/base_serializer.rb
+++ b/api/app/serializers/spree/api/v2/base_serializer.rb
@@ -33,6 +33,10 @@ module Spree
 
           super(opts, fieldset, include_list, params)
         end
+
+        def self.url_helpers
+          Rails.application.routes.url_helpers
+        end
       end
     end
   end

--- a/api/app/serializers/spree/api/v2/platform/digital_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/digital_serializer.rb
@@ -6,7 +6,6 @@ module Spree
           set_type :digital
 
           attribute :url do |digital|
-            url_helpers = Rails.application.routes.url_helpers
             url_helpers.polymorphic_url(digital.attachment, only_path: true)
           end
 

--- a/api/app/serializers/spree/api/v2/platform/taxon_serializer.rb
+++ b/api/app/serializers/spree/api/v2/platform/taxon_serializer.rb
@@ -12,7 +12,7 @@ module Spree
           end
 
           attribute :header_url do |taxon|
-            taxon.image.attachment&.url
+            url_helpers.cdn_image_url(taxon.image.attachment) if taxon.image.present? && taxon.image.attached?
           end
 
           attribute :is_root do |taxon|

--- a/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/taxon_serializer.rb
@@ -16,7 +16,7 @@ module Spree
         end
 
         attribute :header_url do |taxon|
-          taxon.image.attachment&.url
+          url_helpers.cdn_image_url(taxon.image.attachment) if taxon.image.present? && taxon.image.attached?
         end
 
         attribute :is_root do |taxon|

--- a/api/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
+++ b/api/spec/serializers/spree/v2/storefront/taxon_serializer_spec.rb
@@ -1,14 +1,18 @@
 require 'spec_helper'
 
-describe Spree::Api::V2::Platform::TaxonSerializer do
-  include_context 'API v2 serializers params'
+describe Spree::V2::Storefront::TaxonSerializer do
+  subject { described_class.new(taxon, params: serializer_params).serializable_hash }
 
-  subject { described_class.new(taxon.reload, params: serializer_params).serializable_hash }
+  include_context 'API v2 serializers params'
 
   let(:taxonomy) { create(:taxonomy, store: store) }
   let(:taxon) { create(:taxon, :with_description, taxonomy: taxonomy, products: create_list(:product, 2, stores: [store])) }
   let!(:children) { create_list(:taxon, 2, taxonomy: taxonomy, parent: taxon) }
   let(:url_helpers) { Rails.application.routes.url_helpers }
+
+  before do
+    taxon.reload # Reload taxon to ensure all associations are loaded
+  end
 
   context 'without products' do
     it do
@@ -18,29 +22,26 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
             id: taxon.id.to_s,
             type: :taxon,
             attributes: {
-              position: taxon.position,
               name: taxon.name,
+              pretty_name: taxon.pretty_name,
               permalink: taxon.permalink,
-              lft: taxon.lft,
-              rgt: taxon.rgt,
-              description: taxon.description.to_plain_text,
-              created_at: taxon.created_at,
-              updated_at: taxon.updated_at,
+              seo_title: taxon.seo_title,
               meta_title: taxon.meta_title,
               meta_description: taxon.meta_description,
               meta_keywords: taxon.meta_keywords,
+              left: taxon.left,
+              right: taxon.right,
+              position: taxon.position,
               depth: taxon.depth,
-              pretty_name: taxon.pretty_name,
-              seo_title: taxon.seo_title,
+              updated_at: taxon.updated_at,
+              public_metadata: {},
+              description: taxon.description.to_plain_text,
+              has_products: taxon.active_products_with_descendants.exists?,
+              header_url: nil,
               is_root: taxon.root?,
               is_child: taxon.child?,
               is_leaf: taxon.leaf?,
-              automatic: taxon.automatic?,
-              sort_order: taxon.sort_order,
-              rules_match_policy: taxon.rules_match_policy,
-              header_url: nil,
-              public_metadata: {},
-              private_metadata: {}
+              localized_slugs: taxon.localized_slugs_for_store(store)
             },
             relationships: {
               parent: {
@@ -55,12 +56,6 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
                   type: :taxonomy
                 }
               },
-              image: {
-                data: {
-                  id: taxon.icon.id.to_s,
-                  type: :taxon_image
-                }
-              },
               children: {
                 data: [
                   {
@@ -72,6 +67,12 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
                     type: :taxon
                   }
                 ]
+              },
+              image: {
+                data: {
+                  id: taxon.icon.id.to_s,
+                  type: :taxon_image
+                }
               }
             }
           }
@@ -92,29 +93,26 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
             id: taxon.id.to_s,
             type: :taxon,
             attributes: {
-              position: taxon.position,
               name: taxon.name,
+              pretty_name: taxon.pretty_name,
               permalink: taxon.permalink,
-              lft: taxon.lft,
-              rgt: taxon.rgt,
-              description: taxon.description.to_plain_text,
-              created_at: taxon.created_at,
-              updated_at: taxon.updated_at,
+              seo_title: taxon.seo_title,
               meta_title: taxon.meta_title,
               meta_description: taxon.meta_description,
               meta_keywords: taxon.meta_keywords,
+              left: taxon.left,
+              right: taxon.right,
+              position: taxon.position,
               depth: taxon.depth,
-              pretty_name: taxon.pretty_name,
-              seo_title: taxon.seo_title,
+              updated_at: taxon.updated_at,
+              public_metadata: {},
+              description: taxon.description.to_plain_text,
+              has_products: taxon.active_products_with_descendants.exists?,
+              header_url: nil,
               is_root: taxon.root?,
               is_child: taxon.child?,
               is_leaf: taxon.leaf?,
-              automatic: taxon.automatic?,
-              sort_order: taxon.sort_order,
-              rules_match_policy: taxon.rules_match_policy,
-              header_url: nil,
-              public_metadata: {},
-              private_metadata: {}
+              localized_slugs: taxon.localized_slugs_for_store(store)
             },
             relationships: {
               parent: {
@@ -129,11 +127,17 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
                   type: :taxonomy
                 }
               },
-              image: {
-                data: {
-                  id: taxon.icon.id.to_s,
-                  type: :taxon_image
-                }
+              children: {
+                data: contain_exactly(
+                  {
+                    id: taxon.children.first.id.to_s,
+                    type: :taxon
+                  },
+                  {
+                    id: taxon.children.second.id.to_s,
+                    type: :taxon
+                  }
+                )
               },
               products: {
                 data: [
@@ -147,17 +151,11 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
                   }
                 ]
               },
-              children: {
-                data: contain_exactly(
-                  {
-                    id: taxon.children.first.id.to_s,
-                    type: :taxon
-                  },
-                  {
-                    id: taxon.children.second.id.to_s,
-                    type: :taxon
-                  }
-                )
+              image: {
+                data: {
+                  id: taxon.icon.id.to_s,
+                  type: :taxon_image
+                }
               }
             }
           }
@@ -173,6 +171,4 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
       expect(subject[:data][:attributes][:header_url]).to eq(url_helpers.cdn_image_url(taxon.image.attachment))
     end
   end
-
-  it_behaves_like 'an ActiveJob serializable hash'
 end

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -9,6 +9,12 @@ FactoryBot.define do
     trait :with_description do
       description { '<div>Test <strong>description</strong></div>' }
     end
+
+    trait :with_header_image do
+      after(:create) do |taxon|
+        taxon.image.attach(io: File.new(Spree::Core::Engine.root.join('spec', 'fixtures', 'thinking-cat.jpg')), filename: 'thinking-cat.jpg')
+      end
+    end
   end
 
   factory :automatic_taxon, parent: :taxon do


### PR DESCRIPTION
…ge URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new test suite to verify serialization of taxons, including scenarios with header images and product relationships.
  * Introduced a factory trait to easily create taxons with header images for testing.

* **Bug Fixes**
  * Updated serialization logic to generate header image URLs using CDN helpers, ensuring more reliable and consistent URL generation for taxon images.

* **Tests**
  * Enhanced and expanded test coverage for taxon serializers, including explicit checks for header image URLs and various taxon relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->