### PR TITLE
Make Policies more flexible, also add ability to attach Page Links to…

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/plugins/_trix_custom.scss
+++ b/admin/app/assets/stylesheets/spree/admin/plugins/_trix_custom.scss
@@ -67,6 +67,11 @@ trix-toolbar .trix-button, trix-toolbar .trix-button-group {
   margin-bottom: 0 !important;
 }
 
+trix-toolbar .trix-button {
+  width: 32px !important;
+  height: 28px !important;
+  padding: 4px;
+}
 trix-toolbar .trix-button:hover {
   background-color: $border-color !important;
   color: theme-color('black') !important;

--- a/admin/app/controllers/spree/admin/page_links_controller.rb
+++ b/admin/app/controllers/spree/admin/page_links_controller.rb
@@ -18,6 +18,10 @@ module Spree
                               spree.edit_admin_page_section_path(@parent)
                             elsif @parent.is_a?(Spree::PageBlock)
                               spree.edit_admin_page_section_block_path(@parent.section, @parent)
+                            elsif @parent.is_a?(Spree::Store)
+                              spree.edit_admin_store_path(section: :checkout)
+                            else
+                              [:admin, @parent, :links]
                             end
       end
 
@@ -28,6 +32,8 @@ module Spree
                       Spree::PageBlock.find(params[:block_id])
                     elsif params[:page_section_id].present?
                       Spree::PageSection.find(params[:page_section_id])
+                    elsif params[:store_id].present?
+                      current_store
                     end
       end
 
@@ -39,7 +45,7 @@ module Spree
         @page_link.linkable ||= @parent.default_linkable_resource
       end
 
-      # for create action we don't pass the page_link at all
+      # for create action we don't pass    page_link at all
       def permitted_resource_params
         if params[:page_link].present?
           params.require(:page_link).permit(permitted_page_link_attributes)

--- a/admin/app/controllers/spree/admin/page_links_controller.rb
+++ b/admin/app/controllers/spree/admin/page_links_controller.rb
@@ -13,6 +13,10 @@ module Spree
 
       private
 
+      def find_resource
+        model_class.accessible_by(current_ability, :manage).find(params[:id])
+      end
+
       def collection_url
         @collection_url ||= if @parent.is_a?(Spree::PageSection)
                               spree.edit_admin_page_section_path(@parent)
@@ -20,8 +24,6 @@ module Spree
                               spree.edit_admin_page_section_block_path(@parent.section, @parent)
                             elsif @parent.is_a?(Spree::Store)
                               spree.edit_admin_store_path(section: :checkout)
-                            else
-                              [:admin, @parent, :links]
                             end
       end
 

--- a/admin/app/controllers/spree/admin/policies_controller.rb
+++ b/admin/app/controllers/spree/admin/policies_controller.rb
@@ -6,7 +6,7 @@ module Spree
       private
 
       def collection
-        model_class.accessible_by(current_ability, :manage).order(:position)
+        model_class.accessible_by(current_ability, :manage)
       end
 
       def find_resource

--- a/admin/app/controllers/spree/admin/policies_controller.rb
+++ b/admin/app/controllers/spree/admin/policies_controller.rb
@@ -6,7 +6,11 @@ module Spree
       private
 
       def collection
-        super.order(:position)
+        model_class.accessible_by(current_ability, :manage).order(:position)
+      end
+
+      def find_resource
+        model_class.accessible_by(current_ability, :manage).friendly.find(params[:id])
       end
 
       def permitted_resource_params

--- a/admin/app/helpers/spree/admin/stores_helper.rb
+++ b/admin/app/helpers/spree/admin/stores_helper.rb
@@ -4,7 +4,7 @@ module Spree
       include Spree::ImagesHelper
 
       def available_stores
-        @available_stores ||= Spree::Store.accessible_by(current_ability).includes(:logo_attachment, :favicon_image_attachment, :default_custom_domain)
+        @available_stores ||= Spree::Store.accessible_by(current_ability, :manage).includes(:logo_attachment, :favicon_image_attachment, :default_custom_domain)
       end
 
       DEFAULT_ICON_SIZE = 40

--- a/admin/app/views/spree/admin/page_links/_form.html.erb
+++ b/admin/app/views/spree/admin/page_links/_form.html.erb
@@ -1,4 +1,4 @@
-<% data_action = (@page_link.persisted? ? { action: 'blur->auto-submit#submit' } : {}) %>
+<% data_action = (@page_link.persisted? && !@page_link.parent.is_a?(Spree::Store) ? { action: 'blur->auto-submit#submit' } : {}) %>
 
 <div class="form-group">
   <%= f.label :linkable_type, 'Link' %>
@@ -9,8 +9,8 @@
 <hr class="my-4" />
 
 <div class="form-group">
-  <%= f.label :label, 'Name' %>
-  <%= f.text_field :label, class: 'form-control', data: data_action, placeholder: 'eg. About us', required: true %>
+  <%= f.label :label, Spree.t(:name) %>
+  <%= f.text_field :label, class: 'form-control', data: data_action, required: true %>
 </div>
 
 <div class="custom-control custom-checkbox">

--- a/admin/app/views/spree/admin/page_links/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/page_links/create.turbo_stream.erb
@@ -1,5 +1,7 @@
 <% if @page_link.parent.is_a?(Spree::Store) %>
-
+  <%= turbo_stream.replace :checkout_links do %>
+    <%= render 'spree/admin/stores/form/checkout_links' %>
+  <% end %>
 <% else %>
   <%= turbo_stream.replace :page_sidebar do %>
     <%= render template: 'spree/admin/page_links/edit' %>

--- a/admin/app/views/spree/admin/page_links/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/page_links/create.turbo_stream.erb
@@ -1,4 +1,8 @@
-<%= turbo_stream.replace :page_sidebar do %>
-  <%= render template: 'spree/admin/page_links/edit' %>
+<% if @page_link.parent.is_a?(Spree::Store) %>
+
+<% else %>
+  <%= turbo_stream.replace :page_sidebar do %>
+    <%= render template: 'spree/admin/page_links/edit' %>
+  <% end %>
+  <%= render 'spree/admin/page_links/refresh_theme_preview' %>
 <% end %>
-<%= render 'spree/admin/page_links/refresh_theme_preview' %>

--- a/admin/app/views/spree/admin/page_links/destroy.turbo_stream.erb
+++ b/admin/app/views/spree/admin/page_links/destroy.turbo_stream.erb
@@ -1,11 +1,15 @@
-<%= turbo_stream.replace :page_sidebar do %>
-  <% if @page_link.parent.is_a?(Spree::PageSection) %>
-    <% @page_section = @page_link.parent %>
-    <%= render template: 'spree/admin/page_sections/edit' %>
-  <% elsif @page_link.parent.is_a?(Spree::PageBlock) %>
-    <% @page_block = @page_link.parent %>
-    <%= render template: 'spree/admin/page_blocks/edit' %>
+<% if @page_link.parent.is_a?(Spree::Store) %>
+  <%= turbo_stream.remove spree_dom_id(@page_link) %>
+<% else %>
+  <%= turbo_stream.replace :page_sidebar do %>
+    <% if @page_link.parent.is_a?(Spree::PageSection) %>
+      <% @page_section = @page_link.parent %>
+      <%= render template: 'spree/admin/page_sections/edit' %>
+    <% elsif @page_link.parent.is_a?(Spree::PageBlock) %>
+      <% @page_block = @page_link.parent %>
+      <%= render template: 'spree/admin/page_blocks/edit' %>
+    <% end %>
   <% end %>
-<% end %>
 
-<%= render 'spree/admin/page_links/refresh_theme_preview' %>
+  <%= render 'spree/admin/page_links/refresh_theme_preview' %>
+<% end %>

--- a/admin/app/views/spree/admin/page_links/edit.html.erb
+++ b/admin/app/views/spree/admin/page_links/edit.html.erb
@@ -1,5 +1,5 @@
 <% if @page_link.parent.is_a?(Spree::Store) %>
-  <%= turbo_frame_tag spree_dom_id(@page_link) do %>
+  <%= turbo_frame_tag spree_dom_id(@page_link), class: 'd-flex align-items-center w-100 py-2 px-3' do %>
     <%= link_to collection_url, class: 'btn-close position-absolute top-0 right-0 mt-1 mr-1' do %>
       <%= icon 'x', class: 'mr-0' %>
     <% end %>

--- a/admin/app/views/spree/admin/page_links/edit.html.erb
+++ b/admin/app/views/spree/admin/page_links/edit.html.erb
@@ -1,16 +1,29 @@
-<%= turbo_frame_tag :page_sidebar do %>
-  <h6 class="sidebar-header">
-    <%= link_to collection_url, data: { action: 'click->page-builder#clearActiveOverlays' }, class: 'btn hover-gray px-2' do %>
-      <%= icon 'chevron-left', class: 'mr-0' %>
+<% if @page_link.parent.is_a?(Spree::Store) %>
+  <%= turbo_frame_tag spree_dom_id(@page_link) do %>
+    <%= link_to collection_url, class: 'btn-close position-absolute top-0 right-0 mt-1 mr-1' do %>
+      <%= icon 'x', class: 'mr-0' %>
     <% end %>
-    <%= @page_link.label %>
-  </h6>
-  <div class="px-3 pb-5 mb-5 edit-block">
-    <%= form_for @page_link, url: spree.admin_page_link_path(@page_link), data: { controller: 'auto-submit' } do |f| %>
+    <%= form_for @page_link, url: spree.admin_page_link_path(@page_link), data: { controller: 'auto-submit' }, html: { class: 'w-100 mt-2' } do |f| %>
       <%= render 'spree/admin/page_links/form', f: f %>
+      <hr class="my-3">
+      <%= render 'spree/admin/shared/edit_resource_links', f: f %>
     <% end %>
-  </div>
-  <div class="sidebar-footer">
-    <%= link_to_delete(@page_link, url: spree.admin_page_link_path(@page_link)) %>
-  </div>
+  <% end %>
+<% else %>
+  <%= turbo_frame_tag :page_sidebar do %>
+    <h6 class="sidebar-header">
+      <%= link_to collection_url, data: { action: 'click->page-builder#clearActiveOverlays' }, class: 'btn hover-gray px-2' do %>
+        <%= icon 'chevron-left', class: 'mr-0' %>
+      <% end %>
+      <%= @page_link.label %>
+    </h6>
+    <div class="px-3 pb-5 mb-5 edit-block">
+      <%= form_for @page_link, url: spree.admin_page_link_path(@page_link), data: { controller: 'auto-submit' } do |f| %>
+        <%= render 'spree/admin/page_links/form', f: f %>
+      <% end %>
+    </div>
+    <div class="sidebar-footer">
+      <%= link_to_delete(@page_link, url: spree.admin_page_link_path(@page_link)) %>
+    </div>
+  <% end %>
 <% end %>

--- a/admin/app/views/spree/admin/page_links/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/page_links/update.turbo_stream.erb
@@ -3,4 +3,4 @@
     <%= render template: 'spree/admin/page_links/edit' %>
   <% end %>
 <% end %>
-<%= render 'spree/admin/page_links/refresh_theme_preview' %>
+<%= render 'spree/admin/page_links/refresh_theme_preview' unless @page_link.parent.is_a?(Spree::Store) %>

--- a/admin/app/views/spree/admin/page_links/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/page_links/update.turbo_stream.erb
@@ -1,6 +1,12 @@
-<% unless params[:sorting_only] %>
-  <%= turbo_stream.replace :page_sidebar do %>
-    <%= render template: 'spree/admin/page_links/edit' %>
+<% if @page_link.parent.is_a?(Spree::Store) %>
+  <%= turbo_stream.replace spree_dom_id(@page_link) do %>
+      <%= render template: 'spree/admin/page_links/edit' %>
+    <% end %>
+<% else %>
+  <% unless params[:sorting_only] %>
+    <%= turbo_stream.replace :page_sidebar do %>
+      <%= render template: 'spree/admin/page_links/edit' %>
+    <% end %>
   <% end %>
+  <%= render 'spree/admin/page_links/refresh_theme_preview' %>
 <% end %>
-<%= render 'spree/admin/page_links/refresh_theme_preview' unless @page_link.parent.is_a?(Spree::Store) %>

--- a/admin/app/views/spree/admin/policies/_filters.html.erb
+++ b/admin/app/views/spree/admin/policies/_filters.html.erb
@@ -1,0 +1,8 @@
+<%= search_form_for [:admin, search_collection], class: "filter-wrap", data: { controller: "filters" } do |f| %>
+  <div class="d-flex flex-column flex-lg-row gap-2">
+    <%= render 'spree/admin/shared/filters_search_bar', param: :name_i_cont, label: Spree.t(:name) %>
+  </div>
+
+  <%= render "spree/admin/shared/filter_badge_template" %>
+  <div data-filters-target="badgesContainer" class="filter-badges-container"></div>
+<% end %>

--- a/admin/app/views/spree/admin/policies/_form.html.erb
+++ b/admin/app/views/spree/admin/policies/_form.html.erb
@@ -3,6 +3,5 @@
     <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record?, data: { slug_form_target: 'name', action: 'slug-form#updateUrlFromName' } %>
     <%= f.spree_text_field :slug, required: true, data: { slug_form_target: 'url' } %>
     <%= f.spree_rich_text_area :body %>
-    <%= f.spree_check_box :show_in_checkout_footer %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/policies/_table_header.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_header.html.erb
@@ -1,5 +1,4 @@
 <tr>
-  <th scope="col"></th>
   <th scope="col"><%= Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:slug) %></th>
   <th scope="col"><%= Spree.t(:filled) %></th>

--- a/admin/app/views/spree/admin/policies/_table_header.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_header.html.erb
@@ -3,5 +3,6 @@
   <th scope="col"><%= Spree.t(:slug) %></th>
   <th scope="col"><%= Spree.t(:filled) %></th>
   <th scope="col"><%= Spree.t(:updated_at) %></th>
+  <th scope="col"><%= I18n.t('activerecord.attributes.spree/policy.owner') %></th>
   <th scope="col"></th>
 </tr>

--- a/admin/app/views/spree/admin/policies/_table_header.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_header.html.erb
@@ -2,7 +2,7 @@
   <th scope="col"></th>
   <th scope="col"><%= Spree.t(:name) %></th>
   <th scope="col"><%= Spree.t(:slug) %></th>
-  <th scope="col"><%= I18n.t('activerecord.attributes.spree/policy.show_in_checkout_footer') %></th>
+  <th scope="col"><%= Spree.t(:filled) %></th>
   <th scope="col"><%= Spree.t(:updated_at) %></th>
   <th scope="col"></th>
 </tr>

--- a/admin/app/views/spree/admin/policies/_table_row.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_row.html.erb
@@ -1,8 +1,8 @@
 <tr id="<%= spree_dom_id policy %>" data-controller="row-link">
-  <td class="w-40 cursor-pointer" data-action="click->row-link#openLink">
+  <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
     <%= link_to policy.name, spree.edit_admin_policy_path(policy), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link, turbo_frame: '_top' } %>
   </td>
-  <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
+  <td class="w-25 cursor-pointer" data-action="click->row-link#openLink">
     <code><%= policy.slug %></code>
   </td>
   <td class="w-10 cursor-pointer" data-action="click->row-link#openLink">
@@ -10,6 +10,9 @@
   </td>
   <td class="w-10 cursor-pointer" data-action="click->row-link#openLink">
     <%= spree_time(policy.updated_at) %>
+  </td>
+  <td class="w-15 cursor-pointer" data-action="click->row-link#openLink">
+    <%= policy.owner.name %>
   </td>
   <td class="w-10 actions">
     <%= link_to_edit(policy, class: 'btn btn-light btn-sm', data: { turbo_frame: '_top' }) if can?(:edit, policy) %>

--- a/admin/app/views/spree/admin/policies/_table_row.html.erb
+++ b/admin/app/views/spree/admin/policies/_table_row.html.erb
@@ -1,15 +1,12 @@
-<tr id="<%= spree_dom_id policy %>" data-controller="row-link" data-sortable-update-url="<%= spree.admin_policy_path(policy) %>">
-  <td class="w-10 move-handle text-center">
-    <%= icon('grip-vertical', class: 'rounded hover-gray p-2') %>
+<tr id="<%= spree_dom_id policy %>" data-controller="row-link">
+  <td class="w-40 cursor-pointer" data-action="click->row-link#openLink">
+    <%= link_to policy.name, spree.edit_admin_policy_path(policy), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link, turbo_frame: '_top' } %>
   </td>
   <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
-    <%= policy.name %>
-  </td>
-  <td class="w-30 cursor-pointer" data-action="click->row-link#openLink">
-    <%= link_to policy.slug, spree.edit_admin_policy_path(policy), class: 'text-decoration-none d-flex align-items-center font-weight-bold text-dark', data: { row_link_target: :link, turbo_frame: '_top' } %>
+    <code><%= policy.slug %></code>
   </td>
   <td class="w-10 cursor-pointer" data-action="click->row-link#openLink">
-    <%= active_badge(policy.show_in_checkout_footer) %>
+    <%= active_badge(policy.with_body?) %>
   </td>
   <td class="w-10 cursor-pointer" data-action="click->row-link#openLink">
     <%= spree_time(policy.updated_at) %>

--- a/admin/app/views/spree/admin/policies/index.html.erb
+++ b/admin/app/views/spree/admin/policies/index.html.erb
@@ -6,4 +6,4 @@
   <%= link_to_with_icon 'plus', Spree.t(:new_policy), new_object_url, class: 'btn btn-primary' if can?(:create, Spree::Policy) %>
 <% end %>
 
-<%= render 'spree/admin/shared/index_table', sortable: true %>
+<%= render 'spree/admin/shared/index_table' %>

--- a/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
@@ -8,12 +8,10 @@
       <%= nav_item(Spree.t(:users), spree.admin_admin_users_path, icon: 'users', active: %w[admin_users invitations roles].include?(controller_name)) %>
     <% end %>
 
-    <% if can?(:manage, current_store) %>
-      <%= nav_item(Spree.t(:emails), spree.edit_admin_store_path(section: 'emails'), icon: 'send', active: params[:section] == 'emails') %>
-      <%= nav_item(Spree.t(:policies), spree.admin_policies_path, icon: 'list-check') if can?(:manage, Spree::Policy) %>
-      <%= nav_item(Spree.t(:checkout), spree.edit_admin_store_path(section: 'checkout'), icon: 'shopping-cart', active: params[:section] == 'checkout') %>
-      <%= render_admin_partials(:store_settings_nav_partials) %>
-    <% end %>
+    <%= nav_item(Spree.t(:emails), spree.edit_admin_store_path(section: 'emails'), icon: 'send', active: params[:section] == 'emails') if can?(:manage, current_store) %>
+    <%= nav_item(Spree.t(:policies), spree.admin_policies_path, icon: 'list-check') if can?(:manage, Spree::Policy) %>
+    <%= nav_item(Spree.t(:checkout), spree.edit_admin_store_path(section: 'checkout'), icon: 'shopping-cart', active: params[:section] == 'checkout') if can?(:manage, current_store) %>
+    <%= render_admin_partials(:store_settings_nav_partials) %>
 
     <% if can?(:manage, Spree::CustomDomain) %>
       <%= nav_item(Spree.t(:domains), spree.admin_custom_domains_path, icon: 'world-www') %>

--- a/admin/app/views/spree/admin/stores/form/_checkout.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_checkout.html.erb
@@ -35,33 +35,6 @@
         <%= Spree.t('admin.checkout_settings.checkout_links.description') %>
       </div>
     </div>
-    <div>
-      <% if @store.links.any? %>
-        <ul class="list-group mb-3"
-            data-controller="sortable"
-            data-sortable-handle-value=".handle"
-            data-sortable-resource-name-value="page_link"
-            data-sortable-response-kind-value="turbo-stream">
-          <% @store.links.each do |link| %>
-            <li class="list-group-item p-0"
-                data-sortable-update-url="<%= spree.admin_page_link_path(link, sorting_only: true, format: :turbo_stream) %>"
-            >
-              <%= turbo_frame_tag spree_dom_id(link), class: 'd-flex align-items-center w-100 py-2 px-3' do %>
-                <%= link_to link.label, spree.edit_admin_page_link_path(link), class: 'd-block text-dark flex-fill' %>
-                <button class="btn btn-sm pr-0 handle hover-light h-100 px-1">
-                  <%= icon 'grip-vertical', class: 'mr-0' %>
-                </button>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      <% else %>
-        <p class="text-muted text-center p-5">
-          <%= Spree.t(:no_resource_found, resource: Spree::PageLink.model_name.human) %>
-        </p>
-      <% end %>
-
-      <%= link_to_with_icon 'plus', Spree.t(:add_link), spree.admin_page_link_path(@store), class: 'btn btn-primary w-100', data: { turbo_method: :post } %>
-    </div>
+    <%= render 'spree/admin/stores/form/checkout_links' %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/stores/form/_checkout.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_checkout.html.erb
@@ -2,12 +2,6 @@
 <%= Spree.t(:checkout) %> <%= Spree.t(:settings) %>
 <% end %>
 
-<div class="alert alert-info mb-3">
-  <p>
-    <%= Spree.t('admin.checkout_settings.policy_copy', policies_link: link_to(Spree.t(:policies), spree.admin_policies_path, class: 'alert-link')).html_safe %>
-  </p>
-</div>
-
 <div class="card mb-4">
   <div class="card-header">
     <h5 class="card-title"><%= Spree.t(:settings) %></h5>
@@ -27,5 +21,47 @@
 
   <div class="card-body">
     <%= f.spree_rich_text_area :checkout_message, label: false, help: Spree.t('admin.checkout_settings.checkout_message_description') %>
+  </div>
+</div>
+
+<div class="card mb-4">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t('admin.checkout_settings.checkout_links.label') %></h5>
+  </div>
+
+  <div class="card-body">
+    <div class="alert alert-info">
+      <div>
+        <%= Spree.t('admin.checkout_settings.checkout_links.description') %>
+      </div>
+    </div>
+    <div>
+      <% if @store.links.any? %>
+        <ul class="list-group mb-3"
+            data-controller="sortable"
+            data-sortable-handle-value=".handle"
+            data-sortable-resource-name-value="page_link"
+            data-sortable-response-kind-value="turbo-stream">
+          <% @store.links.each do |link| %>
+            <li class="list-group-item p-0"
+                data-sortable-update-url="<%= spree.admin_page_link_path(link, sorting_only: true, format: :turbo_stream) %>"
+            >
+              <%= turbo_frame_tag spree_dom_id(link), class: 'd-flex align-items-center w-100 py-2 px-3' do %>
+                <%= link_to link.label, spree.edit_admin_page_link_path(link), class: 'd-block text-dark flex-fill' %>
+                <button class="btn btn-sm pr-0 handle hover-light h-100 px-1">
+                  <%= icon 'grip-vertical', class: 'mr-0' %>
+                </button>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-muted text-center p-5">
+          <%= Spree.t(:no_resource_found, resource: Spree::PageLink.model_name.human) %>
+        </p>
+      <% end %>
+
+      <%= link_to_with_icon 'plus', Spree.t(:add_link), spree.admin_page_link_path(@store), class: 'btn btn-primary w-100', data: { turbo_method: :post } %>
+    </div>
   </div>
 </div>

--- a/admin/app/views/spree/admin/stores/form/_checkout_links.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_checkout_links.html.erb
@@ -1,0 +1,28 @@
+<div id="checkout_links">
+  <% if current_store.links.any? %>
+    <ul class="list-group mb-3"
+        data-controller="sortable"
+        data-sortable-handle-value=".handle"
+        data-sortable-resource-name-value="page_link"
+        data-sortable-response-kind-value="turbo-stream">
+      <% current_store.links.each do |link| %>
+        <li class="list-group-item p-0"
+            data-sortable-update-url="<%= spree.admin_page_link_path(link, sorting_only: true, format: :turbo_stream) %>"
+        >
+          <%= turbo_frame_tag spree_dom_id(link), class: 'd-flex align-items-center w-100 py-2 px-3' do %>
+            <%= link_to link.label, spree.edit_admin_page_link_path(link), class: 'd-block text-dark flex-fill' %>
+            <button class="btn btn-sm pr-0 handle hover-light h-100 px-1">
+              <%= icon 'grip-vertical', class: 'mr-0' %>
+            </button>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-muted text-center p-5">
+      <%= Spree.t(:no_resource_found, resource: Spree::PageLink.model_name.human) %>
+    </p>
+  <% end %>
+
+  <%= link_to_with_icon 'plus', Spree.t(:add_link), spree.admin_store_links_path(current_store), class: 'btn btn-primary w-100', data: { turbo_method: :post } %>
+</div>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -38,13 +38,13 @@ en:
             add_tags: Add tags
             remove_tags: Remove tags
       checkout_settings:
+        checkout_links:
+          description: Links to these pages will be displayed in the checkout footer.
+          label: Checkout links
         checkout_message_description: Visible to your customers on the checkout page in the right sidebar.
         guest_checkout:
           description: Allow customers to checkout without creating an account.
           label: Allow guest checkout
-        checkout_links:
-          label: Checkout links
-          description: Links to these pages will be displayed in the checkout footer.
         special_instructions:
           description: Allow customers to add special instructions to their order.
           label: Display the special instructions field

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -42,7 +42,9 @@ en:
         guest_checkout:
           description: Allow customers to checkout without creating an account.
           label: Allow guest checkout
-        policy_copy: Checkout footer links are added automatically based on the %{policies_link} content.
+        checkout_links:
+          label: Checkout links
+          description: Links to these pages will be displayed in the checkout footer.
         special_instructions:
           description: Allow customers to add special instructions to their order.
           label: Display the special instructions field

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -155,6 +155,7 @@ Spree::Core::Engine.add_routes do
     # setting up a new store
     resources :stores, only: [:new, :create] do
       resources :role_users, only: [:destroy]
+      resources :links, controller: 'page_links', only: [:create]
     end
     resources :policies, except: :show
     resources :payment_methods, except: :show

--- a/admin/spec/controllers/spree/admin/page_links_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/page_links_controller_spec.rb
@@ -64,6 +64,16 @@ RSpec.describe Spree::Admin::PageLinksController, type: :controller do
         expect(page_block.links.last.linkable).to be_a Spree::Pages::Homepage
       end
     end
+
+    context 'for store checkout' do
+      subject :post_create do
+        post :create, params: { store_id: store.id }, as: :turbo_stream
+      end
+
+      it 'creates a new page link' do
+        expect { post_create }.to change { store.page_links.count }.by 1
+      end
+    end
   end
 
   describe '#edit' do

--- a/admin/spec/controllers/spree/admin/policies_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/policies_controller_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::PoliciesController, type: :controller do
+  stub_authorization!
+  render_views
+
+  let(:store) { @default_store }
+
+  describe 'GET #index' do
+    subject(:index) { get :index }
+
+    let!(:policies) { create_list(:policy, 3, owner: store) }
+
+    it 'renders the list of policies' do
+      index
+
+      expect(response).to render_template(:index)
+      expect(assigns[:collection]).to contain_exactly(*store.policies)
+    end
+  end
+
+  describe 'GET #new' do
+    subject(:new) { get :new }
+
+    it 'renders the new policy page' do
+      new
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST #create' do
+    subject(:create_policy) { post :create, params: { policy: policy_params } }
+
+    let(:policy_params) do
+      {
+        name: 'Privacy Policy',
+        body: 'This is our privacy policy content',
+        slug: 'privacy-policy'
+      }
+    end
+
+    it 'creates a new policy' do
+      expect { create_policy }.to change(Spree::Policy, :count).by(1)
+
+      policy = Spree::Policy.last
+      expect(policy.name).to eq('Privacy Policy')
+      expect(policy.body.to_plain_text).to eq('This is our privacy policy content')
+      expect(policy.slug).to eq('privacy-policy')
+    end
+  end
+
+  describe 'GET #edit' do
+    subject(:edit) { get :edit, params: { id: policy.id } }
+
+    let(:policy) { create(:policy, owner: store) }
+
+    it 'renders the edit page' do
+      edit
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'PUT #update' do
+    subject(:update_policy) { put :update, params: { id: policy.id, policy: policy_params } }
+
+    let!(:policy) { create(:policy, owner: store) }
+    let(:policy_params) do
+      {
+        name: 'Updated Privacy Policy',
+        body: 'This is updated privacy policy content',
+        slug: 'updated-privacy-policy'
+      }
+    end
+
+    it 'updates the policy' do
+      update_policy
+      policy.reload
+
+      expect(policy.name).to eq('Updated Privacy Policy')
+      expect(policy.body.to_plain_text).to eq('This is updated privacy policy content')
+      expect(policy.slug).to eq('updated-privacy-policy')
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    subject(:destroy_policy) { delete :destroy, params: { id: policy.id } }
+
+    let!(:policy) { create(:policy, owner: store) }
+
+    it 'destroys the policy' do
+      expect { destroy_policy }.to change(Spree::Policy, :count).by(-1)
+    end
+  end
+end

--- a/api/app/serializers/spree/v2/storefront/policy_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/policy_serializer.rb
@@ -4,7 +4,7 @@ module Spree
       class PolicySerializer < BaseSerializer
         set_type :policy
 
-        attributes :name, :slug, :show_in_checkout_footer, :created_at, :updated_at
+        attributes :name, :slug, :created_at, :updated_at
 
         attribute :body do |object|
           object.body.to_plain_text

--- a/api/spec/requests/spree/api/v2/storefront/policies_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/policies_spec.rb
@@ -10,7 +10,7 @@ describe 'Storefront API v2 Policies spec', type: :request do
   end
 
   describe 'policies#index' do
-    let!(:other_store_policy) { create(:policy, slug: 'other-store-policy', store: other_store) }
+    let!(:other_store_policy) { create(:policy, slug: 'other-store-policy', owner: other_store) }
 
     before { get '/api/v2/storefront/policies' }
 
@@ -49,7 +49,7 @@ describe 'Storefront API v2 Policies spec', type: :request do
 
     context 'with locale set to pl' do
       let!(:localized_policy) do
-        policy = create(:policy, store: store, slug: 'localized-policy', name: 'Privacy Policy EN')
+        policy = create(:policy, owner: store, slug: 'localized-policy', name: 'Privacy Policy EN')
 
         I18n.with_locale(:pl) do
           policy.name = 'Polityka Prywatności'
@@ -93,7 +93,7 @@ describe 'Storefront API v2 Policies spec', type: :request do
     end
 
     context 'accessing policy from different store' do
-      let(:other_store_policy) { create(:policy, store: other_store, slug: 'other-policy') }
+      let(:other_store_policy) { create(:policy, owner: other_store, slug: 'other-policy') }
 
       before { get "/api/v2/storefront/policies/#{other_store_policy.slug}" }
 

--- a/api/spec/requests/spree/api/v2/storefront/policies_spec.rb
+++ b/api/spec/requests/spree/api/v2/storefront/policies_spec.rb
@@ -31,7 +31,6 @@ describe 'Storefront API v2 Policies spec', type: :request do
         expect(json_response['data']['type']).to eq('policy')
         expect(json_response['data']['attributes']['name']).to eq(policy.name)
         expect(json_response['data']['attributes']['slug']).to eq(policy.slug)
-        expect(json_response['data']['attributes']['show_in_checkout_footer']).to eq(policy.show_in_checkout_footer)
         expect(json_response['data']['attributes']['body']).to eq(policy.body.to_plain_text)
         expect(json_response['data']['attributes']['body_html']).to eq(policy.body.to_s)
         expect(json_response['data']['attributes']['created_at']).to be_present

--- a/core/app/models/spree/page_link.rb
+++ b/core/app/models/spree/page_link.rb
@@ -8,7 +8,7 @@ module Spree
     #
     # Associations
     #
-    belongs_to :parent, polymorphic: true, touch: true, counter_cache: true # Block or Section
+    belongs_to :parent, polymorphic: true, touch: true # Block or Section
     belongs_to :linkable, polymorphic: true, optional: true # Page, Product, etc.
     has_one :theme, through: :parent
 

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -35,8 +35,8 @@ module Spree
     #
     # Scopes
     #
-    scope :with_body, -> { where.not(body: nil) }
-    scope :without_body, -> { where(body: nil) }
+    scope :with_body,    -> { joins(:rich_text_body).distinct }
+    scope :without_body, -> { where.missing(:rich_text_body) }
 
     #
     #  Ransack

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -5,8 +5,6 @@ module Spree
 
     UNIQUENESS_SCOPE = %i[owner_id owner_type].freeze
 
-    acts_as_list scope: UNIQUENESS_SCOPE
-
     #
     # FriendlyId
     #

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -41,7 +41,7 @@ module Spree
     #
     #  Ransack
     #
-    self.whitelisted_ransackable_attributes = %w[name]
+    self.whitelisted_ransackable_attributes = %w[name owner_type owner_id]
 
     def page_builder_url
       return unless Spree::Core::Engine.routes.url_helpers.respond_to?(:policy_path)

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -14,6 +14,7 @@ module Spree
     include Spree::Webhooks::HasWebhooks if defined?(Spree::Webhooks::HasWebhooks)
     include Spree::Security::Stores if defined?(Spree::Security::Stores)
     include Spree::UserManagement
+    include Spree::HasPageLinks
 
     #
     # Magic methods
@@ -111,7 +112,7 @@ module Spree
 
     has_many :gift_cards, class_name: 'Spree::GiftCard', dependent: :destroy
 
-    has_many :policies, class_name: 'Spree::Policy', dependent: :destroy
+    has_many :policies, class_name: 'Spree::Policy', dependent: :destroy, as: :owner
 
     #
     # Page Builder associations
@@ -125,6 +126,7 @@ module Spree
              inverse_of: :store,
              dependent: :destroy
     has_one :default_theme, -> { without_previews.where(default: true) }, class_name: 'Spree::Theme', inverse_of: :store
+    alias theme default_theme
     has_many :theme_pages, class_name: 'Spree::Page', through: :themes, source: :pages
     has_many :theme_page_previews, class_name: 'Spree::Page', through: :theme_pages, source: :previews
     has_many :pages, -> { without_previews.custom }, class_name: 'Spree::Pages::Custom', dependent: :destroy, as: :pageable

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -103,7 +103,6 @@ en:
         name: Name
       spree/policy:
         body: Body
-        show_in_checkout_footer: Show in checkout footer
       spree/product:
         available_on: Available On
         cost_currency: Cost Currency

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
         name: Name
       spree/policy:
         body: Body
+        owner: Policy for
       spree/product:
         available_on: Available On
         cost_currency: Cost Currency

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1066,6 +1066,7 @@ en:
     field: Field
     filename: Filename
     fill_in_customer_info: Please fill in customer info
+    filled: Filled
     filter: Filter
     filter_results: Filter Results
     filterable: Filterable

--- a/core/db/migrate/20250811112056_create_spree_policies.rb
+++ b/core/db/migrate/20250811112056_create_spree_policies.rb
@@ -4,15 +4,11 @@ class CreateSpreePolicies < ActiveRecord::Migration[7.2]
       t.belongs_to :store, null: false
       t.string :slug, null: false
       t.string :name, null: false
-      t.boolean :show_in_checkout_footer, null: false, default: true
-      t.integer :position,               null: false, default: 0
 
       t.timestamps
     end
 
-    add_index :spree_policies, [:store_id, :slug],                    unique: true
-    add_index :spree_policies, [:store_id, :show_in_checkout_footer]
-    add_index :spree_policies, [:store_id, :position]
+    add_index :spree_policies, [:store_id, :slug], unique: true
     create_table :spree_policy_translations do |t|
       t.string :locale, null: false
       t.string :name

--- a/core/db/migrate/20250902143122_fix_policies_store_association.rb
+++ b/core/db/migrate/20250902143122_fix_policies_store_association.rb
@@ -1,0 +1,17 @@
+class FixPoliciesStoreAssociation < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :spree_policies, :owner, polymorphic: true, index: true
+
+    Spree::Policy.reset_column_information
+    Spree::Policy.all.each do |policy|
+      policy.update(owner: policy.store)
+    end
+
+    remove_index :spree_policies, [:store_id, :slug], unique: true
+    remove_index :spree_policies, [:store_id, :position]
+    remove_column :spree_policies, :store_id
+
+    add_index :spree_policies, [:owner_id, :owner_type, :slug], unique: true
+    add_index :spree_policies, [:owner_id, :owner_type, :position]
+  end
+end

--- a/core/db/migrate/20250902143122_fix_policies_store_association.rb
+++ b/core/db/migrate/20250902143122_fix_policies_store_association.rb
@@ -7,11 +7,12 @@ class FixPoliciesStoreAssociation < ActiveRecord::Migration[7.2]
       policy.update(owner: policy.store)
     end
 
-    remove_index :spree_policies, [:store_id, :slug], unique: true
-    remove_index :spree_policies, [:store_id, :position]
-    remove_column :spree_policies, :store_id
+    remove_index :spree_policies, [:store_id, :slug], unique: true, if_exists: true
+    remove_index :spree_policies, [:store_id, :position], if_exists: true
+    remove_column :spree_policies, :store_id, if_exists: true
+    remove_column :spree_policies, :show_in_checkout_footer, if_exists: true
+    remove_column :spree_policies, :position, if_exists: true
 
     add_index :spree_policies, [:owner_id, :owner_type, :slug], unique: true
-    add_index :spree_policies, [:owner_id, :owner_type, :position]
   end
 end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -144,7 +144,7 @@ module Spree
 
     @@payment_method_attributes = [:name, :type, :description, :active, :display_on, :auto_capture, :position]
 
-    @@policy_attributes = [:name, :slug, :body, :show_in_checkout_footer, :position]
+    @@policy_attributes = [:name, :slug, :body]
 
     @@post_attributes = [:title, :meta_title, :meta_description, :slug, :author_id, :post_category_id, :published_at, :content, :excerpt, :image, tag_list: []]
 

--- a/core/lib/spree/testing_support/factories/policy_factory.rb
+++ b/core/lib/spree/testing_support/factories/policy_factory.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :policy, class: 'Spree::Policy' do
-    store { Spree::Store.default }
+    owner { Spree::Store.default }
     slug { 'my-policy' }
     name { 'My Policy' }
-    show_in_checkout_footer { true }
     body { 'This is the my policy' }
   end
 end

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Spree::Policy, type: :model do
   let(:store) { Spree::Store.default }
-  let(:policy) { create(:policy, store: store) }
+  let(:policy) { create(:policy, owner: store) }
 
   describe 'validations' do
     context 'slug uniqueness' do
@@ -10,7 +10,7 @@ RSpec.describe Spree::Policy, type: :model do
 
       it 'allows same slug for different stores' do
         other_store = create(:store)
-        other_policy = create(:policy, store: other_store, slug: policy.slug)
+        other_policy = create(:policy, owner: other_store, slug: policy.slug)
         expect(other_policy.slug).to eq(policy.slug)
       end
     end
@@ -54,21 +54,10 @@ RSpec.describe Spree::Policy, type: :model do
   end
 
   describe 'scopes' do
-    describe '.show_in_checkout_footer' do
-      let!(:visible_policy) { create(:policy, show_in_checkout_footer: true) }
-      let!(:hidden_policy) { create(:policy, show_in_checkout_footer: false) }
-
-      it 'returns only policies that should be shown in checkout footer' do
-        result = described_class.show_in_checkout_footer
-        expect(result).to include(visible_policy)
-        expect(result).not_to include(hidden_policy)
-      end
-    end
-
     describe '.for_store' do
       let(:other_store) { create(:store) }
-      let!(:store1_policy) { create(:policy, store: store) }
-      let!(:store2_policy) { create(:policy, store: other_store) }
+      let!(:store1_policy) { create(:policy, owner: store) }
+      let!(:store2_policy) { create(:policy, owner: other_store) }
 
       it 'returns policies for specific store' do
         result = described_class.for_store(store)

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -3350,10 +3350,6 @@ components:
               type: string
               example: terms-and-conditions
               description: URL-friendly identifier for the policy
-            show_in_checkout_footer:
-              type: boolean
-              example: true
-              description: Whether to display this policy in the checkout footer
             created_at:
               $ref: '#/components/schemas/Timestamp'
             updated_at:
@@ -3371,7 +3367,6 @@ components:
           required:
             - name
             - slug
-            - show_in_checkout_footer
             - created_at
             - updated_at
       required:
@@ -8777,7 +8772,6 @@ components:
                   attributes:
                     name: Terms and Conditions
                     slug: terms-and-conditions
-                    show_in_checkout_footer: true
                     created_at: '2025-08-12T12:13:09.183Z'
                     updated_at: '2025-08-12T13:27:59.470Z'
                     body: asdrdfas
@@ -15776,7 +15770,6 @@ components:
                     attributes:
                       name: Terms and Conditions
                       slug: terms-and-conditions
-                      show_in_checkout_footer: true
                       created_at: '2025-08-12T12:13:09.183Z'
                       updated_at: '2025-08-12T13:27:59.470Z'
                       body: asdrdfas
@@ -15786,7 +15779,6 @@ components:
                     attributes:
                       name: Privacy Policy
                       slug: privacy-policy
-                      show_in_checkout_footer: false
                       created_at: '2025-08-12T10:00:00.000Z'
                       updated_at: '2025-08-12T10:00:00.000Z'
                       body: Privacy policy content

--- a/storefront/app/views/themes/default/spree/checkout/_footer.html.erb
+++ b/storefront/app/views/themes/default/spree/checkout/_footer.html.erb
@@ -1,8 +1,8 @@
 <% cache spree_storefront_base_cache_scope.call(current_store) do %>
-  <% if current_store.policies.show_in_checkout_footer.any? %>
+  <% if current_store.policies.any? %>
     <div class="flex flex-col gap-4 text-sm">
       <ul class="flex justify-center flex-wrap gap-4">
-        <% current_store.policies.show_in_checkout_footer.order(:position).each do |policy| %>
+        <% current_store.policies.each do |policy| %>
           <%= link_to policy.name, spree.policy_path(policy), target: '_blank' %>
         <% end %>
       </ul>

--- a/storefront/spec/controllers/spree/policies_controller_spec.rb
+++ b/storefront/spec/controllers/spree/policies_controller_spec.rb
@@ -10,7 +10,7 @@ describe Spree::PoliciesController, type: :controller do
   end
 
   describe 'GET #show' do
-    let(:policy) { create(:policy, store: store) }
+    let(:policy) { create(:policy, owner: store) }
 
     it 'renders the policy' do
       get :show, params: { id: policy.slug }


### PR DESCRIPTION
… Store to manage links in checkout footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Checkout links: manage, add, and drag‑reorder store checkout links with per‑item editing.

- Changes
  - Policies: owner-based scoping; removed "Show in checkout footer" option and sorting; admin list shows clickable rows, new "Filled" and "Owner" columns.
  - Checkout footer now displays all policies (ordering may differ).
  - Sidebar items visibility checked per item.

- UI/Style
  - Form/localization tweaks and adjusted toolbar button sizing.

- API/Docs
  - Policy API no longer exposes show_in_checkout_footer; docs updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->