### PR TITLE
Fix `Spree::ShippingRate#free?`

### DIFF
--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -7,9 +7,9 @@ module Spree
 
     money_methods :base_price, :final_price, :tax_amount
 
-    delegate :order, :currency, :free?, :with_free_shipping_promotion?, to: :shipment
-    delegate :name,             to: :shipping_method
-    delegate :code,             to: :shipping_method, prefix: true
+    delegate :order, :currency, :with_free_shipping_promotion?, to: :shipment
+    delegate :name, to: :shipping_method
+    delegate :code, to: :shipping_method, prefix: true
 
     def display_price
       price = display_base_price.to_s
@@ -26,6 +26,10 @@ module Spree
     end
     alias display_cost display_price
     alias_attribute :base_price, :cost
+
+    def free?
+      final_price.zero?
+    end
 
     def tax_amount
       @tax_amount ||= tax_rate&.calculator&.compute_shipping_rate(self) || BigDecimal(0)

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -11,11 +11,11 @@ FactoryBot.define do
   end
 
   factory :shipping_calculator, class: Spree::Calculator::Shipping::FlatRate do
-    after(:create) { |c| c.set_preference(:amount, 10.0) }
+    preferred_amount { 10.0 }
   end
 
   factory :shipping_no_amount_calculator, class: Spree::Calculator::Shipping::FlatRate do
-    after(:create) { |c| c.set_preference(:amount, 0) }
+    preferred_amount { 0 }
   end
 
   factory :flat_rate_calculator, class: Spree::Calculator::FlatRate do

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -78,7 +78,7 @@ describe 'exchanges:charge_unreturned_items' do
       it 'authorizes the order for the full amount of the unreturned items including taxes' do
         expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
         new_order = Spree::Order.last
-        expected_amount = return_item_2.reload.exchange_variant.price + new_order.additional_tax_total + new_order.included_tax_total
+        expected_amount = return_item_2.reload.exchange_variant.price + new_order.additional_tax_total + new_order.included_tax_total + new_order.ship_total
         expect(new_order.total).to eq expected_amount
         payment = new_order.payments.first
         expect(payment.amount).to eq expected_amount

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -227,19 +227,20 @@ module Spree
       end
 
       it 'incorporates refund reimbursements' do
-        # Creates an order w/total 10
+        # Creates an order w/total 20
         reimbursement = create :reimbursement
-        # Set the payment amount to actually be the order total of 10
-        reimbursement.order.payments.first.update_column :amount, 10
-        # Creates a refund of 10
-        create :refund, amount: 10,
-                        payment: reimbursement.order.payments.first,
+        order = reimbursement.order
+        # Set the payment amount to actually be the order total of 20
+        order.payments.first.update_column :amount, order.total
+        # Creates a refund of 20
+        create :refund, amount: order.total,
+                        payment: order.payments.first,
                         reimbursement: reimbursement
         order = reimbursement.order.reload
         # Update the order totals so payment_total goes to 0 reflecting the refund..
         order.update_with_updater!
         # Order Total - (Payment Total + Reimbursed)
-        # 10 - (0 + 10) = 0
+        # 20 - (0 + 20) = 0
         expect(order.outstanding_balance).to eq 0
       end
 

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -211,12 +211,12 @@ describe Spree::ShippingMethod, type: :model do
   end
 
   describe '#display_estimated_price' do
-    it { expect(shipping_method.display_estimated_price).to eq('Flat rate: Free') }
+    it { expect(shipping_method.display_estimated_price).to eq('Flat rate: $10.00') }
 
-    context 'with calculator' do
-      let(:shipping_method) { build(:shipping_method, calculator: create(:shipping_calculator)) }
+    context 'with the free rate' do
+      let(:shipping_method) { build(:free_shipping_method) }
 
-      it { expect(shipping_method.display_estimated_price).to eq('Flat rate: $10.00') }
+      it { expect(shipping_method.display_estimated_price).to eq('Flat rate: Free') }
     end
   end
 end

--- a/core/spec/services/spree/checkout/advance_spec.rb
+++ b/core/spec/services/spree/checkout/advance_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Spree::Checkout::Advance do
   describe '#call' do
     context 'with no specific target state' do
       before do
-        order.update!(total: 19.99, payment_total: 0, shipment_total: 5, item_total: 14.99, completed_at: nil)
-        order.payments.last.update!(amount: 19.99)
+        order.update!(total: 29.99, payment_total: 0, shipment_total: 10.00, item_total: 19.99, completed_at: nil)
+        order.payments.first.update!(amount: 29.99)
         order.reload
 
         Spree::StockItem.where(variant: order.variants).update_all(count_on_hand: 10, backorderable: false)

--- a/storefront/spec/features/checkout_steps_spec.rb
+++ b/storefront/spec/features/checkout_steps_spec.rb
@@ -306,7 +306,7 @@ describe 'Checkout steps (address and delivery)' do
     let!(:promotion) { create(:free_shipping_promotion, code: 'freeshipping') }
     let!(:order) { create(:order_with_line_items, line_items_count: 1, user: user, ship_address: user.ship_address, bill_address: user.ship_address) }
     let!(:shipping_method) do
-      create(:shipping_method, name: 'Shipping Method', code: 'shipping_method', calculator: create(:shipping_calculator))
+      create(:shipping_method, name: 'Shipping Method', code: 'shipping_method', calculator: create(:shipping_calculator, preferred_amount: 15))
     end
     let!(:other_shipping_method) do
       create(
@@ -336,11 +336,11 @@ describe 'Checkout steps (address and delivery)' do
           choose "order_ship_address_id_#{user.shipping_address.id}"
           click_on 'Save and Continue'
 
-          expect(find('#summary-order-total')).to have_content('$19.99')
-
-          page.find("input[data-cost='$10.00']").click
-          wait_for_turbo
           expect(find('#summary-order-total')).to have_content('$29.99')
+
+          page.find("input[data-cost='$15.00']").click
+          wait_for_turbo
+          expect(find('#summary-order-total')).to have_content('$34.99')
 
           page.find("input[data-cost='$20.00']").click
           wait_for_turbo
@@ -358,8 +358,8 @@ describe 'Checkout steps (address and delivery)' do
         choose "order_ship_address_id_#{user.shipping_address.id}"
         click_on 'Save and Continue'
 
-        expect(page).to have_selector("input[data-cost='$0.00'][checked='checked']")
-        expect(page).to have_selector("input[data-cost='$10.00']")
+        expect(page).to have_selector("input[data-cost='$10.00'][checked='checked']")
+        expect(page).to have_selector("input[data-cost='$15.00']")
 
         fill_in 'coupon_code', with: promotion.code
         click_on 'Apply'
@@ -370,7 +370,7 @@ describe 'Checkout steps (address and delivery)' do
           expect(page).to have_content("#{Spree.t(:total)}\nUSD $19.99")
         end
 
-        page.find("input[data-cost='$10.00']").click
+        page.find("input[data-cost='$15.00']").click
 
         within('div.summary-content') do
           expect(page).to have_content('Free')
@@ -398,7 +398,7 @@ describe 'Checkout steps (address and delivery)' do
         expect(page).to have_content('Delivery')
         expect(page).to have_content(Spree::ShippingMethod.first.name)
 
-        page.find("input[data-cost='$10.00']").click
+        page.find("input[data-cost='$15.00']").click
 
         expect(page).to have_content('Payment')
       end
@@ -409,7 +409,7 @@ describe 'Checkout steps (address and delivery)' do
     let(:user) { create(:user_with_addresses) }
     let!(:order) { create(:order_with_line_items, line_items_count: 1, user: user, ship_address: user.ship_address, bill_address: user.ship_address) }
     let!(:shipping_method) do
-      create(:shipping_method, name: 'Shipping Method', code: 'shipping_method', calculator: create(:shipping_calculator))
+      create(:shipping_method, name: 'Shipping Method', code: 'shipping_method', calculator: create(:shipping_calculator, preferred_amount: 15))
     end
 
     before do
@@ -420,13 +420,13 @@ describe 'Checkout steps (address and delivery)' do
       visit "/checkout/#{order.token}"
       choose "order_ship_address_id_#{user.shipping_address.id}"
       click_on 'Save and Continue'
-      page.find("input[data-cost='$10.00']").click
+      page.find("input[data-cost='$15.00']").click
       click_on 'Save and Continue'
 
-      expect(page).to have_content('Shipping Method · $10.00')
+      expect(page).to have_content('Shipping Method · $15.00')
       expect(page).to have_content("Subtotal:\n$19.99")
-      expect(page).to have_content("Shipping:\n$10.00")
-      expect(page).to have_content("Total\nUSD $29.99")
+      expect(page).to have_content("Shipping:\n$15.00")
+      expect(page).to have_content("Total\nUSD $34.99")
 
       uncheck 'Use Shipping Address'
       fill_in_address_form('order_bill_address_attributes_country_id')
@@ -445,15 +445,15 @@ describe 'Checkout steps (address and delivery)' do
         visit "/checkout/#{order.token}"
         choose "order_ship_address_id_#{user.shipping_address.id}"
         click_on 'Save and Continue'
-        page.find("input[data-cost='$10.00']").click
+        page.find("input[data-cost='$15.00']").click
         click_on 'Save and Continue'
 
-        expect(page).to have_content('Shipping Method · $10.00')
-        expect(page).to have_content("Show\norder summary\n$29.99")
+        expect(page).to have_content('Shipping Method · $15.00')
+        expect(page).to have_content("Show\norder summary\n$34.99")
         click_on 'toggle-order-summary'
         expect(page).to have_content("Subtotal:\n$19.99")
-        expect(page).to have_content("Shipping:\n$10.00")
-        expect(page).to have_content("Total\nUSD $29.99")
+        expect(page).to have_content("Shipping:\n$15.00")
+        expect(page).to have_content("Total\nUSD $34.99")
 
         uncheck 'Use Shipping Address'
         fill_in_address_form('order_bill_address_attributes_country_id')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shipping rates now correctly report "Free" when the final price is zero or a free-shipping promotion applies, fixing display/logic around free shipping.

* **Tests**
  * Added and expanded tests for shipping free determination and updated specs to account for shipping totals and revised order/payment values.

* **Chores**
  * Shipping calculator test fixtures updated to set preferred amounts directly; storefront tests adjusted to reflect higher shipping amounts and updated display totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->