### PR TITLE
Add Spree Admin form builder to clean up forms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ end
 - Use Spree's admin styling conventions
 - Use as much as possible Turbo Rails features (Hotwire)
 - Re-usable components should be helpers
-- Implement proper form helpers
+- Please use `Spree::Admin::FormBuilder` methods for form fields
 - Follow UX patterns established in core admin
 - Use Stimulus controllers for JavaScript interactions
 
@@ -258,21 +258,13 @@ For create new resource form:
 
 ```erb
 <!-- ✅ Proper admin form structure -->
-<%= form_with model: [:admin, @product] do |f| %>
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @product } %>
-  <%= render 'spree/admin/products/form', f: f %>
-  <%= render 'spree/admin/new_resource_links', f: f %>
-<% end %>
+<%= render 'spree/admin/shared/new_resource' %>
 ```
 
 For edit resource form:
 
 ```erb
-<%= form_with model: [:admin, @product] do |f| %>
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @product } %>
-  <%= render 'spree/admin/products/form', f: f %>
-  <%= render 'spree/admin/edit_resource_links', f: f %>
-<% end %>
+<%= render 'spree/admin/shared/edit_resource' %>
 ```
 
 And the re-usable form partial should be in `app/views/spree/admin/products/_form.html.erb`, eg.
@@ -286,18 +278,12 @@ And the re-usable form partial should be in `app/views/spree/admin/products/_for
   </div>
 
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: f.object.new_record? %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name %>
+    <%= f.spree_rich_text_area :description %>
+    <%= f.spree_check_box :active %>
   </div>
 </div>
 ```
-
-Try to group form fields into cards.
-Use Bootstrap 4.6 form elements and components, such as form-group, form-control. 
-Always use custom bootstrap classes for checkbox and radio buttons.
 
 ## Performance & Best Practices
 

--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -4,6 +4,7 @@ module Spree
       include Spree::Admin::BreadcrumbConcern
 
       layout :choose_layout
+      default_form_builder Spree::Admin::FormBuilder
 
       helper 'spree/base'
       helper 'spree/admin/navigation'

--- a/admin/app/controllers/spree/admin/stores_controller.rb
+++ b/admin/app/controllers/spree/admin/stores_controller.rb
@@ -50,7 +50,10 @@ module Spree
 
         if @store.save
           remove_assets(%w[logo mailer_logo], object: @store)
-          flash[:success] = flash_message_for(@store, :successfully_updated)
+          respond_to do |format|
+            format.turbo_stream { flash.now[:success] = flash_message_for(@store, :successfully_updated) }
+            format.html { flash[:success] = flash_message_for(@store, :successfully_updated) }
+          end
         else
           flash[:error] = "#{Spree.t('store_errors.unable_to_update')}: #{@store.errors.full_messages.join(', ')}"
         end

--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -57,7 +57,7 @@ module Spree
       def spree_collection_select(method, collection, value_method, text_method, options = {})
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
-            @template.collection_select(@object_name, method, collection, value_method, text_method, options, { class: 'custom-select' })
+            @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), { class: 'custom-select' }) +
             @template.error_message_on(@object_name, method) + field_help(method, options)
         end
       end
@@ -67,15 +67,12 @@ module Spree
           @template.content_tag(:div, class: 'custom-control custom-checkbox') do
             @template.check_box(@object_name, method, objectify_options(options.merge(class: 'custom-control-input'))) +
             @template.label(@object_name, method, get_label(method, options), class: 'custom-control-label')
-            @template.error_message_on(@object_name, method) + field_help(method, options)
-          end
+          end + @template.error_message_on(@object_name, method) + field_help(method, options)
         end
       end
 
       def field_help(_method, options = {})
-        @template.content_tag(:span, class: 'form-text text-muted mt-2') do
-          options[:help]
-        end
+        @template.content_tag(:span, options[:help], class: 'form-text text-muted mt-2')
       end
 
       private

--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -1,0 +1,100 @@
+module Spree
+  module Admin
+    class FormBuilder < ActionView::Helpers::FormBuilder
+      def error_message_on(method, options = {})
+        @template.error_message_on(@object_name, method, objectify_options(options))
+      end
+
+      def spree_text_field(method, options = {})
+        options[:class] ||= 'form-control'
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.text_field(@object_name, method, objectify_options(options)) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_number_field(method, options = {})
+        options[:class] ||= 'form-control'
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.number_field(@object_name, method, objectify_options(options)) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_date_field(method, options = {})
+        options[:class] ||= 'form-control'
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.date_field(@object_name, method, objectify_options(options)) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_text_area(method, options = {})
+        @template.content_tag(:div, class: 'form-group') do
+          options[:class] ||= 'form-control'
+          options[:rows] ||= 5
+          options[:data] ||= { controller: 'textarea-autogrow' }
+
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.text_area(@object_name, method, objectify_options(options)) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_rich_text_area(method, options = {})
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.content_tag(:div, class: 'trix-container') do
+              @template.rich_text_area(@object_name, method, objectify_options(options))
+            end +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_collection_select(method, collection, value_method, text_method, options = {})
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.collection_select(@object_name, method, collection, value_method, text_method, options, { class: 'custom-select' })
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_check_box(method, options = {})
+        @template.content_tag(:div, class: 'form-group') do
+          @template.content_tag(:div, class: 'custom-control custom-checkbox') do
+            @template.check_box(@object_name, method, objectify_options(options.merge(class: 'custom-control-input'))) +
+            @template.label(@object_name, method, get_label(method, options), class: 'custom-control-label')
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+          end
+        end
+      end
+
+      def field_help(_method, options = {})
+        @template.content_tag(:span, class: 'form-text text-muted mt-2') do
+          options[:help]
+        end
+      end
+
+      private
+
+      def get_label(method, options)
+        translated_label = if options[:label]
+                              options[:label]
+                            elsif I18n.exists?("spree.#{method}")
+                              I18n.t("spree.#{method}")
+                            else
+                              I18n.t("activerecord.attributes.spree/#{@object_name.to_s.underscore}.#{method}")
+                            end
+
+        required_label = options[:required] ? ' ' + @template.required_span_tag : ''
+
+        help_bubble = options[:help_bubble] ? ' ' + @template.help_bubble(options[:help_bubble]) : ''
+
+        @template.raw(translated_label + required_label + help_bubble)
+      end
+    end
+  end
+end

--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -54,6 +54,16 @@ module Spree
         end
       end
 
+      def spree_select(method, choices = nil, options = {}, html_options = {}, &block)
+        html_options[:class] ||= 'custom-select'
+
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.select(@object_name, method, choices, objectify_options(options), html_options, &block) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
       def spree_collection_select(method, collection, value_method, text_method, options = {})
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +

--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -23,11 +23,29 @@ module Spree
         end
       end
 
+      def spree_email_field(method, options = {})
+        options[:class] ||= 'form-control'
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.email_field(@object_name, method, objectify_options(options)) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
       def spree_date_field(method, options = {})
         options[:class] ||= 'form-control'
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.date_field(@object_name, method, objectify_options(options)) +
+            @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
+      def spree_datetime_field(method, options = {})
+        options[:class] ||= 'form-control'
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+            @template.datetime_field(@object_name, method, objectify_options(options)) +
             @template.error_message_on(@object_name, method) + field_help(method, options)
         end
       end
@@ -55,7 +73,12 @@ module Spree
       end
 
       def spree_select(method, choices = nil, options = {}, html_options = {}, &block)
-        html_options[:class] ||= 'custom-select'
+        if options[:autocomplete]
+          html_options[:data] ||= {}
+          html_options[:data][:controller] ||= 'autocomplete-select'
+        else
+          html_options[:class] ||= 'custom-select'
+        end
 
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
@@ -81,6 +104,15 @@ module Spree
         end
       end
 
+      def spree_radio_button(method, tag_value, options = {})
+        @template.content_tag(:div, class: 'form-group') do
+          @template.content_tag(:div, class: 'custom-control custom-radio') do
+            @template.radio_button(@object_name, method, tag_value, objectify_options(options.merge(class: 'custom-control-input'))) +
+              @template.label(@object_name, method, get_label(method, options), class: 'custom-control-label', for: options[:id])
+          end + @template.error_message_on(@object_name, method) + field_help(method, options)
+        end
+      end
+
       def field_help(_method, options = {})
         @template.content_tag(:span, options[:help], class: 'form-text text-muted mt-2')
       end
@@ -88,6 +120,8 @@ module Spree
       private
 
       def get_label(method, options)
+        return '' if options[:label] == false
+
         translated_label = if options[:label]
                               options[:label]
                             elsif I18n.exists?("spree.#{method}")

--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -1,10 +1,30 @@
 module Spree
   module Admin
+    # Custom form builder for Spree admin interface
+    #
+    # This form builder provides helper methods for creating form fields with
+    # consistent styling and behavior across the Spree admin interface. It includes
+    # form groups, error handling, help text, and other features.
     class FormBuilder < ActionView::Helpers::FormBuilder
+      # Display error messages for a specific field
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] additional options for the error message
+      # @return [String] HTML string containing the error message
       def error_message_on(method, options = {})
         @template.error_message_on(@object_name, method, objectify_options(options))
       end
 
+      # Create a text field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options including:
+      #   - :class [String] CSS classes (defaults to 'form-control')
+      #   - :label [String, Boolean] label text or false to hide label
+      #   - :required [Boolean] whether field is required
+      #   - :help [String] help text to display below the field
+      #   - :help_bubble [String] help bubble text
+      # @return [String] HTML string containing the complete form group
       def spree_text_field(method, options = {})
         options[:class] ||= 'form-control'
         @template.content_tag(:div, class: 'form-group') do
@@ -14,6 +34,11 @@ module Spree
         end
       end
 
+      # Create a number field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options (see {#spree_text_field} for available options)
+      # @return [String] HTML string containing the complete form group
       def spree_number_field(method, options = {})
         options[:class] ||= 'form-control'
         @template.content_tag(:div, class: 'form-group') do
@@ -23,6 +48,11 @@ module Spree
         end
       end
 
+      # Create an email field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options (see {#spree_text_field} for available options)
+      # @return [String] HTML string containing the complete form group
       def spree_email_field(method, options = {})
         options[:class] ||= 'form-control'
         @template.content_tag(:div, class: 'form-group') do
@@ -32,6 +62,11 @@ module Spree
         end
       end
 
+      # Create a date field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options (see {#spree_text_field} for available options)
+      # @return [String] HTML string containing the complete form group
       def spree_date_field(method, options = {})
         options[:class] ||= 'form-control'
         @template.content_tag(:div, class: 'form-group') do
@@ -41,6 +76,11 @@ module Spree
         end
       end
 
+      # Create a datetime field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options (see {#spree_text_field} for available options)
+      # @return [String] HTML string containing the complete form group
       def spree_datetime_field(method, options = {})
         options[:class] ||= 'form-control'
         @template.content_tag(:div, class: 'form-group') do
@@ -50,6 +90,15 @@ module Spree
         end
       end
 
+      # Create a textarea with Spree form styling and auto-grow functionality
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options including:
+      #   - :class [String] CSS classes (defaults to 'form-control')
+      #   - :rows [Integer] number of rows (defaults to 5)
+      #   - :data [Hash] data attributes (defaults to textarea-autogrow controller)
+      #   - other options from {#spree_text_field}
+      # @return [String] HTML string containing the complete form group
       def spree_text_area(method, options = {})
         @template.content_tag(:div, class: 'form-group') do
           options[:class] ||= 'form-control'
@@ -62,6 +111,11 @@ module Spree
         end
       end
 
+      # Create a rich text area (Trix editor) with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options (see {#spree_text_field} for available options)
+      # @return [String] HTML string containing the complete form group with Trix editor
       def spree_rich_text_area(method, options = {})
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
@@ -72,6 +126,16 @@ module Spree
         end
       end
 
+      # Create a select field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param choices [Array, nil] options for the select field
+      # @param options [Hash] field options including:
+      #   - :autocomplete [Boolean] whether to enable autocomplete functionality
+      #   - other options from {#spree_text_field}
+      # @param html_options [Hash] HTML options for the select element
+      # @param block [Proc] optional block for generating options
+      # @return [String] HTML string containing the complete form group
       def spree_select(method, choices = nil, options = {}, html_options = {}, &block)
         if options[:autocomplete]
           html_options[:data] ||= {}
@@ -87,6 +151,17 @@ module Spree
         end
       end
 
+      # Create a collection select field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param collection [Array] collection of objects for the select options
+      # @param value_method [Symbol] method to call on each object for the option value
+      # @param text_method [Symbol] method to call on each object for the option text
+      # @param options [Hash] field options including:
+      #   - :autocomplete [Boolean] whether to enable autocomplete functionality
+      #   - other options from {#spree_text_field}
+      # @param html_options [Hash] HTML options for the select element
+      # @return [String] HTML string containing the complete form group
       def spree_collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
         if options[:autocomplete]
           html_options[:data] ||= {}
@@ -102,6 +177,11 @@ module Spree
         end
       end
 
+      # Create a checkbox with Spree custom control styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options (see {#spree_text_field} for available options)
+      # @return [String] HTML string containing the complete form group with custom checkbox
       def spree_check_box(method, options = {})
         @template.content_tag(:div, class: 'form-group') do
           @template.content_tag(:div, class: 'custom-control custom-checkbox') do
@@ -111,6 +191,14 @@ module Spree
         end
       end
 
+      # Create a radio button with Spree custom control styling
+      #
+      # @param method [Symbol] the field name
+      # @param tag_value [String] the value for this radio button option
+      # @param options [Hash] field options including:
+      #   - :id [String] the HTML ID for the radio button
+      #   - other options from {#spree_text_field}
+      # @return [String] HTML string containing the complete form group with custom radio button
       def spree_radio_button(method, tag_value, options = {})
         @template.content_tag(:div, class: 'form-group') do
           @template.content_tag(:div, class: 'custom-control custom-radio') do
@@ -120,12 +208,26 @@ module Spree
         end
       end
 
+      # Generate help text for a field
+      #
+      # @param _method [Symbol] the field name (unused but kept for consistency)
+      # @param options [Hash] field options
+      # @option options [String] :help help text to display
+      # @return [String] HTML string containing the help text or empty string
       def field_help(_method, options = {})
         @template.content_tag(:span, options[:help], class: 'form-text text-muted mt-2')
       end
 
       private
 
+      # Generate the label for a field with required indicator and help bubble
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options
+      # @option options [String, Boolean] :label label text or false to hide label
+      # @option options [Boolean] :required whether field is required
+      # @option options [String] :help_bubble help bubble text
+      # @return [String] HTML string containing the complete label
       def get_label(method, options)
         return '' if options[:label] == false
 

--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -87,10 +87,17 @@ module Spree
         end
       end
 
-      def spree_collection_select(method, collection, value_method, text_method, options = {})
+      def spree_collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
+        if options[:autocomplete]
+          html_options[:data] ||= {}
+          html_options[:data][:controller] ||= 'autocomplete-select'
+        else
+          html_options[:class] ||= 'custom-select'
+        end
+
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
-            @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), { class: 'custom-select' }) +
+            @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), html_options) +
             @template.error_message_on(@object_name, method) + field_help(method, options)
         end
       end

--- a/admin/app/views/spree/admin/admin_users/_form.html.erb
+++ b/admin/app/views/spree/admin/admin_users/_form.html.erb
@@ -1,12 +1,3 @@
-<div class="form-group">
-  <%= f.label :email %>
-  <%= f.email_field :email, class: 'form-control', required: true, autofocus: true %>
-</div>
-<div class="form-group">
-  <%= f.label :first_name %>
-  <%= f.text_field :first_name, class: 'form-control', required: true %>
-</div>
-<div class="form-group">
-  <%= f.label :last_name %>
-  <%= f.text_field :last_name, class: 'form-control', required: true %>
-</div>
+<%= f.spree_text_field :email, required: true, autofocus: true, type: :email %>
+<%= f.spree_text_field :first_name, required: true %>
+<%= f.spree_text_field :last_name, required: true %>

--- a/admin/app/views/spree/admin/admin_users/edit.html.erb
+++ b/admin/app/views/spree/admin/admin_users/edit.html.erb
@@ -19,13 +19,10 @@
       <%= render'spree/admin/shared/error_messages', target: @admin_user %>
       <%= render 'form', f: f %>
       <% if can?(:manage, Spree::Role) && @roles.any? %>
-        <div class="form-group">
-          <%= f.label :spree_role_ids, Spree.t(:roles) %>
-          <%= f.select :spree_role_ids,
-                  options_from_collection_for_select(@roles, 'id', 'name', @admin_user.spree_roles.pluck(:id)),
-                  { prompt: false },
-                  { multiple: true,  data: { controller: 'autocomplete-select' } } %>          
-        </div>
+        <%= f.spree_select :spree_role_ids,
+                options_from_collection_for_select(@roles, 'id', 'name', @admin_user.spree_roles.pluck(:id)),
+                { prompt: false, label: Spree.t(:roles), autocomplete: true },
+                { multiple: true } %>          
       <% end %>
     </div>
     <div class="card-footer">

--- a/admin/app/views/spree/admin/assets/edit.html.erb
+++ b/admin/app/views/spree/admin/assets/edit.html.erb
@@ -6,10 +6,7 @@
         <%= render 'active_storage/upload_form', form: f, field_name: :attachment, width: 200, height: 200, can_delete: false %>
       </div>
       <div class="modal-body" style="min-height: 200px">
-        <div class="form-group">
-          <%= f.label :alt, Spree.t(:alt_text) %>
-          <%= f.text_area :alt, rows: 4, class: 'form-control' %>
-        </div>
+        <%= f.spree_text_area :alt, rows: 4 %>
       </div>
       <div class="modal-footer">
         <%= turbo_save_button_tag %>

--- a/admin/app/views/spree/admin/digital_assets/_form.html.erb
+++ b/admin/app/views/spree/admin/digital_assets/_form.html.erb
@@ -5,14 +5,9 @@
 <%= f.error_message_on :attachment %>
 
 <% if @product.has_variants? %>
-  <div class="form-group">
-    <%= f.label :variant_id, Spree.t(:variant) %>
-    <%= f.select :variant_id,
-             @product.variants.map { |variant| [variant.options_text, variant.id] },
-             {},
-             required: true,
-             class: "custom-select" %>
-  </div>
+  <%= f.spree_select :variant_id,
+           @product.variants.map { |variant| [variant.options_text, variant.id] },
+           { required: true, label: Spree.t(:variant), autocomplete: true } %>
 <% else %>
   <%= hidden_field_tag "digital_asset[variant_id]", @product.master.id %>
 <% end %>

--- a/admin/app/views/spree/admin/gift_card_batches/_form.html.erb
+++ b/admin/app/views/spree/admin/gift_card_batches/_form.html.erb
@@ -6,25 +6,9 @@
   </div>
 
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :prefix, raw(Spree.t('admin.gift_card_batches.prefix') + required_span_tag)%>
-      <%= f.text_field :prefix, class: 'form-control', disabled: f.object.persisted? %>
-      <%= f.error_message_on :prefix %>
-    </div>
-    <div class="form-group">
-      <%= f.label :amount, raw(Spree.t(:amount) + required_span_tag) %>
-      <%= f.number_field :amount, class: 'form-control', disabled: f.object.persisted?, required: true %>
-      <%= f.error_message_on :amount %>
-    </div>
-    <div class="form-group">
-      <%= f.label :codes_count, raw(Spree.t('admin.gift_card_batches.codes_count') + required_span_tag) %>
-      <%= f.number_field :codes_count, class: 'form-control', disabled: f.object.persisted?, required: true, min: 1, max: Spree::Config[:gift_card_batch_limit] %>
-      <%= f.error_message_on :codes_count %>
-    </div>
-    <div class="form-group">
-      <%= f.label :expires_at, Spree.t(:expires_at) %>
-      <%= f.date_field :expires_at, class: 'form-control', disabled: f.object.persisted? %>
-      <%= f.error_message_on :expires_at %>
-    </div>
+    <%= f.spree_text_field :prefix, disabled: f.object.persisted?, label: Spree.t('admin.gift_card_batches.prefix') %>
+    <%= f.spree_number_field :amount, required: true, disabled: f.object.persisted? %>
+    <%= f.spree_number_field :codes_count, required: true, min: 1, max: Spree::Config[:gift_card_batch_limit], label: Spree.t('admin.gift_card_batches.codes_count') %>
+    <%= f.spree_date_field :expires_at, disabled: f.object.persisted?, help: 'Gift cards will expire after this date.' %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/gift_cards/_form.html.erb
+++ b/admin/app/views/spree/admin/gift_cards/_form.html.erb
@@ -1,21 +1,10 @@
 <div class="card mb-4">
   <div class="card-body">
     <% unless f.object.persisted? %>
-      <div class="form-group">
-        <%= f.label :code do %>
-          <%= Spree.t(:code) %>
-          <%= help_bubble(Spree.t('admin.gift_cards.code_help_text')) %>
-        <% end %>
-        <%= f.text_field :code, class: 'form-control'  %>
-        <%= f.error_message_on :code %>
-      </div>
+      <%= f.spree_text_field :code, required: true, help_bubble: Spree.t('admin.gift_cards.code_help_text') %>
     <% end %>
 
-    <div class="form-group">
-      <%= f.label :amount, raw(Spree.t(:amount) + required_span_tag) %>
-      <%= f.text_field :amount, class: 'form-control', required: true %>
-      <%= f.error_message_on :amount %>
-    </div>
+    <%= f.spree_number_field :amount, required: true %>
 
     <div class="form-group">
       <%= f.label :user_id, Spree.t(:customer) %>
@@ -24,10 +13,7 @@
             include_blank: true,
             options: users_for_select_options %>
     </div>
-    <div class="form-group">
-      <%= f.label :expires_at, Spree.t(:expires_at) %>
-      <%= f.date_field :expires_at, class: 'form-control' %>
-      <%= f.error_message_on :expires_at %>
-    </div>
+
+    <%= f.spree_date_field :expires_at %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/invitations/new.html.erb
+++ b/admin/app/views/spree/admin/invitations/new.html.erb
@@ -6,20 +6,11 @@
       <%= modal_header Spree.t('actions.send_invitation') %>
       <div class="modal-body">
         <%= render 'spree/admin/shared/error_messages', target: @invitation %>
-        <div class="form-group">
-          <%= f.label :email, Spree.t(:email) %>
-          <%= f.email_field :email, class: 'form-control', required: :required, data: { 'enable-button-target': 'input' }, placeholder: 'eg. steve@apple.com', autofocus: true %>
-        </div>
+        <%= f.spree_email_field :email, required: true, data: { 'enable-button-target': 'input' }, placeholder: 'eg. steve@apple.com', autofocus: true %>
         <% if @roles.any? %>
-          <div class="form-group">
-            <%= f.label :role, Spree.t(:role_id) %>
-            <%= f.select :role_id, @roles.map { |role| [role.name, role.id] }, {}, { data: { controller: 'autocomplete-select', 'enable-button-target': 'input' }, required: true } %>
-          </div>
+          <%= f.spree_select :role_id, @roles.map { |role| [role.name, role.id] }, { label: Spree.t(:role_id), autocomplete: true, required: true }, { data: { 'enable-button-target': 'input' } } %>
         <% end %>
-        <div class="form-group">
-          <%= f.label :expires_at %>
-          <%= f.date_field :expires_at, class: 'form-control', required: true, data: { 'enable-button-target': 'input' } %>
-        </div>
+        <%= f.spree_date_field :expires_at, required: true, data: { 'enable-button-target': 'input' } %>
       </div>
       <div class="modal-footer">
         <%= turbo_save_button_tag nil, class: 'btn btn-primary', data: { 'enable-button-target': 'button' } do %>

--- a/admin/app/views/spree/admin/oauth_applications/_form.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/_form.html.erb
@@ -1,15 +1,6 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: f.object.new_record? %>
-      <%= f.error_message_on :name %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :scopes, raw(Spree.t(:scopes) + required_span_tag) %>
-      <%= f.select :scopes, [['Read Only', 'admin read'], ['Read & Write', 'admin write']], { selected: @oauth_application.scopes.to_s }, { class: 'custom-select' } %>
-      <%= f.error_message_on :scopes %>
-    </div>
+    <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
+    <%= f.spree_select :scopes, [['Read Only', 'admin read'], ['Read & Write', 'admin write']], { selected: @oauth_application.scopes.to_s }, { required: true } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/oauth_applications/_table_row.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/_table_row.html.erb
@@ -1,8 +1,8 @@
 <tr id="<%= spree_dom_id oauth_application %>">
   <td class="w-20"><code><%= oauth_application.name %></code></td>
   <td class="w-40">
-    <div class="input-group" data-controller="password-toggle">
-      <%= button_tag class: 'btn hover-gray px-1', data: { action: 'click->password-toggle#password' } do %>
+    <div class="d-flex gap-2 align-items-center" data-controller="password-toggle">
+      <%= button_tag class: 'btn btn-light btn-sm px-1', data: { action: 'click->password-toggle#password' } do %>
         <%= icon 'eye', class: 'mr-0' %>
       <% end %>
       <%= password_field_tag :password, oauth_application.uid, class: 'form-control-plaintext', data: { password_toggle_target: 'unhide' }, readonly: true %>

--- a/admin/app/views/spree/admin/oauth_applications/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/oauth_applications/create.turbo_stream.erb
@@ -1,41 +1,31 @@
 <%= turbo_stream.replace "new_oauth_application" do %>
-  <div class="card">
-    <div class="card-body">
-      <div data-controller="clipboard" class="mb-3">
-        <div class="form-group">
-          <%= label_tag :client_id, 'Client ID' %>
-          <div class="input-group">
-            <%= text_area_tag :client_id, @object.uid, class: 'form-control', rows: 1, data: { clipboard_target: 'source', action: 'clipboard#copy' }, readonly: true %>
-            <div class="input-append">
-              <button data-action="clipboard#copy" class="btn btn-light">
-                <%= icon 'clone.svg', class: 'mr-2' %>
-                <%= Spree.t('admin.copy_to_clipboard') %>
-              </button>
+  <div class="row">
+    <div class="col-lg-6 offset-lg-3">
+      <div class="card">
+        <div class="card-body">
+          <div class="form-group">
+            <%= label_tag :client_id, Spree.t('admin.oauth_applications.client_id') %>
+            <div class="d-flex gap-2 align-items-center">
+              <%= text_field_tag :client_id, @object.uid, class: 'form-control-plaintext bg-light rounded', readonly: true %>
+              <%= clipboard_component(@object.uid) %>
             </div>
           </div>
-        </div>
-      </div>
 
-      <div data-controller="clipboard" class="mb-3">
-        <div class="form-group">
-          <%= label_tag :client_secret, 'Client Secret' %>
-          <div class="input-group">
-            <%= text_area_tag :client_secret, @object.plaintext_secret, class: 'form-control', rows: 1, data: { clipboard_target: 'source', action: 'clipboard#copy' }, readonly: true %>
-            <div class="input-append">
-              <button data-action="clipboard#copy" class="btn btn-light">
-                <%= icon 'clone.svg', class: 'mr-2' %>
-                <%= Spree.t('admin.copy_to_clipboard') %>
-              </button>
+          <div class="form-group">
+            <%= label_tag :client_secret, Spree.t('admin.oauth_applications.client_secret') %>
+            <div class="d-flex gap-2 align-items-center">
+              <%= text_field_tag :client_secret, @object.plaintext_secret, class: 'form-control-plaintext bg-light rounded', readonly: true %>
+              <%= clipboard_component(@object.plaintext_secret) %>
+            </div>
+            <div class="alert alert-warning mt-3">
+              This is your application's secret token, copy it now and keep it safe. It won't be shown again.
             </div>
           </div>
-          <div class="alert alert-warning mt-3">
-            This is your application's secret token, copy it now and keep it safe. It won't be shown again.
-          </div>
+        </div>
+        <div class="card-footer border-top">
+          <%= link_to 'Back to list', spree.admin_oauth_applications_url, class: 'btn btn-light' %>
         </div>
       </div>
-    </div>
-    <div class="card-footer">
-      <%= link_to 'Back to list', spree.admin_oauth_applications_url, class: 'btn btn-light' %>
     </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/option_types/_form.html.erb
+++ b/admin/app/views/spree/admin/option_types/_form.html.erb
@@ -5,38 +5,16 @@
     <div class="card-body" data-controller="slug-form">
       <div class="row mb-3">
         <div class="col-md-6">
-          <div class="form-group">
-            <%= f.label :presentation, raw(Spree.t(:presentation) + required_span_tag) %>
-            <%= f.text_field :presentation, class: "form-control", required: true, autofocus: f.object.new_record?, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName' } %>
-            <%= f.error_message_on :presentation %>
-            <p class="text-muted form-text mt-2 mb-0">
-              This is used to display the option type on the storefront.
-            </p>
-          </div>
+          <%= f.spree_text_field :presentation, required: true, autofocus: f.object.new_record?, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName' }, help_text: "This is used to display the option type on the storefront." %>
         </div>
 
         <div class="col-md-6">
-          <div class="form-group">
-            <%= f.label :name, Spree.t(:internal_name) %>
-            <%= f.text_field :name, class: "form-control", data: { slug_form_target: :url } %>
-            <%= f.error_message_on :name %>
-            <p class="text-muted form-text mt-2 mb-0">
-              This is used internally to identify the option type. <strong>It must be unique.</strong>
-            </p>
-          </div>
+          <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, help_text: raw("This is used internally to identify the option type. <strong>It must be unique.</strong>") %>
         </div>
       </div>
       <div class="row">
         <div class="col-12 col-md-6">
-          <div class="form-group">
-            <div class="custom-control custom-checkbox mb-3">
-              <%= f.check_box :filterable, class: "custom-control-input", id: "option_type_filterable" %>
-              <%= f.label :filterable, Spree.t(:filterable), class: "custom-control-label", for: "option_type_filterable" %>
-            </div>
-            <small class="form-text text-muted">
-              <%= raw Spree.t('option_type_filterable_info') %>
-            </small>
-          </div>
+          <%= f.spree_check_box :filterable, help_text: raw(Spree.t('option_type_filterable_info')) %>
         </div>
       </div>
     </div>

--- a/admin/app/views/spree/admin/orders/customer_returns/new.html.erb
+++ b/admin/app/views/spree/admin/orders/customer_returns/new.html.erb
@@ -36,14 +36,10 @@
 
     <div class="card mb-4">
       <div class="card-body">
-        <div class="form-group">
-          <%= f.label :stock_location, raw(Spree.t(:stock_location) + required_span_tag) %>
-          <%= f.select :stock_location_id,
+        <%= f.spree_select :stock_location_id,
                    available_stock_locations_list,
                    { include_blank: Spree.t(:select_a_stock_location) },
-                   class: "custom-select" %>
-          <%= f.error_message_on :stock_location %>
-        </div>
+                   { label: Spree.t(:stock_location), required: true } %>
       </div>
     </div>
 

--- a/admin/app/views/spree/admin/orders/return_authorizations/_form.html.erb
+++ b/admin/app/views/spree/admin/orders/return_authorizations/_form.html.erb
@@ -143,23 +143,13 @@
 
   <div class="card mb-4">
     <div class="card-body">
-      <div class="form-group">
-        <%= f.label :stock_location, raw(Spree.t(:stock_location) + required_span_tag) %>
-        <%= f.select :stock_location_id,
-                 available_stock_locations_list,
-                 { include_blank: Spree.t(:select_a_stock_location) },
-                 { class: "custom-select" } %>
-        <%= f.error_message_on :stock_location %>
-      </div>
+      <%= f.spree_select :stock_location_id,
+               available_stock_locations_list,
+               { include_blank: Spree.t(:select_a_stock_location), label: Spree.t(:stock_location), required: true } %>
 
-      <div class="form-group">
-        <%= f.label :reason, raw(Spree.t(:reason) + required_span_tag) %>
-        <%= f.select :return_authorization_reason_id,
-                 @reasons.collect { |r| [r.name, r.id] },
-                 { include_blank: Spree.t(:select_a_return_authorization_reason) },
-                 { class: "custom-select" } %>
-        <%= f.error_message_on :reason %>
-      </div>
+      <%= f.spree_select :return_authorization_reason_id,
+               @reasons.collect { |r| [r.name, r.id] },
+               { include_blank: Spree.t(:select_a_return_authorization_reason), label: Spree.t(:reason), required: true } %>
 
       <%= f.spree_text_area :memo %>
     </div>

--- a/admin/app/views/spree/admin/orders/return_authorizations/_form.html.erb
+++ b/admin/app/views/spree/admin/orders/return_authorizations/_form.html.erb
@@ -161,11 +161,7 @@
         <%= f.error_message_on :reason %>
       </div>
 
-      <div class="form-group">
-        <%= f.label :memo, Spree.t(:memo) %>
-        <%= f.text_area :memo, class: "form-control" %>
-        <%= f.error_message_on :memo %>
-      </div>
+      <%= f.spree_text_area :memo %>
     </div>
   </div>
 </div>

--- a/admin/app/views/spree/admin/page_builder/_sidebar_fonts.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_sidebar_fonts.html.erb
@@ -55,12 +55,11 @@
     </div>
     <div class="tab-pane fade" id="pills-custom-tab" role="tabpanel" aria-labelledby="pills-custom">
       <div class="px-3 py-2">
-        <div class="mb-3 form-group">
+        <div class="mb-3">
           <div class="alert alert-warning">
             Using custom fonts can slow down your store.
           </div>
-          <%= f.label :preferred_custom_font_code, Spree.t(:custom_font_code) %>
-          <%= f.text_area :preferred_custom_font_code, class: 'form-control', style: 'min-height: 6em', data: { controller: 'textarea-autogrow'} %>
+          <%= f.spree_text_area :preferred_custom_font_code, style: 'min-height: 6em' %>
         </div>
         <%= f.submit Spree.t('actions.update'), class: 'btn btn-primary' %>
 

--- a/admin/app/views/spree/admin/pages/_form.html.erb
+++ b/admin/app/views/spree/admin/pages/_form.html.erb
@@ -5,10 +5,7 @@
     </h5>
   </div>
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control', required: true, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName', seo_form_target: 'sourceTitleInput' }, autofocus: true %>
-    </div>
+    <%= f.spree_text_field :name, required: true, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName', seo_form_target: 'sourceTitleInput' }, autofocus: true %>
   </div>
 </div>
 <%= render 'spree/admin/shared/seo',

--- a/admin/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/_form.html.erb
@@ -22,15 +22,7 @@
     <h5 class="card-title"><%= Spree.t(:display_settings) %></h5>
   </div>
   <div class="card-body">
-    <div class="form-group">
-      <%= label_tag :payment_method_name, Spree.t(:name) %>
-      <%= text_field :payment_method, :name, class: 'form-control' %>
-      <span class="text-muted form-text mt-2">
-        This name will be used to identify the payment method on the storefront
-      </span>
-
-      <%= error_message_on :payment_method, :name %>
-    </div>
+    <%= f.spree_text_field :name, help: 'This name will be used to identify the payment method on the storefront' %>
 
     <% if can?(:manage, Spree::Store) && available_stores.count > 1 %>
       <div class="form-group">
@@ -44,21 +36,9 @@
       </div>
     <% end %>
 
-    <div class="form-group">
-      <%= label_tag :payment_method_display_on, Spree.t(:display) %>
-      <%= f.select :display_on, display_on_options, {}, { class: 'custom-select' } %>
-    </div>
-    <div class="form-group">
-      <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>
-      <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes).to_s, true], [Spree.t(:say_no).to_s, false]], {}, {class: 'custom-select'}) %>
-    </div>
+    <%= f.spree_select :display_on, display_on_options, { label: Spree.t(:display) } %>
+    <%= f.spree_select :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes).to_s, true], [Spree.t(:say_no).to_s, false]], { label: Spree.t(:auto_capture) } %>
 
-    <div class="form-group">
-      <label><%= Spree.t(:active) %></label>
-      <div class="custom-control custom-switch">
-        <%= f.check_box :active, class: 'custom-control-input' %>
-        <%= f.label :active, '&nbsp;'.html_safe, class: 'custom-control-label' %>
-      </div>
-    </div>
+    <%= f.spree_check_box :active %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/post_categories/_form.html.erb
+++ b/admin/app/views/spree/admin/post_categories/_form.html.erb
@@ -1,15 +1,6 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :title, Spree.t(:title) %>
-      <%= f.text_field :title, class: "form-control", required: true, autofocus: f.object.new_record? %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :description, Spree.t(:description) %>
-      <div class="trix-container">
-        <%= f.rich_text_area :description %>
-      </div>
-    </div>
+    <%= f.spree_text_field :title, required: true, autofocus: f.object.new_record? %>
+    <%= f.spree_rich_text_area :description %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/post_categories/_table_row.html.erb
+++ b/admin/app/views/spree/admin/post_categories/_table_row.html.erb
@@ -4,6 +4,6 @@
   </td>
   <td class="w-10 cursor-pointer" data-action="click->row-link#openLink"><%= post_category.posts.count %></td>
   <td class="w-10 cursor-pointer text-right" data-action="click->row-link#openLink">
-    <%= link_to_edit(post_category, class: 'btn btn-light btn-sm') if can? :edit, post_category %>
+    <%= link_to_edit(post_category, class: 'btn btn-light btn-sm', data: { turbo_frame: '_top' }) if can? :edit, post_category %>
   </td>
 </tr>

--- a/admin/app/views/spree/admin/posts/_form.html.erb
+++ b/admin/app/views/spree/admin/posts/_form.html.erb
@@ -2,18 +2,14 @@
   <div class="col-lg-8">
     <div class="card mb-4">
       <div class="card-body">
-        <div class="form-group">
-          <%= f.label :title, Spree.t(:title) %>
-          <%= f.text_field :title,
-                class: "form-control",
-                required: true,
-                autofocus: true,
-                data: {
-                  seo_form_target: 'sourceTitleInput',
-                  slug_form_target: 'name',
-                  action: 'slug-form#updateUrlFromName'
-                } %>
-        </div>
+        <%= f.spree_text_field :title,
+              required: true,
+              autofocus: true,
+              data: {
+                seo_form_target: 'sourceTitleInput',
+                slug_form_target: 'name',
+                action: 'slug-form#updateUrlFromName'
+              } %>
 
         <div class="form-group">
           <%= f.label :content, Spree.t(:content) %>

--- a/admin/app/views/spree/admin/posts/_form.html.erb
+++ b/admin/app/views/spree/admin/posts/_form.html.erb
@@ -11,21 +11,15 @@
                 action: 'slug-form#updateUrlFromName'
               } %>
 
-        <div class="form-group">
-          <%= f.label :content, Spree.t(:content) %>
-          <div class="trix-container mb-0">
-            <%= f.rich_text_area :content, class: 'overflow-auto', style: 'height: 300px', data: { seo_form_target: 'sourceDescriptionInput' } %>
-          </div>
-        </div>
+        <%= f.spree_rich_text_area :content,
+              help_bubble: 'Add a summary of the post',
+              style: 'height: 300px',
+              data: { seo_form_target: 'sourceDescriptionInput' } %>
 
-        <div class="form-group mb-0">
-          <%= f.label :excerpt, Spree.t(:excerpt) %>
-          <%= help_bubble('Add a summary of the post') %>
-
-          <div class="trix-container mb-0">
-            <%= f.rich_text_area :excerpt, class: 'overflow-auto', style: 'height: 100px', data: { seo_form_target: 'sourceExcerptInput' } %>
-          </div>
-        </div>
+        <%= f.spree_rich_text_area :excerpt,
+              help_bubble: 'Add a summary of the post',
+              style: 'height: 100px',
+              data: { seo_form_target: 'sourceExcerptInput' } %>
       </div>
     </div>
   </div>
@@ -42,21 +36,9 @@
 
     <div class="card mb-4">
       <div class="card-body">
-        <div class="form-group">
-          <%= f.label :author_id, Spree.t(:author) %>
-          <%= f.select :author_id, options_for_select(post_authors_select_options, @post.author_id || try_spree_current_user.id), {}, { data: { controller: 'autocomplete-select' } } %>
-        </div>
-
-        <div class="form-group">
-          <%= f.label :post_category_id, Spree.t(:category) %>
-          <%= f.select :post_category_id, options_for_select(@post_categories.pluck(:title, :id), @post.post_category_id), { include_blank: true }, { data: { controller: 'autocomplete-select' } } %>
-        </div>
-
-        <div class="form-group">
-          <%= f.label :published_at, Spree.t(:published_at) %>
-          <%= help_bubble('Marks when the post will be published, leave it blank to hide it') %>
-          <%= f.datetime_field :published_at, class: 'form-control' %>
-        </div>
+        <%= f.spree_select :author_id, options_for_select(post_authors_select_options, @post.author_id || try_spree_current_user.id), { label: Spree.t(:author), autocomplete: true } %>
+        <%= f.spree_select :post_category_id, options_for_select(@post_categories.pluck(:title, :id), @post.post_category_id), { label: Spree.t(:category), include_blank: true, autocomplete: true } %>
+        <%= f.spree_datetime_field :published_at, help_bubble: 'Marks when the post will be published, leave it blank to hide it' %>
 
         <div class="form-group mb-0">
           <%= f.label :tag_list, Spree.t(:tags) %>

--- a/admin/app/views/spree/admin/products/form/_base.html.erb
+++ b/admin/app/views/spree/admin/products/form/_base.html.erb
@@ -1,16 +1,7 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: f.object.new_record?, data: { seo_form_target: 'sourceTitleInput', slug_form_target: :name, action: 'slug-form#updateUrlFromName' } %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record?, data: { seo_form_target: 'sourceTitleInput', slug_form_target: :name, action: 'slug-form#updateUrlFromName' } %>
 
-    <div class="form-group mb-0">
-      <%= f.label :description, Spree.t(:description) %>
-      <div class="trix-container mb-0">
-        <%= f.text_area :description, { rows: 10, class: "form-control spree-rte", data: { seo_form_target: 'sourceDescriptionInput' } } %>
-      </div>
-    </div>
+    <%= f.spree_rich_text_area :description, data: { seo_form_target: 'sourceDescriptionInput' } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/products/form/_base.html.erb
+++ b/admin/app/views/spree/admin/products/form/_base.html.erb
@@ -2,6 +2,11 @@
   <div class="card-body">
     <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record?, data: { seo_form_target: 'sourceTitleInput', slug_form_target: :name, action: 'slug-form#updateUrlFromName' } %>
 
-    <%= f.spree_rich_text_area :description, data: { seo_form_target: 'sourceDescriptionInput' } %>
+    <div class="form-group mb-0">
+      <%= f.label :description, Spree.t(:description) %>
+      <div class="trix-container mb-0">
+        <%= f.text_area :description, { rows: 10, class: "form-control spree-rte", data: { seo_form_target: 'sourceDescriptionInput' } } %>
+      </div>
+    </div>
   </div>
 </div>

--- a/admin/app/views/spree/admin/products/form/_shipping.html.erb
+++ b/admin/app/views/spree/admin/products/form/_shipping.html.erb
@@ -7,10 +7,6 @@
       <%= render 'spree/admin/variants/form/dimensions', f: f %>
     <% end %>
 
-    <div class="form-group">
-      <%= f.label :shipping_category_id, Spree.t(:shipping_category) %>
-      <%= f.select(:shipping_category_id, @shipping_categories.pluck(:name, :id), { include_blank: Spree.t('match_choices.none') }, { class: 'custom-select' }) %>
-      <%= f.error_message_on :shipping_category %>
-    </div>
+    <%= f.spree_select :shipping_category_id, @shipping_categories.pluck(:name, :id), { include_blank: Spree.t('match_choices.none') } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/products/form/_shipping.html.erb
+++ b/admin/app/views/spree/admin/products/form/_shipping.html.erb
@@ -7,6 +7,6 @@
       <%= render 'spree/admin/variants/form/dimensions', f: f %>
     <% end %>
 
-    <%= f.spree_select :shipping_category_id, @shipping_categories.pluck(:name, :id), { include_blank: Spree.t('match_choices.none') } %>
+    <%= f.spree_select :shipping_category_id, @shipping_categories.pluck(:name, :id), { include_blank: Spree.t('match_choices.none'), label: Spree.t(:shipping_category) } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/products/form/_tax.html.erb
+++ b/admin/app/views/spree/admin/products/form/_tax.html.erb
@@ -3,6 +3,6 @@
     <h5 class="card-title"><%= Spree.t(:tax) %></h5>
   </div>
   <div class="card-body">
-    <%= f.spree_select :tax_category_id, @tax_categories.pluck(:name, :id), { include_blank: false } %>
+    <%= f.spree_select :tax_category_id, @tax_categories.pluck(:name, :id), { include_blank: false, label: Spree.t(:tax_category) } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/products/form/_tax.html.erb
+++ b/admin/app/views/spree/admin/products/form/_tax.html.erb
@@ -3,10 +3,6 @@
     <h5 class="card-title"><%= Spree.t(:tax) %></h5>
   </div>
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
-      <%= f.select(:tax_category_id, @tax_categories.pluck(:name, :id), { include_blank: false }, { class: 'custom-select' }) %>
-      <%= f.error_message_on :tax_category %>
-    </div>
+    <%= f.spree_select :tax_category_id, @tax_categories.pluck(:name, :id), { include_blank: false } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/promotions/_form.html.erb
+++ b/admin/app/views/spree/admin/promotions/_form.html.erb
@@ -5,14 +5,7 @@
     </h5>
   </div>
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: true %>
-      <%= f.error_message_on :name %>
-      <span class="form-text text-muted mt-2">
-        Customers will see this in their cart and at checkout.
-      </span>
-    </div>
+    <%= f.spree_text_field :name, required: true, autofocus: true, help: 'Customers will see this in their cart and at checkout.' %>
   </div>
 </div>
 

--- a/admin/app/views/spree/admin/promotions/form/_settings.html.erb
+++ b/admin/app/views/spree/admin/promotions/form/_settings.html.erb
@@ -1,11 +1,5 @@
 <% unless @promotion.multi_codes? %>
-  <div class="form-group">
-    <%= f.label :usage_limit, Spree.t('limit_usage_to') %>
-    <%= f.number_field :usage_limit, min: 0, step: 1, class: 'form-control' %>
-    <span class="form-text text-muted mt-2">
-      Leave this field blank for unlimited usage.
-    </span>
-  </div>
+  <%= f.spree_number_field :usage_limit, min: 0, step: 1, help: 'Leave this field blank for unlimited usage.' %>
 <% end %>
 
 <div class="form-group">

--- a/admin/app/views/spree/admin/properties/_form.html.erb
+++ b/admin/app/views/spree/admin/properties/_form.html.erb
@@ -2,15 +2,7 @@
   <div class="card-body">
     <%= f.spree_text_field :presentation, data: { slug_form_target: :name, action: 'input->slug-form#updateUrlFromName' }, required: true, autofocus: f.object.new_record? %>
     <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, required: true %>
-    <div class="form-group">
-      <%= f.label :kind, Spree.t(:kind) %>
-      <%= f.select :kind, options_for_select(Spree::Property.kinds.map{ |k| [k.first.humanize, k.first.to_sym] }, @object.kind), {}, { class: 'custom-select' } %>
-      <%= f.error_message_on :kind %>
-    </div>
-    <div class="form-group">
-      <%= f.label :display_on, Spree.t(:display_on) %>
-      <%= f.select :display_on, display_on_options, {}, { class: 'custom-select' } %>
-      <%= f.error_message_on :display_on %>
-    </div>
+    <%= f.spree_select :kind, options_for_select(Spree::Property.kinds.map{ |k| [k.first.humanize, k.first.to_sym] }, @object.kind) %>
+    <%= f.spree_select :display_on, display_on_options, { label: Spree.t(:display_on) } %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/properties/_form.html.erb
+++ b/admin/app/views/spree/admin/properties/_form.html.erb
@@ -1,15 +1,7 @@
 <div data-controller="slug-form" class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :presentation, raw(Spree.t(:presentation) + required_span_tag) %>
-      <%= f.text_field :presentation, class: 'form-control', data: { slug_form_target: :name, action: 'input->slug-form#updateUrlFromName' }, required: true, autofocus: f.object.new_record? %>
-      <%= f.error_message_on :presentation %>
-    </div>
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:internal_name) %>
-      <%= f.text_field :name, class: 'form-control', data: { slug_form_target: :url }, required: true %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :presentation, data: { slug_form_target: :name, action: 'input->slug-form#updateUrlFromName' }, required: true, autofocus: f.object.new_record? %>
+    <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, required: true %>
     <div class="form-group">
       <%= f.label :kind, Spree.t(:kind) %>
       <%= f.select :kind, options_for_select(Spree::Property.kinds.map{ |k| [k.first.humanize, k.first.to_sym] }, @object.kind), {}, { class: 'custom-select' } %>

--- a/admin/app/views/spree/admin/properties/_table_row.html.erb
+++ b/admin/app/views/spree/admin/properties/_table_row.html.erb
@@ -20,6 +20,6 @@
     <% end %>
   </td>
   <td class="w-10 actions">
-    <%= link_to_edit(property, class: 'btn btn-light btn-sm') if can?(:edit, property) %>
+    <%= link_to_edit(property, class: 'btn btn-light btn-sm', data: { turbo_frame: '_top' }) if can?(:edit, property) %>
   </td>
 </tr>

--- a/admin/app/views/spree/admin/refunds/_form.html.erb
+++ b/admin/app/views/spree/admin/refunds/_form.html.erb
@@ -10,8 +10,4 @@
   </div>
 <% end %>
 
-<div class="form-group mb-0">
-  <%= f.label :refund_reason_id, Spree.t(:reason) %>
-  <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, { include_blank: true }, { data: { controller: 'autocomplete-select' }, required: true }) %>
-  <%= f.error_message_on :reason %>
-</div>
+<%= f.spree_collection_select :refund_reason_id, refund_reasons, :id, :name, { include_blank: true, label: Spree.t(:reason), required: true, autocomplete: true } %>

--- a/admin/app/views/spree/admin/reimbursement_types/_form.html.erb
+++ b/admin/app/views/spree/admin/reimbursement_types/_form.html.erb
@@ -2,18 +2,13 @@
   <div class="card-body">
     <%= f.spree_text_field :name, autofocus: f.object.new_record?, required: true %>
 
-    <div class="form-group">
-      <%= f.label :type, Spree.t(:type) %>
-      <%= f.select :type,
-                options_for_select(
-                  Spree::ReimbursementType::KINDS.map do |kind|
-                    [kind.demodulize.titleize, kind]
-                  end,
-                ),
-                { include_blank: false },
-                { class: "custom-select" } %>
-      <%= f.error_message_on :type %>
-    </div>
+    <%= f.spree_select :type,
+              options_for_select(
+                Spree::ReimbursementType::KINDS.map do |kind|
+                  [kind.demodulize.titleize, kind]
+                end,
+              ),
+              { include_blank: false, label: Spree.t(:type), autocomplete: true } %>
 
     <%= f.spree_check_box :active, label: Spree.t(:active) %>
 

--- a/admin/app/views/spree/admin/reimbursement_types/_form.html.erb
+++ b/admin/app/views/spree/admin/reimbursement_types/_form.html.erb
@@ -1,10 +1,6 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: "form-control", autofocus: f.object.new_record?, required: true %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, autofocus: f.object.new_record?, required: true %>
 
     <div class="form-group">
       <%= f.label :type, Spree.t(:type) %>
@@ -19,20 +15,8 @@
       <%= f.error_message_on :type %>
     </div>
 
-    <div class="form-group">
-      <div class="custom-control custom-checkbox">
-        <%= f.check_box :active, class: "custom-control-input" %>
-        <%= f.label :active, Spree.t(:active), class: "custom-control-label" %>
-      </div>
-      <%= f.error_message_on :active %>
-    </div>
+    <%= f.spree_check_box :active, label: Spree.t(:active) %>
 
-    <div class="form-group">
-      <div class="custom-control custom-checkbox">
-        <%= f.check_box :mutable, class: "custom-control-input" %>
-        <%= f.label :mutable, Spree.t(:mutable), class: "custom-control-label" %>
-      </div>
-      <%= f.error_message_on :mutable %>
-    </div>
+    <%= f.spree_check_box :mutable, label: Spree.t(:mutable) %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/roles/_form.html.erb
+++ b/admin/app/views/spree/admin/roles/_form.html.erb
@@ -1,9 +1,5 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-      <%= f.text_field :name, class: 'form-control', required: true %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, required: true %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/roles/index.html.erb
+++ b/admin/app/views/spree/admin/roles/index.html.erb
@@ -28,7 +28,7 @@
                 <%= Spree.t(:all) %>
               </td>
               <td class="actions">
-                <%= link_to_edit(role) %>
+                <%= link_to_edit(role, data: { turbo_frame: '_top' }) %>
               </td>
             </tr>
           <% end %>

--- a/admin/app/views/spree/admin/shared/_edit_resource.html.erb
+++ b/admin/app/views/spree/admin/shared/_edit_resource.html.erb
@@ -3,7 +3,7 @@
   <%= @object.try(:name) || @object.try(:title) || @object.try(:number) %>
 <% end %>
 
-<%= form_with model: [:admin, @object], url: object_url, scope: @resource.object_name, id: "edit_#{controller_name.singularize}_#{@object.id}" do |f| %>
+<%= form_with model: [:admin, @object], url: object_url, scope: @resource.object_name, id: "edit_#{controller_name.singularize}_#{@object.id}", data: local_assigns[:data] || {} do |f| %>
   <div class="row">
     <div class="col-lg-6 offset-lg-3">
       <%= render 'spree/admin/shared/error_messages', target: @object %>

--- a/admin/app/views/spree/admin/shared/_new_resource.html.erb
+++ b/admin/app/views/spree/admin/shared/_new_resource.html.erb
@@ -3,7 +3,7 @@
   <%= Spree.t("new_#{controller_name.singularize}") %>
 <% end %>
 
-<%= form_with model: [:admin, @object], url: collection_url, id: "new_#{controller_name.singularize}" do |f| %>
+<%= form_with model: [:admin, @object], url: collection_url, id: "new_#{controller_name.singularize}", data: local_assigns[:data] || {} do |f| %>
   <div class="row">
     <div class="col-lg-6 offset-lg-3">
       <%= render 'spree/admin/shared/error_messages', target: @object %>

--- a/admin/app/views/spree/admin/shared/_seo.html.erb
+++ b/admin/app/views/spree/admin/shared/_seo.html.erb
@@ -17,14 +17,9 @@
       <%= placeholder %>
     </div>
     <div class="seo__inputs d-none" data-seo-form-target="inputsContainer">
-      <div class="form-group">
-        <%= f.label :meta_title, Spree.t(:meta_title) %>
-        <%= f.text_field :meta_title, class: 'form-control', data: { seo_form_target: 'titleInput', action: 'input->seo-form#updatePreviews' } %>
-      </div>
-      <div class="form-group">
-        <%= f.label :meta_description, Spree.t(:meta_description) %>
-        <%= f.text_area :meta_description, class: 'form-control', rows: 4, data: { seo_form_target: 'descriptionInput', action: 'input->seo-form#updatePreviews' } %>
-      </div>
+      <%= f.spree_text_field :meta_title, data: { seo_form_target: 'titleInput', action: 'input->seo-form#updatePreviews' } %>
+      <%= f.spree_text_area :meta_description, rows: 4, data: { seo_form_target: 'descriptionInput', action: 'input->seo-form#updatePreviews' } %>
+      
       <div class="form-group">
         <% if defined?(slug_attribute_name) %>
           <%= label_tag slug_attribute_name, Spree.t(:slug) %>

--- a/admin/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/admin/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -1,15 +1,6 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-      <%= f.text_field :name, class: 'form-control', autofocus: f.object.new_record?, required: true %>
-      <%= f.error_message_on :name %>
-    </div>
-    <div class="custom-control custom-checkbox">
-      <%= f.check_box :active, class: 'custom-control-input' %>
-      <%= f.label :active, class: 'custom-control-label' do %>
-        <%= Spree.t(:active) %>
-      <% end %>
-    </div>
+    <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
+    <%= f.spree_check_box :active %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/admin/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,9 +1,5 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control', autofocus: f.object.new_record?, required: true %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, autofocus: f.object.new_record?, required: true %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/shipping_methods/form/_tax_category.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_tax_category.html.erb
@@ -7,10 +7,7 @@
     </div>
 
     <div class="card-body">
-      <div class="form-group">
-        <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'custom-select' }) %>
-        <%= f.error_message_on :tax_category %>
-      </div>
+      <%= f.spree_collection_select :tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') } %>
     </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/admin/app/views/spree/admin/stock_locations/_form.html.erb
@@ -5,22 +5,10 @@
     </h5>
   </div>
   <div class="card-body" >
-    <div class="form-group">
-      <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: f.object.new_record? %>
-      <%= f.error_message_on :name %>
-    </div>
-    <div class="form-group">
-      <%= f.label :admin_name, Spree.t(:internal_name) %>
-      <%= f.text_field :admin_name, class: 'form-control', label: false %>
-    </div>
+    <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
+    <%= f.spree_text_field :admin_name, label: Spree.t(:internal_name) %>
     <% unless f.object.default? %>
-      <div class="form-group">
-        <div class="custom-control custom-checkbox">
-          <%= f.check_box :active, class: 'custom-control-input' %>
-          <%= f.label :active, class: 'custom-control-label' %>
-        </div>
-      </div>
+      <%= f.spree_check_box :active %>
     <% end %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/store_credit_categories/_form.html.erb
+++ b/admin/app/views/spree/admin/store_credit_categories/_form.html.erb
@@ -1,5 +1,1 @@
-<div class="form-group">
-  <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-  <%= f.text_field :name, class: 'form-control' %>
-  <%= f.error_message_on :name %>
-</div>
+<%= f.spree_text_field :name %>

--- a/admin/app/views/spree/admin/store_credit_categories/index.html.erb
+++ b/admin/app/views/spree/admin/store_credit_categories/index.html.erb
@@ -26,7 +26,7 @@
                 <%= store_credit_category.name %>
               </td>
               <td class="actions">
-                <%= link_to_edit(store_credit_category, no_text: true) if can? :edit, store_credit_category %>
+                <%= link_to_edit(store_credit_category, no_text: true, data: { turbo_frame: '_top' }) if can? :edit, store_credit_category %>
               </td>
             </tr>
           <% end %>

--- a/admin/app/views/spree/admin/store_credits/_form.html.erb
+++ b/admin/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,16 +1,8 @@
-<div class="form-group">
-  <%= f.label :amount, raw(Spree.t(:amount) + required_span_tag) %>
-  <%= f.number_field :amount, class: 'form-control', min: 0.01, step: 0.01, required: true, disabled: !f.object.editable? %>
-  <%= f.error_message_on :amount %>
-</div>
+<%= f.spree_number_field :amount, label: raw(Spree.t(:amount) + required_span_tag), min: 0.01, step: 0.01, required: true, disabled: !f.object.editable? %>
 
 <div class="form-group">
   <%= f.label :currency, raw(Spree.t(:currency) + required_span_tag), class: 'form-label' %>
   <%= f.select :currency, preferred_currencies_select_options, {}, { data: { controller: 'autocomplete-select', enable_button_target: 'input', store_form_target: 'currency' } } %>
 </div>
 
-<div class="form-group">
-<%= f.label :memo, Spree.t(:memo) %>
-<%= f.text_area :memo, class: 'form-control' %>
-<%= f.error_message_on :memo %>
-</div>
+<%= f.spree_text_area :memo %>

--- a/admin/app/views/spree/admin/store_credits/_form.html.erb
+++ b/admin/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,8 +1,3 @@
-<%= f.spree_number_field :amount, label: raw(Spree.t(:amount) + required_span_tag), min: 0.01, step: 0.01, required: true, disabled: !f.object.editable? %>
-
-<div class="form-group">
-  <%= f.label :currency, raw(Spree.t(:currency) + required_span_tag), class: 'form-label' %>
-  <%= f.select :currency, preferred_currencies_select_options, {}, { data: { controller: 'autocomplete-select', enable_button_target: 'input', store_form_target: 'currency' } } %>
-</div>
-
+<%= f.spree_number_field :amount, label: Spree.t(:amount), min: 0.01, step: 0.01, required: true, disabled: !f.object.editable? %>
+<%= f.spree_select :currency, preferred_currencies_select_options, { label: Spree.t(:currency), autocomplete: true }, { data: { enable_button_target: 'input', store_form_target: 'currency' } } %>
 <%= f.spree_text_area :memo %>

--- a/admin/app/views/spree/admin/storefront/edit.html.erb
+++ b/admin/app/views/spree/admin/storefront/edit.html.erb
@@ -30,10 +30,7 @@
             <%= f.label :name, Spree.t(:site_name) %>
             <%= f.text_field :name, class: 'form-control' %>
           </div>
-          <div class="form-group">
-            <%= f.label :meta_description, 'Search description' %>
-            <%= f.text_area :meta_description, class: 'form-control', style: 'min-height: 5em', data: { controller: 'textarea-autogrow'} %>
-          </div>
+          <%= f.spree_text_area :meta_description, label: 'Search description', style: 'min-height: 5em' %>
           <div class="custom-control custom-checkbox mb-2">
             <%= f.check_box :preferred_index_in_search_engines, class: 'custom-control-input' %>
             <%= f.label :preferred_index_in_search_engines, Spree.t(:index_in_search_engines), class: 'custom-control-label' %>
@@ -73,20 +70,11 @@
           </h5>
         </div>
         <div class="card-body">
-          <div class="form-group">
-            <%= f.label :storefront_custom_code_head, Spree.t(:head_tag) %>
-            <%= f.text_area :storefront_custom_code_head, class: 'form-control', rows: 4, data: { controller: 'textarea-autogrow'} %>
-          </div>
+          <%= f.spree_text_area :storefront_custom_code_head, rows: 4 %>
 
-          <div class="form-group">
-            <%= f.label :storefront_custom_code_body_start, Spree.t(:body_tag_start) %>
-            <%= f.text_area :storefront_custom_code_body_start, class: 'form-control', rows: 4, data: { controller: 'textarea-autogrow'} %>
-          </div>
+          <%= f.spree_text_area :storefront_custom_code_body_start, rows: 4 %>
 
-          <div class="form-group">
-            <%= f.label :storefront_custom_code_body_end, Spree.t(:body_tag_end) %>
-            <%= f.text_area :storefront_custom_code_body_end, class: 'form-control', rows: 4, data: { controller: 'textarea-autogrow'} %>
-          </div>
+          <%= f.spree_text_area :storefront_custom_code_body_end, rows: 4 %>
         </div>
       </div>
 

--- a/admin/app/views/spree/admin/stores/edit.html.erb
+++ b/admin/app/views/spree/admin/stores/edit.html.erb
@@ -4,9 +4,13 @@
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @store }, class: 'mb-5 pb-5' %>
 
-<%= form_for current_store, url: spree.admin_store_path(section: params[:section]), method: :patch do |f| %>
-  <%= render partial: 'spree/admin/stores/form/basic', locals: { f: f } if params[:section].blank? || params[:section] == 'general-settings' %>
-  <%= render partial: 'spree/admin/stores/form/emails', locals: { f: f } if params[:section] == 'emails' %>
-  <%= render partial: 'spree/admin/stores/form/checkout', locals: { f: f } if params[:section] == 'checkout' %>
-  <%= render partial: 'spree/admin/stores/form/policies', locals: { f: f } if params[:section] == 'policies' %>
-<% end %>
+<div class="row">
+  <div class="col-lg-6 offset-lg-3">
+    <%= form_for current_store, url: spree.admin_store_path(section: params[:section]), method: :patch do |f| %>
+      <%= render partial: 'spree/admin/stores/form/basic', locals: { f: f } if params[:section].blank? || params[:section] == 'general-settings' %>
+      <%= render partial: 'spree/admin/stores/form/emails', locals: { f: f } if params[:section] == 'emails' %>
+      <%= render partial: 'spree/admin/stores/form/checkout', locals: { f: f } if params[:section] == 'checkout' %>
+      <%= render partial: 'spree/admin/stores/form/policies', locals: { f: f } if params[:section] == 'policies' %>
+    <% end %>
+  </div>
+</div>

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -6,137 +6,90 @@
   <%= link_to_edit_translations(@store) %>
 <% end %>
 
-<div class="row">
-  <div class="col-lg-6">
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:name) %> & <%= Spree.t(:logo) %></h5>
-      </div>
-      <div class="card-body">
-        <p class="text-muted">
-          <%= Spree.t(:store_name_help) %>
-        </p>
-        <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
-        
-        <div class="form-group mb-0">
-          <%= f.label :logo do %>
-            <%= Spree.t(:logo) %>
-            <%= help_bubble("Used in the admin dashboard") %>
-          <% end %>
-          <%= render 'active_storage/upload_form', form: f, field_name: :logo, width: 240, height: 240, crop: true %>
-        </div>
-      </div>
-    </div>
-
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:phone) %> & <%= Spree.t(:address) %></h5>
-      </div>
-      <div class="card-body">
-        <%= f.spree_text_field :contact_phone %>
-        <%= f.spree_text_area :address %>
-      </div>
-    </div>
-
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:standards_and_formats) %></h5>
-      </div>
-      <div class="card-body">
-        <p class="text-muted">
-          <%= Spree.t(:standards_and_formats_help) %>
-        </p>
-        <div class="form-group mb-3">
-          <%= label_tag :preferred_timezone, raw(Spree.t(:timezone) + required_span_tag) %>
-          <%= time_zone_select :store, :preferred_timezone, nil, {}, { data: { controller: 'autocomplete-select' } } %>
-        </div>
-        <div data-controller="unit-system">
-          <div class="form-group mb-3">
-            <%= label_tag :preferred_unit_system, raw(Spree.t(:unit_system) + required_span_tag) %>
-            <%= select_tag 'store[preferred_unit_system]', options_for_select(unit_systems, @store.preferred_unit_system), {class: 'custom-select', data: {unit_system_target: "body", action: "change->unit-system#unitSystemHandler"}} %>
-            <p class="text-muted form-text mt-2 mb-0">
-              <%= Spree.t(:unit_system_help) %>
-            </p>
-          </div>
-          <div class="form-group">
-            <%= label_tag :preferred_weight_unit, raw(Spree.t(:weight_unit) + required_span_tag) %>
-            <%= select_tag 'store[preferred_weight_unit]', options_for_select(weight_units(@store), @store.preferred_weight_unit), {class: 'custom-select', data: {unit_system_target: "weightUnit"}} %>
-            <p class="text-muted form-text mt-2 mb-0">
-              <%= Spree.t(:weight_unit_help) %>
-            </p>
-          </div>
-        </div>
-      </div>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:name) %> & <%= Spree.t(:logo) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      <%= Spree.t(:store_name_help) %>
+    </p>
+    <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
+    
+    <div class="form-group mb-0">
+      <%= f.label :logo do %>
+        <%= Spree.t(:logo) %>
+        <%= help_bubble("Used in the admin dashboard") %>
+      <% end %>
+      <%= render 'active_storage/upload_form', form: f, field_name: :logo, width: 240, height: 240, crop: true %>
     </div>
   </div>
+</div>
 
-  <div class="col-lg-6">
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:currencies) %> & <%= Spree.t(:countries) %></h5>
-      </div>
-      <div class="card-body">
-        <p class="text-muted">
-          <%= Spree.t(:currency_and_country_help) %>
-        </p>
-        <div class="form-group">
-          <%= f.label :default_currency, Spree.t(:default_currency) %>
-          <%= f.currency_select :default_currency, preferred_currencies, {}, data: { controller: 'autocomplete-select' } %>
-          <%= f.error_message_on :default_currency %>
-        </div>
-        <div class="form-group">
-          <%= f.label :supported_currencies, Spree.t(:supported_currencies) %>
-          <%= f.select :supported_currencies,
-          currency_options(@store.supported_currencies&.split(',')),
-          { prompt: false },
-          { multiple: true, data: { controller: 'autocomplete-select' } } %>
-          <%= f.error_message_on :supported_currencies %>
-        </div>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:currencies) %> & <%= Spree.t(:countries) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      <%= Spree.t(:currency_and_country_help) %>
+    </p>
+    <%= f.spree_select :default_currency, currency_options(@store.default_currency), { label: Spree.t(:default_currency), autocomplete: true } %>
+    <%= f.spree_select :supported_currencies, currency_options(@store.supported_currencies&.split(',')), { prompt: false, multiple: true, autocomplete: true } %>
+    <%= f.spree_select :default_country_iso, Spree::Country.pluck(:name, :iso), { include_blank: false, label: Spree.t(:default_country), autocomplete: true } %>
 
-        <div class="form-group">
-          <%= f.label :default_country_iso, Spree.t(:default_country) %>
-          <%= f.collection_select :default_country_iso, Spree::Country.pluck(:iso, :name), :first, :last, { include_blank: false }, { data: { controller: 'autocomplete-select' } } %>
-          <%= f.error_message_on :default_country_iso %>
-        </div>
-        <div class="form-group">
-          <%= f.label :checkout_zone_id, Spree.t(:shipping_zone) %>
-          <%= f.select :checkout_zone_id, options_for_select(@zones, @store.checkout_zone_id), { }, { data: { controller: 'autocomplete-select' } } %>
-          <small class="form-text text-muted mt-2">
-            <%= Spree.t(:shipping_zone_help) %>
-            <%= link_to Spree.t('admin.manage_zones'), spree.admin_zones_path %>
-          </small>
-          <%= f.error_message_on :checkout_zone_id %>
-        </div>
+    <%= f.spree_select :checkout_zone_id, options_for_select(@zones, @store.checkout_zone_id), { label: Spree.t(:shipping_zone), autocomplete: true } %>
+    <small class="form-text text-muted mb-3">
+      <%= Spree.t(:shipping_zone_help) %>
+      <%= link_to Spree.t('admin.manage_zones'), spree.admin_zones_path, class: 'text-blue' %>
+    </small>
 
-        <div class="form-group">
-          <%= f.label :default_locale, Spree.t(:default_locale) %>
-          <%= f.select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), {}, { data: { controller: 'autocomplete-select' } } %>
-          <%= f.error_message_on :default_locale %>
-        </div>
-        <div class="form-group">
-          <%= f.label :supported_locales, Spree.t(:supported_locales) %>
-          <%= f.select :supported_locales, options_from_collection_for_select(all_locales_options, :last, :first, @store.supported_locales&.split(',')), {}, { multiple: true, data: { controller: 'autocomplete-select' } } %>
-          <%= f.error_message_on :supported_locales %>
-        </div>
-      </div>
+    <%= f.spree_select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), { autocomplete: true } %>
+    <%= f.spree_select :supported_locales, options_from_collection_for_select(all_locales_options, :last, :first, @store.supported_locales&.split(',')), { multiple: true, autocomplete: true } %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:standards_and_formats) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      <%= Spree.t(:standards_and_formats_help) %>
+    </p>
+    <div class="form-group mb-3">
+      <%= label_tag :preferred_timezone, raw(Spree.t(:timezone) + required_span_tag) %>
+      <%= time_zone_select :store, :preferred_timezone, nil, {}, { data: { controller: 'autocomplete-select' } } %>
+    </div>
+    <div data-controller="unit-system">
+      <%= f.spree_select :preferred_unit_system, options_for_select(unit_systems, @store.preferred_unit_system), { label: Spree.t(:unit_system), data: { unit_system_target: "body", action: "change->unit-system#unitSystemHandler" }, help: Spree.t(:unit_system_help) } %>
+      <%= f.spree_select :preferred_weight_unit, options_for_select(weight_units(@store), @store.preferred_weight_unit), { label: Spree.t(:weight_unit), data: { unit_system_target: "weightUnit" }, help: Spree.t(:weight_unit_help) } %>
     </div>
   </div>
+</div>
 
-  <div class="col-lg-6">
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:digital_assets) %></h5>
-      </div>
-      <div class="card-body">
-        <p class="text-muted">
-          <%= Spree.t(:digital_assets_help) %>
-        </p>
-        <%= f.spree_check_box :preferred_limit_digital_download_days %>
-        <%= f.spree_number_field :preferred_digital_asset_authorized_days, min: 1 %>
-        <%= f.spree_check_box :preferred_limit_digital_download_count %>
-        <%= f.spree_number_field :preferred_digital_asset_authorized_clicks, min: 1 %>
-      </div>
-    </div>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:phone) %> & <%= Spree.t(:address) %></h5>
+  </div>
+  <div class="card-body">
+    <%= f.spree_text_field :contact_phone %>
+    <%= f.spree_text_area :address %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:digital_assets) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      <%= Spree.t(:digital_assets_help) %>
+    </p>
+    <%= f.spree_check_box :preferred_limit_digital_download_days %>
+    <%= f.spree_number_field :preferred_digital_asset_authorized_days, min: 1 %>
+    <%= f.spree_check_box :preferred_limit_digital_download_count %>
+    <%= f.spree_number_field :preferred_digital_asset_authorized_clicks, min: 1 %>
   </div>
 </div>
 

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -16,11 +16,8 @@
         <p class="text-muted">
           <%= Spree.t(:store_name_help) %>
         </p>
-        <div class="form-group">
-          <%= f.label :name, Spree.t(:name) %>
-          <%= f.text_field :name, class: 'form-control', required: true, autofocus: f.object.new_record? %>
-          <%= f.error_message_on :name %>
-        </div>
+        <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
+        
         <div class="form-group mb-0">
           <%= f.label :logo do %>
             <%= Spree.t(:logo) %>
@@ -36,15 +33,8 @@
         <h5 class="card-title"><%= Spree.t(:phone) %> & <%= Spree.t(:address) %></h5>
       </div>
       <div class="card-body">
-        <div class="form-group">
-          <%= f.label :contact_phone, Spree.t(:contact_phone) %>
-          <%= f.text_field :contact_phone, class: 'form-control' %>
-        </div>
-
-        <div class="form-group">
-          <%= f.label :address, Spree.t(:address) %>
-          <%= f.text_area :address, rows: 5, class: 'form-control', data: { controller: 'textarea-autogrow' } %>
-        </div>
+        <%= f.spree_text_field :contact_phone %>
+        <%= f.spree_text_area :address %>
       </div>
     </div>
 
@@ -141,33 +131,10 @@
         <p class="text-muted">
           <%= Spree.t(:digital_assets_help) %>
         </p>
-        <div class="custom-control custom-checkbox mb-3">
-          <%= f.check_box :preferred_limit_digital_download_days,
-                      class: "custom-control-input" %>
-          <%= f.label :preferred_limit_digital_download_days, class: "custom-control-label" %>
-          <%= f.error_message_on :preferred_limit_digital_download_days %>
-        </div>
-        <div class="form-group">
-          <%= f.label :preferred_digital_asset_authorized_days %>
-          <%= f.number_field :preferred_digital_asset_authorized_days,
-                         class: "form-control",
-                         min: 1 %>
-          <%= f.error_message_on :preferred_digital_asset_authorized_days %>
-        </div>
-
-        <div class="custom-control custom-checkbox mb-3">
-          <%= f.check_box :preferred_limit_digital_download_count,
-                      class: "custom-control-input" %>
-          <%= f.label :preferred_limit_digital_download_count, class: "custom-control-label" %>
-          <%= f.error_message_on :preferred_limit_digital_download_count %>
-        </div>
-        <div class="form-group">
-          <%= f.label :preferred_digital_asset_authorized_clicks %>
-          <%= f.number_field :preferred_digital_asset_authorized_clicks,
-                         class: "form-control",
-                         min: 1 %>
-          <%= f.error_message_on :preferred_digital_asset_authorized_clicks %>
-        </div>
+        <%= f.spree_check_box :preferred_limit_digital_download_days %>
+        <%= f.spree_number_field :preferred_digital_asset_authorized_days, min: 1 %>
+        <%= f.spree_check_box :preferred_limit_digital_download_count %>
+        <%= f.spree_number_field :preferred_digital_asset_authorized_clicks, min: 1 %>
       </div>
     </div>
   </div>

--- a/admin/app/views/spree/admin/stores/form/_checkout.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_checkout.html.erb
@@ -1,66 +1,31 @@
 <%= content_for(:page_title) do %>
-  <%= Spree.t(:checkout) %> <%= Spree.t(:settings) %>
+<%= Spree.t(:checkout) %> <%= Spree.t(:settings) %>
 <% end %>
 
-<div class="row">
-  <div class="col-lg-6 offset-lg-3">
-    <div class="alert alert-info mb-3">
-      <p>
-        <%= Spree.t('admin.checkout_settings.policy_copy', policies_link: link_to(Spree.t(:policies), spree.edit_admin_store_path + '?section=policies', class: 'alert-link')).html_safe %>
-      </p>
-    </div>
+<div class="alert alert-info mb-3">
+  <p>
+    <%= Spree.t('admin.checkout_settings.policy_copy', policies_link: link_to(Spree.t(:policies), spree.edit_admin_store_path + '?section=policies', class: 'alert-link')).html_safe %>
+  </p>
+</div>
 
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:settings) %></h5>
-      </div>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:settings) %></h5>
+  </div>
 
-      <div class="card-body">
-        <div class="custom-control custom-checkbox mb-3">
-          <%= f.check_box :preferred_guest_checkout, class: "custom-control-input" %>
-          <%= f.label :preferred_guest_checkout, Spree.t('admin.checkout_settings.guest_checkout.label'), class: "custom-control-label" %>
-          <%= f.error_message_on :preferred_guest_checkout %>
+  <div class="card-body">
+    <%= f.spree_check_box :preferred_guest_checkout, label: Spree.t('admin.checkout_settings.guest_checkout.label'), help: Spree.t('admin.checkout_settings.guest_checkout.description') %>
+    <%= f.spree_check_box :preferred_company_field_enabled, label: Spree.t('admin.store_form.company_field.label'), help: Spree.t('admin.store_form.company_field.description') %>
+    <%= f.spree_check_box :preferred_special_instructions_enabled, label: Spree.t('admin.checkout_settings.special_instructions.label'), help: Spree.t('admin.checkout_settings.special_instructions.description') %>
+  </div>
+</div>
 
-          <p class="text-muted mt-1">
-            <%= Spree.t('admin.checkout_settings.guest_checkout.description') %>
-          </p>
-        </div>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:checkout_message) %></h5>
+  </div>
 
-        <div class="custom-control custom-checkbox mb-3">
-          <%= f.check_box :preferred_company_field_enabled, class: "custom-control-input" %>
-          <%= f.label :preferred_company_field_enabled, Spree.t('admin.store_form.company_field.label'), class: "custom-control-label" %>
-          <%= f.error_message_on :preferred_company_field_enabled %>
-
-          <div class="text-muted mt-1">
-            <%= Spree.t('admin.store_form.company_field.description') %>
-          </div>
-        </div>
-
-        <div class="custom-control custom-checkbox">
-          <%= f.check_box :preferred_special_instructions_enabled, class: "custom-control-input" %>
-          <%= f.label :preferred_special_instructions_enabled, Spree.t('admin.checkout_settings.special_instructions.label'), class: "custom-control-label" %>
-          <%= f.error_message_on :preferred_special_instructions_enabled %>
-
-          <p class="text-muted mt-1">
-            <%= Spree.t('admin.checkout_settings.special_instructions.description') %>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:checkout_message) %></h5>
-      </div>
-
-      <div class="card-body">
-        <p class="text-muted">
-          <%= Spree.t('admin.checkout_settings.checkout_message_description') %>
-        </p>
-        <div class="trix-container">
-          <%= f.rich_text_area :checkout_message, class: 'overflow-auto', style: 'height: 300px' %>
-        </div>
-      </div>
-    </div>
+  <div class="card-body">
+    <%= f.spree_rich_text_area :checkout_message, label: false, help: Spree.t('admin.checkout_settings.checkout_message_description') %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -9,15 +9,7 @@
         <h5 class="card-title"><%= Spree.t(:settings) %></h5>
       </div>
       <div class="card-body">
-        <div class="form-group">
-          <div class="custom-control custom-checkbox">
-            <%= f.check_box :preferred_send_consumer_transactional_emails, class: 'custom-control-input' %>
-            <%= f.label :preferred_send_consumer_transactional_emails, Spree.t(:send_consumer_transactional_emails), class: 'custom-control-label' %>
-            <small class="form-text text-muted mt-2">
-              <%= Spree.t('admin.store_form.send_consumer_transactional_emails_help') %>
-            </small>
-          </div>
-        </div>
+        <%= f.spree_check_box :preferred_send_consumer_transactional_emails, help: Spree.t('admin.store_form.send_consumer_transactional_emails_help') %>
       </div>
     </div>
 
@@ -30,29 +22,9 @@
           Please provide the email address that will be used as the sender of all emails sent from your store.
         </p>
 
-        <div class="form-group">
-          <%= f.label :mail_from_address, raw(Spree.t(:mail_from_address)  + required_span_tag) %>
-          <%= f.text_field :mail_from_address, class: 'form-control', required: true %>
-          <%= f.error_message_on :mail_from_address %>
-        </div>
-
-        <div class="form-group">
-          <%= f.label :customer_support_email, Spree.t(:customer_support_email) %>
-          <%= f.text_field :customer_support_email, class: 'form-control' %>
-          <%= f.error_message_on :customer_support_email %>
-          <small class="form-text text-muted mt-2">
-            <%= Spree.t('admin.store_form.customer_support_email_help') %>
-          </small>
-        </div>
-
-        <div class="form-group">
-          <%= f.label :new_order_notifications_email, Spree.t(:new_order_notifications_email) %>
-          <%= f.text_field :new_order_notifications_email, class: 'form-control' %>
-          <%= f.error_message_on :new_order_notifications_email %>
-          <small class="form-text text-muted mt-2">
-            <%= Spree.t('admin.store_form.new_order_notifications_email_help') %>
-          </small>
-        </div>
+        <%= f.spree_text_field :mail_from_address, required: true %>
+        <%= f.spree_text_field :customer_support_email, help: Spree.t('admin.store_form.customer_support_email_help') %>
+        <%= f.spree_text_field :new_order_notifications_email, help: Spree.t('admin.store_form.new_order_notifications_email_help') %>
       </div>
     </div>
 

--- a/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -2,45 +2,42 @@
   <%= Spree.t(:emails) %>
 <% end %>
 
-<div class="row">
-  <div class="col-lg-6 offset-lg-3">
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title"><%= Spree.t(:settings) %></h5>
-      </div>
-      <div class="card-body">
-        <%= f.spree_check_box :preferred_send_consumer_transactional_emails, help: Spree.t('admin.store_form.send_consumer_transactional_emails_help') %>
-      </div>
-    </div>
 
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title">Email addresses</h5>
-      </div>
-      <div class="card-body">
-        <p class="text-muted">
-          Please provide the email address that will be used as the sender of all emails sent from your store.
-        </p>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:settings) %></h5>
+  </div>
+  <div class="card-body">
+    <%= f.spree_check_box :preferred_send_consumer_transactional_emails, help: Spree.t('admin.store_form.send_consumer_transactional_emails_help'), label: Spree.t(:send_consumer_transactional_emails) %>
+  </div>
+</div>
 
-        <%= f.spree_text_field :mail_from_address, required: true %>
-        <%= f.spree_text_field :customer_support_email, help: Spree.t('admin.store_form.customer_support_email_help') %>
-        <%= f.spree_text_field :new_order_notifications_email, help: Spree.t('admin.store_form.new_order_notifications_email_help') %>
-      </div>
-    </div>
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title">Email addresses</h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      Please provide the email address that will be used as the sender of all emails sent from your store.
+    </p>
 
-    <div class="card mb-4">
-      <div class="card-header">
-        <h5 class="card-title">Logo for emails</h5>
-      </div>
-      <div class="card-body">
-        <p class="text-muted">This logo is included in all email notifications such as order confirmation</p>
-        <%= render 'active_storage/upload_form', form: f, field_name: :mailer_logo, width: 204, height: 104 %>
-        <p class="form-text text-muted mb-0 mt-2">
-          We recommend images with a transparent background.
-          <br />
-          Only JPEG and PNG formats are supported.
-        </p>
-      </div>
-    </div>
+    <%= f.spree_email_field :mail_from_address, required: true %>
+    <%= f.spree_email_field :customer_support_email, help: Spree.t('admin.store_form.customer_support_email_help') %>
+    <%= f.spree_email_field :new_order_notifications_email, help: Spree.t('admin.store_form.new_order_notifications_email_help') %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:logo) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">This logo is included in all email notifications such as order confirmation</p>
+    <%= render 'active_storage/upload_form', form: f, field_name: :mailer_logo, width: 204, height: 104 %>
+    <p class="form-text text-muted mb-0 mt-2">
+      We recommend images with a transparent background.
+      <br />
+      Only JPEG and PNG formats are supported.
+    </p>
   </div>
 </div>

--- a/admin/app/views/spree/admin/stores/form/_policies.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_policies.html.erb
@@ -2,84 +2,68 @@
   <%= Spree.t(:policies) %>
 <% end %>
 
-<%= content_for :page_alerts do %>
-  <div class="alert alert-info mb-3">
-    Policies will be automatically added to footer of your store and will be available to customers during checkout.
+<div class="alert alert-info mb-3">
+  Policies will be automatically added to footer of your store and will be available to customers during checkout.
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:terms_of_service) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      Customers will need to accept these terms of service during signup.
+    </p>
+    <%= f.spree_rich_text_area :customer_terms_of_service, style: 'height: 300px', label: Spree.t(:terms_of_service) %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:privacy_policy) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      Customers will need to accept these privacy policy during signup.
+    </p>
+    <%= f.spree_rich_text_area :customer_privacy_policy, style: 'height: 300px', label: Spree.t(:privacy_policy) %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:returns_policy) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      Please provide your customers with a clear and transparent returns policy.
+    </p>
+    <%= f.spree_rich_text_area :customer_returns_policy, style: 'height: 300px', label: Spree.t(:returns_policy) %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t(:shipping_policy) %></h5>
+  </div>
+  <div class="card-body">
+    <p class="text-muted">
+      Please provide your customers with a clear and transparent shipping policy.
+    </p>
+    <%= f.spree_rich_text_area :customer_shipping_policy, style: 'height: 300px', label: Spree.t(:shipping_policy) %>
+  </div>
+</div>
+
+<% if current_store.respond_to?(:partners_terms_of_service) %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h5 class="card-title">Vendors <%= Spree.t(:terms_of_service) %></h5>
+    </div>
+    <div class="card-body">
+      <p class="text-muted">
+        Vendors you invite will need to accept these terms of service during their onboarding process.
+      </p>
+      <%= f.spree_rich_text_area :partners_terms_of_service, style: 'height: 300px', label: Spree.t(:terms_of_service) %>
+    </div>
   </div>
 <% end %>
-
-<div class="card-lg p-4">
-  <h5 class="mb-3"><%= Spree.t(:terms_of_service) %></h5>
-  <div class="row">
-    <div class="col-lg-4">
-      <p class="text-muted">
-        Customers will need to accept these terms of service during signup.
-      </p>
-    </div>
-    <div class="col-lg-7 offset-lg-1">
-      <div class="trix-container">
-        <%= f.rich_text_area :customer_terms_of_service, class: 'overflow-auto', style: 'height: 300px' %>
-      </div>
-    </div>
-  </div>
-  <hr class="my-5" />
-  <h5 class="mb-3"><%= Spree.t(:privacy_policy) %></h5>
-  <div class="row">
-    <div class="col-lg-4">
-      <p class="text-muted">
-        Customers will need to accept these privacy policy during signup.
-      </p>
-    </div>
-    <div class="col-lg-7 offset-lg-1">
-      <div class="trix-container">
-        <%= f.rich_text_area :customer_privacy_policy, class: 'overflow-auto', style: 'height: 300px' %>
-      </div>
-    </div>
-  </div>
-
-  <hr class="my-5" />
-  <h5 class="mb-3"><%= Spree.t(:returns_policy) %></h5>
-  <div class="row">
-    <div class="col-lg-4">
-      <p class="text-muted">
-        Please provide your customers with a clear and transparent returns policy.
-      </p>
-    </div>
-    <div class="col-lg-7 offset-lg-1">
-      <div class="trix-container">
-        <%= f.rich_text_area :customer_returns_policy, class: 'overflow-auto', style: 'height: 300px' %>
-      </div>
-    </div>
-  </div>
-  <hr class="my-5" />
-  <h5 class="mb-3"><%= Spree.t(:shipping_policy) %></h5>
-  <div class="row">
-    <div class="col-lg-4">
-      <p class="text-muted">
-        Please provide your customers with a clear and transparent shipping policy.
-      </p>
-    </div>
-    <div class="col-lg-7 offset-lg-1">
-      <div class="trix-container">
-        <%= f.rich_text_area :customer_shipping_policy, class: 'overflow-auto', style: 'height: 300px' %>
-      </div>
-    </div>
-  </div>
-
-  <% if current_store.respond_to?(:partners_terms_of_service) %>
-    <hr class="my-5">
-    <h5 class="mb-3">Vendors <%= Spree.t(:terms_of_service) %></h5>
-    <div class="row" id="partners-terms">
-      <div class="col-lg-4">
-        <p class="text-muted">
-          Vendors you invite will need to accept these terms of service during their onboarding process.
-        </p>
-      </div>
-      <div class="col-lg-7 offset-lg-1">
-        <div class="trix-container">
-          <%= f.rich_text_area :partners_terms_of_service, class: 'overflow-auto', style: 'height: 300px' %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-</div>

--- a/admin/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/admin/app/views/spree/admin/tax_categories/_form.html.erb
@@ -7,6 +7,6 @@
 
     <%= f.spree_text_area :description %>
 
-    <%= f.spree_check_box :is_default %>
+    <%= f.spree_check_box :is_default, label: Spree.t(:default) %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/admin/app/views/spree/admin/tax_categories/_form.html.erb
@@ -1,25 +1,12 @@
 <div class="card mb-4">
   <div class="card-body">
 
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control', autofocus: f.object.new_record?, required: true %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, autofocus: f.object.new_record?, required: true %>
 
-    <div class="form-group">
-      <%= f.label :tax_code, Spree.t(:tax_code) %>
-      <%= f.text_field :tax_code, class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :tax_code %>
 
-    <div class="form-group">
-      <%= f.label :description, Spree.t(:description) %><br>
-      <%= f.text_area :description, class: 'form-control' %>
-    </div>
+    <%= f.spree_text_area :description %>
 
-    <div class="custom-control custom-checkbox">
-      <%= f.check_box :is_default, class: 'custom-control-input' %>
-      <%= f.label :is_default, class: 'custom-control-label' %>
-    </div>
+    <%= f.spree_check_box :is_default %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/admin/app/views/spree/admin/tax_rates/_form.html.erb
@@ -6,11 +6,8 @@
   </div>
 
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: f.object.new_record? %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, required: true %>
+
     <div class="form-group">
       <%= f.label :amount_percentage, Spree.t(:rate) %>
       <div class="input-group">
@@ -22,30 +19,13 @@
       <%= f.error_message_on :amount %>
     </div>
 
-    <div class="form-group">
-      <%= f.label :zone_id, Spree.t(:zone) %>
-      <%= f.collection_select(:zone_id, @available_zones, :id, :name, {}, { class: 'custom-select' }) %>
-    </div>
-    <div class="form-group">
-      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
-      <%= f.collection_select(:tax_category_id, @available_categories,:id, :name, {}, { class: 'custom-select' }) %>
-    </div>
+    <%= f.spree_collection_select :zone_id, @available_zones, :id, :name, label: Spree.t(:zone) %>
+    <%= f.spree_collection_select :tax_category_id, @available_categories, :id, :name, label: Spree.t(:tax_category) %>
 
     <hr class="my-4" />
 
-    <div class="form-group">
-      <div class="custom-control custom-checkbox">
-        <%= f.check_box :included_in_price, class: 'custom-control-input' %>
-        <%= f.label :included_in_price, class: 'custom-control-label' %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <div class="custom-control custom-checkbox">
-        <%= f.check_box :show_rate_in_label, class: 'custom-control-input' %>
-        <%= f.label :show_rate_in_label, class: 'custom-control-label' %>
-      </div>
-    </div>
+    <%= f.spree_check_box :included_in_price %>
+    <%= f.spree_check_box :show_rate_in_label %>
   </div>
 </div>
 

--- a/admin/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/admin/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,9 +1,5 @@
 <div class="card mb-4">
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-      <%= f.text_field :name, class: 'form-control', required: true, autofocus: true %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name, required: true, autofocus: true %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/taxons/_form.html.erb
+++ b/admin/app/views/spree/admin/taxons/_form.html.erb
@@ -110,11 +110,7 @@
         <% else %>
           <% disabled = @taxon.root? %>
         <% end %>
-        <div class="form-group">
-          <%= f.label :parent_id, Spree.t('admin.navigation.nested_under') %>
-          <%= f.select :parent_id, nested_set_options(@taxonomy.taxons.includes(:parent), @taxon) {|i| i.pretty_name }, { include_blank: false }, { data: { controller: 'autocomplete-select' }, disabled: disabled  } %>
-          <%= f.error_message_on :parent_id %>
-        </div>
+        <%= f.spree_select :parent_id, nested_set_options(@taxonomy.taxons.includes(:parent), @taxon) {|i| i.pretty_name }, { include_blank: false, label: Spree.t('admin.navigation.nested_under'), autocomplete: true }, { disabled: disabled } %>
       </div>
     </div>
 

--- a/admin/app/views/spree/admin/taxons/_form.html.erb
+++ b/admin/app/views/spree/admin/taxons/_form.html.erb
@@ -2,25 +2,8 @@
   <div class="col-lg-8">
     <div class="card mb-4">
       <div class="card-body pb-0 pt-3">
-        <div class="form-group">
-          <%= f.label :name, raw(Spree.t(:name) + required_span_tag) %>
-          <%= f.text_field :name,
-                class: 'form-control',
-                required: true,
-                autofocus: @taxon.new_record?,
-                data: {
-                  seo_form_target: 'sourceTitleInput',
-                  slug_form_target: 'name',
-                  action: 'slug-form#updateUrlFromName'
-                } %>
-          <%= f.error_message_on :name %>
-        </div>
-        <div class="form-group">
-          <%= f.label :description, Spree.t(:description) %>
-          <div class="trix-container">
-            <%= f.rich_text_area :description, data: { seo_form_target: 'sourceDescriptionInput' } %>
-          </div>
-        </div>
+        <%= f.spree_text_field :name, required: true, autofocus: @taxon.new_record?, data: { seo_form_target: 'sourceTitleInput', slug_form_target: 'name', action: 'slug-form#updateUrlFromName' } %>
+        <%= f.spree_rich_text_area :description, data: { seo_form_target: 'sourceDescriptionInput' } %>
       </div>
     </div>
 
@@ -80,7 +63,7 @@
         <div class="card-body border-bottom">
           <div class="d-flex align-items-center">
             <%= f.label :sort_order, class: 'text-nowrap mr-2 mb-0' %>
-            <%= f.select :sort_order, taxon_sort_options_for_select, {}, { class: 'custom-select custom-select-sm w-auto',  data: { action: 'change->auto-submit#submit' } } %>
+            <%= f.spree_select :sort_order, taxon_sort_options_for_select, {}, { class: 'custom-select-sm w-auto',  data: { action: 'change->auto-submit#submit' } } %>
           </div>
         </div>
 

--- a/admin/app/views/spree/admin/users/_form.html.erb
+++ b/admin/app/views/spree/admin/users/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="card mb-4">
   <div class="card-body">
-    <%= render 'form_fields', f: f %>  
+    <%= render 'spree/admin/users/form_fields', f: f %>  
   </div>
 </div>

--- a/admin/app/views/spree/admin/users/_form_fields.html.erb
+++ b/admin/app/views/spree/admin/users/_form_fields.html.erb
@@ -1,23 +1,7 @@
-<div class="form-group">
-  <%= f.label :email, raw(Spree.t(:email) + required_span_tag) %>
-  <%= f.email_field :email, class: 'form-control', required: true, autofocus: f.object.new_record? %>
-  <%= f.error_message_on :email %>
-</div>
-<div class="form-group">
-  <%= f.label :first_name, raw(Spree.t(:first_name) + required_span_tag) %>
-  <%= f.text_field :first_name, class: 'form-control', required: true %>
-  <%= f.error_message_on :first_name %>
-</div>
-<div class="form-group">
-  <%= f.label :last_name, raw(Spree.t(:last_name) + required_span_tag) %>
-  <%= f.text_field :last_name, class: 'form-control', required: true %>
-  <%= f.error_message_on :last_name %>
-</div>
-<div class="form-group">
-  <%= f.label :phone, Spree.t(:phone) %>
-  <%= f.text_field :phone, class: 'form-control' %>
-  <%= f.error_message_on :phone %>
-</div>
+<%= f.spree_text_field :email, required: true, autofocus: f.object.new_record?, label: raw(Spree.t(:email) + required_span_tag), type: :email %>
+<%= f.spree_text_field :first_name, required: true, label: raw(Spree.t(:first_name) + required_span_tag) %>
+<%= f.spree_text_field :last_name, required: true, label: raw(Spree.t(:last_name) + required_span_tag) %>
+<%= f.spree_text_field :phone %>
 <div class="form-group">
   <%= f.label :tag_list, Spree.t(:tags) %>
   <%= tom_select_tag 'user[tag_list]', multiple: true, class: 'w-100', options: user_tags_json_array, active_option: @user.tag_list, value_field: :name, create: true %>
@@ -31,8 +15,4 @@
             { multiple: true,  data: { controller: 'autocomplete-select' } } %>          
   </div>
 <% end %>
-<div class="custom-control custom-checkbox mb-3">
-  <%= f.check_box :accepts_email_marketing, class: 'custom-control-input' %>
-  <%= f.label :accepts_email_marketing, Spree.t(:accepts_email_marketing), class: 'custom-control-label' %>
-  <%= f.error_message_on :accepts_email_marketing %>
-</div>
+<%= f.spree_check_box :accepts_email_marketing %>

--- a/admin/app/views/spree/admin/users/_form_fields.html.erb
+++ b/admin/app/views/spree/admin/users/_form_fields.html.erb
@@ -1,18 +1,15 @@
-<%= f.spree_text_field :email, required: true, autofocus: f.object.new_record?, label: raw(Spree.t(:email) + required_span_tag), type: :email %>
-<%= f.spree_text_field :first_name, required: true, label: raw(Spree.t(:first_name) + required_span_tag) %>
-<%= f.spree_text_field :last_name, required: true, label: raw(Spree.t(:last_name) + required_span_tag) %>
+<%= f.spree_email_field :email, required: true, autofocus: f.object.new_record? %>
+<%= f.spree_text_field :first_name, required: true %>
+<%= f.spree_text_field :last_name, required: true %>
 <%= f.spree_text_field :phone %>
 <div class="form-group">
   <%= f.label :tag_list, Spree.t(:tags) %>
   <%= tom_select_tag 'user[tag_list]', multiple: true, class: 'w-100', options: user_tags_json_array, active_option: @user.tag_list, value_field: :name, create: true %>
 </div>
 <% if @user.class == Spree.admin_user_class && can?(:manage, Spree::Role) %>
-  <div class="form-group">
-    <%= f.label :spree_role_ids, Spree.t(:roles) %>
-    <%= f.select :spree_role_ids,
-            options_from_collection_for_select(Spree::Role.all, 'id', 'name', @user.spree_roles.pluck(:id)),
-            { prompt: false },
-            { multiple: true,  data: { controller: 'autocomplete-select' } } %>          
-  </div>
+  <%= f.spree_select :spree_role_ids,
+          options_from_collection_for_select(Spree::Role.all, 'id', 'name', @user.spree_roles.pluck(:id)),
+          { prompt: false, label: Spree.t(:roles), autocomplete: true },
+          { multiple: true } %>
 <% end %>
 <%= f.spree_check_box :accepts_email_marketing %>

--- a/admin/app/views/spree/admin/variants/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_basic.html.erb
@@ -5,26 +5,13 @@
     </h5>
   </div>
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :sku, Spree.t(:sku) %>
-      <%= f.text_field :sku, class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :sku %>
 
-    <div class="form-group">
-      <%= f.label :barcode, Spree.t(:barcode) %>
-      <%= f.text_field :barcode, class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :barcode %>
 
-    <div class="form-group">
-      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
-      <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { data: { controller: 'autocomplete-select' } }) %>
-    </div>
+    <%= f.spree_collection_select :tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, data: { controller: 'autocomplete-select' } %>
 
-    <div class="form-group">
-      <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
-      <%= f.error_message_on :discontinue_on %>
-      <%= f.date_field :discontinue_on, class: 'form-control' %>
-    </div>
+    <%= f.spree_date_field :discontinue_on %>
 
     <%= render 'spree/admin/variants/form/dimensions', f: f %>
   </div>

--- a/admin/app/views/spree/admin/variants/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_basic.html.erb
@@ -9,7 +9,7 @@
 
     <%= f.spree_text_field :barcode %>
 
-    <%= f.spree_collection_select :tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, data: { controller: 'autocomplete-select' } %>
+    <%= f.spree_collection_select :tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none'), label: Spree.t(:tax_category), autocomplete: true } %>
 
     <%= f.spree_date_field :discontinue_on %>
 

--- a/admin/app/views/spree/admin/variants/form/_dimensions.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_dimensions.html.erb
@@ -1,21 +1,12 @@
 <div class="row">
   <div class="col-lg-6">
-    <div class="form-group mb-3">
-      <%= f.label :width %>
-      <%= f.text_field :width, value: number_with_precision(f.object.width, precision: 2), class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :width, value: number_with_precision(f.object.width, precision: 2) %>
 
-    <div class="form-group mb-3">
-      <%= f.label :height %>
-      <%= f.text_field :height, value: number_with_precision(f.object.height, precision: 2), class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :height, value: number_with_precision(f.object.height, precision: 2) %>
   </div>
 
   <div class="col-lg-6">
-    <div class="form-group mb-3">
-      <%= f.label :depth %>
-      <%= f.text_field :depth, value: number_with_precision(f.object.depth, precision: 2), class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :depth, value: number_with_precision(f.object.depth, precision: 2) %>
 
     <div class="form-group mb-3">
       <%= f.label :dimensions_unit, Spree.t(:unit) %>

--- a/admin/app/views/spree/admin/variants/form/_dimensions.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_dimensions.html.erb
@@ -1,17 +1,12 @@
 <div class="row">
   <div class="col-lg-6">
     <%= f.spree_text_field :width, value: number_with_precision(f.object.width, precision: 2) %>
-
     <%= f.spree_text_field :height, value: number_with_precision(f.object.height, precision: 2) %>
   </div>
 
   <div class="col-lg-6">
     <%= f.spree_text_field :depth, value: number_with_precision(f.object.depth, precision: 2) %>
-
-    <div class="form-group mb-3">
-      <%= f.label :dimensions_unit, Spree.t(:unit) %>
-      <%= f.select :dimensions_unit, options_for_select(dimension_units(current_store), f.object.dimensions_unit), { include_blank: false }, { class: 'custom-select' } %>
-    </div>
+    <%= f.spree_select :dimensions_unit, options_for_select(dimension_units(current_store), f.object.dimensions_unit), { include_blank: false, label: Spree.t(:unit) } %>
   </div>
 </div>
 

--- a/admin/app/views/spree/admin/variants/form/_inventory.html.erb
+++ b/admin/app/views/spree/admin/variants/form/_inventory.html.erb
@@ -5,14 +5,8 @@
     </h5>
   </div>
   <div class="card-body p-0" data-controller="reveal" data-reveal-hidden-class="d-none">
-    <div class="custom-control custom-checkbox mb-4 m-3">
-      <%= f.check_box :track_inventory,
-            class: 'custom-control-input',
-            data: {
-              action: 'change->reveal#toggle'
-            }
-          %>
-      <%= f.label :track_inventory, Spree.t(:track_quantity), class: 'custom-control-label' %>
+    <div class="mb-4 m-3">
+      <%= f.spree_check_box :track_inventory, data: { action: 'change->reveal#toggle' } %>
     </div>
 
     <table class="table <%= 'd-none' unless f.object.track_inventory? %>" data-reveal-target="item">

--- a/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/_form.html.erb
@@ -5,19 +5,8 @@
     </h5>
   </div>
   <div class="card-body">
-    <div class="row">
-      <div class="form-group col-12">
-        <%= f.label :url, raw(Spree.t(:url) + required_span_tag) %>
-        <%= f.text_field :url, class: 'form-control', placeholder: 'https://example.com/endpoint' %>
-        <%= f.error_message_on :url %>
-      </div>
-      <div class="form-group col-3">
-        <div class="custom-control custom-checkbox">
-          <%= f.check_box :active, class: 'custom-control-input' %>
-          <%= f.label :active, class: 'custom-control-label' %>
-        </div>
-      </div>
-    </div>
+    <%= f.spree_text_field :url, placeholder: 'https://example.com/endpoint' %>
+    <%= f.spree_check_box :active %>
   </div>
 </div>
 <div class="card mb-4">

--- a/admin/app/views/spree/admin/webhooks_subscribers/_table_row.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/_table_row.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   </td>
   <td class="w-15">
-    <%= link_to_with_icon 'eye', Spree.t(:view), spree.admin_webhooks_subscriber_path(webhooks_subscriber), class: "btn btn-light btn-sm", data: { row_link_target: 'link' } %>
-    <%= link_to_edit(webhooks_subscriber) if can? :edit, webhooks_subscriber %>
+    <%= link_to_with_icon 'eye', Spree.t(:view), spree.admin_webhooks_subscriber_path(webhooks_subscriber), class: "btn btn-light btn-sm", data: { row_link_target: 'link', turbo_frame: '_top' } %>
+    <%= link_to_edit(webhooks_subscriber, data: { turbo_frame: '_top' }) if can? :edit, webhooks_subscriber %>
   </td>
 </tr>

--- a/admin/app/views/spree/admin/webhooks_subscribers/show.html.erb
+++ b/admin/app/views/spree/admin/webhooks_subscribers/show.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_admin_webhooks_subscriber_path(@webhooks_subscriber), class: 'btn btn-primary' %>
+  <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_admin_webhooks_subscriber_path(@webhooks_subscriber), class: 'btn btn-light' %>
 <% end %>
 
 <ul class="list-group bg-white mb-4 rounded-lg">

--- a/admin/app/views/spree/admin/zones/_form.html.erb
+++ b/admin/app/views/spree/admin/zones/_form.html.erb
@@ -10,17 +10,9 @@
 
     <%= f.spree_check_box :default_tax, label: Spree.t(:default_tax_zone) %>
 
-    <div class="form-group">
-      <strong><%= Spree.t(:type) %></strong>
-      <div class="custom-control custom-radio my-2">
-        <%= f.radio_button :kind, :country, id: 'country_based', class: 'custom-control-input', data: { action: 'auto-submit#submit' } %>
-        <%= label_tag :country_based, Spree.t(:country_based), class: 'custom-control-label' %>
-      </div>
-      <div class="custom-control custom-radio my-2">
-        <%= f.radio_button :kind, :state, id: 'state_based', class: 'custom-control-input', data: { action: 'auto-submit#submit' } %>
-        <%= label_tag :state_based, Spree.t(:state_based), class: 'custom-control-label' %>
-      </div>
-    </div>
+    <h6 class="mb-2 mt-3"><%= Spree.t(:type) %></h6>
+    <%= f.spree_radio_button :kind, :country, id: 'country_based', data: { action: 'auto-submit#submit' }, label: Spree.t(:country_based) %>
+    <%= f.spree_radio_button :kind, :state, id: 'state_based', data: { action: 'auto-submit#submit' }, label: Spree.t(:state_based) %>
   </div>
 </div>
 

--- a/admin/app/views/spree/admin/zones/_form.html.erb
+++ b/admin/app/views/spree/admin/zones/_form.html.erb
@@ -4,23 +4,11 @@
   </div>
 
   <div class="card-body">
-    <div class="form-group">
-      <%= f.label :name, Spree.t(:name) %>
-      <%= f.text_field :name, class: 'form-control' %>
-      <%= f.error_message_on :name %>
-    </div>
+    <%= f.spree_text_field :name %>
 
-    <div class="form-group">
-      <%= f.label :description, Spree.t(:description) %>
-      <%= f.text_field :description, class: 'form-control' %>
-    </div>
+    <%= f.spree_text_field :description %>
 
-    <div class="form-group">
-      <div class="custom-control custom-checkbox">
-        <%= f.check_box :default_tax, class: 'custom-control-input' %>
-        <%= f.label :default_tax, Spree.t(:default_tax_zone), class: 'custom-control-label' %>
-      </div>
-    </div>
+    <%= f.spree_check_box :default_tax, label: Spree.t(:default_tax_zone) %>
 
     <div class="form-group">
       <strong><%= Spree.t(:type) %></strong>

--- a/admin/app/views/spree/admin/zones/edit.html.erb
+++ b/admin/app/views/spree/admin/zones/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render 'spree/admin/shared/edit_resource' %>
+<%= render 'spree/admin/shared/edit_resource', data: { controller: 'auto-submit' } %>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
       num_orders: No. of Orders
       oauth_applications:
         client_id: Client ID
+        client_secret: Client Secret
         last_used: Last used
         list: API keys
         never: Never

--- a/admin/spec/features/spree/admin/settings/api_keys_spec.rb
+++ b/admin/spec/features/spree/admin/settings/api_keys_spec.rb
@@ -15,11 +15,14 @@ describe 'API keys', type: :feature do
     visit '/admin/oauth_applications/new'
 
     fill_in 'Name', with: 'My app'
+    select 'Read & Write', from: 'Scopes'
     click_button 'Create'
 
     expect(page).to have_content('Client ID')
     expect(page).to have_content('Client Secret')
-    expect(page).to have_content(Spree::OauthApplication.last.uid)
+
+    oauth_application = Spree::OauthApplication.last
+    expect(page).to have_field('Client ID', with: oauth_application.uid, readonly: true)
   end
 
   it 'can modify existing app' do

--- a/admin/spec/features/spree/admin/settings/tax_categories_spec.rb
+++ b/admin/spec/features/spree/admin/settings/tax_categories_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Tax categories' do
     fill_in 'Name', with: 'Non-Taxable'
     fill_in 'Description', with: 'Non-Taxable Tax Category'
     fill_in 'Tax Code', with: 'NON_TAXABLE_TAX_CATEGORY'
-    uncheck 'Is default', allow_label_click: true
+    uncheck 'Default', allow_label_click: true
 
     within('#page-header') { click_button 'Update' }
 

--- a/admin/spec/features/spree/admin/settings/tax_categories_spec.rb
+++ b/admin/spec/features/spree/admin/settings/tax_categories_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Tax categories' do
     fill_in 'Name', with: 'New Tax Category'
     fill_in 'Description', with: 'New Tax Category Description'
     fill_in 'Tax Code', with: 'NEW_TAX_CATEGORY'
-    check 'Is default', allow_label_click: true
+    check 'Default', allow_label_click: true
 
     click_on 'Create'
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -172,6 +172,7 @@ en:
         name: Name
       spree/tax_category:
         description: Description
+        is_default: Is default
         name: Name
       spree/tax_rate:
         amount: Rate

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -172,7 +172,6 @@ en:
         name: Name
       spree/tax_category:
         description: Description
-        is_default: Is default
         name: Name
       spree/tax_rate:
         amount: Rate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced unified Spree-specific form helpers for text, email, number, date, select, checkbox, and rich text inputs, providing consistent styling, labeling, help text, and error display across the admin interface.
  * Added support for dynamic data attributes and Turbo Frame targeting in admin forms and action links for improved navigation and interactivity.

* **Refactor**
  * Refactored nearly all admin forms to use new Spree form helpers, replacing manual markup and standard Rails helpers for streamlined, maintainable, and accessible UI.
  * Simplified form layouts and markup, consolidating multi-column grids into single-column cards and standardizing section structures.

* **Style**
  * Updated button and layout classes for improved visual consistency and alignment with Bootstrap standards.

* **Bug Fixes**
  * Improved Turbo Stream and HTML response handling in admin actions for more accurate flash messaging and navigation.

* **Documentation**
  * Updated frontend development guidelines to align with new form helper usage and best practices.

* **Tests**
  * Enhanced feature specs to align with new form structures and labels, ensuring accurate test coverage.

* **Chores**
  * Added new translation key for "Client Secret" in localization files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->