### PR TITLE
Fix custom_domain to accept composed TLDs e.g: .com.br

### DIFF
--- a/core/app/models/spree/custom_domain.rb
+++ b/core/app/models/spree/custom_domain.rb
@@ -29,7 +29,7 @@ module Spree
       return if url.blank?
       parts = url.split('.')
 
-      errors.add(:url, 'use domain or subdomain') if (parts[0] != 'www' && parts.size > 3) || (parts[0] == 'www' && parts.size > 4) || parts.size < 2
+      errors.add(:url, 'use domain or subdomain') if parts.size > 4 || parts.size < 2
     end
 
     def ensure_default

--- a/core/spec/models/spree/custom_domain_spec.rb
+++ b/core/spec/models/spree/custom_domain_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Spree::CustomDomain, type: :model do
         expect(build(:custom_domain, url: 'shop.custom.domain')).to be_valid
       end
 
+      it 'is valid with composed tlds' do
+        expect(build(:custom_domain, url: 'shop.domain.com.br')).to be_valid
+      end
+
       it 'is invalid with wrong number of parts' do
         expect(build(:custom_domain, url: 'com')).not_to be_valid
       end


### PR DESCRIPTION
Small change [here](https://github.com/spree/spree/blob/main/core/app/models/spree/custom_domain.rb#L32C43-L33C8) at `Spree::CustomDomain`  to accept composed TLDs like `.com.br` for example.

I assumed that this is an expected approach based on that the error message says "subdomain" and not only "domain"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation logic to support custom domains with composed top-level domains (e.g., .com.br).

* **Tests**
  * Added a test to ensure domains with composed TLDs are recognized as valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->