### PR TITLE
Improve Admin Tax Rate form

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(rm:*)",
       "Bash(find:*)",
       "Bash(bundle exec rspec:*)",
-      "Bash(bundle exec rails c:*)"
+      "Bash(bundle exec rails c:*)",
+      "Bash(ruby test:*)"
     ],
     "deny": []
   }

--- a/admin/app/assets/stylesheets/spree/admin/shared/_forms.scss
+++ b/admin/app/assets/stylesheets/spree/admin/shared/_forms.scss
@@ -186,3 +186,7 @@ turbo-frame.blur-busy[busy] {
     pointer-events: none;
   }
 }
+
+.input-group-text {
+  background-color: transparent;
+}

--- a/admin/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/admin/app/views/spree/admin/tax_rates/_form.html.erb
@@ -12,12 +12,14 @@
       <%= f.error_message_on :name %>
     </div>
     <div class="form-group">
-      <%= f.label :amount, Spree.t(:rate) %>
-      <%= f.number_field :amount, class: 'form-control', min: 0, step: 0.0001, required: true %>
+      <%= f.label :amount_percentage, Spree.t(:rate) %>
+      <div class="input-group">
+        <%= f.number_field :amount_percentage, class: 'form-control', min: 0, step: 0.1, required: true %>
+        <div class="input-group-append">
+          <span class="input-group-text">%</span>
+        </div>
+      </div>
       <%= f.error_message_on :amount %>
-      <small class="form-text text-muted">
-        <%= Spree.t(:tax_rate_amount_explanation) %>
-      </small>
     </div>
 
     <div class="form-group">

--- a/admin/spec/features/spree/admin/settings/tax_rates_spec.rb
+++ b/admin/spec/features/spree/admin/settings/tax_rates_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Tax rates', js: true do
+RSpec.feature 'Tax Rates', js: true do
   stub_authorization!
 
   before do
@@ -15,7 +15,7 @@ RSpec.feature 'Tax rates', js: true do
     click_on 'New Tax Rate'
 
     fill_in 'Name', with: 'New Tax Rate'
-    fill_in 'Rate', with: 0.10
+    fill_in 'Rate', with: 10
     check 'Included in Price', allow_label_click: true
     check 'Show rate in label', allow_label_click: true
     select 'Default', from: 'Tax Category'
@@ -55,7 +55,7 @@ RSpec.feature 'Tax rates', js: true do
     click_on 'Edit'
 
     fill_in 'Name', with: 'Updated Tax Rate'
-    fill_in 'Rate', with: 0.20
+    fill_in 'Rate', with: 20
     uncheck 'Included in Price', allow_label_click: true
     uncheck 'Show rate in label', allow_label_click: true
     select 'Default', from: 'Tax Category'

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -33,6 +33,17 @@ module Spree
 
     self.whitelisted_ransackable_attributes = %w[amount zone_id tax_category_id included_in_price name]
 
+    # Virtual attribute for percentage display in admin forms
+    def amount_percentage
+      return nil if amount.nil?
+
+      (amount * 100).round(2)
+    end
+
+    def amount_percentage=(value)
+      self.amount = value.present? ? (value.to_f / 100) : nil
+    end
+
     # Gets the array of TaxRates appropriate for the specified tax zone
     def self.match(order_tax_zone)
       return [] unless order_tax_zone

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -261,7 +261,7 @@ module Spree
 
     @@tax_category_attributes = [:name, :tax_code,:description, :is_default]
 
-    @@tax_rate_attributes = [:name, :amount, :zone_id, :tax_category_id, :included_in_price, :show_rate_in_label, :calculator_type, calculator_attributes: {}]
+    @@tax_rate_attributes = [:name, :amount, :amount_percentage, :zone_id, :tax_category_id, :included_in_price, :show_rate_in_label, :calculator_type, calculator_attributes: {}]
 
     @@taxon_attributes = [
       :name, :parent_id, :position, :icon, :description, :permalink, :hide_from_nav,

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -567,4 +567,60 @@ describe Spree::TaxRate, type: :model do
       expect(tax_rate.send(:amount_for_label)).to eq(' 10%')
     end
   end
+
+  describe 'percentage conversion' do
+    describe '#amount_percentage' do
+      it 'converts decimal amount to percentage' do
+        tax_rate = build(:tax_rate, amount: 0.0825)
+        expect(tax_rate.amount_percentage).to eq(8.25)
+      end
+
+      it 'returns nil when amount is nil' do
+        tax_rate = build(:tax_rate, amount: nil)
+        expect(tax_rate.amount_percentage).to be_nil
+      end
+
+      it 'handles zero amount' do
+        tax_rate = build(:tax_rate, amount: 0.0)
+        expect(tax_rate.amount_percentage).to eq(0.0)
+      end
+
+      it 'rounds to 2 decimal places' do
+        tax_rate = build(:tax_rate, amount: 0.12345)
+        expect(tax_rate.amount_percentage).to eq(12.35)
+      end
+    end
+
+    describe '#amount_percentage=' do
+      it 'converts percentage to decimal amount' do
+        tax_rate = build(:tax_rate)
+        tax_rate.amount_percentage = 8.25
+        expect(tax_rate.amount).to eq(0.0825)
+      end
+
+      it 'sets amount to nil when percentage is nil' do
+        tax_rate = build(:tax_rate)
+        tax_rate.amount_percentage = nil
+        expect(tax_rate.amount).to be_nil
+      end
+
+      it 'sets amount to nil when percentage is empty string' do
+        tax_rate = build(:tax_rate)
+        tax_rate.amount_percentage = ''
+        expect(tax_rate.amount).to be_nil
+      end
+
+      it 'handles zero percentage' do
+        tax_rate = build(:tax_rate)
+        tax_rate.amount_percentage = 0
+        expect(tax_rate.amount).to eq(0.0)
+      end
+
+      it 'handles string percentage values' do
+        tax_rate = build(:tax_rate)
+        tax_rate.amount_percentage = '5.5'
+        expect(tax_rate.amount).to eq(0.055)
+      end
+    end
+  end
 end


### PR DESCRIPTION
rather than forcing user to provide decimal amount for rate, automatically convert it from percentage to decimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tax rate amounts in the admin interface can now be entered and displayed as percentages, improving clarity for users managing tax rates.

* **Style**
  * Updated the appearance of input fields for tax rates, including a transparent background for input group text and a visual percentage sign next to the input.

* **Tests**
  * Added tests to ensure correct conversion between percentage and decimal values for tax rates and to verify the new form behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->