### PR TITLE
Admin: Replace bootstrap collapse with stimulus reveal controller

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_tooltips.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_tooltips.scss
@@ -7,7 +7,7 @@
   background-color: $tooltip-bg;
   color: $tooltip-color;
   border: 0 none;
-  box-shadow: 0px 0px 0px 1px $border-color, 0px 3px 6px -1px $gray-100, 0px 3px 6px 0px $gray-100;
+  box-shadow: 0px 0px 0px 1px $border-color, 0px 3px 6px -1px rgba($gray-300, 0.35), 0px 3px 6px 0px rgba($gray-300, 0.35);
   border-radius: $tooltip-border-radius;
   padding: $tooltip-padding-y $tooltip-padding-x;
   font-size: $font-size-base !important;

--- a/admin/app/views/spree/admin/orders/_customer.html.erb
+++ b/admin/app/views/spree/admin/orders/_customer.html.erb
@@ -5,7 +5,7 @@
     </h5>
     <% if can?(:update_customer, @order) || can?(:update_addresses, @order) %>
       <%= dropdown id: 'customer-edit-dropdown', class: 'ml-auto' do %>
-        <%= dropdown_toggle class: 'btn-sm px-1', data: { test_id: 'dropdown-toggle' } do %>
+        <%= dropdown_toggle class: 'btn-light btn-sm px-1', data: { test_id: 'dropdown-toggle' } do %>
           <%= icon 'dots-vertical' %>
         <% end %>
         <%= dropdown_menu class: 'dropdown-menu-right' do %>

--- a/admin/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/admin/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -1,4 +1,4 @@
-<ul class="list-group mt-3 collapse" id="risk-analysis-<%= payment.id %>">
+<ul class="list-group mt-3 hidden" data-reveal-target="item">
   <li class="list-group-item d-flex justify-content-between align-items-center">
     <%= Spree.t(:avs_response) %>
     <span class="badge badge-<%= payment.is_avs_risky? ? 'warning' : 'complete' %>">

--- a/admin/app/views/spree/admin/orders/_summary.html.erb
+++ b/admin/app/views/spree/admin/orders/_summary.html.erb
@@ -63,22 +63,22 @@
 
     <% tax_lines = order_summary_tax_lines_additional(@order) %>
 
-    <li class="list-group-item border-0">
+    <li class="list-group-item border-0" data-controller="reveal">
       <span class="d-flex justify-content-between align-items-center">
         <span><%= Spree.t(:tax) %></span>
         <span id="additional_tax_total">
           <% if tax_lines.any? %>
-            <%= link_to '#tax-lines-additional', class: 'btn btn-light btn-sm mr-2', data: { toggle: 'collapse' } do %>
+            <button type="button" class="btn btn-light btn-sm mr-2" data-action="click->reveal#toggle">
               <%= Spree.t(:show_details) %>
               <%= icon('selector', height: 12, class: 'mr-0 ml-1') %>
-            <% end %>
+            </button>
           <% end %>
 
           <%= @order.display_additional_tax_total.to_html %>
         </span>
       </span>
 
-      <%= render 'tax_lines', tax_lines: tax_lines, id: 'tax-lines-additional' %>
+      <%= render 'tax_lines', tax_lines: tax_lines %>
     </li>
 
     <%= render_admin_partials(:order_page_summary_partials, order: @order) %>

--- a/admin/app/views/spree/admin/orders/_tax_lines.html.erb
+++ b/admin/app/views/spree/admin/orders/_tax_lines.html.erb
@@ -1,4 +1,4 @@
-<ul class="list-group mt-3 mb-3 collapse" id="<%= id %>">
+<ul class="list-group mt-3 mb-3 hidden" data-reveal-target="item">
   <% tax_lines.each do |tax_line| %>
     <li class="list-group-item d-flex justify-content-between align-items-center">
       <%= tax_line.name %>

--- a/admin/app/views/spree/admin/page_builder/_add_block.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_add_block.html.erb
@@ -6,7 +6,7 @@
       <%= icon("circle-plus") %>
       Add block
     <% end %>
-    <%= dropdown_menu class: 'p-1' do %>
+    <%= dropdown_menu direction: 'top-left' do %>
     <% section.available_blocks_to_add.each do |block_class| %>
       <a href="#" class="dropdown-item btn-sm"
           data-action="click->block-form#addBlock"

--- a/admin/app/views/spree/admin/page_builder/_pages_dropdown.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_pages_dropdown.html.erb
@@ -1,12 +1,12 @@
 <%= dropdown id: 'pages_dropdown' do %>
-  <%= dropdown_toggle do %>
+  <%= dropdown_toggle class: 'btn-light' do %>
     <span class="d-flex align-items-center pr-5">
       <%= icon @page.icon_name, class: 'mr-2' %>
       <%= @page.display_name %>
     </span>
     <%= icon 'selector', class: 'mr-0 ml-2 mb-0 text-muted' %>
   <% end %>
-  <%= dropdown_menu style: 'min-width: 300px' do %>
+  <%= dropdown_menu direction: 'left', style: 'min-width: 250px' do %>
     <% @theme.pages.standard.order(name: :asc).find_all(&:customizable?).each do |page| %>
       <%= active_link_to spree.edit_admin_theme_path(@theme, theme_preview_id: @theme_preview.id, page_id: page.id), class: 'dropdown-item', active: @page == page, data: { turbo_prefetch: false } do %>
         <%= icon page.icon_name, class: 'mr-2' %>

--- a/admin/app/views/spree/admin/page_builder/_sidebar_section.html.erb
+++ b/admin/app/views/spree/admin/page_builder/_sidebar_section.html.erb
@@ -23,7 +23,7 @@
     </div>
     <% if section.blocks_available?  %>
       <div class="d-flex flex-column ml-1 mb-2">
-        <%= turbo_frame_tag [:blocks, section.id].join('_'), class: 'list-group-flush collapse show' do %>
+        <%= turbo_frame_tag [:blocks, section.id].join('_'), class: 'list-group-flush' do %>
           <% if section.can_sort_blocks? %>
           <div data-controller="sortable"
             data-sortable-handle-value=".handle-block"

--- a/admin/app/views/spree/admin/payments/_payment.html.erb
+++ b/admin/app/views/spree/admin/payments/_payment.html.erb
@@ -17,7 +17,7 @@
     <%= spree_time(payment.created_at, class: 'ml-auto text-muted font-size-sm') %>
 
     <%= dropdown do %>
-      <%= dropdown_toggle class: 'btn-sm px-1' do %>
+      <%= dropdown_toggle class: 'btn-light btn-sm px-1' do %>
         <%= icon('dots-vertical', class: 'mr-0') %>
       <% end %>
       <%= dropdown_menu do %>
@@ -73,7 +73,7 @@
     </div>
   </div>
   <% if payment.transaction_id.present? && !payment.store_credit? %>
-    <div class="card-footer border-top border-top-dashed">
+    <div class="card-footer border-top border-top-dashed" data-controller="reveal">
       <p class="mb-0 d-flex justify-content-between align-items-center">
         <span>
           <%= Spree.t(:risk_analysis) %>
@@ -84,10 +84,10 @@
             <span class="text-success"><%= icon('shield-check-filled') %> <%= Spree.t(:not_risky) %></span>
           <% end %>
         </span>
-        <%= link_to "#risk-analysis-#{payment.id}", class: 'btn btn-light btn-sm bg-transparent', data: { toggle: 'collapse' } do %>
+        <button type="button" class="btn btn-light btn-sm bg-transparent" data-action="click->reveal#toggle">
           <%= Spree.t(:show_details) %>
           <%= icon('selector', class: 'mr-0 ml-1') %>
-        <% end %>
+        </button>
       </p>
       <%= render 'spree/admin/orders/risk_analysis', payment: payment %>
     </div>

--- a/admin/app/views/spree/admin/promotion_actions/_promotion_action.html.erb
+++ b/admin/app/views/spree/admin/promotion_actions/_promotion_action.html.erb
@@ -5,7 +5,7 @@
 
       <% if can?(:update, promotion_action) || can?(:destroy, promotion_action) %>
         <%= dropdown do %>
-          <%= dropdown_toggle class: 'btn-sm px-1' do %>
+          <%= dropdown_toggle class: 'btn-light btn-sm px-1' do %>
             <%= icon('dots-vertical', class: 'mr-0') %>
           <% end %>
           <%= dropdown_menu do %>

--- a/admin/app/views/spree/admin/promotion_rules/_promotion_rule.html.erb
+++ b/admin/app/views/spree/admin/promotion_rules/_promotion_rule.html.erb
@@ -5,7 +5,7 @@
 
       <% if can?(:update, promotion_rule) || can?(:destroy, promotion_rule) %>
         <%= dropdown do %>
-          <%= dropdown_toggle class: 'btn-sm px-1' do %>
+          <%= dropdown_toggle class: 'btn-light btn-sm px-1' do %>
             <%= icon('dots-vertical', class: 'mr-0') %>
           <% end %>
           <%= dropdown_menu do %>

--- a/admin/app/views/spree/admin/promotions/form/_kind.html.erb
+++ b/admin/app/views/spree/admin/promotions/form/_kind.html.erb
@@ -1,57 +1,61 @@
-<div class="custom-control custom-radio">
-  <%= f.radio_button :kind, :coupon_code, data: { toggle: :collapse, target: '#coupon-code' }, class: 'custom-control-input' %>
-  <%= f.label :kind_coupon_code, Spree.t(:coupon_code), class: 'custom-control-label' %>
+<div data-controller="reveal" data-reveal-hidden-class="hidden">
+  <div class="custom-control custom-radio">
+    <%= f.radio_button :kind, :coupon_code, data: { action: 'change->reveal#show' }, class: 'custom-control-input' %>
+    <%= f.label :kind_coupon_code, Spree.t(:coupon_code), class: 'custom-control-label' %>
 
-  <div id="coupon-code" class="rounded p-3 bg-light mt-3 collapse <% unless @promotion.automatic? %>show<% end %>">
-    <div class="d-flex align-items-start custom-control custom-radio">
-      <%= f.radio_button :multi_codes, false, data: { toggle: :collapse, target: '#single-code' }, class: 'custom-control-input' %>
-      <%= f.label :multi_codes_false, class: 'custom-control-label' do %>
-        One code for all customers
-        <span class="form-text font-weight-normal mr-1">
-          You can limit the number of times this code can be used.
-        </span>
-      <% end %>
-    </div>
-    <div id="single-code" class="mb-4 mt-2 ml-4 collapse <% unless @promotion.multi_codes? %>show<% end %>" data-parent="#coupon-code">
-      <%= f.text_field :code, class: 'form-control text-uppercase', placeholder: 'Your coupon code' %>
-    </div>
-
-    <div class="mt-2 d-flex align-items-start custom-control custom-radio">
-      <%= f.radio_button :multi_codes, true, data: { toggle: :collapse, target: '#multi-codes' }, class: 'custom-control-input' %>
-      <%= f.label :multi_codes_true, class: 'custom-control-label' do %>
-        Generate unique codes
-        <span class="form-text font-weight-normal mr-1">
-          These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
-        </span>
-      <% end %>
-    </div>
-    <div id="multi-codes" class="ml-3 mt-2 row collapse <% if @promotion.multi_codes? %>show<% end %>" data-parent="#coupon-code">
-      <div class="col-6">
-        <%= f.text_field :code_prefix, class: 'form-control text-uppercase', placeholder: 'Coupon Prefix (optional)' %>
-        <span class="form-text">
-          eg. <strong>ABC</strong>
-        </span>
-      </div>
-      <div class="col-6">
-        <% minimum_number_of_codes = @promotion.persisted? && @promotion.coupon_codes.count.positive? ? @promotion.coupon_codes.count : 1 %>
-        <% maximum_number_of_codes = ENV.fetch('PROMOTION_MAX_NUMBER_OF_CODES', 5000) %>
-        <%= f.number_field :number_of_codes, class: 'form-control', placeholder: 'Number of codes', min: minimum_number_of_codes, max: maximum_number_of_codes, step: 1 %>
-        <span class="form-text">
-          How many codes you want to generate.
-          <% if @promotion.persisted? %>
-            To add more codes just increase this number
+    <div data-reveal-target="item" class="rounded p-3 bg-light mt-3 <% if @promotion.automatic? %>hidden<% end %>">
+      <div data-controller="reveal" data-reveal-hidden-class="hidden">
+        <div class="d-flex align-items-start custom-control custom-radio">
+          <%= f.radio_button :multi_codes, false, data: { action: 'change->reveal#toggle' }, class: 'custom-control-input' %>
+          <%= f.label :multi_codes_false, class: 'custom-control-label' do %>
+            One code for all customers
+            <span class="form-text font-weight-normal mr-1">
+              You can limit the number of times this code can be used.
+            </span>
           <% end %>
-        </span>
+        </div>
+        <div data-reveal-target="item" class="mb-4 mt-2 ml-4 <% if @promotion.multi_codes? %>hidden<% end %>">
+          <%= f.text_field :code, class: 'form-control text-uppercase', placeholder: 'Your coupon code' %>
+        </div>
+
+        <div class="mt-2 d-flex align-items-start custom-control custom-radio">
+          <%= f.radio_button :multi_codes, true, data: { action: 'change->reveal#toggle' }, class: 'custom-control-input' %>
+          <%= f.label :multi_codes_true, class: 'custom-control-label' do %>
+            Generate unique codes
+            <span class="form-text font-weight-normal mr-1">
+              These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
+            </span>
+          <% end %>
+        </div>
+        <div data-reveal-target="item" class="ml-3 mt-2 row <% unless @promotion.multi_codes? %>hidden<% end %>">
+          <div class="col-6">
+            <%= f.text_field :code_prefix, class: 'form-control text-uppercase', placeholder: 'Coupon Prefix (optional)' %>
+            <span class="form-text">
+              eg. <strong>ABC</strong>
+            </span>
+          </div>
+          <div class="col-6">
+            <% minimum_number_of_codes = @promotion.persisted? && @promotion.coupon_codes.count.positive? ? @promotion.coupon_codes.count : 1 %>
+            <% maximum_number_of_codes = ENV.fetch('PROMOTION_MAX_NUMBER_OF_CODES', 5000) %>
+            <%= f.number_field :number_of_codes, class: 'form-control', placeholder: 'Number of codes', min: minimum_number_of_codes, max: maximum_number_of_codes, step: 1 %>
+            <span class="form-text">
+              How many codes you want to generate.
+              <% if @promotion.persisted? %>
+                To add more codes just increase this number
+              <% end %>
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<div class="mt-4 custom-control custom-radio">
-  <%= f.radio_button :kind, :automatic, data: { toggle: :collapse, target: '#coupon-code' }, class: 'custom-control-input' %>
-  <%= f.label :kind_automatic, Spree.t(:automatic_promotion), class: 'custom-control-label' %>
+  <div class="mt-4 custom-control custom-radio">
+    <%= f.radio_button :kind, :automatic, data: { action: 'change->reveal#hide' }, class: 'custom-control-input' %>
+    <%= f.label :kind_automatic, Spree.t(:automatic_promotion), class: 'custom-control-label' %>
 
-  <p class="form-text mt-2 mb-0">
-    This promotion will be automatically applied to all eligible orders.
-  </p>
+    <p class="form-text mt-2 mb-0">
+      This promotion will be automatically applied to all eligible orders.
+    </p>
+  </div>
 </div>


### PR DESCRIPTION
ref https://github.com/spree/spree/issues/12867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip shadows with translucent effects for improved visual hierarchy
  * Updated button styling consistency across admin sections
  * Adjusted dropdown menu positioning for better layout flow

* **Improvements**
  * Refined visibility controls for order details, tax information, and promotion sections
  * Improved interaction consistency in admin interfaces for showing/hiding details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->