### PR TITLE
Newsletter subscribers

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -39,6 +39,7 @@ group :test do
   gem 'timecop'
   gem 'test-prof'
   gem 'rails-controller-testing'
+  gem 'shoulda-matchers', '~> 6.0'
 end
 
 group :test, :development do

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -23,14 +23,13 @@ module Spree
     end
 
     def self.subscribe(email:, user: nil)
-      raise NotImplementedError
+      Spree::Newsletter::Subscribe.new(email: email, user: user).call
     end
 
     def self.verify(verification_token)
-      subscriber = find_by(verification_token: verification_token)
-      return unless subscriber
+      subscriber = find_by!(verification_token: verification_token)
 
-      raise NotImplementedError
+      Spree::Newsletter::Verify.new(subscriber: subscriber).call
     end
   end
 end

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -1,5 +1,9 @@
+require_dependency 'spree/newsletter_subscriber/emails'
+
 module Spree
   class NewsletterSubscriber < Spree.base_class
+    include Spree::NewsletterSubscriber::Emails
+
     has_secure_token :verification_token
 
     belongs_to :user, optional: true, class_name: Spree.user_class.name

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -4,10 +4,15 @@ module Spree
 
     belongs_to :user, optional: true, class_name: Spree.user_class.name
 
-    validates :email, presence: true, uniqueness: true
+    validates :email,
+              presence: true,
+              format: { with: URI::MailTo::EMAIL_REGEXP },
+              uniqueness: { case_sensitive: false }
 
     scope :verified, -> { where.not(verified_at: nil) }
     scope :unverified, -> { where(verified_at: nil) }
+
+    normalizes :email, with: ->(email) { email.to_s.strip.downcase.presence }
 
     def verified?
       verified_at.present?

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -26,8 +26,8 @@ module Spree
       Spree::Newsletter::Subscribe.new(email: email, user: user).call
     end
 
-    def self.verify(verification_token)
-      subscriber = find_by!(verification_token: verification_token)
+    def self.verify(token:)
+      subscriber = unverified.find_by!(verification_token: token)
 
       Spree::Newsletter::Verify.new(subscriber: subscriber).call
     end

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -1,0 +1,27 @@
+module Spree
+  class NewsletterSubscriber < Spree.base_class
+    has_secure_token :verification_token
+
+    belongs_to :user, optional: true, class_name: Spree.user_class.name
+
+    validates :email, presence: true, uniqueness: true
+
+    scope :verified, -> { where.not(verified_at: nil) }
+    scope :unverified, -> { where(verified_at: nil) }
+
+    def verified?
+      verified_at.present?
+    end
+
+    def self.subscribe(email:, user: nil)
+      raise NotImplementedError
+    end
+
+    def self.verify(verification_token)
+      subscriber = find_by(verification_token: verification_token)
+      return unless subscriber
+
+      raise NotImplementedError
+    end
+  end
+end

--- a/core/app/models/spree/newsletter_subscriber/emails.rb
+++ b/core/app/models/spree/newsletter_subscriber/emails.rb
@@ -3,7 +3,7 @@ module Spree
     module Emails
       extend ActiveSupport::Concern
 
-      def deliver_newsletter_subscription_confirmation
+      def deliver_newsletter_email_verification
         # you can overwrite this method in your application / extension to send out the confirmation email
         # or use `spree_emails` gem
       end

--- a/core/app/models/spree/newsletter_subscriber/emails.rb
+++ b/core/app/models/spree/newsletter_subscriber/emails.rb
@@ -1,0 +1,12 @@
+module Spree
+  class NewsletterSubscriber < Spree.base_class
+    module Emails
+      extend ActiveSupport::Concern
+
+      def deliver_newsletter_subscription_confirmation
+        # you can overwrite this method in your application / extension to send out the confirmation email
+        # or use `spree_emails` gem
+      end
+    end
+  end
+end

--- a/core/app/services/spree/newsletter/subscribe.rb
+++ b/core/app/services/spree/newsletter/subscribe.rb
@@ -16,9 +16,6 @@ module Spree
           if subscriber.email == user&.email
             # no need to verified since user email is already verified
             Spree::Newsletter::Verify.new(subscriber: subscriber).call
-          elsif subscriber.previous_changes.blank?
-            # non verified subscriber already existed
-            subscriber.regenerate_verification_token
           end
         end
 
@@ -34,6 +31,8 @@ module Spree
       def upsert_subscriber
         @upsert_subscriber ||= Spree::NewsletterSubscriber.where(email: email).first_or_create do |new_record|
           new_record.user = Spree.user_class.find_by(email: new_record.email)
+        rescue ActiveRecord::RecordNotFound
+          retry
         end
       end
       alias_method :subscriber, :upsert_subscriber

--- a/core/app/services/spree/newsletter/subscribe.rb
+++ b/core/app/services/spree/newsletter/subscribe.rb
@@ -1,0 +1,40 @@
+module Spree
+  module Newsletter
+    class Subscribe
+      def initialize(email:, user: nil)
+        @email = email
+        @user = user
+      end
+
+      def call
+        return if already_subscribed?
+
+        ActiveRecord::Base.transaction do
+          upsert_subscriber
+          if subscriber.email == user&.email
+            # no need to verified since user email is already verified
+            Spree::Newsletter::Verify.new(subscriber: subscriber).call
+          elsif subscriber.id_changed?
+            subscriber.regenerate_verification_token
+          end
+        end
+
+        subscriber.deliver_newsletter_subscriber_confirmation unless subscriber.verified?
+      end
+
+      private
+
+      attr_reader :email, :user, :subscriber
+
+      def upsert_subscriber
+        @upsert_subscriber ||= Spree::NewsletterSubscriber.where(email: email).first_or_create do |new_record|
+          new_record.user = Spree.user_class.find_by(email: new_record.email)
+        end
+      end
+
+      def already_subscribed?
+        Spree::NewsletterSubscriber.verified.exists?(email: email)
+      end
+    end
+  end
+end

--- a/core/app/services/spree/newsletter/subscribe.rb
+++ b/core/app/services/spree/newsletter/subscribe.rb
@@ -11,7 +11,7 @@ module Spree
 
         ActiveRecord::Base.transaction do
           upsert_subscriber
-          
+
           if subscriber.email == user&.email
             # no need to verified since user email is already verified
             Spree::Newsletter::Verify.new(subscriber: subscriber).call

--- a/core/app/services/spree/newsletter/verify.rb
+++ b/core/app/services/spree/newsletter/verify.rb
@@ -1,0 +1,30 @@
+module Spree
+  module Newsletter
+    class Verify
+      def initialize(subscriber:)
+        @subscriber = subscriber
+      end
+
+      def call
+        verify_subscriber
+        set_user_email_marketing_to_true
+
+        subscriber
+      end
+
+      private
+
+      attr_reader :subscriber
+
+      def verify_subscriber
+        subscriber.update!(verified_at: Time.current, verification_token: nil)
+      end
+
+      def set_user_email_marketing_to_true
+        return if subscriber.user.blank?
+
+        subscriber.user.update!(accepts_email_marketing: true)
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1351,6 +1351,15 @@ en:
     new_user: New User
     new_variant: New Variant
     new_zone: New Zone
+    newsletter_mailer:
+      email_confirmation:
+        subject: Verify your email address
+        dear_customer: Hey %{name},
+        instructions: Please click the button below to verify your email address.
+        verify_email_address_link: Verify email address
+        thanks: Thank you
+        store_team: "%{store_name} Team"
+        message_copy_link: 'If the button doesn''t work please copy and paste the following link to your browser:'
     newsletters: Newsletters
     next: Next
     no_actions_added: No actions added

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1359,7 +1359,8 @@ en:
         verify_email_address_link: Verify email address
         thanks: Thank you
         store_team: "%{store_name} Team"
-        message_copy_link: 'If the button doesn''t work please copy and paste the following link to your browser:'
+        message_copy_link: "If the button doesn't work please copy and paste the following link to your browser:"
+        ignore_disclaimer: "If you didn't request this, please ignore this email."
     newsletters: Newsletters
     next: Next
     no_actions_added: No actions added

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1353,14 +1353,14 @@ en:
     new_zone: New Zone
     newsletter_mailer:
       email_confirmation:
-        subject: Verify your email address
         dear_customer: Hey,
+        ignore_disclaimer: If you didn't request this, please ignore this email.
         instructions: Please click the button below to verify your email address.
-        verify_email_address_link: Verify email address
-        thanks: Thank you
+        message_copy_link: 'If the button doesn''t work please copy and paste the following link to your browser:'
         store_team: "%{store_name} Team"
-        message_copy_link: "If the button doesn't work please copy and paste the following link to your browser:"
-        ignore_disclaimer: "If you didn't request this, please ignore this email."
+        subject: Verify your email address
+        thanks: Thank you
+        verify_email_address_link: Verify email address
     newsletters: Newsletters
     next: Next
     no_actions_added: No actions added

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1354,7 +1354,7 @@ en:
     newsletter_mailer:
       email_confirmation:
         subject: Verify your email address
-        dear_customer: Hey %{name},
+        dear_customer: Hey,
         instructions: Please click the button below to verify your email address.
         verify_email_address_link: Verify email address
         thanks: Thank you

--- a/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
+++ b/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
@@ -1,4 +1,4 @@
-class CreateSpreeNewsletterSubscribers < ActiveRecord::Migration[8.0]
+class CreateSpreeNewsletterSubscribers < ActiveRecord::Migration[7.2]
   def change
     create_table :spree_newsletter_subscribers do |t|
       t.string :email, index: { unique: true }, null: false

--- a/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
+++ b/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
@@ -2,7 +2,7 @@ class CreateSpreeNewsletterSubscribers < ActiveRecord::Migration[7.2]
   def change
     create_table :spree_newsletter_subscribers do |t|
       t.string :email, index: { unique: true }, null: false
-      t.bigint :user_id, index: true
+      t.references :user, index: true
       t.datetime :verified_at, index: true
       t.string :verification_token, index: { unique: true }
 

--- a/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
+++ b/core/db/migrate/20250826093602_create_spree_newsletter_subscribers.rb
@@ -1,0 +1,12 @@
+class CreateSpreeNewsletterSubscribers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :spree_newsletter_subscribers do |t|
+      t.string :email, index: { unique: true }, null: false
+      t.bigint :user_id, index: true
+      t.datetime :verified_at, index: true
+      t.string :verification_token, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/newsletter_subscriber_factory.rb
+++ b/core/lib/spree/testing_support/factories/newsletter_subscriber_factory.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :newsletter_subscriber, class: Spree::NewsletterSubscriber do
+    email { FFaker::Internet.unique.email }
+    verified_at { nil }
+
+    trait :with_user do
+      association :user, factory: :user
+    end
+
+    trait :verified do
+      verified_at { Time.current }
+    end
+
+    trait :unverified do
+      verified_at { nil }
+    end
+  end
+end

--- a/core/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/core/spec/models/spree/newsletter_subscriber_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'shoulda/matchers'
+
+describe Spree::NewsletterSubscriber, type: :model do
+  let(:subscriber) { build(:newsletter_subscriber) }
+
+  describe 'validations' do
+    it { expect(subscriber).to validate_presence_of(:email) }
+    it { expect(subscriber).to validate_uniqueness_of(:email) }
+  end
+
+  describe 'scopes' do
+    let!(:verified_subscriber) { create(:newsletter_subscriber, :verified) }
+    let!(:unverified_subscriber) { create(:newsletter_subscriber, :unverified) }
+
+    describe 'verified' do
+      it { expect(Spree::NewsletterSubscriber.verified).to eq([verified_subscriber]) }
+    end
+
+    describe 'unverified' do
+      it { expect(Spree::NewsletterSubscriber.unverified).to eq([unverified_subscriber]) }
+    end
+  end
+
+  describe 'subscribe' do
+    subject { described_class.subscribe(email: 'test@example.com') }
+
+    it 'raises NotImplementedError' do
+      expect { subject }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'verify' do
+    subject { described_class.verify(token) }
+
+    context 'when subscriber is found' do
+      let(:subscriber) { create(:newsletter_subscriber, :unverified) }
+      let(:token) { subscriber.verification_token }
+
+      it 'raises NotImplementedError' do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context 'when subscriber is not found' do
+      let(:token) { 'invalid-token' }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe 'verified?' do
+    it { expect(subscriber.verified?).to eq(false) }
+
+    context 'when email is verified' do
+      let!(:verified_subscriber) { create(:newsletter_subscriber, :verified) }
+
+      it { expect(verified_subscriber.verified?).to eq(true) }
+    end
+  end
+end

--- a/core/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/core/spec/models/spree/newsletter_subscriber_spec.rb
@@ -70,7 +70,7 @@ describe Spree::NewsletterSubscriber, type: :model do
   end
 
   describe 'verify' do
-    subject { described_class.verify(token) }
+    subject { described_class.verify(token: token) }
 
     context 'when subscriber is found' do
       let(:subscriber) { create(:newsletter_subscriber, :unverified) }

--- a/core/spec/services/spree/newsletter/subscribe_spec.rb
+++ b/core/spec/services/spree/newsletter/subscribe_spec.rb
@@ -19,7 +19,7 @@ module Spree
       let(:email) { user.email }
 
       it 'does not send a confirmation email' do
-        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_subscription_confirmation)
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_email_verification)
 
         service
       end
@@ -34,7 +34,7 @@ module Spree
       let(:email) { 'test@example.com' }
 
       it 'sends a confirmation email' do
-        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:deliver_newsletter_subscription_confirmation)
+        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:deliver_newsletter_email_verification).once
 
         service
       end
@@ -45,7 +45,7 @@ module Spree
     end
 
     context 'when verified subscription already exists' do
-      let!(:subscriber) { create(:newsletter_subscriber, email: email, verified_at: Time.current) }
+      let!(:subscriber) { create(:newsletter_subscriber, :verified, email: email) }
 
       it 'does not create new subscriber' do
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
@@ -56,14 +56,14 @@ module Spree
       end
 
       it 'does not send a confirmation email' do
-        expect(subscriber).not_to receive(:deliver_newsletter_subscription_confirmation)
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_email_verification)
 
         service
       end
     end
 
     context 'when unverified subscription has been already created' do
-      let!(:subscriber) { create(:newsletter_subscriber, email: email, verified_at: nil) }
+      let!(:subscriber) { create(:newsletter_subscriber, :unverified, email: email) }
 
       it 'does not create new subscriber' do
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
@@ -74,7 +74,7 @@ module Spree
       end
 
       it 'sends a confirmation email' do
-        expect(subscriber).to receive(:deliver_newsletter_subscription_confirmation)
+        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:deliver_newsletter_email_verification).once
 
         service
       end

--- a/core/spec/services/spree/newsletter/subscribe_spec.rb
+++ b/core/spec/services/spree/newsletter/subscribe_spec.rb
@@ -28,7 +28,7 @@ module Spree
       end
 
       it 'does not create a new record' do
-        expect { service }.not_to change { Spree::NewsletterSubscriber.verified.count }
+        expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
       end
     end
 
@@ -81,10 +81,6 @@ module Spree
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
       end
 
-      it 'does not regenerate verification token' do
-        expect { service }.not_to change { subscriber.reload.verification_token }
-      end
-
       it 'does not send a confirmation email' do
         expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_email_verification)
 
@@ -101,10 +97,6 @@ module Spree
 
       it 'does not create new subscriber' do
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
-      end
-
-      it 'regenerates verification token' do
-        expect { service }.to change { subscriber.reload.verification_token }
       end
 
       it 'sends a confirmation email' do

--- a/core/spec/services/spree/newsletter/subscribe_spec.rb
+++ b/core/spec/services/spree/newsletter/subscribe_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+module Spree
+  describe Newsletter::Subscribe do
+    subject(:service) { described_class.new(**params).call }
+
+    let(:params) do
+      {
+        email: email,
+        user: user
+      }
+    end
+
+    let(:email) { 'foo@example.com' }
+    let(:user) { nil }
+
+    context 'when logged in user has the same email as inputed email' do
+      let(:user) { create(:user) }
+      let(:email) { user.email }
+
+      it 'does not send a confirmation email' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_subscription_confirmation)
+
+        service
+      end
+
+      it 'creates a new verified subscriber' do
+        expect { service }.to change { Spree::NewsletterSubscriber.verified.count }.by(1)
+      end
+    end
+
+    context 'when logged in user inputs another email' do
+      let(:user) { create(:user) }
+      let(:email) { 'test@example.com' }
+
+      it 'sends a confirmation email' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:deliver_newsletter_subscription_confirmation)
+
+        service
+      end
+
+      it 'creates a new unverified subscriber' do
+        expect { service }.to change { Spree::NewsletterSubscriber.unverified.count }.by(1)
+      end
+    end
+
+    context 'when verified subscription already exists' do
+      let!(:subscriber) { create(:newsletter_subscriber, email: email, verified_at: Time.current) }
+
+      it 'does not create new subscriber' do
+        expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
+      end
+
+      it 'does not regenerate verification token' do
+        expect { service }.not_to change { subscriber.reload.verification_token }
+      end
+
+      it 'does not send a confirmation email' do
+        expect(subscriber).not_to receive(:deliver_newsletter_subscription_confirmation)
+
+        service
+      end
+    end
+
+    context 'when unverified subscription has been already created' do
+      let!(:subscriber) { create(:newsletter_subscriber, email: email, verified_at: nil) }
+
+      it 'does not create new subscriber' do
+        expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
+      end
+
+      it 'regenerates verification token' do
+        expect { service }.to change { subscriber.reload.verification_token }
+      end
+
+      it 'sends a confirmation email' do
+        expect(subscriber).to receive(:deliver_newsletter_subscription_confirmation)
+
+        service
+      end
+    end
+  end
+end

--- a/core/spec/services/spree/newsletter/subscribe_spec.rb
+++ b/core/spec/services/spree/newsletter/subscribe_spec.rb
@@ -14,9 +14,31 @@ module Spree
     let(:email) { 'foo@example.com' }
     let(:user) { nil }
 
+    context 'with invalid params' do
+      let(:email) { 'hehe' }
+
+      it 'returns a record with errors' do
+        expect(service.errors).to be_present
+      end
+
+      it 'does not send a confirmation email' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_email_verification)
+
+        service
+      end
+
+      it 'does not create a new record' do
+        expect { service }.not_to change { Spree::NewsletterSubscriber.verified.count }
+      end
+    end
+
     context 'when logged in user has the same email as inputed email' do
       let(:user) { create(:user) }
       let(:email) { user.email }
+
+      it 'returns an instance of NewsletterSubscriber' do
+        expect(service).to be_a(NewsletterSubscriber)
+      end
 
       it 'does not send a confirmation email' do
         expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:deliver_newsletter_email_verification)
@@ -39,6 +61,10 @@ module Spree
         service
       end
 
+      it 'returns an instance of NewsletterSubscriber' do
+        expect(service).to be_a(NewsletterSubscriber)
+      end
+
       it 'creates a new unverified subscriber' do
         expect { service }.to change { Spree::NewsletterSubscriber.unverified.count }.by(1)
       end
@@ -46,6 +72,10 @@ module Spree
 
     context 'when verified subscription already exists' do
       let!(:subscriber) { create(:newsletter_subscriber, :verified, email: email) }
+
+      it 'returns an instance of NewsletterSubscriber' do
+        expect(service).to be_a(NewsletterSubscriber)
+      end
 
       it 'does not create new subscriber' do
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
@@ -64,6 +94,10 @@ module Spree
 
     context 'when unverified subscription has been already created' do
       let!(:subscriber) { create(:newsletter_subscriber, :unverified, email: email) }
+
+      it 'returns an instance of NewsletterSubscriber' do
+        expect(service).to be_a(NewsletterSubscriber)
+      end
 
       it 'does not create new subscriber' do
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)

--- a/core/spec/services/spree/newsletter/verify_spec.rb
+++ b/core/spec/services/spree/newsletter/verify_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+module Spree
+  describe Newsletter::Verify do
+    subject(:service) { described_class.new(**params).call }
+
+    let(:params) do
+      {
+        subscriber: subscriber
+      }
+    end
+
+    let(:subscriber) { create(:newsletter_subscriber, :unverified, user: user) }
+
+    around do |example|
+      Timecop.freeze('2137-01-01') { example.run }
+    end
+
+    context 'with associated user' do
+      let(:user) { create(:user, accepts_email_marketing: false) }
+
+      it 'verifies a subscription' do
+        expect { service }.to change { subscriber.reload.verified_at }.from(nil).to('2137-01-01'.to_datetime).
+          and change { subscriber.reload.verification_token }.to(nil)
+      end
+
+      it 'updates user email marketing attribute' do
+        expect { service }.to change { subscriber.user.accepts_email_marketing }.to(true)
+      end
+    end
+
+    context 'without user' do
+      let(:user) { nil }
+
+      it 'verifies a subscription' do
+        expect { service }.to change { subscriber.reload.verified_at }.from(nil).to('2137-01-01'.to_datetime).
+          and change { subscriber.reload.verification_token }.to(nil)
+      end
+    end
+  end
+end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -35,6 +35,7 @@ end
 require 'rspec/rails'
 require 'database_cleaner/active_record'
 require 'ffaker'
+require 'shoulda-matchers'
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
@@ -86,4 +87,11 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/emails/app/mailers/spree/newsletter_mailer.rb
+++ b/emails/app/mailers/spree/newsletter_mailer.rb
@@ -1,0 +1,9 @@
+module Spree
+  class NewsletterMailer < BaseMailer
+    def email_confirmation(subscriber)
+      @subscriber = subscriber
+      @confirm_email_url = spree.verify_newsletter_subscribers_url(token: @subscriber.verification_token, host: Spree::Store.default.url)
+      mail(to: @subscriber.email, from: from_address, subject: Spree.t('newsletter_mailer.email_confirmation.subject'))
+    end
+  end
+end

--- a/emails/app/models/spree/newsletter_subscriber/emails.rb
+++ b/emails/app/models/spree/newsletter_subscriber/emails.rb
@@ -1,0 +1,9 @@
+module Spree
+  class NewsletterSubscriber < Spree.base_class
+    module Emails
+      def deliver_newsletter_email_verification
+        NewsletterMailer.email_confirmation(self).deliver_later
+      end
+    end
+  end
+end

--- a/emails/app/views/spree/newsletter_mailer/email_confirmation.html.erb
+++ b/emails/app/views/spree/newsletter_mailer/email_confirmation.html.erb
@@ -1,22 +1,21 @@
-<h1>
-  <%= Spree.t('newsletter_mailer.email_confirmation.dear_customer') %>
-</h1>
-<p>
-  <%= Spree.t('newsletter_mailer.email_confirmation.instructions') %>
+<h1><%= Spree.t('newsletter_mailer.email_confirmation.dear_customer') %></h1>
+
+<p><%= Spree.t('newsletter_mailer.email_confirmation.instructions') %></p>
+
+<p class="align-center">
+<%= link_to Spree.t('newsletter_mailer.email_confirmation.verify_email_address_link'), @confirm_email_url, class: 'button' %>
 </p>
+
 <p>
-  <%= link_to Spree.t('newsletter_mailer.email_confirmation.verify_email_address_link'), @confirm_email_url, class: 'button' %>
-  <p>
-    <%= Spree.t('newsletter_mailer.email_confirmation.message_copy_link') %>
-    <br>
-    <span style="word-break: break-all;">
-      <%= link_to @confirm_email_url, @confirm_email_url %>
-    </span>
-  </p>
+  <%= Spree.t('newsletter_mailer.email_confirmation.message_copy_link') %>
+  <br>
+  <span style="word-break: break-all;">
+    <%= link_to @confirm_email_url, @confirm_email_url %>
+  </span>
 </p>
 
 <p>
   <%= Spree.t('newsletter_mailer.email_confirmation.thanks') %>
   <br />
-  <%= Spree.t('newsletter_mailer.email_confirmation.store_team', store_name: current_store.name) %>
+  <%= Spree.t('newsletter_mailer.email_confirmation.store_team') %>
 </p>

--- a/emails/app/views/spree/newsletter_mailer/email_confirmation.html.erb
+++ b/emails/app/views/spree/newsletter_mailer/email_confirmation.html.erb
@@ -1,0 +1,22 @@
+<h1>
+  <%= Spree.t('newsletter_mailer.email_confirmation.dear_customer') %>
+</h1>
+<p>
+  <%= Spree.t('newsletter_mailer.email_confirmation.instructions') %>
+</p>
+<p>
+  <%= link_to Spree.t('newsletter_mailer.email_confirmation.verify_email_address_link'), @confirm_email_url, class: 'button' %>
+  <p>
+    <%= Spree.t('newsletter_mailer.email_confirmation.message_copy_link') %>
+    <br>
+    <span style="word-break: break-all;">
+      <%= link_to @confirm_email_url, @confirm_email_url %>
+    </span>
+  </p>
+</p>
+
+<p>
+  <%= Spree.t('newsletter_mailer.email_confirmation.thanks') %>
+  <br />
+  <%= Spree.t('newsletter_mailer.email_confirmation.store_team', store_name: current_store.name) %>
+</p>

--- a/emails/app/views/spree/newsletter_mailer/email_confirmation.html.erb
+++ b/emails/app/views/spree/newsletter_mailer/email_confirmation.html.erb
@@ -14,8 +14,10 @@
   </span>
 </p>
 
+<p><%= Spree.t('newsletter_mailer.email_confirmation.ignore_disclaimer') %></p>
+
 <p>
   <%= Spree.t('newsletter_mailer.email_confirmation.thanks') %>
   <br />
-  <%= Spree.t('newsletter_mailer.email_confirmation.store_team') %>
+  <%= Spree.t('newsletter_mailer.email_confirmation.store_team', store_name: current_store.name) %>
 </p>

--- a/emails/app/views/spree/newsletter_mailer/email_confirmation.text.erb
+++ b/emails/app/views/spree/newsletter_mailer/email_confirmation.text.erb
@@ -1,4 +1,4 @@
-<%= Spree.t('newsletter_mailer.email_confirmation.dear_customer' %>
+<%= Spree.t('newsletter_mailer.email_confirmation.dear_customer') %>
 <%= Spree.t('newsletter_mailer.email_confirmation.instructions') %>
 
 <%= @confirm_email_url %>

--- a/emails/app/views/spree/newsletter_mailer/email_confirmation.text.erb
+++ b/emails/app/views/spree/newsletter_mailer/email_confirmation.text.erb
@@ -1,0 +1,9 @@
+<%= Spree.t('newsletter_mailer.email_confirmation.dear_customer' %>
+<%= Spree.t('newsletter_mailer.email_confirmation.instructions') %>
+
+<%= @confirm_email_url %>
+
+<%= Spree.t('newsletter_mailer.email_confirmation.ignore_disclaimer') %>
+============================================================
+<%= Spree.t('newsletter_mailer.email_confirmation.thanks') %>
+<%= Spree.t('newsletter_mailer.email_confirmation.store_team', store_name: current_store.name) %>

--- a/emails/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/emails/spec/models/spree/newsletter_subscriber_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+describe Spree::NewsletterSubscriber, type: :model do
+  let(:subscriber) { create(:newsletter_subscriber) }
+
+  describe '#deliver_newsletter_email_verification' do
+    subject(:deliver_newsletter_email_verification) { subscriber.deliver_newsletter_email_verification }
+
+    it 'calls newsletter mailer' do
+      expect(Spree::NewsletterMailer).to receive(:email_confirmation).with(subscriber).and_return(double(deliver_later: true))
+
+      deliver_newsletter_email_verification
+    end
+  end
+end

--- a/storefront/app/controllers/spree/account/newsletter_controller.rb
+++ b/storefront/app/controllers/spree/account/newsletter_controller.rb
@@ -14,8 +14,10 @@ module Spree
         }
 
         if try_spree_current_user.accepts_email_marketing?
+          Spree::NewsletterSubscriber.subscribe(email: try_spree_current_user.email, user: try_spree_current_user)
           track_event('subscribed_to_newsletter', event_properties)
         else
+          Spree::NewsletterSubscriber.find_by(email: try_spree_current_user.email)&.destroy
           track_event('unsubscribed_from_newsletter', event_properties)
         end
       end

--- a/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
+++ b/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
@@ -24,7 +24,7 @@ module Spree
 
     # GET /newsletter_subscribers/verify?token=VERIFICATION_TOKEN
     def verify
-      subscriber = Spree::Newsletter::Verify.call(token: params[:token])
+      subscriber = Spree::NewsletterSubscriberv.verify(token: params[:token])
 
       if subscriber.verified?
         redirect_to spree.root_path, notice: Spree.t('storefront.newsletter_subscribers.verified')

--- a/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
+++ b/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
       if subscriber.errors.any?
         flash[:error] = subscriber.errors.full_messages.to_sentence.presence || Spree.t('something_went_wrong')
-      elsif subscriber.previous_changes.any?
+      elsif !subscriber.verified?
         track_event('subscribed_to_newsletter', { email: subscriber.email, user: try_spree_current_user })
         flash[:success] = Spree.t('storefront.newsletter_subscribers.success')
       else

--- a/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
+++ b/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
@@ -2,6 +2,7 @@ module Spree
   class NewsletterSubscribersController < StoreController
     skip_before_action :redirect_to_password
     before_action :load_newsletter_section, only: :create
+    rescue_from ActiveRecord::RecordNotFound, with: :subscriber_not_found
 
     # POST /newsletter_subscribers
     def create
@@ -24,7 +25,7 @@ module Spree
 
     # GET /newsletter_subscribers/verify?token=VERIFICATION_TOKEN
     def verify
-      subscriber = Spree::NewsletterSubscriberv.verify(token: params[:token])
+      subscriber = Spree::NewsletterSubscriber.verify(token: params[:token])
 
       if subscriber.verified?
         redirect_to spree.root_path, notice: Spree.t('storefront.newsletter_subscribers.verified')
@@ -34,6 +35,10 @@ module Spree
     end
 
     private
+
+    def subscriber_not_found
+      redirect_to spree.root_path, alert: Spree.t('storefront.newsletter_subscribers.verification_failed')
+    end
 
     def newsletter_params
       params.require(:newsletter).permit(:email)

--- a/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
+++ b/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
@@ -10,11 +10,11 @@ module Spree
 
       if subscriber.errors.any?
         flash[:error] = subscriber.errors.full_messages.to_sentence.presence || Spree.t('something_went_wrong')
-      elsif !subscriber.verified?
+      elsif subscriber.verified? && subscriber.previous_changes.blank?
+        flash[:notice] = Spree.t('storefront.newsletter_subscribers.already_subscribed')
+      else
         track_event('subscribed_to_newsletter', { email: subscriber.email, user: try_spree_current_user })
         flash[:success] = Spree.t('storefront.newsletter_subscribers.success')
-      else
-        flash[:notice] = Spree.t('storefront.newsletter_subscribers.already_subscribed')
       end
 
       respond_to do |format|

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -50,10 +50,10 @@ en:
         message_not_sent: Unfortunately we weren't able to send the email at this time. Please try again later
         message_sent: Message sent!
       newsletter_subscribers:
+        already_subscribed: You are already subscribed to our newsletter
         success: Thank you for subscribing to our newsletter!
         verification_failed: Verification failed
         verified: Your email has been verified!
-        already_subscribed: You are already subscribed to our newsletter
       newsletter_subscription:
         description: Take control of your settings and tailor your experience according to your preferences. Customize your notifications to suit your needs.
         join: Email me about new products, sales, and more. You can unsubscribe at any time.

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -51,6 +51,9 @@ en:
         message_sent: Message sent!
       newsletter_subscribers:
         success: Thank you for subscribing to our newsletter!
+        verification_failed: Verification failed
+        verified: Your email has been verified!
+        already_subscribed: You are already subscribed to our newsletter
       newsletter_subscription:
         description: Take control of your settings and tailor your experience according to your preferences. Customize your notifications to suit your needs.
         join: Email me about new products, sales, and more. You can unsubscribe at any time.

--- a/storefront/config/routes.rb
+++ b/storefront/config/routes.rb
@@ -75,7 +75,9 @@ Spree::Core::Engine.add_routes do
     resource :settings, only: [:update, :show]
 
     # Newsletter
-    resources :newsletter_subscribers, only: [:create]
+    resources :newsletter_subscribers, only: [:create] do
+      get :verify, on: :collection
+    end
 
     # Contact form
     resources :contacts, only: [:new, :create]

--- a/storefront/spec/controllers/spree/account/newsletter_controller_spec.rb
+++ b/storefront/spec/controllers/spree/account/newsletter_controller_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe Spree::Account::NewsletterController, type: :controller do
 
       context 'with newsletter subscriber record' do
         before do
-          create(:newsletter_subscriber, email: user.email)
+          create(:newsletter_subscriber, email: user.email, user: user)
           create(:newsletter_subscriber, email: 'foo@bar.com')
         end
 
         it 'removes newsletter subscriber record' do
-          expect { subject }.to change { Spree::NewsletterSubscriber.where(email: user.email).count }.by(-1)
+          expect { subject }.to change { Spree::NewsletterSubscriber.where(email: user.email, user: user).count }.by(-1)
         end
       end
     end

--- a/storefront/spec/controllers/spree/account/newsletter_controller_spec.rb
+++ b/storefront/spec/controllers/spree/account/newsletter_controller_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Spree::Account::NewsletterController, type: :controller do
   render_views
 
   before do
-    allow(controller).to receive(:current_store).and_return(store)
-    allow(controller).to receive(:try_spree_current_user).and_return(user)
+    allow(controller).to receive_messages(current_store: store, try_spree_current_user: user)
   end
 
   describe 'GET #edit' do
@@ -34,6 +33,10 @@ RSpec.describe Spree::Account::NewsletterController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(user.reload.accepts_email_marketing).to be(true)
       end
+
+      it 'creates newsletter subscriber record' do
+        expect { subject }.to change { Spree::NewsletterSubscriber.where(email: user.email, user: user).count }.by(1)
+      end
     end
 
     context 'when user unsubscribes from the newsletter' do
@@ -45,6 +48,17 @@ RSpec.describe Spree::Account::NewsletterController, type: :controller do
 
         expect(response).to have_http_status(:ok)
         expect(user.reload.accepts_email_marketing).to be(false)
+      end
+
+      context 'with newsletter subscriber record' do
+        before do
+          create(:newsletter_subscriber, email: user.email)
+          create(:newsletter_subscriber, email: 'foo@bar.com')
+        end
+
+        it 'removes newsletter subscriber record' do
+          expect { subject }.to change { Spree::NewsletterSubscriber.where(email: user.email).count }.by(-1)
+        end
       end
     end
   end


### PR DESCRIPTION
[linear task](https://linear.app/vendo/issue/V-3108/bug-user-signup-subscribing-to-newsletter-blocks-normal-user-signup)

- added newsletter_subscriber model
- added email verification mailers
- updated acount and newsletter_subscriber to use new model
- add storefront endpoint for verifying email address
- add subscribe logic - do not verifty email address when subscribing current user's email address

visual changes (mailer):
<img width="1100" height="715" alt="Zrzut ekranu 2025-09-2 o 16 00 15" src="https://github.com/user-attachments/assets/d95d7557-8ac2-46bc-a377-dd050dcb81e1" />
<img width="1461" height="735" alt="Zrzut ekranu 2025-09-2 o 16 00 55" src="https://github.com/user-attachments/assets/c9545f9c-3079-4a23-80a8-b31ccba01910" />
<img width="1459" height="734" alt="Zrzut ekranu 2025-09-2 o 16 02 15" src="https://github.com/user-attachments/assets/5679766e-3b85-43ef-90f2-5043c6aae58d" />
<img width="1469" height="733" alt="Zrzut ekranu 2025-09-2 o 16 02 33" src="https://github.com/user-attachments/assets/392287ed-f3b0-4ab2-96a2-6aa9ddf61507" />
<img width="1481" height="714" alt="Zrzut ekranu 2025-09-2 o 16 02 56" src="https://github.com/user-attachments/assets/fcc72e07-ddc1-486c-9960-8c0608039061" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newsletter subscription system with verified/unverified states, email verification flow, unsubscribe support, localized HTML/text confirmation emails, public verification endpoint, account-preferences auto-subscribe/unsubscribe, background delivery of verification emails, and a rake task to migrate consenting users.

* **Tests**
  * Added specs and factory coverage for models, services, mailer, controllers, and subscribe/verify flows.

* **Chores**
  * Test dependency added and configured: shoulda-matchers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->