### PR TITLE
Add ability to re-order theme layout sections for header and footer

### DIFF
--- a/admin/app/views/spree/admin/page_builder/_sidebar_section.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_sidebar_section.html.erb
@@ -16,11 +16,9 @@
         %>
       </div>
       <div class="d-flex align-items-center d-none">
-        <% if section.can_be_sorted? %>
-          <button class="btn btn-sm pr-0 handle hover-gray-200 h-100 mr-1 px-1 handle-section">
-            <%= icon('grip-vertical', class: 'mr-0') %>
-          </button>
-        <% end %>
+        <button class="btn btn-sm pr-0 handle hover-gray-200 h-100 mr-1 px-1 handle-section">
+          <%= icon('grip-vertical', class: 'mr-0') %>
+        </button>
       </div>
     </div>
     <% if section.blocks_available?  %>

--- a/admin/app/views/spree/admin/page_builder/_sidebar_sections.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_sidebar_sections.html.erb
@@ -3,7 +3,12 @@
   <h6 class="sidebar-header">Page sections</h6>
   <% if @page_preview.layout_sections? %>
     <div class="list-group-flush border-bottom mb-1 pb-2">
-      <%= render collection: @theme_preview.sections.find_all { |s| s.role == 'header' }, partial: 'spree/admin/page_builder/sidebar_section', as: :section  %>
+      <div data-controller="sortable"
+         data-sortable-handle-value=".handle-section"
+         data-sortable-resource-name-value="page_section"
+         data-sortable-response-kind-value="turbo-stream">
+        <%= render collection: @theme_preview.sections.find_all { |s| s.role == 'header' }, partial: 'spree/admin/page_builder/sidebar_section', as: :section  %>
+      </div>
     </div>
   <% end %>
   <div id="page-sections-list" class="list-group-flush py-2">
@@ -21,7 +26,12 @@
   </div>
   <% if @page_preview.layout_sections? %>
     <div class="list-group-flush border-top py-2">
-      <%= render collection: @theme_preview.sections.find_all { |s| s.role == 'footer' }, partial: 'spree/admin/page_builder/sidebar_section', as: :section  %>
+      <div data-controller="sortable"
+         data-sortable-handle-value=".handle-section"
+         data-sortable-resource-name-value="page_section"
+         data-sortable-response-kind-value="turbo-stream">
+        <%= render collection: @theme_preview.sections.find_all { |s| s.role == 'footer' }, partial: 'spree/admin/page_builder/sidebar_section', as: :section  %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/admin/app/views/spree/admin/page_builder/_sidebar_sections_toolbar.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_sidebar_sections_toolbar.html.erb
@@ -9,52 +9,52 @@
     <% sections.each do |parent, section| %>
       <% next if section.new_record? %>
 
-      <% unless parent.is_a?(Spree::Theme) %>
-        <div id="editor-toolbar-section-<%= section.id %>">
-          <button class="editor-toolbar-lower">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              class="bi bi-arrow-down"
-              viewBox="0 0 16 16"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M8 1a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L7.5 13.293V1.5A.5.5 0 0 1 8 1z"
-              />
-            </svg>
-          </button>
-          <button class="editor-toolbar-higher">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              class="bi bi-arrow-up"
-              viewBox="0 0 16 16"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M8 15a.5.5 0 0 0 .5-.5V2.707l3.146 3.147a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L7.5 2.707V14.5a.5.5 0 0 0 .5.5z"
-              />
-            </svg>
-          </button>
-          <button class="editor-toolbar-edit">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              class="bi bi-pencil"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"
-              />
-            </svg>
-          </button>
+      <div id="editor-toolbar-section-<%= section.id %>">
+        <button class="editor-toolbar-lower">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-arrow-down"
+            viewBox="0 0 16 16"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M8 1a.5.5 0 0 1 .5.5v11.793l3.146-3.147a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 .708-.708L7.5 13.293V1.5A.5.5 0 0 1 8 1z"
+            />
+          </svg>
+        </button>
+        <button class="editor-toolbar-higher">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-arrow-up"
+            viewBox="0 0 16 16"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M8 15a.5.5 0 0 0 .5-.5V2.707l3.146 3.147a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L7.5 2.707V14.5a.5.5 0 0 0 .5.5z"
+            />
+          </svg>
+        </button>
+        <button class="editor-toolbar-edit">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-pencil"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"
+            />
+          </svg>
+        </button>
+        <% if section.can_be_deleted? && can?(:destroy, section) %>
           <button class="editor-toolbar-delete">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -72,25 +72,27 @@
               />
             </svg>
           </button>
-        </div>
+        <% end %>
+      </div>
 
         <%= button_to Spree.t(:move_up),
         spree.move_higher_admin_page_section_path(parent, section),
         method: :patch,
-        id: "editor-toolbar-higher-section-#{section.id}" %>
+        id: "editor-toolbar-higher-section-#{section.id}" if can?(:update, section) %>
         <%= button_to Spree.t(:move_down),
         spree.move_lower_admin_page_section_path(parent, section),
         method: :patch,
-        id: "editor-toolbar-lower-section-#{section.id}" %>
-        <%= link_to Spree.t(:destroy),
-        spree.admin_page_section_path(section),
-        data: {
-          turbo_confirm: Spree.t(:are_you_sure),
-          turbo_method: :delete,
-        },
-        id: "editor-toolbar-delete-section-#{section.id}" %>
+        id: "editor-toolbar-lower-section-#{section.id}" if can?(:update, section) %>
+        <% if section.can_be_deleted? && can?(:destroy, section) %>
+          <%= link_to Spree.t(:destroy),
+          spree.admin_page_section_path(section),
+          data: {
+            turbo_confirm: Spree.t(:are_you_sure),
+            turbo_method: :delete,
+          },
+          id: "editor-toolbar-delete-section-#{section.id}" %>
+        <% end %>
 
-      <% end %>
 
       <% section.blocks.each do |block| %>
         <div id="editor-toolbar-block-<%= block.id %>">

--- a/core/app/models/spree/page_section.rb
+++ b/core/app/models/spree/page_section.rb
@@ -123,7 +123,7 @@ module Spree
     end
 
     def can_be_sorted?
-      role == 'content'
+      true
     end
 
     def lazy?

--- a/core/app/models/spree/theme.rb
+++ b/core/app/models/spree/theme.rb
@@ -21,7 +21,7 @@ module Spree
     has_many :previews, class_name: 'Spree::Theme', foreign_key: :parent_id, dependent: :destroy_async
     has_many :pages, -> { without_previews }, class_name: 'Spree::Page', dependent: :destroy, as: :pageable
     has_many :page_previews, -> { only_previews }, class_name: 'Spree::Page', dependent: :destroy_async, as: :pageable
-    has_many :layout_sections, class_name: 'Spree::PageSection', dependent: :destroy, as: :pageable
+    has_many :layout_sections, -> { order(position: :asc) }, class_name: 'Spree::PageSection', dependent: :destroy, as: :pageable
     alias sections layout_sections
 
     #

--- a/storefront/app/helpers/spree/page_helper.rb
+++ b/storefront/app/helpers/spree/page_helper.rb
@@ -12,7 +12,7 @@ module Spree
       page ||= current_page
 
       sections = current_page_preview.present? ? current_page_preview.sections : page.sections
-      sections_html = sections.includes(:links, :rich_text_text, :rich_text_description, { asset_attachment: :blob }, { blocks: [:rich_text_text, :links] }).map do |section|
+      sections_html = sections.includes(section_includes).map do |section|
         render_section(section, variables)
       end.join.html_safe
 
@@ -66,6 +66,42 @@ module Spree
       Rails.error.report(e, context: { section_id: section.id }, source: 'spree.storefront')
 
       ''
+    end
+
+    # Returns the layout sections of the page with current theme or theme preview.
+    #
+    # @return [Array] the layout sections of the page
+    def layout_sections
+      @layout_sections ||= current_theme_or_preview.sections.includes(section_includes)
+    end
+
+    # Renders the header sections of the page.
+    #
+    # @return [String] the rendered header sections
+    def render_header_sections
+      @render_header_sections ||= layout_sections.find_all { |section| section.role == 'header' }.map do |section|
+        render_section(section)
+      end.join.html_safe
+    end
+
+    # Renders the footer sections of the page.
+    #
+    # @return [String] the rendered footer sections
+    def render_footer_sections
+      @render_footer_sections ||= layout_sections.find_all { |section| section.role == 'footer' }.map do |section|
+        render_section(section)
+      end.join.html_safe
+    end
+
+    # Returns the includes for the section.
+    #
+    # @return [Array] the includes for the section
+    def section_includes
+      [
+        :links, :rich_text_text,
+        :rich_text_description, { asset_attachment: :blob },
+        { blocks: [:rich_text_text, :links] }
+      ]
     end
 
     # Renders a link to the page builder for the given link.

--- a/storefront/app/helpers/spree/theme_helper.rb
+++ b/storefront/app/helpers/spree/theme_helper.rb
@@ -72,8 +72,9 @@ module Spree
     #
     # @return [Hash] the theme layout sections
     def theme_layout_sections
-      @theme_layout_sections ||= current_theme_or_preview.sections.includes(:links, :rich_text_text, :rich_text_description, { asset_attachment: :blob },
-                                                                            { blocks: [:rich_text_text, :links] }).all.each_with_object({}) do |section, hash|
+      Spree::Deprecation.warn('theme_layout_sections is deprecated and will be removed in Spree 6.0. Please use render_header_sections and render_footer_sections instead.')
+
+      @theme_layout_sections ||= current_theme_or_preview.sections.includes(section_includes).all.each_with_object({}) do |section, hash|
         hash[section.type.to_s.demodulize.underscore] = section
       end
     rescue StandardError => e

--- a/storefront/app/views/layouts/spree/storefront.html.erb
+++ b/storefront/app/views/layouts/spree/storefront.html.erb
@@ -13,17 +13,12 @@
     <% if theme_layout_sections.empty? %>
       <%= render template: 'errors/500' %>
     <% else %>
-      <%= render_section(theme_layout_sections['announcement_bar']) if theme_layout_sections['announcement_bar'].present? %>
-      <%= render_section(theme_layout_sections['header']) if theme_layout_sections['header'].present? %>
-
+      <%= render_header_sections %>
       <%= turbo_frame_tag :flash do %>
         <%= render('spree/shared/flashes') %>
       <% end %>
-
       <%= yield %>
-
-      <%= render_section(theme_layout_sections['newsletter']) if  theme_layout_sections['newsletter'].present? %>
-      <%= render_section(theme_layout_sections['footer']) if theme_layout_sections['footer'].present? %>
+      <%= render_footer_sections %>
     <% end %>
 
     <%= current_store.storefront_custom_code_body_end&.html_safe %>


### PR DESCRIPTION
Next step - add ability to create new sections and delete existing ones from header/footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Drag-and-drop reordering enabled for header, main, and footer sections in the Page Builder.
  - Reorder handles and the editor toolbar are now consistently available where permissions allow.

- Improvements
  - Consistent rendering of header and footer sections across storefront pages.
  - Deterministic section ordering within themes for predictable layouts.
  - Faster page loads through smarter preloading of section data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->