### PR TITLE
V-3256 Metafields fixes

### DIFF
--- a/admin/app/views/spree/admin/metafields/types/_boolean.html.erb
+++ b/admin/app/views/spree/admin/metafields/types/_boolean.html.erb
@@ -1,4 +1,4 @@
 <div class="custom-control custom-checkbox">
-  <%= f.check_box :value, class: 'custom-control-input' %>
+  <%= f.check_box :value, class: 'custom-control-input', checked: f.object.value&.to_b %>
   <%= f.label :value, Spree.t(:say_yes), class: 'custom-control-label' %>
 </div>

--- a/admin/spec/controllers/spree/admin/metafields_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/metafields_controller_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
   describe 'PUT #update' do
     let!(:metafield) { create(:metafield, resource: product, metafield_definition: metafield_definition) }
     let!(:metafield_definition_2) { create(:metafield_definition, :rich_text_field, resource_type: 'Spree::Product') }
+    let!(:metafield_definition_3) { create(:metafield_definition, :boolean_field, resource_type: 'Spree::Product') }
 
     let(:metafield_attributes) do
       {
@@ -74,6 +75,12 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
             type: metafield_definition_2.metafield_type,
             metafield_definition_id: metafield_definition_2.id,
             value: '<strong>Test Value</strong>'
+          },
+          "2" => {
+            id: nil,
+            type: metafield_definition_3.metafield_type,
+            metafield_definition_id: metafield_definition_3.id,
+            value: '0'
           }
         }
       }
@@ -95,6 +102,9 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
       metafield2 = product.metafields.find_by(metafield_definition_id: metafield_definition_2.id)
       expect(metafield2.value).to be_kind_of(ActionText::RichText)
       expect(metafield2.value.to_s).to include('<strong>Test Value</strong>')
+
+      metafield3 = product.metafields.find_by(metafield_definition_id: metafield_definition_3.id)
+      expect(metafield3.value).to eq('false')
     end
 
     context 'when resource_type is missing' do

--- a/core/app/models/concerns/spree/display_on.rb
+++ b/core/app/models/concerns/spree/display_on.rb
@@ -10,6 +10,10 @@ module Spree
       scope :available_on_back_end,  -> { where(display_on: [:back_end, :both]) }
 
       validates :display_on, presence: true, inclusion: { in: DISPLAY.map(&:to_s) }
+
+      def available_on_front_end?
+        display_on == 'front_end' || display_on == 'both'
+      end
     end
   end
 end

--- a/core/app/models/spree/metafields/boolean.rb
+++ b/core/app/models/spree/metafields/boolean.rb
@@ -1,10 +1,14 @@
 module Spree
   module Metafields
     class Boolean < Spree::Metafield
-      normalizes :value, with: lambda(&:to_b)
+      normalizes :value, with: ->(value) { value.to_b.to_s }
 
       def csv_value
         value.to_b ? Spree.t(:say_yes) : Spree.t(:say_no)
+      end
+
+      def serialize_value
+        value.to_b
       end
     end
   end

--- a/core/app/models/spree/metafields/number.rb
+++ b/core/app/models/spree/metafields/number.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def csv_value
-        value.to_s
+        value.to_d
       end
     end
   end

--- a/core/app/models/spree/metafields/number.rb
+++ b/core/app/models/spree/metafields/number.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def csv_value
-        value.to_d
+        value.to_d.to_s
       end
     end
   end

--- a/core/spec/models/spree/metafields/boolean_spec.rb
+++ b/core/spec/models/spree/metafields/boolean_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Spree::Metafields::Boolean, type: :model do
+  let(:metafield_definition) { create(:metafield_definition, :boolean_field) }
+  let(:metafield) { described_class.new(metafield_definition: metafield_definition, value: 'true') }
+
+  describe 'normalizes' do
+    it 'normalizes the boolean value' do
+      metafield.value = '0'
+      expect(metafield.value).to eq('false')
+      metafield.value = '1'
+      expect(metafield.value).to eq('true')
+    end
+  end
+
+  describe '#serialize_value' do
+    it 'returns the boolean value' do
+      expect(metafield.serialize_value).to eq(true)
+    end
+  end
+
+  describe '#csv_value' do
+    it 'returns the boolean value' do
+      expect(metafield.csv_value).to eq('Yes')
+    end
+  end
+end

--- a/core/spec/models/spree/metafields/number_spec.rb
+++ b/core/spec/models/spree/metafields/number_spec.rb
@@ -19,4 +19,11 @@ describe Spree::Metafields::Number, type: :model do
       expect(metafield.serialize_value).to eq(123)
     end
   end
+
+  describe '#csv_value' do
+    it 'returns the number' do
+      expect(metafield.csv_value).to be_kind_of(BigDecimal)
+      expect(metafield.csv_value).to eq(123)
+    end
+  end
 end

--- a/core/spec/models/spree/metafields/number_spec.rb
+++ b/core/spec/models/spree/metafields/number_spec.rb
@@ -21,9 +21,9 @@ describe Spree::Metafields::Number, type: :model do
   end
 
   describe '#csv_value' do
-    it 'returns the number' do
-      expect(metafield.csv_value).to be_kind_of(BigDecimal)
-      expect(metafield.csv_value).to eq(123)
+    it 'returns the number as a string' do
+      expect(metafield.csv_value).to be_kind_of(String)
+      expect(metafield.csv_value).to eq('123.0')
     end
   end
 end

--- a/storefront/app/views/themes/default/spree/metafields/_boolean.html.erb
+++ b/storefront/app/views/themes/default/spree/metafields/_boolean.html.erb
@@ -1,0 +1,5 @@
+<% if metafield.value == 'true' %>
+  <%= Spree.t(:say_yes) %>
+<% else %>
+  <%= Spree.t(:say_no) %>
+<% end %>

--- a/storefront/app/views/themes/default/spree/metafields/_json.html.erb
+++ b/storefront/app/views/themes/default/spree/metafields/_json.html.erb
@@ -1,0 +1,3 @@
+<code>
+  <%= metafield.value.as_json.as_json %>
+</code>

--- a/storefront/app/views/themes/default/spree/metafields/_number.html.erb
+++ b/storefront/app/views/themes/default/spree/metafields/_number.html.erb
@@ -1,0 +1,1 @@
+<%= metafield.value %>

--- a/storefront/app/views/themes/default/spree/products/_metafields.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_metafields.html.erb
@@ -3,6 +3,7 @@
   <% block.preferred_metafield_definition_ids.each do |definition_id| %>
     <% metafield = metafields_by_definition[definition_id.to_s] %>
     <% next unless metafield %>
+    <% next unless metafield.metafield_definition.available_on_front_end? %>
     
     <details class="product-metafield border-b border-default group" id="metafield_<%= metafield.id %>">
       <summary class="text-sm uppercase tracking-widest inline-flex w-full justify-between items-center py-4 cursor-pointer focus:outline-none">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Storefront renders number metafields and displays JSON metafields.
  * Product pages skip metafields not available on the storefront (front-end availability check).
* Bug Fixes
  * Admin boolean metafield checkbox correctly reflects the saved value.
  * Boolean metafields display localized “Yes/No” on the storefront.
  * Number metafields export as decimals in CSV.
* Tests
  * Added tests for boolean normalization/serialization and CSV output for number metafields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->