### PR TITLE
Lazy load hidden turbo frames (eg. cart pane)

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -96,7 +96,7 @@
                   </span>
                 <% end %>
               <% end %>
-              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :eager  %>
+              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :lazy  %>
             </div>
           <% end %>
           <!-- Desktop Account -->

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -123,7 +123,7 @@
                   </span>
                 <% end %>
               <% end %>
-              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :eager  %>
+              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :lazy  %>
             </div>
           </div>
         <% end %>

--- a/storefront/app/views/themes/default/spree/shared/_cart_pane.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_cart_pane.html.erb
@@ -34,7 +34,7 @@
       </span>
     </div>
     <div class='flex-1 h-0 overflow-y-auto'>
-      <%= turbo_frame_tag cart_id(order), class: 'cart-contents', src: spree.cart_path, data: { turbo_permanent: true } %>
+      <%= turbo_frame_tag cart_id(order), class: 'cart-contents', src: spree.cart_path, data: { turbo_permanent: true }, loading: :lazy %>
     </div>
   </div>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Settings modal now loads on demand in header and mobile navigation, reducing initial page load time and improving responsiveness.
  * Cart pane content is lazily loaded, decreasing initial render overhead and speeding up first paint.
  * Overall, users should experience faster initial load with content fetched only when needed, with no changes to functionality or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->