### PR TITLE
Respect `Store#send_consumer_transactional_emails` setting in newslet…

### DIFF
--- a/emails/app/models/spree/newsletter_subscriber/emails.rb
+++ b/emails/app/models/spree/newsletter_subscriber/emails.rb
@@ -1,8 +1,12 @@
 module Spree
   class NewsletterSubscriber < Spree.base_class
     module Emails
+      def store
+        @store ||= Spree::Store.current || Spree::Store.default
+      end
+
       def deliver_newsletter_email_verification
-        NewsletterMailer.email_confirmation(self).deliver_later
+        NewsletterMailer.email_confirmation(self).deliver_later if store.prefers_send_consumer_transactional_emails?
       end
     end
   end

--- a/emails/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/emails/spec/models/spree/newsletter_subscriber_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe Spree::NewsletterSubscriber, type: :model do
+  let(:store) { Spree::Store.default }
   let(:subscriber) { create(:newsletter_subscriber) }
 
   describe '#deliver_newsletter_email_verification' do
@@ -9,6 +10,16 @@ describe Spree::NewsletterSubscriber, type: :model do
       expect(Spree::NewsletterMailer).to receive(:email_confirmation).with(subscriber).and_return(double(deliver_later: true))
 
       deliver_newsletter_email_verification
+    end
+
+    context 'when send_consumer_transactional_emails store setting is disabled' do
+      before do
+        allow(store).to receive(:prefers_send_consumer_transactional_emails?).and_return(false)
+      end
+
+      it 'does not call newsletter mailer' do
+        expect(Spree::NewsletterMailer).not_to receive(:email_confirmation)
+      end
     end
   end
 end

--- a/emails/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/emails/spec/models/spree/newsletter_subscriber_spec.rb
@@ -14,6 +14,7 @@ describe Spree::NewsletterSubscriber, type: :model do
 
     context 'when send_consumer_transactional_emails store setting is disabled' do
       before do
+        allow(Spree::Current).to receive(:store).and_return(store)
         allow(store).to receive(:prefers_send_consumer_transactional_emails?).and_return(false)
       end
 

--- a/emails/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/emails/spec/models/spree/newsletter_subscriber_spec.rb
@@ -19,6 +19,7 @@ describe Spree::NewsletterSubscriber, type: :model do
 
       it 'does not call newsletter mailer' do
         expect(Spree::NewsletterMailer).not_to receive(:email_confirmation)
+        deliver_newsletter_email_verification
       end
     end
   end


### PR DESCRIPTION
…ter subscriber mailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Newsletter verification emails now respect the store setting for sending consumer transactional emails; when disabled, verification emails are not sent, with no change when enabled.

- Tests
  - Added a spec ensuring no newsletter verification email is sent when the store’s consumer transactional emails setting is disabled, improving coverage and preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->