### PR TITLE
Destroy Page Links when Linkable object is destroyed

### DIFF
--- a/core/app/models/concerns/spree/linkable.rb
+++ b/core/app/models/concerns/spree/linkable.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Linkable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :page_links, as: :linkable, class_name: 'Spree::PageLink', dependent: :destroy
+    end
+  end
+end

--- a/core/app/models/spree/page.rb
+++ b/core/app/models/spree/page.rb
@@ -1,6 +1,7 @@
 module Spree
   class Page < Spree.base_class
     include Spree::Previewable
+    include Spree::Linkable
 
     #
     # Magic methods

--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -2,6 +2,7 @@ module Spree
   class Policy < Spree.base_class
     extend FriendlyId
     include Spree::TranslatableResource
+    include Spree::Linkable
 
     UNIQUENESS_SCOPE = %i[owner_id owner_type].freeze
 

--- a/core/app/models/spree/post.rb
+++ b/core/app/models/spree/post.rb
@@ -1,6 +1,7 @@
 module Spree
   class Post < Spree.base_class
     include Spree::SingleStoreResource
+    include Spree::Linkable
     extend FriendlyId
 
     friendly_id :slug_candidates, use: %i[slugged scoped history], scope: %i[store_id deleted?]

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -29,6 +29,7 @@ module Spree
     include Spree::TranslatableResource
     include Spree::MemoizedData
     include Spree::Metadata
+    include Spree::Linkable
     include Spree::Product::Webhooks
     include Spree::Product::Slugs
     if defined?(Spree::VendorConcern)

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -18,6 +18,7 @@ module Spree
     include Spree::TranslatableResourceSlug
     include Spree::Metadata
     include Spree::MemoizedData
+    include Spree::Linkable
     if defined?(Spree::Webhooks::HasWebhooks)
       include Spree::Webhooks::HasWebhooks
     end

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Spree::Policy, type: :model do
   let(:store) { Spree::Store.default }
   let(:policy) { create(:policy, owner: store) }
 
-  describe 'validations' do
+  describe 'Validations' do
     context 'slug uniqueness' do
       before { policy }
 
@@ -19,6 +19,18 @@ RSpec.describe Spree::Policy, type: :model do
       it 'is invalid without an owner' do
         policy.owner = nil
         expect(policy).to be_invalid
+      end
+    end
+  end
+
+  describe 'Callbacks' do
+    context 'after destroy destroys links in which policy is linked to' do
+      let!(:page_link) { create(:page_link, linkable: policy, parent: store) }
+
+      it 'destroys links' do
+        expect(store.links).to include(page_link)
+        expect { policy.destroy }.to change(Spree::PageLink, :count).by(-1)
+        expect(store.links).not_to include(page_link)
       end
     end
   end
@@ -38,7 +50,7 @@ RSpec.describe Spree::Policy, type: :model do
     end
   end
 
-  describe 'translations' do
+  describe 'Translations' do
     it 'has translatable name field' do
       expect(described_class::TRANSLATABLE_FIELDS).to include(:name)
     end
@@ -60,7 +72,7 @@ RSpec.describe Spree::Policy, type: :model do
     end
   end
 
-  describe 'scopes' do
+  describe 'Scopes' do
     describe '.for_store' do
       let(:other_store) { create(:store) }
       let!(:store1_policy) { create(:policy, owner: store) }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced link associations across products, posts, pages, categories, and policies, enabling them to be linked from navigations or content.
  - Related links are automatically removed when the associated item is deleted, keeping navigation and content clean.

- Tests
  - Added coverage to ensure associated links are destroyed when an item is removed.
  - Updated test descriptions for clarity without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->