### PR TITLE
Fix: ensure selected reimbursement type is correctly set in the form

### DIFF
--- a/admin/app/views/spree/admin/reimbursement_types/_form.html.erb
+++ b/admin/app/views/spree/admin/reimbursement_types/_form.html.erb
@@ -7,6 +7,7 @@
                 Spree::ReimbursementType::KINDS.map do |kind|
                   [kind.demodulize.titleize, kind]
                 end,
+                f.object.type
               ),
               { include_blank: false, label: Spree.t(:type), autocomplete: true } %>
 


### PR DESCRIPTION
Previously the form didnt shown the value of the type as selected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preselects the current reimbursement type in the admin reimbursement type form.
> 
> - **Admin UI**:
>   - Update `admin/app/views/spree/admin/reimbursement_types/_form.html.erb` to pass `f.object.type` as the selected value to `options_for_select` for `spree_select :type`, ensuring the current type is shown as selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c113bad35f42fb25a736b4c99014552d3e52a749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the reimbursement type selection form in the admin interface to properly display and allow selection of the current reimbursement type as an available option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->