### PR TITLE
Fix the Gift Card show view for guest orders

### DIFF
--- a/admin/app/views/spree/admin/gift_cards/show.html.erb
+++ b/admin/app/views/spree/admin/gift_cards/show.html.erb
@@ -67,7 +67,7 @@
                       <% end %>
                     </td>
                     <td>
-                      <%= order.user.email %>
+                      <%= render 'spree/admin/orders/customer_summary', order: order %>
                     </td>
                     <td class="text-right">
                       <%= order.display_gift_card_total %>

--- a/admin/spec/controllers/spree/admin/gift_cards_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/gift_cards_controller_spec.rb
@@ -79,6 +79,47 @@ describe Spree::Admin::GiftCardsController, type: :controller do
       subject
       expect(assigns(:object)).to eq(gift_card)
     end
+
+    context 'for a redeemed gift card' do
+      let!(:order) { create(:order, email: 'user@example.com', user: user, gift_card: gift_card) }
+      let(:gift_card) { create(:gift_card, :redeemed, user: user) }
+
+      it 'renders the show template' do
+        subject
+        expect(response).to render_template(:show)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'assigns the gift card' do
+        subject
+        expect(assigns(:object)).to eq(gift_card)
+      end
+
+      it 'assigns the order' do
+        subject
+        expect(assigns(:orders)).to eq([order])
+      end
+
+      context 'when the order is a guest order' do
+        let(:user) { nil }
+
+        it 'renders the show template' do
+          subject
+          expect(response).to render_template(:show)
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'assigns the gift card' do
+          subject
+          expect(assigns(:object)).to eq(gift_card)
+        end
+
+        it 'assigns the order' do
+          subject
+          expect(assigns(:orders)).to eq([order])
+        end
+      end
+    end
   end
 
   describe '#new' do


### PR DESCRIPTION
Gift Card view for guest order:

<img width="839" height="201" alt="Screenshot 2025-10-16 at 14 42 52" src="https://github.com/user-attachments/assets/f43a7d49-9717-403a-acdd-8595f37e718b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Gift card details view now renders customer information via a modularized customer summary component for clearer display and maintainability.

* **Tests**
  * Added coverage for redeemed gift cards, including cases where the related order is a guest order, validating template rendering and assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->