### PR TITLE
Fix newsletter section rendering by passing loaded flag

### DIFF
--- a/storefront/app/views/spree/newsletter_subscribers/create.turbo_stream.erb
+++ b/storefront/app/views/spree/newsletter_subscribers/create.turbo_stream.erb
@@ -2,6 +2,6 @@
 
 <% if @newsletter_section.present? %>
   <%= turbo_stream.update "section-#{@newsletter_section.id}" do %>
-    <%= render 'spree/page_sections/newsletter', section: @newsletter_section %>
+    <%= render 'spree/page_sections/newsletter', section: @newsletter_section, loaded: true %>
   <% end %>
 <% end %>

--- a/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb
@@ -1,3 +1,5 @@
+<% loaded ||= false %>
+
 <div class="w-full flex justify-center items-center relative min-h-[200px]" style="<%= section_styles(section) %>">
   <% if loaded %>
     <% img = section.image %>


### PR DESCRIPTION
### Summary
Prevent undefined variable error in `storefront/app/views/themes/default/spree/page_sections/_newsletter.html.erb` by setting default false.
Pass loaded: true in `storefront/app/views/spree/newsletter_subscribers/create.turbo_stream.erb` render so the full section shows after submit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newsletter section now updates reliably after subscribing, showing the correct loaded state without flicker or partial content.
  * Ensures consistent default behavior when the newsletter section hasn’t finished loading, preventing premature rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->