### PR TITLE
Fixed ability to override storefront Stimulus controllers

### DIFF
--- a/storefront/app/views/spree/shared/_head.html.erb
+++ b/storefront/app/views/spree/shared/_head.html.erb
@@ -16,9 +16,11 @@
 
 <script async src="https://ga.jspm.io/npm:es-module-shims@1.8.2/dist/es-module-shims.js" data-turbo-track="reload"></script>
 
-<%= javascript_importmap_tags "application-spree-storefront" %>
 <% if Rails.application.importmap.packages["application"].present? %>
-  <%= javascript_import_module_tag "application" %>
+  <%= javascript_importmap_tags "application" %>
+  <%= javascript_import_module_tag "application-spree-storefront" %>
+<% else %>
+  <%= javascript_importmap_tags "application-spree-storefront" %>
 <% end %>
 
 <%= javascript_tag "wishedVariantIds = #{(current_wishlist&.variant_ids&.map(&:to_s) || []).to_json.html_safe};" %>


### PR DESCRIPTION
Now, Storefront properly sees already registered Stimulus application in the host rails application and won't load already loaded Stimulus controllers. So developers can create overrides of Stimulus controllers from Spree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures storefront JavaScript initializes consistently across different app setups, preventing duplicate or missing initialization and reducing related console errors.

* **Refactor**
  * Streamlined script loading in the head to conditionally load storefront and application bundles based on configuration for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->