### PR TITLE
Add ability to delete admin user

### DIFF
--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -233,7 +233,7 @@ Spree::Core::Engine.add_routes do
         put :resend
       end
     end
-    resources :admin_users, except: [:destroy]
+    resources :admin_users
 
     # Action Text
     namespace :action_text do

--- a/admin/spec/controllers/spree/admin/admin_users_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/admin_users_controller_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
 
     context 'with invalid token' do
       it 'raises RecordNotFound' do
-        expect {
+        expect do
           get :new, params: { token: 'invalid' }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
@@ -122,17 +122,17 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
 
     context 'with invalid token' do
       it 'raises RecordNotFound' do
-        expect {
+        expect do
           post :create, params: { token: 'invalid' }
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'with valid parameters' do
       it 'creates a new admin user' do
-        expect {
+        expect do
           post :create, params: valid_params
-        }.to change(Spree.admin_user_class, :count).by(1)
+        end.to change(Spree.admin_user_class, :count).by(1)
       end
 
       it 'accepts the invitation' do
@@ -167,9 +167,9 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
       end
 
       it 'does not create a new admin user' do
-        expect {
+        expect do
           post :create, params: invalid_params
-        }.not_to change(Spree.admin_user_class, :count)
+        end.not_to change(Spree.admin_user_class, :count)
       end
 
       it 'renders the new template' do
@@ -259,6 +259,28 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
 
       it 'returns unprocessable entity status' do
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    stub_authorization!
+
+    context 'can delete user' do
+      let!(:other_admin) { create(:admin_user) }
+
+      it 'deletes the admin user' do
+        expect { delete :destroy, params: { id: admin_user.id } }.to change(Spree.admin_user_class, :count).by(-1)
+        expect(response).to redirect_to(spree.admin_admin_users_path)
+      end
+    end
+
+    context 'cannot delete user' do
+      it 'does not delete the admin user' do
+        delete :destroy, params: { id: admin_user.id }
+        expect(response).to redirect_to(spree.admin_admin_users_path)
+        expect(flash[:error]).to include ('Cannot delete the last admin user')
+        expect(admin_user).not_to be_destroyed
       end
     end
   end

--- a/api/spec/integration/api/v2/platform/users_spec.rb
+++ b/api/spec/integration/api/v2/platform/users_spec.rb
@@ -3,6 +3,8 @@ require 'swagger_helper'
 describe 'Users API', swagger: true do
   include_context 'Platform API v2'
 
+  let!(:another_admin_user) { create(:admin_user) }
+
   resource_name = 'User'
   options = {
     include_example: 'ship_address,bill_address',

--- a/core/app/models/concerns/spree/admin_user_methods.rb
+++ b/core/app/models/concerns/spree/admin_user_methods.rb
@@ -52,6 +52,7 @@ module Spree
 
     def check_if_there_are_other_admin_users
       return if self.class != Spree.admin_user_class
+      return unless has_spree_role?(Spree::Role::ADMIN_ROLE)
 
       if Spree::Store.current.users.where.not(id: id).none?
         errors.add(:base, I18n.t('activerecord.errors.models.spree/admin_user.attributes.base.cannot_destroy_last_admin_user'))

--- a/core/app/models/concerns/spree/admin_user_methods.rb
+++ b/core/app/models/concerns/spree/admin_user_methods.rb
@@ -1,0 +1,62 @@
+module Spree
+  module AdminUserMethods
+    extend ActiveSupport::Concern
+
+    included do
+      # Associations
+      has_many :canceled_orders, class_name: 'Spree::Order', foreign_key: :canceler_id
+      has_many :created_orders, class_name: 'Spree::Order', foreign_key: :created_by_id
+      has_many :approved_orders, class_name: 'Spree::Order', foreign_key: :approver_id
+      has_many :created_gift_cards, class_name: 'Spree::GiftCard', foreign_key: :created_by_id
+      has_many :created_gift_card_batches, class_name: 'Spree::GiftCardBatch', foreign_key: :created_by_id
+      has_many :refunded_refunds, class_name: 'Spree::Refund', foreign_key: :refunder_id
+      has_many :performed_reimbursements, class_name: 'Spree::Reimbursement', foreign_key: :performed_by_id
+      has_many :authored_posts, class_name: 'Spree::Post', foreign_key: :author_id
+      has_many :created_store_credits, class_name: 'Spree::StoreCredit', foreign_key: :created_by_id
+      has_many :reports, class_name: 'Spree::Report', foreign_key: :user_id
+      has_many :exports, class_name: 'Spree::Export', foreign_key: :user_id
+
+      # Callbacks
+      before_destroy :check_if_there_are_other_admin_users
+      after_destroy :nullify_approver_id_in_approved_orders
+      after_destroy :cleanup_admin_user_resources
+    end
+
+    private
+
+    def nullify_approver_id_in_approved_orders
+      return if self.class != Spree.admin_user_class
+
+      approved_orders.update_all(approver_id: nil, updated_at: Time.current)
+    end
+
+    def cleanup_admin_user_resources
+      return if self.class != Spree.admin_user_class
+
+      # resources to nullify
+      # TODO: we should change these associations to polymorphic and resolve this via standard rails association
+      # declarations with dependent: :nullify
+      canceled_orders.update_all(canceler_id: nil, updated_at: Time.current)
+      created_orders.update_all(created_by_id: nil, updated_at: Time.current)
+      created_gift_cards.update_all(created_by_id: nil, updated_at: Time.current)
+      created_gift_card_batches.update_all(created_by_id: nil, updated_at: Time.current)
+      refunded_refunds.update_all(refunder_id: nil, updated_at: Time.current)
+      performed_reimbursements.update_all(performed_by_id: nil, updated_at: Time.current)
+      authored_posts.update_all(author_id: nil, updated_at: Time.current)
+      created_store_credits.update_all(created_by_id: nil, updated_at: Time.current)
+
+      # resources to destroy
+      reports.destroy_all
+      exports.destroy_all
+    end
+
+    def check_if_there_are_other_admin_users
+      return if self.class != Spree.admin_user_class
+
+      if Spree::Store.current.users.where.not(id: id).none?
+        errors.add(:base, I18n.t('activerecord.errors.models.spree/admin_user.attributes.base.cannot_destroy_last_admin_user'))
+        throw(:abort)
+      end
+    end
+  end
+end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -5,6 +5,7 @@ module Spree
     include Spree::UserPaymentSource
     include Spree::UserReporting
     include Spree::UserRoles
+    include Spree::AdminUserMethods
     include Spree::RansackableAttributes
     include Spree::MultiSearchable
     included do
@@ -12,7 +13,6 @@ module Spree
       # https://github.com/rails/rails/issues/3458
       before_validation :clone_billing_address, if: :use_billing?
       before_destroy :check_completed_orders
-      after_destroy :nullify_approver_id_in_approved_orders
 
       attr_accessor :use_billing
 
@@ -142,12 +142,6 @@ module Spree
 
     def check_completed_orders
       raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
-    end
-
-    def nullify_approver_id_in_approved_orders
-      return unless Spree.admin_user_class != Spree.user_class
-
-      Spree::Order.where(approver_id: id).update_all(approver_id: nil)
     end
 
     def clone_billing_address

--- a/core/app/models/concerns/spree/user_payment_source.rb
+++ b/core/app/models/concerns/spree/user_payment_source.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :credit_cards, class_name: 'Spree::CreditCard', foreign_key: :user_id
+      has_many :credit_cards, class_name: 'Spree::CreditCard', foreign_key: :user_id, dependent: :destroy
       def default_credit_card
         credit_cards.default.first
       end

--- a/core/app/models/concerns/spree/user_roles.rb
+++ b/core/app/models/concerns/spree/user_roles.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id, as: :user, dependent: :destroy
+      has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id, as: :user, dependent: :destroy_async # async as we need to check if the user has admin role before destroying
       has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
       has_many :stores, through: :role_users, source: :resource, source_type: 'Spree::Store'
       has_many :invitations, class_name: 'Spree::Invitation', as: :invitee, dependent: :destroy

--- a/core/app/models/concerns/spree/user_roles.rb
+++ b/core/app/models/concerns/spree/user_roles.rb
@@ -6,8 +6,8 @@ module Spree
       has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id, as: :user, dependent: :destroy
       has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
       has_many :stores, through: :role_users, source: :resource, source_type: 'Spree::Store'
-      has_many :invitations, class_name: 'Spree::Invitation', foreign_key: :invitee_id, as: :invitee, dependent: :destroy
-      has_many :sent_invitations, class_name: 'Spree::Invitation', foreign_key: :inviter_id, as: :inviter, dependent: :destroy
+      has_many :invitations, class_name: 'Spree::Invitation', as: :invitee, dependent: :destroy
+      has_many :sent_invitations, class_name: 'Spree::Invitation', as: :inviter, dependent: :destroy
 
       scope :spree_admin, -> { joins(:spree_roles).where(Spree::Role.table_name => { name: Spree::Role::ADMIN_ROLE }) }
 

--- a/core/app/models/concerns/spree/user_roles.rb
+++ b/core/app/models/concerns/spree/user_roles.rb
@@ -6,7 +6,8 @@ module Spree
       has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id, as: :user, dependent: :destroy
       has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
       has_many :stores, through: :role_users, source: :resource, source_type: 'Spree::Store'
-      has_many :invitations, class_name: 'Spree::Invitation', foreign_key: :invitee_id, dependent: :destroy
+      has_many :invitations, class_name: 'Spree::Invitation', foreign_key: :invitee_id, as: :invitee, dependent: :destroy
+      has_many :sent_invitations, class_name: 'Spree::Invitation', foreign_key: :inviter_id, as: :inviter, dependent: :destroy
 
       scope :spree_admin, -> { joins(:spree_roles).where(Spree::Role.table_name => { name: Spree::Role::ADMIN_ROLE }) }
 

--- a/core/app/models/spree/gift_card_batch.rb
+++ b/core/app/models/spree/gift_card_batch.rb
@@ -10,7 +10,6 @@ module Spree
     belongs_to :created_by, class_name: Spree.admin_user_class.to_s, optional: true
     has_many :gift_cards, class_name: 'Spree::GiftCard', inverse_of: :batch, dependent: :destroy
 
-
     #
     # Validations
     #

--- a/core/app/models/spree/post.rb
+++ b/core/app/models/spree/post.rb
@@ -45,7 +45,7 @@ module Spree
     #
     # Validations
     #
-    validates :title, :store, :author, presence: true
+    validates :title, :store, presence: true
     validates :slug, presence: true, uniqueness: { scope: :store_id, conditions: -> { where(deleted_at: nil) } }
     validates :meta_title, length: { maximum: 160 }, allow_blank: true
     validates :meta_description, length: { maximum: 320 }, allow_blank: true

--- a/core/app/models/spree/post.rb
+++ b/core/app/models/spree/post.rb
@@ -37,7 +37,7 @@ module Spree
     #
     # Associations
     #
-    belongs_to :author, class_name: Spree.admin_user_class.to_s
+    belongs_to :author, class_name: Spree.admin_user_class.to_s, optional: true
     belongs_to :store, class_name: 'Spree::Store'
     belongs_to :post_category, class_name: 'Spree::PostCategory', optional: true
     alias category post_category

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -13,7 +13,7 @@ module Spree
       belongs_to :reimbursement, optional: true
     end
     belongs_to :reason, class_name: 'Spree::RefundReason', foreign_key: :refund_reason_id
-    belongs_to :refunder, class_name: "::#{Spree.admin_user_class}", optional: true
+    belongs_to :refunder, class_name: Spree.admin_user_class.to_s, optional: true
 
     has_many :log_entries, as: :source
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -19,7 +19,7 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store'
     belongs_to :user, class_name: "::#{Spree.user_class}", foreign_key: 'user_id'
     belongs_to :category, class_name: 'Spree::StoreCreditCategory', optional: true
-    belongs_to :created_by, class_name: "::#{Spree.admin_user_class}", foreign_key: 'created_by_id', optional: true
+    belongs_to :created_by, class_name: Spree.admin_user_class.to_s, foreign_key: 'created_by_id', optional: true
     belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id', optional: true
     belongs_to :originator, polymorphic: true, optional: true
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -216,6 +216,10 @@ en:
       messages:
         blank: can't be blank
       models:
+        spree/admin_user:
+          attributes:
+            base:
+              cannot_destroy_last_admin_user: Cannot delete the last admin user
         spree/calculator/tiered_flat_rate:
           attributes:
             base:

--- a/core/lib/spree/testing_support/factories/export_factory.rb
+++ b/core/lib/spree/testing_support/factories/export_factory.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
   factory :export, class: 'Spree::Export' do
     store { create(:store) }
     user { create(:admin_user) }
-    type { 'Spree::Export::Products' }
+    type { 'Spree::Exports::Products' }
     format { 'csv' }
 
     factory :product_export, class: 'Spree::Exports::Products', parent: :export do

--- a/core/spec/models/spree/admin_user_spec.rb
+++ b/core/spec/models/spree/admin_user_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::LegacyUser, type: :model do
+  let(:admin_user) { create(:admin_user) }
+
+  context 'Callbacks' do
+    describe 'do not allow to delete last admin user' do
+      it 'raises an error' do
+        admin_user
+        expect { admin_user.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      end
+    end
+
+    describe 'cleans up admin user resources' do
+      let!(:other_admin_user) { create(:admin_user) }
+      let!(:cancelled_orders) { create_list(:order, 2, canceler: admin_user, state: 'canceled') }
+      let!(:approved_orders) { create_list(:order, 2, approver: admin_user) }
+      let!(:gift_card_batches) { create_list(:gift_card_batch, 2, created_by: admin_user, amount: 100, prefix: 'TEST') }
+      let!(:gift_cards) { create_list(:gift_card, 2, created_by: admin_user) }
+      let!(:refunds) { create_list(:refund, 2, refunder: admin_user, amount: 1) }
+      let!(:reimbursements) { create_list(:reimbursement, 2, performed_by: admin_user) }
+      let!(:posts) { create_list(:post, 2, author: admin_user) }
+      let!(:reports) { create_list(:report, 2, user: admin_user) }
+      let!(:store_credits) { create_list(:store_credit, 2, created_by: admin_user) }
+      let!(:exports) { create_list(:export, 2, user: admin_user) }
+
+      it 'nullifies admin user resources' do
+        expect { admin_user.destroy }.to change(Spree.admin_user_class, :count).by(-1).and change(Spree::Export, :count).by(-2).and change(Spree::Report, :count).by(-2)
+
+        expect(cancelled_orders.all? { |order| order.reload.canceler_id.nil? }).to be_truthy
+        expect(approved_orders.all? { |order| order.reload.approver_id.nil? }).to be_truthy
+        expect(gift_card_batches.all? { |batch| batch.reload.created_by_id.nil? }).to be_truthy
+        expect(gift_cards.all? { |gift_card| gift_card.reload.created_by_id.nil? }).to be_truthy
+        expect(refunds.all? { |refund| refund.reload.refunder_id.nil? }).to be_truthy
+        expect(reimbursements.all? { |reimbursement| reimbursement.reload.performed_by_id.nil? }).to be_truthy
+        expect(posts.all? { |post| post.reload.author_id.nil? }).to be_truthy
+        expect(store_credits.all? { |store_credit| store_credit.reload.created_by_id.nil? }).to be_truthy
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Spree::UserMethods do
   let(:test_user) { create :user }
+  let!(:another_user) { create(:user) }
   let(:current_store) { @default_store }
 
   describe '#last_incomplete_spree_order' do
@@ -57,16 +58,6 @@ describe Spree::UserMethods do
       end
     end
   end
-
-  context 'when user destroyed with approved orders' do
-    let(:order) { create(:order, approver_id: test_user.id, created_at: 1.day.ago) }
-
-    it 'nullifies all approver ids' do
-      expect(test_user).to receive(:nullify_approver_id_in_approved_orders)
-      test_user.destroy
-    end
-  end
-
   describe '#payment_sources' do
     subject { test_user.payment_sources }
 

--- a/core/spec/models/spree/post_spec.rb
+++ b/core/spec/models/spree/post_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Spree::Post, type: :model do
   let(:post) { create(:post) }
 
-  describe 'validations' do
+  context 'Validations' do
     describe 'image' do
       it 'validates content type' do
         post.image.attach(
@@ -30,6 +30,22 @@ RSpec.describe Spree::Post, type: :model do
 
         other_post.destroy
         expect(post).to be_valid
+      end
+    end
+  end
+
+  describe '#author_name' do
+    it 'returns the author name' do
+      expect(post.author_name).to eq(post.author.name)
+    end
+
+    context 'when author is deleted' do
+      let!(:other_admin_user) { create(:admin_user) }
+
+      it 'returns the author name' do
+        post.author.destroy!
+        post.reload
+        expect(post.author_name).to be_nil
       end
     end
   end

--- a/storefront/app/views/themes/default/spree/posts/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/posts/_json_ld.html.erb
@@ -6,14 +6,12 @@
     "image": <%= post.image.attached? ? [spree_image_url(post.image, width: 1200, height: 675)].to_json.html_safe : [].to_json.html_safe %>,
     "datePublished": "<%= post.published_at&.iso8601 %>",
     "dateModified": "<%= post.updated_at&.iso8601 %>",
-    <% if post.author.present? %>
     "author": [
       {
         "@type": "Person",
         "name": "<%= post.author_name %>"
       }
     ]
-    <% end %>
   }
 </script>
 

--- a/storefront/app/views/themes/default/spree/posts/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/posts/_json_ld.html.erb
@@ -6,12 +6,14 @@
     "image": <%= post.image.attached? ? [spree_image_url(post.image, width: 1200, height: 675)].to_json.html_safe : [].to_json.html_safe %>,
     "datePublished": "<%= post.published_at&.iso8601 %>",
     "dateModified": "<%= post.updated_at&.iso8601 %>",
+    <% if post.author.present? %>
     "author": [
       {
         "@type": "Person",
         "name": "<%= post.author_name %>"
       }
     ]
+    <% end %>
   }
 </script>
 


### PR DESCRIPTION
Also cleanup after deletion
Prohibit from deleting the last one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can delete other admin users; deletion now cleans up or nullifies related resources and prevents removing the last admin.
  * Posts’ author is optional and author reference becomes nil when removed.
  * Users’ saved credit cards are removed when the user is deleted.
  * Invitations support sent and received lists; role-related removals occur asynchronously.

* **Localization**
  * Added error message for attempting to delete the last admin user.

* **Tests**
  * Added specs for admin deletion, resource cleanup, last-admin protection, and post author behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->