### PR TITLE
V-3249 Fixed handling of lazy loaded frames on Safari, mainly the cart pane …

### DIFF
--- a/storefront/app/helpers/spree/cart_helper.rb
+++ b/storefront/app/helpers/spree/cart_helper.rb
@@ -48,7 +48,7 @@ module Spree
     def cart_id(order)
       return 'cart_contents' if order.blank? || order.id.blank? || order.updated_at.blank?
 
-      "cart_contents_#{order.id}_#{order.updated_at.to_i}"
+      "cart_contents_#{order.id}"
     end
   end
 end

--- a/storefront/app/javascript/spree/storefront/application.js
+++ b/storefront/app/javascript/spree/storefront/application.js
@@ -140,6 +140,14 @@ document.addEventListener('turbo:submit-end', () => {
   Turbo.navigator.delegate.adapter.progressBar.hide()
 })
 
+// fix for Safari buggy behavior with lazy loaded turbo frames
+document.addEventListener("turbo:before-fetch-request", (event) => {
+  const frame = event.target.closest("turbo-frame");
+  if (frame && frame.id) {
+    event.detail.fetchOptions.headers["Turbo-Frame"] = frame.id;
+  }
+});
+
 function replaceCsrfMetaTags() {
   const csrfMetaTagsTemplate = document.querySelector('template#csrf_meta_tags')
   if (!csrfMetaTagsTemplate) return

--- a/storefront/app/views/themes/default/spree/shared/_cart_pane.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_cart_pane.html.erb
@@ -33,8 +33,8 @@
         <span class='sr-only'><%= Spree.t('storefront.cart.items_in_cart') %>, <%= Spree.t('storefront.cart.view_bag') %></span>
       </span>
     </div>
-    <div class='flex-1 h-0 overflow-y-auto'>
-      <%= turbo_frame_tag cart_id(order), class: 'cart-contents', src: spree.cart_path, data: { turbo_permanent: true }, loading: :lazy %>
+    <div class='flex-1 h-0 overflow-y-auto' id="cart-pane-container" data-turbo-permanent>
+      <%= turbo_frame_tag cart_id(order), class: 'cart-contents', src: spree.cart_path, loading: :lazy %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
…frame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved Safari compatibility for lazy-loaded content by ensuring correct frame headers are sent.
  - Ensured the cart pane persists across page navigations by making its outer container permanent.
  - Stabilized cart behavior by using a consistent cart identifier, reducing unnecessary refreshes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->