### PR TITLE
Ability to toggle off and disable transactional emails

### DIFF
--- a/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -6,6 +6,23 @@
   <div class="col-lg-6 offset-lg-3">
     <div class="card mb-4">
       <div class="card-header">
+        <h5 class="card-title"><%= Spree.t(:settings) %></h5>
+      </div>
+      <div class="card-body">
+        <div class="form-group">
+          <div class="custom-control custom-checkbox">
+            <%= f.check_box :preferred_send_consumer_transactional_emails, class: 'custom-control-input' %>
+            <%= f.label :preferred_send_consumer_transactional_emails, Spree.t(:send_consumer_transactional_emails), class: 'custom-control-label' %>
+            <small class="form-text text-muted mt-2">
+              <%= Spree.t('admin.store_form.send_consumer_transactional_emails_help') %>
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-4">
+      <div class="card-header">
         <h5 class="card-title">Email addresses</h5>
       </div>
       <div class="card-body">

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
           label: Display the company address field
         customer_support_email_help: This email is visible to your Store visitors in the Footer section
         new_order_notifications_email_help: If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to
+        send_consumer_transactional_emails_help: When unchecked, transactional emails like order confirmations and shipment notifications will not be sent to customers
       store_setup_tasks:
         add_billing_address: Add billing address
         add_products: Add products

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1856,6 +1856,7 @@ en:
     select_user: Select customer
     selected_quantity_not_available: selected of %{item} is not available.
     send_copy_of_all_mails_to: Send Copy of All Mails To
+    send_consumer_transactional_emails: Send Customer Transactional Emails
     send_mails_as: Send Mails As
     send_message: Send message
     send_payment_link: Send payment link

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1855,8 +1855,8 @@ en:
     select_stores: Select Store(s)
     select_user: Select customer
     selected_quantity_not_available: selected of %{item} is not available.
-    send_copy_of_all_mails_to: Send Copy of All Mails To
     send_consumer_transactional_emails: Send Customer Transactional Emails
+    send_copy_of_all_mails_to: Send Copy of All Mails To
     send_mails_as: Send Mails As
     send_message: Send message
     send_payment_link: Send payment link

--- a/core/lib/spree/core/configuration.rb
+++ b/core/lib/spree/core/configuration.rb
@@ -54,7 +54,7 @@ module Spree
       preference :require_master_price, :boolean, default: false
       preference :restock_inventory, :boolean, default: true # Determines if a return item is restocked automatically once it has been received
       preference :return_eligibility_number_of_days, :integer, default: 365
-      preference :send_core_emails, :boolean, default: true # Default mail headers settings
+      preference :send_core_emails, :boolean, default: true, deprecated: true # Default mail headers settings
       preference :shipping_instructions, :boolean, deprecated: true
       preference :show_only_complete_orders_by_default, :boolean, deprecated: true
       preference :show_variant_full_price, :boolean, default: false # Displays variant full price or difference with product price. Default false to be compatible with older behavior

--- a/emails/app/models/spree/order/emails.rb
+++ b/emails/app/models/spree/order/emails.rb
@@ -3,7 +3,7 @@ module Spree
     module Emails
       def deliver_order_confirmation_email
         if completed?
-          OrderMailer.confirm_email(id).deliver_later
+          OrderMailer.confirm_email(id).deliver_later if store.prefers_send_consumer_transactional_emails?
           update_column(:confirmation_delivered, true)
         else
           errors.add(:base, Spree.t(:order_email_resent_error))


### PR DESCRIPTION
Also deprecate `Spree::Config[:send_core_emails]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Settings" section in store email settings with an option to enable or disable sending customer transactional emails.
  * Store administrators can now control whether order confirmation and shipment notification emails are sent to customers.

* **Bug Fixes**
  * Improved handling to ensure confirmation emails are only sent when the new setting is enabled.

* **Documentation**
  * Updated help text and labels for the new setting with localized translations.

* **Tests**
  * Added test coverage for scenarios where customer transactional emails are enabled or disabled.

* **Chores**
  * Marked an old email preference as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->