### PR TITLE
Added `StorefrontHelper#spree_storefront_base_cache_key`

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -238,9 +238,7 @@ module Spree
         I18n.locale,
         (current_currency if defined?(current_currency)),
         defined?(try_spree_current_user) && try_spree_current_user.present?,
-        defined?(try_spree_current_user) && try_spree_current_user.try(:has_spree_role?, 'admin'),
-        defined?(current_wishlist) && current_wishlist.present?,
-        defined?(current_order) && current_order.present?
+        defined?(try_spree_current_user) && try_spree_current_user.respond_to?(:role_users) && try_spree_current_user.role_users.cache_key_with_version
       ].compact
     end
 

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -197,7 +197,7 @@ describe Spree::BaseHelper, type: :helper do
         let!(:user) { create(:admin_user) }
 
         it 'returns base cache key' do
-          expect(spree_base_cache_key).to eq [:en, 'USD', true, true]
+          expect(spree_base_cache_key).to eq [:en, 'USD', true, user.role_users.cache_key_with_version]
         end
       end
 
@@ -205,7 +205,7 @@ describe Spree::BaseHelper, type: :helper do
         let!(:user) { create(:user) }
 
         it 'returns base cache key' do
-          expect(spree_base_cache_key).to eq [:en, 'USD', true, false]
+          expect(spree_base_cache_key).to eq [:en, 'USD', true, user.role_users.cache_key_with_version]
         end
       end
 
@@ -213,7 +213,7 @@ describe Spree::BaseHelper, type: :helper do
         let!(:user) { nil }
 
         it 'returns base cache key' do
-          expect(spree_base_cache_key).to eq [:en, 'USD', false]
+          expect(spree_base_cache_key).to eq [:en, 'USD', false, false]
         end
       end
     end

--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -5,6 +5,24 @@ module Spree
     include Spree::ShipmentHelper
     include Heroicon::Engine.helpers
 
+    # Returns the cache key for the storefront including the current wishlist and order.
+    #
+    # @return [Array] The cache key
+    def spree_storefront_base_cache_key
+      @spree_storefront_base_cache_key ||= [
+        spree_base_cache_key,
+        current_wishlist,
+        current_order
+      ].compact
+    end
+
+    # Returns the cache scope for the storefront including the current wishlist and order.
+    #
+    # @return [Proc] The cache scope
+    def spree_storefront_base_cache_scope
+      ->(record = nil) { [*spree_storefront_base_cache_key, record].compact_blank }
+    end
+
     # Renders the storefront partials for the given section.
     #
     # @param section [String] The section to render

--- a/storefront/app/views/spree/checkout/_line_items.html.erb
+++ b/storefront/app/views/spree/checkout/_line_items.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag :checkout_line_items, id: 'line_items', target: '_top' do %>
-  <% cache spree_base_cache_scope.call(order.line_items.cache_key_with_version) do %>
+  <% cache spree_storefront_base_cache_scope.call(order.line_items.cache_key_with_version) do %>
     <div class="overflow-y-auto line-items flex flex-col gap-5 pt-5 md:pt-0" data-checkout-summary-target="line_items">
-      <%= render collection: order.line_items, partial: 'spree/checkout/line_item', cached: spree_base_cache_scope %>
+      <%= render collection: order.line_items, partial: 'spree/checkout/line_item', cached: spree_storefront_base_cache_scope %>
     </div>
   <% end %>
 <% end %>

--- a/storefront/app/views/spree/checkout/_missing_line_items.html.erb
+++ b/storefront/app/views/spree/checkout/_missing_line_items.html.erb
@@ -9,7 +9,7 @@
           </p>
 
           <div class="mb-5 overflow-y-auto pt-3 mx-3 lg:mx-8 lg:mt-4 lg:pt-6 line-items" data-checkout-summary-target="line_items">
-            <%= render collection: @order.line_items_without_shipping_rates, partial: 'spree/checkout/line_item', cached: spree_base_cache_scope %>
+            <%= render collection: @order.line_items_without_shipping_rates, partial: 'spree/checkout/line_item', cached: spree_storefront_base_cache_scope %>
           </div>
 
           <div class="flex justify-end items-center flex-wrap mt-6">

--- a/storefront/app/views/spree/checkout/_summary.html.erb
+++ b/storefront/app/views/spree/checkout/_summary.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :checkout_summary, id: 'summary' do %>
   <div class="checkout-content-summary text-sm">
-    <% cache [*spree_base_cache_scope.call(order.cache_key_with_version), order.state] do %>
+    <% cache [*spree_storefront_base_cache_scope.call(order.cache_key_with_version), order.state] do %>
       <div data-hook="order_summary">
         <div class="flex justify-between items-center mb-2">
           <span><%= Spree.t(:subtotal) %>:</span>
@@ -8,7 +8,7 @@
         </div>
         <div class="d-table-cell text-right font-weight-bold"></div>
 
-        <% cache spree_base_cache_scope.call(order.line_item_adjustments.nonzero.cache_key_with_version) do %>
+        <% cache spree_storefront_base_cache_scope.call(order.line_item_adjustments.nonzero.cache_key_with_version) do %>
           <% if order.line_item_adjustments.nonzero.exists? %>
             <% order.line_item_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
               <div class="flex justify-between items-center mb-2">
@@ -59,7 +59,7 @@
         <% end %>
 
         <% if order.payment? || order.completed? %>
-          <% cache spree_base_cache_scope.call(order.all_adjustments.nonzero.tax.eligible.cache_key_with_version) do %>
+          <% cache spree_storefront_base_cache_scope.call(order.all_adjustments.nonzero.tax.eligible.cache_key_with_version) do %>
             <% order.all_adjustments.nonzero.tax.eligible.group_by(&:label).each do |label, adjustments| %>
               <div class="flex justify-between items-center mb-2">
                 <span><%= label %></span>

--- a/storefront/app/views/spree/home/index.html.erb
+++ b/storefront/app/views/spree/home/index.html.erb
@@ -1,3 +1,3 @@
-<% cache_if page_cache_enabled? && !page_builder_enabled?, spree_base_cache_scope.call(current_page), expires_in: Spree::Storefront::Config.page_cache_ttl do %>
+<% cache_if page_cache_enabled? && !page_builder_enabled?, spree_storefront_base_cache_scope.call(current_page), expires_in: Spree::Storefront::Config.page_cache_ttl do %>
   <%= render_page(current_page) %>
 <% end %>

--- a/storefront/app/views/themes/default/spree/account/_orders.html.erb
+++ b/storefront/app/views/themes/default/spree/account/_orders.html.erb
@@ -10,7 +10,7 @@
     </tr>
   </thead>
   <tbody class="block md:table-row-group">
-    <%= render collection: orders, partial: 'spree/account/order', cached: spree_base_cache_scope %>
+    <%= render collection: orders, partial: 'spree/account/order', cached: spree_storefront_base_cache_scope %>
   </tbody>
 </table>
 

--- a/storefront/app/views/themes/default/spree/account/addresses/index.html.erb
+++ b/storefront/app/views/themes/default/spree/account/addresses/index.html.erb
@@ -9,7 +9,7 @@
       </div>
       <% if @addresses.any? %>
         <ul>
-          <%= render partial: 'spree/account/addresses/address', collection: @addresses, cached: ->a {[*spree_base_cache_scope.call(a), try_spree_current_user.ship_address_id, try_spree_current_user.bill_address_id]}, as: :address %>
+          <%= render partial: 'spree/account/addresses/address', collection: @addresses, cached: ->a {[*spree_storefront_base_cache_scope.call(a), try_spree_current_user.ship_address_id, try_spree_current_user.bill_address_id]}, as: :address %>
         </ul>
         <div class="flex">
           <div data-controller="modal" data-modal-allow-background-close="true">

--- a/storefront/app/views/themes/default/spree/account/gift_cards/index.html.erb
+++ b/storefront/app/views/themes/default/spree/account/gift_cards/index.html.erb
@@ -18,7 +18,7 @@
           </tr>
         </thead>
         <tbody class="block md:table-row-group">
-          <%= render collection: @gift_cards, partial: 'spree/account/gift_cards/gift_card', cached: spree_base_cache_scope %>
+          <%= render collection: @gift_cards, partial: 'spree/account/gift_cards/gift_card', cached: spree_storefront_base_cache_scope %>
         </tbody>
       </table>
     <% else %>

--- a/storefront/app/views/themes/default/spree/account/store_credits/index.html.erb
+++ b/storefront/app/views/themes/default/spree/account/store_credits/index.html.erb
@@ -21,7 +21,7 @@
           </tr>
         </thead>
         <tbody class="block md:table-row-group">
-          <%= render collection: @store_credit_events, partial: 'spree/account/store_credits/store_credit_event', cached: spree_base_cache_scope %>
+          <%= render collection: @store_credit_events, partial: 'spree/account/store_credits/store_credit_event', cached: spree_storefront_base_cache_scope %>
         </tbody>
       </table>
     <% else %>

--- a/storefront/app/views/themes/default/spree/checkout/_footer.html.erb
+++ b/storefront/app/views/themes/default/spree/checkout/_footer.html.erb
@@ -1,4 +1,4 @@
-<% cache spree_base_cache_scope.call(current_store) do %>
+<% cache spree_storefront_base_cache_scope.call(current_store) do %>
   <% if current_store.policies.show_in_checkout_footer.any? %>
     <div class="flex flex-col gap-4 text-sm">
       <ul class="flex justify-center flex-wrap gap-4">

--- a/storefront/app/views/themes/default/spree/orders/_cart.html.erb
+++ b/storefront/app/views/themes/default/spree/orders/_cart.html.erb
@@ -2,7 +2,7 @@
   <div class="h-full flex flex-col" id="cart-container" data-cart-target="container">
     <%== color_options_style_for_line_items(@line_items) %>
     <ul class="w-full" id="line-items">
-      <%= render collection: @line_items, partial: 'spree/orders/line_item', cached: spree_base_cache_scope %>
+      <%= render collection: @line_items, partial: 'spree/orders/line_item', cached: spree_storefront_base_cache_scope %>
     </ul>
     <%= render 'spree/orders/summary', order: @order %>
   </div>

--- a/storefront/app/views/themes/default/spree/page_sections/_announcement_bar.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_announcement_bar.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <% if section.present? && section.text.body.to_plain_text.present? %>
     <div
       class='w-full justify-center items-center flex announcement-bar'

--- a/storefront/app/views/themes/default/spree/page_sections/_custom_code.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_custom_code.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <div style="<%= section_styles(section) %>">
     <%= raw(section.preferred_custom_code) %>
   </div>

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_posts.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_posts.html.erb
@@ -41,7 +41,7 @@
         <div class='swiper-wrapper px-4 lg:px-0 h-auto'>
           <%= render partial: "spree/posts/post",
           collection: section.posts,
-          cached: spree_base_cache_scope,
+          cached: spree_storefront_base_cache_scope,
           as: :post %>
         </div>
         <%= button_tag class: "absolute p-2 bg-white rounded-full z-10 border border-accent left-0 disabled:hidden hover:border-primary ml-2 lg:ml-0 swiper-custom-button-prev-#{section.id} block top-[100px]", aria: { label: "Previous posts" }, style: "transform: translate(-50%, -50%);" do %>

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, [spree_base_cache_key, section.cache_key_with_version, loaded.to_b] do %>
+<% cache_unless page_builder_enabled?, [spree_storefront_base_cache_key, section.cache_key_with_version, loaded.to_b] do %>
   <div style='<%= section_styles(section) %>' class='animate-fadeIn'>
     <div class='page-container'>
       <% heading_size = case section.preferred_heading_size

--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxons.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <div class="page-container py-5" style="<%= section_styles(section) %>">
     <% heading_size = case section.preferred_heading_size
                       when 'small' then 'text-base font-medium'

--- a/storefront/app/views/themes/default/spree/page_sections/_footer.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_footer.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, [*spree_base_cache_scope.call(section), current_store] do %>
+<% cache_unless page_builder_enabled?, [*spree_storefront_base_cache_scope.call(section), current_store] do %>
   <footer
     id='footer'
     <% unless current_theme_preview %>
@@ -32,7 +32,7 @@
             <div class="gap-1 flex flex-col py-6 md:py-0">
               <h3 class="text-sm py-2"><%= Spree.t(:follow_us) %></h3>
               <div class="flex flex-wrap gap-2 max-w-48 py-2">
-                <% cache spree_base_cache_scope.call(current_store) do %>
+                <% cache spree_storefront_base_cache_scope.call(current_store) do %>
                   <% Spree::Store::SUPPORTED_SOCIAL_NETWORKS.each do |media| %>
                     <% if current_store.send(media).present? %>
                       <%= link_to current_store.send("#{media}_link") do %>

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, [spree_base_cache_scope.call(section), request.path] do %>
+<% cache_unless page_builder_enabled?, [spree_storefront_base_cache_scope.call(section), request.path] do %>
   <% layout = section.preferred_layout %>
   <header
     class='header-<%= layout %>'

--- a/storefront/app/views/themes/default/spree/page_sections/_image_banner.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_image_banner.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <div class="w-full relative image-banner" style="<%= section_styles(section) %>;height: <%= section.preferred_height %>px">
     <div class="w-full absolute left-0 image-banner--image-wrapper" style="height: <%= section.preferred_height %>px; opacity: <%= section.preferred_overlay_transparency %>%;">
       <% if section.image.attached? && section.image.variable? %>

--- a/storefront/app/views/themes/default/spree/page_sections/_image_with_text.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_image_with_text.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <div style="<%= section_styles(section) %>" class="image-with-text <%= 'right-aligned' if section.preferred_desktop_image_alignment == 'right' %>">
     <div class="page-container">
       <div class="lg:grid lg:grid-cols-12 lg:gap-6 image-with-text--container">

--- a/storefront/app/views/themes/default/spree/page_sections/_page_title.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_page_title.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <div class="page-container">
     <h1 class="text-xl lg:text-2xl font-medium py-10 lg:pt-16 lg:pb-6" style="<%= section_heading_styles(section) %>">
       <%= section.preferred_title.presence || title %>

--- a/storefront/app/views/themes/default/spree/page_sections/_rich_text.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_rich_text.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <div style="<%= section_styles(section) %>">
     <div class="page-container rich-text">
       <% section.blocks.each do |block| %>

--- a/storefront/app/views/themes/default/spree/page_sections/_taxon_banner.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_taxon_banner.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, [*spree_base_cache_scope.call(section), taxon].compact do %>
+<% cache_unless page_builder_enabled?, [*spree_storefront_base_cache_scope.call(section), taxon].compact do %>
   <div
     style="<%= section_styles(section) %>"
     id="taxon-banner-<%= taxon.id %>"

--- a/storefront/app/views/themes/default/spree/page_sections/_taxon_grid.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_taxon_grid.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, [*spree_base_cache_scope.call(section), @taxons].compact do %>
+<% cache_unless page_builder_enabled?, [*spree_storefront_base_cache_scope.call(section), @taxons].compact do %>
   <div style='<%= section_styles(section) %>'>
     <h1 class='text-xl lg:text-2xl font-medium pb-8 page-container' style='<%= section_heading_styles(section) %>'>
       <%= section.heading %>

--- a/storefront/app/views/themes/default/spree/page_sections/_video.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_video.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
   <% separated_vertically = section.preferred_separated == 'vertically' %>
 
   <div style="<%= section_styles(section) %>">

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_desktop.html.erb
@@ -31,7 +31,7 @@
                 </div>
               <% end %>
               <% if block.try(:featured_taxon) %>
-                <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
+                <% cache spree_storefront_base_cache_scope.call(block.featured_taxon) do %>
                   <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
                     <%= link_to spree_storefront_resource_url(block.featured_taxon), class: "flex flex-col col-start-4" do %>
                       <%= spree_image_tag(block.featured_taxon.image, width: 360, height: 360, class: 'w-full h-auto aspect-1', loading: :lazy, alt: block.featured_taxon.name) %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -21,7 +21,7 @@
                   </button>
                   <div class="p-4 pt-0 w-full gap-2 flex flex-col">
                     <% if block.try(:featured_taxon) %>
-                      <% cache spree_base_cache_scope.call(block.featured_taxon) do %>
+                      <% cache spree_storefront_base_cache_scope.call(block.featured_taxon) do %>
                         <% if block.featured_taxon.image.attached? && block.featured_taxon.image.variable? %>
                           <%= link_to spree_storefront_resource_url(block.featured_taxon), class: "flex w-full pt-4" do %>
                             <%= spree_image_tag(block.featured_taxon.image, width: 140, height: 140, class: 'h-auto aspect-1 w-2/5 max-w-[140px]', loading: :lazy, alt: block.featured_taxon.name) %>

--- a/storefront/app/views/themes/default/spree/products/_color_swatches.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_color_swatches.html.erb
@@ -2,7 +2,7 @@
 <% variants_with_color = product.variants.find_all { |variant| variant.option_values.find { |ov| ov.option_type_id == color_option.id } } if color_option.present? %>
 
 <% if color_option.present? && variants_with_color.length > 0 %>
-  <% cache spree_base_cache_scope.call(variants_with_color) do %>
+  <% cache spree_storefront_base_cache_scope.call(variants_with_color) do %>
     <% color_values = product.option_values.find_all { |ov| ov.option_type_id == color_option.id }.uniq %>
     <%= raw(Spree::ColorsPreviewStylesPresenter.new(color_values.map { |o| { name: o.presentation, filter_name: o.name } }).to_s) %>
 
@@ -11,7 +11,7 @@
         <% selected_variant = variants_with_color.find { |variant| variant.option_values.include?(color_value) } %>
         <% next if selected_variant.blank? %>
 
-        <% cache spree_base_cache_scope.call(selected_variant) do %>
+        <% cache spree_storefront_base_cache_scope.call(selected_variant) do %>
           <div
             data-variant-id="<%= selected_variant.id %>"
             class="[&:nth-of-type(n+4)]:hidden [&:nth-of-type(n+4)]:md:block [&:nth-of-type(n+8)]:md:hidden cursor-pointer"

--- a/storefront/app/views/themes/default/spree/products/_details.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_details.html.erb
@@ -1,4 +1,4 @@
-<% cache spree_base_cache_scope.call(product) do %>
+<% cache spree_storefront_base_cache_scope.call(product) do %>
   <% if product.storefront_description.present? %>
     <% description_text = strip_tags(product.storefront_description) %>
     <div data-controller="read-more" class="py-4 flex flex-col gap-4" data-read-more-more-text-value="<%= Spree.t(:read_more) %>" data-read-more-less-text-value="Read less">

--- a/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
@@ -26,7 +26,7 @@
   <% end %>
   "offers": [
   <% if product.has_variants? %>
-    <%= render partial: "spree/products/json_ld_variant", collection: product.variants, as: :variant, locals: { product: product }, cached: spree_base_cache_scope %>
+    <%= render partial: "spree/products/json_ld_variant", collection: product.variants, as: :variant, locals: { product: product }, cached: spree_storefront_base_cache_scope %>
   <% else %>
     <%= render "spree/products/json_ld_variant", product: product, variant: first_or_default_variant %>
   <% end %>

--- a/storefront/app/views/themes/default/spree/products/_media_gallery.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_media_gallery.html.erb
@@ -1,6 +1,6 @@
 <% desktop ||= false %>
 
-<% cache [*spree_base_cache_scope.call(product), images, desktop].compact do %>
+<% cache [*spree_storefront_base_cache_scope.call(product), images, desktop].compact do %>
   <% if desktop == true %>
     <div
       class="media-gallery w-full h-full media-gallery-desktop"

--- a/storefront/app/views/themes/default/spree/shared/_address.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_address.html.erb
@@ -1,4 +1,4 @@
-<% cache [*spree_base_cache_scope.call(address), address.user] do %>
+<% cache [*spree_storefront_base_cache_scope.call(address), address.user] do %>
   <div class="text-sm">
     <div class="mb-1"><%= address.full_name %></div>
     <% unless address.company.blank? %>

--- a/storefront/app/views/themes/default/spree/shared/_css_variables.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_css_variables.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless page_builder_enabled?, spree_base_cache_scope.call(current_theme) do %>
+<% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(current_theme) do %>
   <style data-turbo-track="reload">
     <%= theme_setting(:custom_font_css_import) if theme_setting(:custom_font_css_import).present? %>
 

--- a/storefront/app/views/themes/default/spree/shared/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_json_ld.html.erb
@@ -1,4 +1,4 @@
-<% cache spree_base_cache_scope.call(current_store) do %>
+<% cache spree_storefront_base_cache_scope.call(current_store) do %>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/storefront/app/views/themes/default/spree/shared/_order_details.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_details.html.erb
@@ -21,7 +21,7 @@
 <%== color_options_style_for_line_items(shipments.flat_map(&:line_items)) %>
 
 <ul>
-  <%= render partial: 'spree/shared/order_shipment', collection: shipments, as: :shipment, cached: spree_base_cache_scope %>
+  <%= render partial: 'spree/shared/order_shipment', collection: shipments, as: :shipment, cached: spree_storefront_base_cache_scope %>
 </ul>
 
 <% if order.special_instructions.present? %>
@@ -52,7 +52,7 @@
         <%= Spree.t(:payment_information) %>
       </div>
       <div class="!leading-[1.375rem] text-neutral-800">
-        <%= render collection: order.payments.valid, partial: 'spree/shared/payment', cached: spree_base_cache_scope %>
+        <%= render collection: order.payments.valid, partial: 'spree/shared/payment', cached: spree_storefront_base_cache_scope %>
       </div>
     </div>
   </div>

--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -65,6 +65,6 @@
     <%= render partial: "spree/shared/order_line_item",
     collection: shipment.inventory_units,
     as: :inventory_unit,
-    cached: spree_base_cache_scope %>
+    cached: spree_storefront_base_cache_scope %>
   </div>
 </li>

--- a/storefront/app/views/themes/default/spree/wishlists/show.html.erb
+++ b/storefront/app/views/themes/default/spree/wishlists/show.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <% if @wished_items.any? %>
       <div class="grid lg:grid-cols-3 gap-x-6 gap-y-10 lg:mb-24">
-        <%= render collection: @wished_items, partial: 'spree/wishlists/wished_item', cached: ->(wished_item) { [*spree_base_cache_scope.call(wished_item), wished_item.variant, current_currency] } %>
+        <%= render collection: @wished_items, partial: 'spree/wishlists/wished_item', cached: ->(wished_item) { [*spree_storefront_base_cache_scope.call(wished_item), wished_item.variant, current_currency] } %>
       </div>
     <% else %>
       <%= render 'no_wished_items' %>


### PR DESCRIPTION
To not pollute with storefront specific keys (order/wishlist) into other parts of the Spree stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Introduced storefront-specific caching across checkout, products, account, navigation, and page sections to improve cache accuracy and page load performance.
  - Simplified base cache key to depend on locale, currency, and user role data with safe fallbacks, altering cache invalidation behavior.

- Style
  - Checkout summary now truncates overly long adjustment labels for a cleaner, more readable layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->