### PR TITLE
Storefront API - Fix line items data in the response after applying a coupon code

### DIFF
--- a/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
+++ b/api/app/controllers/spree/api/v2/storefront/cart_controller.rb
@@ -12,7 +12,6 @@ module Spree
           before_action :load_variant, only: :add_item
           before_action :require_spree_current_user, only: :associate
 
-
           def create
             spree_authorize! :create, Spree::Order
 
@@ -104,6 +103,7 @@ module Spree
             result = coupon_handler.new(spree_current_order).apply
 
             if result.error.blank?
+              spree_current_order.reload
               render_serialized_payload { serialized_current_order }
             else
               render_error_payload(result.error)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where applying a coupon code didn't reflect the latest order totals. Orders now properly refresh after successful coupon application to display correct pricing information.

* **Tests**
  * Added test coverage for coupon codes with item-level discounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->