### PR TITLE
Use safe operator when fetching current webhook subscribers

### DIFF
--- a/core/app/models/spree/current.rb
+++ b/core/app/models/spree/current.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     def webhooks_subscribers
-      super || store.active_webhooks_subscribers
+      super || store&.active_webhooks_subscribers || []
     end
   end
 end

--- a/core/app/models/spree/current.rb
+++ b/core/app/models/spree/current.rb
@@ -7,7 +7,7 @@ module Spree
     end
 
     def webhooks_subscribers
-      super || store&.active_webhooks_subscribers || []
+      super || store&.active_webhooks_subscribers || Spree::Webhooks::Subscriber.none
     end
   end
 end


### PR DESCRIPTION
In a rare scenario when there's no current store, eg. multi tenant, guard before returning an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of webhook subscriber handling by defaulting to an empty subscriber list when no store or subscribers are available. This prevents nil-related errors and ensures consistent behavior across admin, storefront, and background processes that rely on webhooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->