### PR TITLE
newsletter subscribe on complete order event

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -122,6 +122,7 @@ module Spree
               after_transition to: :complete, do: :redeem_gift_card
               after_transition to: :resumed, do: :after_resume
               after_transition to: :canceled, do: :after_cancel
+              after_transition to: :complete, do: :subscribe_to_newsletter
 
               after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|
                 order.update_totals
@@ -130,6 +131,12 @@ module Spree
             end
 
             alias_method :save_state, :save
+          end
+
+          def subscribe_to_newsletter
+            return unless accept_marketing?
+
+            Spree::NewsletterSubscriber.subscribe(email: email, user: user)
           end
 
           def self.go_to_state(name, options = {})

--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -6,12 +6,8 @@ module Spree
       prepend ::Spree::ServiceModule::Base
 
       def call(order:, accepts_email_marketing: false)
-        Spree.user_class.find_by(email: order.email).tap do |existing_user|
-          next if existing_user.blank?
-
-          create_newsletter_subscriber(existing_user) if accepts_email_marketing
-          return existing_user
-        end
+        existing_user = Spree.user_class.find_by(email: order.email)
+        return existing_user if existing_user.present?
 
         user = create_new_user(order, accepts_email_marketing)
         return failure(:user_creation_failed) unless user.persisted?
@@ -26,7 +22,6 @@ module Spree
 
         # send welcome email
         user.send_welcome_email if user.respond_to?(:send_welcome_email)
-        create_newsletter_subscriber(user) if accepts_email_marketing
 
         success(user.reload)
       end
@@ -69,10 +64,6 @@ module Spree
 
           user.update_columns(ship_address_id: order.ship_address_id, updated_at: Time.current) unless user.ship_address_id.present?
         end
-      end
-
-      def create_newsletter_subscriber(user)
-        Spree::NewsletterSubscriber.subscribe(email: user.email, user: user)
       end
     end
   end

--- a/core/spec/services/spree/orders/create_user_account_spec.rb
+++ b/core/spec/services/spree/orders/create_user_account_spec.rb
@@ -10,26 +10,6 @@ describe Spree::Orders::CreateUserAccount do
     create(:completed_order_with_totals, bill_address: address, ship_address: address, store: store, user: nil, email: 'new@customer.com')
   end
 
-  context 'when accepts_email_marketing is true' do
-    let(:accepts_email_marketing) { true }
-
-    it 'calls subscribe for newsletter' do
-      expect(Spree::NewsletterSubscriber).to receive(:subscribe).with(email: order.email, user: kind_of(Spree.user_class))
-
-      service
-    end
-  end
-
-  context 'when accepts_email_marketing is false' do
-    let(:accepts_email_marketing) { false }
-
-    it 'does not call subscribe for newsletter' do
-      expect(Spree::NewsletterSubscriber).to_not receive(:subscribe)
-
-      service
-    end
-  end
-
   context 'when order has no user' do
     let(:new_user) { Spree.user_class.find_by!(email: order.email) }
 
@@ -63,16 +43,6 @@ describe Spree::Orders::CreateUserAccount do
 
     it 'does not create a new user' do
       expect { subject }.to change { Spree.user_class.count }.by(0)
-    end
-
-    context 'when accepts_email_marketing is true' do
-      let(:accepts_email_marketing) { true }
-
-      it 'calls subscribe for newsletter' do
-        expect(Spree::NewsletterSubscriber).to receive(:subscribe).with(email: order.email, user: user)
-
-        service
-      end
     end
   end
 end


### PR DESCRIPTION
## Issue description:
- during checkout newsletter subscription was created only when user checks 'create account'
- this was an obvious issue for oos spree
- this fix is needed to simplify spree_klaviyo


## Solution
- call subscribe on complete order state event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Automatically subscribes customers to the newsletter when an order is completed, only if marketing consent is given.
* Refactor
  - Removed newsletter subscription during account creation; subscription now occurs exclusively at checkout completion. Existing users are no longer auto-subscribed on account creation.
* Tests
  - Added tests verifying subscription triggers based on marketing consent at checkout completion.
  - Removed tests tied to the previous account-creation subscription flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->