### PR TITLE
Block general settings

### DIFF
--- a/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
@@ -76,9 +76,7 @@
       <% end %>
     <% end %>
 
-    <% if can?(:manage, :dashboard) %>
-      <%= nav_item(Spree.t(:home), spree.admin_path, icon: 'home', active: controller_name == 'dashboard' && action_name == 'show') %>
-    <% end %>
+    <%= nav_item(Spree.t(:home), spree.admin_path, icon: 'home', active: controller_name == 'dashboard' && action_name == 'show') %>
 
     <%= render 'spree/admin/shared/sidebar/orders_nav' %>
     <%= render 'spree/admin/shared/sidebar/returns_nav' %>

--- a/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
@@ -76,7 +76,9 @@
       <% end %>
     <% end %>
 
-    <%= nav_item(Spree.t(:home), spree.admin_path, icon: 'home', active: controller_name == 'dashboard' && action_name == 'show') %>
+    <% if can?(:manage, :dashboard) %>
+      <%= nav_item(Spree.t(:home), spree.admin_path, icon: 'home', active: controller_name == 'dashboard' && action_name == 'show') %>
+    <% end %>
 
     <%= render 'spree/admin/shared/sidebar/orders_nav' %>
     <%= render 'spree/admin/shared/sidebar/returns_nav' %>

--- a/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_nav.html.erb
@@ -64,13 +64,15 @@
   </ul>
 <% else %>
   <ul class="nav flex-column">
-    <% unless current_store.setup_completed? %>
-      <%= nav_item(nil, spree.admin_getting_started_path, icon: 'map') do %>
-        <%= icon 'map' %>
-        <%= Spree.t('admin.getting_started') %>
-        <span class="badge ml-auto badge-info">
-          <%= current_store.setup_tasks_done %><span class="opacity-50">/<%= current_store.setup_tasks_total %></span>
-        </span>
+    <% if can?(:manage, current_store) %>
+      <% unless current_store.setup_completed? %>
+        <%= nav_item(nil, spree.admin_getting_started_path, icon: 'map') do %>
+          <%= icon 'map' %>
+          <%= Spree.t('admin.getting_started') %>
+          <span class="badge ml-auto badge-info">
+            <%= current_store.setup_tasks_done %><span class="opacity-50">/<%= current_store.setup_tasks_total %></span>
+          </span>
+        <% end %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Getting Started” item in the admin sidebar now appears only for users with permission to manage the current store.
  * Visibility still respects whether the store setup is completed, ensuring the item shows only when relevant.
  * Existing label, icon, and badge are unchanged when the item is visible.
  * Reduces confusion for users without appropriate access by hiding non-actionable navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->