### PR TITLE
Improve `Shipment#with_free_shipping_promotion?`

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -201,8 +201,11 @@ module Spree
       with_free_shipping_promotion?
     end
 
+    # Returns true if the shipment has a free shipping promotion applied
+    #
+    # @return [Boolean]
     def with_free_shipping_promotion?
-      adjustments.promotion.any? { |p| p.source.type == 'Spree::Promotion::Actions::FreeShipping' }
+      adjustments.promotion.includes(:source).any? { |p| p.source.respond_to?(:free_shipping?) && p.source.free_shipping? }
     end
 
     def finalize!


### PR DESCRIPTION
Fix N+1, don't hardcode source_type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliably recognizes free shipping promotions, including custom configurations, ensuring eligible orders receive free shipping as expected.

* **Refactor**
  * Improved promotion detection logic for free shipping to enhance compatibility across different promotion setups.

* **Documentation**
  * Clarified the behavior of free shipping detection in code comments for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->