### PR TITLE
Fix track quantity for line items

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -84,7 +84,7 @@ module Spree
       end
 
       # adding to this shipment, and removing from stock_location
-      if order.completed?
+      if order.completed? && variant.should_track_inventory?
         shipment.stock_location.unstock(variant, quantity, shipment)
       end
 

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -15,7 +15,7 @@ describe Spree::OrderInventory, type: :model do
     end
   end
 
-  context '#add_to_shipment' do
+  describe '#add_to_shipment' do
     let(:shipment) { order.shipments.first }
 
     context 'order is not completed' do
@@ -49,6 +49,8 @@ describe Spree::OrderInventory, type: :model do
       it 'creates only on hand inventory units' do
         variant.stock_items.destroy_all
 
+        expect_any_instance_of(Spree::StockLocation).not_to receive(:unstock)
+
         # The before_save callback in LineItem would verify inventory
         line_item = Spree::Cart::AddItem.call(order: order, variant: variant, options: { shipment: shipment }).value
 
@@ -65,6 +67,8 @@ describe Spree::OrderInventory, type: :model do
 
       it 'creates only on hand inventory units' do
         variant.stock_items.destroy_all
+
+        expect_any_instance_of(Spree::StockLocation).not_to receive(:unstock)
 
         line_item = Spree::Cart::AddItem.call(order: order, variant: variant).value
         subject.verify(shipment)
@@ -85,7 +89,7 @@ describe Spree::OrderInventory, type: :model do
     end
   end
 
-  context '#determine_target_shipment' do
+  describe '#determine_target_shipment' do
     let(:stock_location) { create :stock_location }
     let(:variant) { line_item.variant }
 
@@ -142,7 +146,7 @@ describe Spree::OrderInventory, type: :model do
       expect(subject.inventory_units.reload.sum(:quantity)).to eq 2
     end
 
-    context '#remove_from_shipment' do
+    describe '#remove_from_shipment' do
       let!(:shipment) { order.shipments.first }
       let!(:variant) { subject.variant }
       let!(:inventory_units_for_item) do

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -15,7 +15,7 @@ describe Spree::OrderInventory, type: :model do
     end
   end
 
-  describe '#add_to_shipment' do
+  context '#add_to_shipment' do
     let(:shipment) { order.shipments.first }
 
     context 'order is not completed' do
@@ -89,7 +89,7 @@ describe Spree::OrderInventory, type: :model do
     end
   end
 
-  describe '#determine_target_shipment' do
+  context '#determine_target_shipment' do
     let(:stock_location) { create :stock_location }
     let(:variant) { line_item.variant }
 
@@ -146,7 +146,7 @@ describe Spree::OrderInventory, type: :model do
       expect(subject.inventory_units.reload.sum(:quantity)).to eq 2
     end
 
-    describe '#remove_from_shipment' do
+    context '#remove_from_shipment' do
       let!(:shipment) { order.shipments.first }
       let!(:variant) { subject.variant }
       let!(:inventory_units_for_item) do


### PR DESCRIPTION
Before: <img width="1094" height="485" alt="Zrzut ekranu 2025-09-6 o 16 53 59" src="https://github.com/user-attachments/assets/8b5a41cf-6da2-4f23-b683-8fb95c5b9f11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents inventory from being decremented for items that don’t track inventory, even in completed orders, avoiding unintended stock changes.

- Tests
  - Added test coverage to ensure no unstocking occurs when inventory tracking is disabled at the store or variant level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->