### PR TITLE
Docs: fix typo (bellow → below) in developing Spree guide

### DIFF
--- a/docs/developer/contributing/developing-spree.mdx
+++ b/docs/developer/contributing/developing-spree.mdx
@@ -35,7 +35,7 @@ Install gem dependencies:
     bundle install
     ```
 
-Bellow command will setup a Rails application with Spree pre-installed with some data seeded:
+Below command will setup a Rails application with Spree pre-installed with some data seeded:
 
     ```bash
     bin/sandbox.sh


### PR DESCRIPTION
This PR fixes a small spelling error in the developing Spree documentation.

**Changes made**

- Corrected the spelling of `bellow → below`

**Reason**
Improves accuracy and clarity of the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects “Bellow” to “Below” in `docs/developer/contributing/developing-spree.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f59a65d37179f0171f07aac51a2b55d3bb112f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->