### PR TITLE
Fixed: admin - creating line items for orders with non-default currency

### DIFF
--- a/admin/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe Spree::Admin::LineItemsController, type: :controller do
       expect(response).to redirect_to(spree.edit_admin_order_path(order, line_item_updated: true))
       expect(order.line_items.count).to eq(1)
     end
+
+    context 'when order is non-default currency' do
+      let(:order) { create(:order, store: store, currency: 'EUR') }
+
+      before do
+        product.default_variant.prices.create(currency: 'EUR', amount: 89)
+      end
+
+      it 'returns a success response' do
+        post :create, params: { order_id: order.number, line_item: { variant_id: product.default_variant.id, quantity: 1 } }
+
+        line_items = order.line_items.last
+        expect(line_items.price).to eq(89)
+        expect(line_items.currency).to eq('EUR')
+      end
+    end
   end
 
   describe '#edit' do

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -67,7 +67,7 @@ module Spree
       if variant
         update_price if price.nil?
         self.cost_price = variant.cost_price if cost_price.nil?
-        self.currency = variant.currency if currency.nil?
+        self.currency = order.currency if currency.nil?
       end
     end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -179,9 +179,9 @@ describe Spree::LineItem, type: :model do
       line_item.currency = nil
       line_item.copy_price
       variant = line_item.variant
-      expect(line_item.price).to eq(variant.price)
+      expect(line_item.price).to eq(variant.amount_in(order.currency))
       expect(line_item.cost_price).to eq(variant.cost_price)
-      expect(line_item.currency).to eq(variant.currency)
+      expect(line_item.currency).to eq(order.currency)
     end
 
     context "variant price amount is equal 0" do


### PR DESCRIPTION
Fixes #13165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Line items now correctly use the order’s currency when setting prices, ensuring accurate amounts and currency display for non-default currencies (e.g., EUR). This prevents mismatches caused by falling back to a variant’s default currency.

- Tests
  - Added coverage to verify correct price and currency selection when creating line items for orders in non-default currencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->