### PR TITLE
Added `Promotion#cached_rules` to cache promotion rules

### DIFF
--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -4,7 +4,7 @@ module Spree
   class PromotionAction < Spree.base_class
     acts_as_paranoid
 
-    belongs_to :promotion, class_name: 'Spree::Promotion'
+    belongs_to :promotion, class_name: 'Spree::Promotion', touch: true
 
     validates :promotion, :type, presence: true
 

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -1,7 +1,7 @@
 # Base class for all promotion rules
 module Spree
   class PromotionRule < Spree.base_class
-    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules
+    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules, touch: true
 
     delegate :stores, to: :promotion
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -857,4 +857,10 @@ describe Spree::Promotion, type: :model do
       end
     end
   end
+
+  describe '#cached_rules' do
+    it 'returns the rules' do
+      expect(promotion.cached_rules).to eq(promotion.rules)
+    end
+  end
 end


### PR DESCRIPTION
this is super handy when applying a promo to a large number of line items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented caching for promotion rules to reduce database lookups and speed up promotion eligibility checks, improving checkout performance.
  * Ensured promotions automatically refresh when related rules or actions are updated, keeping discounts accurate and up to date.

* **Tests**
  * Added test coverage to verify cached promotion rules behave consistently with existing rule retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->