### PR TITLE
Improve Custom Domains / Internal URL UI

### DIFF
--- a/admin/app/controllers/spree/admin/custom_domains_controller.rb
+++ b/admin/app/controllers/spree/admin/custom_domains_controller.rb
@@ -9,10 +9,6 @@ module Spree
         spree.admin_custom_domains_path
       end
 
-      def create_turbo_stream_enabled?
-        helpers.entri_enabled?
-      end
-
       def location_after_save
         spree.admin_custom_domains_path
       end

--- a/admin/app/helpers/spree/admin/custom_domains_helper.rb
+++ b/admin/app/helpers/spree/admin/custom_domains_helper.rb
@@ -1,9 +1,0 @@
-module Spree
-  module Admin
-    module CustomDomainsHelper
-      def entri_enabled?
-        false
-      end
-    end
-  end
-end

--- a/admin/app/views/spree/admin/custom_domains/_custom_domain.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_custom_domain.html.erb
@@ -4,10 +4,8 @@
     <%= active_badge(custom_domain.active?) %>
   </td>
 
-  <% unless entri_enabled? %>
-    <td><%= active_badge(custom_domain.default?) %></td>
-    <td class="actions">
-      <%= link_to_edit(custom_domain, no_text: true, url: spree.edit_admin_custom_domain_path(custom_domain), data: { turbo: false }) %>
-    </td>
-  <% end %>
+  <td><%= active_badge(custom_domain.default?) %></td>
+  <td class="actions">
+    <%= link_to_edit(custom_domain, no_text: true, url: spree.edit_admin_custom_domain_path(custom_domain), data: { turbo: false }) %>
+  </td>
 </tr>

--- a/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
@@ -4,12 +4,9 @@
       <thead>
         <tr>
           <th><%= Spree.t(:name) %></th>
-          <th>Active?</th>
-
-          <% unless entri_enabled? %>
-            <th>Default</th>
-            <th></th>
-          <% end %>
+          <th><%= Spree.t(:active) %>?</th>
+          <th><%= Spree.t(:default) %>?</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -18,7 +15,5 @@
     </table>
   </div>
 <% else %>
-  <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center">
-    You don't have any custom domains set yet.
-  </div>
+  <%= render 'spree/admin/shared/no_resource_found' %>
 <% end %>

--- a/admin/app/views/spree/admin/custom_domains/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/custom_domains/create.turbo_stream.erb
@@ -1,3 +1,0 @@
-<%= turbo_stream.replace('admin_custom_domains_index') do %>
-  <%= render partial: 'custom_domains' %>
-<% end %>

--- a/admin/app/views/spree/admin/custom_domains/index.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/index.html.erb
@@ -6,42 +6,56 @@
   <%= render_admin_partials(:custom_domains_actions_partials) %>
 <% end %>
 
+<%= render_admin_partials(:custom_domains_header_partials) %>
+
 <div class="card-lg p-4">
   <h5 class="mb-3">Internal URL</h5>
   <div class="row mb-4">
     <div class="col-lg-4">
       <p class="text-muted">
-        This is your internal URL.
+        This is your internal Admin URL.
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
-      <%= form_for current_store, url: spree.admin_store_path(current_store), data: { turbo: false, controller: 'enable-button', 'enable-button-disable-when-not-changed-value': true } do |f| %>
-        <div class="form-control d-flex align-items-center py-0 focus-shadow focus-border mb-3 <% if current_store.custom_domains.any? %>disabled<% end %>">
-          <%= f.text_field :code, class: 'form-control-plaintext pl-0',  data: { enable_button_target: 'input' }, required: true, disabled: current_store.custom_domains.any? %>
-          <span>.<%= Spree.root_domain %></span>
-        </div>
-        <% unless current_store.custom_domains.any? %>
-          <%= turbo_save_button_tag Spree.t('actions.update') %>
+      <%= form_for current_store, url: spree.admin_store_path, data: { turbo: false, controller: 'enable-button', 'enable-button-disable-when-not-changed-value': true } do |f| %>
+        <% if Spree.root_domain.present? %>
+          <div class="d-flex align-items-center gap-3">
+            <div class="form-control d-flex align-items-center py-0 focus-shadow focus-border pr-2 gap-1 <% if current_store.custom_domains.any? %>disabled<% end %>">
+              <span class="text-muted">https://</span>
+              <%= f.text_field :code, class: 'form-control-plaintext pl-0', data: { enable_button_target: 'input' }, required: true, disabled: current_store.custom_domains.any? %>
+              <span>.<%= Spree.root_domain %></span>
+
+              <%= clipboard_component(current_store.formatted_url) %>
+            </div>
+            <% unless current_store.custom_domains.any? %>
+              <%= turbo_save_button_tag %>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="d-flex align-items-center gap-3">
+            <div class="form-control d-flex align-items-center py-0 focus-shadow focus-border pr-2 gap-1">
+              <span class="text-muted">https://</span>
+              <%= f.text_field :url, class: 'form-control-plaintext pl-0', required: true, data: { enable_button_target: 'input' } %>
+              <%= clipboard_component(current_store.formatted_url) %>
+            </div>
+            <%= turbo_save_button_tag %>
+          </div>
         <% end %>
       <% end %>
     </div>
   </div>
   <hr class="my-5" />
-  <h5>Custom domains</h5>
+  <h5><%= Spree.t(:custom_domains) %></h5>
   <div class="row">
     <div class="col-lg-4">
       <p class="text-muted">
-        Connect your domain or subdomain to your store.
+        Connect your domain or subdomain to your storefront.
       </p>
     </div>
     <div class="col-lg-7 offset-lg-1">
-      <% if entri_enabled? %>
-        <%= render 'setup_domain_entri' %>
-      <% else %>
-        <div class="text-right">
-          <%= link_to Spree.t(:new_domain), spree.new_admin_custom_domain_path, class: "btn btn-primary" %>
-        </div>
-      <% end %>
+      <div class="text-right">
+        <%= link_to Spree.t(:new_domain), spree.new_admin_custom_domain_path, class: "btn btn-primary" %>
+      </div>
 
       <%= turbo_frame_tag 'admin_custom_domains_index' do %>
         <%= render 'custom_domains' %>

--- a/admin/app/views/spree/admin/shared/_new_item_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/_new_item_dropdown.html.erb
@@ -21,7 +21,7 @@
 
     <%= invite_vendor_button(class: 'dropdown-item') if defined?(invite_vendor_button) %>
 
-    <% if can?(:create, Spree::Store) %>
+    <% if can?(:create, Spree::Store) && Spree.root_domain.present? %>
       <div class="dropdown-divider"></div>
 
       <span data-toggle="modal" data-target="#modal-lg">

--- a/admin/spec/controllers/spree/admin/custom_domains_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/custom_domains_controller_spec.rb
@@ -7,6 +7,26 @@ describe Spree::Admin::CustomDomainsController, type: :controller do
 
   let(:store) { Spree::Store.default }
 
+  describe '#index' do
+    subject { get :index, format: :html }
+
+    it 'renders index template' do
+      subject
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+    end
+
+    context 'with custom domains' do
+      let!(:custom_domain) { create(:custom_domain, store: store) }
+
+      it 'renders index template' do
+        subject
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+
   describe '#new' do
     subject { get :new, format: :html }
 

--- a/admin/spec/controllers/spree/admin/stores_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/stores_controller_spec.rb
@@ -15,6 +15,8 @@ describe Spree::Admin::StoresController do
 
     store.add_user(user)
     store.add_user(user2)
+
+    allow(Spree).to receive(:root_domain).and_return('lvh.me')
   end
 
   describe 'POST #create' do

--- a/admin/spec/features/spree/admin/settings/custom_domains_spec.rb
+++ b/admin/spec/features/spree/admin/settings/custom_domains_spec.rb
@@ -1,37 +1,52 @@
 require 'spec_helper'
 
-describe 'Custom domains admin', type: :feature do
+describe 'Custom Domains', type: :feature do
   stub_authorization!
   let(:store) { Spree::Store.default }
 
-  context 'without custom domains' do
-    it 'can change store code' do
-      visit spree.admin_custom_domains_path
+  it 'can change store URL' do
+    visit spree.admin_custom_domains_path
 
-      fill_in 'store[code]', with: 'new-code'
-      click_on 'Update'
+    fill_in 'store[url]', with: 'new-url.com'
+    click_on 'Save'
 
-      expect(page).to have_field('store[code]', with: 'new-code')
-      expect(page.current_url).to include('new-code')
-    end
+    expect(store.reload.url).to eq('new-url.com')
   end
 
-  context 'with custom domains' do
-    let!(:custom_domain) { create(:custom_domain, store: store) }
-
-    it 'cannot change store code' do
-      visit spree.admin_custom_domains_path
-
-      expect(page).to have_field('store[code]', with: store.code, disabled: true)
+  context 'when multi store is enabled' do
+    before do
+      allow(Spree).to receive(:root_domain).and_return('lvh.me')
     end
 
-    it 'can manage custom domains' do
-      visit spree.admin_custom_domains_path
+    context 'without custom domains' do
+      it 'can change store code' do
+        visit spree.admin_custom_domains_path
 
-      expect(page).to have_link('New domain')
+        fill_in 'store[code]', with: 'new-code'
+        click_on 'Save'
 
-      within_row(1) do
-        expect(page).to have_content(custom_domain.url)
+        expect(page).to have_field('store[code]', with: 'new-code')
+        expect(page.current_url).to include('new-code')
+      end
+    end
+
+    context 'with custom domains' do
+      let!(:custom_domain) { create(:custom_domain, store: store) }
+
+      it 'cannot change store code' do
+        visit spree.admin_custom_domains_path
+
+        expect(page).to have_field('store[code]', with: store.code, disabled: true)
+      end
+
+      it 'can manage custom domains' do
+        visit spree.admin_custom_domains_path
+
+        expect(page).to have_link('New domain')
+
+        within_row(1) do
+          expect(page).to have_content(custom_domain.url)
+        end
       end
     end
   end

--- a/admin/spec/features/spree/admin/settings/store_spec.rb
+++ b/admin/spec/features/spree/admin/settings/store_spec.rb
@@ -8,6 +8,7 @@ describe 'Store admin', type: :feature, js: true do
   let!(:zone) { create(:zone, name: 'EU_VAT') }
 
   before do
+    allow(Spree).to receive(:root_domain).and_return('lvh.me')
     allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(admin_user)
   end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -874,6 +874,7 @@ en:
     current: Current
     current_password: Current password
     custom_code: Custom code
+    custom_domains: Custom domains
     custom_font_code: Custom font code
     customer: Customer
     customer_details: Customer Details

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -91,7 +91,7 @@ module Spree
   end
 
   def self.root_domain
-    @@root_domain ||= Rails.application.routes.default_url_options[:host] || 'lvh.me'
+    @@root_domain
   end
 
   def self.queues


### PR DESCRIPTION
Allow to set URL directly (not only code) when multi-store is not enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved admin interface for managing custom domains, including always-visible "default" badges, edit links, and a simplified table header.
  * Enhanced form for editing internal Admin URLs with better handling of root domain presence and clipboard copy functionality.
  * Added new translation for "Custom domains".

* **Bug Fixes**
  * The "new store" dropdown option now only appears when a root domain is configured.

* **Tests**
  * Added tests for the custom domains admin controller index action.
  * Expanded feature tests for custom domains and store settings, covering multi-store scenarios and domain management.

* **Chores**
  * Removed unused helper methods and Turbo Stream template, streamlining the codebase.
  * Updated method for root domain retrieval to remove default fallback assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->