### PR TITLE
Handle manually captured payments

### DIFF
--- a/admin/app/views/spree/admin/payments/_payment.html.erb
+++ b/admin/app/views/spree/admin/payments/_payment.html.erb
@@ -48,7 +48,7 @@
   <div class="card-body">
     <% if payment.gateway_processing_error_messages.any? %>
       <div class="alert alert-danger inline-block">
-        <strong><%= Spree.t(:payments_gateway_processing_errors, payment_method_name: payment_method_name(payment)).html_safe %>:</strong>
+        <strong><%= Spree.t(:payments_gateway_processing_errors, payment_method_name: payment.payment_method&.name) %>:</strong>
         <%= payment.gateway_processing_error_messages.join(', ') %>
       </div>
     <% end %>

--- a/admin/app/views/spree/admin/payments/_payment.html.erb
+++ b/admin/app/views/spree/admin/payments/_payment.html.erb
@@ -46,6 +46,13 @@
     <% end %>
   </div>
   <div class="card-body">
+    <% if payment.gateway_processing_error_messages.any? %>
+      <div class="alert alert-danger inline-block">
+        <strong><%= Spree.t(:payments_gateway_processing_errors, payment_method_name: payment_method_name(payment)).html_safe %>:</strong>
+        <%= payment.gateway_processing_error_messages.join(', ') %>
+      </div>
+    <% end %>
+
     <div class="d-flex">
       <div class="w-50">
         <p class="mb-1"><%= Spree.t(:amount) %>:</p>

--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -60,7 +60,7 @@ module Spree
     end
 
     def void(_response_code, _credit_card, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: 'void-12345')
     end
 
     def cancel(_response_code, _payment = nil)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -910,7 +910,7 @@ module Spree
         payments.completed.store_credits.each(&:void!)
       else
         payments.completed.each(&:cancel!)
-        payments.incomplete.each(&:void_transaction!)
+        payments.incomplete.not_store_credits.each(&:void_transaction!)
         payments.store_credits.pending.each(&:void!)
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -910,6 +910,7 @@ module Spree
         payments.completed.store_credits.each(&:void!)
       else
         payments.completed.each(&:cancel!)
+        payments.incomplete.each(&:void_transaction!)
         payments.store_credits.pending.each(&:void!)
       end
 

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -44,6 +44,8 @@ module Spree
         def process_payments_with(method)
           # Don't run if there is nothing to pay.
           return if payment_total >= total
+          # Don't run if there are authorized payments
+          return if pending_payments.any? && unprocessed_payments.empty?
           # Prevent orders from transitioning to complete without a successfully processed payment.
           raise Core::GatewayError, Spree.t(:no_payment_found) if unprocessed_payments.empty?
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -255,6 +255,26 @@ module Spree
       payment_method&.source_required?
     end
 
+    def add_gateway_processing_error(error_message)
+      if has_metafield?('gateway.processing_errors')
+        errors = JSON.parse(get_metafield('gateway.processing_errors').value)
+        errors << { message: error_message }
+
+        set_metafield('gateway.processing_errors', errors.to_json)
+      else
+        set_metafield('gateway.processing_errors', [{ message: error_message }].to_json)
+      end
+    end
+
+    def gateway_processing_error_messages
+      @gateway_processing_error_messages ||= begin
+        errors = JSON.parse(get_metafield('gateway.processing_errors')&.value || '[]')
+        errors.map { |error| error['message'] }
+      rescue JSON::ParserError
+        []
+      end
+    end
+
     private
 
     def set_amount

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -26,6 +26,19 @@ module Spree
         handle_payment_preconditions { process_purchase }
       end
 
+      # Confirms a payment by completing it or pending it depending on the payment method's auto_capture setting
+      # Useful for payments that are authorized/captured with SDK/Drop-in elements
+      def confirm!
+        started_processing! if checkout?
+
+        if payment_method&.auto_capture? && can_complete?
+          complete!
+          capture_events.create!(amount: amount)
+        elsif can_pend?
+          pend!
+        end
+      end
+
       # Takes the amount in cents to capture.
       # Can be used to capture partial amounts of a payment, and will create
       # a new pending payment record for the remaining amount to capture later.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1622,6 +1622,7 @@ en:
     payment_updated: Payment Updated
     payments: Payments
     payments_count: Payments count
+    payments_gateway_processing_errors: "%{payment_method_name} processing errors"
     pending: Pending
     pending_sale: Pending Sale
     percent: Percent

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -121,6 +121,7 @@ describe Spree::Order, type: :model do
 
     context 'resets payment state' do
       let(:payment) { create(:payment, amount: order.total) }
+      let(:incomplete_payment) { create(:payment, state: 'pending') }
 
       before do
         # TODO: This is ugly :(
@@ -131,6 +132,7 @@ describe Spree::Order, type: :model do
         allow(order).to receive_message_chain(:payments, :valid, :empty?).and_return(false)
         allow(order).to receive_message_chain(:payments, :completed).and_return([payment])
         allow(order).to receive_message_chain(:payments, :completed, :includes).and_return([payment])
+        allow(order).to receive_message_chain(:payments, :incomplete, :not_store_credits).and_return([incomplete_payment])
         allow(order).to receive_message_chain(:payments, :last).and_return(payment)
         allow(order).to receive_message_chain(:payments, :store_credits, :pending).and_return([])
       end
@@ -161,8 +163,10 @@ describe Spree::Order, type: :model do
           allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
           allow(order).to receive_message_chain(:payments, :completed).and_return([payment])
           allow(order).to receive_message_chain(:payments, :completed, :includes).and_return([payment])
+          allow(order).to receive_message_chain(:payments, :incomplete, :not_store_credits).and_return([incomplete_payment])
           allow(order).to receive_message_chain(:payments, :last).and_return(payment)
           expect(payment).to receive(:cancel!)
+          expect(incomplete_payment).to receive(:void_transaction!)
           order.cancel!
         end
       end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -654,7 +654,7 @@ describe Spree::Payment, type: :model do
           # Change it to something different
           payment.response_code = 'abc'
           payment.void_transaction!
-          expect(payment.response_code).to eq('12345')
+          expect(payment.response_code).to eq('void-12345')
         end
       end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -1254,4 +1254,41 @@ describe Spree::Payment, type: :model do
       end
     end
   end
+
+  describe '#add_gateway_processing_error' do
+    subject { payment.add_gateway_processing_error('Insufficient balance on payment') }
+
+    it 'adds a gateway processing error' do
+      subject
+      expect(payment.get_metafield('gateway.processing_errors').value).to eq([{ message: 'Insufficient balance on payment' }].to_json)
+    end
+
+    context 'when the metafield already exists' do
+      before do
+        payment.set_metafield('gateway.processing_errors', [{ message: 'Gateway processing error' }].to_json)
+      end
+
+      it 'adds a gateway processing error' do
+        subject
+
+        expect(payment.get_metafield('gateway.processing_errors').value).to eq(
+          [
+            { message: 'Gateway processing error' },
+            { message: 'Insufficient balance on payment' }
+          ].to_json
+        )
+      end
+    end
+  end
+
+  describe '#gateway_processing_error_messages' do
+    before do
+      payment.add_gateway_processing_error('Gateway processing error')
+      payment.add_gateway_processing_error('Another gateway processing error')
+    end
+
+    it 'returns the gateway processing error messages' do
+      expect(payment.gateway_processing_error_messages).to eq(['Gateway processing error', 'Another gateway processing error'])
+    end
+  end
 end

--- a/storefront/lib/generators/spree/storefront/install/templates/application.css
+++ b/storefront/lib/generators/spree/storefront/install/templates/application.css
@@ -604,6 +604,7 @@ textarea.text-input {
 .badge,
 .badge-success,
 .badge-paid,
+.badge-balance_due,
 .badge-warning,
 .badge-canceled,
 .badge-failed,
@@ -630,6 +631,7 @@ textarea.text-input {
 .badge:last-child,
 .badge-success:last-child,
 .badge-paid:last-child,
+.badge-balance_due:last-child,
 .badge-warning:last-child,
 .badge-canceled:last-child,
 .badge-failed:last-child,
@@ -656,6 +658,7 @@ textarea.text-input {
 }
 
 .badge,
+.badge-balance_due,
 .badge-refunded,
 .badge-pending,
 .badge-void,


### PR DESCRIPTION
This PR allows to complete an order/checkout with payment methods that set `auto_capture` to `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storefront: added "balance due" badge styling.
  * Admin: payment view shows gateway processing error alerts.

* **Improvements**
  * Order cancellation now voids incomplete payments as well as completed ones.
  * Payment processing skips already-pending payments and adds a confirm flow to handle auto-capture vs manual pending.
  * Payments persist and expose gateway processing error messages.

* **Bug Fixes**
  * Void responses consistently include a "void-" prefix in response codes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->