### PR TITLE
Fixes #13168 undefined currency_options_for_select

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,10 @@ commands:
       - install_libvips
       - run:
           name: Install global dependencies
-          command: bundle check || bundle install
+          command: bundle update
+      - run:
+          name: Clean old gems
+          command: bundle clean
       - run:
           name: Install per-project gem dependencies
           command: bin/build-ci.rb install

--- a/admin/app/views/spree/admin/gift_card_batches/_form.html.erb
+++ b/admin/app/views/spree/admin/gift_card_batches/_form.html.erb
@@ -8,6 +8,7 @@
   <div class="card-body">
     <%= f.spree_text_field :prefix, disabled: f.object.persisted?, label: Spree.t('admin.gift_card_batches.prefix') %>
     <%= f.spree_number_field :amount, required: true, disabled: f.object.persisted? %>
+    <%= f.spree_select :currency, options_for_select(supported_currency_options, f.object.currency), { label: Spree.t(:currency), autocomplete: true } %>
     <%= f.spree_number_field :codes_count, required: true, min: 1, max: Spree::Config[:gift_card_batch_limit], label: Spree.t('admin.gift_card_batches.codes_count') %>
     <%= f.spree_date_field :expires_at, disabled: f.object.persisted?, help: 'Gift cards will expire after this date.' %>
   </div>

--- a/admin/app/views/spree/admin/gift_cards/_form.html.erb
+++ b/admin/app/views/spree/admin/gift_cards/_form.html.erb
@@ -5,6 +5,7 @@
     <% end %>
 
     <%= f.spree_number_field :amount, required: true %>
+    <%= f.spree_select :currency, options_for_select(supported_currency_options, f.object.currency), { label: Spree.t(:currency), autocomplete: true }, { disabled: f.object.persisted? } %>
 
     <div class="form-group">
       <%= f.label :user_id, Spree.t(:customer) %>

--- a/admin/app/views/spree/admin/promotion_rules/forms/_currency.html.erb
+++ b/admin/app/views/spree/admin/promotion_rules/forms/_currency.html.erb
@@ -1,9 +1,6 @@
 <div class="form-group">
   <%= f.select :preferred_currency,
-    currency_options_for_select(
-      f.object.preferred_currency,
-      current_store.supported_currencies.split(',')
-    ),
+    options_for_select(supported_currency_options, f.object.preferred_currency),
     {},
     { data: { controller: 'autocomplete-select' } } 
   %>

--- a/admin/app/views/spree/admin/store_credits/_form.html.erb
+++ b/admin/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,3 +1,3 @@
 <%= f.spree_number_field :amount, label: Spree.t(:amount), min: 0.01, step: 0.01, required: true, disabled: !f.object.editable? %>
-<%= f.spree_select :currency, preferred_currencies_select_options, { label: Spree.t(:currency), autocomplete: true }, { data: { enable_button_target: 'input', store_form_target: 'currency' } } %>
+<%= f.spree_select :currency, options_for_select(supported_currency_options, f.object.currency), { label: Spree.t(:currency), autocomplete: true }, { data: { enable_button_target: 'input', store_form_target: 'currency' } } %>
 <%= f.spree_text_area :memo %>

--- a/admin/spec/controllers/spree/admin/gift_card_batches_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/gift_card_batches_controller_spec.rb
@@ -27,7 +27,7 @@ describe Spree::Admin::GiftCardBatchesController, type: :controller do
         gift_card_batch: {
           prefix: 'BATCH001',
           amount: 10,
-          currency: 'USD',
+          currency: 'EUR',
           codes_count: 20,
           expires_at: 1.year.from_now.to_date
         }
@@ -43,7 +43,7 @@ describe Spree::Admin::GiftCardBatchesController, type: :controller do
         gift_card_batch = Spree::GiftCardBatch.last
         expect(gift_card_batch.prefix).to eq('BATCH001')
         expect(gift_card_batch.amount).to eq(10)
-        expect(gift_card_batch.currency).to eq('USD')
+        expect(gift_card_batch.currency).to eq('EUR')
         expect(gift_card_batch.codes_count).to eq(20)
         expect(gift_card_batch.expires_at).to eq(1.year.from_now.to_date)
         expect(gift_card_batch.store).to eq(store)
@@ -67,7 +67,7 @@ describe Spree::Admin::GiftCardBatchesController, type: :controller do
         {
           gift_card_batch: {
             amount: -100,
-            currency: 'USD'
+            currency: 'EUR'
           }
         }
       end

--- a/admin/spec/controllers/spree/admin/gift_cards_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/gift_cards_controller_spec.rb
@@ -110,7 +110,7 @@ describe Spree::Admin::GiftCardsController, type: :controller do
       {
         gift_card: {
           amount: 100,
-          currency: 'USD',
+          currency: 'EUR',
           user_id: user.id,
           expires_at: 1.year.from_now.to_date,
           code: '1234567890'
@@ -150,7 +150,7 @@ describe Spree::Admin::GiftCardsController, type: :controller do
         {
           gift_card: {
             amount: -100,
-            currency: 'USD'
+            currency: 'EUR'
           }
         }
       end

--- a/core/app/helpers/spree/currency_helper.rb
+++ b/core/app/helpers/spree/currency_helper.rb
@@ -1,18 +1,23 @@
 module Spree
   module CurrencyHelper
+    # Returns the list of all currencies as options for a select field.
+    # By default the value is the default currency of the default store.
+    # @param selected_value [String] the selected value
+    # @return [String] the options for a select field
     def currency_options(selected_value = nil)
       selected_value ||= Spree::Store.default.default_currency
       currencies = ::Money::Currency.table.map do |_code, details|
-        iso = details[:iso_code]
-        [iso, "#{details[:name]} (#{iso})"]
+        currency_presentation(details[:iso_code])
       end
-      options_from_collection_for_select(currencies, :first, :last, selected_value)
+      options_from_collection_for_select(currencies, :last, :first, selected_value)
     end
 
+    # Returns the list of supported currencies for the current store as options for a select field.
+    # @return [String] the options for a select field
     def supported_currency_options
       return if current_store.nil?
 
-      current_store.supported_currencies_list.map(&:iso_code).map { |currency| currency_presentation(currency) }
+      @supported_currency_options ||= current_store.supported_currencies_list.map(&:iso_code).map { |currency| currency_presentation(currency) }
     end
 
     def should_render_currency_dropdown?
@@ -21,22 +26,32 @@ module Spree
       current_store.supported_currencies_list.size > 1
     end
 
+    # Returns the currency symbol for the given currency.
+    # @param currency [String] the currency ISO code
+    # @return [String] the currency symbol
     def currency_symbol(currency)
       ::Money::Currency.find(currency).symbol
     end
 
+    # @param currency [String] the currency ISO code
+    # @return [Array] the currency presentation and ISO code
     def currency_presentation(currency)
-      label = [currency_symbol(currency), currency].compact.join(' ')
+      currency_money = currency_money(currency)
+      label = "#{currency_money.name} (#{currency_money.iso_code})"
 
       [label, currency]
     end
 
+    # Returns the list of supported currencies for the current store.
+    # @return [Array<Money::Currency>] the list of supported currencies
     def preferred_currencies
+      Spree::Deprecation.warn('preferred_currencies is deprecated and will be removed in Spree 6.0. Use current_store.supported_currencies_list instead.')
       @preferred_currencies ||= current_store.supported_currencies_list
     end
 
     def preferred_currencies_select_options
-      preferred_currencies.map { |currency| ["#{currency.name} - #{currency.iso_code}", currency] }
+      Spree::Deprecation.warn('preferred_currencies_select_options is deprecated and will be removed in Spree 6.0. Use supported_currency_options instead.')
+      preferred_currencies.map { |currency| currency_presentation(currency) }
     end
 
     def currency_money(currency = current_currency)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -110,9 +110,9 @@ module Spree
 
     @@export_attributes = [:type, :format, :record_selection, :search_params]
 
-    @@gift_card_attributes = [:code, :amount, :expires_at, :user_id]
+    @@gift_card_attributes = [:code, :amount, :expires_at, :user_id, :currency]
 
-    @@gift_card_batch_attributes = [:prefix, :codes_count, :amount, :expires_at]
+    @@gift_card_batch_attributes = [:prefix, :codes_count, :amount, :expires_at, :currency]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -30,13 +30,13 @@ namespace :common do
     Spree::DummyGenerator.start dummy_app_args
 
     unless skip_javascript
-      system('bin/rails importmap:install turbo:install stimulus:install')
+      system('bundle exec rails importmap:install turbo:install stimulus:install')
     end
 
     # install devise if it's not the legacy user, useful for testing storefront
     if args[:authentication] == 'devise' && args[:user_class] != 'Spree::LegacyUser'
-      system('bin/rails g devise:install --force --auto-accept')
-      system("bin/rails g devise #{args[:user_class]} --force --auto-accept")
+      system('bundle exec rails g devise:install --force --auto-accept')
+      system("bundle exec rails g devise #{args[:user_class]} --force --auto-accept")
       system('rm -rf spec') # we need to cleanup factories created by devise to avoid naming conflict
     end
 
@@ -59,7 +59,7 @@ namespace :common do
 
     unless ENV['NO_MIGRATE']
       puts 'Setting up dummy database...'
-      system('bin/rails db:environment:set RAILS_ENV=test > /dev/null 2>&1')
+      system('bundle exec rails db:environment:set RAILS_ENV=test > /dev/null 2>&1')
       system('bundle exec rake db:drop db:create > /dev/null 2>&1')
       Spree::DummyModelGenerator.start
       system('bundle exec rake db:migrate > /dev/null 2>&1')
@@ -81,7 +81,7 @@ namespace :common do
 
   task :db_setup do |_t|
     puts 'Setting up dummy database...'
-    system('bin/rails db:environment:set RAILS_ENV=test > /dev/null 2>&1')
+    system('bundle exec rails db:environment:set RAILS_ENV=test > /dev/null 2>&1')
     system('bundle exec rake db:drop db:create > /dev/null 2>&1')
     Spree::DummyModelGenerator.start
     system('bundle exec rake db:migrate > /dev/null 2>&1')

--- a/core/spec/helpers/currency_helper_spec.rb
+++ b/core/spec/helpers/currency_helper_spec.rb
@@ -9,7 +9,7 @@ describe Spree::CurrencyHelper, type: :helper do
   end
 
   describe '#supported_currency_options' do
-    it { expect(supported_currency_options).to contain_exactly(['zł PLN', 'PLN'], ['£ GBP', 'GBP'], ['€ EUR', 'EUR']) }
+    it { expect(supported_currency_options).to contain_exactly(['Polish Złoty (PLN)', 'PLN'], ['British Pound (GBP)', 'GBP'], ['Euro (EUR)', 'EUR']) }
   end
 
   describe '#should_render_currency_dropdown?' do
@@ -29,7 +29,7 @@ describe Spree::CurrencyHelper, type: :helper do
   end
 
   describe '#currency_presentation' do
-    it { expect(currency_presentation('EUR')).to eq(['€ EUR', 'EUR']) }
+    it { expect(currency_presentation('EUR')).to eq(['Euro (EUR)', 'EUR']) }
   end
 
   describe '#currency_money' do


### PR DESCRIPTION
This regression was introduced afrer removing `currency_select` gem. Replaced with Spree native methods. Also deprecated some old currency methods and unified currency dropdowns across the application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Currency dropdowns now use descriptive labels like “Euro (EUR)” across admin screens.
  - Currency selection added to gift card and gift card batch forms; default selection aligns with the record’s currency.
  - Currency symbols available for display in the UI.

- Bug Fixes
  - Safer handling of currency dropdown visibility when store context is unavailable.

- Refactor
  - Standardized source for currency options and deprecated older helpers.

- Tests / Chores
  - Permitted attributes updated to include currency; test app setup commands run under Bundler and CI dependency steps cleaned/updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->