### PR TITLE
V-3252 Fix accessing the checkout complete page on user orders for guests

### DIFF
--- a/storefront/app/controllers/spree/checkout_controller.rb
+++ b/storefront/app/controllers/spree/checkout_controller.rb
@@ -171,7 +171,7 @@ module Spree
           clear_order_token
           flash[:error] = 'You cannot access this checkout'
           redirect_to_cart
-        elsif try_spree_current_user.nil? && !@order.completed?
+        elsif try_spree_current_user.nil? && !allow_access_to_complete_order_with_new_user?
           if params[:guest] && current_store.prefers_guest_checkout?
             @order = current_store.
                        orders.
@@ -201,6 +201,12 @@ module Spree
         @order.associate_user!(try_spree_current_user) if try_spree_current_user && @order.user.nil?
       end
       @current_order = @order # for compatibility with the rest of storefront, analytics, etc
+    end
+
+    def allow_access_to_complete_order_with_new_user?
+      cookies_order_token = cookies.permanent.signed[:token]
+
+      @order.completed? && @order.signup_for_an_account? && @order.user_id.present? && cookies_order_token.present? && cookies_order_token == @order.token
     end
 
     def remove_out_of_stock_items


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout completion behavior for guests and users who sign up during checkout.
  * Enforces cookie-based order token validation to prevent unauthorized access.
  * Correct redirects: shows completion when valid, sends guests without a valid token to login, and redirects mismatched signed-in users to cart.
  * Consistently clears the checkout completion session flag.

* **Tests**
  * Expanded coverage for checkout completion across guest, new-user signup, signed-in, mismatched user, and token validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->