### PR TITLE
feat[fre-411]: admin deletion flow fix

### DIFF
--- a/core/app/models/spree/invitation.rb
+++ b/core/app/models/spree/invitation.rb
@@ -15,7 +15,7 @@ module Spree
     belongs_to :inviter, polymorphic: true # User or AdminUser
     belongs_to :invitee, polymorphic: true, optional: true # User or AdminUser
     belongs_to :role, class_name: 'Spree::Role'
-    has_one :role_user, dependent: :destroy, class_name: 'Spree::RoleUser'
+    has_one :role_user, dependent: :nullify, class_name: 'Spree::RoleUser'
 
     #
     # Validations

--- a/core/app/models/spree/invitation.rb
+++ b/core/app/models/spree/invitation.rb
@@ -15,7 +15,7 @@ module Spree
     belongs_to :inviter, polymorphic: true # User or AdminUser
     belongs_to :invitee, polymorphic: true, optional: true # User or AdminUser
     belongs_to :role, class_name: 'Spree::Role'
-    has_one :role_user, dependent: :nullify, class_name: 'Spree::RoleUser'
+    has_one :role_user, dependent: :nullify, class_name: 'Spree::RoleUser', inverse_of: :invitation
 
     #
     # Validations

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -6,7 +6,7 @@ module Spree
     belongs_to :role, class_name: 'Spree::Role', foreign_key: :role_id
     belongs_to :user, polymorphic: true
     belongs_to :resource, polymorphic: true
-    belongs_to :invitation, class_name: 'Spree::Invitation', optional: true
+    belongs_to :invitation, class_name: 'Spree::Invitation', optional: true, inverse_of: :role_user
 
     #
     # Validations

--- a/core/spec/models/spree/admin_user_spec.rb
+++ b/core/spec/models/spree/admin_user_spec.rb
@@ -27,7 +27,7 @@ describe Spree::LegacyUser, type: :model do
 
   context 'Callbacks' do
     describe 'cleans up admin user resources' do
-      let!(:other_user) { create(:admin_user) }
+      let!(:other_admin_user) { create(:admin_user) }
       let!(:cancelled_orders) { create_list(:order, 2, canceler: admin_user, state: 'canceled') }
       let!(:approved_orders) { create_list(:order, 2, approver: admin_user) }
       let!(:gift_card_batches) { create_list(:gift_card_batch, 2, created_by: admin_user, amount: 100, prefix: 'TEST') }

--- a/core/spec/models/spree/admin_user_spec.rb
+++ b/core/spec/models/spree/admin_user_spec.rb
@@ -67,7 +67,7 @@ describe Spree::LegacyUser, type: :model do
         end
 
         it 'does not remove other user\'s role' do
-          expect { destroy_admin_user }.to_not change { other_user.role_users.count }
+          expect { destroy_admin_user }.not_to change { other_user.role_users.count }
         end
       end
     end

--- a/core/spec/models/spree/admin_user_spec.rb
+++ b/core/spec/models/spree/admin_user_spec.rb
@@ -58,7 +58,7 @@ describe Spree::LegacyUser, type: :model do
     subject(:destroy_admin_user) { admin_user.destroy }
 
     context 'admin user invited other' do
-      let(:other_user) { create(:user, email: 'other_user@example.com') }
+      let(:other_user) { create(:admin_user, email: 'other_user@example.com', without_admin_role: true) }
       let(:invitation) { create(:invitation, email: other_user.email, inviter: admin_user) }
 
       context 'other users accept invitation' do


### PR DESCRIPTION
## steps to reproduce:
- invite USER B using USER A
- remove USER A using USER B

result:
- both users lost access to resource

## issue description
- when user is being destroyed all sent invitations by him are also destroyed
- when invitation is destroyed user role is being destroyed

## solution
- change dependency invitation -> user_role to nullify
- add regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an admin who sent invitations no longer removes roles from invited users — invited users now retain their roles and access after the inviting admin is deleted.

* **Tests**
  * Added a regression test verifying that invited users’ role associations remain intact when the admin who invited them is destroyed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->