### PR TITLE
Added New Order screen

### DIFF
--- a/admin/app/controllers/spree/admin/orders_controller.rb
+++ b/admin/app/controllers/spree/admin/orders_controller.rb
@@ -12,11 +12,21 @@ module Spree
 
       helper_method :model_class, :object_url
 
+      # GET /admin/orders/new
+      def new
+        @order = current_store.orders.new
+      end
+
       # POST /admin/orders
       def create
-        @order = Spree::Order.create(created_by: try_spree_current_user, store: current_store)
-
-        redirect_to spree.edit_admin_order_path(@order)
+        @order = current_store.orders.new(permitted_resource_params)
+        @order.created_by = try_spree_current_user
+        if @order.save
+          flash[:success] = flash_message_for(@order, :successfully_created)
+          redirect_to spree.edit_admin_order_path(@order)
+        else
+          render :new, status: :unprocessable_entity
+        end
       end
 
       # GET /admin/orders/:id/edit
@@ -112,6 +122,10 @@ module Spree
       # needed to show the delete button in the content header
       def object_url
         spree.admin_order_path(@order)
+      end
+
+      def permitted_resource_params
+        params.require(:order).permit(permitted_order_attributes)
       end
     end
   end

--- a/admin/app/views/spree/admin/orders/_form.html.erb
+++ b/admin/app/views/spree/admin/orders/_form.html.erb
@@ -3,8 +3,8 @@
 <hr class="my-4" />
 
 <div class="form-group">
-  <%= label_tag :user_id, Spree.t(:select_user) %>
-  <%= tom_select_tag :user_id, { include_blank: Spree.t(:select_user), options: users_for_select_options } %>
+  <%= f.label :user_id, Spree.t(:select_user) %>
+  <%= tom_select_tag 'order[user_id]', { include_blank: Spree.t(:select_user), options: users_for_select_options } %>
 </div>
 
 <p class="text-center text-muted my-0"><%= Spree.t(:or) %></p>

--- a/admin/app/views/spree/admin/orders/_form.html.erb
+++ b/admin/app/views/spree/admin/orders/_form.html.erb
@@ -1,0 +1,12 @@
+<%= f.spree_select :currency, options_for_select(supported_currency_options, current_store.default_currency), { label: Spree.t(:currency), autocomplete: true } %>
+
+<hr class="my-4" />
+
+<div class="form-group">
+  <%= label_tag :user_id, Spree.t(:select_user) %>
+  <%= tom_select_tag :user_id, { include_blank: Spree.t(:select_user), options: users_for_select_options } %>
+</div>
+
+<p class="text-center text-muted my-0"><%= Spree.t(:or) %></p>
+
+<%= f.spree_email_field :email, autofocus: f.object.new_record?, label: Spree.t('admin.orders.provide_email') %>

--- a/admin/app/views/spree/admin/orders/_summary.html.erb
+++ b/admin/app/views/spree/admin/orders/_summary.html.erb
@@ -21,6 +21,13 @@
     <% end %>
 
     <li class="list-group-item d-flex justify-content-between align-items-center border-0">
+      <span><%= Spree.t(:currency) %></span>
+      <span id='currency'>
+        <%= @order.currency %>
+      </span>
+    </li>
+
+    <li class="list-group-item d-flex justify-content-between align-items-center border-0">
       <span data-hook='admin_order_tab_subtotal_title'><%= Spree.t(:subtotal) %></span>
       <span id='item_total'>
         <%= @order.display_item_total.to_html %>

--- a/admin/app/views/spree/admin/orders/index.html.erb
+++ b/admin/app/views/spree/admin/orders/index.html.erb
@@ -9,7 +9,7 @@
 <% content_for :page_actions do %>
   <%= render_admin_partials(:orders_actions_partials) %>
   <%= link_to_export_modal %>
-  <%= link_to_with_icon 'plus', Spree.t(:new_order), spree.admin_orders_path, class: "btn btn-primary", data: { turbo_method: :post } if can?(:create, Spree::Order)  %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_order), spree.new_admin_order_path, class: "btn btn-primary" if can?(:create, Spree::Order)  %>
 <% end %>
 
 <%= render_admin_partials(:orders_header_partials) %>

--- a/admin/app/views/spree/admin/orders/new.html.erb
+++ b/admin/app/views/spree/admin/orders/new.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title do %>
+  <%= Spree.t(:orders) %>
+<% end %>
+
+<% content_for :page_title do %>
+  <%= page_header_back_button spree.admin_orders_path %>
+  <%= Spree.t(:new_order) %>
+<% end %>
+
+<%= form_for @order, url: spree.admin_orders_path do |f| %>
+  <div class="row">
+    <div class="col-lg-6 offset-lg-3">
+      <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @order } %>
+      <div class="card mb-4">
+        <div class="card-body">
+          <%= render 'form', f: f %>
+        </div>
+      </div>
+      <%= render partial: 'spree/admin/shared/new_resource_links', locals: { collection_url: spree.admin_orders_path } %>
+    </div>
+  </div>
+<% end %>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
         orders_to_fulfill: Orders to fulfill
         partially_refunded: Partially Refunded
         payment_link_sent: Payment link was sent to the customer
+        provide_email: Provide an email address
         refunded: Refunded
         remove_user_from_this_order: Remove customer from this order
         unfulfilled: Unfulfilled

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -54,7 +54,7 @@ Spree::Core::Engine.add_routes do
 
     # orders
     resources :checkouts, only: %i[index]
-    resources :orders, only: [:index, :edit, :create, :destroy] do
+    resources :orders, only: [:index, :edit, :new, :create, :destroy] do
       member do
         post :resend
         put :cancel

--- a/admin/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -6,20 +6,30 @@ RSpec.describe Spree::Admin::OrdersController, type: :controller do
 
   let(:store) { @default_store }
 
+  describe '#new' do
+    it 'returns a success response' do
+      get :new
+      expect(response).to render_template(:new)
+    end
+  end
+
   describe '#create' do
-    subject { post :create }
+    subject { post :create, params: { order: { currency: 'EUR', email: 'test@example.com' } } }
 
     let(:order) { Spree::Order.last }
 
-    it 'creates a blank order' do
+    it 'creates a new order' do
       expect { subject }.to change(Spree::Order, :count).by(1)
 
       expect(assigns[:order]).to eq(order)
       expect(response).to redirect_to(spree.edit_admin_order_path(order))
+      expect(flash[:success]).to eq('Order has been successfully created!')
 
       expect(order.line_items).to be_empty
       expect(order.created_by).to eq(admin_user)
       expect(order.store).to eq(assigns[:current_store])
+      expect(order.currency).to eq('EUR')
+      expect(order.email).to eq('test@example.com')
     end
   end
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -86,7 +86,7 @@ module Spree
 
     @@checkout_attributes = [
       :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing, :use_shipping,
-      :user_id, :bill_address_id, :ship_address_id, :accept_marketing, :signup_for_an_account
+      :user_id, :bill_address_id, :ship_address_id, :accept_marketing, :signup_for_an_account, :currency
     ]
 
     @@classification_attributes = [


### PR DESCRIPTION
to select currency, customer/email before creating a new draft order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated “New Order” page in Admin for streamlined order creation.
  * Added fields to select currency, choose an existing user, or provide an email for the order.
  * Order summary now displays the order’s currency.
  * “New Order” action on the Orders index now navigates to the new order form.
  * Orders can be created with a specified currency and show success feedback on creation.

* **Localization**
  * Added a label prompting admins to provide an email address during order creation.

* **Tests**
  * Added coverage for the new order form and create flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->