### PR TITLE
Added `scope: spree_base_uniqueness_scope` to newsletter subscriber e…

### DIFF
--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -11,7 +11,7 @@ module Spree
     validates :email,
               presence: true,
               format: { with: URI::MailTo::EMAIL_REGEXP },
-              uniqueness: { case_sensitive: false }
+              uniqueness: { case_sensitive: false, scope: spree_base_uniqueness_scope }
 
     scope :verified, -> { where.not(verified_at: nil) }
     scope :unverified, -> { where(verified_at: nil) }


### PR DESCRIPTION
…mail validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newsletter email uniqueness is now correctly scoped per store/tenant, reducing false “already subscribed” errors and preventing cross-store conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->