### PR TITLE
Skip unique name migrations in multi tenant environment

### DIFF
--- a/core/db/migrate/20250730102644_add_missing_unique_indexes_to_spree_option_types_and_values.rb
+++ b/core/db/migrate/20250730102644_add_missing_unique_indexes_to_spree_option_types_and_values.rb
@@ -1,5 +1,8 @@
 class AddMissingUniqueIndexesToSpreeOptionTypesAndValues < ActiveRecord::Migration[7.2]
   def change
+    # we don't need to run this migration in multi-tenant mode as it's already handled there
+    return if defined?(SpreeMultiTenant)
+
     # Rename duplicated option types
     duplicates = Spree::OptionType.select(:name).group(:name).having('COUNT(*) > 1').reorder('').pluck(:name)
 

--- a/core/db/migrate/20250730154601_add_unique_index_on_spree_properties_name.rb
+++ b/core/db/migrate/20250730154601_add_unique_index_on_spree_properties_name.rb
@@ -1,5 +1,8 @@
 class AddUniqueIndexOnSpreePropertiesName < ActiveRecord::Migration[7.2]
   def change
+    # we don't need to run this migration in multi-tenant mode as it's already handled there
+    return if defined?(SpreeMultiTenant)
+
     # Rename duplicated properties
     duplicates = Spree::Property.select(:name).group(:name).having('COUNT(*) > 1').reorder('').pluck(:name)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migrations to prevent duplicate entries and ensure unique indexes are only applied in appropriate environments, avoiding issues in multi-tenant setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->