### PR TITLE
AnnouncementBar enabled option

### DIFF
--- a/admin/app/views/spree/admin/page_sections/forms/_announcement_bar.html.erb
+++ b/admin/app/views/spree/admin/page_sections/forms/_announcement_bar.html.erb
@@ -3,3 +3,8 @@
     action: 'trix-change->auto-submit#submit'
   }, class: 'mb-3' %>
 </div>
+
+<div class="pb-2 custom-control custom-checkbox">
+  <%= f.check_box :preferred_enabled, class: 'custom-control-input', data: { action: 'auto-submit#submit' } %>
+  <%= f.label :preferred_enabled, Spree.t('admin.page_builder.enabled'), class: 'custom-control-label' %>
+</div>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -156,6 +156,7 @@ en:
         description_alignment: Description alignment
         desktop_image_alignment: Image alignment for desktop
         desktop_logo_height: Logo height (desktop)
+        enabled: Enabled?
         heading: Heading
         heading_alignment: Heading alignment
         heading_size: Heading size

--- a/core/app/models/spree/page_sections/announcement_bar.rb
+++ b/core/app/models/spree/page_sections/announcement_bar.rb
@@ -3,6 +3,8 @@ module Spree
     class AnnouncementBar < Spree::PageSection
       before_validation :set_default_text, on: :create
 
+      preference :enabled, :boolean, default: true
+
       BACKGROUND_COLOR_DEFAULT = '#F5F5F4'
       TOP_PADDING_DEFAULT = 8
       BOTTOM_PADDING_DEFAULT = 8

--- a/core/spec/jobs/spree/themes/duplicate_components_job_spec.rb
+++ b/core/spec/jobs/spree/themes/duplicate_components_job_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Spree::Themes::DuplicateComponentsJob do
         top_padding: 20,
         bottom_padding: 20,
         top_border_width: 2,
-        bottom_border_width: 4
+        bottom_border_width: 4,
+        enabled: true
       }
     )
   end

--- a/storefront/app/views/themes/default/spree/page_sections/_announcement_bar.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_announcement_bar.html.erb
@@ -1,5 +1,5 @@
 <% cache_unless page_builder_enabled?, spree_storefront_base_cache_scope.call(section) do %>
-  <% if section.present? && section.text.body.to_plain_text.present? %>
+  <% if section.present? && section.text.body.to_plain_text.present? && (section.preferred_enabled || page_builder_enabled?) %>
     <div
       class='w-full justify-center items-center flex announcement-bar'
       style='<%= section_styles(section) %>'


### PR DESCRIPTION
In case that https://github.com/spree/spree/pull/13196 does not comply with the idea of deleting a header section, we can go with this alternative and allow the AnnouncementBar to be enabled or not. 

I was thinking about `Enabled?` vs `Visible?`, but I do not have a strong opinion about it.

<img width="323" height="284" alt="image" src="https://github.com/user-attachments/assets/208cd817-ae26-45eb-9673-d14f9a5e972a" />

Even if the preference is `false` in the page builder, the "component" still appears. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an enable/disable toggle to Announcement Bar settings in the admin; changes auto-save on toggle.
  * Announcement Bar now renders only when it has text and is enabled, respecting both section toggle and page-builder visibility.
  * Default state remains enabled to preserve current behavior for existing stores.
  * Added an English label for the toggle (“Enabled?”) for clarity in the settings UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->