### PR TITLE
Store Policies

### DIFF
--- a/admin/app/controllers/spree/admin/policies_controller.rb
+++ b/admin/app/controllers/spree/admin/policies_controller.rb
@@ -1,0 +1,21 @@
+module Spree
+  module Admin
+    class PoliciesController < ResourceController
+      add_breadcrumb Spree.t(:policies), :admin_policies_path
+
+      private
+
+      def collection
+        super.order(:position)
+      end
+
+      def permitted_resource_params
+        params.require(:policy).permit(permitted_policy_attributes)
+      end
+
+      def update_turbo_stream_enabled?
+        true
+      end
+    end
+  end
+end

--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -38,7 +38,7 @@ module Spree
         @settings_active || %w[admin_users audits custom_domains exports imports invitations oauth_applications
                                payment_methods refund_reasons reimbursement_types return_authorization_reasons roles
                                shipping_categories shipping_methods stock_locations store_credit_categories
-                               stores tax_categories tax_rates webhooks webhooks_subscribers zones].include?(controller_name)
+                               stores tax_categories tax_rates webhooks webhooks_subscribers zones policies].include?(controller_name)
       end
 
       # @return [Array<String>] the available countries for checkout

--- a/admin/app/helpers/spree/admin/page_builder_helper.rb
+++ b/admin/app/helpers/spree/admin/page_builder_helper.rb
@@ -88,12 +88,7 @@ module Spree
       end
 
       def all_linkable_policies
-        @all_linkable_policies = [
-          current_store.customer_privacy_policy,
-          current_store.customer_terms_of_service,
-          current_store.customer_returns_policy,
-          current_store.customer_shipping_policy
-        ].compact.map { |policy| [policy.name.humanize, policy.id] }
+        @all_linkable_policies ||= current_store.policies.pluck(:name, :id)
       end
 
       def refresh_theme_preview(section = nil, block = nil)

--- a/admin/app/views/spree/admin/customer_returns/_table_header.html.erb
+++ b/admin/app/views/spree/admin/customer_returns/_table_header.html.erb
@@ -1,4 +1,4 @@
-<tr data-hook="rate_header">
+<tr>
   <th scope="col"><%= Spree.t(:number) %></th>
   <th scope="col"><%= Spree.t(:created_at) %></th>
   <th scope="col"><%= Spree.t(:customer) %></th>

--- a/admin/app/views/spree/admin/page_links/_linkable_type_dropdown.html.erb
+++ b/admin/app/views/spree/admin/page_links/_linkable_type_dropdown.html.erb
@@ -6,7 +6,7 @@
   <%= tom_select_tag "#{form_name}[linkable_id]", class: 'w-100', url: spree.select_options_admin_posts_path(format: :json), active_option: page_link.linkable_id, select_data: { action: 'auto-submit#submit' } %>
 <% elsif page_link.linkable_type == 'Spree::Page' %>
   <%= select_tag "#{form_name}[linkable_id]", options_for_select(all_linkable_pages, page_link.linkable_id), { class: 'custom-select', data: { action: 'auto-submit#submit' } } %>
-<% elsif page_link.linkable_type == 'ActionText::RichText' %>
+<% elsif page_link.linkable_type == 'Spree::Policy' %>
   <%= select_tag "#{form_name}[linkable_id]", options_for_select(all_linkable_policies, page_link.linkable_id), { class: 'custom-select', data: { action: 'auto-submit#submit' } } %>
 <% elsif page_link.linkable_type == 'Spree::Vendor' %>
   <%= tom_select_tag "#{form_name}[linkable_id]", class: 'w-100', url: spree.select_options_admin_vendors_path(format: :json), active_option: page_link.linkable_id, select_data: { action: 'auto-submit#submit' } %>

--- a/admin/app/views/spree/admin/page_links/_linkable_type_dropdown.html.erb
+++ b/admin/app/views/spree/admin/page_links/_linkable_type_dropdown.html.erb
@@ -5,9 +5,9 @@
 <% elsif page_link.linkable_type == 'Spree::Post' %>
   <%= tom_select_tag "#{form_name}[linkable_id]", class: 'w-100', url: spree.select_options_admin_posts_path(format: :json), active_option: page_link.linkable_id, select_data: { action: 'auto-submit#submit' } %>
 <% elsif page_link.linkable_type == 'Spree::Page' %>
-  <%= select_tag "#{form_name}[linkable_id]", options_for_select(all_linkable_pages, page_link.linkable_id), { class: 'custom-select', data: { action: 'auto-submit#submit' } } %>
+  <%= select_tag "#{form_name}[linkable_id]", options_for_select(all_linkable_pages, page_link.linkable_id), { data: { controller: 'autocomplete-select', action: 'auto-submit#submit' } } %>
 <% elsif page_link.linkable_type == 'Spree::Policy' %>
-  <%= select_tag "#{form_name}[linkable_id]", options_for_select(all_linkable_policies, page_link.linkable_id), { class: 'custom-select', data: { action: 'auto-submit#submit' } } %>
+  <%= select_tag "#{form_name}[linkable_id]", options_for_select(all_linkable_policies, page_link.linkable_id), { data: { controller: 'autocomplete-select', action: 'auto-submit#submit' } } %>
 <% elsif page_link.linkable_type == 'Spree::Vendor' %>
   <%= tom_select_tag "#{form_name}[linkable_id]", class: 'w-100', url: spree.select_options_admin_vendors_path(format: :json), active_option: page_link.linkable_id, select_data: { action: 'auto-submit#submit' } %>
 <% else %>

--- a/admin/app/views/spree/admin/payments/source_views/_storecredit.html.erb
+++ b/admin/app/views/spree/admin/payments/source_views/_storecredit.html.erb
@@ -1,4 +1,4 @@
-<fieldset data-hook="store_credit">
+<fieldset>
   <legend><%= Spree.t(:store_credits) %></legend>
   <div class="table-responsive border rounded bg-white">
     <table class="table table-condensed border rounded">

--- a/admin/app/views/spree/admin/policies/_form.html.erb
+++ b/admin/app/views/spree/admin/policies/_form.html.erb
@@ -1,0 +1,8 @@
+<div class="card mb-4">
+  <div class="card-body" data-controller="slug-form">
+    <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record?, data: { slug_form_target: 'name', action: 'slug-form#updateUrlFromName' } %>
+    <%= f.spree_text_field :slug, required: true, data: { slug_form_target: 'url' } %>
+    <%= f.spree_rich_text_area :body %>
+    <%= f.spree_check_box :show_in_checkout_footer %>
+  </div>
+</div>

--- a/admin/app/views/spree/admin/policies/_table_header.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_header.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <th scope="col"></th>
+  <th scope="col"><%= Spree.t(:name) %></th>
+  <th scope="col"><%= Spree.t(:slug) %></th>
+  <th scope="col"><%= I18n.t('activerecord.attributes.spree/policy.show_in_checkout_footer') %></th>
+  <th scope="col"><%= Spree.t(:updated_at) %></th>
+  <th scope="col"></th>
+</tr>

--- a/admin/app/views/spree/admin/policies/_table_row.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_row.html.erb
@@ -1,0 +1,20 @@
+<tr id="<%= spree_dom_id policy %>" data-controller="row-link" data-sortable-update-url="<%= spree.admin_policy_path(policy) %>">
+  <td class="w-10 move-handle text-center">
+    <%= icon('grip-vertical', class: 'rounded hover-gray p-2') %>
+  </td>
+  <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
+    <%= policy.name %>
+  </td>
+  <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
+    <%= link_to policy.slug, spree.edit_admin_policy_path(policy), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link, turbo_frame: '_top' } %>
+  </td>
+  <td class="w-10 cursor-pointer" data-action="click->row-link#openLink">
+    <%= active_badge(policy.show_in_checkout_footer) %>
+  </td>
+  <td class="w-10 cursor-pointer" data-action="click->row-link#openLink">
+    <%= spree_time(policy.updated_at) %>
+  </td>
+  <td class="w-10 actions">
+    <%= link_to_edit(policy, class: 'btn btn-light btn-sm', data: { turbo_frame: '_top' }) if can?(:edit, policy) %>
+  </td>
+</tr>

--- a/admin/app/views/spree/admin/policies/edit.html.erb
+++ b/admin/app/views/spree/admin/policies/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/admin/shared/edit_resource' %>

--- a/admin/app/views/spree/admin/policies/edit.html.erb
+++ b/admin/app/views/spree/admin/policies/edit.html.erb
@@ -1,1 +1,5 @@
+<% content_for :page_actions_dropdown do %>
+  <%= link_to_edit_translations(@policy) %>
+<% end %>
+
 <%= render 'spree/admin/shared/edit_resource' %>

--- a/admin/app/views/spree/admin/policies/index.html.erb
+++ b/admin/app/views/spree/admin/policies/index.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :page_title do %>
+  <%= Spree.t(:policies) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_policy), new_object_url, class: 'btn btn-primary' if can?(:create, Spree::Policy) %>
+<% end %>
+
+<%= render 'spree/admin/shared/index_table', sortable: true %>

--- a/admin/app/views/spree/admin/policies/new.html.erb
+++ b/admin/app/views/spree/admin/policies/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/admin/shared/new_resource' %>

--- a/admin/app/views/spree/admin/policies/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/policies/update.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_render_alerts %>

--- a/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
@@ -10,7 +10,7 @@
 
     <% if can?(:manage, current_store) %>
       <%= nav_item(Spree.t(:emails), spree.edit_admin_store_path(section: 'emails'), icon: 'send', active: params[:section] == 'emails') %>
-      <%= nav_item(Spree.t(:policies), spree.edit_admin_store_path(section: 'policies'), icon: 'list-check', active: params[:section] == 'policies') %>
+      <%= nav_item(Spree.t(:policies), spree.admin_policies_path, icon: 'list-check') if can?(:manage, Spree::Policy) %>
       <%= nav_item(Spree.t(:checkout), spree.edit_admin_store_path(section: 'checkout'), icon: 'shopping-cart', active: params[:section] == 'checkout') %>
       <%= render_admin_partials(:store_settings_nav_partials) %>
     <% end %>

--- a/admin/app/views/spree/admin/stores/form/_checkout.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_checkout.html.erb
@@ -4,7 +4,7 @@
 
 <div class="alert alert-info mb-3">
   <p>
-    <%= Spree.t('admin.checkout_settings.policy_copy', policies_link: link_to(Spree.t(:policies), spree.edit_admin_store_path + '?section=policies', class: 'alert-link')).html_safe %>
+    <%= Spree.t('admin.checkout_settings.policy_copy', policies_link: link_to(Spree.t(:policies), spree.admin_policies_path, class: 'alert-link')).html_safe %>
   </p>
 </div>
 

--- a/admin/app/views/spree/admin/tax_rates/_table_header.html.erb
+++ b/admin/app/views/spree/admin/tax_rates/_table_header.html.erb
@@ -1,4 +1,4 @@
-<tr data-hook="rate_header">
+<tr>
   <th scope="col"><%= sort_link search_collection, :name, Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:tax_category) %></th>
   <th scope="col"><%= Spree.t(:zone) %></th>

--- a/admin/app/views/spree/admin/translations/edit.html.erb
+++ b/admin/app/views/spree/admin/translations/edit.html.erb
@@ -39,6 +39,8 @@
                 <%= render 'spree/admin/translations/taxons/form', options %>
               <% when 'Spree::Taxonomy' %>
                 <%= render 'spree/admin/translations/taxonomies/form', options %>
+              <% when 'Spree::Policy' %>
+                <%= render 'spree/admin/translations/policies/form', options %>
               <% end %>
             </tbody>
           </table>

--- a/admin/app/views/spree/admin/translations/policies/_form.html.erb
+++ b/admin/app/views/spree/admin/translations/policies/_form.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (f:, resource:, locale:) %>
+
+<% resource.class.translatable_fields.each do |field| %>
+  <% case field %>
+  <% when :name %>
+    <%= render "spree/admin/translations/translation_rows/text_field_row", f: f, field: field, locale: locale %>
+  <% when :body %>
+    <%= render "spree/admin/translations/translation_rows/rich_textarea_row", f: f, field: field, locale: locale %>
+  <% else %>
+    <%= render "spree/admin/translations/translation_rows/text_field_row", f: f, field: field, locale: locale %>
+  <% end %>
+<% end %>

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -156,6 +156,7 @@ Spree::Core::Engine.add_routes do
     resources :stores, only: [:new, :create] do
       resources :role_users, only: [:destroy]
     end
+    resources :policies, except: :show
     resources :payment_methods, except: :show
     resources :shipping_methods, except: :show
     resources :shipping_categories, except: :show

--- a/admin/lib/spree/admin/runtime_configuration.rb
+++ b/admin/lib/spree/admin/runtime_configuration.rb
@@ -1,3 +1,6 @@
+require 'spree/core/preferences/runtime_configuration'
+require 'kaminari'
+
 module Spree
   module Admin
     class RuntimeConfiguration < ::Spree::Preferences::RuntimeConfiguration

--- a/api/app/controllers/spree/api/v2/storefront/policies_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/policies_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Api
+    module V2
+      module Storefront
+        class PoliciesController < ::Spree::Api::V2::ResourceController
+          private
+
+          def collection_serializer
+            Spree::Api::Dependencies.storefront_policy_serializer.constantize
+          end
+
+          def resource_serializer
+            Spree::Api::Dependencies.storefront_policy_serializer.constantize
+          end
+
+          def resource
+            @resource ||= find_with_fallback_default_locale { scope.find_by(slug: params[:id]) } || scope.find(params[:id])
+          end
+
+          def model_class
+            Spree::Policy
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/spree/api/v2/storefront/policies_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/policies_controller.rb
@@ -20,6 +20,10 @@ module Spree
           def model_class
             Spree::Policy
           end
+
+          def scope_includes
+            [:rich_text_translations]
+          end
         end
       end
     end

--- a/api/app/serializers/spree/v2/storefront/policy_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/policy_serializer.rb
@@ -1,0 +1,19 @@
+module Spree
+  module V2
+    module Storefront
+      class PolicySerializer < BaseSerializer
+        set_type :policy
+
+        attributes :name, :locale, :created_at, :updated_at
+
+        attribute :body_plain_text do |object|
+          object.to_plain_text
+        end
+
+        attribute :body_html do |object|
+          object.to_html
+        end
+      end
+    end
+  end
+end

--- a/api/app/serializers/spree/v2/storefront/policy_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/policy_serializer.rb
@@ -4,14 +4,14 @@ module Spree
       class PolicySerializer < BaseSerializer
         set_type :policy
 
-        attributes :name, :locale, :created_at, :updated_at
+        attributes :name, :slug, :show_in_checkout_footer, :created_at, :updated_at
 
-        attribute :body_plain_text do |object|
-          object.to_plain_text
+        attribute :body do |object|
+          object.body.to_plain_text
         end
 
         attribute :body_html do |object|
-          object.to_html
+          object.body.to_s
         end
       end
     end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -53,6 +53,7 @@ Spree::Core::Engine.add_routes do
 
         resources :menus, only: %i[index show]
         resources :cms_pages, only: %i[index show]
+        resources :policies, only: %i[index show]
 
         resources :wishlists do
           get :default, on: :collection

--- a/api/lib/spree/api/dependencies.rb
+++ b/api/lib/spree/api/dependencies.rb
@@ -65,6 +65,7 @@ module Spree
         storefront_product_serializer: 'Spree::V2::Storefront::ProductSerializer',
         storefront_estimated_shipment_serializer: 'Spree::V2::Storefront::EstimatedShippingRateSerializer',
         storefront_store_serializer: 'Spree::V2::Storefront::StoreSerializer',
+        storefront_policy_serializer: 'Spree::V2::Storefront::PolicySerializer',
         storefront_order_serializer: 'Spree::V2::Storefront::OrderSerializer',
         storefront_variant_serializer: 'Spree::V2::Storefront::VariantSerializer',
 

--- a/api/spec/requests/spree/api/v2/storefront/policies_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/policies_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe 'Storefront API v2 Policies spec', type: :request do
+  let(:store) { Spree::Store.default }
+  let(:other_store) { create(:store, name: 'Other Store') }
+  let!(:policy) { store.policies.first }
+
+  before do
+    allow_any_instance_of(Spree::Api::V2::Storefront::PoliciesController).to receive(:current_store).and_return(store)
+  end
+
+  describe 'policies#index' do
+    let!(:other_store_policy) { create(:policy, slug: 'other-store-policy', store: other_store) }
+
+    before { get '/api/v2/storefront/policies' }
+
+    it 'returns policies for current store' do
+      expect(json_response['data'].count).to eq(4)
+      policy_names = json_response['data'].map { |p| p['attributes']['name'] }
+      expect(policy_names).to include('Privacy Policy', 'Terms of Service', 'Returns Policy', 'Shipping Policy')
+      expect(policy_names).not_to include('My Policy') # other store policy
+    end
+  end
+
+  describe 'policies#show' do
+    context 'with slug param' do
+      before { get "/api/v2/storefront/policies/#{policy.slug}" }
+
+      it 'returns policy with attributes' do
+        expect(json_response['data']['id']).to eq(policy.id.to_s)
+        expect(json_response['data']['type']).to eq('policy')
+        expect(json_response['data']['attributes']['name']).to eq(policy.name)
+        expect(json_response['data']['attributes']['slug']).to eq(policy.slug)
+        expect(json_response['data']['attributes']['show_in_checkout_footer']).to eq(policy.show_in_checkout_footer)
+        expect(json_response['data']['attributes']['body']).to eq(policy.body.to_plain_text)
+        expect(json_response['data']['attributes']['body_html']).to eq(policy.body.to_s)
+        expect(json_response['data']['attributes']['created_at']).to be_present
+        expect(json_response['data']['attributes']['updated_at']).to be_present
+      end
+    end
+
+    context 'with id param' do
+      before { get "/api/v2/storefront/policies/#{policy.id}" }
+
+      it 'returns policy with attributes' do
+        expect(response.status).to eq(200)
+        expect(json_response['data']['id']).to eq(policy.id.to_s)
+      end
+    end
+
+    context 'with locale set to pl' do
+      let!(:localized_policy) do
+        policy = create(:policy, store: store, slug: 'localized-policy', name: 'Privacy Policy EN')
+
+        I18n.with_locale(:pl) do
+          policy.name = 'Polityka Prywatności'
+          policy.body = 'To jest polityka prywatności'
+          policy.save!
+        end
+
+        policy
+      end
+
+      before do
+        store.update!(supported_locales: 'en,pl')
+        get "/api/v2/storefront/policies/#{localized_policy.slug}?locale=pl"
+      end
+
+      after do
+        I18n.locale = :en
+        store.update!(supported_locales: 'en')
+      end
+
+      it 'returns policy with translated attributes' do
+        expect(json_response['data']).to have_attribute(:name).with_value('Polityka Prywatności')
+        expect(json_response['data']).to have_attribute(:body).with_value('To jest polityka prywatności')
+      end
+    end
+
+    context 'with invalid slug param' do
+      before { get '/api/v2/storefront/policies/non-existent-policy' }
+
+      it 'returns error' do
+        expect(json_response['error']).to eq('The resource you were looking for could not be found.')
+      end
+    end
+
+    context 'with invalid id param' do
+      before { get '/api/v2/storefront/policies/999999' }
+
+      it 'returns error' do
+        expect(json_response['error']).to eq('The resource you were looking for could not be found.')
+      end
+    end
+
+    context 'accessing policy from different store' do
+      let(:other_store_policy) { create(:policy, store: other_store, slug: 'other-policy') }
+
+      before { get "/api/v2/storefront/policies/#{other_store_policy.slug}" }
+
+      it 'returns error when policy belongs to different store' do
+        expect(json_response['error']).to eq('The resource you were looking for could not be found.')
+      end
+    end
+  end
+end

--- a/core/app/models/concerns/spree/has_one_link.rb
+++ b/core/app/models/concerns/spree/has_one_link.rb
@@ -12,7 +12,7 @@ module Spree
           [Spree.t(:product), 'Spree::Product'],
           [Spree.t(:post), 'Spree::Post'],
           [Spree.t(:taxon), 'Spree::Taxon'],
-          [Spree.t(:policy), 'ActionText::RichText'],
+          [Spree.t(:policy), 'Spree::Policy'],
           [Spree.t(:url), nil]
         ]
       end

--- a/core/app/models/concerns/spree/has_page_links.rb
+++ b/core/app/models/concerns/spree/has_page_links.rb
@@ -17,7 +17,7 @@ module Spree
           [Spree.t(:product), 'Spree::Product'],
           [Spree.t(:post), 'Spree::Post'],
           [Spree.t(:taxon), 'Spree::Taxon'],
-          [Spree.t(:policy), 'ActionText::RichText'],
+          [Spree.t(:policy), 'Spree::Policy'],
           [Spree.t(:url), nil]
         ]
       end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -99,6 +99,8 @@ module Spree
         wished_item.wishlist.user == user
       end
       can :accept, Spree::Invitation, invitee_id: [user.id, nil], invitee_type: user.class.name, status: 'pending'
+      can :read, ::Spree::Policy
+      can :read, ::Spree::Page
     end
 
     def protect_admin_role

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -87,7 +87,7 @@ class Spree::Base < ApplicationRecord
 
   # Try building a slug based on the following fields in increasing order of specificity.
   def slug_candidates
-    if defined?(:deleted_at) && deleted_at.present?
+    if defined?(deleted_at) && deleted_at.present?
       [
         ['deleted', :name],
         ['deleted', :name, :uuid_for_friendly_id]

--- a/core/app/models/spree/page_sections/footer.rb
+++ b/core/app/models/spree/page_sections/footer.rb
@@ -72,17 +72,8 @@ module Spree
           ),
           Spree::PageBlocks::Nav.new(
             preferred_label: 'Info',
-            default_links: [
-              Spree::PageLink.new(
-                label: 'Privacy Policy',
-                linkable: store.customer_privacy_policy
-              ),
-              Spree::PageLink.new(
-                label: 'Terms of Service',
-                linkable: store.customer_terms_of_service
-              ),
-            ]
-          ),
+            default_links: []
+          )
         ]
       end
 

--- a/core/app/models/spree/page_sections/footer.rb
+++ b/core/app/models/spree/page_sections/footer.rb
@@ -48,16 +48,32 @@ module Spree
           shop_default_links << Spree::PageLink.new(linkable: new_arrivals_collection) if new_arrivals_collection.present?
         end
 
+        default_info_links = []
+
+        if store.policies.find_by(name: Spree.t('terms_of_service')).present?
+          default_info_links << Spree::PageLink.new(
+            label: Spree.t('terms_of_service'),
+            linkable: store.policies.find_by(name: Spree.t('terms_of_service'))
+          )
+        end
+
+        if store.policies.find_by(name: Spree.t('privacy_policy')).present?
+          default_info_links << Spree::PageLink.new(
+            label: Spree.t('privacy_policy'),
+            linkable: store.policies.find_by(name: Spree.t('privacy_policy'))
+          )
+        end
+
         [
           Spree::PageBlocks::Nav.new(
             preferred_label: 'Shop',
             default_links: shop_default_links
           ),
           Spree::PageBlocks::Nav.new(
-            preferred_label: 'Account',
+            preferred_label: Spree.t('account'),
             default_links: [
               Spree::PageLink.new(
-                label: 'My Account',
+                label: Spree.t('my_account'),
                 linkable: pages.find_by(type: 'Spree::Pages::Account')
               ),
               Spree::PageLink.new(
@@ -72,7 +88,7 @@ module Spree
           ),
           Spree::PageBlocks::Nav.new(
             preferred_label: 'Info',
-            default_links: []
+            default_links: default_info_links
           )
         ]
       end

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -17,15 +17,15 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store', touch: true
 
     #
+    # Translations
+    #
+    TRANSLATABLE_FIELDS = %i[name body].freeze
+    translates(*TRANSLATABLE_FIELDS, column_fallback: !Spree.always_use_translations?)
+
+    #
     # ActionText
     #
     translates :body, backend: :action_text
-
-    #
-    # Translations
-    #
-    TRANSLATABLE_FIELDS = %i[name].freeze
-    translates(*TRANSLATABLE_FIELDS, column_fallback: !Spree.always_use_translations?)
 
     #
     # Validations

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -1,0 +1,47 @@
+module Spree
+  class Policy < Spree.base_class
+    extend FriendlyId
+    include Spree::SingleStoreResource
+    include Spree::TranslatableResource
+
+    acts_as_list scope: %i[store_id]
+
+    #
+    # FriendlyId
+    #
+    friendly_id :slug_candidates, use: %i[slugged scoped history], scope: %i[store_id]
+
+    #
+    # Associations
+    #
+    belongs_to :store, class_name: 'Spree::Store', touch: true
+
+    #
+    # ActionText
+    #
+    translates :body, backend: :action_text
+
+    #
+    # Translations
+    #
+    TRANSLATABLE_FIELDS = %i[name].freeze
+    translates(*TRANSLATABLE_FIELDS, column_fallback: !Spree.always_use_translations?)
+
+    #
+    # Validations
+    #
+    validates :slug, presence: true, uniqueness: { scope: %i[store_id] }
+    validates :name, :body, presence: true
+    validates :show_in_checkout_footer, inclusion: { in: [true, false] }
+
+    #
+    # Scopes
+    #
+    scope :show_in_checkout_footer, -> { where(show_in_checkout_footer: true) }
+
+    #
+    #  Ransack
+    #
+    self.whitelisted_ransackable_attributes = %w[name show_in_checkout_footer]
+  end
+end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -111,7 +111,7 @@ module Spree
 
     has_many :gift_cards, class_name: 'Spree::GiftCard', dependent: :destroy
 
-    has_many :policies, as: :owner, class_name: 'Spree::Policy', dependent: :destroy
+    has_many :policies, class_name: 'Spree::Policy', dependent: :destroy
 
     #
     # Page Builder associations

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -111,6 +111,8 @@ module Spree
 
     has_many :gift_cards, class_name: 'Spree::GiftCard', dependent: :destroy
 
+    has_many :policies, as: :owner, class_name: 'Spree::Policy', dependent: :destroy
+
     #
     # Page Builder associations
     #

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -187,6 +187,7 @@ module Spree
     after_create :import_products_from_store, if: -> { import_products_from_store_id.present? }
     after_create :import_payment_methods_from_store, if: -> { import_payment_methods_from_store_id.present? }
     after_create :create_default_theme
+    after_create :create_default_policies
     before_destroy :validate_not_last, unless: :skip_validate_not_last
     before_destroy :pass_default_flag_to_other_store
     after_commit :clear_cache
@@ -405,6 +406,14 @@ module Spree
       StorePaymentMethod.insert_all(payment_method_ids.map { |payment_method_id| { store_id: id, payment_method_id: payment_method_id } })
     end
 
+    %w[customer_terms_of_service customer_privacy_policy customer_returns_policy customer_shipping_policy].each do |policy_method|
+      define_method policy_method do
+        Spree::Deprecation.warn("Store##{policy_method} is deprecated and will be removed in Spree 6.0. Please use Store#policies instead.")
+
+        ActionText::RichText.find_by(name: policy_method, record: self)
+      end
+    end
+
     private
 
     def countries_available_for_checkout_cache_key
@@ -496,6 +505,25 @@ module Spree
       post_categories.find_or_create_by(title: Spree.t('default_post_categories.resources'))
       post_categories.find_or_create_by(title: Spree.t('default_post_categories.articles'))
       post_categories.find_or_create_by(title: Spree.t('default_post_categories.news'))
+    end
+
+    def create_default_policies
+      policies.find_or_initialize_by(name: Spree.t('terms_of_service')) do |policy|
+        policy.body = Spree.t('terms_of_service')
+        policy.save!
+      end
+      policies.find_or_initialize_by(name: Spree.t('privacy_policy')) do |policy|
+        policy.body = Spree.t('privacy_policy')
+        policy.save!
+      end
+      policies.find_or_initialize_by(name: Spree.t('returns_policy')) do |policy|
+        policy.body = Spree.t('returns_policy')
+        policy.save!
+      end
+      policies.find_or_initialize_by(name: Spree.t('shipping_policy')) do |policy|
+        policy.body = Spree.t('shipping_policy')
+        policy.save!
+      end
     end
 
     # code is slug, so we don't want to generate new slug when code changes

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -101,6 +101,9 @@ en:
         number: Number
       spree/payment_method:
         name: Name
+      spree/policy:
+        body: Body
+        show_in_checkout_footer: Show in checkout footer
       spree/product:
         available_on: Available On
         cost_currency: Cost Currency

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1315,6 +1315,7 @@ en:
     new_password: New password
     new_payment: New Payment
     new_payment_method: New Payment Method
+    new_policy: New Policy
     new_post: New Post
     new_post_category: New Post Category
     new_product: New Product

--- a/core/db/migrate/20250811112056_create_spree_policies.rb
+++ b/core/db/migrate/20250811112056_create_spree_policies.rb
@@ -4,15 +4,15 @@ class CreateSpreePolicies < ActiveRecord::Migration[7.2]
       t.belongs_to :store, null: false
       t.string :slug, null: false
       t.string :name, null: false
-      t.boolean :show_in_checkout_footer, null: false, default: true, index: true
-      t.integer :position, null: false, default: 0, index: true
+      t.boolean :show_in_checkout_footer, null: false, default: true
+      t.integer :position,               null: false, default: 0
 
       t.timestamps
     end
 
-    add_index :spree_policies, [:store_id, :slug], unique: true
+    add_index :spree_policies, [:store_id, :slug],                    unique: true
     add_index :spree_policies, [:store_id, :show_in_checkout_footer]
-
+    add_index :spree_policies, [:store_id, :position]
     create_table :spree_policy_translations do |t|
       t.string :locale, null: false
       t.string :name

--- a/core/db/migrate/20250811112056_create_spree_policies.rb
+++ b/core/db/migrate/20250811112056_create_spree_policies.rb
@@ -1,0 +1,26 @@
+class CreateSpreePolicies < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spree_policies do |t|
+      t.belongs_to :store, null: false
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.boolean :show_in_checkout_footer, null: false, default: true, index: true
+      t.integer :position, null: false, default: 0, index: true
+
+      t.timestamps
+    end
+
+    add_index :spree_policies, [:store_id, :slug], unique: true
+    add_index :spree_policies, [:store_id, :show_in_checkout_footer]
+
+    create_table :spree_policy_translations do |t|
+      t.string :locale, null: false
+      t.string :name
+      t.references :spree_policy, null: false
+
+      t.timestamps
+    end
+
+    add_index :spree_policy_translations, [:spree_policy_id, :locale], unique: true
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -247,7 +247,8 @@ module Spree
           Spree::Property,
           Spree::Taxon,
           Spree::Taxonomy,
-          Spree::Store
+          Spree::Store,
+          Spree::Policy
         ]
 
         Rails.application.config.spree.analytics_events = {

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -29,6 +29,7 @@ module Spree
       :page_section_attributes,
       :payment_attributes,
       :payment_method_attributes,
+      :policy_attributes,
       :post_attributes,
       :post_category_attributes,
       :product_attributes,
@@ -142,6 +143,8 @@ module Spree
     @@payment_attributes = [:amount, :payment_method_id, :payment_method]
 
     @@payment_method_attributes = [:name, :type, :description, :active, :display_on, :auto_capture, :position]
+
+    @@policy_attributes = [:name, :slug, :body, :show_in_checkout_footer, :position]
 
     @@post_attributes = [:title, :meta_title, :meta_description, :slug, :author_id, :post_category_id, :published_at, :content, :excerpt, :image, tag_list: []]
 

--- a/core/lib/spree/testing_support/factories/policy_factory.rb
+++ b/core/lib/spree/testing_support/factories/policy_factory.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :policy, class: 'Spree::Policy' do
     store { Spree::Store.default }
-    slug { 'privacy-policy' }
-    name { 'Privacy Policy' }
+    slug { 'my-policy' }
+    name { 'My Policy' }
     show_in_checkout_footer { true }
-    body { 'This is the privacy policy' }
+    body { 'This is the my policy' }
   end
 end

--- a/core/lib/spree/testing_support/factories/policy_factory.rb
+++ b/core/lib/spree/testing_support/factories/policy_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :policy, class: 'Spree::Policy' do
+    store { Spree::Store.default }
+    slug { 'privacy-policy' }
+    name { 'Privacy Policy' }
+    show_in_checkout_footer { true }
+    body { 'This is the privacy policy' }
+  end
+end

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -225,9 +225,9 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
       if action_text.record_type == 'Spree::Store' && action_text.name.to_s.include?('policy')
         # Find the corresponding policy in the new policies system
         store = action_text.record
-        policy_name = action_text.name.to_s.gsub(/customer_/, '').gsub(/_policy$/, '')
+      policy_name = derive_policy_name.call(action_text.name)
 
-        policy = store.policies.find_by(name: Spree.t(policy_name))
+      policy = store.policies.find_by(name: Spree.t(policy_name))
 
         if policy
           # Update the page link to point to the policy instead

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -195,6 +195,12 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
 
   desc 'Migrate policies to store policies'
   task migrate_policies_to_store_policies: :environment do |_t, _args|
+    # Check if migration has already been run
+    if Spree::Policy.any?
+      say "Policies already exist. Skipping migration to prevent duplicates."
+      return
+    end
+
     Spree::Store.all.each do |store|
       %w[customer_terms_of_service customer_privacy_policy customer_returns_policy customer_shipping_policy].each do |policy_slug|
         policy = store.send(policy_slug)

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -207,7 +207,7 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
         next unless policy.present?
 
         store.policies.create(
-          name: Spree.t(policy_slug.gsub(/customer_/, '')),
+          name: Spree.t(policy_slug.gsub(/customer_/, '').gsub(/_policy$/, '')),
           body: policy.body
         )
 

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Policy, type: :model do
+  let(:store) { Spree::Store.default }
+  let(:policy) { create(:policy, store: store) }
+
+  describe 'validations' do
+    context 'slug uniqueness' do
+      before { policy }
+
+      it 'allows same slug for different stores' do
+        other_store = create(:store)
+        other_policy = create(:policy, store: other_store, slug: policy.slug)
+        expect(other_policy.slug).to eq(policy.slug)
+      end
+    end
+  end
+
+  describe 'friendly_id' do
+    it 'generates friendly URLs from slug' do
+      policy = create(:policy, slug: 'privacy-policy')
+      expect(policy.to_param).to eq('privacy-policy')
+    end
+
+    it 'maintains slug history' do
+      policy = create(:policy, slug: 'old-slug')
+      policy.update(slug: 'new-slug')
+
+      expect(policy.to_param).to eq('new-slug')
+      expect(policy.friendly_id_config.uses?(:history)).to be true
+    end
+  end
+
+  describe 'translations' do
+    it 'has translatable name field' do
+      expect(described_class::TRANSLATABLE_FIELDS).to include(:name)
+    end
+
+    it 'supports translations for name' do
+      policy = create(:policy, name: 'Privacy Policy')
+
+      I18n.with_locale(:es) do
+        policy.name = 'Política de Privacidad'
+        policy.body = 'Política de Privacidad'
+        policy.save!
+      end
+
+      expect(policy.name).to eq('Privacy Policy')
+      I18n.with_locale(:es) do
+        expect(policy.name).to eq('Política de Privacidad')
+        expect(policy.body.to_plain_text).to eq('Política de Privacidad')
+      end
+    end
+  end
+
+  describe 'scopes' do
+    describe '.show_in_checkout_footer' do
+      let!(:visible_policy) { create(:policy, show_in_checkout_footer: true) }
+      let!(:hidden_policy) { create(:policy, show_in_checkout_footer: false) }
+
+      it 'returns only policies that should be shown in checkout footer' do
+        result = described_class.show_in_checkout_footer
+        expect(result).to include(visible_policy)
+        expect(result).not_to include(hidden_policy)
+      end
+    end
+
+    describe '.for_store' do
+      let(:other_store) { create(:store) }
+      let!(:store1_policy) { create(:policy, store: store) }
+      let!(:store2_policy) { create(:policy, store: other_store) }
+
+      it 'returns policies for specific store' do
+        result = described_class.for_store(store)
+        expect(result).to include(store1_policy)
+        expect(result).not_to include(store2_policy)
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Spree::Policy, type: :model do
 
   describe 'friendly_id' do
     it 'generates friendly URLs from slug' do
-      policy = create(:policy, slug: 'privacy-policy')
-      expect(policy.to_param).to eq('privacy-policy')
+      policy = create(:policy, slug: 'my-policy')
+      expect(policy.to_param).to eq('my-policy')
     end
 
     it 'maintains slug history' do

--- a/storefront/app/controllers/spree/policies_controller.rb
+++ b/storefront/app/controllers/spree/policies_controller.rb
@@ -1,26 +1,8 @@
 module Spree
   class PoliciesController < StoreController
+    # GET /policies/<policy_slug>
     def show
-      if params[:id].in?(supported_policies)
-        @policy = case params[:id]
-                  when 'privacy_policy'
-                    current_store.customer_privacy_policy
-                  when 'terms_of_service'
-                    current_store.customer_terms_of_service
-                  when 'returns_policy'
-                    current_store.customer_returns_policy
-                  when 'shipping_policy'
-                    current_store.customer_shipping_policy
-                  end
-      else
-        raise ActiveRecord::RecordNotFound
-      end
-    end
-
-    private
-
-    def supported_policies
-      %w[privacy_policy terms_of_service returns_policy shipping_policy]
+      @policy = current_store.policies.friendly.find(params[:id])
     end
   end
 end

--- a/storefront/app/views/themes/default/spree/checkout/_footer.html.erb
+++ b/storefront/app/views/themes/default/spree/checkout/_footer.html.erb
@@ -1,10 +1,11 @@
 <% cache spree_base_cache_scope.call(current_store) do %>
-  <div class="flex flex-col gap-4 text-sm">
-    <ul class="flex justify-center flex-wrap gap-4">
-      <%= link_to Spree.t(:privacy_policy), "/policies/privacy_policy", target: '_blank' if legal_policy('privacy_policy').present? %>
-      <%= link_to Spree.t(:terms_of_service), "/policies/terms_of_service", target: '_blank' if legal_policy('terms_of_service').present? %>
-      <%= link_to Spree.t(:returns_policy), "/policies/returns_policy", target: '_blank' if legal_policy('returns_policy').present? %>
-      <%= link_to Spree.t(:shipping_policy), "/policies/shipping_policy", target: '_blank' if legal_policy('shipping_policy').present? %>
-    </ul>
-  </div>
+  <% if current_store.policies.show_in_checkout_footer.any? %>
+    <div class="flex flex-col gap-4 text-sm">
+      <ul class="flex justify-center flex-wrap gap-4">
+        <% current_store.policies.show_in_checkout_footer.order(:position).each do |policy| %>
+          <%= link_to policy.name, spree.policy_path(policy), target: '_blank' %>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/storefront/app/views/themes/default/spree/policies/show.html.erb
+++ b/storefront/app/views/themes/default/spree/policies/show.html.erb
@@ -1,15 +1,14 @@
 <div class="page-container py-12">
   <h1 class="text-2xl tracking-tight text-center lg:text-left mb-3 uppercase">
-    <%= Spree.t(params[:id]) %>
+    <%= @policy.name %>
   </h1>
 
-  <% if @policy.present? %>
-    <p class="mb-8 text-center lg:text-left">
-      <%= Spree.t("storefront.policies.last_update_at", date: l(@policy.updated_at.to_date)) %>
-    </p>
+  <p class="mb-8 text-center lg:text-left">
+    <%= Spree.t(:updated_at) %>:
+    <%= l(@policy.updated_at.to_date) %>
+  </p>
 
-    <div class="mb-5">
-      <%= @policy&.to_s %>
-    </div>
-  <% end %>
+  <div class="mb-5">
+    <%= @policy.body.to_s %>
+  </div>
 </div>

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -55,8 +55,6 @@ en:
         description: Take control of your settings and tailor your experience according to your preferences. Customize your notifications to suit your needs.
         join: Email me about new products, sales, and more. You can unsubscribe at any time.
         status: You are currently %{status} to the newsletters.
-      policies:
-        last_update_at: Last update %{date}
       products:
         pinch_to_zoom_html: Pinch to<br>zoom
       refund_action_not_required_message:

--- a/storefront/spec/controllers/spree/policies_controller_spec.rb
+++ b/storefront/spec/controllers/spree/policies_controller_spec.rb
@@ -10,42 +10,12 @@ describe Spree::PoliciesController, type: :controller do
   end
 
   describe 'GET #show' do
-    context 'with valid policy types' do
-      it 'renders privacy_policy' do
-        get :show, params: { id: 'privacy_policy' }
-        expect(assigns(:policy)).to eq(store.customer_privacy_policy)
-        expect(response).to render_template(:show)
-        expect(response).to have_http_status(:ok)
-      end
+    let(:policy) { create(:policy, store: store) }
 
-      it 'renders terms_of_service' do
-        get :show, params: { id: 'terms_of_service' }
-        expect(assigns(:policy)).to eq(store.customer_terms_of_service)
-        expect(response).to render_template(:show)
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'renders returns_policy' do
-        get :show, params: { id: 'returns_policy' }
-        expect(assigns(:policy)).to eq(store.customer_returns_policy)
-        expect(response).to render_template(:show)
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'renders shipping_policy' do
-        get :show, params: { id: 'shipping_policy' }
-        expect(assigns(:policy)).to eq(store.customer_shipping_policy)
-        expect(response).to render_template(:show)
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context 'with invalid policy type' do
-      it 'raises RecordNotFound error' do
-        expect {
-          get :show, params: { id: 'invalid_policy' }
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
+    it 'renders the policy' do
+      get :show, params: { id: policy.slug }
+      expect(response).to be_successful
+      expect(response.body).to include(policy.body.to_plain_text)
     end
   end
 end


### PR DESCRIPTION
- [X] Ability to create/edit/delete policies
- [X] Ability to translate policies
- [X] Storefront API to fetch policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Admin: full Policies management (create, edit, reorder) with translations and live Turbo updates; new admin UI and list/table views.
  - Storefront: policy pages by slug; checkout footer auto-lists chosen policies.
  - API: storefront endpoint returning policy HTML and plain-text bodies.

- Improvements
  - Admin navigation and link autocomplete updated to surface Policies; footer and account labels localized; stores auto-create default policies on creation.

- Chores
  - Added a migration task to move legacy store policy content into new Policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->