### PR TITLE
Move Checkout terms and conditions into partial

### DIFF
--- a/storefront/app/views/spree/checkout/_payment_methods.html.erb
+++ b/storefront/app/views/spree/checkout/_payment_methods.html.erb
@@ -54,11 +54,7 @@
     <% end %>
   <% end %>
 
-  <p id="payment-and-conditions" class="text-xs mt-2 mb-4">
-    <%= Spree.t('storefront.checkout.by_placing_this_order_you_agree_to') %>
-    <%= link_to Spree.t(:terms_of_service), policy_path('terms_of_service'), target: :_blank, class: 'text-primary' %><%= I18n.t('support.array.two_words_connector') %>
-    <%= link_to Spree.t(:privacy_policy), policy_path('privacy_policy'), target: :_blank, class: 'text-primary' %>.
-  </p>
+  <%= render 'spree/checkout/terms_and_conditions' %>
 
   <div class="flex justify-end w-full">
     <button type="submit"

--- a/storefront/app/views/spree/checkout/_terms_and_conditions.html.erb
+++ b/storefront/app/views/spree/checkout/_terms_and_conditions.html.erb
@@ -1,0 +1,5 @@
+  <p id="payment-and-conditions" class="text-xs mt-2 mb-4">
+    <%= Spree.t('storefront.checkout.by_placing_this_order_you_agree_to') %>
+    <%= link_to Spree.t(:terms_of_service), policy_path('terms_of_service'), target: :_blank, class: 'text-primary' %><%= I18n.t('support.array.two_words_connector') %>
+    <%= link_to Spree.t(:privacy_policy), policy_path('privacy_policy'), target: :_blank, class: 'text-primary' %>.
+  </p>


### PR DESCRIPTION
for easier customization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the Terms and Conditions notice into a reusable component for the checkout payment step, ensuring consistent messaging and styling.
  * Ensures the Terms of Service and Privacy Policy links are consistently presented and open in a new tab for easier reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->