### PR TITLE
Speed up `TaxRate#adjust` by operating on IDs rather than full objects

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -381,6 +381,12 @@ module Spree
       @tax_category ||= super || TaxCategory.default
     end
 
+    # Returns tax category ID for Product
+    # @return [Integer]
+    def tax_category_id
+      @tax_category_id ||= super || TaxCategory.default.id
+    end
+
     # Adding properties and option types on creation based on a chosen prototype
     attr_accessor :prototype_id
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -381,12 +381,6 @@ module Spree
       @tax_category ||= super || TaxCategory.default
     end
 
-    # Returns tax category ID for Product
-    # @return [Integer, nil]
-    def tax_category_id
-      @tax_category_id ||= super || TaxCategory.default&.id
-    end
-
     # Adding properties and option types on creation based on a chosen prototype
     attr_accessor :prototype_id
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -376,15 +376,15 @@ module Spree
     end
 
     # Returns tax category for Product
-    # @return [Spree::TaxCategory]
+    # @return [Spree::TaxCategory, nil]
     def tax_category
       @tax_category ||= super || TaxCategory.default
     end
 
     # Returns tax category ID for Product
-    # @return [Integer]
+    # @return [Integer, nil]
     def tax_category_id
-      @tax_category_id ||= super || TaxCategory.default.id
+      @tax_category_id ||= super || TaxCategory.default&.id
     end
 
     # Adding properties and option types on creation based on a chosen prototype

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -358,12 +358,25 @@ module Spree
       self.shipped_at = Time.current
     end
 
+    # Returns the shipping method of the selected shipping rate
+    #
+    # @return [Spree::ShippingMethod]
     def shipping_method
       selected_shipping_rate&.shipping_method || shipping_rates.first&.shipping_method
     end
 
+    # Returns the tax category of the selected shipping rate
+    #
+    # @return [Spree::TaxCategory]
     def tax_category
       selected_shipping_rate.try(:tax_rate).try(:tax_category)
+    end
+
+    # Returns the tax category ID of the selected shipping rate
+    #
+    # @return [Integer]
+    def tax_category_id
+      selected_shipping_rate.try(:tax_rate).try(:tax_category_id)
     end
 
     # Only one of either included_tax_total or additional_tax_total is set

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -72,18 +72,18 @@ module Spree
     # to relevant items.
     def self.adjust(order, items)
       rates = match(order.tax_zone)
-      tax_categories = rates.map(&:tax_category)
+      tax_category_ids = rates.map(&:tax_category_id)
 
       # using destroy_all to ensure adjustment destroy callback fires.
       Spree::Adjustment.where(adjustable: items).tax.destroy_all
 
       relevant_items = items.select do |item|
-        tax_categories.include?(item.tax_category)
+        tax_category_ids.include?(item.tax_category_id)
       end
 
       relevant_items.each do |item|
         relevant_rates = rates.select do |rate|
-          rate.tax_category == item.tax_category
+          rate.tax_category_id == item.tax_category_id
         end
         store_pre_tax_amount(item, relevant_rates)
         relevant_rates.each do |rate|

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -223,12 +223,24 @@ module Spree
       self.class.in_stock_or_backorderable.exists?(id: id)
     end
 
+    # Returns tax category for Variant
+    # @return [Spree::TaxCategory]
     def tax_category
       @tax_category ||= if self[:tax_category_id].nil?
                           product.tax_category
                         else
                           Spree::TaxCategory.find_by(id: self[:tax_category_id]) || product.tax_category
                         end
+    end
+
+    # Returns tax category ID for Variant
+    # @return [Integer]
+    def tax_category_id
+      @tax_category_id ||= if self[:tax_category_id].nil?
+                             product.tax_category_id
+                           else
+                             self[:tax_category_id]
+                           end
     end
 
     def options_text

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -176,7 +176,7 @@ describe Spree::TaxRate, type: :model do
 
       before do
         allow(Spree::TaxRate).to receive_messages match: [rate_1, rate_2]
-        allow(shipment).to receive_messages cost: 10.0, tax_category: tax_category_1
+        allow(shipment).to receive_messages cost: 10.0, tax_category: tax_category_1, tax_category_id: tax_category_1.id
       end
 
       it 'applies adjustments for two tax rates to the order' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate tax calculations for products, variants, and shipments so checkout totals better reflect applicable taxes.
  * Fixed cases where missing or mismatched tax data produced incorrect shipping or line-item taxes.

* **Refactor**
  * Standardized tax lookup and fallback behavior across variants and shipments for greater consistency and checkout stability.

* **Documentation**
  * Clarified return/type information in tax-related method docs for improved developer clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->