### PR TITLE
fix: Pages can not be edit after theme was published

### DIFF
--- a/admin/app/views/spree/admin/pages/index.html.erb
+++ b/admin/app/views/spree/admin/pages/index.html.erb
@@ -19,7 +19,8 @@
           </tr>
         </thead>
         <tbody>
-          <%= render collection: @collection, partial: "spree/admin/pages/page", cached: spree_base_cache_scope %>
+          <% default_theme = current_store.default_theme %>
+          <%= render collection: @collection, partial: "spree/admin/pages/page", cached: ->(page) { [*spree_base_cache_scope.call(page), default_theme] } %>
         </tbody>
       </table>
       <%= render "spree/admin/shared/index_table_options", collection: @collection %>


### PR DESCRIPTION
The custom page can not be edited after I published the default theme without editing custom pages.

The root cause is that the custom page is not updated after default theme was published.

please check the issue https://github.com/spree/spree/issues/12941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved caching behavior on the admin pages list to ensure content updates appropriately when the store's default theme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->