### PR TITLE
Admin: don't throw an error when trying to render pagination when col…

### DIFF
--- a/admin/app/views/spree/admin/shared/_index_table_options.html.erb
+++ b/admin/app/views/spree/admin/shared/_index_table_options.html.erb
@@ -5,7 +5,7 @@
   <% args[:action] = per_page_action %>
 <% end %>
 
-<% if collection.any? %>
+<% if collection.any? && collection.respond_to?(:current_page) %>
   <div class="pagination-container">
     <div class="index-pagination-row d-flex align-items-center">
       <div class="col-6 col-lg-3">


### PR DESCRIPTION
…lection isn't paginated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination display logic to ensure the pagination UI only appears when the collection supports pagination, preventing unnecessary or incorrect pagination controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->