### PR TITLE
Adjustment updater: only run SQL update if totals changed

### DIFF
--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -31,6 +31,11 @@ module Spree
         attributes[:adjustment_total] = totals[:non_taxable_adjustment_total] +
           totals[:taxable_adjustment_total] +
           totals[:additional_tax_total]
+
+        # Only update if totals have changed
+        current_attributes = @adjustable.attributes.slice(*attributes.keys.map(&:to_s))
+        return if attributes.all? { |key, value| current_attributes[key.to_s] == value }
+
         attributes[:updated_at] = Time.current
         @adjustable.update_columns(totals)
       end

--- a/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
+++ b/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
@@ -18,10 +18,24 @@ module Spree
           it 'updates all linked adjusters' do
             line_item.price = 10
             line_item.tax_category = tax_rate.tax_category
+            line_item.adjustment_total = 0
+            line_item.additional_tax_total = 0
+
+            old_updated_at = line_item.updated_at
 
             subject.update
             expect(line_item.adjustment_total).to eq(0.5)
             expect(line_item.additional_tax_total).to eq(0.5)
+            expect(line_item.updated_at).not_to eq(old_updated_at)
+
+            old_updated_at = line_item.updated_at
+
+            subject.update
+            # skipping the update because the totals have not changed
+            line_item.reload
+            expect(line_item.adjustment_total).to eq(0.5)
+            expect(line_item.additional_tax_total).to eq(0.5)
+            expect(line_item.updated_at).to eq(old_updated_at)
           end
         end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized totals persistence to skip database updates when values haven’t changed, reducing unnecessary writes and improving performance.
  * Preserves existing behavior and public API; updated_at no longer changes on no-op updates.

* **Tests**
  * Added coverage to confirm no-op updates leave totals and updated_at unchanged.
  * Ensured persisted, non-persisted, and nil contexts continue to behave correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->