### PR TITLE
Fix (#13320): admin product lookup fails with non-default locale

### DIFF
--- a/admin/app/controllers/spree/admin/products_controller.rb
+++ b/admin/app/controllers/spree/admin/products_controller.rb
@@ -151,7 +151,9 @@ module Spree
       protected
 
       def find_resource
-        current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
+        find_with_fallback_default_locale do
+          current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
+        end
       end
 
       def load_data

--- a/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -498,6 +498,35 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         expect(response).to render_template(:edit)
       end
     end
+
+    context 'with multi-locale' do
+      let!(:product) { create(:product, name: 'Test Product', slug: 'test-product', stores: [store], status: 'active') }
+
+      before do
+        # Add a non-default locale to the store
+        store.update(supported_locales: 'en,da')
+      end
+
+      it 'finds product by slug using locale fallback when viewing in non-default locale' do
+        # Switch to non-default locale (Danish)
+        I18n.with_locale(:da) do
+          # Product only has English slug, should fall back to default locale
+          get :edit, params: { id: 'test-product' }
+
+          expect(response).to render_template(:edit)
+          expect(assigns(:product)).to eq(product)
+        end
+      end
+
+      it 'finds product by ID in any locale' do
+        I18n.with_locale(:da) do
+          get :edit, params: { id: product.id }
+
+          expect(response).to render_template(:edit)
+          expect(assigns(:product)).to eq(product)
+        end
+      end
+    end
   end
 
   describe 'PUT #update' do

--- a/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
 
       before do
         # Add a non-default locale to the store
-        store.update(supported_locales: 'en,da')
+        allow(store).to receive(:supported_locales).and_return('en,da')
       end
 
       it 'finds product by slug using locale fallback when viewing in non-default locale' do


### PR DESCRIPTION
## Summary
Fixes an issue where the admin product lookup fails when the admin user's locale is non-default.

## Root Cause
The admin lookup logic did not apply the default-locale fallback used in the storefront, causing localized lookups to fail when products existed only in the default locale.

## Fix
- Added fallback-to-default-locale handling in admin product lookup.
- Added a test verifying that admin users can access products with non-default locales.

## Testing
- Reproduced the issue locally using locales [en, da].
- Confirmed the fix allows product editing in non-default locale.
- Ran `bundle exec rspec` — all tests passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use default-locale fallback when finding admin products (slug/ID) and add specs for non-default locale access.
> 
> - **Controller**
>   - Update `Spree::Admin::ProductsController#find_resource` to wrap lookup with `find_with_fallback_default_locale { current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id]) }` for locale fallback.
> - **Tests**
>   - Add multi-locale specs in `admin/spec/controllers/spree/admin/products_controller_spec.rb` verifying edit access by slug in non-default locale and by ID in any locale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3267fa5af55ee7076bd8ef4fc7e2c7e2876bb269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->