### PR TITLE
Clean up after payment method is deleted

### DIFF
--- a/admin/app/helpers/spree/admin/payments_helper.rb
+++ b/admin/app/helpers/spree/admin/payments_helper.rb
@@ -2,6 +2,8 @@ module Spree
   module Admin
     module PaymentsHelper
       def payment_method_name(payment)
+        return unless payment.payment_method.present?
+
         payment_method = payment.payment_method
 
         if can?(:update, payment_method)

--- a/admin/app/views/spree/admin/payments/_payment.html.erb
+++ b/admin/app/views/spree/admin/payments/_payment.html.erb
@@ -10,7 +10,7 @@
       <% end %>
       <%= Spree.t('payment_states.' + payment.state) %>
     </span>
-    <% if payment.payment_method.payment_icon_name.present? %>
+    <% if payment.payment_method.present? && payment.payment_method.payment_icon_name.present? %>
       <%= payment_method_icon_tag(payment.payment_method.payment_icon_name) %>
     <% end %>
     <strong><%= payment.number.upcase %></strong>
@@ -28,13 +28,13 @@
           <%= link_to_with_icon 'eye', Spree.t(:details), spree.admin_gift_card_path(payment.source.originator), class: 'dropdown-item' %>
         <% end %>
 
-        <% if can?(:update, payment) && (payment.checkout? || payment.pending?) %>
+        <% if can?(:update, payment) && (payment.checkout? || payment.pending?) && payment.payment_method.present? %>
           <%= link_to_with_icon 'check', Spree.t(:capture), spree.capture_admin_order_payment_path(@order, payment), class: 'dropdown-item', data: { turbo_method: :put, turbo_confirm: Spree.t(:are_you_sure) } %>
         <% end %>
-        <% if can?(:refund, @order) && payment.completed? && payment.can_credit? %>
+        <% if can?(:refund, @order) && payment.completed? && payment.can_credit? && payment.payment_method.present? %>
           <%= link_to_with_icon 'credit-card-refund', Spree.t(:refund), spree.new_admin_order_payment_refund_path(@order, payment), class: 'dropdown-item' %>
         <% end %>
-        <% if can?(:cancel, payment) && payment.pending? %>
+        <% if can?(:cancel, payment) && payment.pending? && payment.payment_method.present? %>
           <div class="dropdown-divider"></div>
           <%= link_to_with_icon 'cancel', Spree.t(:void), spree.void_admin_order_payment_path(@order, payment), class: 'dropdown-item btn-danger', data: { turbo_method: :put, turbo_confirm: Spree.t(:are_you_sure) } %>
         <% end %>
@@ -52,7 +52,7 @@
         <strong><%= payment.display_amount %></strong>
 
         <p class="mb-1 mt-2"><%= Spree.t(:payment_method) %>:</p>
-        <strong><%= link_to payment.payment_method.name, spree.admin_payment_method_path(payment.payment_method) %></strong>
+        <strong><%= payment_method_name(payment) %></strong>
 
         <% if payment.transaction_id.present? %>
           <p class="mb-1 mt-2">

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -205,16 +205,30 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
 
     let(:order) { create(:order_ready_to_ship, total: 100, with_payment: false, store: store) }
 
-    let!(:invalid_payment) { create(:payment, state: 'invalid', amount: 100, order: order) }
-    let!(:valid_payment) { create(:payment, state: 'completed', amount: 100, order: order) }
+    let(:invalid_payment) { create(:payment, state: 'invalid', amount: order.total, order: order) }
+    let(:valid_payment) { create(:payment, state: 'completed', amount: order.total, order: order) }
 
     it 'shows an order' do
+      invalid_payment
+      valid_payment
       subject
 
       expect(assigns[:order]).to eq(order)
       expect(assigns[:line_items]).to eq(order.line_items)
       expect(assigns[:shipments]).to eq(order.shipments)
       expect(assigns[:payments]).to contain_exactly(valid_payment, invalid_payment)
+    end
+
+    context 'when payment method is destroyed' do
+      let(:payment_method) { create(:credit_card_payment_method) }
+      let!(:payment) { create(:payment, payment_method: payment_method, source: credit_card, order: order, amount: order.total) }
+      let!(:credit_card) { create(:credit_card, payment_method: payment_method) }
+
+      it 'shows an order' do
+        subject
+        expect(response).to render_template(:edit)
+        expect(assigns[:payments]).to contain_exactly(payment)
+      end
     end
   end
 

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -224,6 +224,10 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
       let!(:payment) { create(:payment, payment_method: payment_method, source: credit_card, order: order, amount: order.total) }
       let!(:credit_card) { create(:credit_card, payment_method: payment_method) }
 
+      before do
+        payment_method.destroy
+      end
+
       it 'shows an order' do
         subject
         expect(response).to render_template(:edit)

--- a/api/app/serializers/spree/v2/storefront/payment_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/payment_serializer.rb
@@ -10,7 +10,7 @@ module Spree
         attributes :amount, :response_code, :number, :cvv_response_code, :cvv_response_message, :payment_method_name, :state, :public_metadata
 
         attribute :payment_method_id do |payment|
-          payment.payment_method_id.to_s
+          payment.payment_method_id&.to_s
         end
       end
     end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -22,12 +22,10 @@ module Spree
     has_many :store_payment_methods, class_name: 'Spree::StorePaymentMethod'
     has_many :stores, class_name: 'Spree::Store', through: :store_payment_methods
 
-    with_options dependent: :restrict_with_error do
-      has_many :payments, class_name: 'Spree::Payment', inverse_of: :payment_method
-      has_many :credit_cards, class_name: 'Spree::CreditCard'
-    end
+    has_many :payments, class_name: 'Spree::Payment', inverse_of: :payment_method, dependent: :nullify
+    has_many :credit_cards, class_name: 'Spree::CreditCard', dependent: :destroy # CCs are soft deleted
 
-    has_many :gateway_customers, class_name: 'Spree::GatewayCustomer'
+    has_many :gateway_customers, class_name: 'Spree::GatewayCustomer', dependent: :destroy
 
     def self.providers
       Rails.application.config.spree.payment_methods

--- a/core/app/views/spree/shared/_payment.html.erb
+++ b/core/app/views/spree/shared/_payment.html.erb
@@ -20,7 +20,7 @@
           <%= @order.display_gift_card_total %>
         </div>
       </div>
-    <% elsif payment_method_icon_tag(payment.payment_method.payment_icon_name).present? %>
+    <% elsif payment.payment_method.present? && payment_method_icon_tag(payment.payment_method.payment_icon_name).present? %>
       <div class="d-flex flex align-items-center items-center">
         <div><%= payment_method_icon_tag(payment.payment_method.payment_icon_name) %></div>
         <div class="ml-3"><%= Spree.t(:store_credit_name) %></div>
@@ -31,7 +31,7 @@
       <%= payment_method_icon_tag source.class.to_s.demodulize.downcase, height: 30 %>
     </div>
     <div>
-      <% if payment.payment_method.respond_to?(:source_partial_name) %>
+      <% if payment.payment_method.present? && payment.payment_method.respond_to?(:source_partial_name) %>
         <%= render partial: "spree/payment_sources/#{payment.payment_method.source_partial_name}", locals: { payment: payment, source: source } %>
       <% elsif source.respond_to?(:name) %>
         <%= source.name %>
@@ -39,7 +39,7 @@
         <%= source.class.to_s.demodulize.downcase %>
       <% end %>
     </div>
-  <% else %>
+  <% elsif payment.payment_method.present? %>
     <div class="flex-shrink-0">
       <%= payment_method_icon_tag payment.payment_method.payment_icon_name %>
     </div>

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -184,4 +184,18 @@ describe Spree::PaymentMethod, type: :model do
   describe '#payment_icon_name' do
     it { expect(build(:credit_card_payment_method, type: 'Spree::Gateway::AuthorizeNetGateway').payment_icon_name).to eq('authorizenet') }
   end
+
+  context 'when payment method is destroyed' do
+    let(:payment_method) { create(:credit_card_payment_method) }
+    let!(:payment) { create(:payment, payment_method: payment_method, source: credit_card) }
+    let!(:credit_card) { create(:credit_card, payment_method: payment_method) }
+    let!(:gateway_customer) { create(:gateway_customer, payment_method: payment_method) }
+
+    it 'destroys the payment method' do
+      expect { payment_method.destroy }.to change(Spree::PaymentMethod, :count).by(-1).and change(Spree::CreditCard, :count).by(-1).and change(Spree::GatewayCustomer, :count).by(-1)
+      expect(payment.reload.payment_method).to be_nil
+      expect(credit_card.reload.payment_method).to be_nil
+      expect(credit_card.reload.deleted_at).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Also added ability to remove a previously used payment method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now delete a payment method even if it has historical payments. Existing payments remain but are disassociated; related saved cards and gateway profiles are removed.

- Bug Fixes
  - Prevented errors and broken icons when payments lack an associated payment method in storefront and admin views.
  - Admin actions (capture, refund, void) only appear when valid, avoiding failures on missing methods.
  - API returns null for missing payment_method_id instead of an empty string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->