### PR TITLE
Fix/gift card transitions for multiple partial redemptions and final redemption #13153

### DIFF
--- a/core/app/models/spree/gift_card.rb
+++ b/core/app/models/spree/gift_card.rb
@@ -15,11 +15,13 @@ module Spree
 
       event :redeem do
         transition active: :redeemed
+        transition partially_redeemed: :redeemed
       end
       after_transition to: :redeemed, do: :after_redeem
 
       event :partial_redeem do
         transition active: :partially_redeemed
+        transition partially_redeemed: :partially_redeemed
       end
     end
 

--- a/core/spec/models/spree/gift_card_spec.rb
+++ b/core/spec/models/spree/gift_card_spec.rb
@@ -149,4 +149,47 @@ RSpec.describe Spree::GiftCard, type: :model do
       expect(subject[7]).to eq(user.email)
     end
   end
+
+  describe 'State transitions' do
+  let(:store) { Spree::Store.default }
+
+  context 'when active' do
+    let(:gift_card) { create(:gift_card, state: :active, amount: 100, amount_used: 0, store: store) }
+
+    it 'transitions from active to partially_redeemed' do
+      expect { gift_card.partial_redeem! }
+        .to change(gift_card, :state).from('active').to('partially_redeemed')
+    end
+
+    it 'transitions from active to redeemed' do
+      expect { gift_card.redeem! }
+        .to change(gift_card, :state).from('active').to('redeemed')
+    end
+  end
+
+  context 'when partially_redeemed' do
+    let(:gift_card) { create(:gift_card, state: :partially_redeemed, amount: 100, amount_used: 50, store: store) }
+
+    it 'allows multiple partial redemptions (remains partially_redeemed)' do
+      expect { gift_card.partial_redeem! }
+        .to_not change(gift_card, :state)
+      expect(gift_card.state).to eq('partially_redeemed')
+    end
+
+    it 'transitions from partially_redeemed to redeemed when fully used' do
+      gift_card.update!(amount_used: 100)
+      expect { gift_card.redeem! }
+        .to change(gift_card, :state).from('partially_redeemed').to('redeemed')
+    end
+  end
+
+  context 'when redeemed' do
+    let(:gift_card) { create(:gift_card, state: :redeemed, amount: 100, amount_used: 100, store: store) }
+
+    it 'does not allow further redemption' do
+      expect { gift_card.partial_redeem! }.to raise_error(StateMachines::InvalidTransition)
+      expect { gift_card.redeem! }.to raise_error(StateMachines::InvalidTransition)
+    end
+  end
+  end
 end


### PR DESCRIPTION
**Description**

This PR updates the Spree::GiftCard state machine to allow:

- Multiple partial redemptions when the gift card still has remaining balance.
- A final redemption when the balance reaches zero.

**Changes**

- Added new state transition logic for `Spree::GiftCard`:
  - `partially_redeemed → partially_redeemed` (allows multiple partial redemptions)
  - `partially_redeemed → redeemed` (for final redemption when balance is 0)
- Ensured state machine consistency and updated model tests to cover all transitions.

**Issue**

Fixes #13153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Supports partial gift card redemption with a dedicated “partially redeemed” state.
- Bug Fixes
  - Ensures gift cards transition to “redeemed” when fully used.
  - Prevents invalid state changes during partial or full redemption attempts.
- Tests
  - Added comprehensive tests covering gift card state transitions for active, partially redeemed, and redeemed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->