### PR TITLE
Fix datepicker handling

### DIFF
--- a/admin/app/controllers/spree/admin/reports_controller.rb
+++ b/admin/app/controllers/spree/admin/reports_controller.rb
@@ -31,7 +31,10 @@ module Spree
       end
 
       def build_resource
-        model_class.new(store: current_store, date_from: params[:date_from], date_to: params[:date_to], currency: params[:currency])
+        model_class.new(store: current_store,
+                        date_from: parse_date_param(params[:date_from]),
+                        date_to: parse_date_param(params[:date_to])&.end_of_day,
+                        currency: params[:currency])
       end
 
       def model_class
@@ -55,7 +58,16 @@ module Spree
       end
 
       def permitted_resource_params
-        params.require(:report).permit(permitted_report_attributes)
+        attributes = params.require(:report).permit(permitted_report_attributes)
+        attributes[:date_from] = parse_date_param(attributes[:date_from]) if attributes[:date_from].present?
+        attributes[:date_to] = parse_date_param(attributes[:date_to])&.end_of_day if attributes[:date_to].present?
+        attributes
+      end
+
+      def parse_date_param(date_string)
+        return if date_string.blank?
+
+        date_string.to_date&.in_time_zone(current_timezone)
       end
     end
   end

--- a/admin/app/helpers/spree/admin/orders_filters_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_filters_helper.rb
@@ -14,7 +14,8 @@ module Spree
 
         if search_params[:created_at_gt].present?
           search_params[:created_at_gt] = begin
-                                            Time.parse(search_params[:created_at_gt]).beginning_of_day
+                                            date = Time.parse(search_params[:created_at_gt]).to_date.to_s
+                                            Time.zone.parse(date).beginning_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -22,7 +23,8 @@ module Spree
 
         if search_params[:created_at_lt].present?
           search_params[:created_at_lt] = begin
-                                            Time.parse(search_params[:created_at_lt]).end_of_day
+                                            date = Time.parse(search_params[:created_at_lt]).to_date.to_s
+                                            Time.zone.parse(date).end_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -30,7 +32,8 @@ module Spree
 
         if search_params[:completed_at_gt].present?
           search_params[:completed_at_gt] = begin
-                                            Time.parse(search_params[:completed_at_gt]).beginning_of_day
+                                            date = Time.parse(search_params[:completed_at_gt]).to_date.to_s
+                                            Time.zone.parse(date).beginning_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -38,7 +41,8 @@ module Spree
 
         if search_params[:completed_at_lt].present?
           search_params[:completed_at_lt] = begin
-                                            Time.parse(search_params[:completed_at_lt]).end_of_day
+                                            date = Time.parse(search_params[:completed_at_lt]).to_date.to_s
+                                            Time.zone.parse(date).end_of_day
                                           rescue StandardError
                                             ''
                                           end

--- a/admin/app/helpers/spree/admin/orders_filters_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_filters_helper.rb
@@ -15,8 +15,7 @@ module Spree
         if search_params[:created_at_gt].present?
           search_params[:created_at_gt] = begin
                                             # Firstly we parse to date to avoid issues with timezones because frontend sends time in local timezone
-                                            date = Time.parse(search_params[:created_at_gt]).to_date.to_s
-                                            Time.zone.parse(date).beginning_of_day
+                                            search_params[:created_at_gt].to_date&.in_time_zone(current_timezone)
                                           rescue StandardError
                                             ''
                                           end
@@ -24,8 +23,7 @@ module Spree
 
         if search_params[:created_at_lt].present?
           search_params[:created_at_lt] = begin
-                                            date = Time.parse(search_params[:created_at_lt]).to_date.to_s
-                                            Time.zone.parse(date).end_of_day
+                                            search_params[:created_at_lt].to_date&.in_time_zone(current_timezone)&.end_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -33,8 +31,7 @@ module Spree
 
         if search_params[:completed_at_gt].present?
           search_params[:completed_at_gt] = begin
-                                            date = Time.parse(search_params[:completed_at_gt]).to_date.to_s
-                                            Time.zone.parse(date).beginning_of_day
+                                            search_params[:completed_at_gt].to_date&.in_time_zone(current_timezone)
                                           rescue StandardError
                                             ''
                                           end
@@ -42,8 +39,7 @@ module Spree
 
         if search_params[:completed_at_lt].present?
           search_params[:completed_at_lt] = begin
-                                            date = Time.parse(search_params[:completed_at_lt]).to_date.to_s
-                                            Time.zone.parse(date).end_of_day
+                                            search_params[:completed_at_lt].to_date&.in_time_zone(current_timezone)&.end_of_day
                                           rescue StandardError
                                             ''
                                           end

--- a/admin/app/helpers/spree/admin/orders_filters_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_filters_helper.rb
@@ -14,6 +14,7 @@ module Spree
 
         if search_params[:created_at_gt].present?
           search_params[:created_at_gt] = begin
+                                            # Firstly we parse to date to avoid issues with timezones because frontend sends time in local timezone
                                             date = Time.parse(search_params[:created_at_gt]).to_date.to_s
                                             Time.zone.parse(date).beginning_of_day
                                           rescue StandardError

--- a/admin/app/helpers/spree/admin/orders_filters_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_filters_helper.rb
@@ -14,7 +14,7 @@ module Spree
 
         if search_params[:created_at_gt].present?
           search_params[:created_at_gt] = begin
-                                            Time.zone.parse(search_params[:created_at_gt]).beginning_of_day
+                                            Time.parse(search_params[:created_at_gt]).beginning_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -22,7 +22,7 @@ module Spree
 
         if search_params[:created_at_lt].present?
           search_params[:created_at_lt] = begin
-                                            Time.zone.parse(search_params[:created_at_lt]).end_of_day
+                                            Time.parse(search_params[:created_at_lt]).end_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -30,7 +30,7 @@ module Spree
 
         if search_params[:completed_at_gt].present?
           search_params[:completed_at_gt] = begin
-                                            Time.zone.parse(search_params[:completed_at_gt]).beginning_of_day
+                                            Time.parse(search_params[:completed_at_gt]).beginning_of_day
                                           rescue StandardError
                                             ''
                                           end
@@ -38,7 +38,7 @@ module Spree
 
         if search_params[:completed_at_lt].present?
           search_params[:completed_at_lt] = begin
-                                            Time.zone.parse(search_params[:completed_at_lt]).end_of_day
+                                            Time.parse(search_params[:completed_at_lt]).end_of_day
                                           rescue StandardError
                                             ''
                                           end

--- a/admin/app/views/spree/admin/dashboard/show.html.erb
+++ b/admin/app/views/spree/admin/dashboard/show.html.erb
@@ -15,8 +15,8 @@
       <%= form_tag spree.admin_dashboard_analytics_path, method: :get, data: { turbo_frame: :analytics } do %>
         <%= hidden_field_tag :vendor_id, @vendor.id if @vendor.present? %>
         <%= render 'spree/admin/shared/calendar_range_picker',
-          date_from_value: params[:date_from] || 1.month.ago.beginning_of_month,
-          date_to_value: params[:date_to] || 1.month.ago.end_of_month,
+          date_from_value: params[:date_from] || 1.month.ago.end_of_day,
+          date_to_value: params[:date_to] || Time.zone.now.beginning_of_day,
           css_classes: "btn btn-sm border rounded-lg hover-light d-inline-flex align-items-center h-100 dropdown-toggle" %>
       <% end %>
     </div>

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
           expect(assigns(:orders).to_a).to contain_exactly(order1, order2)
         end
       end
+
+      context 'filtering in different timezones' do
+        let(:date_from) { 'Tue Jul 08 2025 00:00:00 GMT+0200 (czas środkowoeuropejski letni)' }
+        let(:date_to) { 'Tue Jul 09 2025 00:00:00 GMT+0200 (czas środkowoeuropejski letni)' }
+
+        let(:q) { { completed_at_gt: date_from, completed_at_lt: date_to } }
+
+        before do
+          order1.update(completed_at: date_from.to_date.in_time_zone(store.preferred_timezone) + 1.minute)
+          order2.update(completed_at: date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day - 1.minute)
+        end
+
+        it 'filters by orders completed_at in the store timezone' do
+          subject
+          expect(assigns(:orders).to_a).to contain_exactly(order1, order2)
+        end
+      end
     end
   end
 

--- a/admin/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -40,6 +40,33 @@ describe Spree::Admin::ReportsController, type: :controller do
         expect { subject }.to raise_error('Unknown report type')
       end
     end
+
+    context 'when dates are provided' do
+      subject { get :new, params: { type: 'sales_total', date_from: date_from, date_to: date_to } }
+
+      let(:date_from) { 'Tue Jul 08 2025 00:00:00 GMT+0200 (czas środkowoeuropejski letni)' }
+      let(:date_to) { 'Tue Jul 09 2025 00:00:00 GMT+0200 (czas środkowoeuropejski letni)' }
+
+      it 'sets the dates in the store timezone' do
+        subject
+        expect(assigns(:object).date_from).to eq(date_from.to_date.in_time_zone(store.preferred_timezone))
+        expect(assigns(:object).date_to).to eq(date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day)
+      end
+    end
+
+    context 'when no dates are provided' do
+      subject { get :new, params: { type: 'sales_total' } }
+
+      before { Timecop.freeze(Time.current) }
+
+      after { Timecop.return }
+
+      it 'sets default values' do
+        subject
+        expect(assigns(:object).date_from).to eq(1.month.ago.in_time_zone(store.preferred_timezone).beginning_of_day)
+        expect(assigns(:object).date_to).to eq(Time.current.in_time_zone(store.preferred_timezone).end_of_day)
+      end
+    end
   end
 
   describe '#create' do
@@ -71,6 +98,40 @@ describe Spree::Admin::ReportsController, type: :controller do
     it 'sets success flash message' do
       subject
       expect(flash[:success]).to eq Spree.t('admin.report_created')
+    end
+
+    context 'when dates with different timezones are provided' do
+      let(:date_from) { 'Tue Jul 08 2025 00:00:00 GMT+0200 (czas środkowoeuropejski letni)' }
+      let(:date_to) { 'Tue Jul 09 2025 00:00:00 GMT+0200 (czas środkowoeuropejski letni)' }
+
+      let(:report_params) do
+        {
+          type: 'sales_total',
+          date_from: date_from,
+          date_to: date_to,
+          currency: 'USD'
+        }
+      end
+
+      it 'sets the dates in the store timezone' do
+        subject
+        expect(assigns(:object).date_from).to eq(date_from.to_date.in_time_zone(store.preferred_timezone))
+        expect(assigns(:object).date_to).to eq(date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day)
+      end
+    end
+
+    context 'when no dates are provided' do
+      let(:report_params) { { type: 'sales_total', currency: 'USD' } }
+
+      before { Timecop.freeze(Time.current) }
+
+      after { Timecop.return }
+
+      it 'sets default values' do
+        subject
+        expect(assigns(:object).date_from).to eq(1.month.ago.in_time_zone(store.preferred_timezone).beginning_of_day)
+        expect(assigns(:object).date_to).to eq(Time.current.in_time_zone(store.preferred_timezone).end_of_day)
+      end
     end
   end
 end

--- a/admin/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       it 'sets the dates in the store timezone' do
         subject
         expect(assigns(:object).date_from).to eq(date_from.to_date.in_time_zone(store.preferred_timezone))
-        expect(assigns(:object).date_to).to eq(date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day)
+        expect(assigns(:object).date_to.change(usec: 0)).to eq(date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day.change(usec: 0))
       end
     end
 
@@ -64,7 +64,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       it 'sets default values' do
         subject
         expect(assigns(:object).date_from).to eq(1.month.ago.in_time_zone(store.preferred_timezone).beginning_of_day)
-        expect(assigns(:object).date_to).to eq(Time.current.in_time_zone(store.preferred_timezone).end_of_day)
+        expect(assigns(:object).date_to.change(usec: 0)).to eq(Time.current.in_time_zone(store.preferred_timezone).end_of_day.change(usec: 0))
       end
     end
   end
@@ -116,7 +116,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       it 'sets the dates in the store timezone' do
         subject
         expect(assigns(:object).date_from).to eq(date_from.to_date.in_time_zone(store.preferred_timezone))
-        expect(assigns(:object).date_to).to eq(date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day)
+        expect(assigns(:object).date_to.change(usec: 0)).to eq(date_to.to_date.in_time_zone(store.preferred_timezone).end_of_day.change(usec: 0))
       end
     end
 
@@ -130,7 +130,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       it 'sets default values' do
         subject
         expect(assigns(:object).date_from).to eq(1.month.ago.in_time_zone(store.preferred_timezone).beginning_of_day)
-        expect(assigns(:object).date_to).to eq(Time.current.in_time_zone(store.preferred_timezone).end_of_day)
+        expect(assigns(:object).date_to.change(usec: 0)).to eq(Time.current.in_time_zone(store.preferred_timezone).end_of_day.change(usec: 0))
       end
     end
   end


### PR DESCRIPTION
This fixes problem where date picker sends local timezone and for different store preferred timezone it gets results for wrong day. 

<img width="609" alt="Zrzut ekranu 2025-07-9 o 15 18 24" src="https://github.com/user-attachments/assets/1b5f080a-3aef-408a-b538-a54e118662e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of date and time filters in order searches to ensure correct timezone interpretation and more accurate filtering results.
  * Enhanced date range processing in reports and dashboard to provide consistent timezone-aware defaults and parameter parsing.
* **Tests**
  * Added tests verifying correct timezone-aware filtering and default date range behavior in orders and reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->