### PR TITLE
Fix/export date filter normalization

### DIFF
--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -148,17 +148,20 @@ module Spree
     def normalize_search_params
       return if search_params.blank?
 
-      if search_params.is_a?(Hash)
-        params_hash = search_params.deep_dup
-        self.search_params = normalize_date_filters(params_hash).to_json
-      else
-        begin
-          params_hash = JSON.parse(search_params.to_s)
-          self.search_params = normalize_date_filters(params_hash).to_json
-        rescue JSON::ParserError
-          # keep original input
+      params_hash =
+        case search_params
+        when Hash
+          search_params.deep_dup
+        else
+          begin
+            JSON.parse(search_params.to_s)
+          rescue JSON::ParserError => e
+            self.search_params = nil
+            return
+          end
         end
-      end
+
+      self.search_params = normalize_date_filters(params_hash).to_json if params_hash.present?
     end
 
     def current_ability

--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -150,6 +150,12 @@ module Spree
           begin
             JSON.parse(search_params.to_s)
           rescue JSON::ParserError => e
+            Rails.error.report(
+              e,
+              handled: true,
+              severity: :warning,
+              context: { component: 'Spree::Export', method: 'normalize_search_params', raw: search_params.to_s, export_id: id }
+            )
             self.search_params = nil
             return
           end
@@ -240,7 +246,13 @@ module Spree
         else
           ''
         end
-      rescue StandardError
+      rescue ArgumentError => e
+        Rails.error.report(
+          e,
+          handled: true,
+          severity: :warning,
+          context: { component: 'Spree::Export', method: 'parse_to_day_boundary', value: value, boundary: boundary, export_id: id }
+        )
         ''
       end
     end
@@ -254,7 +266,13 @@ module Spree
         begin
           parsed = Time.use_zone(store_timezone) { Time.zone.parse(value) }
           parsed ? parsed.iso8601 : ''
-        rescue StandardError
+        rescue ArgumentError => e
+          Rails.error.report(
+            e,
+            handled: true,
+            severity: :warning,
+            context: { component: 'Spree::Export', method: 'normalize_single_date_filter', value: value, export_id: id }
+          )
           ''
         end
       elsif value.is_a?(String)

--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -270,15 +270,17 @@ module Spree
 
     def date_time_like?(value)
       return false unless value.is_a?(String)
-
-      !!(
-        value.match(/\A\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(:\d{2})?(Z|[+-]\d{2}:?\d{2})?)?\z/) ||
-        value.match(/[A-Za-z]{3}, \d{1,2} [A-Za-z]{3} \d{4}/)
-      )
+      s = value.strip
+      return true if date_only?(s)
+      return true if /\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?(Z|[+\-]\d{2}:?\d{2})?\z/.match?(s)
+      return true if /\A\d{1,2}\/\d{1,2}\/\d{2,4}(\s+\d{1,2}:\d{2}(:\d{2})?\s*(AM|PM|am|pm)?)?\z/.match?(s)
+      return true if /\A\w{3},\s\d{1,2}\s\w{3}\s\d{4}\s\d{2}:\d{2}:\d{2}\s(UTC|GMT|[A-Z]{3})\z/.match?(s)
+      (s.match?(/[\-\/]\d{1,2}/) && s.match?(/\d{2}:\d{2}/))
     end
-    
-    def date_attribute?(attr)
-      attr.to_s.match?(/(_at|_on|_date|date)$/i)
+
+    def date_attribute?(attr_name)
+      return false if attr_name.blank?
+      attr_name.to_s.match?(/(_at|_on|_date|date)$/i)
     end
   end
 end

--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -232,7 +232,7 @@ module Spree
     end
 
     def parse_to_day_boundary(value, boundary)
-      timezone = store&.preferred_timezone.presence || Time.zone.name || 'UTC'
+      timezone = store.preferred_timezone.presence || Time.zone.name || 'UTC'
 
       begin
         date = value.respond_to?(:to_date) ? value.to_date : Date.parse(value.to_s)

--- a/core/spec/models/spree/export_spec.rb
+++ b/core/spec/models/spree/export_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe Spree::Export, :job, type: :model do
     end
 
     context 'with invalid JSON string' do
-      it 'preserves the original string' do
+      it 'sets search_params to nil to avoid crashes' do
         export.search_params = '{invalid: json'
         expect { export.normalize_search_params }.not_to raise_error
-        expect(export.search_params).to eq('{invalid: json')
+        expect(export.search_params).to be_nil
       end
     end
 


### PR DESCRIPTION
Ensure export search filters with same-day date ranges expand to the whole day.  
This prevents queries like `completed_at > X AND completed_at < X` from returning no results.  

Changes:
- Normalize `created_at` and `completed_at` filters to beginning/end of day.
- Handle invalid date values safely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Date-only export filters for created_at and completed_at are expanded to full-day boundaries using the store’s preferred timezone when saved.
  - Date normalization now runs at save time when export search parameters are present.

- Bug Fixes
  - Malformed or invalid JSON/date inputs are cleared to prevent errors instead of causing failures.
  - Invalid date values are dropped (set empty) rather than raising.

- Tests
  - Added tests for full-day expansion, timezone correctness, and invalid JSON/date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize export search_params on save, parsing/validating JSON and expanding date-only filters to full-day ISO8601 values using store timezone.
> 
> - **Model (`core/app/models/spree/export.rb`)**
>   - Run `normalize_search_params` on `before_save` (replacing create-time validation hook).
>   - Rework `normalize_search_params` to:
>     - Parse JSON or duplicate Hash; on parse error, report and set `search_params` to `nil`.
>     - Normalize date filters (`*_gt/gteq/lt/lteq`) for date-like attributes to ISO8601:
>       - Date-only inputs expand to beginning/end of day in store timezone.
>       - Date-time strings parsed in store timezone; invalid strings become empty.
>   - Add helpers: `normalize_date_filters`, `normalize_single_date_filter`, `parse_to_day_boundary`, `date_only?`, `date_time_like?`, `date_attribute?`.
> - **Tests (`core/spec/models/spree/export_spec.rb`)**
>   - Set store `preferred_timezone` to `UTC` in fixtures.
>   - Update invalid JSON behavior to set `search_params` to `nil`.
>   - Add specs verifying full-day expansion, timezone handling, and invalid date handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd2fdcb47b5b26486f9317db000eaffe453675c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->