### PR TITLE
Update Storefront API docs with the complete Adyen payment session endpoint

### DIFF
--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -1928,6 +1928,34 @@ paths:
           $ref: '#/components/responses/422UnprocessableEntity'
       security:
         - orderToken: []
+  /api/v2/storefront/adyen/payment_sessions/{id}/complete:
+    post:
+      summary: Complete an Adyen payment session and order
+      description: "Complete an Adyen payment session and order. Adyen support is currently in private beta. [Please contact us](https://spreecommerce.org/contact) to get access."
+      tags:
+        - Adyen
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                session_result:
+                  type: string
+                  description: The Adyen payment session result
+              required:
+                - session_result
+            example:
+              session_result: AdyenResultData
+      operationId: complete-adyen-payment-session
+      responses:
+        '200':
+          $ref: '#/components/responses/AdyenPaymentSession'
+        '422':
+          $ref: '#/components/responses/422UnprocessableEntity'
+      security:
+        - orderToken: []
   "/api/v2/storefront/adyen/payment_sessions/{id}":
     get:
       summary: Get Adyen Payment Session


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds POST `/api/v2/storefront/adyen/payment_sessions/{id}/complete` to finalize Adyen payment sessions and orders using `session_result`.
> 
> - **Storefront API Docs (Adyen)**:
>   - Add `POST /api/v2/storefront/adyen/payment_sessions/{id}/complete` endpoint
>     - Request body: `{ session_result: string }`
>     - `operationId`: `complete-adyen-payment-session`
>     - Responses: `200 -> AdyenPaymentSession`, `422 -> 422UnprocessableEntity`
>     - Security: `orderToken`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c9717461868a5db8d038a36b7ecd88e6a4d58a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API endpoint to the storefront API for completing Adyen payment sessions. The endpoint accepts required session result parameters in the request body, returns finalized payment session details on success, and provides detailed validation error responses when needed. Order token authentication is enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->