### PR TITLE
ADD ability to handle phone on quick checkout and FIX duplicated cookies issue

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -179,7 +179,7 @@ module Spree
     end
 
     def require_phone?
-      Spree::Config[:address_requires_phone]
+      !quick_checkout && Spree::Config[:address_requires_phone]
     end
 
     def require_zipcode?

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -179,6 +179,8 @@ module Spree
     end
 
     def require_phone?
+      # We want to collect phone number for quick checkout but not to validate it
+      # as it's not available before payment by browser.
       !quick_checkout && Spree::Config[:address_requires_phone]
     end
 

--- a/core/app/services/spree/addresses/phone_validator.rb
+++ b/core/app/services/spree/addresses/phone_validator.rb
@@ -8,7 +8,7 @@ module Spree
   module Addresses
     class PhoneValidator < ActiveModel::Validator
       def validate(address)
-        return if !Spree::Config[:address_requires_phone] || address.phone.blank? || address.country.blank? || address.country_iso.blank?
+        return if !address.require_phone? || address.phone.blank? || address.country.blank? || address.country_iso.blank?
 
         phone = Phonelib.parse(address.phone)
         unless phone.valid_for_country?(address.country_iso)

--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -24,6 +24,8 @@ module Spree
         order.update_columns(user_id: user.id, updated_at: Time.current)
         order.user = user
 
+        order.associate_user!(user, false)
+
         # send welcome email
         user.send_welcome_email if user.respond_to?(:send_welcome_email)
 

--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -24,6 +24,9 @@ module Spree
         order.update_columns(user_id: user.id, updated_at: Time.current)
         order.user = user
 
+        # create payment customer if order was completed as a guest
+        order.create_payment_customer if order.respond_to?(:create_payment_customer)
+        
         # send welcome email
         user.send_welcome_email if user.respond_to?(:send_welcome_email)
 

--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -24,8 +24,6 @@ module Spree
         order.update_columns(user_id: user.id, updated_at: Time.current)
         order.user = user
 
-        order.associate_user!(user, false)
-
         # send welcome email
         user.send_welcome_email if user.respond_to?(:send_welcome_email)
 

--- a/core/app/services/spree/orders/create_user_account.rb
+++ b/core/app/services/spree/orders/create_user_account.rb
@@ -24,9 +24,6 @@ module Spree
         order.update_columns(user_id: user.id, updated_at: Time.current)
         order.user = user
 
-        # create payment customer if order was completed as a guest
-        order.create_payment_customer if order.respond_to?(:create_payment_customer)
-        
         # send welcome email
         user.send_welcome_email if user.respond_to?(:send_welcome_email)
 

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -707,4 +707,36 @@ describe Spree::Address, type: :model do
       address.valid?
     end
   end
+
+  context 'require_phone?' do
+    context 'when quick_checkout is true' do
+      let(:address) { create(:address, quick_checkout: true) }
+
+      it 'returns false' do
+        expect(address.require_phone?).to be(false)
+      end
+    end
+
+    context 'when quick_checkout is false' do
+      let(:address) { build_stubbed(:address, quick_checkout: false) }
+
+      context 'and Spree::Config[:address_requires_phone] is true' do
+        before { Spree::Config[:address_requires_phone] = true }
+
+        after { Spree::Config[:address_requires_phone] = false }
+
+        it 'returns true' do
+          expect(address.require_phone?).to be(true)
+        end
+      end
+      
+      context 'and Spree::Config[:address_requires_phone] is false' do
+        before { Spree::Config[:address_requires_phone] = false }
+
+        it 'returns false' do
+          expect(address.require_phone?).to be(false)
+        end
+      end
+    end
+  end
 end

--- a/storefront/app/controllers/spree/line_items_controller.rb
+++ b/storefront/app/controllers/spree/line_items_controller.rb
@@ -15,7 +15,7 @@ module Spree
       @quantity = params[:quantity].to_i || 1
       options   = params[:options] || {}
 
-      create_token_cookie(@order.token) if @order.persisted?
+      cookies.permanent.signed[:token] = { value: @order.token, domain: current_store.url_or_custom_domain } if @order.persisted?
 
       result = cart_add_item_service.call(order: @order,
                                           variant: @variant,

--- a/storefront/app/controllers/spree/line_items_controller.rb
+++ b/storefront/app/controllers/spree/line_items_controller.rb
@@ -15,7 +15,7 @@ module Spree
       @quantity = params[:quantity].to_i || 1
       options   = params[:options] || {}
 
-      cookies.permanent.signed[:token] = @order.token if @order.persisted?
+      create_token_cookie(@order.token) if @order.persisted?
 
       result = cart_add_item_service.call(order: @order,
                                           variant: @variant,

--- a/storefront/spec/features/cart_spec.rb
+++ b/storefront/spec/features/cart_spec.rb
@@ -89,6 +89,11 @@ describe 'Cart', type: :feature do
   context 'order by cookie' do
     context 'order exists', js: true do
       before do
+        # Mock store url to match Capybara url for cookie domain
+        allow_any_instance_of(Spree::LineItemsController).to receive(:current_store)
+          .and_return(store)
+        host = Capybara.current_session.server.host
+        allow(store).to receive(:url_or_custom_domain).and_return(host)
         add_to_cart(product)
       end
 

--- a/storefront/spec/features/product_details_page_spec.rb
+++ b/storefront/spec/features/product_details_page_spec.rb
@@ -136,6 +136,11 @@ RSpec.describe 'Product detail page', type: :feature do
       it_behaves_like 'can be added to cart'
 
       it 'cannot add more than available quantity', js: true do
+        # Mock store url to match Capybara url for cookie domain
+        allow_any_instance_of(Spree::LineItemsController).to receive(:current_store)
+          .and_return(store)
+        host = Capybara.current_session.server.host
+        allow(store).to receive(:url_or_custom_domain).and_return(host)
         # we need to populate cart first
         within turbo_frame do
           fill_in 'quantity', with: 10


### PR DESCRIPTION
1. This feature allows user to gather phone on quick checkout and goes with: https://github.com/spree/spree_stripe/pull/36
2. Now token cookie is duplicated as path is not unique when no domain param is passed. It creates same cookies with path: `shop.lvh.me` and `.shop.lvh.me`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Phone field validation is no longer required during quick checkout flows.
  * Cart persistence via cookies now respects store domain, improving order recovery across store domains.

* **Tests**
  * Added coverage for phone-requirement behavior across quick checkout and configuration states.
  * Updated tests to align cookie/domain behavior for cart scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->