### PR TITLE
Optimize and reduce number of SQL queries when applying promotions

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -193,7 +193,7 @@ module Spree
     # if the rules make this promotable ineligible, then nil is returned (i.e. this promotable is not eligible)
     def eligible_rules(promotable, options = {})
       # Promotions without rules are eligible by default.
-      return [] if rules.to_a.none?
+      return [] if rules.to_a.none? # preloaded rules as we're going to use them anyway, so avoiding additional database queries
 
       specific_rules = rules.select { |rule| rule.applicable?(promotable) }
       return [] if specific_rules.none?
@@ -329,8 +329,8 @@ module Spree
     end
 
     def remove_coupons
-      return unless (saved_change_to_kind? && kind_was == 'coupon_code' && kind == 'automatic') ||
-                    (saved_change_to_multi_codes? && multi_codes_was == true && multi_codes == false)
+      return unless (previous_changes.key?('kind') && previous_changes['kind'][0] == 'coupon_code' && kind == 'automatic') ||
+                    (previous_changes.key?('multi_codes') && previous_changes['multi_codes'][0] == true && multi_codes == false)
 
       coupon_codes.where(deleted_at: nil).update_all(deleted_at: Time.current)
     end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -49,7 +49,7 @@ module Spree
     before_validation :downcase_code, if: -> { code.present? }
     before_validation :set_starts_at_to_current_time, if: -> { starts_at.blank? }
     after_commit :generate_coupon_codes, if: -> { multi_codes? }, on: [:create, :update]
-    after_commit :remove_coupons, unless: -> { multi_codes? }, on: :update
+    after_commit :remove_coupons, on: :update
     before_destroy :not_used?
 
     #
@@ -193,7 +193,7 @@ module Spree
     # if the rules make this promotable ineligible, then nil is returned (i.e. this promotable is not eligible)
     def eligible_rules(promotable, options = {})
       # Promotions without rules are eligible by default.
-      return [] if rules.none?
+      return [] if rules.to_a.none?
 
       specific_rules = rules.select { |rule| rule.applicable?(promotable) }
       return [] if specific_rules.none?
@@ -329,6 +329,9 @@ module Spree
     end
 
     def remove_coupons
+      return unless (saved_change_to_kind? && kind_was == 'coupon_code' && kind == 'automatic') ||
+                    (saved_change_to_multi_codes? && multi_codes_was == true && multi_codes == false)
+
       coupon_codes.where(deleted_at: nil).update_all(deleted_at: Time.current)
     end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Promotion, type: :model do
   let(:store) { @default_store }
   let(:promotion) { create(:promotion, kind: :automatic) }
 
-  describe 'validations' do
+  describe 'Validations' do
     let!(:valid_promotion) { build(:promotion, name: 'A promotion', stores: [store], kind: :automatic) }
 
     it 'valid_promotion is valid' do
@@ -69,8 +69,8 @@ describe Spree::Promotion, type: :model do
     end
   end
 
-  describe 'callbacks' do
-    describe 'set_usage_limit_to_nil' do
+  describe 'Callbacks' do
+    describe '#set_usage_limit_to_nil' do
       let(:promotion) { create(:promotion, kind: :coupon_code, usage_limit: 100) }
 
       context 'when promo has one code for all customers' do
@@ -87,6 +87,14 @@ describe Spree::Promotion, type: :model do
 
           expect{ promotion.save }.to change{ promotion.usage_limit }.from(100).to(nil)
         end
+      end
+    end
+
+    describe '#remove_coupons' do
+      let!(:promotion) { create(:promotion, kind: :coupon_code, multi_codes: true, number_of_codes: 1) }
+
+      it 'removes the coupons' do
+        expect { promotion.update!(kind: :automatic) }.to change { promotion.coupon_codes.count }.from(1).to(0)
       end
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Obsolete coupon codes are now reliably removed when a promotion is converted from coupon-based to automatic or when multi-code coupons are disabled.
  * Prevents outdated coupons from remaining redeemable after promotion updates, reducing customer confusion at checkout.
  * Improves accuracy when detecting promotions with no rules, ensuring eligibility is evaluated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->