### PR TITLE
Fix drawer overflow form scroll

### DIFF
--- a/admin/app/assets/stylesheets/spree/admin/components/_dialogs.scss
+++ b/admin/app/assets/stylesheets/spree/admin/components/_dialogs.scss
@@ -80,7 +80,7 @@ dialog:open {
 
   .alerts-container {
     position: absolute;
-  } 
+  }
 
   @media (max-width: 991.98px) {
     max-width: 100vw;
@@ -93,6 +93,7 @@ dialog:open {
     height: 100%;
     flex-direction: column;
     justify-content: space-between;
+    overflow: hidden;
   }
 
   .drawer-header {
@@ -110,8 +111,6 @@ dialog:open {
   }
 
   .drawer-footer {
-    position: sticky;
-    bottom: 0;
     padding: $modal-inner-padding;
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents drawer form overflow by hiding overflow on frame/form containers and removes sticky footer positioning in the drawer.
> 
> - **Admin UI — Drawer styles (`_dialogs.scss`)**:
>   - Constrain content by adding `overflow: hidden` to `> turbo-frame`/`form` containers inside `.drawer`.
>   - Adjust layout by removing sticky positioning from `.drawer-footer`.
>   - Keep drawer body scrollable via `overflow-y: auto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cd9f38083ed5a971a406d528459cb1e167fb60b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->