### PR TITLE
Fixed: don't cache product carousel in page builder mode

### DIFF
--- a/storefront/app/helpers/spree/theme_helper.rb
+++ b/storefront/app/helpers/spree/theme_helper.rb
@@ -65,7 +65,7 @@ module Spree
     #
     # @return [Boolean] whether the page builder is enabled
     def page_builder_enabled?
-      @page_builder_enabled ||= (current_theme_preview.present? || current_page_preview.present?) && params[:page_builder] == 'true'
+      @page_builder_enabled ||= current_theme_preview.present? || current_page_preview.present?
     end
 
     # Returns whether the page cache is enabled

--- a/storefront/app/views/spree/shared/_products.html.erb
+++ b/storefront/app/views/spree/shared/_products.html.erb
@@ -1,1 +1,5 @@
-<%= render partial: 'spree/products/product', collection: products, cached: ->(product) { product_cache_key(product) } %>
+<% unless page_builder_enabled? %>
+  <%= render partial: 'spree/products/product', collection: products, cached: ->(product) { product_cache_key(product) } %>
+<% else %>
+  <%= render partial: 'spree/products/product', collection: products %>
+<% end %>

--- a/storefront/spec/helpers/spree/theme_helper_spec.rb
+++ b/storefront/spec/helpers/spree/theme_helper_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Spree::ThemeHelper, type: :helper do
 
   describe '#page_builder_enabled?' do
     it 'returns true if page builder is enabled' do
-      allow(helper).to receive(:params).and_return(theme_preview_id: theme_preview.id, page_builder: 'true')
+      allow(helper).to receive(:params).and_return(theme_preview_id: theme_preview.id)
       expect(helper.page_builder_enabled?).to be_truthy
     end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Page Builder now auto-enables during theme/page previews—no URL parameter required.
  * Product listings update in real time while Page Builder is active by temporarily disabling caching during previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->