### PR TITLE
Added support for legacy browsers such as Safari on iOS 15

### DIFF
--- a/admin/app/views/spree/admin/shared/_head.html.erb
+++ b/admin/app/views/spree/admin/shared/_head.html.erb
@@ -37,6 +37,8 @@
 <%= tinymce_assets %>
 <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.1.12/dist/trix.css">
 
+<script async src="https://ga.jspm.io/npm:es-module-shims@1.8.2/dist/es-module-shims.js" data-turbo-track="reload"></script>
+
 <%= javascript_importmap_tags 'application-spree-admin', importmap: Rails.application.config.spree_admin.importmap %>
 
 <%= yield :head %>

--- a/storefront/app/views/spree/shared/_head.html.erb
+++ b/storefront/app/views/spree/shared/_head.html.erb
@@ -14,6 +14,8 @@
 <%= render 'spree/shared/css_variables' %>
 <%= render 'spree/shared/fonts' %>
 
+<script async src="https://ga.jspm.io/npm:es-module-shims@1.8.2/dist/es-module-shims.js" data-turbo-track="reload"></script>
+
 <%= javascript_importmap_tags "application-spree-storefront" %>
 <% if Rails.application.importmap.packages["application"].present? %>
   <%= javascript_import_module_tag "application" %>


### PR DESCRIPTION
https://github.com/rails/importmap-rails?tab=readme-ov-file#supporting-legacy-browsers-such-as-safari-on-ios-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved JavaScript module compatibility by adjusting script loading in both Admin and Storefront headers, ensuring smoother import map usage across browsers.
  * Loaded supporting script asynchronously to reduce blocking and enhance perceived page responsiveness.
  * Ensures updates are properly tracked during navigation, reducing potential issues after deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->