### PR TITLE
Remove promotion touching when applying promo on checkout

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -107,7 +107,7 @@ module Spree
       attributes[:eligible] = source.promotion.eligible?(target) if promotion?
 
       update_columns(attributes)
-      source.promotion.touch if promotion?
+      source.promotion.touch if promotion? && source.promotion.coupon_code?
 
       amount
     end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -107,7 +107,6 @@ module Spree
       attributes[:eligible] = source.promotion.eligible?(target) if promotion?
 
       update_columns(attributes)
-      source.promotion.touch if promotion? && source.promotion.coupon_code?
 
       amount
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -207,10 +207,6 @@ describe Spree::Adjustment, type: :model do
             subject
             expect(adjustment.eligible).to eq true
           end
-
-          it 'touches the promotion' do
-            expect { subject }.to change { promotion.reload.updated_at }
-          end
         end
 
         context "the promotion is not eligible" do
@@ -219,10 +215,6 @@ describe Spree::Adjustment, type: :model do
           it "sets the adjustment eligible to false" do
             subject
             expect(adjustment.eligible).to eq false
-          end
-
-          it 'touches the promotion' do
-            expect { subject }.to change { promotion.reload.updated_at }
           end
         end
       end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -289,21 +289,6 @@ describe Spree::Promotion, type: :model do
         expect(promotion.activate(payload)).to be true
         expect(promotion.orders.first).to eql order
       end
-
-      it 'touches the promotion' do
-        previous_updated_at = promotion.updated_at
-        expect(promotion.activate(payload)).to be true
-        expect(promotion.reload.updated_at).not_to eq(previous_updated_at)
-      end
-
-      context 'automatic promotion' do
-        let(:promotion) { create(:promotion, kind: :automatic) }
-
-        it 'does not touch the promotion' do
-          expect(promotion.activate(payload)).to be true
-          expect(promotion.reload.updated_at).to eq(promotion.created_at)
-        end
-      end
     end
 
     context 'when not activated' do
@@ -313,12 +298,6 @@ describe Spree::Promotion, type: :model do
         expect(promotion.orders).to be_empty
         expect(promotion.activate(payload)).to be_falsey
         expect(promotion.orders).to be_empty
-      end
-
-      it "doesn't the promotion" do
-        previous_updated_at = promotion.updated_at
-        expect(promotion.activate(payload)).to be_falsey
-        expect(promotion.reload.updated_at).to eq(previous_updated_at)
       end
     end
   end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -295,6 +295,15 @@ describe Spree::Promotion, type: :model do
         expect(promotion.activate(payload)).to be true
         expect(promotion.reload.updated_at).not_to eq(previous_updated_at)
       end
+
+      context 'automatic promotion' do
+        let(:promotion) { create(:promotion, kind: :automatic) }
+
+        it 'does not touch the promotion' do
+          expect(promotion.activate(payload)).to be true
+          expect(promotion.reload.updated_at).to eq(promotion.created_at)
+        end
+      end
     end
 
     context 'when not activated' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjustments no longer change a promotion's "Last updated" timestamp when an adjustment is updated.

* **Tests**
  * Removed tests that asserted promotions were touched during activation/update; remaining promotion activation tests are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->