### PR TITLE
FIX disappearing addresses on update

### DIFF
--- a/core/app/services/spree/addresses/update.rb
+++ b/core/app/services/spree/addresses/update.rb
@@ -11,8 +11,8 @@ module Spree
         default_billing = opts.fetch(:default_billing, false)
         default_shipping = opts.fetch(:default_shipping, false)
         address_changes_except = opts.fetch(:address_changes_except, [])
-        Spree::Deprecation.warn('Spree::Addresses::Update create_new_address_on_update parameter is deprecated and will be removed in Spree 6.')
         create_new_address_on_update = opts.fetch(:create_new_address_on_update, false)
+        Spree::Deprecation.warn('Spree::Addresses::Update create_new_address_on_update parameter is deprecated and will be removed in Spree 6.') if create_new_address_on_update
 
         prepare_address_params!(address, address_params)
         address.assign_attributes(address_params)

--- a/core/app/services/spree/addresses/update.rb
+++ b/core/app/services/spree/addresses/update.rb
@@ -17,11 +17,11 @@ module Spree
 
         address_changes = address.changes.except(*address_changes_except)
 
-        # Ignore changes that are only different in case as encrypted fields are processd by rails as downcased
+        # Ignore changes that are only different in case as encrypted fields are processed by rails as downcased
         address_changes.reject! do |attr, (old_val, new_val)|
           old_val.to_s.casecmp?(new_val.to_s)
         end
-        
+
         address_changed = address_changes.any?
         if !address_changed && defaults_changed?(address, default_billing, default_shipping)
           assign_to_user_as_default(

--- a/core/spec/services/spree/addresses/update_spec.rb
+++ b/core/spec/services/spree/addresses/update_spec.rb
@@ -50,10 +50,12 @@ RSpec.describe Spree::Addresses::Update do
             expect { subject.call(address: address, address_params: new_address_params, order: order) }.not_to change { Spree::Address.count }
           end
 
-          context 'when setting the create_new_address_on_update param to true' do
-            it 'does not create new address' do
-              expect { subject.call(address: address, address_params: new_address_params, order: order, create_new_address_on_update: true) }.not_to change { Spree::Address.count }
-            end
+          it 'does not update address nor create when attribute changed only in case' do
+            result.value.update(address1: '123 Main St')
+
+            new_address_params[:address1] = '123 MAIN ST'
+            expect { subject.call(address: address, address_params: new_address_params, order: order) }.not_to change { address.reload }
+            expect { subject.call(address: address, address_params: new_address_params, order: order) }.not_to change { Spree::Address.count }
           end
         end
 
@@ -80,72 +82,6 @@ RSpec.describe Spree::Addresses::Update do
             expect(user.bill_address_id).to eq(previous_address.id)
             result
             expect(user.reload.bill_address_id).to eq(value.id)
-          end
-        end
-      end
-
-      shared_examples 'always create a new address on update' do
-        context 'when the create_new_address_on_update param is set to true' do
-          let(:result) { subject.call(address: address, address_params: new_address_params, order: order, **params) }
-          let(:params) { { create_new_address_on_update: true } }
-
-          it 'creates a new address and keeps the previous one' do
-            expect { result }.to change(Spree::Address, :count).by(1)
-
-            expect(result).to be_success
-            expect(value).to have_attributes(new_address_params)
-            expect(value.id).not_to eq(address.id)
-            expect(value.country).to eq(country)
-            expect(value.state).to eq(state)
-            expect(value.user).to eq(user)
-            expect(address.deleted_at).to be_nil
-          end
-
-          context 'with a user' do
-            before do
-              new_address_params.merge!(user_id: user.id)
-              user.update!(ship_address: address, bill_address: address)
-            end
-
-            it "doesn't change the user's bill and ship addresses by default" do
-              expect(result).to be_success
-
-              expect(user.reload.bill_address).to eq(address.reload)
-              expect(user.ship_address).to eq(address)
-            end
-
-            context 'when the default_billing param is set to true' do
-              let(:params) { { create_new_address_on_update: true, default_billing: true } }
-
-              it 'changes user\'s bill address' do
-                expect(result).to be_success
-
-                expect(user.reload.bill_address).to eq(value)
-                expect(user.ship_address).to eq(address.reload)
-              end
-            end
-
-            context 'when the default_shipping param is set to true' do
-              let(:params) { { create_new_address_on_update: true, default_shipping: true } }
-
-              it 'changes user\'s ship address' do
-                expect(result).to be_success
-
-                expect(user.reload.ship_address).to eq(value)
-                expect(user.bill_address).to eq(address.reload)
-              end
-            end
-          end
-
-          context 'with an order' do
-            let(:order) { create(:order, user: user, state: 'delivery', ship_address: address, bill_address: address) }
-
-            it "doesn't change the order addresses" do
-              expect(result).to be_success
-
-              expect(order.reload.bill_address).to eq(address)
-              expect(order.reload.ship_address).to eq(address)
-            end
           end
         end
       end
@@ -194,7 +130,6 @@ RSpec.describe Spree::Addresses::Update do
         end
 
         it_behaves_like 'updating with same params'
-        include_examples 'always create a new address on update'
       end
 
       context 'when address is uneditable' do
@@ -307,7 +242,6 @@ RSpec.describe Spree::Addresses::Update do
         end
 
         it_behaves_like 'updating with same params'
-        include_examples 'always create a new address on update'
       end
     end
 


### PR DESCRIPTION
1. FIX disappearing addresses on update which was caused by destroying address which was updated
2. DEL unused and problematic create_new_address_on_update flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Address comparisons now ignore case-only differences (case changes no longer trigger updates or new records).
* **Chore**
  * Added a deprecation warning for the create-new-on-update behavior.
* **Tests**
  * Added coverage ensuring case-only attribute changes do not create or update address records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->