### PR TITLE
Add `confirmation_required?` to payment methods and use it in `Spree::Order#confirmation_required?`

### DIFF
--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -72,6 +72,10 @@ module Spree
       true
     end
 
+    def confirmation_required?
+      true
+    end
+
     def payment_profiles_supported?
       true
     end

--- a/core/app/models/spree/gateway/custom_payment_source_method.rb
+++ b/core/app/models/spree/gateway/custom_payment_source_method.rb
@@ -8,6 +8,10 @@ module Spree
       Spree::PaymentSource
     end
 
+    def confirmation_required?
+      true
+    end
+
     def payment_profiles_supported?
       true
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -302,7 +302,7 @@ module Spree
     # If true, causes the confirmation step to happen during the checkout process
     def confirmation_required?
       Spree::Config[:always_include_confirm_step] ||
-        payments.valid.map(&:payment_method).compact.any?(&:payment_profiles_supported?) ||
+        payments.valid.map(&:payment_method).compact.any?(&:confirmation_required?) ||
         # Little hacky fix for #4117
         # If this wasn't here, order would transition to address state on confirm failure
         # because there would be no valid payments any more.

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -20,7 +20,7 @@ module Spree
         #   :allow_checkout_on_gateway_error is set to false
         #
         def process_payments!
-          process_payments_with(:process!)
+          with_lock { process_payments_with(:process!) }
         end
 
         def authorize_payments!

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -61,6 +61,10 @@ module Spree
       unscoped { find(*args) }
     end
 
+    def confirmation_required?
+      false
+    end
+
     def payment_profiles_supported?
       false
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -505,6 +505,8 @@ describe Spree::Order, type: :model do
   end
 
   describe '#confirmation_required?' do
+    subject { order.confirmation_required? }
+
     # Regression test for #4117
     it "is required if the state is currently 'confirm'" do
       order = Spree::Order.new
@@ -535,6 +537,26 @@ describe Spree::Order, type: :model do
         order.payments.build
         assert !order.confirmation_required?
       end
+    end
+
+    context 'when the payment does not require confirmation' do
+      before do
+        order.update_column(:total, 50)
+        create(:payment, order: order, amount: 50)
+
+        allow_any_instance_of(Spree::Gateway::Bogus).to receive(:confirmation_required?).and_return(false)
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when at least one payment method requires confirmation' do
+      before do
+        order.update_column(:total, 50)
+        create(:payment, order: order, amount: 50)
+      end
+
+      it { is_expected.to be(true) }
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Checkout now respects whether a payment method requires confirmation, guiding users back to a confirm step when applicable.
  - Payment methods default to no confirmation unless explicitly marked as requiring it; some gateways now always require confirmation.

- Bug Fixes
  - Improved reliability during payment processing by executing it under a lock, reducing race conditions and potential duplicate handling.

- Tests
  - Expanded test coverage for order confirmation behavior based on payment methods requiring confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->