### PR TITLE
Fix typo in google-tag-manager.mdx

### DIFF
--- a/docs/integrations/analytics/google-tag-manager.mdx
+++ b/docs/integrations/analytics/google-tag-manager.mdx
@@ -44,7 +44,7 @@ This will redirect you to the setup page for Google Tag Manager integration.
 
 Ignore the GA4 Measurement ID field.
 
-Paste your GTM Container ID (e.g., GTM-XXXXXXX) into the Google Tag Manager Key field.
+Paste your GTM Container ID (e.g., GTM-XXXXXXX) into the Google Tag Manager ID field.
 
 ![](/images/integrations/google-tag-manager/3.gtm_id.png)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration guide to refer to the Google Tag Manager container identifier as “Google Tag Manager ID field” instead of “Key field,” improving clarity in setup instructions.
  * Corrected end-of-file formatting in the final note to ensure proper rendering; the note content remains unchanged: “Only one analytics key should be set at a time (GA4 or GTM).”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->