### PR TITLE
Fix setting the policy owner

### DIFF
--- a/admin/app/controllers/spree/admin/policies_controller.rb
+++ b/admin/app/controllers/spree/admin/policies_controller.rb
@@ -3,6 +3,8 @@ module Spree
     class PoliciesController < ResourceController
       add_breadcrumb Spree.t(:policies), :admin_policies_path
 
+      before_action :set_policy_owner, only: %i[create update]
+
       private
 
       def collection
@@ -19,6 +21,10 @@ module Spree
 
       def update_turbo_stream_enabled?
         true
+      end
+
+      def set_policy_owner
+        @policy.owner ||= current_store
       end
     end
   end

--- a/admin/spec/controllers/spree/admin/policies_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/policies_controller_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Spree::Admin::PoliciesController, type: :controller do
 
     let(:policy_params) do
       {
-        name: 'Privacy Policy',
+        name: 'New Privacy Policy',
         body: 'This is our privacy policy content',
-        slug: 'privacy-policy'
+        slug: 'new-privacy-policy'
       }
     end
 
@@ -41,9 +41,27 @@ RSpec.describe Spree::Admin::PoliciesController, type: :controller do
       expect { create_policy }.to change(Spree::Policy, :count).by(1)
 
       policy = Spree::Policy.last
-      expect(policy.name).to eq('Privacy Policy')
+      expect(policy.name).to eq('New Privacy Policy')
       expect(policy.body.to_plain_text).to eq('This is our privacy policy content')
-      expect(policy.slug).to eq('privacy-policy')
+      expect(policy.slug).to eq('new-privacy-policy')
+      expect(policy.owner).to eq(store)
+    end
+
+    context 'when manually passing owner params' do
+      let(:policy_params) do
+        {
+          name: 'New Privacy Policy',
+          body: 'This is our privacy policy content',
+          slug: 'new-privacy-policy',
+          owner_id: 123,
+          owner_type: 'Spree::User'
+        }
+      end
+
+      it 'ignores the given owner params' do
+        expect { create_policy }.to change(Spree::Policy, :count).by(1)
+        expect(Spree::Policy.last.owner).to eq(store)
+      end
     end
   end
 
@@ -77,6 +95,7 @@ RSpec.describe Spree::Admin::PoliciesController, type: :controller do
       expect(policy.name).to eq('Updated Privacy Policy')
       expect(policy.body.to_plain_text).to eq('This is updated privacy policy content')
       expect(policy.slug).to eq('updated-privacy-policy')
+      expect(policy.owner).to eq(store)
     end
   end
 

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -31,6 +31,7 @@ module Spree
     #
     validates :slug, presence: true, uniqueness: { scope: UNIQUENESS_SCOPE }
     validates :name, presence: true
+    validates :owner, presence: true
 
     #
     # Scopes

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Spree::Policy, type: :model do
         expect(other_policy.slug).to eq(policy.slug)
       end
     end
+
+    context 'owner presence' do
+      it 'is invalid without an owner' do
+        policy.owner = nil
+        expect(policy).to be_invalid
+      end
+    end
   end
 
   describe 'friendly_id' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Policies are now automatically associated with the current store when created or updated, ensuring consistent ownership.
* **Bug Fixes**
  * Prevents creation of policies without an owner and blocks incorrect manual owner overrides, reducing cross-store misassignment.
* **Admin**
  * Creating or editing a policy in the admin will default its owner to the current store; validation will alert if ownership is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->