### PR TITLE
Fix newsletter subscribers verify endpoint with multi DB setup

### DIFF
--- a/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
+++ b/storefront/app/controllers/spree/newsletter_subscribers_controller.rb
@@ -25,7 +25,11 @@ module Spree
 
     # GET /newsletter_subscribers/verify?token=VERIFICATION_TOKEN
     def verify
-      subscriber = Spree::NewsletterSubscriber.verify(token: params[:token])
+      raise ActiveRecord::RecordNotFound if params[:token].blank?
+
+      subscriber = ActiveRecord::Base.connected_to(role: :writing) do
+        Spree::NewsletterSubscriber.verify(token: params[:token])
+      end
 
       if subscriber.verified?
         redirect_to spree.root_path, notice: Spree.t('storefront.newsletter_subscribers.verified')

--- a/storefront/spec/controllers/spree/newsletter_subscribers_controller_spec.rb
+++ b/storefront/spec/controllers/spree/newsletter_subscribers_controller_spec.rb
@@ -177,5 +177,21 @@ RSpec.describe Spree::NewsletterSubscribersController, type: :controller do
         expect(response).to redirect_to spree.root_path
       end
     end
+
+    context 'with blank token' do
+      let(:token) { '' }
+
+      it 'sets error flash message' do
+        subject
+
+        expect(flash[:alert]).to be_present
+      end
+
+      it 'redirects to root path for html format' do
+        request
+
+        expect(response).to redirect_to spree.root_path
+      end
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved newsletter verification handling for blank tokens: users now see an appropriate error message and are redirected safely.
  * Preserved consistent messaging for invalid or missing subscribers during verification.

* **Tests**
  * Added coverage for the blank token scenario in newsletter verification, ensuring correct alert and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->