### PR TITLE
Fixed: admin - In the store dropdown show only stores current user ha…

### DIFF
--- a/admin/app/helpers/spree/admin/stores_helper.rb
+++ b/admin/app/helpers/spree/admin/stores_helper.rb
@@ -4,7 +4,7 @@ module Spree
       include Spree::ImagesHelper
 
       def available_stores
-        @available_stores ||= Spree::Store.accessible_by(current_ability).includes(:logo_attachment, :favicon_image_attachment, :default_custom_domain)
+        @available_stores ||= Spree::Store.accessible_by(current_ability, :manage).includes(:logo_attachment, :favicon_image_attachment, :default_custom_domain)
       end
 
       DEFAULT_ICON_SIZE = 40

--- a/admin/spec/helpers/spree/admin/stores_helper_spec.rb
+++ b/admin/spec/helpers/spree/admin/stores_helper_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::StoresHelper, type: :helper do
+  describe '#available_stores' do
+    let(:user) { create(:admin_user) }
+    let!(:store1) { create(:store, name: 'Store 1') }
+    let!(:store2) { create(:store, name: 'Store 2') }
+    let!(:store3) { create(:store, name: 'Store 3') }
+
+    before do
+      allow(helper).to receive(:current_ability).and_return(Spree::Ability.new(user))
+    end
+
+    context 'when user can manage all stores' do
+      before do
+        allow_any_instance_of(Spree::Ability).to receive(:can?).with(:manage, Spree::Store).and_return(true)
+      end
+
+      it 'returns all stores accessible by current ability' do
+        expect(helper.available_stores).to include(store1, store2, store3)
+      end
+    end
+
+    context 'when user has limited store access' do
+      before do
+        allow(Spree::Store).to receive(:accessible_by)
+          .with(kind_of(Spree::Ability), :manage)
+          .and_return(Spree::Store.where(id: [store1.id, store2.id]))
+      end
+
+      it 'returns only accessible stores' do
+        available = helper.available_stores
+        expect(available).to include(store1, store2)
+        expect(available).not_to include(store3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
…s permissions to manage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - The Admin interface now lists only stores that a user is permitted to manage, ensuring the store selector and related areas reflect accurate permissions and preventing visibility of unauthorized stores.

- Tests
  - Added comprehensive tests for store availability in the Admin interface, covering scenarios where users can manage all stores or only a subset, to ensure permission rules are correctly enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->