### PR TITLE
Fix NoMethodError when user name is nil in full_name method

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -154,7 +154,7 @@ module Spree
     # Returns the full name of the user
     # @return [String]
     def full_name
-      name.full
+      name&.full
     end
 
     private

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -18,10 +18,21 @@ describe Spree::LegacyUser, type: :model do # rubocop:disable RSpec/MultipleDesc
   end
 
   describe '#full_name' do
-    let(:user) { create(:user, first_name: 'John', last_name: 'Doe') }
+    context 'when names are present' do
+      let(:user) { create(:user, first_name: 'John', last_name: 'Doe') }
 
-    it 'returns the full name of the user' do
-      expect(user.full_name).to eq('John Doe')
+      it 'returns the full name of the user' do
+        expect(user.full_name).to eq('John Doe')
+      end
+    end
+
+    context 'when both first and last names are nil' do
+      let(:user) { create(:user, first_name: nil, last_name: nil) }
+
+      it 'does not raise and returns nil' do
+        expect { user.full_name }.not_to raise_error
+        expect(user.full_name).to be_nil
+      end
     end
   end
 

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -29,7 +29,7 @@ describe Spree::LegacyUser, type: :model do # rubocop:disable RSpec/MultipleDesc
     context 'when both first and last names are nil' do
       let(:user) { create(:user, first_name: nil, last_name: nil) }
 
-      it 'does not raise and returns nil' do
+      it 'does not raise error and returns nil' do
         expect { user.full_name }.not_to raise_error
         expect(user.full_name).to be_nil
       end


### PR DESCRIPTION
This happens in places such as the `Spree::Csv::NewsletterSubscriberPresenter`, where `user.full_name` is invoked.

### Solution
- Updated `Spree::UserMethods#full_name` to safely handle nil values by using `name&.full`.
- Added specs to cover the case when `name` is nil, ensuring the method no longer raises an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make UserMethods#full_name nil-safe and add tests for nil first/last names.
> 
> - **Models**:
>   - Update `core/app/models/concerns/spree/user_methods.rb`: `full_name` now uses `name&.full` to avoid errors when `name` is nil.
> - **Tests**:
>   - Enhance `core/spec/models/spree/user_spec.rb` for `#full_name`:
>     - Add context for present names returning `'John Doe'`.
>     - Add context for both names nil: no error and returns `nil`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d59078cd3471eceb47da92f34a2a6106737259c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed a crash when a user’s full name is requested but first/last name is missing. Now safely handles missing names and returns nil instead of raising an error, improving stability across profile and order views.

- Tests
  - Added test coverage for cases where both first and last names are nil.
  - Restructured related tests for clearer contexts and expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->