### PR TITLE
Improve and extend `Images::SaveFromUrlJob`

### DIFF
--- a/core/app/jobs/spree/images/save_from_url_job.rb
+++ b/core/app/jobs/spree/images/save_from_url_job.rb
@@ -4,22 +4,22 @@ module Spree
   module Images
     class SaveFromUrlJob < ::Spree::BaseJob
       queue_as Spree.queues.images
-      retry_on ActiveRecord::RecordInvalid, OpenURI::HTTPError, URI::InvalidURIError, wait: :polynomially_longer, attempts: 2
+      retry_on ActiveRecord::RecordInvalid, OpenURI::HTTPError, wait: :polynomially_longer, attempts: 2
+      discard_on URI::InvalidURIError
 
-      def perform(viewable_id, viewable_type, external_url, position = nil)
+      def perform(viewable_id, viewable_type, external_url, external_id = nil, position = nil)
         viewable = viewable_type.safe_constantize.find(viewable_id)
 
         Spree::Image.ensure_metafield_definition_exists!(Spree::Image::EXTERNAL_URL_METAFIELD_KEY)
 
         external_url = external_url.downcase.strip
+        external_id = external_id.to_s.downcase.strip if external_id.present?
 
-        image_scope = if Spree::Image.respond_to?(:with_deleted)
-                        viewable.images.with_deleted
-                      else
-                        viewable.images
-                      end
+        image = find_or_initialize_image(viewable, external_url, external_id)
 
-        image = image_scope.with_external_url(external_url).first || viewable.images.new
+        image.set_default_values_for_import if image.new_record? && image.respond_to?(:set_default_values_for_import)
+
+        return if image.skip_import?
 
         image.restore if image.respond_to?(:deleted?) && image.deleted?
         image.position = position if position.present?
@@ -34,17 +34,36 @@ module Spree
         end
 
         file = uri.open
-        filename = uri.path.split('/').last
+        filename = File.basename(uri.path)
 
         image.attachment.attach(io: file, filename: filename)
         image.external_url = external_url
+        image.external_id = external_id if external_id.present? && image.respond_to?(:external_id)
         image.save!
+      rescue ActiveStorage::IntegrityError => e
+        raise e unless Rails.env.test?
       end
 
       private
 
       def image_already_saved?(image, external_url)
         image.persisted? && image.attachment.attached? && image.external_url.present? && external_url == image.external_url
+      end
+
+      def image_scope(viewable)
+        if Spree::Image.respond_to?(:with_deleted)
+          viewable.images.with_deleted
+        else
+          viewable.images
+        end
+      end
+
+      def find_or_initialize_image(viewable, external_url, external_id = nil)
+        if external_id.present? && viewable.respond_to?(:external_id)
+          image_scope(viewable).find_or_initialize_by(external_id: external_id)
+        else
+          image_scope(viewable).with_external_url(external_url).first || viewable.images.new
+        end
       end
     end
   end

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -35,5 +35,9 @@ module Spree
     def external_url=(url)
       set_metafield(EXTERNAL_URL_METAFIELD_KEY, url.downcase.strip)
     end
+
+    def skip_import?
+      false
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for external image identifiers during import.
  * Ability to skip image import processing when needed.
  * Prevents redundant re-downloads of already saved images.

* **Bug Fixes**
  * Improved error handling for invalid URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->