### PR TITLE
Add missing API reference link to the complete an Adyen payment session endpoint

### DIFF
--- a/docs/api-reference/storefront/adyen/complete-an-adyen-payment-session.mdx
+++ b/docs/api-reference/storefront/adyen/complete-an-adyen-payment-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/v2/storefront/adyen/payment_sessions/{id}/complete
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -340,6 +340,7 @@
                     "group": "Adyen",
                     "pages": [
                       "api-reference/storefront/adyen/create-an-adyen-payment-session",
+                      "api-reference/storefront/adyen/complete-an-adyen-payment-session",
                       "api-reference/storefront/adyen/get-adyen-payment-session"
                     ]
                   },
@@ -1024,22 +1025,22 @@
           {
             "tab": "Use Cases",
             "groups": [
-               {                
+               {
                 "group": "Overview",
                 "pages": [
-                  "use-case/overview" 
+                  "use-case/overview"
                 ]
               },
-              {    
+              {
                 "group": "B2B Commerce",
                 "pages": [
                   "use-case/b2b/b2b-commerce-model",
                   "use-case/b2b/b2b-capabilities",
-                  "use-case/b2b/b2b-admin-capabilities", 
+                  "use-case/b2b/b2b-admin-capabilities",
                   "use-case/b2b/b2b-buyer-capabilities"
                 ]
               },
-              {    
+              {
                 "group": "Digital Products",
                 "pages": [
                   "use-case/digital-products/model",
@@ -1047,15 +1048,15 @@
                   "use-case/digital-products/admin-capabilities"
                 ]
               },
-              {    
+              {
                 "group": "ChatGPT Integration",
                 "pages": [
-                  "use-case/chatgpt-integration/chatgpt-shopping", 
+                  "use-case/chatgpt-integration/chatgpt-shopping",
                   "use-case/chatgpt-integration/chatgpt-instant-checkout",
-                  "use-case/chatgpt-integration/chatgpt-buyer-experience"  
+                  "use-case/chatgpt-integration/chatgpt-buyer-experience"
                 ]
               },
-              {    
+              {
                 "group": "Multi-Store Platform",
                 "pages": [
                   "use-case/multi-store/model",
@@ -1063,26 +1064,26 @@
                   "use-case/multi-store/admin-capabilities"
                 ]
               },
-              {    
+              {
                 "group": "Multi-Tenant Platform",
                 "pages": [
                   "use-case/multi-tenant/multi-tenant-model",
                   "use-case/multi-tenant/multi-tenant-capabilities",
-                  "use-case/multi-tenant/super-admin-capabilities", 
+                  "use-case/multi-tenant/super-admin-capabilities",
                   "use-case/multi-tenant/tenant-capabilities",
                   "use-case/multi-tenant/franchises-and-reseller-networks",
                   "use-case/multi-tenant/multi-brand-enterprise-model",
                   "use-case/multi-tenant/white-label-saas"
                 ]
               },
-               {    
+               {
                 "group": "Multi-Vendor Marketplace",
                 "pages": [
                   "use-case/marketplace/model",
                   "use-case/marketplace/capabilities",
-                  "use-case/marketplace/admin-dashboard", 
+                  "use-case/marketplace/admin-dashboard",
                   "use-case/marketplace/vendor-dashboard",
-                  "use-case/marketplace/customer-ux"  
+                  "use-case/marketplace/customer-ux"
                 ]
               }
             ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds the missing Storefront API doc and nav entry for completing an Adyen payment session.
> 
> - **Ecommerce API → Storefront API → Adyen**:
>   - Add new endpoint doc `api-reference/storefront/adyen/complete-an-adyen-payment-session` (`POST /api/v2/storefront/adyen/payment_sessions/{id}/complete`).
>   - Update `docs/docs.json` navigation to include the new Adyen page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff934365756fc8685dda2ef9c0c347448b892859. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Adyen payment session completion API endpoint and updated the API reference documentation index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->