### PR TITLE
Feature(admin): Add payment state filter to orders page

### DIFF
--- a/admin/app/helpers/spree/admin/orders_filters_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_filters_helper.rb
@@ -14,39 +14,48 @@ module Spree
 
         if search_params[:created_at_gt].present?
           search_params[:created_at_gt] = begin
-                                            # Firstly we parse to date to avoid issues with timezones because frontend sends time in local timezone
-                                            search_params[:created_at_gt].to_date&.in_time_zone(current_timezone)
-                                          rescue StandardError
-                                            ''
-                                          end
+            # Firstly we parse to date to avoid issues with timezones because frontend sends time in local timezone
+            search_params[:created_at_gt].to_date&.in_time_zone(current_timezone)
+          rescue StandardError
+            ''
+          end
         end
 
         if search_params[:created_at_lt].present?
           search_params[:created_at_lt] = begin
-                                            search_params[:created_at_lt].to_date&.in_time_zone(current_timezone)&.end_of_day
-                                          rescue StandardError
-                                            ''
-                                          end
+            search_params[:created_at_lt].to_date&.in_time_zone(current_timezone)&.end_of_day
+          rescue StandardError
+            ''
+          end
         end
 
         if search_params[:completed_at_gt].present?
           search_params[:completed_at_gt] = begin
-                                            search_params[:completed_at_gt].to_date&.in_time_zone(current_timezone)
-                                          rescue StandardError
-                                            ''
-                                          end
+            search_params[:completed_at_gt].to_date&.in_time_zone(current_timezone)
+          rescue StandardError
+            ''
+          end
         end
 
         if search_params[:completed_at_lt].present?
           search_params[:completed_at_lt] = begin
-                                            search_params[:completed_at_lt].to_date&.in_time_zone(current_timezone)&.end_of_day
-                                          rescue StandardError
-                                            ''
-                                          end
+            search_params[:completed_at_lt].to_date&.in_time_zone(current_timezone)&.end_of_day
+          rescue StandardError
+            ''
+          end
         end
 
         search_params[:vendor_orders_vendor_id_eq] = vendor.id if vendor.present?
         search_params[:user_id_eq] = user.id if user.present?
+
+        # Handle refunded and partially_refunded payment state filters
+        if search_params[:payment_state_eq] == 'refunded'
+          search_params[:refunded] = '1'
+          search_params.delete(:payment_state_eq)
+        elsif search_params[:payment_state_eq] == 'partially_refunded'
+          search_params[:partially_refunded] = '1'
+          search_params.delete(:payment_state_eq)
+        end
 
         search_params
       end

--- a/admin/app/views/spree/admin/orders/_filters.html.erb
+++ b/admin/app/views/spree/admin/orders/_filters.html.erb
@@ -95,8 +95,13 @@
       <div class="col-12 col-lg-4">
         <div class="form-group">
           <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
+          <% payment_state_options = Spree::Order::PAYMENT_STATES.map { |state| [Spree.t("payment_states.#{state}"), state] } %>
+          <% payment_state_options += [
+               [Spree.t('payment_states.refunded'), 'refunded'],
+               [Spree.t('payment_states.partially_refunded'), 'partially_refunded']
+             ] %>
           <%= f.select :payment_state_eq,
-                       Spree::Order::PAYMENT_STATES.map { |state| [Spree.t("payment_states.#{state}"), state] },
+                       payment_state_options,
                        { include_blank: true },
                        { class: "custom-select", data: { filters_target: :input } } %>
         </div>

--- a/admin/app/views/spree/admin/orders/_filters.html.erb
+++ b/admin/app/views/spree/admin/orders/_filters.html.erb
@@ -42,10 +42,7 @@
     <%= render 'spree/admin/shared/filters_button' %>
   </div>
   <div data-dropdown-target="menu" id="table-filter">
-    <%= f.hidden_field :payment_state_eq, value: params.dig(:q, :payment_state_eq) %>
     <%= f.hidden_field :payment_state_not_eq, value: params.dig(:q, :payment_state_not_eq) %>
-    <%= f.hidden_field :refunded, value: params.dig(:q, :refunded) %>
-    <%= f.hidden_field :partially_refunded, value: params.dig(:q, :partially_refunded) %>
     <%= f.hidden_field :state_not_eq, value: params.dig(:q, :state_not_eq) %>
     <%= f.hidden_field :user_id_eq, value: @user.try(:id) %>
 
@@ -78,34 +75,18 @@
                 filters_target: :input,
               } %>
     </div>
-      <div class="col-12 col-lg-4">
-        <div class="form-group">
-          <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
-          <%= f.select :promotions_id_in,
-                   Spree::Promotion.applied.pluck(:name, :id),
-                   { include_blank: true },
-                   data: {
-                     controller: "autocomplete-select",
-                     filters_target: :input,
-                   } %>
-        </div>
-      </div>
-
-      <!-- Payment State filter -->
-      <div class="col-12 col-lg-4">
-        <div class="form-group">
-          <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
-          <% payment_state_options = Spree::Order::PAYMENT_STATES.map { |state| [Spree.t("payment_states.#{state}"), state] } %>
-          <% payment_state_options += [
-               [Spree.t('payment_states.refunded'), 'refunded'],
-               [Spree.t('payment_states.partially_refunded'), 'partially_refunded']
-             ] %>
-          <%= f.select :payment_state_eq,
-                       payment_state_options,
-                       { include_blank: true },
-                       { class: "custom-select", data: { filters_target: :input } } %>
-        </div>
-      </div>
+    <div class="form-group">
+      <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
+      <% payment_state_options = Spree::Order::PAYMENT_STATES.map { |state| [Spree.t("payment_states.#{state}"), state] } %>
+      <% payment_state_options += [
+            [Spree.t('payment_states.refunded'), 'refunded'],
+            [Spree.t('payment_states.partially_refunded'), 'partially_refunded']
+          ] %>
+      <%= f.select :payment_state_eq,
+                    payment_state_options,
+                    { include_blank: true },
+                    { class: "custom-select", data: { filters_target: :input } } %>
+    </div>
 
     <%= render_admin_partials(:orders_filters_partials, f: f) %>
     <%= render 'spree/admin/shared/filter_submit' %>

--- a/admin/app/views/spree/admin/orders/_filters.html.erb
+++ b/admin/app/views/spree/admin/orders/_filters.html.erb
@@ -78,6 +78,29 @@
                 filters_target: :input,
               } %>
     </div>
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_promotions_id_in, Spree.t(:promotion) %>
+          <%= f.select :promotions_id_in,
+                   Spree::Promotion.applied.pluck(:name, :id),
+                   { include_blank: true },
+                   data: {
+                     controller: "autocomplete-select",
+                     filters_target: :input,
+                   } %>
+        </div>
+      </div>
+
+      <!-- Payment State filter -->
+      <div class="col-12 col-lg-4">
+        <div class="form-group">
+          <%= label_tag :q_payment_state_eq, Spree.t(:payment_state) %>
+          <%= f.select :payment_state_eq,
+                       Spree::Order::PAYMENT_STATES.map { |state| [Spree.t("payment_states.#{state}"), state] },
+                       { include_blank: true },
+                       { class: "custom-select", data: { filters_target: :input } } %>
+        </div>
+      </div>
 
     <%= render_admin_partials(:orders_filters_partials, f: f) %>
     <%= render 'spree/admin/shared/filter_submit' %>

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -48,40 +48,52 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       expect(assigns(:orders).to_a).to include(shipped_order)
     end
 
-    it "returns all fulfilled orders" do
+    it 'returns all fulfilled orders' do
       get :index, params: { q: { shipment_state_eq: :shipped } }
 
       expect(assigns(:orders).to_a).to eq([shipped_order])
     end
 
-    it "returns all cancelled orders" do
+    it 'returns all cancelled orders' do
       get :index, params: { q: { state_eq: :canceled } }
 
       expect(assigns(:orders).to_a).to eq([cancelled_order])
     end
 
-    it "returns all refunded orders" do
+    it 'returns all refunded orders' do
       get :index, params: { q: { refunded: '1' } }
 
       expect(assigns(:orders).to_a).to eq([shipped_order])
     end
 
-    it "returns all partially refunded orders" do
+    it 'returns all partially refunded orders' do
       get :index, params: { q: { partially_refunded: '1' } }
 
       expect(assigns(:orders).to_a).to eq([order])
     end
 
-    it "returns all paid orders" do
+    it 'returns all paid orders' do
       get :index, params: { q: { payment_state_eq: :paid } }
 
-      expect(assigns(:orders).to_a).to match_array([paid_order, cancelled_order])
+      expect(assigns(:orders).to_a).to contain_exactly(paid_order, cancelled_order)
     end
 
-    it "returns all orders with balance due" do
+    it 'returns all orders with balance due' do
       get :index, params: { q: { payment_state_eq: :balance_due } }
 
-      expect(assigns(:orders).to_a).to match_array([order, shipped_order])
+      expect(assigns(:orders).to_a).to contain_exactly(order, shipped_order)
+    end
+
+    it 'returns all refunded orders via payment_state filter' do
+      get :index, params: { q: { payment_state_eq: :refunded } }
+
+      expect(assigns(:orders).to_a).to eq([shipped_order])
+    end
+
+    it 'returns all partially refunded orders via payment_state filter' do
+      get :index, params: { q: { payment_state_eq: :partially_refunded } }
+
+      expect(assigns(:orders).to_a).to eq([order])
     end
 
     context 'filtering by date' do
@@ -210,7 +222,7 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
     context 'for a completed order' do
       let!(:order) { create(:order_ready_to_ship, with_payment: true, store: store) }
 
-      it "won't delete a completed order" do
+      it 'does not delete a completed order' do
         expect { subject }.not_to change(Spree::Order, :count)
 
         expect(flash[:error]).to eq Spree.t(:authorization_failure)
@@ -224,7 +236,7 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       it 'deletes an order' do
         expect { subject }.to change(Spree::Order, :count).by(-1)
 
-        expect(flash[:success]).to eq "Order has been successfully removed!"
+        expect(flash[:success]).to eq 'Order has been successfully removed!'
         expect(response).to redirect_to spree.admin_checkouts_path
       end
     end

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -75,7 +75,13 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
     it 'returns all paid orders' do
       get :index, params: { q: { payment_state_eq: :paid } }
 
-      expect(assigns(:orders).to_a).to contain_exactly(paid_order, cancelled_order)
+      expect(assigns(:orders).to_a).to contain_exactly(paid_order)
+    end
+
+    it 'returns all cancelled orders' do
+      get :index, params: { q: { payment_state_eq: :credit_owed } }
+
+      expect(assigns(:orders).to_a).to contain_exactly(cancelled_order)
     end
 
     it 'returns all orders with balance due' do

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -24,18 +24,33 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
   end
 
   describe '#index' do
+    # Helper method to ensure payment states are correctly calculated after refunds
+    # This is necessary because refunds affect payment_total calculation:
+    # payment_total = payments.amount - refunds.amount
+    def update_payment_state_after_refund(order)
+      order.updater.update_payment_total
+      order.updater.update_payment_state
+      order.save!
+      order
+    end
+
     let!(:shipped_order) { create(:shipped_order, with_payment: false, total: 100, store: store) }
     let!(:order) { create(:completed_order_with_totals, line_items_count: 2, total: 100, store: store) }
-    let(:line_item) { order.line_items.first }
-    let!(:cancelled_order) { create(:completed_order_with_totals, state: 'canceled', total: 100, store: store) }
+    let!(:cancelled_order) do
+      order = create(:completed_order_with_totals, state: 'canceled', total: 100, store: store)
+      create(:payment, state: 'completed', amount: order.total, order: order)
+      update_payment_state_after_refund(order)
+    end
     let!(:payment) { create(:payment, state: 'completed', amount: shipped_order.total, order: shipped_order) }
-    let!(:cancelled_order_payment) { create(:payment, state: 'completed', amount: cancelled_order.total, order: cancelled_order) }
-    let!(:refund) { create(:refund, payment: payment, amount: payment.amount) }
+    let!(:refund) do
+      create(:refund, payment: payment, amount: payment.amount)
+      update_payment_state_after_refund(shipped_order)
+    end
     let!(:payment_one) { create(:payment, state: 'completed', amount: order.total, order: order) }
-    let!(:partial_refund) { create(:refund, payment: payment_one, amount: (payment_one.amount - 10)) }
-
-    # Additional fixture for payment_state filter specs
-    let!(:paid_order) { create(:order_ready_to_ship, store: store) }
+    let!(:partial_refund) do
+      create(:refund, payment: payment_one, amount: (payment_one.amount - 10))
+      update_payment_state_after_refund(order)
+    end
 
     it 'renders index' do
       get :index
@@ -54,7 +69,7 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       expect(assigns(:orders).to_a).to eq([shipped_order])
     end
 
-    it 'returns all cancelled orders' do
+    it 'returns all cancelled orders by shipment state' do
       get :index, params: { q: { state_eq: :canceled } }
 
       expect(assigns(:orders).to_a).to eq([cancelled_order])
@@ -72,34 +87,42 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       expect(assigns(:orders).to_a).to eq([order])
     end
 
-    it 'returns all paid orders' do
-      get :index, params: { q: { payment_state_eq: :paid } }
+    context 'filtering by payment state' do
+      let!(:balance_due_order) do
+        order = create(:completed_order_with_totals, line_items_count: 2, total: 100, store: store)
+        update_payment_state_after_refund(order)
+      end
+      let!(:paid_order) { create(:shipped_order, store: store) }
 
-      expect(assigns(:orders).to_a).to contain_exactly(paid_order)
-    end
+      it 'returns all paid orders' do
+        get :index, params: { q: { payment_state_eq: :paid } }
 
-    it 'returns all cancelled orders' do
-      get :index, params: { q: { payment_state_eq: :credit_owed } }
+        expect(assigns(:orders).to_a).to contain_exactly(paid_order)
+      end
 
-      expect(assigns(:orders).to_a).to contain_exactly(cancelled_order)
-    end
+      it 'returns all orders with credit owed' do
+        get :index, params: { q: { payment_state_eq: :credit_owed } }
 
-    it 'returns all orders with balance due' do
-      get :index, params: { q: { payment_state_eq: :balance_due } }
+        expect(assigns(:orders).to_a).to contain_exactly(cancelled_order)
+      end
+  
+      it 'returns all orders with balance due' do
+        get :index, params: { q: { payment_state_eq: :balance_due } }
 
-      expect(assigns(:orders).to_a).to contain_exactly(order, shipped_order)
-    end
+        expect(assigns(:orders).to_a).to contain_exactly(balance_due_order, order, shipped_order)
+      end
 
-    it 'returns all refunded orders via payment_state filter' do
-      get :index, params: { q: { payment_state_eq: :refunded } }
+      it 'returns all refunded orders via payment_state filter' do
+        get :index, params: { q: { payment_state_eq: :refunded } }
 
-      expect(assigns(:orders).to_a).to eq([shipped_order])
-    end
+        expect(assigns(:orders).to_a).to eq([shipped_order])
+      end
 
-    it 'returns all partially refunded orders via payment_state filter' do
-      get :index, params: { q: { payment_state_eq: :partially_refunded } }
+      it 'returns all partially refunded orders via payment_state filter' do
+        get :index, params: { q: { payment_state_eq: :partially_refunded } }
 
-      expect(assigns(:orders).to_a).to eq([order])
+        expect(assigns(:orders).to_a).to eq([order])
+      end
     end
 
     context 'filtering by date' do


### PR DESCRIPTION
### Description
This pull request introduces a new filter on the Admin Orders page, allowing administrators to filter orders by their Payment State (e.g., Paid, Balance Due, Credit Owed).

Currently, store admins lack an efficient way to isolate orders based on payment status, which makes tasks like chasing unpaid orders or generating financial reports more difficult. This feature provides that crucial filtering capability directly on the main orders index.

### Changes Made
- Added a new select dropdown for payment_state to the Admin Orders search partial (spree/admin/orders/_filters.html.erb).
- The filter utilizes the payment_state_eq Ransack predicate to filter the results.
- Added a feature spec to cover the new filter's functionality, ensuring it displays and correctly filters the order list.

### Visual Changes
**Before:**
The filters section did not include an option for Payment State.
<img width="1618" height="689" alt="Screenshot 2025-07-18 at 4 51 39 PM" src="https://github.com/user-attachments/assets/7e63444c-d918-4953-92f7-9475df1a6799" />


**After:**
The new "Payment State" dropdown is now available in the filters section.

https://github.com/user-attachments/assets/4c708d0e-7b1e-4c2b-97d5-e3ebb929e909
<img width="1546" height="722" alt="Screenshot 2025-07-18 at 5 31 44 PM" src="https://github.com/user-attachments/assets/018b4b24-8070-46d2-aaed-06af59713f29" />


### How to Test
- Check out this branch.
- Run the application and navigate to the Admin panel.
- Go to Orders.
- Use the new "Payment State" dropdown to select a status (e.g., 'Paid').
- Verify that the list of orders updates to show only orders with the selected payment state.
- Test with other payment states to confirm functionality.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a visible dropdown filter for payment state on the orders page, including "refunded" and "partially_refunded" options.

* **Bug Fixes**
  * Enhanced filtering logic to correctly handle and display orders with "refunded" and "partially_refunded" payment states.

* **Tests**
  * Added tests to verify accurate filtering of orders by all payment state options, including the new states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->