### PR TITLE
Use native rails `dependent: :destroy` for Line Items inventory units…

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -18,7 +18,7 @@ module Spree
     has_one :product, -> { with_deleted }, class_name: 'Spree::Product', through: :variant
 
     has_many :adjustments, as: :adjustable, dependent: :destroy
-    has_many :inventory_units, inverse_of: :line_item, dependent: :destroy
+    has_many :inventory_units, class_name: 'Spree::InventoryUnit', inverse_of: :line_item, dependent: :destroy
     has_many :shipments, through: :inventory_units, source: :shipment
     has_many :digital_links, dependent: :destroy
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -18,7 +18,7 @@ module Spree
     has_one :product, -> { with_deleted }, class_name: 'Spree::Product', through: :variant
 
     has_many :adjustments, as: :adjustable, dependent: :destroy
-    has_many :inventory_units, inverse_of: :line_item
+    has_many :inventory_units, inverse_of: :line_item, dependent: :destroy
     has_many :shipments, through: :inventory_units, source: :shipment
     has_many :digital_links, dependent: :destroy
 
@@ -40,8 +40,6 @@ module Spree
     validate :ensure_proper_currency, if: -> { order.present? }
 
     before_destroy :verify_order_inventory_before_destroy, if: -> { order.has_checkout_step?('delivery') }
-
-    before_destroy :destroy_inventory_units
 
     after_save :update_inventory
     after_save :update_adjustments
@@ -224,10 +222,6 @@ module Spree
 
     def verify_order_inventory_before_destroy
       Spree::OrderInventory.new(order, self).verify(target_shipment)
-    end
-
-    def destroy_inventory_units
-      throw(:abort) unless inventory_units.destroy_all
     end
 
     def update_adjustments


### PR DESCRIPTION
… association

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removing an item from an order now consistently releases its reserved inventory, preventing stale stock allocations and errors during cart updates, edits, or cancellations.

* **Refactor**
  * Cleanup of item removal now relies on built-in lifecycle handling, improving consistency and reducing edge-case failures during destruction of related records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->