### PR TITLE
Add `options` hash to Storefront Variants API

### DIFF
--- a/api/app/serializers/spree/v2/storefront/variant_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/variant_serializer.rb
@@ -6,7 +6,7 @@ module Spree
 
         set_type :variant
 
-        attributes :sku, :barcode, :weight, :height, :width, :depth, :is_master, :options_text, :public_metadata
+        attributes :sku, :barcode, :weight, :height, :width, :depth, :is_master, :options_text, :options, :public_metadata
 
         attribute :purchasable do |variant|
           variant.purchasable?

--- a/api/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
+++ b/api/spec/serializers/spree/v2/storefront/variant_serializer_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Spree::V2::Storefront::VariantSerializer do
+  subject { described_class.new(variant, params: serializer_params).serializable_hash }
+
+  include_context 'API v2 serializers params'
+
+  let!(:variant) { create(:variant, price: 10, compare_at_price: 15) }
+
+  it 'returns expected attributes' do
+    expect(subject[:data][:attributes]).to include(
+      sku: variant.sku,
+      barcode: variant.barcode,
+      weight: variant.weight,
+      height: variant.height,
+      width: variant.width,
+      depth: variant.depth,
+      is_master: variant.is_master,
+      options_text: variant.options_text,
+      options: variant.options,
+      public_metadata: variant.public_metadata,
+      purchasable: variant.purchasable?,
+      in_stock: variant.in_stock?,
+      backorderable: variant.backorderable?,
+      currency: currency,
+      price: BigDecimal(10),
+      display_price: '$10.00',
+      compare_at_price: BigDecimal(15),
+      display_compare_at_price: '$15.00'
+    )
+  end
+
+  it 'returns expected relationships' do
+    expect(subject[:data][:relationships]).to include(
+      :product,
+      :images,
+      :option_values
+    )
+  end
+
+  it 'returns correct type' do
+    expect(subject[:data][:type]).to eq :variant
+  end
+end

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -3808,6 +3808,17 @@ components:
             options_text:
               type: string
               example: 'Size: small, Color: red'
+            options:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                  presentation:
+                    type: string
             purchasable:
               type: boolean
               description: Indicates if Variant is in stock or backorderable
@@ -4771,6 +4782,13 @@ components:
                       depth: null
                       is_master: false
                       options_text: 'Color: white, Size: XS'
+                      options:
+                        - name: color
+                          value: white
+                          presentation: White
+                        - name: size
+                          value: XS
+                          presentation: XS
                       purchasable: true
                       in_stock: true
                       backorderable: false
@@ -5181,6 +5199,13 @@ components:
                       depth: null
                       is_master: false
                       options_text: 'Color: white, Size: XS'
+                      options:
+                        - name: color
+                          value: white
+                          presentation: White
+                        - name: size
+                          value: XS
+                          presentation: XS
                       purchasable: true
                       in_stock: true
                       backorderable: false
@@ -5979,6 +6004,13 @@ components:
                       depth: null
                       is_master: false
                       options_text: 'Color: khaki, Size: XS'
+                      options:
+                        - name: color
+                          value: khaki
+                          presentation: Khaki
+                        - name: size
+                          value: XS
+                          presentation: XS
                       purchasable: true
                       in_stock: true
                       backorderable: false
@@ -15064,6 +15096,13 @@ components:
                       depth: null
                       is_master: false
                       options_text: 'Color: beige, Size: XS'
+                      options:
+                        - name: Color
+                          value: beige
+                          presentation: Beige
+                        - name: Size
+                          value: XS
+                          presentation: XS
                       purchasable: true
                       in_stock: true
                       backorderable: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variant data now includes a structured list of option details (such as color and size) in addition to the existing options text.

* **Documentation**
  * Updated API documentation to reflect the new structured options array in variant responses, with enhanced schema definitions and example data.

* **Tests**
  * Added tests to verify the presence and correctness of the new options attribute in serialized variant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->