### PR TITLE
Properly set `integrations` and `webhooks_subscribers` in `Spree::Cur…

### DIFF
--- a/core/app/helpers/spree/integrations_helper.rb
+++ b/core/app/helpers/spree/integrations_helper.rb
@@ -1,7 +1,7 @@
 module Spree
   module IntegrationsHelper
     def store_integrations
-      @store_integrations ||= current_store.integrations.active.to_a
+      @store_integrations ||= Spree::Current.integrations
     end
 
     def store_integration(name)

--- a/core/app/models/concerns/spree/integrations_concern.rb
+++ b/core/app/models/concerns/spree/integrations_concern.rb
@@ -1,7 +1,7 @@
 module Spree
   module IntegrationsConcern
     def store_integrations
-      @store_integrations ||= Spree::Store.current.integrations.active.to_a
+      @store_integrations ||= Spree::Current.integrations
     end
 
     def store_integration(name)

--- a/core/app/models/spree/current.rb
+++ b/core/app/models/spree/current.rb
@@ -1,13 +1,11 @@
 module Spree
   class Current < ::ActiveSupport::CurrentAttributes
-    attribute :store, :webhooks_subscribers
+    attribute :store, :webhooks_subscribers, :integrations
 
-    def store
-      super || Spree::Store.default
-    end
-
-    def webhooks_subscribers
-      super || store.active_webhooks_subscribers
+    def store=(store)
+      super
+      self.webhooks_subscribers = store.active_webhooks_subscribers
+      self.integrations = store.integrations.active
     end
   end
 end


### PR DESCRIPTION
…rent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integrations and webhook subscribers now reliably reflect the active store across the app, preventing mismatches and stale data.

* **Refactor**
  * Centralized current store context to automatically update related data when the store changes, improving consistency and reducing redundant lookups.
  * Streamlined how integrations are accessed throughout the app, resulting in more predictable behavior and smoother navigation between stores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->