### PR TITLE
Improve checkout settings UI

### DIFF
--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -341,9 +341,13 @@ module Spree
         end
       end
 
-      def tooltip(text)
+      def tooltip(text = nil, &block)
         content_tag(:span, role: 'tooltip', data: { tooltip_target: 'tooltip' }, class: 'tooltip-container') do
-          text
+          if block_given?
+            capture(&block)
+          else
+            text
+          end
         end
       end
     end

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -25,22 +25,12 @@
 
 <div class="card mb-4">
   <div class="card-header">
-    <h5 class="card-title"><%= Spree.t(:currencies) %> & <%= Spree.t(:countries) %></h5>
+    <h5 class="card-title"><%= Spree.t(:currencies) %> & <%= Spree.t(:translations) %></h5>
   </div>
   <div class="card-body">
-    <p class="text-muted">
-      <%= Spree.t(:currency_and_country_help) %>
-    </p>
     <%= f.spree_select :default_currency, currency_options(@store.default_currency), { label: Spree.t(:default_currency), autocomplete: true } %>
     <%= f.spree_select :supported_currencies, currency_options(@store.supported_currencies&.split(',')), { prompt: false, multiple: true, autocomplete: true } %>
-    <%= f.spree_select :default_country_iso, Spree::Country.pluck(:name, :iso), { include_blank: false, label: Spree.t(:default_country), autocomplete: true } %>
-
-    <%= f.spree_select :checkout_zone_id, options_for_select(@zones, @store.checkout_zone_id), { label: Spree.t(:shipping_zone), autocomplete: true } %>
-    <small class="form-text text-muted mb-3">
-      <%= Spree.t(:shipping_zone_help) %>
-      <%= link_to Spree.t('admin.manage_zones'), spree.admin_zones_path, class: 'text-blue' %>
-    </small>
-
+    <hr />
     <%= f.spree_select :default_locale, options_from_collection_for_select(all_locales_options, :last, :first, @store.default_locale || I18n.locale), { autocomplete: true } %>
     <%= f.spree_select :supported_locales, options_from_collection_for_select(all_locales_options, :last, :first, @store.supported_locales&.split(',')), { multiple: true, autocomplete: true } %>
   </div>
@@ -59,8 +49,8 @@
       <%= time_zone_select :store, :preferred_timezone, nil, {}, { data: { controller: 'autocomplete-select' } } %>
     </div>
     <div data-controller="unit-system">
-      <%= f.spree_select :preferred_unit_system, options_for_select(unit_systems, @store.preferred_unit_system), { label: Spree.t(:unit_system), help: Spree.t(:unit_system_help) }, { data: { unit_system_target: "body", action: "change->unit-system#unitSystemHandler" } } %>
-      <%= f.spree_select :preferred_weight_unit, options_for_select(weight_units(@store), @store.preferred_weight_unit), { label: Spree.t(:weight_unit), help: Spree.t(:weight_unit_help) }, { data: { unit_system_target: "weightUnit" } } %>
+      <%= f.spree_select :preferred_unit_system, options_for_select(unit_systems, @store.preferred_unit_system), { label: Spree.t(:unit_system), help_bubble: Spree.t(:unit_system_help) }, { data: { unit_system_target: "body", action: "change->unit-system#unitSystemHandler" } } %>
+      <%= f.spree_select :preferred_weight_unit, options_for_select(weight_units(@store), @store.preferred_weight_unit), { label: Spree.t(:weight_unit), help_bubble: Spree.t(:weight_unit_help) }, { data: { unit_system_target: "weightUnit" } } %>
     </div>
   </div>
 </div>

--- a/admin/app/views/spree/admin/stores/form/_checkout.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_checkout.html.erb
@@ -8,6 +8,16 @@
   </div>
 
   <div class="card-body">
+    <%= f.spree_select :checkout_zone_id, options_for_select(@zones, @store.checkout_zone_id), { label: Spree.t(:shipping_zone), autocomplete: true } %>
+    <small class="form-text text-muted mb-3">
+      <%= Spree.t(:shipping_zone_help) %>
+      <%= link_to Spree.t('admin.manage_zones'), spree.admin_zones_path, class: 'text-blue' %>
+    </small>
+
+    <%= f.spree_select :default_country_iso, Spree::Country.pluck(:name, :iso), { include_blank: false, label: Spree.t(:default_country), autocomplete: true, help: Spree.t(:default_country_help) } %>
+
+    <hr />
+
     <%= f.spree_check_box :preferred_guest_checkout, label: Spree.t('admin.checkout_settings.guest_checkout.label'), help: Spree.t('admin.checkout_settings.guest_checkout.description') %>
     <%= f.spree_check_box :preferred_company_field_enabled, label: Spree.t('admin.store_form.company_field.label'), help: Spree.t('admin.store_form.company_field.description') %>
     <%= f.spree_check_box :preferred_special_instructions_enabled, label: Spree.t('admin.checkout_settings.special_instructions.label'), help: Spree.t('admin.checkout_settings.special_instructions.description') %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -880,7 +880,6 @@ en:
     credits: Credits
     currencies: Currencies
     currency: Currency
-    currency_and_country_help: This determines which vendors you can connect with and what customers see on your store.
     currency_settings: Currency Settings
     current: Current
     current_password: Current password
@@ -909,6 +908,7 @@ en:
     default_billing_address: Default billing address
     default_country: Default Country
     default_country_cannot_be_deleted: Default country cannot be deleted
+    default_country_help: Country that will be used for the default shipping and billing addresses on Checkout
     default_currency: Default currency
     default_locale: Default locale
     default_post_categories:


### PR DESCRIPTION
Move checkout settings to... well checkout page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Checkout Zone and Default Country selectors to Checkout settings, with autocomplete and helpful guidance links.

- Style
  - Streamlined Stores basic settings: replaced “Currencies & Countries” with “Currencies & Translations,” removed outdated help blocks, added compact help bubbles, and improved layout with separators.

- Documentation
  - Updated in-app help text to clarify the role of the default country during checkout; removed obsolete currency/country help copy.

- Refactor
  - Enhanced tooltip support to handle inline help bubbles with richer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->