### PR TITLE
Fix compare_at_amount type casting issue

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -66,8 +66,10 @@ module Spree
       Spree::Money.new(compare_at_amount || 0, currency: currency)
     end
 
-    def compare_at_amount=(compare_at_amount)
-      self[:compare_at_amount] = Spree::LocalizedNumber.parse(compare_at_amount)
+    def compare_at_amount=(value)
+      calculated_value = Spree::LocalizedNumber.parse(value) if value.present?
+
+      self[:compare_at_amount] = calculated_value
     end
 
     alias_attribute :price, :amount

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -259,6 +259,19 @@ namespace :core do
     Spree::Product.where('discontinue_on <= ?', Time.current).where.not(status: 'archived').update_all(status: 'archived', updated_at: Time.current)
   end
 
+  desc 'Migrate amount spree_prices.compare_at_amount.'
+  task migrate_compare_at_amount: :environment do |_t, _args|
+    include ActionView::Helpers::TextHelper
+    puts '... started'
+    total = 0
+    Spree::Price.where(compare_at_amount: nil).in_batches do |prices|
+      prices.update_all(compare_at_amount: nil)
+      total += prices.count
+    end
+    puts '... done'
+    puts "... migrated #{pluralize(total, 'record')}"
+  end
+
   desc 'Migrate newsletter subscribers'
   task migrate_newsletter_subscribers: :environment do |_t, _args|
     Spree.user_class.where(accepts_email_marketing: true).in_batches(of: 500) do |user_batch|

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -264,7 +264,7 @@ namespace :core do
     include ActionView::Helpers::TextHelper
     puts '... started'
     total = 0
-    Spree::Price.where(compare_at_amount: nil).in_batches do |prices|
+    Spree::Price.where(compare_at_amount: 0).in_batches do |prices|
       prices.update_all(compare_at_amount: nil)
       total += prices.count
     end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -96,7 +96,7 @@ describe Spree::Price, type: :model do
   end
 
   describe '#compare_at_amount=' do
-    let(:price) { build :price }
+    let(:price) { build(:price) }
     let(:compare_at_amount) { '169.99' }
 
     before do
@@ -105,6 +105,14 @@ describe Spree::Price, type: :model do
 
     it 'is expected to equal to localized number' do
       expect(price.compare_at_amount).to eq(Spree::LocalizedNumber.parse(compare_at_amount))
+    end
+
+    context 'with empty string being passed as value' do
+      let(:compare_at_amount) { '' }
+
+      it 'casts value to nil' do
+        expect(price.compare_at_amount).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
|priority|task url|sentry|
|-----|-----|-----|
|high|[url](https://linear.app/vendo/issue/VER-15/bug-compare-at-amount-type-casting-issue)|-|

## issue description
spree api returns 0.0 for pricing.compare_at_amount which is connected with overriden setter `compare_at_amount` in price model. 
This prevents user from setting null value for compare_at_amount in admin dashboard. empty string was casted to 0.

```
Failures:

  1) Spree::Price#compare_at_amount= with empty string being passed as value casts value to nil
     Failure/Error: expect(price.compare_at_amount).to be_nil
     
       expected: nil
            got: #<BigDecimal: 0.0>
     # ./spec/models/spree/price_spec.rb:114:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:75:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:74:in `block (2 levels) in <top (required)>'

Finished in 1.29 seconds (files took 3.49 seconds to load)
31 examples, 1 failure
```

## solution
- do not call `Spree::LocalizedNumber` for empty values
- `rake core:migrate_compare_at_amount` - task for migrating 0 values to nils - **assuming that** all 0 values are not intended



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Clearing the “Compare at price” now works as expected: leaving it blank removes the value instead of saving an unintended number.
- Chores
  - Added a maintenance task to migrate existing prices where “Compare at price” is zero, converting them to empty values for consistency, with progress feedback during execution.
- Tests
  - Added coverage to confirm blank “Compare at price” inputs are stored as empty.
  - Minor test formatting cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->