### PR TITLE
fix(frontend): Ensure homepage link is only active on the root path

### DIFF
--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -36,7 +36,7 @@ describe Spree::BaseHelper, type: :helper do
       end
 
       it 'return complete list of countries' do
-        expect(available_countries).to match_array(Spree::Country.all)
+        expect(available_countries).to contain_exactly(*Spree::Country.all)
       end
     end
   end

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -4,7 +4,7 @@
     <% main_link = presenter.main_link %>
     <% next unless main_link.present? %>
     <div class="header--nav-item group" <%= block_attributes(block, allowed_styles: ['padding-top', 'padding-bottom']) %>>
-      <%= active_link_to spree_storefront_resource_url(main_link.linkable || main_link), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
+      <%= active_link_to spree_storefront_resource_url(main_link.linkable || main_link), active: spree_nav_active_option(main_link.linkable || main_link), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
         <span class="group-hover:border-b-[1.5px] group-hover:border-b-accent"><%= main_link.label %></span>
       <% end %>
       <% if presenter.columns.any? %>
@@ -42,7 +42,7 @@
   <% end %>
 <% else %>
   <% section.links.each do |link| %>
-    <%= active_link_to spree_storefront_resource_url(link.linkable || link), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
+    <%= active_link_to spree_storefront_resource_url(link.linkable || link), active: spree_nav_active_option(link.linkable || link), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
       <span><%= link.label %></span>
     <% end %>
   <% end %>


### PR DESCRIPTION
### Summary

Currently, a "Homepage" link created via the Page Builder in the main navigation is incorrectly marked as active on all pages. This occurs because the default navigation logic uses an inclusive path match, causing the root path (`/`) to match every other URL in the application.

This PR corrects this behaviour by introducing a helper that enforces an **exact path match** for the homepage link, ensuring it is only considered active when the user is on the root path. The default inclusive matching is retained for all other links.

### Steps to Reproduce

1.  Using the Admin Panel, navigate to **Configuration → Page Builder**.
2.  Select the **Main Navigation Bar** and add a **Homepage Link** section.
3.  Save the changes and view the storefront.
4.  **Before this fix:** The "Home" link in the navbar is highlighted (active) on every page (e.g., `/products`, `/cart`, `/t/categories/clothing`).
5.  **After this fix:** The "Home" link is only highlighted when on the actual homepage (`/`).

### Solution

1.  **New Helper `spree_nav_active_option`:** A new helper is added to `Spree::BaseHelper`. This helper returns `true` (for an exact match) if the provided resource URL resolves to the root path (`/`). For all other paths, it returns the default `:inclusive` symbol to maintain existing behaviour for non-homepage links.

### Before:
<img width="1557" height="817" alt="Screenshot 2025-08-12 at 4 01 17 AM" src="https://github.com/user-attachments/assets/48825f67-fcc9-435e-8356-0e4909d6dfb5" />

### After:
<img width="1573" height="760" alt="Screenshot 2025-08-12 at 4 00 49 AM" src="https://github.com/user-attachments/assets/0cbe7176-8cbc-4c7a-af39-c2a0383d5760" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate “active” state for navigation links (correct homepage handling), supports multiple resource types and full/relative URLs, safely handles blank/invalid URLs.
  * Added a view-friendly alias for easier use in templates.

* **Tests**
  * Extensive new coverage exercising active-state logic across homepage, non-root paths, full/relative URLs, and various resource types.

* **Style / Documentation**
  * Minor doc and formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->