### PR TITLE
FIX checkout zone

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -342,7 +342,7 @@ module Spree
     end
 
     def supported_shipping_zones
-      @supported_shipping_zones ||= if checkout_zone_id.present?
+      @supported_shipping_zones ||= if checkout_zone.present?
                                       [checkout_zone]
                                     else
                                       Spree::Zone.includes(zone_members: :zoneable).all

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -21,7 +21,7 @@ module Spree
 
     after_save :remove_defunct_members
     after_save :remove_previous_default, if: %i[default_tax? saved_change_to_default_tax?]
-    after_destroy :nullify_checkout_zone
+    before_destroy :nullify_checkout_zone
 
     alias members zone_members
     accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |a| a['zoneable_id'].blank? }

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -21,6 +21,7 @@ module Spree
 
     after_save :remove_defunct_members
     after_save :remove_previous_default, if: %i[default_tax? saved_change_to_default_tax?]
+    after_destroy :nullify_checkout_zone
 
     alias members zone_members
     accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |a| a['zoneable_id'].blank? }
@@ -203,6 +204,12 @@ module Spree
         member.zoneable_type = type
         member.zoneable_id = id
         members << member
+      end
+    end
+
+    def nullify_checkout_zone
+      if id == Spree::Store.current.checkout_zone_id
+        Spree::Store.current.update(checkout_zone_id: nil)
       end
     end
   end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -42,6 +42,18 @@ describe Spree::Zone, type: :model do
           expect(zone_with_default_tax.reload).not_to be_default_tax
         end
       end
+
+      describe '#nullify_checkout_zone' do
+        let!(:zone) { create(:zone) }
+
+        it 'is expected to nullify checkout zone' do
+          Spree::Store.current.update(checkout_zone: zone)
+
+          expect { zone.destroy }
+          .to change { Spree::Store.current.reload.checkout_zone_id }
+          .to(nil)
+        end
+      end
     end
 
     context 'when there is only one qualifying zone' do


### PR DESCRIPTION
When deleting zone which is defined as checkout zone we cannot go to shipping methods and set another zone as we get error:

<img width="1036" height="388" alt="Zrzut ekranu 2025-08-20 o 15 39 12" src="https://github.com/user-attachments/assets/a6259b36-7145-4eb0-ae95-3426db904605" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved logic for determining supported shipping zones so the correct zones are applied during checkout.
  - Automatically clears a store’s checkout shipping zone when that zone is deleted, preventing broken references and checkout errors.

- Tests
  - Added tests to verify the checkout shipping zone is cleared when its associated zone is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->