### PR TITLE
Fixed isntalling Spree on WSL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -173,6 +173,20 @@ detect_os() {
 get_app_name() {
     print_step "Setting up your Spree application..."
 
+    # Check if we're in WSL and in a Windows mount point
+    if [ "$OS" = "linux" ] && [[ $(pwd) == /mnt/* ]]; then
+        print_warning "You are currently in a Windows directory ($(pwd))"
+        print_warning "Rails requires Unix file permissions which Windows filesystems don't support."
+        echo
+        print_info "Changing to your Linux home directory: $HOME"
+        cd "$HOME" || {
+            print_error "Failed to change to home directory"
+            exit 1
+        }
+        print_success "Now in: $(pwd)"
+        echo
+    fi
+
     # Use default app name if auto-accept is enabled and no app name provided
     if [ "$AUTO_ACCEPT" = true ] && [[ -z "$APP_NAME" ]]; then
         APP_NAME="spree"


### PR DESCRIPTION
Automatically switch to home directory when trying to launch the installer on windows filesystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installation script robustness for Windows Subsystem for Linux environments by detecting Windows mount directories and providing warnings about potential filesystem permission issues.
  * Improved installation process by automatically switching to the user's Linux home directory when running from unsupported Windows mounts, with error handling if the directory change fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->