### PR TITLE
Add ability to swap Order Updater via Spree dependencies

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -350,7 +350,7 @@ module Spree
     end
 
     def updater
-      @updater ||= OrderUpdater.new(self)
+      @updater ||= Spree::Dependencies.order_updater.constantize.new(self)
     end
 
     def update_with_updater!

--- a/core/app/services/spree/cart/recalculate.rb
+++ b/core/app/services/spree/cart/recalculate.rb
@@ -4,7 +4,7 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call(order:, line_item:, line_item_created: false, options: {})
-        order_updater = ::Spree::OrderUpdater.new(order)
+        order_updater = order.updater
 
         order.remove_gift_card if order.gift_card.present?
         order.payments.store_credits.checkout.destroy_all if order.payments.store_credits.checkout.any?

--- a/core/lib/spree/core/dependencies.rb
+++ b/core/lib/spree/core/dependencies.rb
@@ -41,6 +41,7 @@ module Spree
         # order
         order_approve_service: 'Spree::Orders::Approve',
         order_cancel_service: 'Spree::Orders::Cancel',
+        order_updater: 'Spree::OrderUpdater',
 
         # shipment
         shipment_change_state_service: 'Spree::Shipments::ChangeState',

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -466,7 +466,7 @@ describe Spree::Order, type: :model do
         allow(order).to receive_messages(payment_required?: true)
         order.line_items << FactoryBot.create(:line_item, variant: variant_digital)
         order.line_items << FactoryBot.create(:line_item, variant: variant_physical_with_digital_asset)
-        Spree::OrderUpdater.new(order).update
+        order.updater.update
 
         order.save!
       end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   describe Spree::Order, type: :model do
     let(:order) { create(:order, total: 100, payment_total: 0) }
-    let(:updater) { Spree::OrderUpdater.new(order) }
+    let(:updater) { order.updater }
 
     context 'processing payments' do
       before do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -120,7 +120,7 @@ describe Spree::Order, type: :model do
   end
 
   describe '#update_with_updater!' do
-    let(:updater) { Spree::OrderUpdater.new(order) }
+    let(:updater) { order.updater }
 
     before do
       allow(order).to receive(:updater).and_return(updater)

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/order_walkthrough'
 module Spree
   describe OrderUpdater, type: :model do
     let(:order) { create(:order) }
-    let(:updater) { Spree::OrderUpdater.new(order) }
+    let(:updater) { order.updater }
 
     context 'order totals' do
       before do
@@ -15,7 +15,7 @@ module Spree
 
       it 'updates payment totals' do
         create(:payment_with_refund, amount: 20, order: order)
-        Spree::OrderUpdater.new(order).update_payment_total
+        order.updater.update_payment_total
         expect(order.payment_total).to eq(15)
       end
 

--- a/core/spec/services/spree/checkout/advance_spec.rb
+++ b/core/spec/services/spree/checkout/advance_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Spree::Checkout::Advance do
   end
 
   def ensure_states_updated_only_once
-    updater_spy = Spree::OrderUpdater.new(order)
+    updater_spy = order.updater
     allow(order).to receive(:updater).and_return(updater_spy)
     expect(updater_spy).to receive(:update_shipment_state).once.and_call_original
     expect(updater_spy).to receive(:update_payment_state).once.and_call_original


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Order update process is now pluggable via dependency injection, enabling easier customization by extensions.
- Refactor
  - Consolidated use of a single updater instance across order and cart recalculation flows for consistency.
- Tests
  - Updated specs to align with the new updater acquisition path; verified no behavior changes.
- Notes
  - No user-facing behavior changes; improvements focus on extensibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->