### PR TITLE
Improve metafields definition admin

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_alerts.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_alerts.scss
@@ -31,7 +31,7 @@
 
 .alert-warning {
   border-color: rgba($warning, 0.1) !important;
-
+  color: inherit;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='icon icon-tabler icons-tabler-outline icon-tabler-alert-circle'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0' /%3E%3Cpath d='M12 8v4' /%3E%3Cpath d='M12 16h.01' /%3E%3C/svg%3E");
 }
 

--- a/admin/app/views/spree/admin/metafield_definitions/_filters.html.erb
+++ b/admin/app/views/spree/admin/metafield_definitions/_filters.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for [:admin, search_collection], class: "filter-wrap", data: {controller: "filters auto-submit"} do |f| %>
   <div class="d-flex">
-    <%= render 'spree/admin/shared/filters_search_bar', param: :name_cont, label: Spree.t(:title) %>
+    <%= render 'spree/admin/shared/filters_search_bar', param: :multi_search, label: Spree.t(:title) %>
 
     <%= select_tag 'q[resource_type_eq]',
           options_for_select(metafield_definition_resource_types, params.dig(:q, :resource_type_eq)),

--- a/admin/app/views/spree/admin/metafield_definitions/_form.html.erb
+++ b/admin/app/views/spree/admin/metafield_definitions/_form.html.erb
@@ -13,13 +13,27 @@
       </div>
     </div>
 
-    <% if f.object.new_record? %>
+    <% if f.object.new_record? || f.object.metafields.empty? %>
       <div class="form-group">
         <%= f.spree_select :resource_type, metafield_definition_resource_types, { include_blank: true, autocomplete: true, label: Spree.t(:resource) }, { required: true } %>
       </div>
 
       <div class="form-group">
         <%= f.spree_select :metafield_type, metafield_definition_types, { include_blank: true, autocomplete: true, label: Spree.t(:type) }, { required: true } %>
+      </div>
+    <% else %>
+      <div class="alert alert-warning">
+        <%= Spree.t('admin.metafield_definitions.edit_warning') %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :resource_type, Spree.t(:resource) %>
+        <p class="font-weight-bold"><%= f.object.resource_type.demodulize.titleize %></p>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :metafield_type, Spree.t(:type) %>
+        <p class="font-weight-bold"><%= f.object.metafield_type.demodulize.titleize %></p>
       </div>
     <% end %>
 

--- a/admin/app/views/spree/admin/metafield_definitions/_table_header.html.erb
+++ b/admin/app/views/spree/admin/metafield_definitions/_table_header.html.erb
@@ -5,6 +5,7 @@
     <th><%= Spree.t(:resource) %></th>
     <th><%= Spree.t(:type) %></th>
     <th><%= Spree.t(:display_on) %></th>
+    <th><%= Spree.t('admin.metafield_definitions.used_in') %></th>
     <th></th>
   </tr>
 </thead>

--- a/admin/app/views/spree/admin/metafield_definitions/_table_row.html.erb
+++ b/admin/app/views/spree/admin/metafield_definitions/_table_row.html.erb
@@ -8,6 +8,14 @@
       <%= f.select :display_on, display_on_options(Spree::MetafieldDefinition), {}, { class: 'custom-select custom-select-sm w-auto', data: { action: 'auto-submit#submit' } } %>
     <% end %>
   </td>
+  <td>
+    <% if metafield_definition.metafields.count.positive? %>
+      <%= metafield_definition.metafields.count %>
+      <%= Spree.t(metafield_definition.resource_type.demodulize.pluralize.to_sym) %>
+    <% else %>
+      <span class="text-muted"><%= Spree.t(:not_available) %></span>
+    <% end %>
+  </td>
   <td class="text-right">
     <%= link_to_edit(metafield_definition, data: { turbo_frame: '_top' }) %>
   </td>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -108,6 +108,9 @@ en:
       manage_stock_locations: Manage Stock Locations
       manage_taxons: Manage Taxons
       manage_zones: Manage Zones
+      metafield_definitions:
+        edit_warning: You can't change the resource type or metafield type after the definition has been used.
+        used_in: Used in
       name: Name
       navigation:
         nested_under: Nested under

--- a/core/app/models/spree/metafield_definition.rb
+++ b/core/app/models/spree/metafield_definition.rb
@@ -21,6 +21,16 @@ module Spree
     # Scopes
     #
     scope :for_resource_type, ->(resource_type) { where(resource_type: resource_type) }
+    scope :multi_search, ->(search) do
+      return all if search.blank?
+
+      search_term = "%#{search.downcase}%"
+      namespace_condition = arel_table[:namespace].lower.matches(search_term)
+      key_condition = arel_table[:key].lower.matches(search_term)
+      name_condition = arel_table[:name].lower.matches(search_term)
+
+      where(namespace_condition.or(key_condition).or(name_condition))
+    end
 
     #
     # Callbacks
@@ -34,6 +44,7 @@ module Spree
     # Ransack
     #
     self.whitelisted_ransackable_attributes = %w[key namespace name resource_type display_on]
+    self.whitelisted_ransackable_scopes = %w[multi_search]
 
     # Returns the full key with namespace
     # @return [String] eg. custom.id


### PR DESCRIPTION
* added fuzzy search
* show which definitions are used and how many objects
* show information why you can't change type/resource after being used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search functionality for metafield definitions
  * Added "Used in" column to admin table displaying current metafield usage
  * Prevents modification of resource and metafield types after initial use, with informational warning

* **Style**
  * Improved alert styling for better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->