### PR TITLE
del: unused class

### DIFF
--- a/storefront/app/views/spree/checkout/_button_processing.html.erb
+++ b/storefront/app/views/spree/checkout/_button_processing.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= 'hidden' if is_hidden %> spinner flex justify-center">
+<div class="<%= 'hidden' if is_hidden %> flex justify-center">
   <svg class="animate-spin h-5 w-5 mr-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>


### PR DESCRIPTION
The class is not used anywhere, and its common name sometimes causes problems

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the checkout processing button to remove the spinner animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->