### PR TITLE
Make it able to define lazy loading strategy for `PageSection` class

### DIFF
--- a/core/app/models/spree/page_section.rb
+++ b/core/app/models/spree/page_section.rb
@@ -137,7 +137,7 @@ module Spree
     end
 
     # Controls how section turbo-frame is being loaded. Either `:eager` or `:lazy`
-    def loading_stategy
+    def loading_strategy
       :eager
     end
 

--- a/core/app/models/spree/page_section.rb
+++ b/core/app/models/spree/page_section.rb
@@ -136,9 +136,9 @@ module Spree
       Spree::Core::Engine.routes.url_helpers.page_section_path(self, **url_options)
     end
 
-    # Controls how section turbo-frame is being loaded. Either `eager` or `lazy`
+    # Controls how section turbo-frame is being loaded. Either `:eager` or `:lazy`
     def loading_stategy
-      "eager"
+      :eager
     end
 
     def rich_text_fields

--- a/core/app/models/spree/page_section.rb
+++ b/core/app/models/spree/page_section.rb
@@ -136,6 +136,11 @@ module Spree
       Spree::Core::Engine.routes.url_helpers.page_section_path(self, **url_options)
     end
 
+    # Controls how section turbo-frame is being loaded. Either `eager` or `lazy`
+    def loading_stategy
+      "eager"
+    end
+
     def rich_text_fields
       self.class.rich_text_association_names.map { |rt| rt.to_s.sub('rich_text_', '') }
     end

--- a/storefront/app/helpers/spree/page_helper.rb
+++ b/storefront/app/helpers/spree/page_helper.rb
@@ -52,7 +52,7 @@ module Spree
 
         path = section.lazy_path(variables)
 
-        turbo_frame_tag(css_id, src: path, loading: :lazy, class: css_class, data: { controller: 'prefetch-lazy', turbo_permanent: true }) do
+        turbo_frame_tag(css_id, src: path, loading: section.loading_strategy, class: css_class, data: { controller: 'prefetch-lazy', turbo_permanent: true }) do
           render('/' + section.to_partial_path, **variables)
         end
       else


### PR DESCRIPTION
Example:

I have a homepage with ten featured taxon sections. If each one of them is an eager-loaded turbo-frame, it means 10 parallel requests to fetch 10 taxon products (20 products per taxon by default) - that's a lot to handle. Thanks to that PR, page sections can be configured as lazy loaded so only the ones entering the viewport will get activated.

Ideally, that should be configurable via UI but even making it able to overwrite this setting per class via decoration is a huge profit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `PageSection#loading_strategy` (default `:eager`) and uses it in `render_section` so lazy sections can choose `:eager` or `:lazy` frame loading.
> 
> - **Page rendering**:
>   - `storefront/app/helpers/spree/page_helper.rb`: `turbo_frame_tag` now uses `section.loading_strategy` instead of hardcoded `:lazy` for lazy sections.
> - **Model**:
>   - `core/app/models/spree/page_section.rb`: Introduces `loading_strategy` method (defaults to `:eager`) to control how a section’s turbo-frame loads; adds inline doc comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54ce34f81cafe27431da3db1450f3436ecd05b45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Page sections now determine their own loading strategy, allowing sections previously lazy-loaded to opt into eager loading when appropriate.
  * Rendering logic updated so per-section loading behavior is applied dynamically, improving perceived performance and flexibility without changing visual output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->