### PR TITLE
Add `spree_file_field` form builder method

### DIFF
--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -30,7 +30,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.text_field(@object_name, method, objectify_options(options)) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -44,7 +44,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.number_field(@object_name, method, objectify_options(options)) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -58,7 +58,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.email_field(@object_name, method, objectify_options(options)) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -72,7 +72,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.date_field(@object_name, method, objectify_options(options)) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -86,7 +86,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.datetime_field(@object_name, method, objectify_options(options)) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -107,7 +107,7 @@ module Spree
 
           @template.label(@object_name, method, get_label(method, options)) +
             @template.text_area(@object_name, method, objectify_options(options)) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -122,7 +122,7 @@ module Spree
             @template.content_tag(:div, class: 'trix-container') do
               @template.rich_text_area(@object_name, method, objectify_options(options))
             end +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -147,7 +147,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.select(@object_name, method, choices, objectify_options(options), html_options, &block) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -173,7 +173,7 @@ module Spree
         @template.content_tag(:div, class: 'form-group') do
           @template.label(@object_name, method, get_label(method, options)) +
             @template.collection_select(@object_name, method, collection, value_method, text_method, objectify_options(options), html_options) +
-            @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+            @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
 
@@ -187,7 +187,7 @@ module Spree
           @template.content_tag(:div, class: 'custom-control custom-checkbox') do
             @template.check_box(@object_name, method, objectify_options(options.merge(class: 'custom-control-input'))) +
             @template.label(@object_name, method, get_label(method, options), class: 'custom-control-label')
-          end + @template.error_message_on(@object_name, method) + field_help(method, options.merge!(class: 'form-text mt-2 ml-4'))
+          end + @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge!(class: 'form-text mt-2 ml-4'))
         end
       end
 
@@ -204,9 +204,31 @@ module Spree
           @template.content_tag(:div, class: 'custom-control custom-radio') do
             @template.radio_button(@object_name, method, tag_value, objectify_options(options.merge(class: 'custom-control-input'))) +
               @template.label(@object_name, method, get_label(method, options), class: 'custom-control-label', for: options[:id])
-          end + @template.error_message_on(@object_name, method) + field_help(method, options.merge(class: 'form-text mt-2'))
+          end + @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
         end
       end
+
+      # Create a direct file upload field with Spree form styling
+      #
+      # @param method [Symbol] the field name
+      # @param options [Hash] field options
+      # @option options [Boolean] :crop whether to crop the image
+      # @option options [Boolean] :auto_submit whether to auto-submit the form when the file is uploaded
+      # @option options [Boolean] :can_delete whether to show the delete button
+      # @option options [Boolean] :inline whether to display the uploader inline
+      # @option options [Integer] :height the height of the uploader
+      # @option options [Integer] :width the width of the uploader
+      # @option options [Array] :allowed_file_types the allowed file types, defaults to image types
+      # @return [String] HTML string containing the complete form group with direct file upload field
+      def spree_file_field(method, options = {})
+        @template.content_tag(:div, class: 'form-group') do
+          @template.label(@object_name, method, get_label(method, options)) +
+          @template.render('active_storage/upload_form', form: self, field_name: method, **options) +
+          @template.error_message_on(@object_name, method) + spree_field_help(method, options.merge(class: 'form-text mt-2'))
+        end
+      end
+
+      private
 
       # Generate help text for a field
       #
@@ -214,12 +236,10 @@ module Spree
       # @param options [Hash] field options
       # @option options [String] :help help text to display
       # @return [String] HTML string containing the help text or empty string
-      def field_help(_method, options = {})
+      def spree_field_help(_method, options = {})
         options[:class] ||= 'form-text mt-2'
         @template.content_tag(:span, options[:help], class: options[:class])
       end
-
-      private
 
       # Generate the label for a field with required indicator and help bubble
       #

--- a/admin/app/views/spree/admin/assets/edit.html.erb
+++ b/admin/app/views/spree/admin/assets/edit.html.erb
@@ -2,7 +2,7 @@
   <%= dialog_header(Spree.t(:edit) + ' ' + Spree.t(:image)) %>
   <%= form_with model: @asset, url: spree.admin_asset_path(@asset), method: :put, scope: :asset do |f| %>
     <div class="dialog-body pb-0" data-turbo-permanent id="asset-<%= @asset.key.parameterize %>">
-      <%= render 'active_storage/upload_form', form: f, field_name: :attachment, width: 200, height: 200, can_delete: false %>
+      <%= f.spree_file_field :attachment, width: 200, height: 200, can_delete: false, label: Spree.t(:image) %>
     </div>
     <div class="dialog-body" style="min-height: 200px">
       <%= f.spree_text_area :alt, label: Spree.t(:alt_text), rows: 4 %>

--- a/admin/app/views/spree/admin/page_blocks/forms/_image.html.erb
+++ b/admin/app/views/spree/admin/page_blocks/forms/_image.html.erb
@@ -1,8 +1,5 @@
-<%= render 'active_storage/upload_form', form: f, field_name: :asset, width: 512, height: 512, auto_submit: true %>
-<div class="mt-2 form-group">
-  <%= f.label :preferred_image_alt, Spree.t(:alt_text) %>
-  <%= f.text_field :preferred_image_alt, data: { action: 'auto-submit#submit' }, class: 'form-control' %>
-</div>
+<%= f.spree_file_field :asset, width: 512, height: 512, auto_submit: true %>
+<%= f.spree_text_field :preferred_image_alt, label: Spree.t(:alt_text), data: { action: 'auto-submit#submit' } %>
 <% content_for(:design_tab) do %>
   <%= render 'spree/admin/page_builder/labeled_range_input',
     f: f, field: :preferred_height, min: 1, max: 1024, unit: 'px', _label: 'Max image height on desktop'

--- a/admin/app/views/spree/admin/page_sections/forms/_header.html.erb
+++ b/admin/app/views/spree/admin/page_sections/forms/_header.html.erb
@@ -1,5 +1,3 @@
-<label>Logo image</label>
-
 <%= render 'spree/admin/shared/page_section_logo', f: f %>
 
 <p class="text-muted small mt-2">

--- a/admin/app/views/spree/admin/posts/_form.html.erb
+++ b/admin/app/views/spree/admin/posts/_form.html.erb
@@ -25,10 +25,7 @@
   <div class="col-lg-4">
     <div class="card mb-4">
       <div class="card-body">
-        <div class="form-group">
-          <%= f.label :image, Spree.t(:featured_image) %>
-          <%= render 'active_storage/upload_form', form: f, field_name: :image, width: 1200, height: 600, crop: true, css: 'flex-col' %>
-        </div>
+        <%= f.spree_file_field :image, width: 1200, height: 600, crop: true, css: 'flex-col', label: Spree.t(:featured_image) %>
       </div>
     </div>
 

--- a/admin/app/views/spree/admin/profile/edit.html.erb
+++ b/admin/app/views/spree/admin/profile/edit.html.erb
@@ -6,72 +6,20 @@
   <%= turbo_save_button_tag Spree.t('actions.update'), form: 'edit_user', data: { admin_target: 'save' } %>
 <% end %>
 
-<%= form_for @user, url: spree.admin_profile_path, method: :put, as: :user do |f| %>
-  <div class="row">
-    <div class="col-lg-6 offset-lg-3">
+<div class="row">
+  <div class="col-lg-6 offset-lg-3">
+    <%= form_for @user, url: spree.admin_profile_path, method: :put, as: :user do |f| %>
       <div class="card mb-4">
         <div class="card-header">
           <h5 class="card-title"><%= Spree.t('admin.personal_details') %></h5>
         </div>
         <div class="card-body">
-          <div class="form-group mb-4">
-            <%= f.label :email, class: 'form-label' %>
-            <%= f.email_field :email, class: 'form-control', required: true %>
-          </div>
-          <div class="form-group mb-4">
-            <%= f.label :first_name, class: 'form-label' %>
-            <%= f.text_field :first_name, class: 'form-control', required: true %>
-          </div>
-          <div class="form-group mb-4">
-            <%= f.label :last_name, class: 'form-label' %>
-            <%= f.text_field :last_name, class: 'form-control', required: true %>
-          </div>
-          <div class="form-group mb-0">
-            <div>
-              <%= f.label :avatar, class: 'form-label' %>
-            </div>
-            <%= render 'active_storage/upload_form', form: f, field_name: :avatar, crop: true %>
-          </div>
+          <%= f.spree_email_field :email, required: true %>
+          <%= f.spree_text_field :first_name, required: true %>
+          <%= f.spree_text_field :last_name, required: true %>
+          <%= f.spree_file_field :avatar, crop: true %>
         </div>
       </div>
-
-      <div class="card">
-        <div class="card-header">
-          <h5 class="card-title"><%= Spree.t('admin.notifications') %></h5>
-        </div>
-        <div class="card-body">
-          <% if @user.respond_to?(:deliver_invitation_accepted_email) %>
-            <div class="custom-control custom-switch mb-3">
-              <%= f.check_box :deliver_invitation_accepted_email, class: 'custom-control-input' %>
-              <%= f.label :deliver_invitation_accepted_email, 'Someone accepted your team invitation', class: 'custom-control-label' %>
-            </div>
-          <% end %>
-
-          <% if @user.respond_to?(:deliver_vendor_new_order_email) %>
-            <hr />
-            <div class="custom-control custom-switch mb-3">
-              <%= f.check_box :deliver_vendor_new_order_email, class: 'custom-control-input' %>
-              <%= f.label :deliver_vendor_new_order_email, 'New order notification', class: 'custom-control-label' %>
-            </div>
-          <% end %>
-
-          <% if @user.respond_to?(:deliver_vendor_onboarding_started_email) %>
-            <hr />
-            <div class="custom-control custom-switch mb-3">
-              <%= f.check_box :deliver_vendor_onboarding_started_email, class: 'custom-control-input' %>
-              <%= f.label :deliver_vendor_onboarding_started_email, 'Vendor started onboarding', class: 'custom-control-label' %>
-            </div>
-            <div class="custom-control custom-switch mb-3">
-              <%= f.check_box :deliver_vendor_onboarding_completed_email, class: 'custom-control-input' %>
-              <%= f.label :deliver_vendor_onboarding_completed_email, 'Vendor completed onboarding', class: 'custom-control-label' %>
-            </div>
-            <div class="custom-control custom-switch mb-3">
-              <%= f.check_box :deliver_vendor_approved_email, class: 'custom-control-input' %>
-              <%= f.label :deliver_vendor_approved_email, 'Vendor has been approved', class: 'custom-control-label' %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/admin/app/views/spree/admin/shared/_page_section_image.html.erb
+++ b/admin/app/views/spree/admin/shared/_page_section_image.html.erb
@@ -1,7 +1,4 @@
-<%= render 'active_storage/upload_form', form: f, field_name: :asset, width: 400, height: 128, auto_submit: true %>
+<%= f.spree_file_field :asset, width: 400, height: 128, auto_submit: true, label: Spree.t(:image) %>
 <% if f.object.has_preference?(:image_alt) %>
-  <div class="form-group">
-    <%= f.label :preferred_image_alt, Spree.t(:alt_text) %>
-    <%= f.text_field :preferred_image_alt, data: { action: 'auto-submit#submit' }, class: 'form-control' %>
-  </div>
+  <%= f.spree_text_field :preferred_image_alt, label: Spree.t(:alt_text), data: { action: 'auto-submit#submit' } %>
 <% end %>

--- a/admin/app/views/spree/admin/shared/_page_section_logo.html.erb
+++ b/admin/app/views/spree/admin/shared/_page_section_logo.html.erb
@@ -1,1 +1,1 @@
-<%= render 'active_storage/upload_form', form: f, field_name: :asset, width: 400, height: 128, auto_submit: true %>
+<%= f.spree_file_field :asset, width: 400, height: 128, auto_submit: true, label: Spree.t(:logo) %>

--- a/admin/app/views/spree/admin/storefront/edit.html.erb
+++ b/admin/app/views/spree/admin/storefront/edit.html.erb
@@ -63,21 +63,9 @@
           </h5>
         </div>
         <div class="card-body">
-          <div class="form-group">
-            <%= f.label :favicon_image do %>
-              Favicon image
-              <%= help_bubble("A favicon is a small image that appears in the tab of your web browser when you visit a website. It is usually a tiny square or rectangle with a unique design or logo that represents the website") %>
-            <% end %>
-            <%= render 'active_storage/upload_form', form: f, field_name: :favicon_image, width: 120, height: 120, crop: true %>
-          </div>
+          <%= f.spree_file_field :favicon_image, width: 120, height: 120, crop: true, label: 'Favicon image', help_bubble: "A favicon is a small image that appears in the tab of your web browser when you visit a website. It is usually a tiny square or rectangle with a unique design or logo that represents the website" %>
 
-          <div class="form-group mb-0">
-            <%= f.label :social_image do %>
-              Preview image
-              <%= help_bubble("This image will be used when your store is shared on social media or in search engines.") %>
-            <% end %>
-            <%= render 'active_storage/upload_form', form: f, field_name: :social_image, width: 1200, height: 630, crop: true %>
-          </div>
+          <%= f.spree_file_field :social_image, width: 1200, height: 630, crop: true, label: 'Preview image', help_bubble: "This image will be used when your store is shared on social media or in search engines." %>
         </div>
       </div>
 

--- a/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -12,14 +12,8 @@
       <%= Spree.t(:store_name_help) %>
     </p>
     <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
-    
-    <div class="form-group mb-0">
-      <%= f.label :logo do %>
-        <%= Spree.t(:logo) %>
-        <%= help_bubble("Used in the admin dashboard") %>
-      <% end %>
-      <%= render 'active_storage/upload_form', form: f, field_name: :logo, width: 240, height: 240, crop: true %>
-    </div>
+
+    <%= f.spree_file_field :logo, width: 240, height: 240, crop: true, help_bubble: "Used in the admin dashboard" %>
   </div>
 </div>
 

--- a/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -33,7 +33,7 @@
   </div>
   <div class="card-body">
     <p class="text-muted">This logo is included in all email notifications such as order confirmation</p>
-    <%= render 'active_storage/upload_form', form: f, field_name: :mailer_logo, width: 204, height: 104 %>
+    <%= f.spree_file_field :mailer_logo, width: 204, height: 104 %>
     <p class="form-text mb-0 mt-2">
       We recommend images with a transparent background.
       <br />

--- a/admin/app/views/spree/admin/taxons/_form.html.erb
+++ b/admin/app/views/spree/admin/taxons/_form.html.erb
@@ -81,17 +81,10 @@
         <h5 class="card-title"><%= Spree.t(:images) %></h5>
       </div>
       <div class="card-body">
-        <%= f.label :image, Spree.t(:image) %>
-        <%= render 'active_storage/upload_form', form: f, field_name: :image, width: 1920, height: 1080 %>
-        <%= f.error_message_on :image %>
+        <%= f.spree_file_field :image, width: 1920, height: 1080 %>
       </div>
       <div class="card-body">
-        <%= f.label :square_image, Spree.t(:square_image) %>
-        <p class="text-muted form-text">
-          Used for the featured image on the homepage.
-        </p>
-        <%= render 'active_storage/upload_form', form: f, field_name: :square_image, width: 400, height: 400, crop: true %>
-        <%= f.error_message_on :square_image %>
+        <%= f.spree_file_field :square_image, width: 400, height: 400, crop: true, help: "Used for the featured image on the homepage." %>
       </div>
     </div>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -200,6 +200,7 @@ en:
       spree/taxonomy:
         name: Name
       spree/user:
+        avatar: Avatar
         email: Email
         password: Password
         password_confirmation: Password Confirmation


### PR DESCRIPTION
To replace using active storage uploader partial directly + clean up the forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized file upload field component with consistent styling and options across admin image and file uploads

* **Refactor**
  * Consolidated file upload form rendering across admin sections for improved consistency
  * Streamlined admin form layouts to use unified helper methods

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->