### PR TITLE
Add metafields support for all CSV exports

### DIFF
--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -90,6 +90,13 @@ module Spree
       raise NotImplementedError, 'csv_headers must be implemented'
     end
 
+    # Returns an array of metafield headers for the model
+    #
+    # @return [Array<String>]
+    def metafields_headers
+      @metafields_headers ||= Spree::MetafieldDefinition.for_resource_type(model_class.to_s).order(:namespace, :key).map(&:csv_header_name)
+    end
+
     def build_csv_line(_record)
       raise NotImplementedError, 'build_csv_line must be implemented'
     end

--- a/core/app/models/spree/exports/customers.rb
+++ b/core/app/models/spree/exports/customers.rb
@@ -5,11 +5,12 @@ module Spree
         [
           { bill_address: :state },
           { ship_address: :state },
+          { metafields: :metafield_definition }
         ]
       end
 
       def csv_headers
-        Spree::CSV::CustomerPresenter::HEADERS
+        Spree::CSV::CustomerPresenter::HEADERS + metafields_headers
       end
     end
   end

--- a/core/app/models/spree/exports/gift_cards.rb
+++ b/core/app/models/spree/exports/gift_cards.rb
@@ -2,11 +2,11 @@ module Spree
   module Exports
     class GiftCards < Spree::Export
       def scope_includes
-        [:user]
+        [:user, { metafields: :metafield_definition }]
       end
 
       def csv_headers
-        Spree::CSV::GiftCardPresenter::HEADERS
+        Spree::CSV::GiftCardPresenter::HEADERS + metafields_headers
       end
     end
   end

--- a/core/app/models/spree/exports/newsletter_subscribers.rb
+++ b/core/app/models/spree/exports/newsletter_subscribers.rb
@@ -2,11 +2,11 @@ module Spree
   module Exports
     class NewsletterSubscribers < Spree::Export
       def scope_includes
-        [:user]
+        [:user, { metafields: :metafield_definition }]
       end
 
       def csv_headers
-        Spree::CSV::NewsletterSubscriberPresenter::HEADERS
+        Spree::CSV::NewsletterSubscriberPresenter::HEADERS + metafields_headers
       end
     end
   end

--- a/core/app/models/spree/exports/orders.rb
+++ b/core/app/models/spree/exports/orders.rb
@@ -7,7 +7,8 @@ module Spree
           :shipments,
           { bill_address: :state },
           { ship_address: :state },
-          { line_items: { variant: { product: [:taxons] } } }
+          { line_items: { variant: { product: [:taxons] } } },
+          { metafields: :metafield_definition }
         ]
       end
 
@@ -16,7 +17,7 @@ module Spree
       end
 
       def csv_headers
-        Spree::CSV::OrderLineItemPresenter::HEADERS
+        Spree::CSV::OrderLineItemPresenter::HEADERS + metafields_headers
       end
     end
   end

--- a/core/app/models/spree/metafield.rb
+++ b/core/app/models/spree/metafield.rb
@@ -34,6 +34,10 @@ module Spree
       value
     end
 
+    def csv_value
+      value.to_s
+    end
+
     private
 
     def set_type_from_metafield_definition

--- a/core/app/models/spree/metafield_definition.rb
+++ b/core/app/models/spree/metafield_definition.rb
@@ -41,6 +41,12 @@ module Spree
       "#{namespace}.#{key}"
     end
 
+    # Returns the CSV header name for this metafield
+    # @return [String] eg. metafield.custom.id
+    def csv_header_name
+      "metafield.#{full_key}"
+    end
+
     # Returns the available types
     # @return [Array<Class>]
     def self.available_types

--- a/core/app/models/spree/metafields/boolean.rb
+++ b/core/app/models/spree/metafields/boolean.rb
@@ -2,6 +2,10 @@ module Spree
   module Metafields
     class Boolean < Spree::Metafield
       normalizes :value, with: lambda(&:to_b)
+
+      def csv_value
+        value.to_b ? Spree.t(:say_yes) : Spree.t(:say_no)
+      end
     end
   end
 end

--- a/core/app/models/spree/metafields/json.rb
+++ b/core/app/models/spree/metafields/json.rb
@@ -9,6 +9,10 @@ module Spree
         value
       end
 
+      def csv_value
+        value.to_s
+      end
+
       private
 
       def value_must_be_valid_json

--- a/core/app/models/spree/metafields/number.rb
+++ b/core/app/models/spree/metafields/number.rb
@@ -6,6 +6,10 @@ module Spree
       def serialize_value
         value.to_d
       end
+
+      def csv_value
+        value.to_s
+      end
     end
   end
 end

--- a/core/app/models/spree/metafields/rich_text.rb
+++ b/core/app/models/spree/metafields/rich_text.rb
@@ -9,6 +9,10 @@ module Spree
       def serialize_value
         value&.body&.to_s
       end
+
+      def csv_value
+        value&.body&.to_plain_text || ''
+      end
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -850,9 +850,13 @@ module Spree
     end
 
     def to_csv(_store = nil)
+      metafields_for_csv ||= Spree::MetafieldDefinition.for_resource_type('Spree::Order').order(:namespace, :key).map do |mf_def|
+        metafields.find { |mf| mf.metafield_definition_id == mf_def.id }&.csv_value
+      end
+
       csv_lines = []
       all_line_items.each_with_index do |line_item, index|
-        csv_lines << Spree::CSV::OrderLineItemPresenter.new(self, line_item, index).call
+        csv_lines << Spree::CSV::OrderLineItemPresenter.new(self, line_item, index, metafields_for_csv).call
       end
       csv_lines
     end

--- a/core/app/presenters/spree/csv/customer_presenter.rb
+++ b/core/app/presenters/spree/csv/customer_presenter.rb
@@ -1,6 +1,8 @@
 module Spree
   module CSV
     class CustomerPresenter
+      include Spree::CSV::MetafieldsHelper
+
       HEADERS = [
         'First Name',
         'Last Name',
@@ -28,7 +30,7 @@ module Spree
       attr_accessor :customer
 
       def call
-        [
+        csv = [
           customer.first_name,
           customer.last_name,
           customer.email,
@@ -47,6 +49,10 @@ module Spree
           customer.completed_orders.count,
           customer.tag_list
         ]
+
+        csv += metafields_for_csv(customer)
+
+        csv
       end
     end
   end

--- a/core/app/presenters/spree/csv/gift_card_presenter.rb
+++ b/core/app/presenters/spree/csv/gift_card_presenter.rb
@@ -1,6 +1,8 @@
 module Spree
   module CSV
     class GiftCardPresenter
+      include Spree::CSV::MetafieldsHelper
+
       HEADERS = [
         'Code',
         'Amount',
@@ -23,7 +25,7 @@ module Spree
       attr_accessor :gift_card
 
       def call
-        [
+        csv = [
           gift_card.display_code,
           gift_card.display_amount,
           gift_card.display_amount_used,
@@ -37,6 +39,10 @@ module Spree
           gift_card.created_at&.strftime('%Y-%m-%d %H:%M:%S'),
           gift_card.updated_at&.strftime('%Y-%m-%d %H:%M:%S')
         ]
+
+        csv += metafields_for_csv(gift_card)
+
+        csv
       end
     end
   end

--- a/core/app/presenters/spree/csv/metafields_helper.rb
+++ b/core/app/presenters/spree/csv/metafields_helper.rb
@@ -1,0 +1,13 @@
+module Spree
+  module CSV
+    module MetafieldsHelper
+      private
+
+      def metafields_for_csv(resource)
+        Spree::MetafieldDefinition.for_resource_type(resource.class.to_s).order(:namespace, :key).map do |mf_def|
+          resource.metafields.find { |mf| mf.metafield_definition_id == mf_def.id }&.csv_value
+        end
+      end
+    end
+  end
+end

--- a/core/app/presenters/spree/csv/newsletter_subscriber_presenter.rb
+++ b/core/app/presenters/spree/csv/newsletter_subscriber_presenter.rb
@@ -1,6 +1,8 @@
 module Spree
   module CSV
     class NewsletterSubscriberPresenter
+      include Spree::CSV::MetafieldsHelper
+
       HEADERS = [
         'Email',
         'Customer Name',
@@ -18,7 +20,7 @@ module Spree
       attr_accessor :newsletter_subscriber
 
       def call
-        [
+        csv = [
           newsletter_subscriber.email,
           newsletter_subscriber.user&.full_name,
           newsletter_subscriber.user_id,
@@ -27,6 +29,10 @@ module Spree
           newsletter_subscriber.created_at,
           newsletter_subscriber.updated_at
         ]
+
+        csv += metafields_for_csv(newsletter_subscriber)
+
+        csv
       end
     end
   end

--- a/core/app/presenters/spree/csv/order_line_item_presenter.rb
+++ b/core/app/presenters/spree/csv/order_line_item_presenter.rb
@@ -59,16 +59,17 @@ module Spree
         'Notes'
       ].freeze
 
-      def initialize(order, line_item, index)
+      def initialize(order, line_item, index, metafields = [])
         @order = order
         @line_item = line_item
         @index = index
+        @metafields = metafields
       end
 
-      attr_accessor :order, :line_item, :index
+      attr_accessor :order, :line_item, :index, :metafields
 
       def call
-        [
+        csv = [
           order.number,
           index.zero? ? order.email : nil,
           index.zero? ? order.state : nil,
@@ -125,6 +126,12 @@ module Spree
           index.zero? ? order.canceler&.email : nil,
           index.zero? ? order.special_instructions : nil
         ]
+
+        if index.zero?
+          csv += metafields
+        end
+
+        csv
       end
 
       private

--- a/core/app/presenters/spree/csv/product_variant_presenter.rb
+++ b/core/app/presenters/spree/csv/product_variant_presenter.rb
@@ -47,7 +47,7 @@ module Spree
         'category3',
       ].freeze
 
-      def initialize(product, variant, index = 0, properties = [], taxons = [], store = nil)
+      def initialize(product, variant, index = 0, properties = [], taxons = [], store = nil, metafields = [])
         @product = product
         @variant = variant
         @index = index
@@ -55,9 +55,10 @@ module Spree
         @taxons = taxons
         @store = store || product.stores.first
         @currency = @store.default_currency
+        @metafields = metafields
       end
 
-      attr_accessor :product, :variant, :index, :properties, :taxons, :store, :currency
+      attr_accessor :product, :variant, :index, :properties, :taxons, :store, :currency, :metafields
 
       ##
       # Generates an array representing a CSV row of product variant data.
@@ -115,6 +116,7 @@ module Spree
         if index.zero?
           csv += taxons
           csv += properties
+          csv += metafields
         end
 
         csv

--- a/core/lib/spree/testing_support/factories/metafield_factory.rb
+++ b/core/lib/spree/testing_support/factories/metafield_factory.rb
@@ -44,6 +44,12 @@ FactoryBot.define do
       value { true }
     end
 
+    trait :json do
+      type { 'Spree::Metafields::Json' }
+      association :metafield_definition, :json_field
+      value { '{"key": "value"}' }
+    end
+
     trait :for_variant do
       association :resource, factory: :variant
       association :metafield_definition, :for_variant

--- a/core/spec/models/spree/exports/customers_spec.rb
+++ b/core/spec/models/spree/exports/customers_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Exports::Customers, type: :model do
+  let(:store) { create(:store) }
+  let(:export) { described_class.new(store: store) }
+
+  describe '#csv_headers' do
+    context 'when no metafields exist' do
+      it 'returns customer headers' do
+        expected_headers = [
+          'First Name',
+          'Last Name',
+          'Email',
+          'Accepts Email Marketing',
+          'Company',
+          'Address 1',
+          'Address 2',
+          'City',
+          'Province',
+          'Province Code',
+          'Country',
+          'Country Code',
+          'Zip',
+          'Phone',
+          'Total Spent',
+          'Total Orders',
+          'Tags'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when metafields exist' do
+      let!(:metafield_definition) do
+        create(:metafield_definition,
+               resource_type: export.model_class.to_s,
+               namespace: 'custom',
+               key: 'loyalty_points')
+      end
+
+      it 'includes metafield headers' do
+        expected_headers = [
+          'First Name',
+          'Last Name',
+          'Email',
+          'Accepts Email Marketing',
+          'Company',
+          'Address 1',
+          'Address 2',
+          'City',
+          'Province',
+          'Province Code',
+          'Country',
+          'Country Code',
+          'Zip',
+          'Phone',
+          'Total Spent',
+          'Total Orders',
+          'Tags',
+          'metafield.custom.loyalty_points'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+  end
+
+  describe '#scope_includes' do
+    it 'includes metafields' do
+      expect(export.scope_includes).to include({ metafields: :metafield_definition })
+    end
+
+    it 'includes bill_address and ship_address' do
+      expect(export.scope_includes).to include({ bill_address: :state })
+      expect(export.scope_includes).to include({ ship_address: :state })
+    end
+  end
+end

--- a/core/spec/models/spree/exports/gift_cards_spec.rb
+++ b/core/spec/models/spree/exports/gift_cards_spec.rb
@@ -29,22 +29,62 @@ RSpec.describe Spree::Exports::GiftCards, type: :model do
   end
 
   describe '#csv_headers' do
-    it 'returns the correct headers' do
-      expected_headers = [
-        'Code',
-        'Amount',
-        'Amount Used',
-        'Amount Remaining',
-        'Currency',
-        'Status',
-        'Expires At',
-        'Customer Email',
-        'Customer First Name',
-        'Customer Last Name',
-        'Created At',
-        'Updated At'
-      ]
-      expect(export.csv_headers).to eq(expected_headers)
+    context 'when no metafields exist' do
+      it 'returns gift card headers' do
+        expected_headers = [
+          'Code',
+          'Amount',
+          'Amount Used',
+          'Amount Remaining',
+          'Currency',
+          'Status',
+          'Expires At',
+          'Customer Email',
+          'Customer First Name',
+          'Customer Last Name',
+          'Created At',
+          'Updated At'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when metafields exist' do
+      let!(:metafield_definition) do
+        create(:metafield_definition,
+               resource_type: 'Spree::GiftCard',
+               namespace: 'custom',
+               key: 'purchase_location')
+      end
+
+      it 'includes metafield headers' do
+        expected_headers = [
+          'Code',
+          'Amount',
+          'Amount Used',
+          'Amount Remaining',
+          'Currency',
+          'Status',
+          'Expires At',
+          'Customer Email',
+          'Customer First Name',
+          'Customer Last Name',
+          'Created At',
+          'Updated At',
+          'metafield.custom.purchase_location'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+  end
+
+  describe '#scope_includes' do
+    it 'includes metafields' do
+      expect(export.scope_includes).to include({ metafields: :metafield_definition })
+    end
+
+    it 'includes user' do
+      expect(export.scope_includes).to include(:user)
     end
   end
 end

--- a/core/spec/models/spree/exports/newsletter_subscribers_spec.rb
+++ b/core/spec/models/spree/exports/newsletter_subscribers_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Exports::NewsletterSubscribers, type: :model do
+  let(:store) { create(:store) }
+  let(:export) { described_class.new(store: store) }
+
+  describe '#csv_headers' do
+    context 'when no metafields exist' do
+      it 'returns newsletter subscriber headers' do
+        expected_headers = [
+          'Email',
+          'Customer Name',
+          'Customer ID',
+          'Verified',
+          'Verified At',
+          'Created At',
+          'Updated At'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when metafields exist' do
+      let!(:metafield_definition) do
+        create(:metafield_definition,
+               resource_type: 'Spree::NewsletterSubscriber',
+               namespace: 'custom',
+               key: 'subscription_source')
+      end
+
+      it 'includes metafield headers' do
+        expected_headers = [
+          'Email',
+          'Customer Name',
+          'Customer ID',
+          'Verified',
+          'Verified At',
+          'Created At',
+          'Updated At',
+          'metafield.custom.subscription_source'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+  end
+
+  describe '#scope_includes' do
+    it 'includes metafields' do
+      expect(export.scope_includes).to include({ metafields: :metafield_definition })
+    end
+
+    it 'includes user' do
+      expect(export.scope_includes).to include(:user)
+    end
+  end
+end

--- a/core/spec/models/spree/exports/orders_spec.rb
+++ b/core/spec/models/spree/exports/orders_spec.rb
@@ -1,0 +1,162 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Exports::Orders, type: :model do
+  let(:store) { create(:store) }
+  let(:export) { described_class.new(store: store) }
+
+  describe '#csv_headers' do
+    context 'when no metafields exist' do
+      it 'returns order line item headers' do
+        expected_headers = [
+          'Number',
+          'Email',
+          'Status',
+          'Currency',
+          'Subtotal',
+          'Shipping',
+          'Taxes',
+          'Taxes included',
+          'Discount Used',
+          'Free Shipping',
+          'Discount',
+          'Discount Code',
+          'Store Credit amount',
+          'Total',
+          'Shipping method',
+          'Total weight',
+          'Payment Type Used',
+          'Product ID',
+          'Item Quantity',
+          'Item SKU',
+          'Item Name',
+          'Item Price',
+          'Item Total Discount',
+          'Item Total Price',
+          'Item requires shipping',
+          'Item taxbale',
+          'Item Vendor',
+          'Category lvl0',
+          'Category lvl1',
+          'Category lvl2',
+          'Category lvl3',
+          'Category lvl4',
+          'Billing Name',
+          'Billing Address 1',
+          'Billing Address 2',
+          'Billing Company',
+          'Billing City',
+          'Billing Zip',
+          'Billing State',
+          'Billing Country',
+          'Billing Phone',
+          'Shipping Name',
+          'Shipping Address 1',
+          'Shipping Address 2',
+          'Shipping Company',
+          'Shipping City',
+          'Shipping Zip',
+          'Shipping State',
+          'Shipping Country',
+          'Shipping Phone',
+          'Placed at',
+          'Shipped at',
+          'Cancelled at',
+          'Cancelled by',
+          'Notes'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when metafields exist' do
+      let!(:metafield_definition) do
+        create(:metafield_definition,
+               resource_type: 'Spree::Order',
+               namespace: 'custom',
+               key: 'gift_message')
+      end
+
+      it 'includes metafield headers' do
+        expected_headers = [
+          'Number',
+          'Email',
+          'Status',
+          'Currency',
+          'Subtotal',
+          'Shipping',
+          'Taxes',
+          'Taxes included',
+          'Discount Used',
+          'Free Shipping',
+          'Discount',
+          'Discount Code',
+          'Store Credit amount',
+          'Total',
+          'Shipping method',
+          'Total weight',
+          'Payment Type Used',
+          'Product ID',
+          'Item Quantity',
+          'Item SKU',
+          'Item Name',
+          'Item Price',
+          'Item Total Discount',
+          'Item Total Price',
+          'Item requires shipping',
+          'Item taxbale',
+          'Item Vendor',
+          'Category lvl0',
+          'Category lvl1',
+          'Category lvl2',
+          'Category lvl3',
+          'Category lvl4',
+          'Billing Name',
+          'Billing Address 1',
+          'Billing Address 2',
+          'Billing Company',
+          'Billing City',
+          'Billing Zip',
+          'Billing State',
+          'Billing Country',
+          'Billing Phone',
+          'Shipping Name',
+          'Shipping Address 1',
+          'Shipping Address 2',
+          'Shipping Company',
+          'Shipping City',
+          'Shipping Zip',
+          'Shipping State',
+          'Shipping Country',
+          'Shipping Phone',
+          'Placed at',
+          'Shipped at',
+          'Cancelled at',
+          'Cancelled by',
+          'Notes',
+          'metafield.custom.gift_message'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+  end
+
+  describe '#scope_includes' do
+    it 'includes metafields' do
+      expect(export.scope_includes).to include({ metafields: :metafield_definition })
+    end
+
+    it 'includes order associations' do
+      expect(export.scope_includes).to include(:payments)
+      expect(export.scope_includes).to include(:shipments)
+      expect(export.scope_includes).to include({ bill_address: :state })
+      expect(export.scope_includes).to include({ ship_address: :state })
+      expect(export.scope_includes).to include({ line_items: { variant: { product: [:taxons] } } })
+    end
+  end
+
+  describe '#multi_line_csv?' do
+    it 'returns true' do
+      expect(export.multi_line_csv?).to be true
+    end
+  end
+end

--- a/core/spec/models/spree/exports/products_spec.rb
+++ b/core/spec/models/spree/exports/products_spec.rb
@@ -24,4 +24,197 @@ RSpec.describe Spree::Exports::Products, type: :model do
       end
     end
   end
+
+  describe '#csv_headers' do
+    context 'when product_properties_enabled is false and no metafields' do
+      before do
+        allow(Spree::Config).to receive(:[]).with(:product_properties_enabled).and_return(false)
+      end
+
+      it 'returns product variant headers without properties' do
+        expected_headers = [
+          'product_id',
+          'sku',
+          'name',
+          'slug',
+          'status',
+          'vendor_name',
+          'brand_name',
+          'description',
+          'meta_title',
+          'meta_description',
+          'meta_keywords',
+          'tags',
+          'labels',
+          'price',
+          'compare_at_price',
+          'currency',
+          'width',
+          'height',
+          'depth',
+          'dimensions_unit',
+          'weight',
+          'weight_unit',
+          'available_on',
+          'discontinue_on',
+          'track_inventory',
+          'inventory_count',
+          'inventory_backorderable',
+          'tax_category',
+          'digital',
+          'image1_src',
+          'image2_src',
+          'image3_src',
+          'option1_name',
+          'option1_value',
+          'option2_name',
+          'option2_value',
+          'option3_name',
+          'option3_value',
+          'category1',
+          'category2',
+          'category3'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when product_properties_enabled is true' do
+      before do
+        allow(Spree::Config).to receive(:[]).with(:product_properties_enabled).and_return(true)
+        create(:property)
+      end
+
+      it 'includes property headers' do
+        expected_headers = [
+          'product_id',
+          'sku',
+          'name',
+          'slug',
+          'status',
+          'vendor_name',
+          'brand_name',
+          'description',
+          'meta_title',
+          'meta_description',
+          'meta_keywords',
+          'tags',
+          'labels',
+          'price',
+          'compare_at_price',
+          'currency',
+          'width',
+          'height',
+          'depth',
+          'dimensions_unit',
+          'weight',
+          'weight_unit',
+          'available_on',
+          'discontinue_on',
+          'track_inventory',
+          'inventory_count',
+          'inventory_backorderable',
+          'tax_category',
+          'digital',
+          'image1_src',
+          'image2_src',
+          'image3_src',
+          'option1_name',
+          'option1_value',
+          'option2_name',
+          'option2_value',
+          'option3_name',
+          'option3_value',
+          'category1',
+          'category2',
+          'category3',
+          'property1_name',
+          'property1_value'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+
+    context 'when metafields exist' do
+      before do
+        allow(Spree::Config).to receive(:[]).with(:product_properties_enabled).and_return(false)
+      end
+
+      let!(:metafield_definition) { create(:metafield_definition, resource_type: 'Spree::Product', namespace: 'custom', key: 'field1') }
+
+      it 'includes metafield headers' do
+        expected_headers = [
+          'product_id',
+          'sku',
+          'name',
+          'slug',
+          'status',
+          'vendor_name',
+          'brand_name',
+          'description',
+          'meta_title',
+          'meta_description',
+          'meta_keywords',
+          'tags',
+          'labels',
+          'price',
+          'compare_at_price',
+          'currency',
+          'width',
+          'height',
+          'depth',
+          'dimensions_unit',
+          'weight',
+          'weight_unit',
+          'available_on',
+          'discontinue_on',
+          'track_inventory',
+          'inventory_count',
+          'inventory_backorderable',
+          'tax_category',
+          'digital',
+          'image1_src',
+          'image2_src',
+          'image3_src',
+          'option1_name',
+          'option1_value',
+          'option2_name',
+          'option2_value',
+          'option3_name',
+          'option3_value',
+          'category1',
+          'category2',
+          'category3',
+          'metafield.custom.field1'
+        ]
+        expect(export.csv_headers).to eq(expected_headers)
+      end
+    end
+  end
+
+  describe '#scope_includes' do
+    it 'includes metafields' do
+      expect(export.scope_includes).to include({ metafields: :metafield_definition })
+    end
+
+    context 'when product_properties_enabled is true' do
+      before do
+        allow(Spree::Config).to receive(:[]).with(:product_properties_enabled).and_return(true)
+      end
+
+      it 'includes product_properties' do
+        expect(export.scope_includes).to include({ product_properties: [:property] })
+      end
+    end
+
+    context 'when product_properties_enabled is false' do
+      before do
+        allow(Spree::Config).to receive(:[]).with(:product_properties_enabled).and_return(false)
+      end
+
+      it 'does not include product_properties' do
+        expect(export.scope_includes).not_to include({ product_properties: [:property] })
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/metafield_definition_spec.rb
+++ b/core/spec/models/spree/metafield_definition_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe Spree::MetafieldDefinition, type: :model do
       end
     end
   end
+
+  describe '#csv_header_name' do
+    it 'returns the CSV header name with metafield prefix' do
+      metafield_definition = build(:metafield_definition, namespace: 'custom', key: 'field1')
+      expect(metafield_definition.csv_header_name).to eq('metafield.custom.field1')
+    end
+  end
+
+  describe '#full_key' do
+    it 'returns the full key with namespace' do
+      metafield_definition = build(:metafield_definition, namespace: 'custom', key: 'field1')
+      expect(metafield_definition.full_key).to eq('custom.field1')
+    end
+  end
 end

--- a/core/spec/models/spree/metafield_spec.rb
+++ b/core/spec/models/spree/metafield_spec.rb
@@ -35,4 +35,73 @@ RSpec.describe Spree::Metafield, type: :model do
       expect(metafield.serialize_value).to eq('Test Value')
     end
   end
+
+  describe '#csv_value' do
+    context 'for base Metafield' do
+      it 'returns the value as string' do
+        metafield = build(:metafield, value: 'Test Value')
+        expect(metafield.csv_value).to eq('Test Value')
+      end
+    end
+
+    context 'for Boolean metafield' do
+      let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::Boolean') }
+
+      it 'returns Yes for true values' do
+        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'true')
+        expect(metafield.csv_value).to eq(Spree.t(:say_yes))
+      end
+
+      it 'returns No for false values' do
+        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'false')
+        expect(metafield.csv_value).to eq(Spree.t(:say_no))
+      end
+    end
+
+    context 'for Number metafield' do
+      let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::Number') }
+
+      it 'returns the number as string' do
+        metafield = create(:metafield, metafield_definition: metafield_definition, value: '123.45')
+        expect(metafield.csv_value).to eq('123.45')
+      end
+    end
+
+    context 'for Json metafield' do
+      let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::Json') }
+
+      it 'returns the JSON string' do
+        metafield = create(:metafield, metafield_definition: metafield_definition, value: '{"key": "value"}')
+        expect(metafield.csv_value).to eq('{"key": "value"}')
+      end
+    end
+
+    context 'for ShortText metafield' do
+      let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::ShortText') }
+
+      it 'returns the text value' do
+        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'Short text')
+        expect(metafield.csv_value).to eq('Short text')
+      end
+    end
+
+    context 'for LongText metafield' do
+      let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::LongText') }
+
+      it 'returns the text value' do
+        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'Long text content')
+        expect(metafield.csv_value).to eq('Long text content')
+      end
+    end
+
+    context 'for RichText metafield' do
+      let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::RichText') }
+
+      it 'returns plain text without HTML tags' do
+        metafield = create(:metafield, metafield_definition: metafield_definition)
+        metafield.value = '<p>Rich <strong>text</strong> content</p>'
+        expect(metafield.csv_value).to eq('Rich text content')
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/metafield_spec.rb
+++ b/core/spec/models/spree/metafield_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Spree::Metafield, type: :model do
   context 'Callbacks' do
     it 'sets the type from the metafield definition' do
       metafield_definition = create(:metafield_definition, metafield_type: 'Spree::Metafields::ShortText')
-      metafield = create(:metafield, metafield_definition: metafield_definition)
+      metafield = create(:metafield, metafield_definition: metafield_definition, type: nil)
       expect(metafield.type).to eq('Spree::Metafields::ShortText')
     end
   end
@@ -48,12 +48,12 @@ RSpec.describe Spree::Metafield, type: :model do
       let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::Boolean') }
 
       it 'returns Yes for true values' do
-        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'true')
+        metafield = Spree::Metafields::Boolean.new(metafield_definition: metafield_definition, value: 'true')
         expect(metafield.csv_value).to eq(Spree.t(:say_yes))
       end
 
       it 'returns No for false values' do
-        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'false')
+        metafield = Spree::Metafields::Boolean.new(metafield_definition: metafield_definition, value: 'false')
         expect(metafield.csv_value).to eq(Spree.t(:say_no))
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe Spree::Metafield, type: :model do
       let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::Number') }
 
       it 'returns the number as string' do
-        metafield = create(:metafield, metafield_definition: metafield_definition, value: '123.45')
+        metafield = Spree::Metafields::Number.new(metafield_definition: metafield_definition, value: '123.45')
         expect(metafield.csv_value).to eq('123.45')
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe Spree::Metafield, type: :model do
       let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::Json') }
 
       it 'returns the JSON string' do
-        metafield = create(:metafield, metafield_definition: metafield_definition, value: '{"key": "value"}')
+        metafield = Spree::Metafields::Json.new(metafield_definition: metafield_definition, value: '{"key": "value"}')
         expect(metafield.csv_value).to eq('{"key": "value"}')
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe Spree::Metafield, type: :model do
       let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::ShortText') }
 
       it 'returns the text value' do
-        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'Short text')
+        metafield = Spree::Metafields::ShortText.new(metafield_definition: metafield_definition, value: 'Short text')
         expect(metafield.csv_value).to eq('Short text')
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe Spree::Metafield, type: :model do
       let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::LongText') }
 
       it 'returns the text value' do
-        metafield = create(:metafield, metafield_definition: metafield_definition, value: 'Long text content')
+        metafield = Spree::Metafields::LongText.new(metafield_definition: metafield_definition, value: 'Long text content')
         expect(metafield.csv_value).to eq('Long text content')
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe Spree::Metafield, type: :model do
       let(:metafield_definition) { create(:metafield_definition, metafield_type: 'Spree::Metafields::RichText') }
 
       it 'returns plain text without HTML tags' do
-        metafield = create(:metafield, metafield_definition: metafield_definition)
+        metafield = Spree::Metafields::RichText.new(metafield_definition: metafield_definition)
         metafield.value = '<p>Rich <strong>text</strong> content</p>'
         expect(metafield.csv_value).to eq('Rich text content')
       end

--- a/core/spec/presenters/spree/csv/customer_presenter_spec.rb
+++ b/core/spec/presenters/spree/csv/customer_presenter_spec.rb
@@ -128,4 +128,39 @@ RSpec.describe Spree::CSV::CustomerPresenter do
       expect(described_class::HEADERS).to eq(expected_headers)
     end
   end
+
+  describe 'metafields' do
+    let!(:metafield_definition) do
+      create(:metafield_definition,
+             resource_type: customer.class.to_s,
+             namespace: 'custom',
+             key: 'loyalty_points')
+    end
+    let!(:metafield) do
+      customer.metafields.create!(
+        metafield_definition: metafield_definition,
+        value: '500'
+      )
+    end
+
+    it 'includes metafield values at the end of the array' do
+      result = presenter.call
+      expect(result.last).to eq '500'
+    end
+
+    context 'when customer has no metafield value' do
+      let(:customer_without_metafield) do
+        create(:user,
+               first_name: 'Jane',
+               last_name: 'Smith',
+               email: 'jane.smith@example.com')
+      end
+      let(:presenter) { described_class.new(customer_without_metafield) }
+
+      it 'returns nil for metafield' do
+        result = presenter.call
+        expect(result.last).to be_nil
+      end
+    end
+  end
 end

--- a/core/spec/presenters/spree/csv/gift_card_presenter_spec.rb
+++ b/core/spec/presenters/spree/csv/gift_card_presenter_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Spree::CSV::GiftCardPresenter, type: :model do
 
     it 'returns the correct CSV data' do
       expect(subject).to be_an(Array)
-      expect(subject.length).to eq(12)
       expect(subject[0]).to eq('ABC123')           # Code
       expect(subject[4]).to eq('USD')              # Currency
       expect(subject[5]).to eq('active')           # Status
@@ -67,6 +66,36 @@ RSpec.describe Spree::CSV::GiftCardPresenter, type: :model do
         'Updated At'
       ]
       expect(Spree::CSV::GiftCardPresenter::HEADERS).to eq(expected_headers)
+    end
+  end
+
+  describe 'metafields' do
+    let!(:metafield_definition) do
+      create(:metafield_definition,
+             resource_type: 'Spree::GiftCard',
+             namespace: 'custom',
+             key: 'purchase_location')
+    end
+    let!(:metafield) do
+      gift_card.metafields.create!(
+        metafield_definition: metafield_definition,
+        value: 'Online Store'
+      )
+    end
+
+    it 'includes metafield values at the end of the array' do
+      result = presenter.call
+      expect(result.last).to eq 'Online Store'
+    end
+
+    context 'when gift card has no metafield value' do
+      let(:gift_card_without_metafield) { create(:gift_card, store: store) }
+      let(:presenter) { described_class.new(gift_card_without_metafield) }
+
+      it 'returns nil for metafield' do
+        result = presenter.call
+        expect(result.last).to be_nil
+      end
     end
   end
 end

--- a/core/spec/presenters/spree/csv/newsletter_subscriber_presenter_spec.rb
+++ b/core/spec/presenters/spree/csv/newsletter_subscriber_presenter_spec.rb
@@ -80,4 +80,37 @@ RSpec.describe Spree::CSV::NewsletterSubscriberPresenter do
       expect(described_class::HEADERS).to eq(expected_headers)
     end
   end
+
+  describe 'metafields' do
+    let!(:metafield_definition) do
+      create(:metafield_definition,
+             resource_type: 'Spree::NewsletterSubscriber',
+             namespace: 'custom',
+             key: 'subscription_source')
+    end
+    let!(:metafield) do
+      newsletter_subscriber.metafields.create!(
+        metafield_definition: metafield_definition,
+        value: 'Homepage Popup'
+      )
+    end
+
+    it 'includes metafield values at the end of the array' do
+      result = presenter.call
+      expect(result.last).to eq 'Homepage Popup'
+    end
+
+    context 'when subscriber has no metafield value' do
+      let(:subscriber_without_metafield) do
+        create(:newsletter_subscriber,
+               email: 'nofield@example.com')
+      end
+      let(:presenter) { described_class.new(subscriber_without_metafield) }
+
+      it 'returns nil for metafield' do
+        result = presenter.call
+        expect(result.last).to be_nil
+      end
+    end
+  end
 end

--- a/core/spec/presenters/spree/csv/order_line_items_presenter_spec.rb
+++ b/core/spec/presenters/spree/csv/order_line_items_presenter_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Spree::CSV::OrderLineItemPresenter do
   let(:order) { create(:completed_order_with_totals, store: store) }
   let(:line_item) { order.line_items.first }
   let(:index) { 0 }
-  let(:presenter) { described_class.new(order, line_item, index) }
+  let(:metafields) { [] }
+  let(:presenter) { described_class.new(order, line_item, index, metafields) }
 
   describe '#call' do
     subject { presenter.call }
@@ -75,6 +76,30 @@ RSpec.describe Spree::CSV::OrderLineItemPresenter do
 
     it 'returns nil for blank date' do
       expect(presenter.send(:format_date, nil)).to be_nil
+    end
+  end
+
+  describe 'metafields' do
+    context 'when index is zero' do
+      let(:metafields) { ['loyalty_tier', '100'] }
+      let(:presenter) { described_class.new(order, line_item, 0, metafields) }
+
+      it 'includes metafields at the end of the array' do
+        result = presenter.call
+        expect(result[-2]).to eq 'loyalty_tier'
+        expect(result[-1]).to eq '100'
+      end
+    end
+
+    context 'when index is not zero' do
+      let(:metafields) { ['loyalty_tier', '100'] }
+      let(:presenter) { described_class.new(order, line_item, 1, metafields) }
+
+      it 'does not include metafields' do
+        result = presenter.call
+        expect(result).not_to include('loyalty_tier')
+        expect(result).not_to include('100')
+      end
     end
   end
 end

--- a/core/spec/presenters/spree/csv/product_variant_presenter_spec.rb
+++ b/core/spec/presenters/spree/csv/product_variant_presenter_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Spree::CSV::ProductVariantPresenter do
   let(:variant) { product.master }
   let(:properties) { [] }
   let(:taxons) { [] }
-  let(:presenter) { described_class.new(product, variant, 0, properties, taxons, store) }
+  let(:metafields) { [] }
+  let(:presenter) { described_class.new(product, variant, 0, properties, taxons, store, metafields) }
 
   let!(:variant_images) { create_list(:image, 3, viewable: variant) }
 
@@ -55,7 +56,7 @@ RSpec.describe Spree::CSV::ProductVariantPresenter do
     end
 
     context 'when index is not zero' do
-      let(:presenter) { described_class.new(product, variant, 1, properties, taxons, store) }
+      let(:presenter) { described_class.new(product, variant, 1, properties, taxons, store, metafields) }
 
       let!(:color_option) { create(:option_type, name: 'Color', presentation: 'Color', products: [product]) }
       let!(:size_option) { create(:option_type, name: 'Size', presentation: 'Size', products: [product]) }
@@ -153,6 +154,30 @@ RSpec.describe Spree::CSV::ProductVariantPresenter do
 
     it 'returns nil for option type without value' do
       expect(presenter.option_value(create(:option_type))).to be_nil
+    end
+  end
+
+  describe 'metafields' do
+    context 'when index is zero' do
+      let(:metafields) { ['value1', 'value2'] }
+      let(:presenter) { described_class.new(product, variant, 0, properties, taxons, store, metafields) }
+
+      it 'includes metafields at the end of the array' do
+        result = presenter.call
+        expect(result[-2]).to eq 'value1'
+        expect(result[-1]).to eq 'value2'
+      end
+    end
+
+    context 'when index is not zero' do
+      let(:metafields) { ['value1', 'value2'] }
+      let(:presenter) { described_class.new(product, variant, 1, properties, taxons, store, metafields) }
+
+      it 'does not include metafields' do
+        result = presenter.call
+        expect(result).not_to include('value1')
+        expect(result).not_to include('value2')
+      end
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CSV exports now include metafields for Products, Orders, Customers, Gift Cards, and Newsletter Subscribers; headers append metafield columns (metafield.namespace.key).
  - Metafield values are CSV-friendly: booleans localized (Yes/No), rich text as plain text, numbers/JSON/strings as text.
  - Product and order exports include metafields on the first row of each item group.

- **Tests**
  - Added comprehensive specs for metafield headers, values, presenters, and export scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->