### PR TITLE
Fix displaying the gift card payment on the checkout complete page

### DIFF
--- a/core/app/views/spree/shared/_payment.html.erb
+++ b/core/app/views/spree/shared/_payment.html.erb
@@ -13,7 +13,11 @@
     </div>
   <% elsif source.is_a?(Spree::StoreCredit) %>
     <% if source.originator_type == 'Spree::GiftCard' %>
-      <%= heroicon 'gift', options: { style: 'margin-right: 0 !important;' } %>
+      <% if respond_to?(:heroicon) %>
+        <%= heroicon('gift', options: { style: 'margin-right: 0 !important;' }) %>
+      <% else %>
+        <%= icon('gift', height: 30) %>
+      <% end %>
       <div>
         <p class="mb-1"><%= Spree.t(:gift_card) %>: <strong><%= source.originator.code.upcase %></strong></p>
         <%= @order.display_gift_card_total %>

--- a/core/app/views/spree/shared/_payment.html.erb
+++ b/core/app/views/spree/shared/_payment.html.erb
@@ -13,12 +13,10 @@
     </div>
   <% elsif source.is_a?(Spree::StoreCredit) %>
     <% if source.originator_type == 'Spree::GiftCard' %>
-      <div class="d-flex align-items-center">
-        <%= icon('gift', height: 30, class: 'mr-3 text-muted opacity-50') %>
-        <div>
-          <p class="mb-1"><%= Spree.t(:gift_card) %>: <strong><%= source.originator.code.upcase %></strong></p>
-          <%= @order.display_gift_card_total %>
-        </div>
+      <%= heroicon 'gift', options: { style: 'margin-right: 0 !important;' } %>
+      <div>
+        <p class="mb-1"><%= Spree.t(:gift_card) %>: <strong><%= source.originator.code.upcase %></strong></p>
+        <%= @order.display_gift_card_total %>
       </div>
     <% elsif payment.payment_method.present? && payment_method_icon_tag(payment.payment_method.payment_icon_name).present? %>
       <div class="d-flex flex align-items-center items-center">


### PR DESCRIPTION
<img width="588" height="192" alt="Screenshot 2025-10-14 at 18 36 08" src="https://github.com/user-attachments/assets/8ad35383-8289-4391-8306-3692af29d47c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the gift card display to use a modern, compact inline icon with the text placed directly beside it for a cleaner look.
  * Simplified the surrounding layout for a neater presentation without altering gift card text or totals.

* **Bug Fixes**
  * Improved icon fallback handling to ensure the correct icon renders consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->