### PR TITLE
Fix admin email search to support underscores in orders and customers

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -62,7 +62,7 @@ module Spree
           name_conditions << multi_search_condition(self, :last_name, full_name.last)
         end
 
-        where(email: sanitized_query).or(where(name_conditions.reduce(:or)))
+        where(arel_table[:email].lower.eq(query.downcase)).or(where(name_conditions.reduce(:or)))
       end
 
       self.whitelisted_ransackable_associations = %w[bill_address ship_address addresses tags spree_roles]

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -229,7 +229,7 @@ module Spree
         conditions << multi_search_condition(Spree::Address, :lastname, full_name.last)
       end
 
-      left_joins(:bill_address).where(email: sanitized_query).or(where(conditions.reduce(:or)))
+      left_joins(:bill_address).where(arel_table[:email].lower.eq(query.downcase)).or(where(conditions.reduce(:or)))
     end
 
     # Use this method in other gems that wish to register their own custom logic

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -119,27 +119,31 @@ describe Spree::UserMethods do
     let!(:user_1) { create(:user, email: 'john.doe@example.com', first_name: 'John', last_name: 'Doe') }
     let!(:user_2) { create(:user, email: 'jane.doe@example.com', first_name: 'Jane', last_name: 'Gone') }
     let!(:user_3) { create(:user, email: 'mary.moe@example.com', first_name: 'Mary', last_name: 'Moe') }
+    let!(:user_4) { create(:user, email: 'john_doe@example.com', first_name: 'Ayn', last_name: 'Rand') }
+    let!(:user_5) { create(:user, email: 'johndoe@example.com', first_name: 'John', last_name: 'Doe') }
 
     it 'returns users based on an email' do
       expect(Spree.user_class.multi_search('john.doe@example.com')).to eq([user_1])
       expect(Spree.user_class.multi_search('jane.doe@example.com')).to eq([user_2])
+      expect(Spree.user_class.multi_search('john_doe@example.com')).to eq([user_4])
+      expect(Spree.user_class.multi_search('johndoe@example.com')).to eq([user_5])
       expect(Spree.user_class.multi_search('mary.moe@')).to eq([])
     end
 
     it 'returns users based on the first name' do
-      expect(Spree.user_class.multi_search('joh')).to eq([user_1])
+      expect(Spree.user_class.multi_search('joh')).to eq([user_1, user_5])
       expect(Spree.user_class.multi_search('jan')).to eq([user_2])
       expect(Spree.user_class.multi_search('greg')).to eq([])
     end
 
     it 'returns users based on the last name' do
-      expect(Spree.user_class.multi_search('do')).to eq([user_1])
+      expect(Spree.user_class.multi_search('do')).to eq([user_1, user_5])
       expect(Spree.user_class.multi_search('moe')).to eq([user_3])
       expect(Spree.user_class.multi_search('smith')).to eq([])
     end
 
     it 'returns users based on the full name' do
-      expect(Spree.user_class.multi_search('joh do')).to eq([user_1])
+      expect(Spree.user_class.multi_search('joh do')).to eq([user_1, user_5])
       expect(Spree.user_class.multi_search('ane gon')).to eq([user_2])
       expect(Spree.user_class.multi_search('mary moe')).to eq([user_3])
       expect(Spree.user_class.multi_search('jane moe')).to eq([user_2, user_3])

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -39,10 +39,14 @@ describe Spree::Order, type: :model do
       let!(:order_1) { create(:order, number: 'R100', user: create(:user, email: 'don.roe@example.com'), bill_address: create(:address, first_name: 'Don', last_name: 'Roe')) }
       let!(:order_2) { create(:order, number: 'R101', user: create(:user, email: 'jane.gone@example.com'), bill_address: create(:address, first_name: 'Jane', last_name: 'Gone')) }
       let!(:order_3) { create(:order, number: 'R200', user: create(:user, email: 'mary.moe@example.com'), bill_address: create(:address, first_name: 'Mary', last_name: 'Moe')) }
+      let!(:order_4) { create(:order, number: 'R300', user: create(:user, email: 'johndoe@example.com'), bill_address: create(:address, first_name: 'Ayn', last_name: 'Rand')) }
+      let!(:order_5) { create(:order, number: 'R400', user: create(:user, email: 'john_doe@example.com'), bill_address: create(:address, first_name: 'John', last_name: 'Doe')) }
 
       it 'returns orders based on an email' do
         expect(described_class.multi_search('don.roe@example.com')).to eq([order_1])
         expect(described_class.multi_search('jane.gone@example.com')).to eq([order_2])
+        expect(described_class.multi_search('johndoe@example.com')).to eq([order_4])
+        expect(described_class.multi_search('john_doe@example.com')).to eq([order_5])
         expect(described_class.multi_search('mary.moe@')).to eq([])
       end
 


### PR DESCRIPTION
### Summary
This PR fixes email searches in the admin panel where valid addresses containing underscores (e.g. `john_doe@example.com`) would not return results.

### Details
- **Orders**: `Spree::Order.multi_search` now uses the raw query for exact email equality (`arel_table[:email].lower.eq(query.downcase)`) instead of the sanitized query. This avoids incorrectly escaping underscores (`_`), which previously prevented matches.
- **Customers**: Applied the same fix in `Spree::UserMethods` so that customer searches in the admin behave consistently.

### Why
`sanitize_query_for_multi_search` correctly escapes `_` and `%` for `LIKE` conditions, but using the sanitized value for equality caused false negatives for emails with underscores.

### Result
- Searching by `spree@example.com` → still works.
- Searching by `john_doe@example.com` (or any underscore) → now works.
- Both Orders and Customers admin searches are consistent and reliable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made email matching in user and order searches case-insensitive, ensuring results are returned regardless of email casing.
  * Improved multi_search behavior to more reliably find users and orders by email and common partial queries.

* **Tests**
  * Expanded test coverage with additional users and orders to validate case-insensitive email matching.
  * Updated expectations for partial query matches to reflect improved search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->