### PR TITLE
Fixed: store `return_to` session for all admin controllers, eg. Order…

### DIFF
--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -14,6 +14,7 @@ module Spree
       helper 'spree/integrations'
 
       before_action :authorize_admin
+      after_action :set_return_to, only: [:index]
 
       protected
 

--- a/admin/app/controllers/spree/admin/resource_controller.rb
+++ b/admin/app/controllers/spree/admin/resource_controller.rb
@@ -4,7 +4,6 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url, :model_class, :search_collection, :paginated_collection
   before_action :load_resource
   before_action :set_currency, :set_current_store, only: [:new, :create]
-  after_action :set_return_to, only: [:index]
 
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
 


### PR DESCRIPTION
…sController

which doesn't inherit from ResourceController

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized return URL storage logic for admin index actions. The functionality remains unchanged; return URL storage is now handled at a higher level in the admin controller hierarchy for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->