### PR TITLE
Remove from the old propietary importer

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/application.scss
+++ b/admin/app/assets/stylesheets/spree/admin/application.scss
@@ -27,7 +27,6 @@
 @import 'plugins/tinymce_custom';
 @import 'plugins/trix_custom';
 @import 'plugins/tom-select.bootstrap4';
-@import 'plugins/flatfile';
 
 @import url('https://unpkg.com/trix@2.1.12/dist/trix.css');
 @import url('https://esm.sh/@uppy/core@4.2.0/dist/style.min.css');

--- a/admin/app/assets/stylesheets/spree/admin/plugins/flatfile.scss
+++ b/admin/app/assets/stylesheets/spree/admin/plugins/flatfile.scss
@@ -1,4 +1,0 @@
-/* A div around the iframe that contains Flatfile */
-.flatfile_iframe-wrapper {
-  z-index: 1100 !important;
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Flatfile plugin stylesheet import from admin application styles.
  * Removed styling for Flatfile iframe wrapper component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->