### PR TITLE
Fixed return authorization reasons view on PostgreSQL

### DIFF
--- a/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
+++ b/admin/app/views/spree/admin/custom_domains/_custom_domains.html.erb
@@ -3,7 +3,7 @@
     <table class="table">
       <thead>
         <tr>
-          <th scope="col"><%= Spree.t(:name) %></th>
+          <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
           <th scope="col"><%= Spree.t(:active) %>?</th>
           <th scope="col"><%= Spree.t(:default) %>?</th>
           <th scope="col"></th>

--- a/admin/app/views/spree/admin/digital_assets/_table.html.erb
+++ b/admin/app/views/spree/admin/digital_assets/_table.html.erb
@@ -4,7 +4,7 @@
       <% if @product.has_variants? %>
         <th scope="col"><%= Spree.t(:variant) %></th>
       <% end %>
-      <th scope="col"><%= Spree.t(:name) %></th>
+      <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
       <th scope="col"><%= Spree.t(:size) %></th>
       <th scope="col"></th>
     </tr>

--- a/admin/app/views/spree/admin/oauth_applications/_table_header.html.erb
+++ b/admin/app/views/spree/admin/oauth_applications/_table_header.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t('admin.oauth_applications.client_id') %></th>
   <th scope="col"><%= Spree.t('admin.oauth_applications.scopes') %></th>
   <th scope="col"><%= Spree.t('admin.oauth_applications.last_used') %></th>

--- a/admin/app/views/spree/admin/promotions/_table_header.html.erb
+++ b/admin/app/views/spree/admin/promotions/_table_header.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:code) %></th>
   <th scope="col"><%= Spree.t(:kind) %></th>
   <th scope="col"><%= Spree.t(:usage_limit) %></th>

--- a/admin/app/views/spree/admin/refund_reasons/_table_header.html.erb
+++ b/admin/app/views/spree/admin/refund_reasons/_table_header.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:status) %></th>
   <th scope="col"><%= Spree.t(:mutable) %></th>
   <th scope="col"></th>

--- a/admin/app/views/spree/admin/reimbursement_types/_table_header.html.erb
+++ b/admin/app/views/spree/admin/reimbursement_types/_table_header.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:type) %></th>
   <th scope="col"><%= Spree.t(:status) %></th>
   <th scope="col"><%= Spree.t(:mutable) %></th>

--- a/admin/app/views/spree/admin/return_authorization_reasons/_table_header.html.erb
+++ b/admin/app/views/spree/admin/return_authorization_reasons/_table_header.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:status) %></th>
   <th scope="col"></th>
 </tr>

--- a/admin/app/views/spree/admin/roles/index.html.erb
+++ b/admin/app/views/spree/admin/roles/index.html.erb
@@ -13,7 +13,7 @@
       <table class="table">
         <thead>
           <tr>
-            <th scope="col"><%= Spree.t(:name) %></th>
+            <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
             <th scope="col"><%= Spree.t(:permissions) %></th>
             <th scope="col"></th>
           </tr>

--- a/admin/app/views/spree/admin/shipping_categories/_table_header.html.erb
+++ b/admin/app/views/spree/admin/shipping_categories/_table_header.html.erb
@@ -1,4 +1,4 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"></th>
 </tr>

--- a/admin/app/views/spree/admin/shipping_methods/_table_header.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/_table_header.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:zone) %></th>
   <th scope="col"><%= Spree.t(:estimated_delivery_time) %></th>
   <th scope="col"><%= Spree.t(:amount) %></th>

--- a/admin/app/views/spree/admin/stock_locations/_table_header.html.erb
+++ b/admin/app/views/spree/admin/stock_locations/_table_header.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
-  <th scope="col"><%= Spree.t(:country) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :country, Spree.t(:country) %></th>
   <th scope="col"><%= Spree.t(:active) %>?</th>
   <% if can?(:mark_as_default, Spree::StockLocation) %>
     <th scope="col"><%= Spree.t(:default) %>?</th>

--- a/admin/app/views/spree/admin/store_credit_categories/index.html.erb
+++ b/admin/app/views/spree/admin/store_credit_categories/index.html.erb
@@ -15,7 +15,7 @@
       <table class="table">
         <thead>
           <tr>
-            <th scope="col"><%= Spree.t(:name) %></th>
+            <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
             <th scope="col"></th>
           </tr>
         </thead>

--- a/admin/app/views/spree/admin/tax_categories/_table_header.html.erb
+++ b/admin/app/views/spree/admin/tax_categories/_table_header.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <th scope="col"><%= Spree.t(:name) %></th>
-  <th scope="col"><%= Spree.t(:tax_code) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :tax_code, Spree.t(:tax_code) %></th>
   <th scope="col"><%= Spree.t(:description) %></th>
   <th scope="col"><%= Spree.t(:default) %></th>
   <th scope="col"></th>

--- a/admin/app/views/spree/admin/tax_rates/_table_header.html.erb
+++ b/admin/app/views/spree/admin/tax_rates/_table_header.html.erb
@@ -1,8 +1,8 @@
 <tr data-hook="rate_header">
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:tax_category) %></th>
   <th scope="col"><%= Spree.t(:zone) %></th>
-  <th scope="col"><%= Spree.t(:amount) %></th>
+  <th scope="col"><%= sort_link search_collection, :amount, Spree.t(:amount) %></th>
   <th scope="col"><%= Spree.t(:included_in_price) %></th>
   <th scope="col"><%= Spree.t(:show_rate_in_label) %></th>
   <th scope="col"></th>

--- a/admin/app/views/spree/admin/taxonomies/_table_header.html.erb
+++ b/admin/app/views/spree/admin/taxonomies/_table_header.html.erb
@@ -1,6 +1,6 @@
 <tr data-hook="listing_taxonomies_header">
   <th class="no-border handel-head"></th>
-  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:taxons) %></th>
   <th scope="col"></th>
 </tr>

--- a/admin/spec/controllers/spree/admin/return_authorization_reasons_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/return_authorization_reasons_controller_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe Spree::Admin::ReturnAuthorizationReasonsController, type: :contro
       get :index
       expect(response).to be_successful
     end
+
+    context 'with existing return authorization reasons' do
+      let!(:return_authorization_reason) { create(:return_authorization_reason) }
+      let!(:return_authorization_reason_2) { create(:return_authorization_reason, name: 'B') }
+
+      it 'returns a successful response' do
+        get :index
+        expect(response).to be_successful
+      end
+
+      it 'orders the return authorization reasons by name' do
+        get :index
+        expect(assigns(:return_authorization_reasons)).to eq([return_authorization_reason_2, return_authorization_reason])
+      end
+    end
   end
 
   describe 'GET #new' do

--- a/core/app/models/concerns/spree/named_type.rb
+++ b/core/app/models/concerns/spree/named_type.rb
@@ -4,7 +4,7 @@ module Spree
 
     included do
       scope :active, -> { where(active: true) }
-      default_scope { order(Arel.sql("LOWER(#{table_name}.name)")) }
+      default_scope { order(name: :asc) }
 
       include Spree::UniqueName
     end


### PR DESCRIPTION
+ added a bunch of handy sort options for users in the admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable sorting functionality to the "name" column in various admin tables, allowing users to sort lists by name directly from the table headers.
  * Enabled sorting on additional columns, such as "country" in stock locations, "tax_code" in tax categories, and "amount" in tax rates.

* **Bug Fixes**
  * Improved consistency and usability of sorting across admin views.

* **Tests**
  * Enhanced test coverage to verify correct ordering of return authorization reasons by name.

* **Refactor**
  * Updated default ordering for certain lists to use a simpler ascending order by name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->