### PR TITLE
Added missing `compare_at_amount` keys to Line Items in Storefront API

### DIFF
--- a/api/app/serializers/spree/v2/storefront/line_item_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/line_item_serializer.rb
@@ -10,7 +10,8 @@ module Spree
                    :discounted_amount, :display_discounted_amount,
                    :display_additional_tax_total, :promo_total, :display_promo_total,
                    :included_tax_total, :display_included_tax_total,
-                   :pre_tax_amount, :display_pre_tax_amount, :public_metadata
+                   :pre_tax_amount, :display_pre_tax_amount, :compare_at_amount, :display_compare_at_amount,
+                   :public_metadata
 
         belongs_to :variant
         has_many :digital_links

--- a/api/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
+++ b/api/spec/serializers/spree/v2/storefront/line_item_serializer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Spree::V2::Storefront::LineItemSerializer do
+  subject { described_class.new(line_item).serializable_hash }
+
+  include_context 'API v2 serializers params'
+
+  let!(:line_item) { create(:line_item) }
+
+  it { expect(subject).to be_kind_of(Hash) }
+
+  describe 'attributes' do
+    it 'returns expected attributes' do
+      expect(subject[:data][:attributes]).to include(
+        name: line_item.name,
+        quantity: line_item.quantity,
+        price: line_item.price,
+        slug: line_item.slug,
+        options_text: line_item.options_text,
+        currency: line_item.currency,
+        display_price: line_item.display_price,
+        total: line_item.total,
+        display_total: line_item.display_total,
+        adjustment_total: line_item.adjustment_total,
+        display_adjustment_total: line_item.display_adjustment_total,
+        additional_tax_total: line_item.additional_tax_total,
+        discounted_amount: line_item.discounted_amount,
+        display_discounted_amount: line_item.display_discounted_amount,
+        display_additional_tax_total: line_item.display_additional_tax_total,
+        promo_total: line_item.promo_total,
+        display_promo_total: line_item.display_promo_total,
+        included_tax_total: line_item.included_tax_total,
+        display_included_tax_total: line_item.display_included_tax_total,
+        pre_tax_amount: line_item.pre_tax_amount,
+        display_pre_tax_amount: line_item.display_pre_tax_amount,
+        compare_at_amount: line_item.compare_at_amount,
+        display_compare_at_amount: line_item.display_compare_at_amount,
+        public_metadata: line_item.public_metadata
+      )
+    end
+  end
+
+  describe 'relationships' do
+    it 'includes variant relationship' do
+      expect(subject[:data][:relationships]).to have_key(:variant)
+    end
+
+    it 'includes digital_links relationship' do
+      expect(subject[:data][:relationships]).to have_key(:digital_links)
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Storefront API line item responses now include compare_at_amount and display_compare_at_amount, providing both numeric and formatted values in addition to existing pricing fields. Existing attributes remain unchanged.

- Tests
  - Added test coverage to validate presence of the new fields in serialized line items and to confirm expected relationships are still returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->