### PR TITLE
Allow to delete AnnouncementBar at page builder

### DIFF
--- a/core/app/models/spree/page_sections/announcement_bar.rb
+++ b/core/app/models/spree/page_sections/announcement_bar.rb
@@ -8,6 +8,10 @@ module Spree
       BOTTOM_PADDING_DEFAULT = 8
       TOP_BORDER_WIDTH_DEFAULT = 0
 
+      def can_be_deleted?
+        true
+      end
+
       def self.role
         'header'
       end


### PR DESCRIPTION
PageSections that belong to the header `role` are not allowed to be deleted by the parent class.
 
With this change, the `Spree::PageSections::AnnouncementBar` starts showing the delete option in the page builder.
 
This bar could be annoying for some theme designs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announcement Bar sections can now be deleted, giving you control to remove site-wide announcements when they’re no longer needed.
  * The delete option appears alongside other page sections for a consistent editing experience.
  * Existing announcements remain unchanged until you choose to delete them, ensuring no unexpected content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->