### PR TITLE
Fix broken Customization Overview link by updating to Customization Quickstart page

### DIFF
--- a/docs/developer/customization/decorators.mdx
+++ b/docs/developer/customization/decorators.mdx
@@ -437,5 +437,5 @@ end
 ## Related Documentation
 
 - [Extending Core Models Tutorial](/developer/tutorial/extending-models) - Step-by-step guide to connecting custom models with Spree core
-- [Customization Overview](/developer/customization/overview) - General customization patterns
+- [Customization Overview](/developer/customization/quickstart) - General customization patterns
 - [Logic Customization](/developer/customization/logic) - Customizing business logic

--- a/docs/developer/tutorial/extending-models.mdx
+++ b/docs/developer/tutorial/extending-models.mdx
@@ -348,5 +348,5 @@ Spree::PermittedAttributes.product_attributes << :brand_id
 
 - [Model Tutorial](/developer/tutorial/model) - Creating the Brand model
 - [Admin Tutorial](/developer/tutorial/admin) - Building the admin interface
-- [Customization Overview](/developer/customization/overview) - More customization patterns
+- [Customization Overview](/developer/customization/quickstart) - More customization patterns
 - [Products](/developer/core-concepts/products) - Product model documentation


### PR DESCRIPTION
### Summary
The documentation contained a broken link pointing to the "Customization Overview" page. 
The correct page is "Customization Quickstart", so the link has been updated accordingly.

### What Was Changed
- Updated the incorrect / outdated Customization Overview URL
- Ensured the link now correctly opens the Customization Quickstart page
- Verified navigation and resolved the broken link issue

### Why This Matters
The previous link resulted in a 404 and caused confusion for users referring to the 
customization documentation. This fix improves the documentation accuracy and usability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken “Customization Overview” links by pointing to “Customization Quickstart” in two documentation pages.
> 
> - **Documentation**:
>   - Update related docs link from `.../customization/overview` to `.../customization/quickstart` in:
>     - `docs/developer/customization/decorators.mdx`
>     - `docs/developer/tutorial/extending-models.mdx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b822cebe17e72136bcc61d6c31e9d1de79ad2aac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->