### PR TITLE
Improve storefront caching

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -238,7 +238,9 @@ module Spree
         I18n.locale,
         (current_currency if defined?(current_currency)),
         defined?(try_spree_current_user) && try_spree_current_user.present?,
-        defined?(try_spree_current_user) && try_spree_current_user.try(:has_spree_role?, 'admin')
+        defined?(try_spree_current_user) && try_spree_current_user.try(:has_spree_role?, 'admin'),
+        defined?(current_wishlist) && current_wishlist.present?,
+        defined?(current_order) && current_order.present?
       ].compact
     end
 

--- a/core/app/models/spree/page_sections/newsletter.rb
+++ b/core/app/models/spree/page_sections/newsletter.rb
@@ -27,6 +27,10 @@ module Spree
         'footer'
       end
 
+      def lazy?
+        !Rails.env.test?
+      end
+
       def blocks_available?
         true
       end

--- a/storefront/app/helpers/spree/page_helper.rb
+++ b/storefront/app/helpers/spree/page_helper.rb
@@ -52,7 +52,7 @@ module Spree
 
         path = section.lazy_path(variables)
 
-        turbo_frame_tag(css_id, src: path, loading: :lazy, class: css_class, data: { controller: 'prefetch-lazy' }) do
+        turbo_frame_tag(css_id, src: path, loading: :lazy, class: css_class, data: { controller: 'prefetch-lazy', turbo_permanent: true }) do
           render('/' + section.to_partial_path, **variables)
         end
       else
@@ -72,7 +72,7 @@ module Spree
     #
     # @return [Array] the layout sections of the page
     def layout_sections
-      @layout_sections ||= current_theme_or_preview.sections.includes(section_includes)
+      @layout_sections ||= current_theme_or_preview.sections
     end
 
     # Renders the header sections of the page.

--- a/storefront/app/helpers/spree/theme_helper.rb
+++ b/storefront/app/helpers/spree/theme_helper.rb
@@ -68,6 +68,13 @@ module Spree
       @page_builder_enabled ||= (current_theme_preview.present? || current_page_preview.present?) && params[:page_builder] == 'true'
     end
 
+    # Returns whether the page cache is enabled
+    #
+    # @return [Boolean] whether the page cache is enabled
+    def page_cache_enabled?
+      @page_cache_enabled ||= Spree::Storefront::Config.page_cache_enabled
+    end
+
     # Returns the theme layout sections, eg. header, footer, etc.
     #
     # @return [Hash] the theme layout sections

--- a/storefront/app/views/spree/home/index.html.erb
+++ b/storefront/app/views/spree/home/index.html.erb
@@ -1,1 +1,3 @@
-<%= render_page(current_page) %>
+<% cache_if page_cache_enabled? && !page_builder_enabled?, spree_base_cache_scope.call(current_page), expires_in: Spree::Storefront::Config.page_cache_ttl do %>
+  <%= render_page(current_page) %>
+<% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -1,159 +1,162 @@
-<% layout = section.preferred_layout %>
-<header
-  class='header-<%= layout %>'
-  data-controller='header toggle-menu slideover <%= "slideover-account" if show_account_pane? %>'
-  data-toggle-menu-class='hamburger-visible'
-  data-slideover-invisible-class='translate-x-full,opacity-0'
-  data-slideover-visible-class='translate-x-0,opacity-100'
-  data-slideover-active-target='#slideover-cart'
-  data-slideover-account-invisible-class='translate-x-full,opacity-0'
-  data-slideover-account-visible-class='translate-x-0,opacity-100'
-  data-slideover-account-active-target='#slideover-account'
->
-  <nav
-    aria-label='Top'
-    style="<%= section_styles(section) %>"
-    class="relative transition-transform duration-300">
-    <div class='page-container'>
-      <div class='flex items-center<%= " lg:items-end" if layout == "logo-centered" %> <%= " lg:items-center" unless layout == "logo-centered" %> justify-between '>
-        <% unless layout == 'logo-centered' %>
-          <div class='hidden lg:flex' id='header-logo'>
-            <%= render 'spree/shared/logo', logo: section.logo, height: section.preferred_desktop_logo_height %>
-          </div>
-        <% end %>
-        <div class='flex -order-1 flex-1 <%= " lg:flex-none lg:order-1 z-10 lg:mr-8" unless layout == "logo-centered" %>'>
-          <!-- Mobile menu toggle, controls the 'mobileMenuOpen' state. -->
-          <button
-            type='button'
-            data-action='click->toggle-menu#toggle touch->toggle-menu#toggle'
-            class='relative w-6 lg:hidden'
-            data-toggle-menu-target='button'
-            >
-            <span class='sr-only'><%= Spree.t(:toggle_menu) %></span>
-            <div
-              class='absolute top-0'
-            >
-              <%= render 'spree/shared/icons/menu', color: section.preferred_text_color %>
+<% cache_unless page_builder_enabled?, [spree_base_cache_scope.call(section), request.path] do %>
+  <% layout = section.preferred_layout %>
+  <header
+    class='header-<%= layout %>'
+    data-controller='header toggle-menu slideover <%= "slideover-account" if show_account_pane? %>'
+    data-toggle-menu-class='hamburger-visible'
+    data-slideover-invisible-class='translate-x-full,opacity-0'
+    data-slideover-visible-class='translate-x-0,opacity-100'
+    data-slideover-active-target='#slideover-cart'
+    data-slideover-account-invisible-class='translate-x-full,opacity-0'
+    data-slideover-account-visible-class='translate-x-0,opacity-100'
+    data-slideover-account-active-target='#slideover-account'
+  >
+    <nav
+      aria-label='Top'
+      style="<%= section_styles(section) %>"
+      class="relative transition-transform duration-300">
+      <div class='page-container'>
+        <div class='flex items-center<%= " lg:items-end" if layout == "logo-centered" %> <%= " lg:items-center" unless layout == "logo-centered" %> justify-between '>
+          <% unless layout == 'logo-centered' %>
+            <div class='hidden lg:flex' id='header-logo'>
+              <%= render 'spree/shared/logo', logo: section.logo, height: section.preferred_desktop_logo_height %>
             </div>
-            <div
-              class='absolute top-0 opacity-0'
-            >
-              <%= render 'spree/shared/icons/close', color: section.preferred_text_color %>
-            </div>
-          </button>
-          <!-- Search button -->
-          <div class='<%= "lg:relative" unless layout == "logo-centered" %> flex'>
+          <% end %>
+          <div class='flex -order-1 flex-1 <%= " lg:flex-none lg:order-1 z-10 lg:mr-8" unless layout == "logo-centered" %>'>
+            <!-- Mobile menu toggle, controls the 'mobileMenuOpen' state. -->
             <button
-              class='flex items-center ml-4 lg:ml-0'
-              id='open-search'
-              data-action='click->toggle-menu#hide touch->toggle-menu#hide'
+              type='button'
+              data-action='click->toggle-menu#toggle touch->toggle-menu#toggle'
+              class='relative w-6 lg:hidden'
+              data-toggle-menu-target='button'
               >
-              <%= render 'spree/shared/icons/search', color: section.preferred_text_color %>
-              <span class='hidden lg:block ml-2 text-sm !leading-6 uppercase'><%= Spree.t(:search) %></span>
+              <span class='sr-only'><%= Spree.t(:toggle_menu) %></span>
+              <div
+                class='absolute top-0'
+              >
+                <%= render 'spree/shared/icons/menu', color: section.preferred_text_color %>
+              </div>
+              <div
+                class='absolute top-0 opacity-0'
+              >
+                <%= render 'spree/shared/icons/close', color: section.preferred_text_color %>
+              </div>
             </button>
+            <!-- Search button -->
+            <div class='<%= "lg:relative" unless layout == "logo-centered" %> flex'>
+              <button
+                class='flex items-center ml-4 lg:ml-0'
+                id='open-search'
+                data-action='click->toggle-menu#hide touch->toggle-menu#hide'
+                >
+                <%= render 'spree/shared/icons/search', color: section.preferred_text_color %>
+                <span class='hidden lg:block ml-2 text-sm !leading-6 uppercase'><%= Spree.t(:search) %></span>
+              </button>
+            </div>
           </div>
-        </div>
-        <div class='flex items-center flex-col<%= " lg:flex-1" unless layout == "logo-centered" %> header-nav-container'>
-          <!-- Logo -->
-          <div class='<%= "flex lg:pb-4" if layout == "logo-centered" %><%= "lg:hidden" unless layout == "logo-centered" %>' id='header-logo'>
-            <%= render 'spree/shared/logo', logo: section.logo, height: section.preferred_desktop_logo_height %>
-          </div>
-          <!-- Desktop Menu -->
-          <% if layout == 'nav-centered' %>
-            <div
-              class='hidden lg:flex absolute top-px left-1/2 -translate-x-1/2 justify-center w-[calc(100%-29rem)] overflow-auto'
-            >
-            <% end %>
-            <div class='hidden lg:flex<%= " w-full px-12" if layout == "left" %>'>
-              <div class='flex flex-wrap justify-center mx-4 h-full'>
-                <%= render 'spree/page_sections/nav/desktop', section: section %>
+          <div class='flex items-center flex-col<%= " lg:flex-1" unless layout == "logo-centered" %> header-nav-container'>
+            <!-- Logo -->
+            <div class='<%= "flex lg:pb-4" if layout == "logo-centered" %><%= "lg:hidden" unless layout == "logo-centered" %>' id='header-logo'>
+              <%= render 'spree/shared/logo', logo: section.logo, height: section.preferred_desktop_logo_height %>
+            </div>
+            <!-- Desktop Menu -->
+            <% if layout == 'nav-centered' %>
+              <div
+                class='hidden lg:flex absolute top-px left-1/2 -translate-x-1/2 justify-center w-[calc(100%-29rem)] overflow-auto'
+              >
+              <% end %>
+              <div class='hidden lg:flex<%= " w-full px-12" if layout == "left" %>'>
+                <div class='flex flex-wrap justify-center mx-4 h-full'>
+                  <%= render 'spree/page_sections/nav/desktop', section: section %>
+                </div>
               </div>
             </div>
-          </div>
-          <% if layout == 'nav-centered' %></div>
-        <% end %>
-        <div
-          class='flex items-center gap-4 flex-1 justify-end<%= " lg:flex-none order-2" unless layout == "logo-centered" %>'
-        >
-          <% if should_render_currency_dropdown? || should_render_locale_dropdown? %>
-            <div
-            data-controller="modal"
-            data-modal-allow-background-close="true"
-            data-modal-
-            class="hidden lg:flex"
-            data-modal-backdrop-color-value="rgba(0,0,0,0.32)">
-              <%= button_tag class: 'flex gap-2 items-center', data: {action: 'modal#open'} do %>
-                <% if should_render_currency_dropdown? %>
-                  <span>
-                    <%= "#{current_currency} (#{currency_money(current_currency).symbol})" %>
-                  </span>
-                <% end %>
-                <% if should_render_locale_dropdown? %>
-                  <span class="uppercase <%= should_render_currency_dropdown?.presence && "border-l pl-2" %> flex items-center gap-1">
-                    <% country_code = current_locale.to_s.split("-").last %>
-                    <%= svg_country_icon(country_code) %>
-                    <span ><%= country_code %></span>
-                  </span>
-                <% end %>
-              <% end %>
-              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :lazy  %>
-            </div>
+            <% if layout == 'nav-centered' %></div>
           <% end %>
-          <!-- Desktop Account -->
-          <div class='hidden lg:flex'>
-            <% if show_account_pane? %>
-              <button
-                data-action='click->slideover-account#toggle click@window->slideover-account#hide click->toggle-menu#hide touch->toggle-menu#hide'
-                >
-                <%= render 'spree/shared/icons/account', color: section.preferred_text_color, section: section %>
-              </button>
-            <% else %>
-              <%= link_to spree.account_path do %>
-                <%= render 'spree/shared/icons/account', color: section.preferred_text_color, section: section %>
-              <% end %>
-            <% end %>
-          </div>
-          <% if show_account_pane? %>
-            <%= form_with url: spree.account_wishlist_path, method: :get, data: { turbo_stream: true } do %>
-              <button
-                type="submit"
-                id="wishlist-icon"
-                class="flex items-end">
-                <%= render 'spree/shared/wishlist_icon', wishlist: current_wishlist, background_color: section.preferred_background_color %>
-              </button>
-            <% end %>
-          <% else %>
-            <%= link_to spree.account_wishlist_path, id: "wishlist-icon" do %>
-              <%= render 'spree/shared/wishlist_icon', background_color: section.preferred_background_color %>
-            <% end %>
-          <% end %>
-          <!-- Cart -->
           <div
-            data-action='click->toggle-menu#hide touch->toggle-menu#hide'
-            >
-            <%= render 'spree/shared/cart_icon' %>
+            class='flex items-center gap-4 flex-1 justify-end<%= " lg:flex-none order-2" unless layout == "logo-centered" %>'
+          >
+            <% if should_render_currency_dropdown? || should_render_locale_dropdown? %>
+              <div
+              data-controller="modal"
+              data-modal-allow-background-close="true"
+              data-modal-
+              class="hidden lg:flex"
+              data-modal-backdrop-color-value="rgba(0,0,0,0.32)">
+                <%= button_tag class: 'flex gap-2 items-center', data: {action: 'modal#open'} do %>
+                  <% if should_render_currency_dropdown? %>
+                    <span>
+                      <%= "#{current_currency} (#{currency_money(current_currency).symbol})" %>
+                    </span>
+                  <% end %>
+                  <% if should_render_locale_dropdown? %>
+                    <span class="uppercase <%= should_render_currency_dropdown?.presence && "border-l pl-2" %> flex items-center gap-1">
+                      <% country_code = current_locale.to_s.split("-").last %>
+                      <%= svg_country_icon(country_code) %>
+                      <span ><%= country_code %></span>
+                    </span>
+                  <% end %>
+                <% end %>
+                <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :lazy  %>
+              </div>
+            <% end %>
+            <!-- Desktop Account -->
+            <div class='hidden lg:flex'>
+              <% if show_account_pane? %>
+                <button
+                  data-action='click->slideover-account#toggle click@window->slideover-account#hide click->toggle-menu#hide touch->toggle-menu#hide'
+                  >
+                  <%= render 'spree/shared/icons/account', color: section.preferred_text_color, section: section %>
+                </button>
+              <% else %>
+                <%= link_to spree.account_path do %>
+                  <%= render 'spree/shared/icons/account', color: section.preferred_text_color, section: section %>
+                <% end %>
+              <% end %>
+            </div>
+            <% if show_account_pane? %>
+              <%= form_with url: spree.account_wishlist_path, method: :get, data: { turbo_stream: true } do %>
+                <button
+                  type="submit"
+                  id="wishlist-icon"
+                  class="flex items-end">
+                  <%= render 'spree/shared/wishlist_icon', wishlist: current_wishlist, background_color: section.preferred_background_color %>
+                </button>
+              <% end %>
+            <% else %>
+              <%= link_to spree.account_wishlist_path, id: "wishlist-icon" do %>
+                <%= render 'spree/shared/wishlist_icon', background_color: section.preferred_background_color %>
+              <% end %>
+            <% end %>
+            <!-- Cart -->
+            <div
+              data-action='click->toggle-menu#hide touch->toggle-menu#hide'
+              >
+              <%= render 'spree/shared/cart_icon' %>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class='h-0 opacity-0 pointer-events-none hide-on-load'
-      data-toggle-menu-target='toggleable'
-      role='dialog'
-      aria-modal='true'
-    >
       <div
-        class='flex justify-between flex-col lg:hidden w-full transition-transform translate-x-[-50%] has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
-        data-toggle-menu-target='content'
-        style='background-color: <%= section.preferred_background_color %>; height: calc(100dvh - 38px);'
-        >
-        <%= render 'spree/page_sections/nav/mobile', section: section %>
+        class='h-0 opacity-0 pointer-events-none hide-on-load'
+        data-toggle-menu-target='toggleable'
+        role='dialog'
+        aria-modal='true'
+      >
+        <div
+          class='flex justify-between flex-col lg:hidden w-full transition-transform translate-x-[-50%] has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
+          data-toggle-menu-target='content'
+          style='background-color: <%= section.preferred_background_color %>; height: calc(100dvh - 38px);'
+          >
+          <%= render 'spree/page_sections/nav/mobile', section: section %>
+        </div>
       </div>
-    </div>
-  </nav>
-  <%= render 'spree/shared/cart_pane', section: section %>
-  <% if show_account_pane? %>
-    <%= render 'spree/shared/account_pane', section: section %>
-  <% end %>
-  <%= render 'spree/shared/search', section: section, logo: section.logo, logo_height: section.preferred_desktop_logo_height %>
-</header>
+    </nav>
+
+    <%= render 'spree/shared/cart_pane', section: section %>
+    <% if show_account_pane? %>
+      <%= render 'spree/shared/account_pane', section: section %>
+    <% end %>
+    <%= render 'spree/shared/search', section: section, logo: section.logo, logo_height: section.preferred_desktop_logo_height %>
+  </header>
+<% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -80,7 +80,6 @@
               <div
               data-controller="modal"
               data-modal-allow-background-close="true"
-              data-modal-
               class="hidden lg:flex"
               data-modal-backdrop-color-value="rgba(0,0,0,0.32)">
                 <%= button_tag class: 'flex gap-2 items-center', data: {action: 'modal#open'} do %>

--- a/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
@@ -1,5 +1,6 @@
-<% if loaded %>
-  <% img = section.image %>
+<div class="w-full flex justify-center items-center relative min-h-[200px]" style="<%= section_styles(section) %>">
+  <% if loaded %>
+    <% img = section.image %>
     <% if img.attached? && img.variable? %>
       <img
         class="w-full h-full absolute top-0 object-cover z-0"
@@ -43,5 +44,5 @@
         <% end %>
       <% end %>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
@@ -1,47 +1,47 @@
-<% img = section.image %>
-
-<div class="w-full flex justify-center items-center relative" style="<%= section_styles(section) %>">
-  <% if img.attached? && img.variable? %>
-    <img
-      class="w-full h-full absolute top-0 object-cover z-0"
-      style="opacity: <%= section.preferred_overlay_transparency %>%"
-      src="<%= spree_image_url(img, width: 2000, height: nil) %>" />
-  <% end %>
-  <div class="w-full page-container flex flex-col text-center py-5 px-5 z-10">
-    <% section.blocks.includes(:rich_text_text).each do |block| %>
-      <% case block.type %>
-        <% when 'Spree::PageBlocks::Heading' %>
-          <h2 class='font-medium <%= block.preferred_size == 'small' ? 'text-xl lg:text-2xl' : block.preferred_size == 'medium' ? 'text-xl lg:text-3xl' : 'text-2xl lg:text-3xl' %>' <%= block_attributes(block) %>>
-            <%= block.text.body %>
-          </h2>
-        <% when 'Spree::PageBlocks::Text' %>
-          <div class='text-sm lg:text-base' <%= block_attributes(block) %>>
-            <%= block.text.body %>
-          </div>
-        <% when 'Spree::PageBlocks::NewsletterForm' %>
-          <%= form_for :newsletter, url: spree.newsletter_subscribers_path do |f| %>
-            <div class="flex items-center flex-col md:flex-row w-full <%= block_css_classes(block) %>" <%= block_attributes(block) %>>
-              <div class='relative w-full lg:w-[424px] flex'>
-                <%= hidden_field_tag :section_id, section.id %>
-                <%= f.email_field :email, placeholder: block.preferred_placeholder, required: true, class: 'focus:border-primary focus:ring-primary pr-36 text-sm bg-accent rounded-input border-accent py-2 px-4 w-full relative z-30 !leading-[46px]' %>
-                <div class="absolute right-2 top-1/2 transform -translate-y-1/2 z-40">
-                  <%= f.submit block.preferred_button_text.html_safe, class: "#{block.preferred_button_style == 'secondary' ? 'btn-secondary' : 'btn-primary'} content-center" %>
+<% if loaded %>
+  <% img = section.image %>
+    <% if img.attached? && img.variable? %>
+      <img
+        class="w-full h-full absolute top-0 object-cover z-0"
+        style="opacity: <%= section.preferred_overlay_transparency %>%"
+        src="<%= spree_image_url(img, width: 2000, height: nil) %>" />
+    <% end %>
+    <div class="w-full page-container flex flex-col text-center py-5 px-5 z-10">
+      <% section.blocks.includes(:rich_text_text).each do |block| %>
+        <% case block.type %>
+          <% when 'Spree::PageBlocks::Heading' %>
+            <h2 class='font-medium <%= block.preferred_size == 'small' ? 'text-xl lg:text-2xl' : block.preferred_size == 'medium' ? 'text-xl lg:text-3xl' : 'text-2xl lg:text-3xl' %>' <%= block_attributes(block) %>>
+              <%= block.text.body %>
+            </h2>
+          <% when 'Spree::PageBlocks::Text' %>
+            <div class='text-sm lg:text-base' <%= block_attributes(block) %>>
+              <%= block.text.body %>
+            </div>
+          <% when 'Spree::PageBlocks::NewsletterForm' %>
+            <%= form_for :newsletter, url: spree.newsletter_subscribers_path do |f| %>
+              <div class="flex items-center flex-col md:flex-row w-full <%= block_css_classes(block) %>" <%= block_attributes(block) %>>
+                <div class='relative w-full lg:w-[424px] flex'>
+                  <%= hidden_field_tag :section_id, section.id %>
+                  <%= f.email_field :email, placeholder: block.preferred_placeholder, required: true, class: 'focus:border-primary focus:ring-primary pr-36 text-sm bg-accent rounded-input border-accent py-2 px-4 w-full relative z-30 !leading-[46px]' %>
+                  <div class="absolute right-2 top-1/2 transform -translate-y-1/2 z-40">
+                    <%= f.submit block.preferred_button_text.html_safe, class: "#{block.preferred_button_style == 'secondary' ? 'btn-secondary' : 'btn-primary'} content-center" %>
+                  </div>
                 </div>
               </div>
-            </div>
-          <% end %>
-        <% when 'Spree::PageBlocks::Subheading' %>
-          <h3 class='<%= block.size == 'small' ? 'text-lg' : block.size == 'medium' ? 'text-xl' : 'text-xl' %>' <%= block_attributes(block) %>>
-            <%= block.text.body %>
-          </h3>
-        <% when 'Spree::PageBlocks::Image' %>
-          <div <%= block_attributes(block) %> class="flex justify-center w-full">
-            <% if block.image.attached? && block.image.variable? %>
-              <% image_style = "aspect-ratio: #{spree_asset_aspect_ratio(block.image)}; --desktop-height: #{block.preferred_height}px; --mobile-height: #{block.preferred_mobile_height}px;" %>
-              <%= image_tag spree_image_url(block.image, width: 1000, height: 1000), height: block.preferred_height, class: "custom-desktop-height custom-mobile-height", style: image_style %>
             <% end %>
-          </div>
+          <% when 'Spree::PageBlocks::Subheading' %>
+            <h3 class='<%= block.size == 'small' ? 'text-lg' : block.size == 'medium' ? 'text-xl' : 'text-xl' %>' <%= block_attributes(block) %>>
+              <%= block.text.body %>
+            </h3>
+          <% when 'Spree::PageBlocks::Image' %>
+            <div <%= block_attributes(block) %> class="flex justify-center w-full">
+              <% if block.image.attached? && block.image.variable? %>
+                <% image_style = "aspect-ratio: #{spree_asset_aspect_ratio(block.image)}; --desktop-height: #{block.preferred_height}px; --mobile-height: #{block.preferred_mobile_height}px;" %>
+                <%= image_tag spree_image_url(block.image, width: 1000, height: 1000), height: block.preferred_height, class: "custom-desktop-height custom-mobile-height", style: image_style %>
+              <% end %>
+            </div>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
@@ -32,8 +32,12 @@
   <meta property="twitter:image" content="<%= image_url %>" />
 <% end %>
 
-<% if @product.present? && @product.price_in(current_currency).present? %>
-  <meta property="og:price:amount" content="<%= @product.price_in(current_currency).amount.to_s %>">
+<% if @product.present? %>
+  <% cache [@product, current_currency] do %>
+    <% if @product.price_in(current_currency).present? %>
+      <meta property="og:price:amount" content="<%= @product.price_in(current_currency).amount.to_s %>">
+    <% end %>
+  <% end %>
   <meta property="og:price:currency" content="<%= current_currency %>">
 <% end %>
 

--- a/storefront/lib/spree/storefront/configuration.rb
+++ b/storefront/lib/spree/storefront/configuration.rb
@@ -3,6 +3,9 @@ require 'spree/core/preferences/runtime_configuration'
 module Spree
   module Storefront
     class Configuration < ::Spree::Preferences::RuntimeConfiguration
+      preference :page_cache_enabled, :boolean, default: true
+      preference :page_cache_ttl, :integer, default: 10.minutes.to_i
+
       preference :products_per_page, :integer, default: 20
 
       preference :search_min_query_length, :integer, default: 2


### PR DESCRIPTION
* Introduce full page caching for home (Can be turned off)
* Improved spree_base_cache_key to also include wishlist/order context to expire cache based on user actions
* Cache header section
* Load newsletter sections lazily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional page caching with configurable TTL for faster browsing.
  - Home page and header can be cached when the page builder is disabled.
  - Added a toggle to detect page caching availability in the theme.
  - Lazy-loaded sections now persist across navigations for smoother transitions.

- Refactor
  - Header layout reorganized and wrapped in caching without changing behavior.
  - Newsletter section now renders only when loaded and has layout tweaks.
  - Cache keys and meta-tag caching updated to account for wishlist/order presence and product price.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->