### PR TITLE
Add Fragment Caching to _json_ld_variant.html.erb

### DIFF
--- a/storefront/app/views/themes/default/spree/products/_json_ld_variant.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_json_ld_variant.html.erb
@@ -1,3 +1,4 @@
+<% cache ["json-ld-variant", spree_base_cache_scope, variant.cache_key_with_version] do %>
 {
   "@type": "Offer",
   <% if variant.sku.present? %>
@@ -8,3 +9,4 @@
   "priceCurrency": <%= current_currency.to_json.html_safe %>,
   "url": <%= spree.product_url(product, variant_id: variant.id, host: current_store.url_or_custom_domain).to_json.html_safe %>
 }
+<% end %>


### PR DESCRIPTION
### Per-variant fragment caching:

We're moving away from collection-level caching and introducing fragment caching inside _json_ld_variant.html.erb, which is ideal for performance and cache granularity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added fragment caching around product variant structured data to improve rendering efficiency without altering content.

* **Performance**
  * Faster product page loads due to cached JSON-LD generation for variants.
  * Reduced server load on repeat visits and across similar requests.

* **No User-Facing Changes**
  * UI, URLs, pricing, availability, and SKU display remain unchanged.
  * Structured data output is identical; only rendering performance is improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->