### PR TITLE
Fixed: do not destroy initialized tom select elements upon page exit

### DIFF
--- a/admin/app/javascript/spree/admin/controllers/select_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/select_controller.js
@@ -38,12 +38,6 @@ export default class extends Controller {
     }
   }
 
-  disconnect() {
-    if (this.select) {
-      this.select.destroy()
-    }
-  }
-
   initTomSelect(options = []) {
     const settings = {
       maxOptions: 1500,


### PR DESCRIPTION
This breaks when someone hits the back button and goes back to a page with these dropdowns as Turbo cached them as deinitialized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the behavior of select controls to simplify their lifecycle management. No explicit cleanup now occurs when navigating away from related admin pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->