### PR TITLE
Skip propshaft for sandbox app/dummy generator

### DIFF
--- a/bin/sandbox.sh
+++ b/bin/sandbox.sh
@@ -33,6 +33,7 @@ bundle exec rails new sandbox --database="$RAILSDB" \
   --skip-keeps \
   --skip-rc \
   --skip-test \
+  --skip-asset-pipeline
 
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -38,6 +38,7 @@ module Spree
       opts[:skip_spring] = true
       opts[:skip_test] = true
       opts[:skip_bootsnap] = true
+      opts[:skip_asset_pipeline] = true # skip installing propshaft, we're still using sprockets as a dependency
 
       puts 'Generating dummy Rails application...'
       invoke Rails::Generators::AppGenerator,


### PR DESCRIPTION
We're still using sprockets and using both sprockets and propshaft doesn't work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sandbox and test dummy app generation to skip installing the default asset pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->