### PR TITLE
Admin: Improve list pagination user experience

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_tables.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_tables.scss
@@ -207,7 +207,30 @@ td.actions {
 }
 
 .pagination-container {
-  border-top: 1px solid $gray-50;
+  border-top: 1px solid $table-border-color;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
+
+  position: sticky;
+  bottom: 0;
+  background-color: $card-bg;
+  z-index: 100;
+  border-bottom-left-radius: $border-radius-lg;
+  border-bottom-right-radius: $border-radius-lg;
+
+  .page-link {
+    @extend .btn;
+    @extend .btn-sm;
+    @extend .btn-light;
+    @extend .ml-1;
+    @extend .p-2;
+  
+    .ti {
+      @extend .mr-0;
+    }
+  }
+  .page-item.disabled {
+    cursor: not-allowed;
+    opacity: 0.2;
+  }
 }

--- a/admin/app/helpers/spree/admin/navigation_helper.rb
+++ b/admin/app/helpers/spree/admin/navigation_helper.rb
@@ -41,7 +41,7 @@ module Spree
           button_tag(raw(selected_option), class: 'btn btn-light btn-sm', data: { toggle: 'dropdown', expanded: false }) +
             content_tag(:div, class: 'dropdown-menu') do
               per_page_options.map do |option|
-                link_to option, per_page_dropdown_params(option), class: "dropdown-item #{'active' if option == selected_option}"
+                link_to option, per_page_dropdown_params(option), class: "dropdown-item #{'active' if option.to_i == selected_option.to_i}"
               end.join.html_safe
             end
         end

--- a/admin/app/views/kaminari/admin-twitter-bootstrap-4/_first_page.html.erb
+++ b/admin/app/views/kaminari/admin-twitter-bootstrap-4/_first_page.html.erb
@@ -6,8 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 
-<% unless current_page.first? %>
-  <li class="first page-item">
-    <%= link_to_unless current_page.first?, icon('double-chevron-left', class: 'mb-0'), url, remote: remote, class: 'page-link', 'aria-label': 'First page' %>
-  </li>
-<% end %>
+<li class="first page-item <%= current_page.first? ? 'disabled' : '' %>">
+  <%= link_to icon('double-chevron-left', class: 'text-dark'), url, remote: remote, class: 'page-link', 'aria-label': 'First page' %>
+</li>

--- a/admin/app/views/kaminari/admin-twitter-bootstrap-4/_last_page.html.erb
+++ b/admin/app/views/kaminari/admin-twitter-bootstrap-4/_last_page.html.erb
@@ -6,8 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 
-<% unless current_page.last? %>
-  <li class="last next page-item"><%# "next" class present for border styling in twitter bootstrap %>
-    <%= link_to_unless current_page.last?, icon('double-chevron-right', class: 'mb-0'), url, remote: remote, class: 'page-link', 'aria-label': 'Last page' %>
-  </li>
-<% end %>
+<li class="last next page-item <%= current_page.last? ? 'disabled' : '' %>">
+  <%= link_to icon('double-chevron-right', class: 'text-dark'), url, remote: remote, class: 'page-link', 'aria-label': 'Last page' %>
+</li>

--- a/admin/app/views/kaminari/admin-twitter-bootstrap-4/_next_page.html.erb
+++ b/admin/app/views/kaminari/admin-twitter-bootstrap-4/_next_page.html.erb
@@ -6,8 +6,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 
-<% unless current_page.last? %>
-  <li class="next_page page-item">
-    <%= link_to_unless current_page.last?, icon('chevron-right', class: 'text-dark'), url, rel: 'next', remote: remote, class: 'page-link', 'aria-label': 'Next page' %>
-  </li>
-<% end %>
+<li class="next page-item <%= current_page.last? ? 'disabled' : '' %>">
+  <%= link_to icon('chevron-right', class: 'text-dark'), url, rel: 'next', remote: remote, class: 'page-link', 'aria-label': 'Next page' %>
+</li>
+

--- a/admin/app/views/kaminari/admin-twitter-bootstrap-4/_paginator.html.erb
+++ b/admin/app/views/kaminari/admin-twitter-bootstrap-4/_paginator.html.erb
@@ -12,6 +12,6 @@
   <ul class="pagination d-inline-flex <%= pagination_class %> mb-0">
 
     <%= prev_page_tag %>
-    <%= next_page_tag unless current_page.last? %>
+    <%= next_page_tag %>
   </ul>
 <% end %>

--- a/admin/app/views/kaminari/admin-twitter-bootstrap-4/_prev_page.html.erb
+++ b/admin/app/views/kaminari/admin-twitter-bootstrap-4/_prev_page.html.erb
@@ -6,8 +6,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 
-<% unless current_page.first? %>
-  <li class="prev page-item">
-    <%= link_to_unless current_page.first?, icon('chevron-left', class: 'text-dark'), url, rel: 'prev', remote: remote, class: 'page-link', 'aria-label': 'Previous page' %>
-  </li>
-<% end %>
+<li class="prev page-item <%= current_page.first? ? 'disabled' : '' %>">
+  <%= link_to icon('chevron-left', class: 'text-dark'), url, rel: 'prev', remote: remote, class: 'page-link', 'aria-label': 'Previous page' %>
+</li>
+


### PR DESCRIPTION
* always show (disabled or not) next/prev buttons
* make the bottom pagination sticky to quickly paginate
* mark which per page option in the dropdown is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance and positioning of pagination controls, including sticky positioning, updated colors, rounded corners, and enhanced button styles.

* **Bug Fixes**
  * Corrected the active state highlighting in the per-page selection menu to ensure consistent behavior regardless of data type.

* **New Features**
  * Pagination controls ("First", "Previous", "Next", "Last") are now always visible, with disabled states indicated visually instead of being hidden or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->