### PR TITLE
Use Custom Domains in `spree_emails` when generating URLs to Storefront

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -40,7 +40,7 @@ module Spree
     # http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
     def ensure_default_action_mailer_url_host(store_url = nil)
       ActionMailer::Base.default_url_options ||= {}
-      ActionMailer::Base.default_url_options[:host] ||= store_url.presence || current_store.url
+      ActionMailer::Base.default_url_options[:host] ||= store_url.presence || current_store.url_or_custom_domain
     end
 
     def set_email_locale

--- a/emails/app/mailers/spree/order_mailer.rb
+++ b/emails/app/mailers/spree/order_mailer.rb
@@ -5,14 +5,14 @@ module Spree
       current_store = @order.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
     end
 
     def store_owner_notification_email(order)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       current_store = @order.store
       subject = Spree.t('order_mailer.store_owner_notification_email.subject', store_name: current_store.name)
-      mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.url, reply_to: reply_to_address)
+      mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
     end
 
     def cancel_email(order, resend = false)
@@ -20,7 +20,7 @@ module Spree
       current_store = @order.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
     end
 
     def payment_link_email(order_id)

--- a/emails/app/mailers/spree/reimbursement_mailer.rb
+++ b/emails/app/mailers/spree/reimbursement_mailer.rb
@@ -6,7 +6,7 @@ module Spree
       current_store = @reimbursement.store || Spree::Store.default
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
     end
   end
 end

--- a/emails/app/mailers/spree/shipment_mailer.rb
+++ b/emails/app/mailers/spree/shipment_mailer.rb
@@ -8,7 +8,7 @@ module Spree
       current_store = @shipment.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
     end
   end
 end

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -35,10 +35,6 @@ describe Spree::OrderMailer, type: :mailer do
     order
   end
 
-  before do
-    ActionMailer::Base.default_url_options = {}
-  end
-
   context ':from not set explicitly' do
     it 'uses store mail from address' do
       message = described_class.confirm_email(order)

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -271,6 +271,18 @@ describe Spree::OrderMailer, type: :mailer do
       described_class.confirm_email(second_order).deliver_now
       expect(ActionMailer::Base.default_url_options[:host]).to eq(second_order.store.url)
     end
+
+    context 'with custom domain' do
+      let!(:custom_domain) { create(:custom_domain, store: store, url: 'custom.example.com') }
+
+      it 'uses custom domain for URLs in emails' do
+        email = described_class.confirm_email(order).deliver_now
+        expect(ActionMailer::Base.default_url_options[:host]).to eq('custom.example.com')
+        # testing HTML body
+        expect(email.body.parts.last.body).to include('custom.example.com')
+        expect(email.body.parts.last.body).not_to include(store.url)
+      end
+    end
   end
 
   describe '#payment_link_email' do

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -35,6 +35,10 @@ describe Spree::OrderMailer, type: :mailer do
     order
   end
 
+  before do
+    ActionMailer::Base.default_url_options = {}
+  end
+
   context ':from not set explicitly' do
     it 'uses store mail from address' do
       message = described_class.confirm_email(order)
@@ -261,13 +265,11 @@ describe Spree::OrderMailer, type: :mailer do
 
   context 'emails contain only urls of the store where the order was made' do
     it 'shows proper host url in email content' do
-      ActionMailer::Base.default_url_options[:host] = order.store.url
       described_class.confirm_email(order).deliver_now
       expect(ActionMailer::Base.default_url_options[:host]).to eq(order.store.url)
     end
 
     it 'shows proper host url in email content #2' do
-      ActionMailer::Base.default_url_options[:host] = second_order.store.url
       described_class.confirm_email(second_order).deliver_now
       expect(ActionMailer::Base.default_url_options[:host]).to eq(second_order.store.url)
     end

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -273,13 +273,13 @@ describe Spree::OrderMailer, type: :mailer do
     end
 
     context 'with custom domain' do
-      let!(:custom_domain) { create(:custom_domain, store: store, url: 'custom.example.com') }
+      let!(:custom_domain) { create(:custom_domain, store: store, url: 'my-store.com') }
 
       it 'uses custom domain for URLs in emails' do
         email = described_class.confirm_email(order).deliver_now
-        expect(ActionMailer::Base.default_url_options[:host]).to eq('custom.example.com')
+        expect(ActionMailer::Base.default_url_options[:host]).to eq('my-store.com')
         # testing HTML body
-        expect(email.body.parts.last.body).to include('custom.example.com')
+        expect(email.body.parts.last.body).to include('my-store.com')
         expect(email.body.parts.last.body).not_to include(store.url)
       end
     end

--- a/emails/spec/mailers/spree/reimbursement_mailer_spec.rb
+++ b/emails/spec/mailers/spree/reimbursement_mailer_spec.rb
@@ -74,12 +74,4 @@ describe Spree::ReimbursementMailer, type: :mailer do
       end
     end
   end
-
-  context 'emails contain only urls of the store where the order was made' do
-    it 'shows proper host url in email content' do
-      ActionMailer::Base.default_url_options[:host] = reimbursement.order.store.url
-      described_class.reimbursement_email(reimbursement).deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq(reimbursement.order.store.url)
-    end
-  end
 end

--- a/emails/spec/mailers/spree/shipment_mailer_spec.rb
+++ b/emails/spec/mailers/spree/shipment_mailer_spec.rb
@@ -83,12 +83,4 @@ describe Spree::ShipmentMailer, type: :mailer do
       expect(shipped_email).to have_body_text("Dear #{order.name}")
     end
   end
-
-  context 'emails contain only urls of the store where the order was made' do
-    it 'shows proper host url in email content' do
-      ActionMailer::Base.default_url_options[:host] = store.url
-      described_class.shipped_email(shipment).deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq(shipment.order.store.url)
-    end
-  end
 end

--- a/emails/spec/mailers/spree/test_mailer_spec.rb
+++ b/emails/spec/mailers/spree/test_mailer_spec.rb
@@ -19,18 +19,4 @@ describe Spree::TestMailer, type: :mailer do
       Spree::TestMailer.test_email('test@example.com')
     end.not_to raise_error
   end
-
-  context 'action mailer host' do
-    it 'falls back to spree store url' do
-      ActionMailer::Base.default_url_options = {}
-      Spree::TestMailer.test_email('test@example.com').deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq(@default_store.url)
-    end
-
-    it 'uses developer set host' do
-      ActionMailer::Base.default_url_options[:host] = 'test.test'
-      Spree::TestMailer.test_email('test@example.com').deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq('test.test')
-    end
-  end
 end

--- a/emails/spec/spec_helper.rb
+++ b/emails/spec/spec_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
     Spree::Webhooks.disabled = true
     reset_spree_preferences
     I18n.locale = :en
+    ActionMailer::Base.default_url_options = {}
   end
 
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emails now use a custom domain for store URLs when available, improving branding and consistency in email communications.

* **Tests**
  * Added tests to verify that emails correctly use the custom domain in URLs when a store has one configured.
  * Removed outdated tests related to default URL host settings to streamline test coverage.
  * Improved test setup by resetting mailer URL options before each test to prevent cross-test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->