### PR TITLE
Fix: nullify posts after destroying post category

### DIFF
--- a/core/app/models/spree/post.rb
+++ b/core/app/models/spree/post.rb
@@ -39,8 +39,8 @@ module Spree
     # Associations
     #
     belongs_to :author, class_name: Spree.admin_user_class.to_s, optional: true
-    belongs_to :store, class_name: 'Spree::Store'
-    belongs_to :post_category, class_name: 'Spree::PostCategory', optional: true
+    belongs_to :store, class_name: 'Spree::Store', inverse_of: :posts
+    belongs_to :post_category, class_name: 'Spree::PostCategory', optional: true, touch: true, inverse_of: :posts
     alias category post_category
 
     #

--- a/core/app/models/spree/post_category.rb
+++ b/core/app/models/spree/post_category.rb
@@ -9,8 +9,8 @@ module Spree
     #
     # Associations
     #
-    belongs_to :store, class_name: 'Spree::Store'
-    has_many :posts, class_name: 'Spree::Post'
+    belongs_to :store, class_name: 'Spree::Store', inverse_of: :post_categories
+    has_many :posts, class_name: 'Spree::Post', dependent: :nullify, inverse_of: :post_category
 
     #
     # Validations
@@ -18,7 +18,15 @@ module Spree
     validates :title, :store, presence: true
     validates :slug, presence: true, uniqueness: { scope: :store_id }
 
+    #
+    # ActionText
+    #
     has_rich_text :description
+
+    #
+    # Ransack
+    #
+    self.whitelisted_ransackable_attributes = %w[title slug]
 
     def should_generate_new_friendly_id?
       slug.blank? || title_changed?

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -106,8 +106,8 @@ module Spree
     has_many :custom_domains, class_name: 'Spree::CustomDomain', dependent: :destroy
     has_one :default_custom_domain, -> { where(default: true) }, class_name: 'Spree::CustomDomain'
 
-    has_many :posts, class_name: 'Spree::Post'
-    has_many :post_categories, class_name: 'Spree::PostCategory'
+    has_many :posts, class_name: 'Spree::Post', dependent: :destroy, inverse_of: :store
+    has_many :post_categories, class_name: 'Spree::PostCategory', dependent: :destroy, inverse_of: :store
 
     has_many :integrations, class_name: 'Spree::Integration'
 

--- a/core/spec/models/spree/post_category_spec.rb
+++ b/core/spec/models/spree/post_category_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Spree::PostCategory, type: :model do
+  let(:post_category) { build(:post_category) }
+
+  context 'Associations' do
+    describe 'posts' do
+      it 'has many posts' do
+        post1 = create(:post, post_category: post_category)
+        post2 = create(:post, post_category: post_category)
+
+        expect(post_category.posts).to include(post1, post2)
+      end
+
+      it 'nullifies posts when destroyed' do
+        post = create(:post, post_category: post_category)
+
+        post_category.destroy
+        post.reload
+
+        expect(post.post_category).to be_nil
+      end
+    end
+  end
+
+  describe 'FriendlyId' do
+    before do
+      post_category.save!
+    end
+
+    describe '#should_generate_new_friendly_id?' do
+      it 'returns true when slug is blank' do
+        post_category.slug = nil
+        expect(post_category.should_generate_new_friendly_id?).to be true
+      end
+
+      it 'returns true when title has changed' do
+        post_category.title = 'New Title'
+        expect(post_category.should_generate_new_friendly_id?).to be true
+      end
+
+      it 'returns false when slug is present and title unchanged' do
+        expect(post_category.should_generate_new_friendly_id?).to be false
+      end
+    end
+
+    describe '#slug_candidates' do
+      it 'returns correct slug candidates' do
+        expected_candidates = [
+          :title,
+          [:title, :id]
+        ]
+        expect(post_category.slug_candidates).to eq(expected_candidates)
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich text editing support added for post category descriptions with enhanced formatting options.

* **Improvements**
  * Strengthened data consistency and relationship integrity across stores, posts, and post categories.
  * Enhanced searchability and filtering capabilities for post categories by title and slug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->