### PR TITLE
Ability to clear metafield when passed empty value

### DIFF
--- a/core/.claude/settings.local.json
+++ b/core/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle exec rspec:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/core/spec/models/concerns/spree/metafields_spec.rb
+++ b/core/spec/models/concerns/spree/metafields_spec.rb
@@ -143,5 +143,95 @@ RSpec.describe Spree::Metafields, type: :concern do
         product.update(attrs)
       }.not_to change { product.metafields.count }
     end
+
+    context 'auto-destroy metafields with empty values' do
+      let!(:metafield) do
+        product.metafields.create!(
+          metafield_definition: definition,
+          value: 'initial value',
+          type: definition.metafield_type
+        )
+      end
+
+      it 'destroys existing metafield when value is set to empty string' do
+        attrs = {
+          metafields_attributes: [
+            {
+              id: metafield.id,
+              metafield_definition_id: definition.id,
+              value: '',
+              type: definition.metafield_type
+            }
+          ]
+        }
+        expect {
+          product.update(attrs)
+        }.to change { product.metafields.count }.by(-1)
+      end
+
+      it 'destroys existing metafield when value is set to nil' do
+        attrs = {
+          metafields_attributes: [
+            {
+              id: metafield.id,
+              metafield_definition_id: definition.id,
+              value: nil,
+              type: definition.metafield_type
+            }
+          ]
+        }
+        expect {
+          product.update(attrs)
+        }.to change { product.metafields.count }.by(-1)
+      end
+
+      it 'updates existing metafield when value is not empty' do
+        attrs = {
+          metafields_attributes: [
+            {
+              id: metafield.id,
+              metafield_definition_id: definition.id,
+              value: 'updated value',
+              type: definition.metafield_type
+            }
+          ]
+        }
+        expect {
+          product.update(attrs)
+        }.not_to change { product.metafields.count }
+        expect(metafield.reload.value).to eq('updated value')
+      end
+
+      it 'handles multiple metafields correctly' do
+        other_definition = create(:metafield_definition, namespace: 'custom', key: 'bar', resource_type: 'Spree::Product')
+        other_metafield = product.metafields.create!(
+          metafield_definition: other_definition,
+          value: 'other value',
+          type: other_definition.metafield_type
+        )
+
+        attrs = {
+          metafields_attributes: [
+            {
+              id: metafield.id,
+              metafield_definition_id: definition.id,
+              value: '',
+              type: definition.metafield_type
+            },
+            {
+              id: other_metafield.id,
+              metafield_definition_id: other_definition.id,
+              value: 'updated other value',
+              type: other_definition.metafield_type
+            }
+          ]
+        }
+        expect {
+          product.update(attrs)
+        }.to change { product.metafields.count }.by(-1)
+        expect(product.metafields.pluck(:id)).not_to include(metafield.id)
+        expect(other_metafield.reload.value).to eq('updated other value')
+      end
+    end
   end
 end

--- a/storefront/.claude/settings.local.json
+++ b/storefront/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable clearing existing product metafields by passing empty values; importer now builds nested metafield attributes to update or remove them.
> 
> - **Core/Metafields**:
>   - Override `metafields_attributes=` to auto-mark existing metafields with blank `value` for destruction (`_destroy: true`).
>   - Add private `value_blank?` helper.
> - **Import (ProductVariant)**:
>   - Replace per-field `set_metafield` with building `metafields_attributes` from `metafield.*` columns.
>   - Find matching `Spree::MetafieldDefinition`; update existing metafields, skip new ones with blank values, and allow clearing existing ones when blank.
>   - Apply via `product.update(metafields_attributes: ...)`.
> - **Tests**:
>   - Add specs for auto-destroying existing metafields on blank values and updating non-blank values.
>   - Add importer specs covering updates, skipping blanks for new metafields, and removing one or all existing metafields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c59521b51503217740828f58bd0bca05692c75b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metafields with empty values are now automatically removed when updating products.
  * CSV imports now properly handle metafield updates and removals, including removal of metafields with blank values.
  * Enhanced metafield validation during product imports using definition-driven workflows.

* **Tests**
  * Added comprehensive test coverage for metafield auto-destruction and CSV import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->