### PR TITLE
V-3266 Support importing taxons from category1, category2, category3 attributes

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -118,6 +118,16 @@ module Spree
       end
     end
 
+    scope :with_matching_name, ->(name_to_match) do
+      value = name_to_match.to_s.strip.downcase
+
+      if Spree.use_translations?
+        i18n { name.lower.eq(value) }
+      else
+        where(arel_table[:name].lower.eq(value))
+      end
+    end
+
     #
     #  Ransack
     #

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -25,6 +25,16 @@ module Spree
 
     default_scope { order("#{table_name}.position, #{table_name}.created_at") }
 
+    scope :with_matching_name, ->(name_to_match) do
+      value = name_to_match.to_s.strip.downcase
+
+      if Spree.use_translations?
+        i18n { name.lower.eq(value) }
+      else
+        where(arel_table[:name].lower.eq(value))
+      end
+    end
+
     self.whitelisted_ransackable_attributes = %w[name]
     self.whitelisted_ransackable_associations = %w[root]
 

--- a/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -72,8 +72,40 @@ module Spree
           product.meta_keywords = attributes['meta_keywords'] if attributes['meta_keywords'].present?
           product.status = to_spree_status(attributes['status']) if attributes['status'].present?
           product.tag_list = attributes['tags'] if attributes['tags'].present?
+
+          product.taxons = prepare_taxons if options.empty?
+
           product.save!
           product
+        end
+
+        def prepare_taxons
+          taxon_pretty_names = [
+            attributes['category1'],
+            attributes['category2'],
+            attributes['category3']
+          ].compact_blank.map(&:strip).uniq
+
+          return [] if taxon_pretty_names.empty?
+
+          taxons = taxon_pretty_names.map { |taxon_pretty_name| handle_taxon_line(taxon_pretty_name) }
+          taxons.compact
+        end
+
+        def handle_taxon_line(taxon_pretty_name)
+          taxon_names = taxon_pretty_name.strip.split('->').map(&:strip).map(&:presence).compact
+          return if taxon_names.empty?
+
+          taxonomy_name = taxon_names.shift
+          taxonomy = store.taxonomies.find_or_create_by!(name: taxonomy_name)
+
+          last_taxon = taxonomy.root
+
+          taxon_names.each do |taxon_name|
+            last_taxon = taxonomy.taxons.find_or_create_by!(name: taxon_name, parent: last_taxon)
+          end
+
+          last_taxon
         end
 
         def prepare_option_value_variants

--- a/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -97,12 +97,12 @@ module Spree
           return if taxon_names.empty?
 
           taxonomy_name = taxon_names.shift
-          taxonomy = store.taxonomies.find_or_create_by!(name: taxonomy_name)
+          taxonomy = store.taxonomies.with_matching_name(taxonomy_name).first || store.taxonomies.create!(name: taxonomy_name)
 
           last_taxon = taxonomy.root
 
           taxon_names.each do |taxon_name|
-            last_taxon = taxonomy.taxons.find_or_create_by!(name: taxon_name, parent: last_taxon)
+            last_taxon = taxonomy.taxons.with_matching_name(taxon_name).where(parent: last_taxon).first || taxonomy.taxons.create!(name: taxon_name, parent: last_taxon)
           end
 
           last_taxon

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -78,6 +78,42 @@ describe Spree::Taxon, type: :model do
         end
       end
     end
+
+    describe '.with_matching_name' do
+      let!(:taxon1) { create(:taxon, name: 'shoes', taxonomy: taxonomy) }
+      let!(:taxon2) { create(:taxon, name: 'Premium Shoes', taxonomy: taxonomy) }
+
+      it 'returns the taxon with the matching name', :aggregate_failures do
+        expect(described_class.with_matching_name('SHOES')).to eq([taxon1])
+        expect(described_class.with_matching_name('Shoes')).to eq([taxon1])
+        expect(described_class.with_matching_name('shoes')).to eq([taxon1])
+
+        expect(described_class.with_matching_name('premium SHOES')).to eq([taxon2])
+        expect(described_class.with_matching_name('Premium shoes')).to eq([taxon2])
+        expect(described_class.with_matching_name('premium shoes')).to eq([taxon2])
+      end
+
+      context 'with translations' do
+        before do
+          I18n.with_locale(:pl) do
+            taxon1.update!(name: 'Buty')
+            taxon2.update!(name: 'Buty Premium')
+          end
+        end
+
+        it 'returns the taxon with the matching name', :aggregate_failures do
+          I18n.with_locale(:pl) do
+            expect(described_class.with_matching_name('BUTY')).to eq([taxon1])
+            expect(described_class.with_matching_name('Buty')).to eq([taxon1])
+            expect(described_class.with_matching_name('buty')).to eq([taxon1])
+
+            expect(described_class.with_matching_name('Buty PREMIUM')).to eq([taxon2])
+            expect(described_class.with_matching_name('Buty premium')).to eq([taxon2])
+            expect(described_class.with_matching_name('buty premium')).to eq([taxon2])
+          end
+        end
+      end
+    end
   end
 
   describe 'callbacks' do

--- a/core/spec/models/spree/taxonomy_spec.rb
+++ b/core/spec/models/spree/taxonomy_spec.rb
@@ -3,6 +3,44 @@ require 'spec_helper'
 describe Spree::Taxonomy, type: :model do
   it_behaves_like 'metadata'
 
+  describe 'scopes' do
+    describe '.with_matching_name' do
+      let!(:taxonomy1) { create(:taxonomy, name: 'Winter 2024') }
+      let!(:taxonomy2) { create(:taxonomy, name: 'Winter 2025') }
+
+      it 'returns the taxonomy with the matching name', :aggregate_failures do
+        expect(described_class.with_matching_name('WINTER 2024')).to eq([taxonomy1])
+        expect(described_class.with_matching_name('Winter 2024')).to eq([taxonomy1])
+        expect(described_class.with_matching_name('winter 2024')).to eq([taxonomy1])
+
+        expect(described_class.with_matching_name('WINTER 2025')).to eq([taxonomy2])
+        expect(described_class.with_matching_name('Winter 2025')).to eq([taxonomy2])
+        expect(described_class.with_matching_name('winter 2025')).to eq([taxonomy2])
+      end
+
+      context 'with translations' do
+        before do
+          I18n.with_locale(:pl) do
+            taxonomy1.update!(name: 'Zima 2024')
+            taxonomy2.update!(name: 'Zima 2025')
+          end
+        end
+
+        it 'returns the taxonomy with the matching name', :aggregate_failures do
+          I18n.with_locale(:pl) do
+            expect(described_class.with_matching_name('ZIMA 2024')).to eq([taxonomy1])
+            expect(described_class.with_matching_name('Zima 2024')).to eq([taxonomy1])
+            expect(described_class.with_matching_name('zima 2024')).to eq([taxonomy1])
+
+            expect(described_class.with_matching_name('ZIMA 2025')).to eq([taxonomy2])
+            expect(described_class.with_matching_name('Zima 2025')).to eq([taxonomy2])
+            expect(described_class.with_matching_name('zima 2025')).to eq([taxonomy2])
+          end
+        end
+      end
+    end
+  end
+
   context '#destroy' do
     before do
       @taxonomy = create(:taxonomy)

--- a/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -174,22 +174,31 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
     context 'when the taxons already exist' do
       let(:categories_taxonomy) { store.taxonomies.find_by(name: 'Categories') }
       let!(:men_taxon) { create(:taxon, name: 'Men', taxonomy: categories_taxonomy, parent: categories_taxonomy.root) }
-      let!(:clothing_taxon) { create(:taxon, name: 'Clothing', taxonomy: categories_taxonomy, parent: men_taxon) }
+      let!(:clothing_taxon) { create(:taxon, name: 'clothing', taxonomy: categories_taxonomy, parent: men_taxon) }
       let!(:shirts_category_taxon) { create(:taxon, name: 'Shirts', taxonomy: categories_taxonomy, parent: clothing_taxon) }
 
       let(:brands_taxonomy) { store.taxonomies.find_by(name: 'Brands') }
-      let!(:awesome_brand_taxon) { create(:taxon, name: 'Awesome Brand', taxonomy: brands_taxonomy, parent: brands_taxonomy.root) }
+      let!(:awesome_brand_taxon) { create(:taxon, name: 'Awesome brand', taxonomy: brands_taxonomy, parent: brands_taxonomy.root) }
 
       let(:collections_taxonomy) { store.taxonomies.find_by(name: 'Collections') }
       let!(:summer_taxon) { create(:taxon, name: 'Summer', taxonomy: collections_taxonomy, parent: collections_taxonomy.root) }
       let!(:shirts_collection_taxon) { create(:taxon, name: 'Shirts', taxonomy: collections_taxonomy, parent: summer_taxon) }
 
+      let(:row_data) do
+        csv_row_hash(
+          'slug' => 'denim-shirt',
+          'category1' => 'categories -> Men -> Clothing -> Shirts',
+          'category2' => 'brands -> awesome brand',
+          'category3' => 'Collections -> Summer -> Shirts'
+        )
+      end
+
       it 'assigns the existing taxons to the product' do
         expect { subject.process! }.to change { Spree::Taxon.count }.by(0)
 
         expect(product.reload.taxons.map(&:pretty_name)).to contain_exactly(
-          'Categories -> Men -> Clothing -> Shirts',
-          'Brands -> Awesome Brand',
+          'Categories -> Men -> clothing -> Shirts',
+          'Brands -> Awesome brand',
           'Collections -> Summer -> Shirts'
         )
       end

--- a/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -148,6 +148,128 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
     end
   end
 
+  context 'with taxons' do
+    let!(:product) { create(:product, slug: 'denim-shirt', name: 'Denim Shirt', stores: [store], taxons: taxons) }
+    let(:taxons) { [] }
+
+    let(:row_data) do
+      csv_row_hash(
+        'slug' => 'denim-shirt',
+        'category1' => 'Categories -> Men -> Clothing -> Shirts',
+        'category2' => 'Brands -> Awesome Brand',
+        'category3' => 'Collections -> Summer -> Shirts'
+      )
+    end
+
+    it 'assigns taxons to the product' do
+      expect { subject.process! }.to change { Spree::Taxon.count }.by(6)
+
+      expect(product.reload.taxons.map(&:pretty_name)).to contain_exactly(
+        'Categories -> Men -> Clothing -> Shirts',
+        'Brands -> Awesome Brand',
+        'Collections -> Summer -> Shirts'
+      )
+    end
+
+    context 'when the taxons already exist' do
+      let(:categories_taxonomy) { store.taxonomies.find_by(name: 'Categories') }
+      let!(:men_taxon) { create(:taxon, name: 'Men', taxonomy: categories_taxonomy, parent: categories_taxonomy.root) }
+      let!(:clothing_taxon) { create(:taxon, name: 'Clothing', taxonomy: categories_taxonomy, parent: men_taxon) }
+      let!(:shirts_category_taxon) { create(:taxon, name: 'Shirts', taxonomy: categories_taxonomy, parent: clothing_taxon) }
+
+      let(:brands_taxonomy) { store.taxonomies.find_by(name: 'Brands') }
+      let!(:awesome_brand_taxon) { create(:taxon, name: 'Awesome Brand', taxonomy: brands_taxonomy, parent: brands_taxonomy.root) }
+
+      let(:collections_taxonomy) { store.taxonomies.find_by(name: 'Collections') }
+      let!(:summer_taxon) { create(:taxon, name: 'Summer', taxonomy: collections_taxonomy, parent: collections_taxonomy.root) }
+      let!(:shirts_collection_taxon) { create(:taxon, name: 'Shirts', taxonomy: collections_taxonomy, parent: summer_taxon) }
+
+      it 'assigns the existing taxons to the product' do
+        expect { subject.process! }.to change { Spree::Taxon.count }.by(0)
+
+        expect(product.reload.taxons.map(&:pretty_name)).to contain_exactly(
+          'Categories -> Men -> Clothing -> Shirts',
+          'Brands -> Awesome Brand',
+          'Collections -> Summer -> Shirts'
+        )
+      end
+    end
+
+    context 'when taxons are not provided' do
+      let(:categories_taxonomy) { store.taxonomies.find_by(name: 'Categories') }
+      let!(:men_taxon) { create(:taxon, name: 'Men', taxonomy: categories_taxonomy, parent: categories_taxonomy.root) }
+      let!(:clothing_taxon) { create(:taxon, name: 'Clothing', taxonomy: categories_taxonomy, parent: men_taxon) }
+
+      let(:taxons) { [clothing_taxon] }
+
+      let(:row_data) do
+        csv_row_hash(
+          'slug' => 'denim-shirt',
+          'category1' => '',
+          'category2' => nil
+        )
+      end
+
+      it 'assigns no taxons to the product' do
+        expect { subject.process! }.to change { Spree::Taxon.count }.by(0)
+        expect(product.reload.taxons).to be_empty
+      end
+    end
+
+    context 'when taxons format is invalid' do
+      let(:row_data) do
+        csv_row_hash(
+          'slug' => 'denim-shirt',
+          'category1' => 'Categories -> Men -> -> Shirts',
+          'category2' => ' -> ',
+          'category3' => '   '
+        )
+      end
+
+      it 'skips invalid taxons' do
+        expect { subject.process! }.to change { Spree::Taxon.count }.by(2)
+
+        expect(product.reload.taxons.map(&:pretty_name)).to contain_exactly(
+          'Categories -> Men -> Shirts'
+        )
+      end
+    end
+
+    context 'when importing a variant row with no taxons' do
+      let(:categories_taxonomy) { store.taxonomies.find_by(name: 'Categories') }
+      let!(:men_taxon) { create(:taxon, name: 'Men', taxonomy: categories_taxonomy, parent: categories_taxonomy.root) }
+      let!(:clothing_taxon) { create(:taxon, name: 'Clothing', taxonomy: categories_taxonomy, parent: men_taxon) }
+
+      let(:taxons) { [clothing_taxon] }
+
+      let(:row_data) do
+        csv_row_hash(
+          'slug' => 'denim-shirt',
+          'sku' => 'DENIM-SHIRT-XS-BLUE',
+          'price' => '62.99',
+          'currency' => 'USD',
+          'weight' => '0.0',
+          'inventory_count' => '100',
+          'inventory_backorderable' => 'true',
+          'option1_name' => 'Color',
+          'option1_value' => 'Blue',
+          'option2_name' => 'Size',
+          'option2_value' => 'XS',
+        )
+      end
+
+      it 'keeps the product taxons' do
+        expect(variant).to be_persisted
+        expect(variant.sku).to eq 'DENIM-SHIRT-XS-BLUE'
+        expect(variant.product).to eq(product)
+
+        expect(product.reload.taxons.map(&:pretty_name)).to contain_exactly(
+          'Categories -> Men -> Clothing'
+        )
+      end
+    end
+  end
+
   context 'when importing a variant with all option columns empty' do
     let!(:product) do
       create(:product, slug: 'denim-shirt', name: 'Denim Shirt', stores: [store])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product variants can now be assigned categories automatically from imported category fields.
  * The system builds and reuses nested category hierarchies when importing complex category paths.
  * Improved category name matching: case-insensitive and translation-aware lookups to better find existing categories.

* **Tests**
  * Added comprehensive tests covering category assignment, reuse of existing categories, preservation when categories are absent, and invalid category formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->