### PR TITLE
Fixed: Importing metafields via CSV doesn't work properly for multi-v…

### DIFF
--- a/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -52,16 +52,26 @@ module Spree
         private
 
         def ensure_product_exists
-          product = Spree::Product.new
-          if attributes['slug'].present?
-            existing_product = product_scope.find_by(slug: attributes['slug'].strip.downcase)
-            product = existing_product if existing_product.present?
-          end
+          if options.empty?
+            # For master variants, create or update the product
+            product = Spree::Product.new
+            if attributes['slug'].present?
+              existing_product = product_scope.find_by(slug: attributes['slug'].strip.downcase)
+              product = existing_product if existing_product.present?
+            end
 
-          product = assign_attributes_to_product(product)
-          product.save!
-          handle_metafields(product)
-          product
+            product = assign_attributes_to_product(product)
+            product.save!
+            handle_metafields(product)
+            product
+          else
+            # For non-master variants, only look up the product
+            if attributes['slug'].present?
+              product_scope.find_by!(slug: attributes['slug'].strip.downcase)
+            else
+              raise ActiveRecord::RecordNotFound, 'Product slug is required for variant rows'
+            end
+          end
         end
 
         def product_scope


### PR DESCRIPTION
…ariant products

It was clearing values, because we've treated empty fields as an indicator to remove metafields after https://github.com/spree/spree/pull/13242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging for product variant imports when required reference information is missing
  * Enhanced variant processing to preserve existing metafields during updates

* **Tests**
  * Expanded test coverage for variant import scenarios, including error cases and metafield preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->