### PR TITLE
Include `sprockets-rails` when creating dummy app via common rake

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -30,6 +30,7 @@ namespace :common do
     Spree::DummyGenerator.start dummy_app_args
 
     unless skip_javascript
+      system('bundle add sprockets-rails') # we need this until we will remove bootstrap/popper_js gems
       system('bundle exec rails importmap:install turbo:install stimulus:install')
     end
 


### PR DESCRIPTION
We need this until we will remove bootstrap/popper_js which references `config.assets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test app setup workflow to ensure proper asset handling configuration during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->