### PR TITLE
Make setting page builder theme/page preview much safer

### DIFF
--- a/admin/app/controllers/concerns/spree/admin/page_builder_concern.rb
+++ b/admin/app/controllers/concerns/spree/admin/page_builder_concern.rb
@@ -8,11 +8,11 @@ module Spree
       end
 
       def set_variables
-        @theme_preview = current_store.theme_previews.find(session[:theme_preview_id]) if session[:theme_preview_id].present?
-        @theme = @theme_preview.parent if @theme_preview
-        if session[:page_preview_id].present?
+        @theme_preview = current_store.theme_previews.find_by(id: session[:theme_preview_id]) if session[:theme_preview_id].present?
+        @theme = @theme_preview.present? ? @theme_preview.parent : current_store.default_theme
+        if @theme.present? && session[:page_preview_id].present?
           @page_preview = @theme.page_previews.find_by(id: session[:page_preview_id]) ||
-                            current_store.page_previews.find(session[:page_preview_id])
+                            current_store.page_previews.find_by(id: session[:page_preview_id])
         end
         @page = @page_preview.parent if @page_preview
       end

--- a/admin/spec/controllers/spree/admin/policies_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/policies_controller_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Spree::Admin::PoliciesController, type: :controller do
   describe 'GET #index' do
     subject(:index) { get :index }
 
-    let!(:policies) { create_list(:policy, 3, owner: store) }
-
     it 'renders the list of policies' do
       index
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents errors in the Page Builder when theme or page previews are missing by safely handling lookups.
  - Falls back to the store’s default theme when no theme preview is present, ensuring previews load reliably.
  - Improves stability when resolving page previews across theme-specific and global contexts.

- Tests
  - Simplifies admin policies controller spec by removing unnecessary test setup for policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->