### PR TITLE
Update confirmation email URL to use current store and custom domain …

### DIFF
--- a/emails/app/mailers/spree/newsletter_mailer.rb
+++ b/emails/app/mailers/spree/newsletter_mailer.rb
@@ -2,7 +2,7 @@ module Spree
   class NewsletterMailer < BaseMailer
     def email_confirmation(subscriber)
       @subscriber = subscriber
-      @confirm_email_url = spree.verify_newsletter_subscribers_url(token: @subscriber.verification_token, host: Spree::Store.default.url)
+      @confirm_email_url = spree.verify_newsletter_subscribers_url(token: @subscriber.verification_token, host: Spree::Current.store.url_or_custom_domain)
       mail(to: @subscriber.email, from: from_address, subject: Spree.t('newsletter_mailer.email_confirmation.subject'))
     end
   end


### PR DESCRIPTION
…if present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newsletter subscription confirmation emails now use the active store’s domain, including custom domains, ensuring verification links open the correct storefront in multi-store setups.
  * Reduces misdirects and failed confirmations caused by links pointing to a default domain.
  * No change to the verification process itself; existing tokens and email content continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->