### PR TITLE
Ability to skip migrations when creating a test app

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -52,21 +52,39 @@ namespace :common do
       "--authentication=#{args[:authentication]}"
     ]
 
+    if !skip_javascript || ENV['LIB_NAME'] == 'spree/emails'
+      puts 'Precompiling assets...'
+      system('bundle exec rake assets:precompile > /dev/null 2>&1')
+    end
+
+    unless ENV['NO_MIGRATE']
+      puts 'Setting up dummy database...'
+      system('bin/rails db:environment:set RAILS_ENV=test > /dev/null 2>&1')
+      system('bundle exec rake db:drop db:create > /dev/null 2>&1')
+      Spree::DummyModelGenerator.start
+      system('bundle exec rake db:migrate > /dev/null 2>&1')
+    end
+
+    begin
+      require "generators/#{ENV['LIB_NAME']}/install/install_generator"
+      puts 'Running extension installation generator...'
+
+      if ENV['NO_MIGRATE']
+        "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start([])
+      else
+        "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(['--auto-run-migrations'])
+      end
+    rescue LoadError
+      puts 'Skipping installation no generator to run...'
+    end
+  end
+
+  task :db_setup do |_t|
     puts 'Setting up dummy database...'
     system('bin/rails db:environment:set RAILS_ENV=test > /dev/null 2>&1')
     system('bundle exec rake db:drop db:create > /dev/null 2>&1')
     Spree::DummyModelGenerator.start
     system('bundle exec rake db:migrate > /dev/null 2>&1')
-
-    begin
-      require "generators/#{ENV['LIB_NAME']}/install/install_generator"
-      puts 'Running extension installation generator...'
-      "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(['--auto-run-migrations'])
-    rescue LoadError
-      puts 'Skipping installation no generator to run...'
-    end
-
-    system('bundle exec rake assets:precompile > /dev/null 2>&1') if !skip_javascript || ENV['LIB_NAME'] == 'spree/emails'
   end
 
   task :seed do |_t|


### PR DESCRIPTION
This will help us speed up tests and create test apps and cache them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new task to always perform database setup and migration for the test app.

* **Chores**
  * Asset precompilation and database migration steps during test app setup are now conditionally executed based on environment variables and configuration.
  * Improved modularity and control over setup steps for test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->