### PR TITLE
Add Metafields support for Post and PostCategory models

### DIFF
--- a/api/app/serializers/spree/v2/storefront/post_category_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/post_category_serializer.rb
@@ -2,6 +2,8 @@ module Spree
   module V2
     module Storefront
       class PostCategorySerializer < ::Spree::Api::V2::BaseSerializer
+        include Spree::Api::V2::PublicMetafieldsConcern
+
         set_type :post_category
 
         attributes :title, :slug, :created_at, :updated_at

--- a/api/app/serializers/spree/v2/storefront/post_serializer.rb
+++ b/api/app/serializers/spree/v2/storefront/post_serializer.rb
@@ -2,6 +2,8 @@ module Spree
   module V2
     module Storefront
       class PostSerializer < ::Spree::Api::V2::BaseSerializer
+        include Spree::Api::V2::PublicMetafieldsConcern
+
         set_type :post
 
         attributes :title, :slug, :published_at, :meta_title, :meta_description, :created_at, :updated_at

--- a/core/app/models/spree/post.rb
+++ b/core/app/models/spree/post.rb
@@ -2,6 +2,7 @@ module Spree
   class Post < Spree.base_class
     include Spree::SingleStoreResource
     include Spree::Linkable
+    include Spree::Metafields
     extend FriendlyId
 
     friendly_id :slug_candidates, use: %i[slugged scoped history], scope: %i[store_id deleted?]

--- a/core/app/models/spree/post_category.rb
+++ b/core/app/models/spree/post_category.rb
@@ -1,6 +1,7 @@
 module Spree
   class PostCategory < Spree.base_class
     include Spree::SingleStoreResource
+    include Spree::Metafields
     extend FriendlyId
 
     friendly_id :slug_candidates, use: %i[slugged scoped history], scope: %i[store_id]

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -277,6 +277,8 @@ module Spree
           Spree::Payment,
           Spree::PaymentMethod,
           Spree::PaymentSource,
+          Spree::Post,
+          Spree::PostCategory,
           Spree::Product,
           Spree::Promotion,
           Spree::Refund,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Posts and Post Categories now support metafields for enhanced customization.
  - Metafields are included in Storefront API responses for posts and categories.
  - API clients can create, update, and retrieve public metafields on these resources.
  - Enables richer integrations by attaching custom key-value data to blog content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->