### PR TITLE
fix shipment.digital? without shipping method

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -64,7 +64,6 @@ module Spree
 
     delegate :store, :currency, to: :order
     delegate :amount_in_cents, to: :display_cost
-    delegate :digital?, to: :shipping_method
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :pending, use_transactions: false do
@@ -123,6 +122,10 @@ module Spree
 
     def amount
       cost
+    end
+
+    def digital?
+      shipping_method&.digital? || false
     end
 
     def add_shipping_method(shipping_method, selected = false)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -42,9 +42,12 @@ describe Spree::Shipment, type: :model do
       expect(shipment.digital?).to eq(false)
     end
 
-    it 'returns false if shipping method is nil' do
-      shipment.shipping_rates.delete_all
-      expect(shipment.digital?).to eq(false)
+    context 'when shipping method is nil' do
+      let(:shipping_method) { nil }
+
+      it 'returns false if shipping method is nil' do
+        expect(shipment.digital?).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
issue:
```
ActiveSupport::DelegationError in Spree::Admin::Orders#edit
digital? delegated to shipping_method, but shipping_method is nil
```

need to move shipment.digital? from delegate back to the normal method with safe navigator
adding allow_nil would add nil response to digital? and i guess that we dont want that



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved stability when a shipment has no shipping method by safely handling digital shipment checks, preventing rare errors during checkout and order processing. Behavior remains unchanged when a shipping method is present.

- Tests
  - Added and refined tests to cover scenarios where the shipping method is missing, ensuring reliable behavior for digital shipment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->