### PR TITLE
Allow to delete AnnouncementBar at page builder

### DIFF
--- a/core/app/models/spree/page_sections/announcement_bar.rb
+++ b/core/app/models/spree/page_sections/announcement_bar.rb
@@ -8,6 +8,10 @@ module Spree
       BOTTOM_PADDING_DEFAULT = 8
       TOP_BORDER_WIDTH_DEFAULT = 0
 
+      def can_be_deleted?
+        true
+      end
+
       def self.role
         'header'
       end


### PR DESCRIPTION
<img width="569" height="105" alt="image" src="https://github.com/user-attachments/assets/d2a13011-6160-48f7-b591-aead5053b843" />

PageSections that are not with `role = 'content'` are not "deletable". 

With this change, the `Spree::PageSections::AnnouncementBar` starts showing the delete option in the page builder.

This bar could be annoying for some theme designs.

https://github.com/user-attachments/assets/20c35384-e5d3-4ae6-903f-e9a7eff467d8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announcement bars can now be deleted from page sections, allowing quick removal of temporary notices and outdated messages. This streamlines content management, helps keep storefront messaging current, and reduces visual clutter. The option is available within existing page section management flows, improving flexibility and control over site-wide announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->