### PR TITLE
FIX: admin - normalize translation locale to handle compound locales (fixes #13150)

### DIFF
--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -1,18 +1,25 @@
 module Spree
   module Admin
     class TranslationsController < Spree::Admin::BaseController
+      # Set the resource being translated and any related data
       before_action :set_resource, only: [:edit, :update]
       before_action :load_data, only: [:edit, :update]
       before_action :set_translation_locale, only: [:edit, :update]
       helper_method :normalized_locale
       helper_method :resource_class
 
+      # GET /admin/translations/:id/edit
+      # Renders the edit translation page for the resource
       def edit; end
 
+      # Normalizes a locale string by replacing '-' with '_' and downcasing
       def normalized_locale(locale)
         locale.to_s.downcase.tr('-', '_')
       end
 
+      # PUT /admin/translations/:id
+      # Updates the translations for the resource
+      # Sets flash messages for success or failure
       def update
         if @resource.update(permitted_translation_params)
           flash.now[:success] = flash_message_for(@resource, :successfully_updated)
@@ -36,10 +43,12 @@ module Spree
         end
       end
 
+      # Build translation field names with normalized locale suffix
       def translation_fields(klass)
         klass.translatable_fields.map { |field| "#{field}_#{normalized_locale(@selected_translation_locale)}" }
       end
 
+      # Determine the class of the resource
       def resource_class
         @resource_class ||= begin
           klass = params[:resource_type]
@@ -48,10 +57,12 @@ module Spree
         end
       end
 
+      # Allowed translatable resources configured in Spree
       def allowed_resource_class
         Rails.application.config.spree.translatable_resources
       end
 
+      # Set the resource object using friendly find if available
       def set_resource
         @resource = if resource_class.respond_to?(:friendly)
                       resource_class.friendly.find(params[:id])
@@ -60,7 +71,7 @@ module Spree
                     end
       end
 
-  
+      # Determine the translation locale to use
       def set_translation_locale
         raw_locale = params[:translation_locale].presence ||
         @locales&.first ||
@@ -70,6 +81,7 @@ module Spree
         @selected_translation_locale = normalized_locale(raw_locale)
       end
 
+      # Load available locales for this resource, excluding default
       def load_data
         @locales = (current_store.supported_locales_list - [@default_locale]).sort
       end

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -9,6 +9,10 @@ module Spree
 
       def edit; end
 
+      def normalized_locale(locale)
+        locale.to_s.downcase.tr('-', '_')
+      end
+
       def update
         if @resource.update(permitted_translation_params)
           flash.now[:success] = flash_message_for(@resource, :successfully_updated)
@@ -33,7 +37,7 @@ module Spree
       end
 
       def translation_fields(klass)
-        klass.translatable_fields.map { |field| "#{field}_#{@selected_translation_locale}" }
+        klass.translatable_fields.map { |field| "#{field}_#{normalized_locale(@selected_translation_locale)}" }
       end
 
       def resource_class
@@ -56,8 +60,13 @@ module Spree
                     end
       end
 
+  
       def set_translation_locale
-        @selected_translation_locale = params[:translation_locale].presence || @locales&.first || current_store.supported_locales_list.first
+        raw_locale = params[:translation_locale].presence ||
+                     @locales&.first ||
+                     current_store.supported_locales_list.first
+
+        @selected_translation_locale = normalized_locale(raw_locale)
       end
 
       def load_data

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -63,8 +63,9 @@ module Spree
   
       def set_translation_locale
         raw_locale = params[:translation_locale].presence ||
-                     @locales&.first ||
-                     current_store.supported_locales_list.first
+             @locales&.first ||
+             current_store.default_locale ||
+             current_store.supported_locales_list.first
 
         @selected_translation_locale = normalized_locale(raw_locale)
       end

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -63,9 +63,9 @@ module Spree
   
       def set_translation_locale
         raw_locale = params[:translation_locale].presence ||
-             @locales&.first ||
-             current_store.default_locale ||
-             current_store.supported_locales_list.first
+        @locales&.first ||
+        current_store.default_locale ||
+        current_store.supported_locales_list.first
 
         @selected_translation_locale = normalized_locale(raw_locale)
       end

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -4,7 +4,7 @@ module Spree
       before_action :set_resource, only: [:edit, :update]
       before_action :load_data, only: [:edit, :update]
       before_action :set_translation_locale, only: [:edit, :update]
-
+      helper_method :normalized_locale
       helper_method :resource_class
 
       def edit; end

--- a/admin/app/views/spree/admin/translations/edit.html.erb
+++ b/admin/app/views/spree/admin/translations/edit.html.erb
@@ -5,10 +5,12 @@
       <div class="drawer-body">
         <ul class="nav nav-pills mb-3">
           <% @locales.each do |locale| %>
+            <% normalized = locale.to_s.downcase.tr('-', '_') %>
             <%= nav_item(
-                  Spree.t('i18n.this_file_language', locale: locale),
-                  spree.edit_admin_translation_path(@resource, resource_type: resource_class.to_s, translation_locale: locale),
-                  active: (locale == @selected_translation_locale)
+                 Spree.t('i18n.this_file_language', locale: locale), # display name
+                 spree.edit_admin_translation_path(@resource, resource_type: resource_class.to_s, translation_locale: locale), # link param
+                 active: (normalized == @selected_translation_locale) # comparison for highlight
+      
                 ) %>
           <% end %>
         </ul>

--- a/admin/app/views/spree/admin/translations/edit.html.erb
+++ b/admin/app/views/spree/admin/translations/edit.html.erb
@@ -7,9 +7,9 @@
           <% @locales.each do |locale| %>
             <% normalized = locale.to_s.downcase.tr('-', '_') %>
             <%= nav_item(
-                 Spree.t('i18n.this_file_language', locale: locale), # display name
-                 spree.edit_admin_translation_path(@resource, resource_type: resource_class.to_s, translation_locale: locale), # link param
-                 active: (normalized == @selected_translation_locale) # comparison for highlight
+                 Spree.t('i18n.this_file_language', locale: locale),
+                 spree.edit_admin_translation_path(@resource, resource_type: resource_class.to_s, translation_locale: locale),
+                 active: (normalized == @selected_translation_locale)
       
                 ) %>
           <% end %>

--- a/admin/app/views/spree/admin/translations/edit.html.erb
+++ b/admin/app/views/spree/admin/translations/edit.html.erb
@@ -5,7 +5,7 @@
       <div class="drawer-body">
         <ul class="nav nav-pills mb-3">
           <% @locales.each do |locale| %>
-            <% normalized = locale.to_s.downcase.tr('-', '_') %>
+            <% normalized = normalized_locale(locale) %>
             <%= nav_item(
                  Spree.t('i18n.this_file_language', locale: locale),
                  spree.edit_admin_translation_path(@resource, resource_type: resource_class.to_s, translation_locale: locale),

--- a/admin/spec/controllers/spree/admin/translations_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/translations_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
   end
 
   describe 'Spree::Admin::TranslationsController translation_fields and normalized_locale' do
-    let(:controller_instance) { Spree::Admin::TranslationsController.new }
+    let(:controller_instance) { described_class.new }
     let(:product_class) { Spree::Product }
 
     describe '#normalized_locale' do

--- a/admin/spec/controllers/spree/admin/translations_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/translations_controller_spec.rb
@@ -86,4 +86,32 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
       end
     end
   end
+
+  describe 'Spree::Admin::TranslationsController translation_fields and normalized_locale' do
+    let(:controller_instance) { Spree::Admin::TranslationsController.new }
+    let(:product_class) { Spree::Product }
+
+    describe '#normalized_locale' do
+      it 'converts en-GB to en_gb' do
+        expect(controller_instance.normalized_locale('en-GB')).to eq('en_gb')
+      end
+
+      it 'converts fr to fr' do
+        expect(controller_instance.normalized_locale('fr')).to eq('fr')
+      end
+    end
+
+    describe '#translation_fields' do
+      before do
+        controller_instance.instance_variable_set(:@selected_translation_locale, 'en_gb')
+        allow(product_class).to receive(:translatable_fields).and_return(['name', 'description'])
+      end
+
+      it 'returns fields with normalized locale suffix' do
+        fields = controller_instance.send(:translation_fields, product_class)
+        expect(fields).to eq(['name_en_gb', 'description_en_gb'])
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
**Title:** Fix translation locale normalization in Spree Admin

**Description:**
This PR fixes the normalization of translation locales in Spree::Admin::TranslationsController. Previously, compound locales (e.g., 'en-GB') were not being normalized correctly when generating translation fields.

Changes include:

- normalized_locale now converts compound locales to the expected format (en-GB → en_gb).
- translation_fields now consistently appends normalized locale suffixes to translatable fields.
- Specs updated to focus on normalized_locale and translation_fields, ensuring correctness without relying on full controller setup.

This ensures consistent behavior across the admin panel for locale-specific translations.

**Fixes:** #13150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin Translations: locale identifiers with hyphens (e.g., en-GB) are consistently normalized to lowercase with underscores (e.g., en_gb), fixing mismatches between selected locale and displayed translation fields.

* **New Features**
  * Locale normalization is exposed to the admin translation UI so active-locale selection and field naming remain consistent across views and updates.

* **Tests**
  * New tests for locale normalization and normalized translation field naming to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->