### PR TITLE
Fixed `migrate_admin_users_to_role_users` script

### DIFF
--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -186,10 +186,9 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]}
   end
 
   task migrate_admin_users_to_role_users: :environment do |_t, _args|
-    Spree.admin_user_class.all.each do |admin_user|
-      Spree::Store.all.each do |store|
-        store.add_user(admin_user)
-      end
+    default_store = Spree::Store.default
+    Spree::RoleUser.where(resource: nil).each do |role_user|
+      role_user.update_columns(resource_type: default_store.class.name, resource_id: default_store.id)
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin user role assignment during migration by efficiently updating incomplete role records to assign a default store, eliminating unnecessary per-user, per-store associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->