### PR TITLE
Refactor/core/check completed orders use spree admin

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -160,7 +160,7 @@ module Spree
     private
 
     def check_completed_orders
-      raise Spree::Core::DestroyWithOrdersError if !has_spree_role?(Spree::Role::ADMIN_ROLE) && orders.complete.present?
+      raise Spree::Core::DestroyWithOrdersError if !spree_admin? && orders.complete.present?
     end
 
     def clone_billing_address


### PR DESCRIPTION
### Description:
Replace `has_spree_role?(admin)` with `spree_admin?` in `Spree::UserMethods#check_completed_orders` to allow downstream role overrides while preserving OSS behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace admin role check with `spree_admin?` when preventing deletion of users with completed orders.
> 
> - **Core**:
>   - Update `Spree::UserMethods#check_completed_orders` to use `spree_admin?` instead of `has_spree_role?(Spree::Role::ADMIN_ROLE)` for the admin check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 443e3753e3b1358cca7e635f31ecc4a057f5d826. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization validation for user account management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->