### PR TITLE
Fixed libvips installation on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,6 @@ commands:
       - run:
           name: Fix APT mirrors
           command: |
-            sudo sed -i 's|http://archive.ubuntu.com|http://ubuntu.cs.utah.edu|g' /etc/apt/sources.list
-            sudo sed -i 's|http://security.ubuntu.com|http://ubuntu.cs.utah.edu|g' /etc/apt/sources.list
             sudo apt-get update
       - run:
           name: Install libvips


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the continuous integration pipeline to use default Ubuntu package sources during dependency installation, removing custom mirror overrides in build steps.
  * Adjustment affects dependency setup only within CI; application code and runtime packages remain unchanged.
  * No user-facing changes to features, functionality, or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->