### PR TITLE
Cart recalculate - update order.item_count before applying promotions

### DIFF
--- a/core/app/services/spree/cart/recalculate.rb
+++ b/core/app/services/spree/cart/recalculate.rb
@@ -8,6 +8,7 @@ module Spree
 
         order.remove_gift_card if order.gift_card.present?
         order.payments.store_credits.checkout.destroy_all if order.payments.store_credits.checkout.any?
+        order_updater.update_item_count
         order_updater.update_totals
         order_updater.persist_totals
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the cart item count updates correctly during recalculation, preventing stale or incorrect counts after removing store credits.
  * Aligns cart totals and item badges with the actual contents of the cart throughout checkout.
  * Reduces inconsistencies between cart display and order summary during promotions, tax updates, and final totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->