### PR TITLE
Properly cache `Store#countries_available_for_checkout` and `Store#st…

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -331,13 +331,13 @@ module Spree
 
     def countries_available_for_checkout
       @countries_available_for_checkout ||= Rails.cache.fetch(countries_available_for_checkout_cache_key) do
-        checkout_zone.try(:country_list) || Spree::Country.all
+        (checkout_zone.try(:country_list) || Spree::Country.all).to_a
       end
     end
 
     def states_available_for_checkout(country)
       Rails.cache.fetch(states_available_for_checkout_cache_key(country)) do
-        checkout_zone.try(:state_list_for, country) || country.states
+        (checkout_zone.try(:state_list_for, country) || country.states).to_a
       end
     end
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -329,12 +329,17 @@ module Spree
       formatted_custom_domain || formatted_url
     end
 
+    # Returns the countries available for checkout for the store or creates a new one if it doesn't exist
+    # @return [Array<Spree::Country>]
     def countries_available_for_checkout
       @countries_available_for_checkout ||= Rails.cache.fetch(countries_available_for_checkout_cache_key) do
         (checkout_zone.try(:country_list) || Spree::Country.all).to_a
       end
     end
 
+    # Returns the states available for checkout for the store or creates a new one if it doesn't exist
+    # @param country [Spree::Country] the country to get the states for
+    # @return [Array<Spree::State>]
     def states_available_for_checkout(country)
       Rails.cache.fetch(states_available_for_checkout_cache_key(country)) do
         (checkout_zone.try(:state_list_for, country) || country.states).to_a

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -430,7 +430,7 @@ describe Spree::Store, type: :model, without_global_store: true do
       include_context 'with checkout zone not set'
 
       it 'returns list of all countries' do
-        checkout_available_countries_ids = subject.countries_available_for_checkout.ids
+        checkout_available_countries_ids = subject.countries_available_for_checkout.pluck(:id)
         all_countries_ids                = Spree::Country.all.ids
 
         expect(checkout_available_countries_ids).to eq(all_countries_ids)


### PR DESCRIPTION
…ates_available_for_checkout`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures country and state lists in checkout consistently display, preventing intermittent missing or duplicated options.
  * Improves reliability of address dropdowns when cached, reducing unexpected behavior across sessions and locales.
  * Stabilizes state selection when switching countries to avoid incomplete or incorrect state lists.

* **Tests**
  * Updated tests to better validate consistent checkout option behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->