### PR TITLE
Add `Spree::LineItem#discounted_price` to calculate the discounted price for the line item

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -82,12 +82,18 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :amount, :subtotal, :discounted_amount, :final_amount, :total, :price,
+    money_methods :amount, :subtotal, :discounted_amount, :final_amount, :total, :price, :discounted_price,
                   :adjustment_total, :additional_tax_total, :promo_total, :included_tax_total,
                   :pre_tax_amount, :shipping_cost, :tax_total, :compare_at_amount
 
     alias single_money display_price
     alias single_display_amount display_price
+
+    def discounted_price
+      return price if quantity.zero?
+
+      price - (promo_total.abs / quantity)
+    end
 
     def amount
       price * quantity

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -563,4 +563,36 @@ describe Spree::LineItem, type: :model do
       expect(line_item.weight_unit).to eq('kg')
     end
   end
+
+  describe '#discounted_price' do
+    subject(:discounted_price) { line_item.discounted_price }
+
+    let(:line_item) { create(:line_item, price: 10, quantity: quantity) }
+    let(:quantity) { 4 }
+    let(:promo_total) { -5 }
+
+    before do
+      line_item.update_column(:promo_total, promo_total)
+    end
+
+    it 'returns the discounted price for the line item' do
+      expect(discounted_price).to eq(8.75)
+    end
+
+    context 'when line item promo_total is zero' do
+      let(:promo_total) { 0 }
+
+      it 'returns the price for the line item' do
+        expect(discounted_price).to eq(10)
+      end
+    end
+
+    context 'when quantity is zero' do
+      let(:quantity) { 0 }
+
+      it 'returns the price for the line item' do
+        expect(discounted_price).to eq(10)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds per-unit discounted_price on line items based on promo_total/quantity, and tests it.
> 
> - **Models (`core/app/models/spree/line_item.rb`)**
>   - **New**: `discounted_price` computes per-unit price after promotional discounts (`price - promo_total.abs / quantity`), defaulting to `price` when `quantity` is zero.
>   - **Money display**: Adds `discounted_price` to `money_methods` for display helpers.
> - **Tests (`core/spec/models/spree/line_item_spec.rb`)**
>   - Add specs for `#discounted_price` covering standard case, zero `promo_total`, and zero `quantity`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cfea0eba5a51bed859cf80b1a805f5571a2ae7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line items now report a discounted price reflecting per-item promotional adjustments; displayed alongside other monetary fields.

* **Tests**
  * Added tests validating discounted price behavior for various quantities and promo adjustments (including zero-quantity and no-promo cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->