### PR TITLE
Include all Spree controller helpers in `DeviseConcern`

### DIFF
--- a/storefront/app/controllers/concerns/spree/storefront/devise_concern.rb
+++ b/storefront/app/controllers/concerns/spree/storefront/devise_concern.rb
@@ -10,7 +10,13 @@ module Spree
         helper_method :stored_location
         layout 'spree/storefront'
 
+        include Spree::Core::ControllerHelpers::Auth
+        include Spree::Core::ControllerHelpers::Store
         include Spree::Core::ControllerHelpers::Order
+        include Spree::Core::ControllerHelpers::StrongParameters
+        include Spree::Core::ControllerHelpers::Locale
+        include Spree::Core::ControllerHelpers::Currency
+        include Spree::Core::ControllerHelpers::Turbo
         include Spree::LocaleUrls
         include Spree::ThemeConcern
         include Spree::IntegrationsHelper if defined?(Spree::IntegrationsHelper)


### PR DESCRIPTION
If someone doesn't use `Spree::BaseController` as Devise base_controller this will fix all the issues and allow that scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced shared controller functionality to improve authentication, store context, localization, currency handling, parameter management, and Turbo support within the storefront. No visible changes to user interface or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->