### PR TITLE
Improve admin updater notification

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_buttons.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_buttons.scss
@@ -131,7 +131,7 @@ button[disabled]        .show-when-enabled { display: none; }
 
   &:hover {
     opacity: 0.8 !important;
-    background-color: $gray-100 !important;
+    background-color: $gray-50 !important;
   }
 }
 

--- a/admin/app/assets/stylesheets/spree/admin/components/_main.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_main.scss
@@ -281,10 +281,10 @@
   width: 100%;
   display: flex;
   flex-direction: row;
-  gap: 0.25rem;
-  justify-content: space-between;
+  gap: 1rem;
+  justify-content: flex-start;
   align-items: center;
-  padding: 0.25rem 0.5rem;
+  padding: 0.5rem 0.5rem;
   border: 1px solid $border-color;
   border-radius: $border-radius-lg;
   box-shadow: $box-shadow-xs;

--- a/admin/app/assets/stylesheets/spree/admin/components/_main.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_main.scss
@@ -276,6 +276,21 @@
   }
 }
 
+#updater-notice {
+  background-color: $white;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid $border-color;
+  border-radius: $border-radius-lg;
+  box-shadow: $box-shadow-xs;
+}
+
+
 .documentation-link-container {
   font-size: $font-size-sm;
   text-align: center;

--- a/admin/app/controllers/spree/admin/dashboard_controller.rb
+++ b/admin/app/controllers/spree/admin/dashboard_controller.rb
@@ -64,6 +64,12 @@ module Spree
         redirect_back(fallback_location: spree.admin_dashboard_path)
       end
 
+      # PATCH /admin/dashboard/dismiss_updater_notice
+      def dismiss_updater_notice
+        session[:spree_updater_notice_dismissed] = { value: true, expires_at: 7.days.from_now }
+        redirect_back(fallback_location: spree.admin_dashboard_path)
+      end
+
       private
 
       def load_vendor

--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -23,7 +23,8 @@ module Spree
       end
 
       def updater_notice_dismissed?
-        session[:spree_updater_notice_dismissed] && session[:spree_updater_notice_dismissed]['expires_at'].to_time <= Time.current
+        dismissal_data = session[:spree_updater_notice_dismissed]
+        dismissal_data.is_a?(Hash) && dismissal_data['expires_at'].to_time > Time.current
       end
 
       def show_spree_updater_notice?

--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -13,12 +13,21 @@ module Spree
         defined?(SpreeEnterprise)
       end
 
+      # @return [Spree::Admin::Updater] the spree updater
       def spree_updater
         @spree_updater ||= Spree::Admin::Updater
       end
 
       def spree_update_available?
         @spree_update_available ||= !Rails.env.test? && spree_updater.update_available?
+      end
+
+      def updater_notice_dismissed?
+        session[:spree_updater_notice_dismissed] && session[:spree_updater_notice_dismissed]['expires_at'].to_time <= Time.current
+      end
+
+      def show_spree_updater_notice?
+        Spree::Admin::RuntimeConfig.admin_updater_enabled && can?(:manage, current_store) && spree_update_available? && !updater_notice_dismissed?
       end
 
       # check if the current controller is a settings controller

--- a/admin/app/models/spree/admin/updater.rb
+++ b/admin/app/models/spree/admin/updater.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       def self.latest_version
-        @latest_version ||= fetch_updates.first&.dig('version')
+        @latest_version ||= fetch_updates.first
       end
 
       def self.fetch_updates

--- a/admin/app/models/spree/admin/updater.rb
+++ b/admin/app/models/spree/admin/updater.rb
@@ -5,7 +5,7 @@ require 'uri'
 module Spree
   module Admin
     class Updater
-      SPREE_CLOUD_UPDATES_URL = 'https://spreecloud.io/updates.json'
+      SPREE_CLOUD_UPDATES_URL = 'https://spreecloud.io/updates.json'.freeze
 
       @updates = nil
 
@@ -13,14 +13,18 @@ module Spree
         fetch_updates.any?
       end
 
-      def self.latest_version
-        @latest_version ||= fetch_updates.first
+      def self.latest_release
+        @latest_release ||= fetch_updates.first
+      end
+
+      def self.current_release
+        @current_release ||= Spree.version
       end
 
       def self.fetch_updates
-        @updates ||= Rails.cache.fetch("spree/admin/updater/fetch_updates/#{Spree.version}", expires_in: 1.day) do
+        @updates ||= Rails.cache.fetch("spree/admin/updater/fetch_updates/#{current_release}", expires_in: 1.day) do
           uri = URI(SPREE_CLOUD_UPDATES_URL)
-          params = { version: Spree.version, environment: Rails.env, url: Spree::Store.current.url_or_custom_domain }
+          params = { version: current_release, environment: Rails.env, url: Spree::Store.current.url_or_custom_domain }
           uri.query = URI.encode_www_form(params)
 
           http = Net::HTTP.new(uri.host, uri.port)

--- a/admin/app/views/spree/admin/dashboard/_updater.html.erb
+++ b/admin/app/views/spree/admin/dashboard/_updater.html.erb
@@ -1,9 +1,15 @@
-<% if Spree::Admin::RuntimeConfig.admin_updater_enabled && can?(:manage, current_store) && spree_update_available? %>
-  <div class="alert alert-info">
-    <div>
-      <p class="mb-1">There's a newer version of Spree available.</p>
+<% if Spree::Admin::RuntimeConfig.admin_updater_enabled && can?(:manage, current_store) && spree_update_available? && !session[:spree_updater_notice_dismissed] %>
+  <div id="updater-notice" class="mb-3">
+    <div class="d-flex align-items-center">
+      <%= image_tag 'favicon_256x256.png', alt: 'Spree', width: 32, height: 32 %>
+      <span class="ml-2">
+        <strong>Spree <%= spree_updater.latest_version['name'] %></strong> is available.
+      </span>
+    </div>
 
-      <%= link_to_with_icon 'settings-up', 'Update now', 'https://spreecommerce.org/docs/developer/upgrades', target: '_blank', class: 'btn btn-light btn-sm' %>
+    <div class="d-flex align-items-center gap-1">
+      <%= link_to_with_icon 'settings-up', 'Update now', spree_updater.latest_version['url'], target: '_blank', class: 'btn btn-light btn-sm' %>
+      <%= link_to '', spree.admin_dismiss_updater_notice_path, data: { turbo_method: :patch }, class: 'btn-close' %>
     </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/dashboard/_updater.html.erb
+++ b/admin/app/views/spree/admin/dashboard/_updater.html.erb
@@ -1,15 +1,19 @@
-<% if Spree::Admin::RuntimeConfig.admin_updater_enabled && can?(:manage, current_store) && spree_update_available? && !session[:spree_updater_notice_dismissed] %>
+<% if show_spree_updater_notice? %>
   <div id="updater-notice" class="mb-3">
-    <div class="d-flex align-items-center">
-      <%= image_tag 'favicon_256x256.png', alt: 'Spree', width: 32, height: 32 %>
-      <span class="ml-2">
-        <strong>Spree <%= spree_updater.latest_version['name'] %></strong> is available.
-      </span>
+    <%= image_tag 'favicon_256x256.png', alt: 'Spree', width: 32, height: 32 %>
+    <div class="d-flex flex-column">
+      <p class="mb-1">
+        <strong>Spree <%= spree_updater.latest_release['name'] %></strong> is available.
+        <br />Your current version is <strong>Spree <%= spree_updater.current_release %></strong>. 
+      </p>
+
+      <% if spree_updater.latest_release['url'] %>
+        <div>
+          <%= external_link_to "View release notes", spree_updater.latest_release['url'], target: '_blank', class: 'btn btn-sm btn-link' %>
+        </div>
+      <% end %>
     </div>
 
-    <div class="d-flex align-items-center gap-1">
-      <%= link_to_with_icon 'settings-up', 'Update now', spree_updater.latest_version['url'], target: '_blank', class: 'btn btn-light btn-sm' %>
-      <%= link_to '', spree.admin_dismiss_updater_notice_path, data: { turbo_method: :patch }, class: 'btn-close' %>
-    </div>
+    <%= link_to '', spree.admin_dismiss_updater_notice_path, data: { turbo_method: :patch }, class: 'btn-close ml-auto' %>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/shared/sidebar/_enterprise_edition_notice.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_enterprise_edition_notice.html.erb
@@ -2,7 +2,7 @@
   <% unless session[:spree_enterprise_edition_notice_dismissed] %>
     <section class="d-none d-lg-block">
       <div id="enterprise-edition-notice">
-        <%= link_to '', spree.admin_dismiss_enterprise_edition_notice_path, method: :patch, class: 'btn-close' %>
+        <%= link_to '', spree.admin_dismiss_enterprise_edition_notice_path, data: { turbo_method: :patch }, class: 'btn-close' %>
         <p>You're using Spree Community Edition. To get access to all features, please upgrade to Enterprise Edition.</p>
 
         <%= external_link_to 'Upgrade', 'https://spreecommerce.org/pricing', target: '_blank', class: 'btn btn-link btn-sm shadow-xs' %>

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -249,7 +249,8 @@ Spree::Core::Engine.add_routes do
     resource :dashboard, controller: 'dashboard'
     get '/dashboard/analytics', to: 'dashboard#analytics', as: :dashboard_analytics
     get '/getting-started', to: 'dashboard#getting_started', as: :getting_started
-    get '/dismiss_enterprise_edition_notice', to: 'dashboard#dismiss_enterprise_edition_notice', as: :dismiss_enterprise_edition_notice
+    patch '/dismiss_enterprise_edition_notice', to: 'dashboard#dismiss_enterprise_edition_notice', as: :dismiss_enterprise_edition_notice
+    patch '/dismiss_updater_notice', to: 'dashboard#dismiss_updater_notice', as: :dismiss_updater_notice
 
     root to: 'dashboard#show'
   end

--- a/admin/spec/controllers/spree/admin/dashboard_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/dashboard_controller_spec.rb
@@ -59,7 +59,10 @@ describe Spree::Admin::DashboardController, type: :controller do
     it 'dismisses the updater notice' do
       patch :dismiss_updater_notice
       expect(response).to redirect_to(spree.admin_dashboard_path)
-      expect(session[:spree_updater_notice_dismissed]).to be_truthy
+      expect(session[:spree_updater_notice_dismissed]).to include(
+        value: true,
+        expires_at: be_within(1.second).of(7.days.from_now)
+      )
     end
   end
 end

--- a/admin/spec/controllers/spree/admin/dashboard_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/dashboard_controller_spec.rb
@@ -54,4 +54,12 @@ describe Spree::Admin::DashboardController, type: :controller do
       expect(session[:spree_enterprise_edition_notice_dismissed]).to be_truthy
     end
   end
+
+  describe '#dismiss_updater_notice' do
+    it 'dismisses the updater notice' do
+      patch :dismiss_updater_notice
+      expect(response).to redirect_to(spree.admin_dashboard_path)
+      expect(session[:spree_updater_notice_dismissed]).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an updater notice to the admin dashboard, displaying the latest release name, logo, and a dynamic release notes link.
  * Introduced the ability to dismiss the updater notice, which will remain hidden for 7 days once dismissed.

* **Improvements**
  * Enhanced the visual styling of the updater notice and close button for a cleaner, more user-friendly appearance.
  * Updated the dismissal of the enterprise edition notice to use a PATCH request for improved consistency.
  * Refined updater notice visibility logic to better control when it is shown.

* **Bug Fixes**
  * Adjusted the close button hover color to improve visual clarity.

* **Tests**
  * Added tests to verify the updater notice dismissal functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->