### PR TITLE
Fix displaying the order status when order with gift card is refunded/cancelled

### DIFF
--- a/admin/app/helpers/spree/admin/orders_helper.rb
+++ b/admin/app/helpers/spree/admin/orders_helper.rb
@@ -20,7 +20,15 @@ module Spree
       def order_payment_state(order, options = {})
         return if order.payment_state.blank?
 
-        content_tag :span, class: "badge  #{options[:class]} badge-#{order.partially_refunded? ? 'warning' : order.payment_state}" do
+        badge_class = if order.order_refunded?
+                        'badge-danger'
+                      elsif order.partially_refunded?
+                        'badge-warning'
+                      else
+                        "badge-#{order.payment_state}"
+                      end
+
+        content_tag :span, class: "badge #{options[:class]} #{badge_class}" do
           if order.order_refunded?
             icon('credit-card-refund') + Spree.t('payment_states.refunded')
           elsif order.partially_refunded?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refund calculations to correctly account for store credits and tax adjustments and to treat void/failed payments as non-refundable in appropriate cases.

* **UI**
  * Adjusted payment-state badge styling so refund/partial-refund states display the correct badge color/class.

* **Tests**
  * Expanded test coverage for refund scenarios, store credit interactions, and payment-state edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->