### PR TITLE
Improve the mobile hamburger menu on default storefront

### DIFF
--- a/storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js
@@ -17,7 +17,6 @@ export default class ToggleMenu extends Toggle {
   }
 
   toggle(e) {
-    this.contentTarget.style.paddingBottom = `${this.contentTarget.offsetTop}px`
     super.toggle(e)
     if (this.openValue) {
       this.buttonTarget.classList.add('menu-open')

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -79,9 +79,8 @@
             <% if should_render_currency_dropdown? || should_render_locale_dropdown? %>
               <div
               data-controller="modal"
-              data-modal-allow-background-close="true"
-              class="hidden lg:flex"
-              data-modal-backdrop-color-value="rgba(0,0,0,0.32)">
+              data-modal-disable-backdrop="true"
+              class="hidden lg:flex">
                 <%= button_tag class: 'flex gap-2 items-center', data: {action: 'modal#open'} do %>
                   <% if should_render_currency_dropdown? %>
                     <span>
@@ -136,7 +135,8 @@
           </div>
         </div>
       </div>
-      <div
+    </nav>
+    <div
         class='h-0 opacity-0 pointer-events-none hide-on-load'
         data-toggle-menu-target='toggleable'
         role='dialog'
@@ -145,12 +145,11 @@
         <div
           class='flex justify-between flex-col lg:hidden w-full transition-transform translate-x-[-50%] has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
           data-toggle-menu-target='content'
-          style='background-color: <%= section.preferred_background_color %>; height: calc(100dvh - 38px);'
+          style='background-color: <%= section.preferred_background_color %>; height: calc(100dvh - 58px - 36px);'
           >
           <%= render 'spree/page_sections/nav/mobile', section: section %>
         </div>
       </div>
-    </nav>
 
     <%= render 'spree/shared/cart_pane', section: section %>
     <% if show_account_pane? %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-background mt-4 border-default border-t overflow-x-hidden h-full w-screen overflow-y-hidden">
+<div class="bg-background border-default border-t overflow-x-hidden h-full w-screen overflow-y-hidden">
   <div class="h-full flex transform has-[.currency-and-locale-modal:not(.hidden)]:transform-none relative transition-transform duration-300" data-controller="mobile-nav">
     <div class="w-screen shrink-0 flex flex-col h-full flex-grow-0">
       <div class="flex-grow overflow-y-scroll">
@@ -103,12 +103,7 @@
 
         <% if should_render_currency_dropdown? || should_render_locale_dropdown? %>
           <div class="flex mt-4 justify-end">
-            <div
-                data-controller="modal"
-                data-modal-allow-background-close="true"
-                data-modal-
-                class=""
-                data-modal-backdrop-color-value="rgba(0,0,0,0.32)">
+            <div data-controller="modal" data-modal-disable-backdrop="true">
               <%= button_tag class: 'flex gap-2 items-center', data: {action: 'modal#open'} do %>
                 <% if should_render_currency_dropdown? %>
                   <span>
@@ -123,7 +118,7 @@
                   </span>
                 <% end %>
               <% end %>
-              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :lazy  %>
+              <%= turbo_frame_tag :settings_modal, src: spree.settings_path, loading: :lazy %>
             </div>
           </div>
         <% end %>

--- a/storefront/app/views/themes/default/spree/settings/show.html.erb
+++ b/storefront/app/views/themes/default/spree/settings/show.html.erb
@@ -2,9 +2,9 @@
   <div
     data-modal-target="container"
     data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard"
-    class="currency-and-locale-modal hidden animate-fadeIn fixed inset-0 overflow-y-auto flex items-end md:items-center justify-center z-[9999] h-dvh w-full"
+    class="currency-and-locale-modal hidden fixed inset-0 overflow-y-auto flex items-end md:items-start justify-center z-[9999] h-dvh w-full"
     style="animation-duration: 150ms;">
-    <div class="w-full lg:w-[600px] relative h-auto lg:max-h-screen flex justify-center flex-col gap-4 bg-background p-5 ">
+    <div class="w-full lg:w-[600px] relative h-auto lg:max-h-screen flex justify-center flex-col gap-4 bg-background p-5 border border-default mt-12">
       <button
       type="button"
       data-action="modal#close"


### PR DESCRIPTION
Also fixed the localization/currency modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved mobile menu modal behavior with disabled backdrop interactions to prevent accidental closes.
- Bug Fixes
  - Stabilized mobile menu layout by removing dynamic padding and adjusting height calculations.
  - Moved mobile menu outside header nav to resolve structural/layout issues.
- Accessibility
  - Added role="dialog" and aria-modal="true" to the mobile menu modal.
- Style
  - Tweaked spacing and alignment (removed top margin, adjusted items alignment).
  - Removed fade-in animation; added borders and top offset to settings modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->