### PR TITLE
feat: add newsletter subscriber model

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -39,6 +39,7 @@ group :test do
   gem 'timecop'
   gem 'test-prof'
   gem 'rails-controller-testing'
+  gem 'shoulda-matchers', '~> 6.0'
 end
 
 group :test, :development do

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -4,10 +4,15 @@ module Spree
 
     belongs_to :user, optional: true, class_name: Spree.user_class.name
 
-    validates :email, presence: true, uniqueness: true
+    validates :email,
+              presence: true,
+              format: { with: URI::MailTo::EMAIL_REGEXP },
+              uniqueness: { case_sensitive: false }
 
     scope :verified, -> { where.not(verified_at: nil) }
     scope :unverified, -> { where(verified_at: nil) }
+
+    normalizes :email, with: ->(email) { email.to_s.strip.downcase.presence }
 
     def verified?
       verified_at.present?

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -1,0 +1,27 @@
+module Spree
+  class NewsletterSubscriber < Spree.base_class
+    has_secure_token :verification_token
+
+    belongs_to :user, optional: true, class_name: Spree.user_class.name
+
+    validates :email, presence: true, uniqueness: true
+
+    scope :verified, -> { where.not(verified_at: nil) }
+    scope :unverified, -> { where(verified_at: nil) }
+
+    def verified?
+      verified_at.present?
+    end
+
+    def self.subscribe(email:, user: nil)
+      raise NotImplementedError
+    end
+
+    def self.verify(verification_token)
+      subscriber = find_by(verification_token: verification_token)
+      return unless subscriber
+
+      raise NotImplementedError
+    end
+  end
+end

--- a/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
+++ b/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
@@ -1,0 +1,12 @@
+class CreateSpreeNewsletterSubscribers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :spree_newsletter_subscribers do |t|
+      t.string :email, index: { unique: true }, null: false
+      t.bigint :user_id, index: true
+      t.datetime :verified_at, index: true
+      t.string :verification_token, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/newsletter_subscriber_factory.rb
+++ b/core/lib/spree/testing_support/factories/newsletter_subscriber_factory.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :newsletter_subscriber, class: Spree::NewsletterSubscriber do
+    email { FFaker::Internet.unique.email }
+    verified_at { nil }
+
+    trait :with_user do
+      association :user, factory: :user
+    end
+
+    trait :verified do
+      verified_at { Time.current }
+    end
+
+    trait :unverified do
+      verified_at { nil }
+    end
+  end
+end

--- a/core/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/core/spec/models/spree/newsletter_subscriber_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'shoulda/matchers'
+
+describe Spree::NewsletterSubscriber, type: :model do
+  let(:subscriber) { build(:newsletter_subscriber) }
+
+  describe 'validations' do
+    it { expect(subscriber).to validate_presence_of(:email) }
+    it { expect(subscriber).to validate_uniqueness_of(:email) }
+  end
+
+  describe 'scopes' do
+    let!(:verified_subscriber) { create(:newsletter_subscriber, :verified) }
+    let!(:unverified_subscriber) { create(:newsletter_subscriber, :unverified) }
+
+    describe 'verified' do
+      it { expect(Spree::NewsletterSubscriber.verified).to eq([verified_subscriber]) }
+    end
+
+    describe 'unverified' do
+      it { expect(Spree::NewsletterSubscriber.unverified).to eq([unverified_subscriber]) }
+    end
+  end
+
+  describe 'subscribe' do
+    subject { described_class.subscribe(email: 'test@example.com') }
+
+    it 'raises NotImplementedError' do
+      expect { subject }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'verify' do
+    subject { described_class.verify(token) }
+
+    context 'when subscriber is found' do
+      let(:subscriber) { create(:newsletter_subscriber, :unverified) }
+      let(:token) { subscriber.verification_token }
+
+      it 'raises NotImplementedError' do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context 'when subscriber is not found' do
+      let(:token) { 'invalid-token' }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe 'verified?' do
+    it { expect(subscriber.verified?).to eq(false) }
+
+    context 'when email is verified' do
+      let!(:verified_subscriber) { create(:newsletter_subscriber, :verified) }
+
+      it { expect(verified_subscriber.verified?).to eq(true) }
+    end
+  end
+end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -35,6 +35,7 @@ end
 require 'rspec/rails'
 require 'database_cleaner/active_record'
 require 'ffaker'
+require 'shoulda-matchers'
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
@@ -86,4 +87,11 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end


### PR DESCRIPTION
changes:
- add NewsletterSubscriber model, migration, specs and factory

chores:
- add shoulda-matchers fo  simple and less error prone active record tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added backend support for newsletter subscriptions with email verification and optional user linkage.
- Tests
  - Introduced model specs covering validations, verification status, and token-based flows.
  - Enabled Shoulda Matchers for concise validation and association testing.
- Chores
  - Added a testing dependency to improve spec coverage and maintainability.
- Database
  - Added a new table to store newsletter subscribers, including email, user reference, verification status, and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->