### PR TITLE
When forbidden error happens in admin try to redirect user back to th…

### DIFF
--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -34,7 +34,7 @@ module Spree
       def redirect_unauthorized_access
         if try_spree_current_user
           flash[:error] = Spree.t(:authorization_failure)
-          redirect_back(fallback_location: spree.admin_forbidden_path, allow_other_host: true)
+          redirect_back(fallback_location: spree.admin_forbidden_path)
         else
           store_location
           try_to_redirect_to_login_path

--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -34,7 +34,7 @@ module Spree
       def redirect_unauthorized_access
         if try_spree_current_user
           flash[:error] = Spree.t(:authorization_failure)
-          redirect_to spree.admin_forbidden_path, allow_other_host: true
+          redirect_back(fallback_location: spree.admin_forbidden_path, allow_other_host: true)
         else
           store_location
           try_to_redirect_to_login_path

--- a/admin/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/base_controller_spec.rb
@@ -32,6 +32,12 @@ describe Spree::Admin::BaseController, type: :controller do
         expect(response).to redirect_to('/admin/products')
         expect(flash[:error]).to eq(Spree.t(:authorization_failure))
       end
+
+      it 'redirects to forbidden path as fallback when no referer and shows a flash error' do
+        get :index
+        expect(response).to redirect_to('/admin/forbidden')
+        expect(flash[:error]).to eq(Spree.t(:authorization_failure))
+      end
     end
 
     context 'when guest user' do

--- a/admin/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/base_controller_spec.rb
@@ -26,9 +26,10 @@ describe Spree::Admin::BaseController, type: :controller do
                                                                              persisted?: true, selected_locale: nil))
       end
 
-      it 'redirects forbidden path' do
+      it 'redirects back and shows a flash error path' do
         get :index
         expect(response).to redirect_to('/admin/forbidden')
+        expect(flash[:error]).to eq(Spree.t(:authorization_failure))
       end
     end
 

--- a/admin/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/base_controller_spec.rb
@@ -26,7 +26,7 @@ describe Spree::Admin::BaseController, type: :controller do
                                                                              persisted?: true, selected_locale: nil))
       end
 
-      it 'redirects to forbidden path as fallback and shows a flash error' do
+      it 'redirects back to referer when present and shows a flash error' do
         request.env['HTTP_REFERER'] = '/admin/products'
         get :index
         expect(response).to redirect_to('/admin/products')

--- a/admin/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/base_controller_spec.rb
@@ -26,9 +26,10 @@ describe Spree::Admin::BaseController, type: :controller do
                                                                              persisted?: true, selected_locale: nil))
       end
 
-      it 'redirects back and shows a flash error path' do
+      it 'redirects to forbidden path as fallback and shows a flash error' do
+        request.env['HTTP_REFERER'] = '/admin/products'
         get :index
-        expect(response).to redirect_to('/admin/forbidden')
+        expect(response).to redirect_to('/admin/products')
         expect(flash[:error]).to eq(Spree.t(:authorization_failure))
       end
     end


### PR DESCRIPTION
…e previous page

Rather than showing the error page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthorized admin access now redirects back to the previous page when a referer is present, otherwise falls back to the forbidden page, and shows an authorization failure message.

* **Tests**
  * Test suite updated to cover referer-based redirect behavior and the fallback to the forbidden page, asserting the authorization error flash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->