### PR TITLE
Replace `Product#brand` with `Product#brand_taxon`

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -255,8 +255,6 @@ module Spree
     delegate :display_amount, :display_price, :has_default_price?, :track_inventory?,
              :display_compare_at_price, :images, to: :default_variant
 
-    delegate :name, to: :brand, prefix: true, allow_nil: true
-
     alias master_images images
 
     state_machine :status, initial: :draft do
@@ -551,6 +549,13 @@ module Spree
     end
 
     def brand
+      Spree::Deprecation.warn('Spree::Product#brand is deprecated and will be removed in Spree 6. Please use Spree::Product#brand_taxon instead.')
+      brand_taxon
+    end
+
+    # Returns the brand taxon for the product
+    # @return [Spree::Taxon]
+    def brand_taxon
       @brand ||= if Spree.use_translations?
                    taxons.joins(:taxonomy).
                      join_translation_table(Taxonomy).
@@ -564,7 +569,20 @@ module Spree
                  end
     end
 
+    # Returns the brand name for the product
+    # @return [String]
+    def brand_name
+      brand_taxon&.name
+    end
+
     def category
+      Spree::Deprecation.warn('Spree::Product#category is deprecated and will be removed in Spree 6. Please use Spree::Product#category_taxon instead.')
+      category_taxon
+    end
+
+    # Returns the category taxon for the product
+    # @return [Spree::Taxon]
+    def category_taxon
       @category ||= if Spree.use_translations?
                       taxons.joins(:taxonomy).
                         join_translation_table(Taxonomy).
@@ -580,7 +598,7 @@ module Spree
     end
 
     def main_taxon
-      category || taxons.first
+      category_taxon || taxons.first
     end
 
     def taxons_for_store(store)

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -694,21 +694,21 @@ describe Spree::Product, type: :model do
     end
   end
 
-  describe '#brand' do
+  describe '#brand_taxon' do
     let(:taxonomy) { store.taxonomies.find_by(name: Spree.t(:taxonomy_brands_name)) }
     let(:product) { create(:product, taxons: [taxonomy.taxons.first], stores: [store]) }
 
     it 'fetches Brand Taxon' do
-      expect(product.brand).to eql(taxonomy.taxons.first)
+      expect(product.brand_taxon).to eql(taxonomy.taxons.first)
     end
   end
 
-  describe '#category' do
+  describe '#category_taxon' do
     let(:taxonomy) { store.taxonomies.find_by(name: Spree.t(:taxonomy_categories_name)) }
     let(:product) { create(:product, taxons: [taxonomy.taxons.first], stores: [store]) }
 
     it 'fetches Category Taxon' do
-      expect(product.category).to eql(taxonomy.taxons.first)
+      expect(product.category_taxon).to eql(taxonomy.taxons.first)
     end
   end
 

--- a/storefront/app/helpers/spree/products_helper.rb
+++ b/storefront/app/helpers/spree/products_helper.rb
@@ -26,12 +26,6 @@ module Spree
       (Time.current - product.activated_at.in_time_zone(current_store.preferred_timezone)).seconds.in_weeks.to_i.abs
     end
 
-    def brand_name(product)
-      Spree::Deprecation.warn('brand_name is deprecated and will be removed in Spree 5.2. Please use `product.brand_name` instead.')
-
-      product.brand&.name || product.try(:vendor)&.display_name
-    end
-
     def product_not_selected_options(product, selected_variant, options_param_name: :options)
       product.option_types.map do |option_type|
         if product_selected_option_for_option(

--- a/storefront/app/views/themes/default/spree/page_sections/_product_details.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_product_details.html.erb
@@ -46,8 +46,8 @@
                         <%= product.name %>
                       </h1>
                     <% when 'Spree::PageBlocks::Products::Brand' %>
-                      <% if product.brand %>
-                        <%= link_to spree.nested_taxons_path(product.brand), title: product.brand_name do %>
+                      <% if product.brand_taxon %>
+                        <%= link_to spree.nested_taxons_path(product.brand_taxon), title: product.brand_name do %>
                           <h3 class="text-sm lg:mt-0 inline-block mb-1">
                             <%= product.brand_name %>
                           </h3>

--- a/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
@@ -18,7 +18,7 @@
   <% elsif selected_variant %>
     <% if selected_variant.sku.present? %>"sku": <%= selected_variant.sku.to_json.html_safe %>,<% end %>
   <% end %>
-  <% if product.brand %>
+  <% if product.brand_name %>
     "brand": {
       "@type": "Brand",
       "name": <%= product.brand_name.to_json.html_safe %>


### PR DESCRIPTION
and `Product#category` with `Product#category_taxon` to avoid name clashing and be more descriptive what these methods return