### PR TITLE
Fixed VER-46 Use ResourceController as the basis for Translations/Met…

### DIFF
--- a/admin/app/controllers/spree/admin/json_previews_controller.rb
+++ b/admin/app/controllers/spree/admin/json_previews_controller.rb
@@ -1,36 +1,22 @@
 module Spree
   module Admin
-    class JsonPreviewsController < BaseController
-      before_action :load_resource
-
-      def show
-        @api_type = params[:api_type].presence&.to_sym || :storefront
-      end
-
+    class JsonPreviewsController < ResourceController
       private
 
-      def load_resource
-        raise ActiveRecord::RecordNotFound if params[:resource_type].blank?
-        raise ActiveRecord::RecordNotFound if resource_type.blank?
-
-        @resource = if resource_type.respond_to?(:friendly)
-                      resource_type.friendly.accessible_by(current_ability, :read).find(params[:id])
-                    else
-                      resource_type.accessible_by(current_ability, :read).find(params[:id])
-                    end
-      end
-
-      def resource_type
-        @resource_type ||= begin
+      def model_class
+        @model_class ||= begin
           klass_name = params[:resource_type]
           # Ensure all Spree models are loaded so that descendants is complete
           Rails.application.eager_load! unless Rails.application.config.eager_load
           klass = Spree.base_class.descendants.find { |spree_klass| spree_klass.name.to_s == klass_name }
           klass ||= Spree.user_class if klass_name == Spree.user_class.to_s
           klass ||= Spree.admin_user_class if klass_name == Spree.admin_user_class.to_s
+
+          raise ActiveRecord::RecordNotFound if klass.blank?
+
           klass
         rescue NameError
-          nil
+          raise ActiveRecord::RecordNotFound
         end
       end
     end

--- a/admin/app/controllers/spree/admin/metafields_controller.rb
+++ b/admin/app/controllers/spree/admin/metafields_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       def build_metafields
         @metafields = @object.metafields
-        @metafield_definitions = Spree::MetafieldDefinition.where(resource_type: @object.class.name)
+        @metafield_definitions = Spree::MetafieldDefinition.where(resource_type: model_class.name)
 
         @metafield_definitions.each do |metafield_definition|
           @object.metafields.build(type: metafield_definition.metafield_type, metafield_definition: metafield_definition) unless @object.has_metafield?(metafield_definition)

--- a/admin/app/controllers/spree/admin/metafields_controller.rb
+++ b/admin/app/controllers/spree/admin/metafields_controller.rb
@@ -22,13 +22,13 @@ module Spree
       def model_class
         @model_class ||= begin
           klass = params[:resource_type]
-          allowed_model_classes.find { |allowed_class| allowed_class.to_s == klass } ||
+          allowed_model_classeses.find { |allowed_class| allowed_class.to_s == klass } ||
             raise(ActiveRecord::RecordNotFound, "Resource type not found")
         end
       end
 
-      def allowed_model_classes
-        @allowed_model_classes ||= Rails.application.config.spree.metafield_enabled_resources
+      def allowed_model_classeses
+        @allowed_model_classeses ||= Rails.application.config.spree.metafield_enabled_resources
       end
 
       def update_turbo_stream_enabled?

--- a/admin/app/controllers/spree/admin/metafields_controller.rb
+++ b/admin/app/controllers/spree/admin/metafields_controller.rb
@@ -22,13 +22,13 @@ module Spree
       def model_class
         @model_class ||= begin
           klass = params[:resource_type]
-          allowed_model_classeses.find { |allowed_class| allowed_class.to_s == klass } ||
+          allowed_model_classes.find { |allowed_class| allowed_class.to_s == klass } ||
             raise(ActiveRecord::RecordNotFound, "Resource type not found")
         end
       end
 
-      def allowed_model_classeses
-        @allowed_model_classeses ||= Rails.application.config.spree.metafield_enabled_resources
+      def allowed_model_classes
+        @allowed_model_classes ||= Rails.application.config.spree.metafield_enabled_resources
       end
 
       def update_turbo_stream_enabled?

--- a/admin/app/controllers/spree/admin/metafields_controller.rb
+++ b/admin/app/controllers/spree/admin/metafields_controller.rb
@@ -1,51 +1,38 @@
 module Spree
   module Admin
-    class MetafieldsController < BaseController
-      before_action :load_resource
+    class MetafieldsController < ResourceController
+      edit_action.before :build_metafields
 
-      # GET /admin/<resource_name_plural>/<id>/edit
-      def edit
-        @metafields = @resource.metafields
-        @metafield_definitions = Spree::MetafieldDefinition.where(resource_type: @resource.class.name)
+      def build_metafields
+        @metafields = @object.metafields
+        @metafield_definitions = Spree::MetafieldDefinition.where(resource_type: @object.class.name)
 
         @metafield_definitions.each do |metafield_definition|
-          @resource.metafields.build(type: metafield_definition.metafield_type, metafield_definition: metafield_definition) unless @resource.has_metafield?(metafield_definition)
-        end
-      end
-
-      # PUT /admin/<resource_name_plural>/<id>
-      def update
-        if @resource.update(permitted_metafields_params)
-          flash.now[:success] = flash_message_for(@resource, :successfully_updated)
-        else
-          flash.now[:error] = @resource.errors.full_messages.to_sentence
+          @object.metafields.build(type: metafield_definition.metafield_type, metafield_definition: metafield_definition) unless @object.has_metafield?(metafield_definition)
         end
       end
 
       private
 
-      def permitted_metafields_params
-        params.require(resource_type.model_name.param_key).permit(metafields_attributes: permitted_metafield_attributes)
+      def permitted_resource_params
+        params.require(@object.model_name.param_key).permit(metafields_attributes: permitted_metafield_attributes)
       end
 
       # eg. Spree::Product
-      def resource_type
-        @resource_type ||= allowed_resource_types.find { |type| type.name == params[:resource_type] }
+      def model_class
+        @model_class ||= begin
+          klass = params[:resource_type]
+          allowed_model_classes.find { |allowed_class| allowed_class.to_s == klass } ||
+            raise(ActiveRecord::RecordNotFound, "Resource type not found")
+        end
       end
 
-      def load_resource
-        raise ActiveRecord::RecordNotFound if params[:resource_type].blank?
-        raise ActiveRecord::RecordNotFound if resource_type.blank?
-
-        @resource = if resource_type.respond_to?(:friendly)
-                   resource_type.friendly.accessible_by(current_ability, :update).find(params[:id])
-                 else
-                   resource_type.accessible_by(current_ability, :update).find(params[:id])
-                 end
+      def allowed_model_classes
+        @allowed_model_classes ||= Rails.application.config.spree.metafield_enabled_resources
       end
 
-      def allowed_resource_types
-        @allowed_resource_types ||= Rails.application.config.spree.metafield_enabled_resources
+      def update_turbo_stream_enabled?
+        true
       end
     end
   end

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -2,9 +2,8 @@ module Spree
   module Admin
     class TranslationsController < ResourceController
       # Set the resource being translated and any related data
-      before_action :load_resource, only: [:edit, :update]
-      before_action :load_data, only: [:edit, :update]
-      before_action :set_translation_locale, only: [:edit, :update]
+      before_action :load_data
+      before_action :set_translation_locale
       helper_method :normalized_locale
 
       # Normalizes a locale string by replacing '-' with '_' and downcasing

--- a/admin/app/controllers/spree/admin/translations_controller.rb
+++ b/admin/app/controllers/spree/admin/translations_controller.rb
@@ -35,13 +35,13 @@ module Spree
       def model_class
         @model_class ||= begin
           klass = params[:resource_type]
-          allowed_model_class.find { |allowed_class| allowed_class.to_s == klass } ||
+          allowed_model_classes.find { |allowed_class| allowed_class.to_s == klass } ||
             raise(ActiveRecord::RecordNotFound, "Resource type not found")
         end
       end
 
       # Allowed translatable resources configured in Spree
-      def allowed_model_class
+      def allowed_model_classes
         Rails.application.config.spree.translatable_resources
       end
 

--- a/admin/app/helpers/spree/admin/json_preview_helper.rb
+++ b/admin/app/helpers/spree/admin/json_preview_helper.rb
@@ -12,7 +12,7 @@ module Spree
         link_to_with_icon(
           'code',
           Spree.t('admin.show_json'),
-          spree.admin_json_preview_resource_path(record.id, resource_type: model_class.to_s),
+          spree.admin_json_preview_resource_path(record.id, resource_type: record.class.to_s),
           options
         )
       end
@@ -22,12 +22,12 @@ module Spree
       end
 
       def storefront_serializer_exists?(record)
-        serializer_class_name = "Spree::V2::Storefront::#{model_class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::V2::Storefront::#{record.class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize.present?
       end
 
       def platform_serializer_exists?(record)
-        serializer_class_name = "Spree::Api::V2::Platform::#{model_class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::Api::V2::Platform::#{record.class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize.present?
       end
 
@@ -54,12 +54,12 @@ module Spree
       private
 
       def storefront_serializer_for(record)
-        serializer_class_name = "Spree::V2::Storefront::#{model_class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::V2::Storefront::#{record.class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize
       end
 
       def platform_serializer_for(record)
-        serializer_class_name = "Spree::Api::V2::Platform::#{model_class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::Api::V2::Platform::#{record.class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize
       end
 
@@ -67,6 +67,7 @@ module Spree
         params = {}
         params[:store] = current_store if defined?(current_store) && current_store.present?
         params[:currency] = current_currency if defined?(current_currency) && current_currency.present?
+        params[:locale] = current_locale if defined?(current_locale) && current_locale.present?
         params
       end
     end

--- a/admin/app/helpers/spree/admin/json_preview_helper.rb
+++ b/admin/app/helpers/spree/admin/json_preview_helper.rb
@@ -12,7 +12,7 @@ module Spree
         link_to_with_icon(
           'code',
           Spree.t('admin.show_json'),
-          spree.admin_json_preview_resource_path(record, resource_type: record.class.to_s),
+          spree.admin_json_preview_resource_path(record.id, resource_type: model_class.to_s),
           options
         )
       end
@@ -22,12 +22,12 @@ module Spree
       end
 
       def storefront_serializer_exists?(record)
-        serializer_class_name = "Spree::V2::Storefront::#{record.class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::V2::Storefront::#{model_class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize.present?
       end
 
       def platform_serializer_exists?(record)
-        serializer_class_name = "Spree::Api::V2::Platform::#{record.class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::Api::V2::Platform::#{model_class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize.present?
       end
 
@@ -54,12 +54,12 @@ module Spree
       private
 
       def storefront_serializer_for(record)
-        serializer_class_name = "Spree::V2::Storefront::#{record.class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::V2::Storefront::#{model_class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize
       end
 
       def platform_serializer_for(record)
-        serializer_class_name = "Spree::Api::V2::Platform::#{record.class.name.demodulize}Serializer"
+        serializer_class_name = "Spree::Api::V2::Platform::#{model_class.name.demodulize}Serializer"
         serializer_class_name.safe_constantize
       end
 

--- a/admin/app/helpers/spree/admin/metafields_helper.rb
+++ b/admin/app/helpers/spree/admin/metafields_helper.rb
@@ -10,7 +10,7 @@ module Spree
         options[:class] ||= 'dropdown-item'
         options[:data]  ||= { action: 'drawer#open', turbo_frame: :drawer }
 
-        link_to_with_icon 'edit', Spree.t(:metafields), spree.edit_admin_metafield_path(record, resource_type: record.class.name), options
+        link_to_with_icon 'edit', Spree.t(:metafields), spree.edit_admin_metafield_path(record.id, resource_type: record.class.name), options
       end
 
       def metafield_definition_resource_types

--- a/admin/app/helpers/spree/admin/translations_helper.rb
+++ b/admin/app/helpers/spree/admin/translations_helper.rb
@@ -12,7 +12,7 @@ module Spree
         link_to_with_icon(
           'language',
           Spree.t(:translations),
-          spree.edit_admin_translation_path(resource, resource_type: resource.class.to_s),
+          spree.edit_admin_translation_path(resource.id, resource_type: resource.class.to_s),
           options
         )
       end

--- a/admin/app/views/spree/admin/import_rows/show.html.erb
+++ b/admin/app/views/spree/admin/import_rows/show.html.erb
@@ -14,7 +14,7 @@
     <div data-tabs-target="panel" class="animate__animated animate__fadeIn">
       <pre class="m-0"><code data-highlight-target="code" class="language-json d-block overflow-auto" style="height: calc(100dvh - 11rem);"><%= JSON.pretty_generate(@import_row.data_json) %></code></pre>
     </div>
-    <div data-tabs-target="panel" class="animate__animated animate__fadeIn" hidden>
+    <div data-tabs-target="panel" hidden class="animate__animated animate__fadeIn">
       <dl class="row rounded border p-2 overflow-auto" style="height: calc(100dvh - 11rem);">
         <% @import_row.to_schema_hash.each do |field_name, value| %>
           <dt class="col-sm-3"><%= field_name.humanize %></dt>

--- a/admin/app/views/spree/admin/json_previews/show.html.erb
+++ b/admin/app/views/spree/admin/json_previews/show.html.erb
@@ -1,29 +1,37 @@
 <%= turbo_frame_tag :drawer do %>
   <%= drawer_header(Spree.t('admin.show_json')) %>
-  <div class="drawer-body">
-    <ul class="nav nav-pills">
-      <%= nav_item(
-            Spree.t('apis.storefront'),
-            spree.admin_json_preview_resource_path(@resource, resource_type: @resource.class.to_s, api_type: :storefront),
-            active: (@api_type == :storefront)
-          ) %>
-      <%= nav_item(
-            Spree.t('apis.platform'),
-            spree.admin_json_preview_resource_path(@resource, resource_type: @resource.class.to_s, api_type: :platform),
-            active: (@api_type == :platform)
-          ) %>
+  <div class="drawer-body" data-controller="highlight tabs">
+    <ul class="nav nav-pills mb-3">
+      <li class="nav-item">
+        <a class="nav-link active" data-tabs-target="tab" data-action="click->tabs#select">Storefront</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select">Platform</a>
+      </li>
     </ul>
-  </div>
-  <div class="drawer-body pt-0" data-controller="highlight">
-    <% if @api_type == :storefront && storefront_serializer_exists?(@resource) || @api_type == :platform && platform_serializer_exists?(@resource) %>
-    <pre class="m-0"><code data-highlight-target="code" class="language-json d-block overflow-auto" style="height: calc(100dvh - 11rem);"><%= serialize_to_json(@resource, api_type: @api_type) %></code></pre>
-    <% else %>
-      <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center flex-column">
-        <%= icon 'map-search', class: 'mb-3 opacity-50', style: 'font-size: 2rem;' %>
-        <p>
-          <%= Spree.t('admin.json_preview.no_api_response') %>
-        </p>
-      </div>
-    <% end %>
+    <div data-tabs-target="panel" class="animate__animated">
+      <% if storefront_serializer_exists?(@object) %>
+        <pre class="m-0"><code data-highlight-target="code" class="language-json d-block overflow-auto" style="height: calc(100dvh - 11rem);"><%= serialize_to_json(@object, api_type: :storefront) %></code></pre>
+      <% else %>
+        <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center flex-column">
+          <%= icon 'map-search', class: 'mb-3 opacity-50', style: 'font-size: 2rem;' %>
+          <p>
+            <%= Spree.t('admin.json_preview.no_api_response') %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+    <div data-tabs-target="panel" class="animate__animated" hidden>
+      <% if platform_serializer_exists?(@object) %>
+        <pre class="m-0"><code data-highlight-target="code" class="language-json d-block overflow-auto" style="height: calc(100dvh - 11rem);"><%= serialize_to_json(@object, api_type: :platform) %></code></pre>
+      <% else %>
+        <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center flex-column">
+          <%= icon 'map-search', class: 'mb-3 opacity-50', style: 'font-size: 2rem;' %>
+          <p>
+            <%= Spree.t('admin.json_preview.no_api_response') %>
+          </p>
+        </div>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/admin/app/views/spree/admin/json_previews/show.html.erb
+++ b/admin/app/views/spree/admin/json_previews/show.html.erb
@@ -3,10 +3,10 @@
   <div class="drawer-body" data-controller="highlight tabs">
     <ul class="nav nav-pills mb-3">
       <li class="nav-item">
-        <a class="nav-link active" data-tabs-target="tab" data-action="click->tabs#select">Storefront</a>
+        <a class="nav-link active" data-tabs-target="tab" data-action="click->tabs#select"><%= Spree.t('apis.storefront') %></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select">Platform</a>
+        <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select"><%= Spree.t('apis.platform') %></a>
       </li>
     </ul>
     <div data-tabs-target="panel" class="animate__animated">

--- a/admin/app/views/spree/admin/metafields/edit.html.erb
+++ b/admin/app/views/spree/admin/metafields/edit.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag :drawer do %>
   <%= drawer_header(Spree.t(:metafields)) %>
   <% if @metafields.present? %>
-    <%= form_for [:admin, @resource], url: spree.admin_metafield_path(@resource, resource_type: @resource.class.to_s), method: :put do |f| %>
+    <%= form_for @object, url: spree.admin_metafield_path(@object.id, resource_type: model_class.to_s), method: :put do |f| %>
       <div class="drawer-body">
         <%= f.fields_for :metafields, @metafields do |metafield_form| %>
           <%= metafield_form.hidden_field :id %>
@@ -34,9 +34,9 @@
   <% else %>
     <div class="drawer-body">
       <div class="text-muted p-5 d-flex align-items-center w-100 justify-content-center flex-column">
-        <%= icon 'map-search', class: 'mb-3 opacity-50', style: 'font-size: 2rem;' %>
-        <p>No metafield definitions configured for <%= @resource.class.name.demodulize.titleize.pluralize %>.</p>
-        <%= link_to_with_icon 'plus', Spree.t(:add_one), spree.new_admin_metafield_definition_path(resource_type: @resource.class.to_s), class: 'btn btn-primary ml-3', data: { 'turbo-frame': '_top' } if can?(:create, Spree::MetafieldDefinition) %>
+        <%= icon 'map-search', class: 'mb-3', style: 'font-size: 2rem;' %>
+        <p>No metafield definitions configured for <%= model_class.name.demodulize.titleize.pluralize %>.</p>
+        <%= link_to_with_icon 'plus', Spree.t(:add_one), spree.new_admin_metafield_definition_path(resource_type: model_class.to_s), class: 'btn btn-primary ml-3', data: { 'turbo-frame': '_top' } if can?(:create, Spree::MetafieldDefinition) %>
       </div>
     </div>
   <% end %>

--- a/admin/app/views/spree/admin/translations/edit.html.erb
+++ b/admin/app/views/spree/admin/translations/edit.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag :drawer do %>
   <%= drawer_header(Spree.t(:translations)) %>
   <% if @locales.any? %>
-    <%= form_for @resource, url: spree.admin_translation_path(@resource, resource_type: resource_class.to_s), method: :put do |f| %>
+    <%= form_for @object, url: spree.admin_translation_path(@object.id, resource_type: model_class.to_s), method: :put do |f| %>
       <div class="drawer-body">
         <ul class="nav nav-pills mb-3">
           <% @locales.each do |locale| %>
             <% normalized = normalized_locale(locale) %>
             <%= nav_item(
                  Spree.t('i18n.this_file_language', locale: locale),
-                 spree.edit_admin_translation_path(@resource, resource_type: resource_class.to_s, translation_locale: locale),
+                 spree.edit_admin_translation_path(@object, resource_type: model_class.to_s, translation_locale: locale),
                  active: (normalized == @selected_translation_locale)
       
                 ) %>
@@ -16,9 +16,9 @@
         </ul>
 
         <%= hidden_field_tag :translation_locale, @selected_translation_locale %>
-        <% options = { f: f, resource: @resource, locale: @selected_translation_locale } %>
+        <% options = { f: f, resource: @object, locale: @selected_translation_locale } %>
 
-        <%= render "spree/admin/translations/#{resource_class.name.demodulize.underscore.pluralize}/form", options %>
+        <%= render "spree/admin/translations/#{model_class.name.demodulize.underscore.pluralize}/form", options %>
       </div>
       <div class="drawer-footer">
         <%= turbo_save_button_tag %>

--- a/admin/spec/controllers/spree/admin/json_previews_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/json_previews_controller_spec.rb
@@ -8,24 +8,16 @@ RSpec.describe Spree::Admin::JsonPreviewsController, type: :controller do
   let(:resource_type) { 'Spree::Product' }
 
   describe 'GET #show' do
-    it 'assigns @resource and renders the show template' do
-      get :show, params: { resource_type: resource_type, id: product.slug }
+    it 'assigns @object and renders the show template' do
+      get :show, params: { resource_type: resource_type, id: product.id }
       expect(response).to render_template(:show)
-      expect(assigns(:resource)).to eq(product)
-      expect(assigns(:api_type)).to eq(:storefront)
-    end
-
-    context 'with api_type param' do
-      it 'assigns @api_type as symbol' do
-        get :show, params: { resource_type: resource_type, id: product.slug, api_type: 'platform' }
-        expect(assigns(:api_type)).to eq(:platform)
-      end
+      expect(assigns(:object)).to eq(product)
     end
 
     context 'when resource_type is missing' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :show, params: { id: product.slug, resource_type: '' }
+          get :show, params: { id: product.id, resource_type: '' }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -33,7 +25,7 @@ RSpec.describe Spree::Admin::JsonPreviewsController, type: :controller do
     context 'when resource_type is invalid' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :show, params: { resource_type: 'InvalidType', id: product.slug }
+          get :show, params: { resource_type: 'InvalidType', id: product.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/admin/spec/controllers/spree/admin/metafields_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/metafields_controller_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
   let(:resource_type) { 'Spree::Product' }
 
   describe 'GET #edit' do
-    it 'assigns @resource and @metafields and renders the edit template' do
-      get :edit, params: { resource_type: resource_type, id: product.slug }
+    it 'assigns @object and @metafields and renders the edit template' do
+      get :edit, params: { resource_type: resource_type, id: product.id }
       expect(response).to render_template(:edit)
-      expect(assigns(:resource)).to eq(product)
+      expect(assigns(:object)).to eq(product)
       expect(assigns(:metafields)).to be_present
       expect(assigns(:metafields).map(&:metafield_definition)).to include(metafield_definition)
       expect(assigns(:metafields).first.value).to be_blank
@@ -27,9 +27,9 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
       let!(:metafield) { create(:metafield, resource: product, metafield_definition: metafield_definition) }
 
       it 'assigns @resource and @metafields and renders the edit template' do
-        get :edit, params: { resource_type: resource_type, id: product.slug }
+        get :edit, params: { resource_type: resource_type, id: product.id }
         expect(response).to render_template(:edit)
-        expect(assigns(:resource)).to eq(product)
+        expect(assigns(:object)).to eq(product)
         expect(assigns(:metafields)).to be_present
         expect(assigns(:metafields).map(&:metafield_definition)).to contain_exactly(metafield_definition, metafield_definition_2)
         expect(assigns(:metafields).map(&:value)).to contain_exactly(metafield.value, nil)
@@ -42,7 +42,7 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
     context 'when resource_type is missing' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :edit, params: { id: product.slug, resource_type: '' }
+          get :edit, params: { id: product.id, resource_type: '' }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
     context 'when resource_type is invalid' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :edit, params: { resource_type: 'InvalidType', id: product.slug }
+          get :edit, params: { resource_type: 'InvalidType', id: product.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
     it 'updates metafields and sets flash success' do
       put :update, format: :turbo_stream, params: {
         resource_type: resource_type,
-        id: product.slug,
+        id: product.id,
         product: metafield_attributes
       }
       expect(response).to have_http_status(:ok)
@@ -110,7 +110,7 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
     context 'when resource_type is missing' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          put :update, format: :turbo_stream, params: { id: product.slug, resource_type: '', product: metafield_attributes }
+          put :update, format: :turbo_stream, params: { id: product.id, resource_type: '', product: metafield_attributes }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe Spree::Admin::MetafieldsController, type: :controller do
     context 'when resource_type is invalid' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          put :update, format: :turbo_stream, params: { resource_type: 'InvalidType', id: product.slug, product: metafield_attributes }
+          put :update, format: :turbo_stream, params: { resource_type: 'InvalidType', id: product.id, product: metafield_attributes }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/admin/spec/controllers/spree/admin/translations_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/translations_controller_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
   end
 
   describe 'GET #edit' do
-    it 'assigns @resource and renders the edit template' do
-      get :edit, params: { resource_type: resource_type, id: product.slug, translation_locale: translation_locale }
+    it 'assigns @object and renders the edit template' do
+      get :edit, params: { resource_type: resource_type, id: product.id, translation_locale: translation_locale }
       expect(response).to render_template(:edit)
-      expect(assigns(:resource)).to eq(product)
+      expect(assigns(:object)).to eq(product)
       expect(assigns(:locales)).to include('fr')
       expect(assigns(:locales)).not_to include('en')
     end
@@ -26,7 +26,7 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
     context 'when resource_type is missing' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :edit, params: { id: product.slug, resource_type: '', translation_locale: translation_locale }
+          get :edit, params: { id: product.id, resource_type: '', translation_locale: translation_locale }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
     context 'when resource_type is invalid' do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
-          get :edit, params: { resource_type: 'InvalidType', id: product.slug, translation_locale: translation_locale }
+          get :edit, params: { resource_type: 'InvalidType', id: product.id, translation_locale: translation_locale }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
     it 'updates the translation and sets flash success' do
       put :update, format: :turbo_stream, params: {
         resource_type: resource_type,
-        id: product.slug,
+        id: product.id,
         translation_locale: translation_locale,
         product: product_params
       }
@@ -64,7 +64,7 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
       it 'raises ActiveRecord::RecordNotFound' do
         expect {
           put :update, format: :turbo_stream, params: {
-            id: product.slug,
+            id: product.id,
             resource_type: '',
             translation_locale: translation_locale,
             product: product_params
@@ -78,7 +78,7 @@ RSpec.describe Spree::Admin::TranslationsController, type: :controller do
         expect {
           put :update, format: :turbo_stream, params: {
             resource_type: 'InvalidType',
-            id: product.slug,
+            id: product.id,
             translation_locale: translation_locale,
             product: product_params
           }


### PR DESCRIPTION
…afields/JSONPrevioews controllers

That way we're always making sure that:
a) scope to fetch resources is proper (eg. store-aware) b) permissions are properly incorporated
c) less code!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * JSON preview now uses client-side tabs for Storefront and Platform.
  * Edit screens for metafields and translations use a consistent object-driven form and link behavior.

* **New Features**
  * Metafields editor auto-builds missing metafields on edit for smoother editing.
  * Turbo-stream updates enabled for relevant admin flows.

* **Bug Fixes**
  * More reliable model/type resolution that surfaces missing-resource errors instead of failing silently.
* **Tests**
  * Controller tests updated to use ID-based requests and new instance naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->