### PR TITLE
Lazy-load sections

### DIFF
--- a/storefront/app/helpers/spree/page_helper.rb
+++ b/storefront/app/helpers/spree/page_helper.rb
@@ -52,7 +52,7 @@ module Spree
 
         path = section.lazy_path(variables)
 
-        turbo_frame_tag(css_id, src: path, loading: 'eager', class: css_class) do
+        turbo_frame_tag(css_id, src: path, loading: :lazy, class: css_class, data: { controller: 'prefetch-lazy' }) do
           render('/' + section.to_partial_path, **variables)
         end
       else

--- a/storefront/app/javascript/spree/storefront/application.js
+++ b/storefront/app/javascript/spree/storefront/application.js
@@ -47,6 +47,7 @@ const controllers = [
   'no-ui-slider',
   'pdp-desktop-gallery',
   'plp-variant-picker',
+  'prefetch-lazy',
   'product-form',
   'quantity-picker',
   'read-more',

--- a/storefront/app/javascript/spree/storefront/controllers/prefetch_lazy_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/prefetch_lazy_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static values = {
-    rootMargin: { type: Integer, default: 300 }
+    rootMargin: { type: Number, default: 300 }
   }
 
   connect() {

--- a/storefront/app/javascript/spree/storefront/controllers/prefetch_lazy_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/prefetch_lazy_controller.js
@@ -2,12 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static values = {
-    rootMargin: { type: Number, default: 300 }
+    rootMargin: { type: Number, default: 200 }
   }
 
   connect() {
     if (this.element.getAttribute("loading") == "lazy") {
-      this.observer = new IntersectionObserver(this.intersect, { rootMargin: `${this.rootMarginValue}px` })
+      this.observer = new IntersectionObserver(this.intersect, { rootMargin: `0px 0px ${this.rootMarginValue}px 0px` })
       this.observer.observe(this.element)
     }
   }

--- a/storefront/app/javascript/spree/storefront/controllers/prefetch_lazy_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/prefetch_lazy_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    rootMargin: { type: Integer, default: 300 }
+  }
+
+  connect() {
+    if (this.element.getAttribute("loading") == "lazy") {
+      this.observer = new IntersectionObserver(this.intersect, { rootMargin: `${this.rootMarginValue}px` })
+      this.observer.observe(this.element)
+    }
+  }
+
+  disconnect() {
+    this.observer?.disconnect()
+  }
+
+  intersect = (entries) => {
+    const lastEntry = entries.slice(-1)[0]
+    if (lastEntry?.isIntersecting) {
+      this.observer.unobserve(this.element) // We only need to do this once
+      this.element.setAttribute("loading", "eager")
+    }
+  }
+}


### PR DESCRIPTION
Previously we eagerly loaded sections for better UX, because the built-in lazy loading of turbo frames only loads them when they become viesable, which meant a waiting time for the visitor for frame to load. Now we load them a bit before so when user scrolls to the frame it's already loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * On-scroll prefetching for lazy sections: content switches from lazy to eager as it nears the viewport.
  * Configurable prefetch threshold (default ~200px) to control when preloading begins.

* Performance Improvements
  * Faster initial page loads by deferring non-visible content.
  * Smoother scrolling and reduced layout shifts as content preloads just before appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->