### PR TITLE
Fetch all webhook subscribers once

### DIFF
--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -82,7 +82,9 @@ module Spree
       end
 
       def no_webhooks_subscribers?(event_name)
-        !Spree::Current.webhooks_subscribers.any? { |subscriber| subscriber.subscriptions.include?(event_name) }
+        Spree::Current.webhooks_subscribers.none? do |subscriber|
+          subscriber.supports_event?(event_name)
+        end
       end
 
       def webhooks_request_options

--- a/api/app/models/concerns/spree/webhooks/has_webhooks.rb
+++ b/api/app/models/concerns/spree/webhooks/has_webhooks.rb
@@ -82,7 +82,7 @@ module Spree
       end
 
       def no_webhooks_subscribers?(event_name)
-        !Spree::Webhooks::Subscriber.active.with_urls_for(event_name).exists?
+        !Spree::Current.webhooks_subscribers.any? { |subscriber| subscriber.subscriptions.include?(event_name) }
       end
 
       def webhooks_request_options

--- a/api/app/models/spree/webhooks/subscriber.rb
+++ b/api/app/models/spree/webhooks/subscriber.rb
@@ -28,6 +28,14 @@ module Spree
         events.order(:created_at).last&.created_at
       end
 
+      # Returns true if the subscriber supports the given event
+      #
+      # @param event [String] The event to check, e.g. 'product.create'
+      # @return [Boolean]
+      def supports_event?(event)
+        subscriptions.include?(event) || subscriptions.include?('*')
+      end
+
       def self.with_urls_for(event)
         where(
           case ActiveRecord::Base.connection.adapter_name

--- a/api/app/services/spree/webhooks/subscribers/queue_requests.rb
+++ b/api/app/services/spree/webhooks/subscribers/queue_requests.rb
@@ -15,7 +15,11 @@ module Spree
         private
 
         def filtered_subscribers(event_name, webhook_payload_body, record, options)
-          Spree::Webhooks::Subscriber.active.with_urls_for(event_name)
+          Spree::Current.webhooks_subscribers.map do |subscriber|
+            if subscriber.subscriptions.include?(event_name)
+              subscriber
+            end
+          end.compact
         end
       end
     end

--- a/api/app/services/spree/webhooks/subscribers/queue_requests.rb
+++ b/api/app/services/spree/webhooks/subscribers/queue_requests.rb
@@ -16,7 +16,7 @@ module Spree
 
         def filtered_subscribers(event_name, webhook_payload_body, record, options)
           Spree::Current.webhooks_subscribers.map do |subscriber|
-            if subscriber.subscriptions.include?(event_name)
+            if subscriber.supports_event?(event_name)
               subscriber
             end
           end.compact

--- a/core/app/models/spree/current.rb
+++ b/core/app/models/spree/current.rb
@@ -1,9 +1,13 @@
 module Spree
   class Current < ::ActiveSupport::CurrentAttributes
-    attribute :store
+    attribute :store, :webhooks_subscribers
 
     def store
       super || Spree::Store.default
+    end
+
+    def webhooks_subscribers
+      super || store.active_webhooks_subscribers
     end
   end
 end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -206,7 +206,11 @@ module Spree
     delegate :iso, to: :default_country, prefix: true, allow_nil: true
 
     def self.current(url = nil)
-      Spree::Dependencies.current_store_finder.constantize.new(url: url).execute || Spree::Current.store
+      if url.present?
+        Spree::Dependencies.current_store_finder.constantize.new(url: url).execute
+      else
+        Spree::Current.store
+      end
     end
 
     # FIXME: we need to drop `or_initialize` in v5
@@ -412,6 +416,13 @@ module Spree
 
         ActionText::RichText.find_by(name: policy_method, record: self)
       end
+    end
+
+    # Returns all active webhooks subscribers for the store
+    #
+    # @return [Array<Spree::Webhooks::Subscriber>]
+    def active_webhooks_subscribers
+      @active_webhooks_subscribers ||= Spree::Webhooks::Subscriber.active
     end
 
     private


### PR DESCRIPTION
Do not query for each event in a single request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Webhook subscriber detection and queuing now use the runtime context’s subscriber list instead of database lookups.
  * The runtime context exposes a default, store-scoped set of active webhook subscribers.

* **New Features**
  * Subscribers now expose event-matching capability to determine if they support a given event.

* **Bug Fixes**
  * Store resolution by URL no longer falls back to the current store, preventing unintended selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->