### PR TITLE
Allow configuring the validation scope for the Spree::UniqueName

### DIFF
--- a/core/app/models/concerns/spree/unique_name.rb
+++ b/core/app/models/concerns/spree/unique_name.rb
@@ -6,7 +6,7 @@ module Spree
       auto_strip_attributes :name
 
       validates :name, presence: true,
-                       uniqueness: { case_sensitive: false, allow_blank: true, scope: spree_base_uniqueness_scope }
+                       uniqueness: { case_sensitive: false, allow_blank: true, scope: spree_base_uniqueness_scope(attribute: :name) }
     end
   end
 end

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -40,8 +40,8 @@ class Spree::Base < ApplicationRecord
     where(nil)
   end
 
-  def self.spree_base_uniqueness_scope
-    ApplicationRecord.try(:spree_base_uniqueness_scope) || []
+  def self.spree_base_uniqueness_scope(attribute: nil)
+    Spree.uniqueness_scopes.dig(name.demodulize.underscore, attribute) || ApplicationRecord.try(:spree_base_uniqueness_scope) || []
   end
 
   # FIXME: https://github.com/rails/rails/issues/40943

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -139,6 +139,10 @@ module Spree
     Spree::Config.always_use_translations || I18n.default_locale != I18n.locale
   end
 
+  def self.uniqueness_scopes
+    @@uniqueness_scopes ||= ActiveSupport::HashWithIndifferentAccess.new
+  end
+
   # Used to configure Spree.
   #
   # Example:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced uniqueness validation configuration with attribute-specific scoping capabilities, allowing more granular control over how duplicate name validation is applied across different record types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->