### PR TITLE
Utilize `Order#item_count` to reduse number of SQL queries

### DIFF
--- a/core/app/services/spree/cart/estimate_shipping_rates.rb
+++ b/core/app/services/spree/cart/estimate_shipping_rates.rb
@@ -9,7 +9,7 @@ module Spree
 
         packages = ::Spree::Stock::Coordinator.new(dummy_order).packages
         estimator = ::Spree::Stock::Estimator.new(dummy_order)
-        shipping_rates = if order.line_items.any? && packages.any?
+        shipping_rates = if order.item_count.positive? && packages.any?
                            estimator.shipping_rates(packages.first)
                          else
                            []

--- a/core/app/services/spree/cart/estimate_shipping_rates.rb
+++ b/core/app/services/spree/cart/estimate_shipping_rates.rb
@@ -9,7 +9,7 @@ module Spree
 
         packages = ::Spree::Stock::Coordinator.new(dummy_order).packages
         estimator = ::Spree::Stock::Estimator.new(dummy_order)
-        shipping_rates = if order.item_count.positive? && packages.any?
+        shipping_rates = if order.line_items.any? && packages.any?
                            estimator.shipping_rates(packages.first)
                          else
                            []

--- a/storefront/app/views/themes/default/spree/orders/_summary.html.erb
+++ b/storefront/app/views/themes/default/spree/orders/_summary.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :cart_summary do %>
-  <% if order.line_items.any? %>
+  <% if order.item_count.positive? %>
     <div class="cart-summary-container p-4">
       <p class="text-center lg:text-right text-sm mb-3">
         <%= Spree.t('storefront.cart.shipping_and_taxes_calculated_at_checkout') %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cart summary now displays only when the cart has a positive total item count, preventing empty or zero-quantity carts from showing a summary.
  * Shipping rates are estimated only when the cart contains actual items, improving accuracy and avoiding misleading rate displays.
  * Aligns cart visibility and shipping calculations with item quantities, reducing edge cases where line items exist but quantity is zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->