### PR TITLE
FIX update payment intents for gift cards

### DIFF
--- a/core/app/services/spree/gift_cards/apply.rb
+++ b/core/app/services/spree/gift_cards/apply.rb
@@ -44,6 +44,7 @@ module Spree
             state: 'checkout',
             response_code: store_credit.generate_authorization_code
           )
+          order.update_with_updater!
         end
 
         success(order.reload)

--- a/core/app/services/spree/gift_cards/remove.rb
+++ b/core/app/services/spree/gift_cards/remove.rb
@@ -29,6 +29,7 @@ module Spree
           end
 
           order.update!(gift_card: nil)
+          order.update_with_updater!
         end
 
         success(true)

--- a/core/spec/services/spree/gift_cards/apply_spec.rb
+++ b/core/spec/services/spree/gift_cards/apply_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Spree::GiftCards::Apply do
     expect(store_credit.originator).to eq(gift_card)
   end
 
+  it 'calls update_with_updater!' do
+    expect(order).to receive(:update_with_updater!)
+    subject
+  end
+
   context 'when the order has applied store credit' do
     let!(:store_credit_payment_method) { create(:store_credit_payment_method, stores: [store]) }
     let!(:store_credit) { create(:store_credit, user: order.user, amount: 10, store: store) }

--- a/core/spec/services/spree/gift_cards/remove_spec.rb
+++ b/core/spec/services/spree/gift_cards/remove_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe Spree::GiftCards::Remove do
       expect(store_credit_payment.source).to be_deleted
     end
 
+    it 'calls update_with_updater!' do
+      expect(order).to receive(:update_with_updater!)
+      subject
+    end
+
     context 'for a completed order' do
       before { order.update_column(:completed_at, Time.current) }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Cart and checkout totals now refresh immediately after applying or removing a gift card, ensuring accurate balances, taxes, shipping, and payment state without needing a manual refresh.
  - Reduces instances of stale or inconsistent order summaries when gift cards are used.

- Tests
  - Added test coverage to verify the order is recalculated when gift cards are applied or removed, preventing regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->