### PR TITLE
Allow for more pages to be added as links in page builder

### DIFF
--- a/admin/app/helpers/spree/admin/page_builder_helper.rb
+++ b/admin/app/helpers/spree/admin/page_builder_helper.rb
@@ -81,10 +81,10 @@ module Spree
 
       def all_linkable_pages
         @all_linkable_pages ||= Spree::Page.
-                                linkable.
                                 without_previews.
                                 where(pageable: [@theme, current_store]).
-                                map { |page| [page.display_name, page.id] }
+                                select(&:linkable?).
+                                map { |page| [page.display_name, page.id] }.sort_by(&:first)
       end
 
       def all_linkable_policies

--- a/core/app/models/spree/page.rb
+++ b/core/app/models/spree/page.rb
@@ -103,6 +103,10 @@ module Spree
       false
     end
 
+    def linkable?
+      false
+    end
+
     def layout_sections?
       true
     end

--- a/core/app/models/spree/pages/account.rb
+++ b/core/app/models/spree/pages/account.rb
@@ -10,6 +10,10 @@ module Spree
       def icon_name
         'user'
       end
+
+      def linkable?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/pages/cart.rb
+++ b/core/app/models/spree/pages/cart.rb
@@ -4,6 +4,10 @@ module Spree
       def icon_name
         'shopping-cart'
       end
+
+      def linkable?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/pages/custom.rb
+++ b/core/app/models/spree/pages/custom.rb
@@ -5,6 +5,10 @@ module Spree
         true
       end
 
+      def linkable?
+        true
+      end
+
       def page_builder_url
         return unless page_builder_url_exists?(:page_path)
 

--- a/core/app/models/spree/pages/homepage.rb
+++ b/core/app/models/spree/pages/homepage.rb
@@ -11,6 +11,10 @@ module Spree
         'home'
       end
 
+      def linkable?
+        true
+      end
+
       def default_sections
         sections = [
           Spree::PageSections::ImageWithText.new(

--- a/core/app/models/spree/pages/login.rb
+++ b/core/app/models/spree/pages/login.rb
@@ -10,6 +10,10 @@ module Spree
 
         Spree::Core::Engine.routes.url_helpers.login_path
       end
+
+      def linkable?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/pages/post_list.rb
+++ b/core/app/models/spree/pages/post_list.rb
@@ -27,6 +27,10 @@ module Spree
       def customizable?
         true
       end
+
+      def linkable?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/pages/shop_all.rb
+++ b/core/app/models/spree/pages/shop_all.rb
@@ -31,6 +31,10 @@ module Spree
       def customizable?
         true
       end
+
+      def linkable?
+        true
+      end
     end
   end
 end

--- a/core/app/models/spree/pages/wishlist.rb
+++ b/core/app/models/spree/pages/wishlist.rb
@@ -6,6 +6,10 @@ module Spree
 
         Spree::Core::Engine.routes.url_helpers.account_wishlist_path
       end
+
+      def linkable?
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
Also allow developers to link to ther custom / new page types by addeding `linkable?` method in class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Link picker now shows only pages that can be linked, reducing clutter.
  - Pages in the picker are sorted alphabetically by name for faster selection.

- Bug Fixes
  - Resolves occasional errors when attempting to link to system pages that previously lacked linkability info.

- Chores
  - Internal consistency updates to support linkability across built-in page types without altering existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->