### PR TITLE
Fixed: remove `payment_icons` gem leftover

### DIFF
--- a/storefront/app/helpers/spree/payment_methods_helper.rb
+++ b/storefront/app/helpers/spree/payment_methods_helper.rb
@@ -1,0 +1,7 @@
+module Spree
+  module PaymentMethodsHelper
+    def credit_card_icons
+      %w[visa mastercard american_express discover]
+    end
+  end
+end

--- a/storefront/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/storefront/app/views/spree/checkout/payment/_gateway.html.erb
@@ -65,9 +65,9 @@
         data: { card_validation_target: "ccType" }
     %>
 
-    <% PaymentIcon.credit_cards.each do |card| %>
-      <div id="credit-card-icon-<%= card.name %>" class="hidden">
-        <%= image_tag card.path, style: 'height: 32px;' %>
+    <% credit_card_icons.each do |card| %>
+      <div id="credit-card-icon-<%= card %>" class="hidden">
+        <%= payment_method_icon_tag card %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace PaymentIcon usage with a helper-provided card list and render icons via payment_method_icon_tag in the checkout gateway view.
> 
> - **Checkout payment view (`storefront/app/views/spree/checkout/payment/_gateway.html.erb`)**:
>   - Replace `PaymentIcon.credit_cards` loop with `credit_card_icons` and render with `payment_method_icon_tag`.
>   - Update icon element IDs from `card.name` to the symbol name (e.g., `visa`, `mastercard`).
> - **Helper (`storefront/app/helpers/spree/payment_methods_helper.rb`)**:
>   - Add `Spree::PaymentMethodsHelper#credit_card_icons` returning `%w[visa mastercard american_express discover]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b7d5ed0e2fa2318eace44edda907318628af7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced payment method icon rendering in the checkout payment process.
  * Consolidated payment method configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->