### PR TITLE
Use `create_token_cookie` everywhere to unify order cookie handling i…

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -118,9 +118,18 @@ module Spree
             value: token,
             expires: 90.days.from_now,
             secure: Rails.configuration.force_ssl || Rails.application.config.ssl_options[:secure_cookies],
-            domain: current_store.url_or_custom_domain,
+            domain: cookie_domain_without_port,
             httponly: true
           }
+        end
+
+        def cookie_domain_without_port
+          domain = current_store.url_or_custom_domain
+          return nil if domain.blank?
+
+          # Remove port from domain (e.g., "localhost:3000" -> "localhost")
+          # Cookies don't support port numbers in the domain attribute
+          domain.split(':').first
         end
 
         def last_incomplete_order(includes = {})

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -216,4 +216,11 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
       expect(controller.ip_address).to eq request.remote_ip
     end
   end
+
+  describe '#create_token_cookie' do
+    it 'creates a new token cookie' do
+      controller.send(:create_token_cookie, 'token-123')
+      expect(request.cookie_jar.signed[:token]).to eq 'token-123'
+    end
+  end
 end

--- a/storefront/app/controllers/spree/checkout_controller.rb
+++ b/storefront/app/controllers/spree/checkout_controller.rb
@@ -182,7 +182,7 @@ module Spree
             end
 
             reset_session
-            cookies.permanent.signed[:token] = @order.token
+            create_token_cookie(@order.token)
 
             redirect_to spree.checkout_path(@order.token)
           else
@@ -204,7 +204,7 @@ module Spree
     end
 
     def allow_access_to_complete_order_with_new_user?
-      cookies_order_token = cookies.permanent.signed[:token]
+      cookies_order_token = cookies.signed[:token]
 
       @order.completed? && @order.signup_for_an_account? && @order.user_id.present? && cookies_order_token.present? && cookies_order_token == @order.token
     end

--- a/storefront/app/controllers/spree/line_items_controller.rb
+++ b/storefront/app/controllers/spree/line_items_controller.rb
@@ -15,7 +15,7 @@ module Spree
       @quantity = params[:quantity].to_i || 1
       options   = params[:options] || {}
 
-      cookies.permanent.signed[:token] = { value: @order.token, domain: current_store.url_or_custom_domain } if @order.persisted?
+      create_token_cookie(@order.token) if @order.persisted?
 
       result = cart_add_item_service.call(order: @order,
                                           variant: @variant,


### PR DESCRIPTION
…n storefront

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie domain handling for URLs with port numbers (e.g., localhost:3000)
  * Enhanced guest checkout token management for better session handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->