### PR TITLE
Fix typo in authentication docs

### DIFF
--- a/docs/developer/customization/authentication.mdx
+++ b/docs/developer/customization/authentication.mdx
@@ -5,7 +5,7 @@ version: v5
 icon: user
 ---
 
-If you installed Spree following the [Quickstart guide](/developer/quickstart), you can completely this step - you are all set and integrated with the [Devise](https://github.com/plataformatec/devise) gem.
+If you installed Spree following the [Quickstart guide](/developer/quickstart), you can completely skip this step - you are all set and integrated with the [Devise](https://github.com/plataformatec/devise) gem.
 
 However if you're adding Spree to an existing application that has its own authentication system, you will need to follow these steps.
 


### PR DESCRIPTION
This PR fixes a grammatical error in `authentication.mdx`.

Before:
"If you installed Spree following the Quickstart guide, you can completely this step..."

After:
"If you installed Spree following the Quickstart guide, you can completely skip this step..."

This improves clarity and ensures correct grammar for readers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Quickstart instructions to explicitly state the authentication step can be skipped when installing via the Quickstart path.
  * Improved wording for better readability; no changes to functionality, APIs, or behavior.
  * Minor formatting cleanup in the Admin Panel authentication doc (newline adjustment) with no content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->