### PR TITLE
Fixed: `TurboHelper#spree_turbo_update_cart` updating cart total, but…

### DIFF
--- a/storefront/app/helpers/spree/turbo_helper.rb
+++ b/storefront/app/helpers/spree/turbo_helper.rb
@@ -7,8 +7,10 @@ module Spree
     end
 
     def spree_turbo_update_cart(order = current_order)
-      turbo_stream.update_all '.cart-counter', order&.item_count&.positive? ? order&.item_count : ''
-      turbo_stream.update_all '.cart-total', order&.display_item_total.to_s
+      [
+        turbo_stream.update_all('.cart-counter', order&.item_count&.positive? ? order&.item_count : ''),
+        turbo_stream.update_all('.cart-total', order&.display_item_total.to_s)
+      ].join.html_safe
     end
   end
 end

--- a/storefront/spec/helpers/spree/turbo_helper_spec.rb
+++ b/storefront/spec/helpers/spree/turbo_helper_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Spree::TurboHelper, type: :helper do
+  let(:order) { create(:order_with_line_items) }
+  let(:empty_order) { create(:order) }
+
+  describe '#spree_turbo_update_cart' do
+    context 'with order containing items' do
+      before do
+        allow(order).to receive(:item_count).and_return(3)
+        allow(order).to receive(:display_item_total).and_return(double(to_s: '$30.00'))
+      end
+
+      it 'returns turbo stream updates for cart counter and total' do
+        result = helper.spree_turbo_update_cart(order)
+
+        expect(result).to include('turbo-stream action="update" targets=".cart-counter"')
+        expect(result).to include('<template>3</template>')
+        expect(result).to include('turbo-stream action="update" targets=".cart-total"')
+        expect(result).to include('<template>$30.00</template>')
+      end
+    end
+
+    context 'with empty order' do
+      before do
+        allow(empty_order).to receive(:item_count).and_return(0)
+        allow(empty_order).to receive(:display_item_total).and_return(double(to_s: '$0.00'))
+      end
+
+      it 'returns empty string for cart counter when no items' do
+        result = helper.spree_turbo_update_cart(empty_order)
+
+        expect(result).to include('turbo-stream action="update" targets=".cart-counter"')
+        expect(result).to include('<template></template>')
+        expect(result).to include('turbo-stream action="update" targets=".cart-total"')
+        expect(result).to include('<template>$0.00</template>')
+      end
+    end
+
+    context 'with nil order' do
+      it 'handles nil order gracefully' do
+        result = helper.spree_turbo_update_cart(nil)
+
+        expect(result).to include('turbo-stream action="update" targets=".cart-counter"')
+        expect(result).to include('<template></template>')
+        expect(result).to include('turbo-stream action="update" targets=".cart-total"')
+        expect(result).to include('<template></template>')
+      end
+    end
+
+    context 'when no order is passed' do
+      before do
+        allow(helper).to receive(:current_order).and_return(order)
+        allow(order).to receive(:item_count).and_return(2)
+        allow(order).to receive(:display_item_total).and_return(double(to_s: '$20.00'))
+      end
+
+      it 'uses current_order as default' do
+        result = helper.spree_turbo_update_cart
+
+        expect(result).to include('turbo-stream action="update" targets=".cart-counter"')
+        expect(result).to include('<template>2</template>')
+        expect(result).to include('turbo-stream action="update" targets=".cart-total"')
+        expect(result).to include('<template>$20.00</template>')
+      end
+    end
+
+    it 'returns html_safe string' do
+      result = helper.spree_turbo_update_cart(order)
+
+      expect(result).to be_html_safe
+    end
+  end
+end


### PR DESCRIPTION
… not cart counter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated cart counter and total update operations into a single, more efficient update process.

* **Tests**
  * Added comprehensive test coverage for cart update functionality, including scenarios for orders with items, empty orders, and default order handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->