### PR TITLE
Override emails host so it always matches the store which sent the email

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -39,8 +39,12 @@ module Spree
     # this is only a fail-safe solution if developer didn't set this in environment files
     # http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
     def ensure_default_action_mailer_url_host(store_url = nil)
+      host_url = store_url.presence || current_store.try(:url_or_custom_domain)
+
+      return if host_url.blank?
+
       ActionMailer::Base.default_url_options ||= {}
-      ActionMailer::Base.default_url_options[:host] ||= store_url.presence || current_store.url_or_custom_domain
+      ActionMailer::Base.default_url_options[:host] = host_url
     end
 
     def set_email_locale

--- a/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -261,6 +261,7 @@ describe Spree::OrderMailer, type: :mailer do
 
   context 'emails contain only urls of the store where the order was made' do
     it 'shows proper host url in email content' do
+      ActionMailer::Base.default_url_options = { host: 'localhost' }
       described_class.confirm_email(order).deliver_now
       expect(ActionMailer::Base.default_url_options[:host]).to eq(order.store.url)
     end


### PR DESCRIPTION
This will fix email url issues in multi-store/multi-tenant environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of email host URLs to ensure emails consistently use the correct store URL.
* **Tests**
  * Updated tests to explicitly set and verify the default host URL in email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->