### PR TITLE
Fixed: added unique index on `spree_order_promotions` and uniqueness …

### DIFF
--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -6,6 +6,9 @@ module Spree
     delegate :name, :description, :code, :public_metadata, to: :promotion
     delegate :currency, to: :order
 
+    validates :order, :promotion, presence: true
+    validates :order, uniqueness: { scope: :promotion }
+
     extend Spree::DisplayMoney
     money_methods :amount
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -148,7 +148,7 @@ module Spree
         # connect to the order
         # create the join_table entry.
         order.promotions << self unless order.promotions.include?(self)
-        save
+        order.save
       end
 
       action_taken
@@ -175,7 +175,7 @@ module Spree
         # connect to the order
         # create the join_table entry.
         order.promotions << self unless order.promotions.include?(self)
-        save
+        order.save
       end
 
       action_taken

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -147,7 +147,7 @@ module Spree
       if action_taken
         # connect to the order
         # create the join_table entry.
-        orders << order
+        order.promotions << self unless order.promotions.include?(self)
         save
       end
 
@@ -174,7 +174,7 @@ module Spree
       if action_taken
         # connect to the order
         # create the join_table entry.
-        orders << order
+        order.promotions << self unless order.promotions.include?(self)
         save
       end
 

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -39,7 +39,7 @@ module Spree
       end
 
       def promotion_scope
-        ::Spree::Promotion.for_store(store)
+        store.promotions
       end
     end
   end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -62,7 +62,7 @@ module Spree
         promotion = order.promotions.with_coupon_code(coupon_code)
         if promotion.present?
           # Order promotion has to be destroyed before line item removing
-          order.order_promotions.where(promotion_id: promotion.id).destroy_all
+          order.promotions.delete(promotion)
 
           if promotion.multi_codes?
             coupon_code = promotion.coupon_codes.find_by(order: order)

--- a/core/db/migrate/20250821211705_fix_unique_index_on_spree_order_promotions.rb
+++ b/core/db/migrate/20250821211705_fix_unique_index_on_spree_order_promotions.rb
@@ -1,0 +1,24 @@
+class FixUniqueIndexOnSpreeOrderPromotions < ActiveRecord::Migration[7.2]
+  def change
+    drop_index :spree_order_promotions, name: 'index_spree_order_promotions_on_promotion_id_and_order_id'
+
+    # Remove duplicate records before adding unique index
+    duplicates = execute(<<~SQL)
+      SELECT promotion_id, order_id, MIN(id) as keep_id
+      FROM spree_order_promotions
+      GROUP BY promotion_id, order_id
+      HAVING COUNT(*) > 1
+    SQL
+
+    duplicates.each do |row|
+      execute(<<~SQL)
+        DELETE FROM spree_order_promotions
+        WHERE promotion_id = #{row['promotion_id']}
+        AND order_id = #{row['order_id']}
+        AND id != #{row['keep_id']}
+      SQL
+    end
+
+    add_index :spree_order_promotions, [:promotion_id, :order_id], unique: true, name: 'index_spree_order_promotions_on_promotion_id_and_order_id'
+  end
+end

--- a/core/spec/models/spree/order_promotion_spec.rb
+++ b/core/spec/models/spree/order_promotion_spec.rb
@@ -1,18 +1,16 @@
 require 'spec_helper'
 
 describe Spree::OrderPromotion, type: :model do
-  subject { create(:order_promotion, order: order, promotion: promotion) }
+  subject { order.order_promotions.find_by(promotion: promotion) }
 
   let(:order) { create(:order_with_line_items) }
   let(:promotion) { create(:promotion_with_item_adjustment, code: 'test') }
 
-  shared_context 'apply promo' do
-    before do
-      order.coupon_code = promotion.code
-      Spree::PromotionHandler::Coupon.new(order).apply
-      order.save!
-      order.all_adjustments.promotion.update_all(amount: -5.0)
-    end
+  before do
+    order.coupon_code = promotion.code
+    Spree::PromotionHandler::Coupon.new(order).apply
+    order.save!
+    order.all_adjustments.promotion.update_all(amount: -5.0)
   end
 
   context '#name' do
@@ -28,16 +26,12 @@ describe Spree::OrderPromotion, type: :model do
   end
 
   context '#amount' do
-    include_context 'apply promo'
-
     it 'equals sum of adjustments created by promotion' do
       expect(subject.amount).to eq(-5.0)
     end
   end
 
   context '#display_amount' do
-    include_context 'apply promo'
-
     it 'returns Spree::Money instance with amount value and proper currency' do
       expect(subject.display_amount.to_s).to eq('-$5.00')
     end

--- a/storefront/spec/features/checkout_steps_spec.rb
+++ b/storefront/spec/features/checkout_steps_spec.rb
@@ -69,7 +69,7 @@ describe 'Checkout steps (address and delivery)' do
     end
 
     context 'with promotion', js: true do
-      let(:promotion) { create(:promotion, code: :welcomepromo) }
+      let(:promotion) { create(:promotion, stores: [store], code: :welcomepromo) }
 
       before do
         order.update!(email: nil, user: nil)
@@ -110,7 +110,7 @@ describe 'Checkout steps (address and delivery)' do
       end
 
       context 'with coupon codes' do
-        let!(:promotion) { create(:promotion, name: '10% OFF', code: nil, multi_codes: true, number_of_codes: 1) }
+        let!(:promotion) { create(:promotion, stores: [store], name: '10% OFF', code: nil, multi_codes: true, number_of_codes: 1) }
         let!(:action) { Spree::Promotion::Actions::CreateAdjustment.create(promotion: promotion, calculator: calculator) }
 
         let(:calculator) { create(:flat_percent_item_total_calculator, preferred_flat_percent: 10) }


### PR DESCRIPTION
…validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents a promotion from being associated multiple times with the same order.
  - Requires both order and promotion to be present before linking.

- **Chores**
  - Cleans up existing duplicate promotion-order links and enforces a unique index.
  - Updates association handling to avoid creating duplicate links and to remove links safely.

- **Behavior**
  - Promotion selection is scoped per store (promotions now tied to a store). 

- **Tests**
  - Adjusts tests to validate behavior against existing order-associated records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->