### PR TITLE
Feat/add date filter admin users

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_filters.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_filters.scss
@@ -31,6 +31,8 @@
   animation: fadeIn 0.2s ease-in-out;
   width: 100%;
   z-index: $zindex-dropdown;
+  max-height: calc(100vh - #{$header-height} - 4rem);
+  overflow-y: auto;
 
   @include media-breakpoint-up(md) {
     width: 50%;

--- a/admin/app/views/spree/admin/users/_filters.html.erb
+++ b/admin/app/views/spree/admin/users/_filters.html.erb
@@ -2,6 +2,13 @@
   <div class="d-flex flex-column flex-lg-row gap-2">
     <%= render 'spree/admin/shared/filters_search_bar', param: :multi_search, placeholder: Spree.t('admin.users.filters.search_placeholder') %>
 
+    <%= render "spree/admin/shared/calendar_range_picker",
+          date_from_input_name: "q[created_at_gt]",
+          date_to_input_name: "q[created_at_lt]",
+          date_from_value: params.dig(:q, :created_at_gt),
+          date_to_value: params.dig(:q, :created_at_lt),
+          dropdown_direction: "right" %>
+
     <%= render 'spree/admin/shared/filters_button' %>
   </div>
   <div data-dropdown-target="menu" id="table-filter" class="hidden">
@@ -42,6 +49,42 @@
                 options_for_select([["Yes", true], ["No", false]], params[:q][:accepts_email_marketing_eq]),
                 { include_blank: true },
                 { class: "custom-select", data: { filters_target: :input } } %>
+    </div>
+    <div class="form-group">
+      <%= f.label :spree_roles_name_in, Spree.t(:roles) %>
+      <%= tom_select_tag "q[spree_roles_name_in]",
+      active_option: params.dig(:q, :spree_roles_name_in),
+      options: user_roles_json_array,
+      multiple: true,
+      value_field: :name,
+      select_class: "w-100",
+      select_data: {
+        filters_target: "input",
+      } %>
+    </div>
+    <div class="form-group">
+      <%= f.label :spree_roles_name_in, Spree.t(:roles) %>
+      <%= tom_select_tag "q[spree_roles_name_in]",
+      active_option: params.dig(:q, :spree_roles_name_in),
+      options: user_roles_json_array,
+      multiple: true,
+      value_field: :name,
+      select_class: "w-100",
+      select_data: {
+        filters_target: "input",
+      } %>
+    </div>
+    <div class="form-group">
+      <%= f.label :spree_roles_name_in, Spree.t(:roles) %>
+      <%= tom_select_tag "q[spree_roles_name_in]",
+      active_option: params.dig(:q, :spree_roles_name_in),
+      options: user_roles_json_array,
+      multiple: true,
+      value_field: :name,
+      select_class: "w-100",
+      select_data: {
+        filters_target: "input",
+      } %>
     </div>
     <div class="form-group">
       <%= f.label :spree_roles_name_in, Spree.t(:roles) %>

--- a/admin/app/views/spree/admin/users/_filters.html.erb
+++ b/admin/app/views/spree/admin/users/_filters.html.erb
@@ -62,42 +62,6 @@
         filters_target: "input",
       } %>
     </div>
-    <div class="form-group">
-      <%= f.label :spree_roles_name_in, Spree.t(:roles) %>
-      <%= tom_select_tag "q[spree_roles_name_in]",
-      active_option: params.dig(:q, :spree_roles_name_in),
-      options: user_roles_json_array,
-      multiple: true,
-      value_field: :name,
-      select_class: "w-100",
-      select_data: {
-        filters_target: "input",
-      } %>
-    </div>
-    <div class="form-group">
-      <%= f.label :spree_roles_name_in, Spree.t(:roles) %>
-      <%= tom_select_tag "q[spree_roles_name_in]",
-      active_option: params.dig(:q, :spree_roles_name_in),
-      options: user_roles_json_array,
-      multiple: true,
-      value_field: :name,
-      select_class: "w-100",
-      select_data: {
-        filters_target: "input",
-      } %>
-    </div>
-    <div class="form-group">
-      <%= f.label :spree_roles_name_in, Spree.t(:roles) %>
-      <%= tom_select_tag "q[spree_roles_name_in]",
-      active_option: params.dig(:q, :spree_roles_name_in),
-      options: user_roles_json_array,
-      multiple: true,
-      value_field: :name,
-      select_class: "w-100",
-      select_data: {
-        filters_target: "input",
-      } %>
-    </div>
     <%= render_admin_partials(:users_filters_partials, f: f) %>
     <%= render 'spree/admin/shared/filter_submit' %>
   </div>


### PR DESCRIPTION
### Description:

- Added date filter based on `created_at` for users index on admin side.
- Updated styling for filters dropdown to add scroll when there is overflow of fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a created_at date range filter to the admin users index and makes the filters dropdown scrollable when overflowing.
> 
> - **Admin Users Filters**:
>   - Add `calendar_range_picker` for `q[created_at_gt]` and `q[created_at_lt]` in `admin/app/views/spree/admin/users/_filters.html.erb`.
> - **Styles**:
>   - Limit dropdown height and enable vertical scrolling by setting `max-height` and `overflow-y: auto` on `#table-filter` in `admin/app/assets/stylesheets/spree/admin/components/_filters.scss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c978e54d8139e58e4e2062e276905f024d4243e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range filtering capability to search users by their creation date in the admin dashboard.
  * Enhanced filter dropdown UI with improved scrolling support for easier navigation of large filter lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->