### PR TITLE
CHG default queue to generator

### DIFF
--- a/cli/lib/spree_cli/templates/extension/lib/%file_name%.rb.tt
+++ b/cli/lib/spree_cli/templates/extension/lib/%file_name%.rb.tt
@@ -5,7 +5,9 @@ require '<%=file_name%>/version'
 require '<%=file_name%>/configuration'
 
 module <%= class_name %>
+  mattr_accessor :queue
+
   def self.queue
-    'default'
+    @@queue ||= Spree.queues.default
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extensions now support a configurable background job queue, defaulting automatically to the platform’s default queue for seamless integration.
* **Refactor**
  * Improved queue initialization to use lazy loading, ensuring consistent and predictable queue selection across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->