### PR TITLE
Admin: add handy integrations directory links

### DIFF
--- a/admin/app/views/spree/admin/integrations/index.html.erb
+++ b/admin/app/views/spree/admin/integrations/index.html.erb
@@ -14,16 +14,28 @@
       <%= Spree.t('admin.integrations.page_subtitle') %>
     </div>
 
-    <% grouped_available_store_integrations.each do |group, integrations| %>
-      <% if group.present? %>
-        <div class="my-2 text-muted font-weight-light text-uppercase"><%= Spree.t(group) %></div>
+    <% if grouped_available_store_integrations.any? %>
+      <% grouped_available_store_integrations.each do |group, integrations| %>
+        <% if group.present? %>
+          <div class="my-2 text-muted font-weight-light text-uppercase"><%= Spree.t(group) %></div>
+        <% end %>
+
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 mb-4">
+          <% integrations.each do |integration| %>
+            <%= render 'spree/admin/integrations/integration', integration_class: integration %>
+          <% end %>
+        </div>
       <% end %>
 
-      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 mb-4">
-        <% integrations.each do |integration| %>
-          <%= render 'spree/admin/integrations/integration', integration_class: integration %>
-        <% end %>
-      </div>
+      <p class="text-muted text-center my-5">
+        Find more integrations in <%= external_link_to 'Integrations Directory', 'https://spreecommerce.org/docs/integrations/integrations', class: 'text-decoration-none font-weight-bold', target: '_blank' %>
+      </p>
+    <% else %>
+      <p class="text-muted text-center my-5">
+        No integrations installed yet. Find integrations in 
+
+        <%= external_link_to 'Integrations Directory', 'https://spreecommerce.org/docs/integrations/integrations', class: 'text-decoration-none font-weight-bold', target: '_blank' %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/admin/app/views/spree/admin/payment_methods/index.html.erb
+++ b/admin/app/views/spree/admin/payment_methods/index.html.erb
@@ -43,3 +43,7 @@
     </table>
   </div>
 <% end %>
+
+<p class="text-muted text-center my-5">
+  Find more payment methods in <%= external_link_to 'Integrations Directory', 'https://spreecommerce.org/docs/integrations/integrations', class: 'text-decoration-none font-weight-bold', target: '_blank' %>
+</p>

--- a/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
+++ b/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
@@ -29,8 +29,9 @@
         <h6 class="dropdown-header mt-2">
           <%= Spree.t(:support) %>
         </h6>
-        <%= external_link_to Spree.t(:help_center), 'https://spreecommerce.org/docs/user', class: 'dropdown-item justify-content-between', target: '_blank' %>
-        <%= external_link_to Spree.t(:contact_us), 'https://spreecommerce.org/contact/', class: 'dropdown-item justify-content-between', target: '_blank' %>
+        <%= link_to_with_icon 'book',  Spree.t('admin.documentation'), 'https://spreecommerce.org/docs', class: 'dropdown-item', target: '_blank' %>
+        <%= link_to_with_icon 'brand-slack', Spree.t('admin.slack'), 'https://slack.spreecommerce.org/', class: 'dropdown-item', target: '_blank' %>
+        <%= link_to_with_icon 'message', Spree.t(:contact_us), 'https://spreecommerce.org/contact/', class: 'dropdown-item', target: '_blank' %>
       <% end %>
 
       <div class="dropdown-divider"></div>

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -228,8 +228,8 @@ en:
         please_provide_tracking_details: Before marking shipment as shipped please provide tracking details
       shipment_transfer:
         wrong_destination: Wrong destination
-      slack: Slack
       show_json: Show JSON
+      slack: Slack
       stock_transfers:
         add_products_tip: You need to select a destination location first
       store_credit:

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
         back_end: Only on admin panel
         both: On both admin panel & storefront
         front_end: Only on storefront
+      documentation: Documentation
       edit_billing_address: Edit billing address
       edit_contact_information: Edit contact information
       edit_profile: Edit Profile
@@ -227,6 +228,7 @@ en:
         please_provide_tracking_details: Before marking shipment as shipped please provide tracking details
       shipment_transfer:
         wrong_destination: Wrong destination
+      slack: Slack
       show_json: Show JSON
       stock_transfers:
         add_products_tip: You need to select a destination location first


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quick-access links for Documentation, Slack, and Contact in the admin support menu (open in new tab).
  * Added an informational Integrations Directory link on the Payment Methods page.

* **Improvements**
  * Redesigned Integrations page layout with per-group display and a clear fallback message and link when no integrations are installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->