### PR TITLE
Fixed missing translation in invitation email

### DIFF
--- a/admin/app/views/spree/admin/invitations/show.html.erb
+++ b/admin/app/views/spree/admin/invitations/show.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex align-items-center gap-2">
+<div class="d-flex align-items-center gap-2 mb-4">
   <div>
     <%= render_avatar(@invitation.inviter, height: 32, width: 32) %>
   </div>
@@ -6,4 +6,4 @@
     <strong><%= @invitation.inviter.name %></strong> has invited you to join <strong><%= @invitation.resource.name %></strong>
   </div>
 </div>
-<%= link_to Spree.t(:accept), spree.accept_admin_invitation_path(@invitation), class: 'btn btn-primary w-100', data: { turbo_method: :put } %>
+<%= link_to Spree.t(:accept), spree.accept_admin_invitation_path(@invitation), class: 'btn btn-primary mx-auto px-5', data: { turbo_method: :put } %>

--- a/core/app/views/spree/invitation_mailer/invitation_email.html.erb
+++ b/core/app/views/spree/invitation_mailer/invitation_email.html.erb
@@ -10,7 +10,7 @@
 
 <% if spree.respond_to?(:admin_invitation_url) %>
   <p>
-    <%= link_to Spree.t('invitation_mailer.invitation_email.link_text'), spree.admin_invitation_url(@invitation, token: @invitation.token, host: @invitation.store.formatted_url) %>
+    <%= link_to Spree.t(:accept), spree.admin_invitation_url(@invitation, token: @invitation.token, host: @invitation.store.formatted_url) %>
   </p>
 <% end %>
 

--- a/core/spec/mailers/spree/invitation_mailer_spec.rb
+++ b/core/spec/mailers/spree/invitation_mailer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Spree::InvitationMailer, type: :mailer do
     end
 
     it 'includes the invitation link in the body' do
+      expect(mail.body.encoded).to include(Spree.t(:accept))
       expect(mail.body.encoded).to include("http://test.com/admin/invitations/#{invitation.id}?token=#{invitation.token}")
     end
   end


### PR DESCRIPTION
Plus improve the invitation view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment for the invitation view and accept button in the admin interface.

* **Documentation**
  * Updated the invitation email to use a more concise link text for accepting invitations.

* **Tests**
  * Enhanced email tests to verify the presence of the updated link text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->