### PR TITLE
Fixed: storefront form not overwriting `store.name`

### DIFF
--- a/admin/app/controllers/spree/admin/storefront_controller.rb
+++ b/admin/app/controllers/spree/admin/storefront_controller.rb
@@ -26,7 +26,7 @@ module Spree
         params.require(:store).permit(
           :preferred_index_in_search_engines,
           :preferred_password_protected, :social_image, :favicon_image, :name,
-          :meta_description, :meta_title, :meta_keywords, :seo_robots,
+          :meta_description, :meta_keywords, :seo_robots, :seo_title,
           :facebook, :twitter, :instagram, :linkedin, :youtube, :tiktok, :pinterest,
           :storefront_custom_code_head, :storefront_custom_code_body_start,
           :storefront_custom_code_body_end, :storefront_password, :spotify, :discord

--- a/admin/app/views/spree/admin/storefront/edit.html.erb
+++ b/admin/app/views/spree/admin/storefront/edit.html.erb
@@ -26,18 +26,9 @@
           </h5>
         </div>
         <div class="card-body">
-          <div class="form-group">
-            <%= f.label :name, Spree.t(:site_name) %>
-            <%= f.text_field :name, class: 'form-control' %>
-          </div>
-          <%= f.spree_text_area :meta_description, label: 'Search description', style: 'min-height: 5em' %>
-          <div class="custom-control custom-checkbox mb-2">
-            <%= f.check_box :preferred_index_in_search_engines, class: 'custom-control-input' %>
-            <%= f.label :preferred_index_in_search_engines, Spree.t(:index_in_search_engines), class: 'custom-control-label' %>
-          </div>
-          <p class="text-muted small pl-4 mb-0">
-            Checking this box will allow your site to appear in search engines.
-          </p>
+          <%= f.spree_text_field :seo_title %>
+          <%= f.spree_text_area :meta_description %>
+          <%= f.spree_check_box :preferred_index_in_search_engines, label: Spree.t(:index_in_search_engines), help: 'Checking this box will allow your site to appear in search engines.' %>
         </div>
       </div>
 
@@ -48,17 +39,9 @@
           </h5>
         </div>
         <div class="card-body" data-controller="reveal" data-reveal-hidden-class="d-none">
-          <div class="custom-control custom-checkbox mb-2">
-            <%= f.check_box :preferred_password_protected, class: 'custom-control-input', data: { action: 'reveal#toggle' } %>
-            <%= f.label :preferred_password_protected, Spree.t(:password_protected), class: 'custom-control-label' %>
-          </div>
-          <p class="text-muted small pl-4">
-            Checking this box will put your storefront behind a password.
-          </p>
-          
-          <div class="form-group <%= @store.prefers_password_protected? ? '' : 'd-none' %>" data-reveal-target="item">
-            <%= f.label :storefront_password, Spree.t(:password) %>
-            <%= f.text_field :storefront_password, class: 'form-control' %>
+          <%= f.spree_check_box :preferred_password_protected, label: Spree.t(:password_protected), help: 'Checking this box will put your storefront behind a password.', data: { action: 'reveal#toggle' } %>
+          <div class="d-none" data-reveal-target="item">
+            <%= f.spree_text_field :storefront_password, label: Spree.t(:password), help: 'Enter a password to protect your storefront.' %>
           </div>
         </div>
       </div>
@@ -71,9 +54,7 @@
         </div>
         <div class="card-body">
           <%= f.spree_text_area :storefront_custom_code_head, rows: 4 %>
-
           <%= f.spree_text_area :storefront_custom_code_body_start, rows: 4 %>
-
           <%= f.spree_text_area :storefront_custom_code_body_end, rows: 4 %>
         </div>
       </div>
@@ -114,16 +95,7 @@
             Social links will be displayed in the footer of your store
           </div>
           <% Spree::Store::SUPPORTED_SOCIAL_NETWORKS.each do |social| %>
-            <div class="form-group">
-              <%= f.label :"store_#{social}" do %>
-                <%= icon social %>
-                <%= social.capitalize %>
-              <% end %>
-              <%= f.text_field social.to_sym,
-                    class: 'form-control',
-                    placeholder: Spree::Store::SOCIAL_NETWORKS_CONFIG[social.to_sym][:input_placeholder]
-              %>
-            </div>
+            <%= f.spree_text_field social.to_sym, label: social.capitalize, placeholder: Spree::Store::SOCIAL_NETWORKS_CONFIG[social.to_sym][:input_placeholder] %>
           <% end %>
         </div>
       </div>

--- a/admin/spec/controllers/spree/admin/storefront_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/storefront_controller_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Admin::StorefrontController do
 
     let(:store_params) do
       {
-        name: 'New Store Name',
+        seo_title: 'New Store Name',
         meta_description: 'This is a cool store',
         storefront_password: 'password',
         facebook: 'https://www.facebook.com/spreecommerce',
@@ -40,7 +40,7 @@ describe Spree::Admin::StorefrontController do
     it 'updates the store data' do
       subject
 
-      expect(store.reload.name).to eq('New Store Name')
+      expect(store.reload.seo_title).to eq('New Store Name')
       expect(store.meta_description).to eq('This is a cool store')
       expect(store.storefront_password).to eq('password')
       expect(store.facebook).to eq('https://www.facebook.com/spreecommerce')

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -165,9 +165,9 @@ en:
         preferred_limit_digital_download_days: Limit digital links download days
         seo_robots: SEO Robots
         seo_title: SEO Title
-        storefront_custom_code_head: "Custom Code in page head"
-        storefront_custom_code_body_start: "Custom Code after opening body tag"
-        storefront_custom_code_body_end: "Custom Code before closing body tag"
+        storefront_custom_code_body_end: Custom Code before closing body tag
+        storefront_custom_code_body_start: Custom Code after opening body tag
+        storefront_custom_code_head: Custom Code in page head
         url: Site URL
       spree/store_credit:
         amount_used: Amount used

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -165,6 +165,9 @@ en:
         preferred_limit_digital_download_days: Limit digital links download days
         seo_robots: SEO Robots
         seo_title: SEO Title
+        storefront_custom_code_head: "Custom Code in page head"
+        storefront_custom_code_body_start: "Custom Code after opening body tag"
+        storefront_custom_code_body_end: "Custom Code before closing body tag"
         url: Site URL
       spree/store_credit:
         amount_used: Amount used

--- a/storefront/app/controllers/spree/store_controller.rb
+++ b/storefront/app/controllers/spree/store_controller.rb
@@ -114,7 +114,7 @@ module Spree
     end
 
     def default_title
-      @default_title ||= current_store.name
+      @default_title ||= current_store.seo_title.presence || current_store.name
     end
 
     # this is a hook for subclasses to provide title


### PR DESCRIPTION
also used new form builder and fixed missing i18n

fixes https://github.com/spree/spree/issues/13004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stores now support an SEO Title and page titles prefer the SEO title when present.
  * Storefront gains a password-protection toggle that reveals the password field.
  * “Index in search engines” consolidated into a single checkbox with help text.
  * Social media settings simplified with streamlined inputs.
  * Clear labels added for injecting custom code in head, after body open, and before body close.

* **Tests**
  * Updated storefront controller spec to use seo_title in updates.

* **Documentation**
  * Added locale keys for the custom-code labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->