### PR TITLE
FIX Homepage Navbar link

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -4,7 +4,14 @@
     <% main_link = presenter.main_link %>
     <% next unless main_link.present? %>
     <div class="header--nav-item group" <%= block_attributes(block, allowed_styles: ['padding-top', 'padding-bottom']) %>>
-      <%= active_link_to spree_storefront_resource_url(main_link.linkable || main_link), data: { title: main_link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1", class_active: "menu-item--active", target: main_link.open_in_new_tab.presence && "_blank", rel: main_link.open_in_new_tab.presence && "noopener noreferrer" do %>
+      <%= active_link_to spree_storefront_resource_url(main_link.linkable || main_link),
+          active: main_link.linkable.present? && main_link.linkable.is_a?(Spree::Pages::Homepage) ? :exclusive : :inclusive,
+          data: { title: main_link.label.downcase.strip },
+          class: "shrink-0 menu-item header--nav-link px-4 py-1",
+          class_active: "menu-item--active",
+          target: main_link.open_in_new_tab.presence && "_blank",
+          rel: main_link.open_in_new_tab.presence && "noopener noreferrer",
+          **link_attributes(main_link, as_html: false) do %>
         <span class="group-hover:border-b-[1.5px] group-hover:border-b-accent"><%= main_link.label %></span>
       <% end %>
       <% if presenter.columns.any? %>
@@ -42,7 +49,14 @@
   <% end %>
 <% else %>
   <% section.links.each do |link| %>
-    <%= active_link_to spree_storefront_resource_url(link.linkable || link), data: { title: link.label.downcase.strip }, class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4", class_active: "menu-item--active", target: link.open_in_new_tab.presence && "_blank", rel: link.open_in_new_tab.presence && "noopener noreferrer", **link_attributes(link, as_html: false) do %>
+    <%= active_link_to spree_storefront_resource_url(link.linkable || link),
+        active: link.linkable.present? && link.linkable.is_a?(Spree::Pages::Homepage) ? :exclusive : :inclusive,
+        data: { title: link.label.downcase.strip },
+        class: "shrink-0 menu-item header--nav-link px-4 py-1 focus:mx-0 focus:px-4",
+        class_active: "menu-item--active",
+        target: link.open_in_new_tab.presence && "_blank",
+        rel: link.open_in_new_tab.presence && "noopener noreferrer",
+        **link_attributes(link, as_html: false) do %>
       <span><%= link.label %></span>
     <% end %>
   <% end %>


### PR DESCRIPTION
Fix for Navbar to make Homepage as exclusive link so it won't be active for any other child links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation links now highlight accurately based on the current page, including correct handling of the homepage.
  * Active state behavior is consistent across both mega and standard navigation paths.
  * No changes to labels or layout; only the active state logic was improved for clearer, more reliable navigation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->