### PR TITLE
Delete policy slugs completely after deleting a policy

### DIFF
--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -45,6 +45,8 @@ module Spree
     #
     self.whitelisted_ransackable_attributes = %w[name owner_type owner_id]
 
+    before_destroy :really_destroy_slugs!
+
     def page_builder_url
       return unless Spree::Core::Engine.routes.url_helpers.respond_to?(:policy_path)
 
@@ -53,6 +55,10 @@ module Spree
 
     def with_body?
       body.present?
+    end
+
+    def really_destroy_slugs!
+      slugs.with_deleted.each(&:really_destroy!)
     end
   end
 end

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Spree::Policy, type: :model do
       expect(policy.to_param).to eq('new-slug')
       expect(policy.friendly_id_config.uses?(:history)).to be true
     end
+
+    context 'when the policy is destroyed' do
+      it 'fully destroys the slug' do
+        policy = create(:policy, name: 'Test policy 123', slug: 'test-policy-123')
+        expect(policy.slugs.count).to eq(1)
+
+        policy.destroy
+
+        expect(FriendlyId::Slug.with_deleted.find_by(slug: 'test-policy-123')).to be_blank
+      end
+    end
   end
 
   describe 'Translations' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a policy now fully removes its associated URLs, ensuring old links don’t linger or reappear. This prevents conflicts when reusing the same URL and improves search/index cleanliness.
* **Tests**
  * Added test coverage to verify URL cleanup when policies are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->