### PR TITLE
Admin: Disable turbo prefetch for links to page builder

### DIFF
--- a/admin/app/views/spree/admin/dashboard/_store_preview.html.erb
+++ b/admin/app/views/spree/admin/dashboard/_store_preview.html.erb
@@ -1,6 +1,6 @@
 <% if current_store.default_theme %>
   <div class="card mb-4">
-    <%= link_to spree.edit_admin_theme_path(current_store.default_theme), class: 'd-block border rounded mx-2 mt-2 mb-0 overflow-auto bg-light position-relative store-preview-link' do %>
+    <%= link_to spree.edit_admin_theme_path(current_store.default_theme), class: 'd-block border rounded mx-2 mt-2 mb-0 overflow-auto bg-light position-relative store-preview-link', data: { turbo_prefetch: false } do %>
       <div class="position-absolute w-100 h-100 align-items-center justify-content-center overlay-background store-preview-actions">
         <button class="btn btn-primary">
           <%= icon('tools') %>
@@ -23,7 +23,7 @@
           &nbsp;
           <%= Spree.t(:view_store) %>
         <% end %>
-        <%= link_to spree.edit_admin_theme_path(current_store.default_theme), class: 'btn btn-light w-50' do %>
+        <%= link_to spree.edit_admin_theme_path(current_store.default_theme), class: 'btn btn-light w-50', data: { turbo_prefetch: false } do %>
           <%= icon 'tools', class: 'mr-1' %>
           &nbsp;
           <%= Spree.t('admin.edit_theme') %>

--- a/admin/app/views/spree/admin/pages/_table_row.html.erb
+++ b/admin/app/views/spree/admin/pages/_table_row.html.erb
@@ -1,6 +1,6 @@
 <tr id="<%= dom_id page %>" data-controller="row-link" class="cursor-pointer">
   <td scope="row" data-action="click->row-link#openLink" class="w-60">
-    <%= link_to page.name, spree.edit_admin_theme_path(current_store.default_theme, page_id: page.id), data: { row_link_target: :link, turbo_frame: '_top' } %>
+    <%= link_to page.name, spree.edit_admin_theme_path(current_store.default_theme, page_id: page.id), data: { row_link_target: :link, turbo_frame: '_top', turbo_prefetch: false } %>
   </td>
   <td data-action="click->row-link#openLink" class="w-15">
     <%= spree_time_ago(page.created_at, class: 'with-tip') %>
@@ -15,7 +15,7 @@
       </button>
       <ul class="dropdown-menu">
         <li>
-          <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_admin_theme_path(current_store.default_theme, page_id: page.id), class: 'dropdown-item', data: { turbo_frame: '_top' } %>
+          <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_admin_theme_path(current_store.default_theme, page_id: page.id), class: 'dropdown-item', data: { turbo_frame: '_top', turbo_prefetch: false } %>
         </li>
         <li>
           <%= link_to_delete(page, class: 'dropdown-item btn-danger', icon: 'trash') %>

--- a/admin/app/views/spree/admin/shared/sidebar/_store_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/sidebar/_store_dropdown.html.erb
@@ -10,7 +10,7 @@
         <%= icon 'eye' %>
         <%= Spree.t(:view_store) %>
       <% end %>
-      <%= link_to spree.edit_admin_theme_path(current_store.default_theme), class: 'dropdown-item' do %>
+      <%= link_to spree.edit_admin_theme_path(current_store.default_theme), class: 'dropdown-item', data: { turbo_prefetch: false } do %>
         <%= icon 'tools' %>
         <%= Spree.t('admin.edit_theme') %>
       <% end if current_store.default_theme && can?(:manage, Spree::Theme) %>

--- a/admin/app/views/spree/admin/themes/_theme.html.erb
+++ b/admin/app/views/spree/admin/themes/_theme.html.erb
@@ -1,6 +1,6 @@
 <tr id="<%= spree_dom_id theme %>">
   <td class="w-70 p-0">
-    <%= link_to theme.ready? ? spree.edit_admin_theme_path(theme) : '#', class: 'd-flex align-items-top p-3' do %>
+    <%= link_to theme.ready? ? spree.edit_admin_theme_path(theme) : '#', class: 'd-flex align-items-top p-3', data: { turbo_prefetch: false } do %>
       <div class="w-20">
         <%= render 'spree/admin/themes/theme_preview_image', theme: theme, css_class: 'img-thumbnail w-100' %>
       </div>
@@ -43,7 +43,7 @@
             <%= icon('dots-vertical', class: 'mr-0') %>
           </button>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-            <%= link_to_edit theme, class: 'dropdown-item' %>
+            <%= link_to_edit theme, class: 'dropdown-item', data: { turbo_prefetch: false } %>
             <%= link_to_with_icon 'copy', Spree.t(:clone), spree.clone_admin_theme_path(theme), class: 'dropdown-item', data: { turbo_method: :post } %>
             <% unless theme.default? %>
             <%= link_to_delete(theme, icon: 'trash', class: 'dropdown-item btn-danger shadow-none') if can?(:delete, theme) %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended preloading on admin theme preview and edit links, improving reliability and reducing flicker in Turbo-enabled navigation.
  * Page edit links in admin now avoid background prefetch, ensuring more predictable behavior when opening edit screens.
  * Store dropdown theme edit link no longer prefetches, minimizing unexpected state changes and improving consistency.

* **Chores**
  * Standardized link behavior across admin views to disable prefetch where editing or previewing actions occur for a smoother, more stable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->