### PR TITLE
Doc: fix minor typo in quickstart.mdx

### DIFF
--- a/docs/developer/customization/quickstart.mdx
+++ b/docs/developer/customization/quickstart.mdx
@@ -23,7 +23,7 @@ There are several ways you can achieve this:
   <Accordion title="Configuration">
     Global application configuration allows you to tweak Spree's behavior without having to modify the source code.
 
-    Please see [Preferences](/developer/customization/configuration) section for more information.
+    Please see [Configuration](/developer/customization/configuration) section for more information.
   </Accordion>
 
   <Accordion title="Authentication">


### PR DESCRIPTION
Update the name of hyper link to the newest section name
<img width="1784" height="1139" alt="image" src="https://github.com/user-attachments/assets/5904d912-9ab2-4d2b-ad23-18675f65ada0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated section navigation label in the developer customization guide for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->