### PR TITLE
FIX create account service

### DIFF
--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -7,7 +7,11 @@ module Spree
 
       def call(order:, accepts_email_marketing: false)
         existing_user = Spree.user_class.find_by(email: order.email)
-        return existing_user if existing_user.present?
+        if existing_user.present?
+          order.update_columns(user_id: existing_user.id, updated_at: Time.current)
+          order.user = existing_user
+          return success(existing_user)
+        end
 
         user = create_new_user(order, accepts_email_marketing)
         return failure(:user_creation_failed) unless user.persisted?

--- a/core/spec/services/spree/orders/create_user_account_spec.rb
+++ b/core/spec/services/spree/orders/create_user_account_spec.rb
@@ -44,5 +44,15 @@ describe Spree::Orders::CreateUserAccount do
     it 'does not create a new user' do
       expect { subject }.to change { Spree.user_class.count }.by(0)
     end
+
+    it 'assigns the user to the order' do
+      subject
+      expect(order.reload.user).to eq(user)
+    end
+
+    it 'returns success with the user' do
+      expect(subject).to be_success
+      expect(subject.value).to eq(user)
+    end
   end
 end


### PR DESCRIPTION
1. Fix service to return user instead of order when existing user present
2. Assign order when existing user present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Existing customers using their email at checkout are now automatically linked to the order, ensuring it appears in their account history.
- Bug Fixes
  - Prevents unintended duplicate account creation by associating orders with existing accounts when detected.
  - Improves consistency for order ownership, status visibility, and related notifications for returning customers.
- Tests
  - Added tests to confirm orders are assigned to existing users and the service reports a successful result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->