### PR TITLE
Remove `sprockets-rails` from dev dependencies

### DIFF
--- a/cli/lib/spree_cli/templates/extension/lib/%file_name%/engine.rb.tt
+++ b/cli/lib/spree_cli/templates/extension/lib/%file_name%/engine.rb.tt
@@ -14,10 +14,12 @@ module <%= class_name %>
     end
 
     initializer '<%= file_name %>.assets' do |app|
-      app.config.assets.paths << root.join('app/javascript')
-      app.config.assets.paths << root.join('vendor/javascript')
-      app.config.assets.paths << root.join('vendor/stylesheets')
-      app.config.assets.precompile += %w[<%= file_name %>_manifest]
+      if app.config.respond_to?(:assets)
+        app.config.assets.paths << root.join('app/javascript')
+        app.config.assets.paths << root.join('vendor/javascript')
+        app.config.assets.paths << root.join('vendor/stylesheets')
+        app.config.assets.precompile += %w[<%= file_name %>_manifest]
+      end
     end
 
     initializer '<%= file_name %>.importmap', before: 'importmap' do |app|

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -17,8 +17,6 @@ platforms :ruby do
   gem 'sqlite3', '>= 2.0'
 end
 
-gem 'sprockets-rails', '>= 3.5.2'
-
 group :test do
   gem 'capybara'
   gem 'capybara-screenshot'

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -45,6 +45,7 @@ module Spree
       opts[:skip_kamal] = true
       opts[:skip_devcontainer] = true
       opts[:skip_solid] = true
+      opts[:skip_sprockets] = true unless defined?(Sprockets)
 
       puts 'Generating dummy Rails application...'
       invoke Rails::Generators::AppGenerator,
@@ -62,7 +63,8 @@ module Spree
       template 'rails/routes.rb', "#{dummy_path}/config/routes.rb", force: true
       template 'rails/test.rb', "#{dummy_path}/config/environments/test.rb", force: true
       template 'initializers/devise.rb', "#{dummy_path}/config/initializers/devise.rb", force: true
-      template "app/assets/config/manifest.js", "#{dummy_path}/app/assets/config/manifest.js", force: true
+      template "app/assets/config/manifest.js", "#{dummy_path}/app/assets/config/manifest.js", force: true if defined?(Sprockets)
+      remove_file "#{dummy_path}/config/initializers/assets.rb" unless defined?(Sprockets)
     end
 
     def test_dummy_inject_extension_requirements

--- a/docs/.claude/settings.local.json
+++ b/docs/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//Users/damian/github/vendo/engines/spree/**)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a global dependency declaration to streamline project configuration.
* **Bug Fixes**
  * Added guards around asset configuration and generation to avoid errors in environments without asset tooling.
  * Made asset-related scaffolding conditional to prevent unnecessary or failing file changes.
* **Documentation**
  * Added a local settings file for tooling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->