### PR TITLE
Fixed: don't run adjustments/tax calculations twice in AddItem service

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -55,7 +55,7 @@ module Spree
 
     scope :with_digital_assets, -> { joins(:variant).merge(Spree::Variant.with_digital_assets) }
 
-    attr_accessor :target_shipment
+    attr_accessor :target_shipment, :skip_update_adjustments, :skip_update_tax_charge
 
     self.whitelisted_ransackable_associations = %w[variant order tax_category]
     self.whitelisted_ransackable_attributes = %w[variant_id order_id tax_category_id quantity
@@ -231,6 +231,8 @@ module Spree
     end
 
     def update_adjustments
+      return if skip_update_adjustments
+
       if saved_change_to_quantity?
         recalculate_adjustments
         update_tax_charge # Called to ensure pre_tax_amount is updated.
@@ -242,6 +244,8 @@ module Spree
     end
 
     def update_tax_charge
+      return if skip_update_tax_charge
+
       Spree::TaxRate.adjust(order, [self])
     end
 

--- a/core/app/services/spree/cart/add_item.rb
+++ b/core/app/services/spree/cart/add_item.rb
@@ -37,6 +37,10 @@ module Spree
         line_item.public_metadata = public_metadata.to_h if public_metadata
         line_item.private_metadata = private_metadata.to_h if private_metadata
 
+        # this is handled by recalculate service
+        line_item.skip_update_adjustments = true
+        line_item.skip_update_tax_charge = true
+
         return failure(line_item) unless line_item.save
 
         line_item.reload.update_price


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the add-to-cart flow to defer adjustments and tax computations until cart recalculation.
  - Reduces latency when adding items, improving responsiveness, especially in carts with multiple promotions or complex tax rules.
  - Price updates continue to apply as expected, and totals are recalculated immediately after adding items, ensuring accurate taxes and discounts without extra steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->