### PR TITLE
Run promotion and other adjusters before tax adjuster

### DIFF
--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -17,8 +17,14 @@ module Spree
           non_taxable_adjustment_total: 0,
           taxable_adjustment_total: 0
         }
-        adjusters.each do |klass|
+        non_tax_adjusters.each do |klass|
           klass.adjust(@adjustable, totals)
+        end
+
+        if tax_adjuster.present?
+          # Other adjustments can change the taxable amount so we need to update it first
+          update_adjustable_attributes(totals)
+          tax_adjuster.adjust(@adjustable, totals)
         end
 
         persist_totals totals
@@ -32,12 +38,16 @@ module Spree
           totals[:taxable_adjustment_total] +
           totals[:additional_tax_total]
 
-        # Only update if totals have changed
+        update_adjustable_attributes(attributes)
+      end
+
+      def update_adjustable_attributes(attributes)
+        # Only update if attributes have changed
         current_attributes = @adjustable.attributes.slice(*attributes.keys.map(&:to_s))
         return if attributes.all? { |key, value| current_attributes[key.to_s] == value }
 
         attributes[:updated_at] = Time.current
-        @adjustable.update_columns(totals)
+        @adjustable.update_columns(attributes)
       end
 
       def shipment?
@@ -46,6 +56,14 @@ module Spree
 
       def adjusters
         Rails.application.config.spree.adjusters
+      end
+
+      def tax_adjuster
+        @tax_adjuster ||= adjusters.find { |adjuster| adjuster.name == 'Spree::Adjustable::Adjuster::Tax' }
+      end
+
+      def non_tax_adjusters
+        adjusters - [tax_adjuster].compact
       end
 
       def adjustable_still_exists?

--- a/core/app/models/spree/adjustable/adjustments_updater.rb
+++ b/core/app/models/spree/adjustable/adjustments_updater.rb
@@ -36,7 +36,7 @@ module Spree
         attributes = totals
         attributes[:adjustment_total] = totals[:non_taxable_adjustment_total] +
           totals[:taxable_adjustment_total] +
-          totals[:additional_tax_total]
+          totals.fetch(:additional_tax_total, 0)
 
         update_adjustable_attributes(attributes)
       end

--- a/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
+++ b/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
@@ -7,13 +7,20 @@ module Spree
       let(:line_item) { order.line_items.first }
       let(:tax_rate) { create(:tax_rate, amount: 0.05) }
 
+      let(:promotion) { create(:promotion, :with_line_item_adjustment, adjustment_rate: 2) }
+      let(:promotion_action) { promotion.actions.first }
+
       describe '#update' do
+        let(:promo_total) { -2 }
+        let(:tax_total) { 0.4 }
+
         before do
+          create(:adjustment, order: order, source: promotion_action, adjustable: line_item)
           create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
         end
 
         context 'persisted object' do
-          let(:subject) { AdjustmentsUpdater.new(line_item) }
+          subject { AdjustmentsUpdater.new(line_item) }
 
           it 'updates all linked adjusters' do
             line_item.price = 10
@@ -24,8 +31,9 @@ module Spree
             old_updated_at = line_item.updated_at
 
             subject.update
-            expect(line_item.adjustment_total).to eq(0.5)
-            expect(line_item.additional_tax_total).to eq(0.5)
+            expect(line_item.promo_total).to eq(promo_total)
+            expect(line_item.additional_tax_total).to eq(tax_total)
+            expect(line_item.adjustment_total).to eq(tax_total + promo_total)
             expect(line_item.updated_at).not_to eq(old_updated_at)
 
             old_updated_at = line_item.updated_at
@@ -33,8 +41,9 @@ module Spree
             subject.update
             # skipping the update because the totals have not changed
             line_item.reload
-            expect(line_item.adjustment_total).to eq(0.5)
-            expect(line_item.additional_tax_total).to eq(0.5)
+            expect(line_item.promo_total).to eq(promo_total)
+            expect(line_item.additional_tax_total).to eq(tax_total)
+            expect(line_item.adjustment_total).to eq(tax_total + promo_total)
             expect(line_item.updated_at).to eq(old_updated_at)
           end
         end

--- a/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
+++ b/core/spec/models/spree/adjustable/adjustments_updater_spec.rb
@@ -14,20 +14,23 @@ module Spree
         let(:promo_total) { -2 }
         let(:tax_total) { 0.4 }
 
-        before do
-          create(:adjustment, order: order, source: promotion_action, adjustable: line_item)
-          create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
+        let(:adjustments) do
+          [
+            create(:adjustment, order: order, source: promotion_action, adjustable: line_item),
+            create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
+          ]
         end
 
         context 'persisted object' do
           subject { AdjustmentsUpdater.new(line_item) }
 
           it 'updates all linked adjusters' do
+            adjustments
+
             line_item.price = 10
             line_item.tax_category = tax_rate.tax_category
             line_item.adjustment_total = 0
             line_item.additional_tax_total = 0
-
             old_updated_at = line_item.updated_at
 
             subject.update
@@ -45,6 +48,38 @@ module Spree
             expect(line_item.additional_tax_total).to eq(tax_total)
             expect(line_item.adjustment_total).to eq(tax_total + promo_total)
             expect(line_item.updated_at).to eq(old_updated_at)
+          end
+
+          context 'when there is no tax adjuster' do
+            before do
+              allow(Rails.application.config.spree).to receive(:adjusters).and_return([Spree::Adjustable::Adjuster::Promotion])
+            end
+
+            it 'updates all linked adjusters without tax' do
+              adjustments
+
+              line_item.price = 10
+              line_item.tax_category = tax_rate.tax_category
+              line_item.adjustment_total = 0
+              line_item.additional_tax_total = 0
+              old_updated_at = line_item.updated_at
+
+              subject.update
+              expect(line_item.promo_total).to eq(promo_total)
+              expect(line_item.additional_tax_total).to eq(0)
+              expect(line_item.adjustment_total).to eq(promo_total)
+              expect(line_item.updated_at).not_to eq(old_updated_at)
+
+              old_updated_at = line_item.updated_at
+
+              subject.update
+              # skipping the update because the totals have not changed
+              line_item.reload
+              expect(line_item.promo_total).to eq(promo_total)
+              expect(line_item.additional_tax_total).to eq(0)
+              expect(line_item.adjustment_total).to eq(promo_total)
+              expect(line_item.updated_at).to eq(old_updated_at)
+            end
           end
         end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures promotion and tax adjustments are applied in the correct order for accurate line-item totals.
  * Correctly persists totals before tax calculation to avoid stale or inconsistent amounts.
  * Handles scenarios with no tax adjuster, applying only promotion adjustments.
  * Reduces unnecessary database writes by updating totals only when values change.

* **Tests**
  * Added comprehensive specs covering promotion-only, tax-only, and combined adjustment scenarios.
  * Validates promo_total, tax_total, and overall adjustment totals across repeated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->