### PR TITLE
Fix admin time helpers and tooltip

### DIFF
--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -342,7 +342,7 @@ module Spree
 
         # Generate the time ago element with tooltip
         content_tag(:span, options) do
-          tooltip_text = strip_tags(content_tag(:time, spree_time(time), datetime: time.iso8601))
+          tooltip_text = spree_time(time)
           local_time_ago(time, class: '', title: nil) + tooltip(tooltip_text)
         end
       end

--- a/admin/app/helpers/spree/admin/base_helper.rb
+++ b/admin/app/helpers/spree/admin/base_helper.rb
@@ -336,12 +336,13 @@ module Spree
       # @param time [Time] the time to format
       # @return [String] the local time ago
       def spree_time_ago(time, options = {})
+        return '' if time.blank?
         options[:data] ||= {}
         options[:data][:controller] = 'tooltip'
 
         # Generate the time ago element with tooltip
         content_tag(:span, options) do
-          tooltip_text = strip_tags(spree_time(time))
+          tooltip_text = strip_tags(content_tag(:time, spree_time(time), datetime: time.iso8601))
           local_time_ago(time, class: '', title: nil) + tooltip(tooltip_text)
         end
       end

--- a/admin/spec/helpers/spree/admin/base_helper_spec.rb
+++ b/admin/spec/helpers/spree/admin/base_helper_spec.rb
@@ -20,4 +20,17 @@ describe Spree::Admin::BaseHelper do
       end
     end
   end
+
+  describe '#spree_time_ago' do
+    it 'returns the local time ago with a tooltip' do
+      time = Time.zone.parse('2025-10-21 12:00')
+      html = helper.spree_time_ago(time)
+      expect(html).to include('<time datetime="2025-10-21T12:00')
+      expect(html).to include('tooltip-container')
+    end
+
+    it 'returns empty string for blank time' do
+      expect(helper.spree_time_ago(nil)).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
### Description
- Return empty string for nil times
- Ensure spree_time_ago tooltip renders correctly
- Compatible with local_time gem


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blank time values now return empty output instead of showing invalid content.
  * Tooltip content for time displays can include richer formatted output for more informative tooltips.

* **Tests**
  * Added coverage for time display, tooltip rendering, and nil/blank time behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->