### PR TITLE
Use `add_reference` instead of bigint column so UUID primary keys wil…

### DIFF
--- a/core/db/migrate/20250304115943_add_performed_by_to_spree_reimbursements.rb
+++ b/core/db/migrate/20250304115943_add_performed_by_to_spree_reimbursements.rb
@@ -1,5 +1,5 @@
 class AddPerformedByToSpreeReimbursements < ActiveRecord::Migration[6.1]
   def change
-    add_column :spree_reimbursements, :performed_by_id, :bigint, index: true, null: true, if_not_exists: true
+    add_reference :spree_reimbursements, :performed_by, index: true, null: true unless column_exists?(:spree_reimbursements, :performed_by_id)
   end
 end


### PR DESCRIPTION
…l work as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved database schema migration for reimbursements by switching to a reference-based column addition with explicit existence checks. This reduces the risk of duplicate columns and index conflicts during upgrades, improving reliability across environments and repeated deploys. The change aligns with framework conventions and does not introduce foreign key constraints. No functional or UI changes; existing behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->