### PR TITLE
Fix | add missing :uk svg country icon.

### DIFF
--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -72,8 +72,8 @@ module Spree
         'uk' => 'ua'
       }
 
-      normilized_code = country_code.to_s.downcase
-      final_country_code = language_to_country.fetch(normilized_code, normilized_code)
+      normalized_code = country_code.to_s.downcase
+      final_country_code = language_to_country.fetch(normalized_code, normalized_code)
 
       tag.span(class: "fi fi-#{final_country_code}")
     end

--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -66,9 +66,16 @@ module Spree
     end
 
     def svg_country_icon(country_code)
-      country_code = :us if country_code.to_s.downcase == 'en'
-      country_code = :jp if country_code.to_s.downcase == 'ja'
-      tag.span(class: "fi fi-#{country_code.downcase}")
+      language_to_country = {
+        'en' => 'us',
+        'ja' => 'jp',
+        'uk' => 'ua'
+      }
+
+      normilized_code = country_code.to_s.downcase
+      final_country_code = language_to_country.fetch(normilized_code, normilized_code)
+
+      tag.span(class: "fi fi-#{final_country_code}")
     end
 
     def show_account_pane?

--- a/storefront/spec/helpers/spree/storefront_helper_spec.rb
+++ b/storefront/spec/helpers/spree/storefront_helper_spec.rb
@@ -95,4 +95,22 @@ describe Spree::StorefrontHelper, type: :helper do
       end
     end
   end
+
+  describe '#svg_country_icon' do
+    it 'returns correct flag class for uk language code' do
+      expect(svg_country_icon(['uk', :uk].sample)).to include('fi fi-ua')
+    end
+
+    it 'returns correct flag class for en language code' do
+      expect(svg_country_icon(['en', :en].sample)).to include('fi fi-us')
+    end
+
+    it 'returns correct flag class for ja language code' do
+      expect(svg_country_icon(['ja', :ja].sample)).to include('fi fi-jp')
+    end
+
+    it 'returns correct flag class for unknown language code' do
+      expect(svg_country_icon('fr')).to include('fi fi-fr')
+    end
+  end
 end


### PR DESCRIPTION
refactor #svg_country_icon helper method to return :uk 🇺🇦 svg country icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying the Ukrainian flag icon when the language code 'uk' is used.

* **Bug Fixes**
  * Improved handling of language-to-country flag mapping for more accurate flag display.

* **Tests**
  * Added new tests to verify correct flag icon rendering for various language codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->