### PR TITLE
Add memoization to `Product#digital?` and `Shipment#digital?`

### DIFF
--- a/core/app/models/spree/order/digital.rb
+++ b/core/app/models/spree/order/digital.rb
@@ -1,6 +1,9 @@
 module Spree
   class Order < Spree.base_class
     module Digital
+      # Returns true if all order line items are digital
+      #
+      # @return [Boolean]
       def digital?
         if line_items.empty?
           false
@@ -9,18 +12,30 @@ module Spree
         end
       end
 
+      # Returns true if any order line item is digital
+      #
+      # @return [Boolean]
       def some_digital?
         line_items.any?(&:digital?)
       end
 
+      # Returns true if any order line item has digital assets
+      #
+      # @return [Boolean]
       def with_digital_assets?
         line_items.any?(&:with_digital_assets?)
       end
 
+      # Returns all line items with digital assets
+      #
+      # @return [Array<Spree::LineItem>]
       def digital_line_items
         line_items.with_digital_assets.distinct
       end
 
+      # Returns all digital links for the order
+      #
+      # @return [Array<Spree::DigitalLink>]
       def digital_links
         digital_line_items.map(&:digital_links).flatten
       end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -38,7 +38,7 @@ module Spree
     MEMOIZED_METHODS = %w[total_on_hand taxonomy_ids taxon_and_ancestors category
                           default_variant_id tax_category default_variant
                           default_image secondary_image
-                          purchasable? in_stock? backorderable? has_variants?]
+                          purchasable? in_stock? backorderable? has_variants? digital?]
 
     STATUS_TO_WEBHOOK_EVENT = {
       'active' => 'activated',
@@ -602,7 +602,7 @@ module Spree
     #
     # @return [Boolean]
     def digital?
-      shipping_category&.shipping_methods&.any? { |method| method.calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery) }
+      @digital ||= shipping_category&.shipping_methods&.includes(:calculator)&.any? { |method| method.calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery) }
     end
 
     def auto_match_taxons

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -81,6 +81,7 @@ module Spree
 
     belongs_to :tax_category, class_name: 'Spree::TaxCategory'
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products
+    has_many :shipping_methods, through: :shipping_category, class_name: 'Spree::ShippingMethod'
 
     has_one :master,
             -> { where is_master: true },
@@ -602,7 +603,7 @@ module Spree
     #
     # @return [Boolean]
     def digital?
-      @digital ||= shipping_category&.shipping_methods&.includes(:calculator)&.any? { |method| method.calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery) }
+      @digital ||= shipping_methods&.digital&.exists?
     end
 
     def auto_match_taxons

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -6,7 +6,6 @@ module Spree
     include Spree::NumberIdentifier
     include Spree::NumberAsParam
     include Spree::Metadata
-    include Spree::MemoizedData
     if defined?(Spree::Security::Shipments)
       include Spree::Security::Shipments
     end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -16,8 +16,6 @@ module Spree
     include Spree::Shipment::Emails
     include Spree::Shipment::Webhooks
 
-    MEMOIZED_METHODS = %w[digital?]
-
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'
       belongs_to :order, class_name: 'Spree::Order', touch: true
@@ -67,6 +65,7 @@ module Spree
 
     delegate :store, :currency, to: :order
     delegate :amount_in_cents, to: :display_cost
+    delegate :digital?, to: :shipping_method
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :pending, use_transactions: false do
@@ -252,10 +251,6 @@ module Spree
 
     def line_items
       inventory_units.includes(:line_item).map(&:line_item).uniq
-    end
-
-    def digital?
-      @digital ||= shipping_method&.calculator&.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end
 
     ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -6,6 +6,7 @@ module Spree
     include Spree::NumberIdentifier
     include Spree::NumberAsParam
     include Spree::Metadata
+    include Spree::MemoizedData
     if defined?(Spree::Security::Shipments)
       include Spree::Security::Shipments
     end
@@ -14,6 +15,8 @@ module Spree
     end
     include Spree::Shipment::Emails
     include Spree::Shipment::Webhooks
+
+    MEMOIZED_METHODS = %w[digital?]
 
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'
@@ -252,7 +255,7 @@ module Spree
     end
 
     def digital?
-      shipping_method&.calculator&.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
+      @digital ||= shipping_method&.calculator&.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end
 
     ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -121,6 +121,9 @@ module Spree
       end
     end
 
+    # Returns true if the shipping method is digital
+    #
+    # @return [Boolean]
     def digital?
       @digital ||= calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -10,8 +10,11 @@ module Spree
     if defined?(Spree::VendorConcern)
       include Spree::VendorConcern
     end
+    include Spree::MemoizedData
 
     extend Spree::DisplayMoney
+
+    MEMOIZED_METHODS = %w[display_estimated_price digital?]
 
     # Used for #refresh_rates
     DISPLAY_ON_FRONT_END = 1
@@ -116,6 +119,10 @@ module Spree
           ''
         end
       end
+    end
+
+    def digital?
+      @digital ||= calculator.is_a?(Spree::Calculator::Shipping::DigitalDelivery)
     end
 
     private

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -480,6 +480,8 @@ module Spree
     end
 
     # Is this variant purely digital? (no physical product)
+    #
+    # @return [Boolean]
     def digital?
       product.digital?
     end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Expanded memoization for product, shipment, and shipping method checks around digital vs physical delivery; shipments now rely on their shipping method for digital detection — improves performance with no behavioral changes.
* **Documentation**
  * Added/updated inline docs for order digital helpers and the variant digital? predicate to clarify return semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->