### PR TITLE
ADD more protocol to page builder links

### DIFF
--- a/core/app/models/spree/page_link.rb
+++ b/core/app/models/spree/page_link.rb
@@ -30,7 +30,7 @@ module Spree
 
     def formatted_url
       return if url.blank?
-      return url if url.start_with?("mailto:")
+      return url if %w[mailto: javascript: tel:].any? { |protocol| url.start_with?(protocol) }
 
       @formatted_url ||= url.match(/http:\/\/|https:\/\//) ? url : "http://#{url}"
     end

--- a/core/app/models/spree/page_link.rb
+++ b/core/app/models/spree/page_link.rb
@@ -30,7 +30,7 @@ module Spree
 
     def formatted_url
       return if url.blank?
-      return url if %w[mailto: javascript: tel:].any? { |protocol| url.start_with?(protocol) }
+      return url if %w[mailto: tel:].any? { |protocol| url.start_with?(protocol) }
 
       @formatted_url ||= url.match(/http:\/\/|https:\/\//) ? url : "http://#{url}"
     end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Preserve special protocol links so they are no longer prefixed with “http://”. Links starting with mailto: and tel: now remain intact, ensuring email and phone links behave correctly across pages, menus, and other linkable areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->