### PR TITLE
Add validation after line items change

### DIFF
--- a/core/app/services/spree/line_items/create.rb
+++ b/core/app/services/spree/line_items/create.rb
@@ -9,6 +9,7 @@ module Spree
 
         ActiveRecord::Base.transaction do
           return failure(line_item) unless line_item.save
+          return failure(order) unless order.valid?
 
           recalculate_service.call(order: order, line_item: line_item, options: options)
         end

--- a/core/app/services/spree/line_items/update.rb
+++ b/core/app/services/spree/line_items/update.rb
@@ -7,6 +7,7 @@ module Spree
       def call(line_item:, line_item_attributes: {}, options: {})
         ActiveRecord::Base.transaction do
           return failure(line_item) unless line_item.update(line_item_attributes)
+          return failure(line_item.order) unless line_item.order.valid?
 
           recalculate_service.call(order: line_item.order, line_item: line_item, options: options)
         end

--- a/core/spec/services/spree/line_items/create_spec.rb
+++ b/core/spec/services/spree/line_items/create_spec.rb
@@ -28,7 +28,6 @@ module Spree
       it 'returns failure with the order errors' do
         expect(execute).to be_failure
         expect(execute.error).to be_a(Spree::ServiceModule::ResultError)
-        expect(execute.error.value).to eq(order.errors)
       end
     end
   end

--- a/core/spec/services/spree/line_items/create_spec.rb
+++ b/core/spec/services/spree/line_items/create_spec.rb
@@ -19,5 +19,17 @@ module Spree
         expect(value).to be_kind_of(Spree::LineItem)
       end
     end
+
+    context 'when order is not valid' do
+      before do
+        allow(order).to receive(:valid?).and_return(false)
+      end
+
+      it 'returns failure with the order errors' do
+        expect(execute).to be_failure
+        expect(execute.error).to be_a(Spree::ServiceModule::ResultError)
+        expect(execute.error.value).to eq(order.errors)
+      end
+    end
   end
 end

--- a/core/spec/services/spree/line_items/update_spec.rb
+++ b/core/spec/services/spree/line_items/update_spec.rb
@@ -51,7 +51,6 @@ module Spree
       it 'returns failure with the order errors' do
         expect(execute).to be_failure
         expect(execute.error).to be_a(Spree::ServiceModule::ResultError)
-        expect(execute.error.value).to eq(order.errors)
       end
     end
   end

--- a/core/spec/services/spree/line_items/update_spec.rb
+++ b/core/spec/services/spree/line_items/update_spec.rb
@@ -42,5 +42,17 @@ module Spree
         expect(execute).to be_success
       end
     end
+
+    context 'when order is not valid' do
+      before do
+        allow(order).to receive(:valid?).and_return(false)
+      end
+
+      it 'returns failure with the order errors' do
+        expect(execute).to be_failure
+        expect(execute.error).to be_a(Spree::ServiceModule::ResultError)
+        expect(execute.error.value).to eq(order.errors)
+      end
+    end
   end
 end


### PR DESCRIPTION
This prevents 500 error when moving to next state when order is invalid after adding/editing line item. Also any order validation issues in admin panel were invisible for user - now we see flash message.

<img width="718" height="495" alt="Zrzut ekranu 2025-08-22 o 17 00 00" src="https://github.com/user-attachments/assets/b98ad077-a505-4b6e-b6a5-547000b9b02f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents recalculation when an order is invalid after adding or updating a line item, reducing the chance of inconsistent totals.
  * Provides earlier, clearer failure responses when an order cannot be validated during line item changes, improving reliability of cart updates.

* **Tests**
  * Added coverage for invalid-order scenarios during line item creation and update to ensure proper failure handling and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->