### PR TITLE
Fix Draft Order back button to redirect to Draft Orders list

### DIFF
--- a/admin/app/views/spree/admin/orders/_header.html.erb
+++ b/admin/app/views/spree/admin/orders/_header.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title do %>
   <% if controller_name == 'orders' %>
-    <%= page_header_back_button spree.admin_orders_path, @order %>
+    <% back_url = @order.present? && !@order.completed? ? spree.admin_checkouts_path : spree.admin_orders_path %>
+    <%= page_header_back_button back_url, @order %>
   <% else %>
     <%= page_header_back_button spree.edit_admin_order_path(@order) %>
   <% end %>


### PR DESCRIPTION
### Fix back button for Draft Orders in admin

The back button on a Draft Order was always sending admins to the main Orders list so, updated the _header.html.erb partial in admin/orders to conditionally set the back URL:
```
<% back_url = @order.present? && !@order.completed? ? spree.admin_checkouts_path : spree.admin_orders_path %>
<%= page_header_back_button back_url, @order %>

```
Now it correctly goes back to the Draft Orders list for incomplete orders, and still goes to Orders for completed ones. This makes navigating draft orders more intuitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The back button in the Orders header now routes you to the most relevant page based on the order’s state. For in-progress orders, it returns to the checkout list; for completed or other orders, it returns to the orders list. This improves navigation consistency and reduces extra clicks for admin users working through checkouts or reviewing completed orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->