### PR TITLE
Fixed: don't crash order view when order doesn't have any addresses

### DIFF
--- a/storefront/app/views/themes/default/spree/shared/_order_details.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_details.html.erb
@@ -37,24 +37,28 @@
 
 <div class="mt-6 bg-accent mb-24">
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 p-4 lg:p-6 text-sm bg-border bg-accent-100">
-    <!-- billing address -->
-    <div>
-      <div class="uppercase tracking-widest mb-2">
-        <%= Spree.t(:billing_address) %>
+    <% if order.billing_address.present? %>
+      <!-- billing address -->
+      <div>
+        <div class="uppercase tracking-widest mb-2">
+          <%= Spree.t(:billing_address) %>
+        </div>
+        <div class="!leading-[1.375rem] text-neutral-800">
+          <%= render 'spree/shared/address', address: order.billing_address %>
+        </div>
       </div>
-      <div class="!leading-[1.375rem] text-neutral-800">
-        <%= render 'spree/shared/address', address: order.billing_address %>
+    <% end %>
+    <% if order.payments.valid.any? %>
+      <!-- payment into -->
+      <div class="mb-5 lg:mb-0">
+        <div class="uppercase tracking-widest mb-2">
+          <%= Spree.t(:payment_information) %>
+        </div>
+        <div class="!leading-[1.375rem] text-neutral-800">
+          <%= render collection: order.payments.valid, partial: 'spree/shared/payment', cached: spree_storefront_base_cache_scope %>
+        </div>
       </div>
-    </div>
-    <!-- payment into -->
-    <div class="mb-5 lg:mb-0">
-      <div class="uppercase tracking-widest mb-2">
-        <%= Spree.t(:payment_information) %>
-      </div>
-      <div class="!leading-[1.375rem] text-neutral-800">
-        <%= render collection: order.payments.valid, partial: 'spree/shared/payment', cached: spree_storefront_base_cache_scope %>
-      </div>
-    </div>
+    <% end %>
   </div>
   <!-- totals/summary -->
   <div class="p-4 lg:p-6 text-sm">

--- a/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_shipment.html.erb
@@ -1,14 +1,15 @@
 <li class="border border-accent mb-4">
   <div class="p-4 lg:p-6">
     <div class="flex flex-col lg:flex-row lg:gap-6 gap-4">
-      <% if shipment.order.requires_ship_address? %>
+      <% ship_address = shipment.address || shipment.order.ship_address %>
+      <% if shipment.order.requires_ship_address? && ship_address.present? %>
         <div class="text-sm lg:w-1/2">
           <div class="tracking-widest uppercase mb-2">
             <%= Spree.t(:delivery_address) %>
           </div>
           <div class="!leading-[1.375rem] text-neutral-800">
             <%= render "spree/shared/address",
-            address: shipment.address || shipment.order.ship_address %>
+            address: ship_address %>
           </div>
         </div>
       <% end %>

--- a/storefront/spec/controllers/spree/orders_controller_spec.rb
+++ b/storefront/spec/controllers/spree/orders_controller_spec.rb
@@ -120,7 +120,6 @@ describe Spree::OrdersController, type: :controller do
       end
     end
 
-
     context 'when order does not require ship address' do
       let(:digital_shipping_method) { create(:digital_shipping_method) }
       let(:digital_product) { create(:product, shipping_category: digital_shipping_method.shipping_categories.first) }
@@ -132,6 +131,16 @@ describe Spree::OrdersController, type: :controller do
         get :show, params: { id: order.number, token: order.token }
         expect(response).to render_template(:show)
         expect(response.body).not_to include(Spree.t(:delivery_address))
+      end
+    end
+
+    context 'when order was free and doesn\'t require billing address' do
+      let(:order) { create(:completed_order_with_totals, store: store, user: user, bill_address: nil) }
+
+      it 'renders the show template' do
+        get :show, params: { id: order.number, token: order.token }
+        expect(response).to render_template(:show)
+        expect(response.body).not_to include(Spree.t(:billing_address))
       end
     end
 


### PR DESCRIPTION
Eg. free digital order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Order and shipment pages now conditionally display sections: billing address, payment details, and delivery address only appear when relevant data exists.
- Bug Fixes
  - Prevents empty or misleading sections by hiding billing address when missing, payment info without valid payments, and delivery address unless required and available.
- Tests
  - Added coverage to ensure billing address is not shown when absent on completed orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->