### PR TITLE
Bring back page links counter cache, add it to Store as well

### DIFF
--- a/api/spec/serializers/spree/api/v2/platform/store_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/store_serializer_spec.rb
@@ -50,7 +50,8 @@ describe Spree::Api::V2::Platform::StoreSerializer do
             favicon_path: nil,
             storefront_custom_code_body_end: nil,
             storefront_custom_code_body_start: nil,
-            storefront_custom_code_head: nil
+            storefront_custom_code_head: nil,
+            page_links_count: store.page_links_count
           },
           relationships: {
             default_country: {

--- a/core/app/models/spree/page.rb
+++ b/core/app/models/spree/page.rb
@@ -15,7 +15,6 @@ module Spree
     #
     belongs_to :pageable, polymorphic: true # this can be either Store or Theme
     has_many :sections, -> { order(position: :asc) }, class_name: 'Spree::PageSection', dependent: :destroy_async, as: :pageable
-    has_many :page_links, as: :linkable, class_name: 'Spree::PageLink', dependent: :destroy
     alias page_sections sections
 
     #

--- a/core/app/models/spree/page_link.rb
+++ b/core/app/models/spree/page_link.rb
@@ -8,7 +8,7 @@ module Spree
     #
     # Associations
     #
-    belongs_to :parent, polymorphic: true, touch: true # Block or Section
+    belongs_to :parent, polymorphic: true, touch: true, counter_cache: true # Block or Section
     belongs_to :linkable, polymorphic: true, optional: true # Page, Product, etc.
     has_one :theme, through: :parent
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -119,8 +119,6 @@ module Spree
     has_many :stores, through: :store_products, class_name: 'Spree::Store'
     has_many :digitals, through: :variants_including_master
 
-    has_many :page_links, as: :linkable, class_name: 'Spree::PageLink', dependent: :destroy
-
     after_initialize :ensure_master
     after_initialize :assign_default_tax_category
 

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -47,8 +47,6 @@ module Spree
     has_many :promotion_rule_taxons, class_name: 'Spree::PromotionRuleTaxon', dependent: :destroy
     has_many :promotion_rules, through: :promotion_rule_taxons, class_name: 'Spree::PromotionRule'
 
-    has_many :page_links, as: :linkable, class_name: 'Spree::PageLink', dependent: :destroy
-
     #
     # Attachments
     #

--- a/core/db/migrate/20250913130044_add_page_links_counter_cache_to_spree_stores.rb
+++ b/core/db/migrate/20250913130044_add_page_links_counter_cache_to_spree_stores.rb
@@ -1,4 +1,4 @@
-class AddPageLinksCounterCacheToSpreeStores < ActiveRecord::Migration[8.0]
+class AddPageLinksCounterCacheToSpreeStores < ActiveRecord::Migration[7.2]
   def change
     add_column :spree_stores, :page_links_count, :integer, default: 0, null: false
 

--- a/core/db/migrate/20250913130044_add_page_links_counter_cache_to_spree_stores.rb
+++ b/core/db/migrate/20250913130044_add_page_links_counter_cache_to_spree_stores.rb
@@ -1,0 +1,9 @@
+class AddPageLinksCounterCacheToSpreeStores < ActiveRecord::Migration[8.0]
+  def change
+    add_column :spree_stores, :page_links_count, :integer, default: 0
+
+    Spree::Store.find_each do |store|
+      Spree::Store.reset_counters(store.id, :page_links)
+    end
+  end
+end

--- a/core/db/migrate/20250913130044_add_page_links_counter_cache_to_spree_stores.rb
+++ b/core/db/migrate/20250913130044_add_page_links_counter_cache_to_spree_stores.rb
@@ -1,7 +1,8 @@
 class AddPageLinksCounterCacheToSpreeStores < ActiveRecord::Migration[8.0]
   def change
-    add_column :spree_stores, :page_links_count, :integer, default: 0
+    add_column :spree_stores, :page_links_count, :integer, default: 0, null: false
 
+    Spree::Store.reset_column_information
     Spree::Store.find_each do |store|
       Spree::Store.reset_counters(store.id, :page_links)
     end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Page link counts are now maintained automatically, improving accuracy and speeding up pages that display these totals across stores.
  - Existing stores have their counts initialized during upgrade to ensure correct numbers from day one.
  - Schema updated to store per-store page link totals so dashboards and listings reflect changes immediately.
  - No action required after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->