### PR TITLE
Allow admin users to delete all user roles

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -137,7 +137,7 @@ module Spree
     # Returns true if the user can be deleted
     # @return [Boolean]
     def can_be_deleted?
-      if has_spree_role?(Spree::Role::ADMIN_ROLE)
+      if role_users.where(resource: Spree::Store.current).exists?
         Spree::Store.current.users.where.not(id: id).exists?
       else
         orders.complete.none?

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -159,8 +159,8 @@ describe Spree::UserMethods do
 
       it 'returns true if another user also has a role on the store' do
         test_user.add_role(role.name, current_store)
-        another_user = create(:user)
-        another_user.add_role(role.name, current_store)
+        other_user = create(:user)
+        other_user.add_role(role.name, current_store)
 
         expect(subject).to be(true)
       end

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -150,4 +150,21 @@ describe Spree::UserMethods do
       expect(Spree.user_class.multi_search('greg smith')).to eq([])
     end
   end
+
+  describe '#can_be_deleted?' do
+    subject { test_user.can_be_deleted? }
+
+    context 'when user has a role on current store' do
+      it 'returns true if user has admin role on current store' do
+        test_user.add_role(Spree::Role::ADMIN_ROLE, current_store)
+        expect(subject).to be(true)
+      end
+
+      it 'returns true if user has other than admin role on current store' do
+        role = create(:role, name: 'test')
+        another_user.add_role(role.name, current_store)
+        expect(subject).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### PR Description
Updated `Spree::UserMethods` to ensure that users with the Admin role can delete other users regardless of their assigned role. Fixes current buggy behaviour where deletion is restricted.
Admin users can now delete:
- Admin role users
- All other user roles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Refines user-deletion rules to use store-scoped role membership so deletions are allowed when another user holds the store role and prevented when the user is the last store-role holder or has completed orders.

- Tests
  - Adds coverage for user deletion across store-scoped role scenarios (last-role vs other users) and non-role scenarios depending on completed orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->