### PR TITLE
Fix(#13148): include product tags in search results

### DIFF
--- a/admin/app/controllers/spree/admin/search_controller.rb
+++ b/admin/app/controllers/spree/admin/search_controller.rb
@@ -17,6 +17,23 @@ module Spree
           render json: []
         end
       end
+
+      def tags
+        query = params[:q]&.strip
+
+        if query.present?
+          json = ActsAsTaggableOn::Tag.search_by_name(query).map do |tag|
+            {
+              id: tag.id,
+              name: tag.name
+            }
+          end
+
+          render json: json
+        else
+          render json: []
+        end
+      end
     end
   end
 end

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -118,6 +118,7 @@ Spree::Core::Engine.add_routes do
       resources :coupon_codes, only: :index
     end
     get 'search/option_values', defaults: { format: :json }, to: 'search#option_values'
+    get 'search/tags', defaults: { format: :json }, to: 'search#tags'
 
     # gift cards
     resources :gift_cards

--- a/core/app/models/acts_as_taggable_on/tag_decorator.rb
+++ b/core/app/models/acts_as_taggable_on/tag_decorator.rb
@@ -3,6 +3,10 @@ module ActsAsTaggableOn
     def self.prepended(base)
       base.include ::Spree::RansackableAttributes
       base.whitelisted_ransackable_attributes = %w[id name]
+
+      base.scope :search_by_name, ->(query) do
+        where(arel_table[:name].lower.matches("%#{query.downcase}%"))
+      end
     end
   end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -175,14 +175,25 @@ module Spree
                                 Spree::Variant.search_by_sku(query).pluck(:product_id)
                               end
 
-        where(id: (product_ids + variant_product_ids).uniq.compact)
+        tag_product_ids = ActsAsTaggableOn::Tag.search_by_name(query)
+                                               .joins(:taggings)
+                                               .where(ActsAsTaggableOn.taggings_table => { taggable_type: 'Spree::Product' })
+                                               .pluck(:taggable_id)
+
+        where(id: (product_ids + variant_product_ids + tag_product_ids).uniq.compact)
       }
     else
       scope :multi_search, lambda { |query|
         return none if query.blank?
 
         product_ids = Spree::Variant.search_by_product_name_or_sku(query).pluck(:product_id)
-        where(id: product_ids.uniq.compact)
+
+        tag_product_ids = ActsAsTaggableOn::Tag.search_by_name(query)
+                                               .joins(:taggings)
+                                               .where(ActsAsTaggableOn.taggings_table => { taggable_type: 'Spree::Product' })
+                                               .pluck(:taggable_id)
+
+        where(id: (product_ids + tag_product_ids).uniq.compact)
       }
     end
 


### PR DESCRIPTION
## Summary
Fixes an issue where products with specific tags did not appear in search results.

## Root Cause
The product search logic was not including tag associations in the search scope, causing tagged products to be ignored.

## Fix
- Added tag-based matching to the search query.
- Added an RSpec test to confirm that tagged products appear in search results.

## Testing
- Created products with tags locally.
- Confirmed search now returns tagged products.
- All specs passing with `bundle exec rspec`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tag matching to product multi_search and introduces an admin JSON endpoint to search tags, with tests.
> 
> - **Backend / Product Search**:
>   - Extend `Spree::Product.multi_search` to include products matched by tag names via `ActsAsTaggableOn::Tag` joins (both PgSearch and non-PgSearch paths).
>   - Add case-insensitive `ActsAsTaggableOn::Tag.search_by_name` scope.
> - **Admin**:
>   - New endpoint `GET /admin/search/tags` in `spree/admin/search_controller` returning tag `id` and `name`.
>   - Route added: `admin/search/tags` (JSON).
> - **Tests**:
>   - Request specs for `GET /admin/search/tags` (matching, multiple, case-insensitive, empty/missing query).
>   - Model specs for `Spree::Product.multi_search` covering name, SKU, tag queries, case-insensitivity, and blank/non-matching cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f241a27afa8822d807781eb0a2979f199188498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->