### PR TITLE
Add method to calculate total item quantity in shipment

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -223,7 +223,7 @@ module Spree
 
     # Returns the total quantity of all line items in the shipment
     def item_quantity
-      manifest.map { |m| m.line_item.quantity }.sum
+      manifest.sum(&:quantity)
     end
 
     # Returns the cost of the shipment

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -221,6 +221,11 @@ module Spree
       inventory_units.where(line_item_id: line_item.id, variant_id: line_item.variant_id || variant.id)
     end
 
+    # Returns the total quantity of all line items in the shipment
+    def item_quantity
+      manifest.map { |m| m.line_item.quantity }.sum
+    end
+
     # Returns the cost of the shipment
     #
     # @return [BigDecimal]


### PR DESCRIPTION
# Summary
This PR adds a new instance method item_quantity to the Spree::Shipment model. The method calculates the total quantity of items across all line items in a shipment.
We need this value to integrate with our courier system, which requires the total number of items in a shipment for packaging and logistics purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to view the total quantity of items in a shipment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->