### PR TITLE
Add ability to include custom JS/stimulus controllers in Admin

### DIFF
--- a/admin/app/views/spree/admin/shared/_head.html.erb
+++ b/admin/app/views/spree/admin/shared/_head.html.erb
@@ -39,7 +39,12 @@
 
 <script async src="https://ga.jspm.io/npm:es-module-shims@1.8.2/dist/es-module-shims.js" data-turbo-track="reload"></script>
 
-<%= javascript_importmap_tags 'application-spree-admin', importmap: Rails.application.config.spree_admin.importmap %>
+<% if Rails.application.importmap.packages["application"].present? && Spree::Admin::RuntimeConfig.include_application_importmap %>
+  <%= javascript_importmap_tags "application" %>
+  <%= javascript_import_module_tag "application-spree-admin" %>
+<% else %>
+  <%= javascript_importmap_tags "application-spree-admin", importmap: Rails.application.config.spree_admin.importmap %>
+<% end %>
 
 <%= yield :head %>
 

--- a/admin/lib/spree/admin/runtime_configuration.rb
+++ b/admin/lib/spree/admin/runtime_configuration.rb
@@ -10,6 +10,8 @@ module Spree
       preference :admin_records_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_products_per_page, :integer, default: Kaminari.config.default_per_page
       preference :admin_orders_per_page, :integer, default: Kaminari.config.default_per_page
+
+      preference :include_application_importmap, :boolean, default: false
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/spree/spree/issues/13189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Admin setting to use the application’s import map for Admin assets (off by default).
  * When enabled, Admin loads scripts via modules; when disabled, existing loading behavior is preserved for full backward compatibility.
  * Option available via runtime configuration.
  * No action required for existing setups unless opting in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->