### PR TITLE
Move the `before_destroy` callback logic to the `can_be_deleted?` for admin users

### DIFF
--- a/admin/spec/controllers/spree/admin/admin_users_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/admin_users_controller_spec.rb
@@ -279,7 +279,6 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
       it 'does not delete the admin user' do
         delete :destroy, params: { id: admin_user.id }
         expect(response).to redirect_to(spree.admin_admin_users_path)
-        expect(flash[:error]).to include ('Cannot delete the last admin user')
         expect(admin_user).not_to be_destroyed
       end
     end

--- a/core/app/models/concerns/spree/admin_user_methods.rb
+++ b/core/app/models/concerns/spree/admin_user_methods.rb
@@ -17,7 +17,6 @@ module Spree
       has_many :exports, class_name: 'Spree::Export', foreign_key: :user_id
 
       # Callbacks
-      before_destroy :check_if_there_are_other_admin_users
       after_destroy :nullify_approver_id_in_approved_orders
       after_destroy :cleanup_admin_user_resources
     end
@@ -48,16 +47,6 @@ module Spree
       # resources to destroy
       reports.destroy_all
       exports.destroy_all
-    end
-
-    def check_if_there_are_other_admin_users
-      return if self.class != Spree.admin_user_class
-      return unless has_spree_role?(Spree::Role::ADMIN_ROLE)
-
-      if Spree::Store.current.users.where.not(id: id).none?
-        errors.add(:base, I18n.t('activerecord.errors.models.spree/admin_user.attributes.base.cannot_destroy_last_admin_user'))
-        throw(:abort)
-      end
     end
   end
 end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -137,7 +137,11 @@ module Spree
     # Returns true if the user can be deleted
     # @return [Boolean]
     def can_be_deleted?
-      orders.complete.none?
+      if has_spree_role?(Spree::Role::ADMIN_ROLE)
+        Spree::Store.current.users.where.not(id: id).exists?
+      else
+        orders.complete.none?
+      end
     end
 
     # Returns the CSV row representation of the user
@@ -156,7 +160,7 @@ module Spree
     private
 
     def check_completed_orders
-      raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
+      raise Spree::Core::DestroyWithOrdersError if !has_spree_role?(Spree::Role::ADMIN_ROLE) && orders.complete.present?
     end
 
     def clone_billing_address

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -218,10 +218,6 @@ en:
       messages:
         blank: can't be blank
       models:
-        spree/admin_user:
-          attributes:
-            base:
-              cannot_destroy_last_admin_user: Cannot delete the last admin user
         spree/calculator/tiered_flat_rate:
           attributes:
             base:

--- a/core/spec/models/spree/admin_user_spec.rb
+++ b/core/spec/models/spree/admin_user_spec.rb
@@ -3,14 +3,29 @@ require 'spec_helper'
 describe Spree::LegacyUser, type: :model do
   let(:admin_user) { create(:admin_user) }
 
-  context 'Callbacks' do
-    describe 'do not allow to delete last admin user' do
-      it 'raises an error' do
-        admin_user
-        expect { admin_user.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+  describe '#can_be_deleted?' do
+    subject { admin_user.can_be_deleted? }
+
+    context 'when store has other admin users' do
+      before do
+        create(:admin_user)
       end
+
+      it { is_expected.to be(true) }
     end
 
+    context 'when store has no other admin users' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the user does not have admin role' do
+      let(:admin_user) { create(:admin_user, without_admin_role: true) }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
+  context 'Callbacks' do
     describe 'cleans up admin user resources' do
       let!(:other_admin_user) { create(:admin_user) }
       let!(:cancelled_orders) { create_list(:order, 2, canceler: admin_user, state: 'canceled') }

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe Spree::LegacyUser, type: :model do # rubocop:disable RSpec/MultipleDescribes
+  describe '#can_be_deleted?' do
+    subject { user.can_be_deleted? }
+
+    context 'when user has completed orders' do
+      let(:user) { create(:user, orders: [create(:order, completed_at: Time.current)]) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when user has no completed orders' do
+      let(:user) { create(:user, orders: [create(:order)]) }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#full_name' do
     let(:user) { create(:user, first_name: 'John', last_name: 'Doe') }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Updated account deletion rules:
    - Admin accounts can be deleted only if another admin exists in the same store.
    - Admin users are no longer blocked from deletion by completed orders.
    - Non-admin users remain protected from deletion if they have completed orders.
- Bug Fixes
  - Removed the obsolete “Cannot delete the last admin user” error message.
- Tests
  - Added and updated tests for the new deletion conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->