### PR TITLE
Dependencies 2.0 - improve developer experience

### DIFF
--- a/api/lib/spree/api.rb
+++ b/api/lib/spree/api.rb
@@ -3,6 +3,51 @@ require 'spree/core'
 module Spree
   module Api
   end
+
+  # API dependencies accessor for cleaner access to API dependencies
+  #
+  # @example Getting a dependency (returns resolved class)
+  #   Spree.api.storefront_coupon_handler.call(order: order, coupon_code: code)
+  #
+  # @example Setting a dependency
+  #   Spree.api.storefront_coupon_handler = MyApp::CouponHandler
+  #
+  # @return [Spree::ApiDependenciesAccessor] the API dependencies accessor
+  def self.api
+    @api_accessor ||= ApiDependenciesAccessor.new
+  end
+
+  class ApiDependenciesAccessor
+    def method_missing(method_name, *args, &block)
+      base_name = method_name.to_s.chomp('=').to_sym
+
+      return super unless api_dependency?(base_name)
+
+      if method_name.to_s.end_with?('=')
+        Spree::Api::Dependencies.send(method_name, args.first)
+      else
+        # Returns resolved class
+        Spree::Api::Dependencies.send("#{method_name}_class")
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      base_name = method_name.to_s.chomp('=').to_sym
+      api_dependency?(base_name) || super
+    end
+
+    # Direct access to raw dependencies object for backwards compatibility
+    def dependencies
+      Spree::Api::Dependencies
+    end
+
+    private
+
+    def api_dependency?(name)
+      defined?(Spree::Api::Dependencies) &&
+        Spree::Api::Dependencies.class::INJECTION_POINTS.include?(name)
+    end
+  end
 end
 
 require 'spree/api/engine'

--- a/api/lib/spree/api/dependencies.rb
+++ b/api/lib/spree/api/dependencies.rb
@@ -53,10 +53,10 @@ module Spree
         # serializers
         storefront_address_serializer: 'Spree::V2::Storefront::AddressSerializer',
         storefront_cart_serializer: 'Spree::V2::Storefront::CartSerializer',
-        storefront_cms_page_serializer: 'Spree::V2::Storefront::CmsPageSerializer', # LEGACY
+        storefront_cms_page_serializer: nil, # LEGACY
         storefront_credit_card_serializer: 'Spree::V2::Storefront::CreditCardSerializer',
         storefront_country_serializer: 'Spree::V2::Storefront::CountrySerializer',
-        storefront_menu_serializer: 'Spree::V2::Storefront::MenuSerializer', # LEGACY
+        storefront_menu_serializer: nil, # LEGACY
         storefront_user_serializer: 'Spree::V2::Storefront::UserSerializer',
         storefront_shipment_serializer: 'Spree::V2::Storefront::ShipmentSerializer',
         storefront_taxon_serializer: 'Spree::V2::Storefront::TaxonSerializer',

--- a/api/spec/models/spree/api_dependencies_spec.rb
+++ b/api/spec/models/spree/api_dependencies_spec.rb
@@ -9,20 +9,111 @@ end
 class MyCustomCreateService
 end
 
+class MyCustomCouponHandler
+end
+
 describe Spree::Api::ApiDependencies, type: :model do
-  let (:deps) { described_class.new }
+  let(:deps) { described_class.new }
 
-  it 'returns the default value' do
-    expect(deps.storefront_cart_serializer).to eq('Spree::V2::Storefront::CartSerializer')
+  describe 'backwards compatibility' do
+    it 'returns the default value as string' do
+      expect(deps.storefront_cart_serializer).to eq('Spree::V2::Storefront::CartSerializer')
+    end
+
+    it 'allows to overwrite the value' do
+      deps.storefront_cart_serializer = MyNewSerializer
+      expect(deps.storefront_cart_serializer).to eq MyNewSerializer
+    end
+
+    it 'respects global dependencies' do
+      original_value = Spree::Dependencies.cart_create_service
+      begin
+        Spree::Dependencies.cart_create_service = MyCustomCreateService
+        expect(deps.storefront_cart_create_service).to eq(MyCustomCreateService)
+      ensure
+        Spree::Dependencies.instance_variable_set(:@cart_create_service, original_value)
+        Spree::Dependencies.remove_instance_variable(:@cart_create_service_resolved) if Spree::Dependencies.instance_variable_defined?(:@cart_create_service_resolved)
+      end
+    end
   end
 
-  it 'allows to overwrite the value' do
-    deps.storefront_cart_serializer = MyNewSerializer
-    expect(deps.storefront_cart_serializer).to eq MyNewSerializer
+  describe '#<dependency>_class' do
+    it 'returns the constantized class for string values' do
+      expect(deps.storefront_cart_serializer_class).to eq Spree::V2::Storefront::CartSerializer
+    end
+
+    it 'returns the class directly when set as class' do
+      deps.storefront_cart_serializer = MyNewSerializer
+      expect(deps.storefront_cart_serializer_class).to eq MyNewSerializer
+    end
+
+    it 'resolves proc-based dependencies from core' do
+      expect(deps.storefront_cart_create_service_class).to eq Spree::Cart::Create
+    end
   end
 
-  it 'respects global dependecies' do
-    Spree::Dependencies.cart_create_service = MyCustomCreateService
-    expect(deps.storefront_cart_create_service).to eq(MyCustomCreateService)
+  describe '#overrides' do
+    it 'tracks overridden dependencies' do
+      deps.storefront_cart_serializer = MyNewSerializer
+      expect(deps.overrides).to have_key(:storefront_cart_serializer)
+    end
+  end
+
+  describe '#current_values' do
+    it 'returns all dependencies with metadata' do
+      values = deps.current_values
+      expect(values).to be_an(Array)
+      expect(values.first).to include(:name, :current, :default, :overridden)
+    end
+  end
+
+  describe '#validate!' do
+    it 'raises Spree::DependencyError for invalid dependencies' do
+      deps.storefront_cart_serializer = 'NonExistentClass'
+      expect { deps.validate! }.to raise_error(Spree::DependencyError)
+    end
+  end
+end
+
+describe 'Spree.api accessor' do
+  describe 'Spree.api.<dependency>' do
+    it 'returns the resolved class' do
+      expect(Spree.api.storefront_cart_serializer).to eq Spree::V2::Storefront::CartSerializer
+    end
+
+    it 'responds to dependency methods' do
+      expect(Spree.api.respond_to?(:storefront_cart_serializer)).to be true
+      expect(Spree.api.respond_to?(:storefront_cart_serializer=)).to be true
+    end
+
+    it 'does not respond to non-dependency methods' do
+      expect(Spree.api.respond_to?(:non_existent_dependency)).to be false
+    end
+  end
+
+  describe 'Spree.api.<dependency>=' do
+    let(:original_value) { Spree::Api::Dependencies.storefront_coupon_handler }
+
+    after do
+      # Restore original value
+      Spree::Api::Dependencies.instance_variable_set(:@storefront_coupon_handler, original_value)
+      Spree::Api::Dependencies.instance_variable_set(:@overrides, {})
+    end
+
+    it 'sets the dependency via Spree.api' do
+      Spree.api.storefront_coupon_handler = MyCustomCouponHandler
+      expect(Spree::Api::Dependencies.storefront_coupon_handler).to eq MyCustomCouponHandler
+    end
+
+    it 'returns the new class via Spree.api' do
+      Spree.api.storefront_coupon_handler = MyCustomCouponHandler
+      expect(Spree.api.storefront_coupon_handler).to eq MyCustomCouponHandler
+    end
+  end
+
+  describe 'Spree.api.dependencies' do
+    it 'returns the raw dependencies object' do
+      expect(Spree.api.dependencies).to eq Spree::Api::Dependencies
+    end
   end
 end

--- a/api/spec/models/spree/api_dependencies_spec.rb
+++ b/api/spec/models/spree/api_dependencies_spec.rb
@@ -95,9 +95,10 @@ describe 'Spree.api accessor' do
     let(:original_value) { Spree::Api::Dependencies.storefront_coupon_handler }
 
     after do
-      # Restore original value
-      Spree::Api::Dependencies.instance_variable_set(:@storefront_coupon_handler, original_value)
-      Spree::Api::Dependencies.instance_variable_set(:@overrides, {})
+      # Restore original value using setter (which clears memoization)
+      Spree::Api::Dependencies.storefront_coupon_handler = original_value
+      # Clear override tracking for this test
+      Spree::Api::Dependencies.instance_variable_get(:@overrides)&.delete(:storefront_coupon_handler)
     end
 
     it 'sets the dependency via Spree.api' do

--- a/api/spec/models/spree/api_dependencies_spec.rb
+++ b/api/spec/models/spree/api_dependencies_spec.rb
@@ -111,6 +111,15 @@ describe 'Spree.api accessor' do
       Spree.api.storefront_coupon_handler = MyCustomCouponHandler
       expect(Spree.api.storefront_coupon_handler).to eq MyCustomCouponHandler
     end
+
+    it 'tracks override source correctly (not internal routing code)' do
+      Spree.api.storefront_coupon_handler = MyCustomCouponHandler
+      info = Spree::Api::Dependencies.override_info(:storefront_coupon_handler)
+
+      # Should point to this spec file, not api.rb method_missing
+      expect(info[:source]).to include('api_dependencies_spec.rb')
+      expect(info[:source]).not_to include('lib/spree/api.rb')
+    end
   end
 
   describe 'Spree.api.dependencies' do

--- a/api/spec/models/spree/api_dependencies_spec.rb
+++ b/api/spec/models/spree/api_dependencies_spec.rb
@@ -93,9 +93,11 @@ describe 'Spree.api accessor' do
   end
 
   describe 'Spree.api.<dependency>=' do
-    let(:original_value) { Spree::Api::Dependencies.storefront_coupon_handler }
-
-    after do
+    # Use around hook with ensure to guarantee cleanup even if test fails
+    around do |example|
+      original_value = Spree::Api::Dependencies.storefront_coupon_handler
+      example.run
+    ensure
       # Restore original value using setter (which clears memoization)
       Spree::Api::Dependencies.storefront_coupon_handler = original_value
       # Clear override tracking for this test

--- a/api/spec/models/spree/api_dependencies_spec.rb
+++ b/api/spec/models/spree/api_dependencies_spec.rb
@@ -31,8 +31,9 @@ describe Spree::Api::ApiDependencies, type: :model do
         Spree::Dependencies.cart_create_service = MyCustomCreateService
         expect(deps.storefront_cart_create_service).to eq(MyCustomCreateService)
       ensure
-        Spree::Dependencies.instance_variable_set(:@cart_create_service, original_value)
-        Spree::Dependencies.remove_instance_variable(:@cart_create_service_resolved) if Spree::Dependencies.instance_variable_defined?(:@cart_create_service_resolved)
+        # Use setter to properly clear memoization
+        Spree::Dependencies.cart_create_service = original_value
+        Spree::Dependencies.instance_variable_get(:@overrides)&.delete(:cart_create_service)
       end
     end
   end

--- a/core/app/finders/spree/line_items/find_by_variant.rb
+++ b/core/app/finders/spree/line_items/find_by_variant.rb
@@ -5,7 +5,7 @@ module Spree
         line_item = order.line_items.loaded? ? order.line_items.detect { |li| li.variant_id == variant.id } : order.line_items.find_by(variant_id: variant.id)
 
         if line_item
-          Spree::Dependencies.cart_compare_line_items_service.constantize.call(order: order, line_item: line_item, options: options).value
+          Spree.cart_compare_line_items_service.call(order: order, line_item: line_item, options: options).value
         end
 
         line_item

--- a/core/app/jobs/spree/variants/remove_line_item_job.rb
+++ b/core/app/jobs/spree/variants/remove_line_item_job.rb
@@ -4,7 +4,7 @@ module Spree
       queue_as Spree.queues.variants
 
       def perform(line_item:)
-        Spree::Dependencies.cart_remove_line_item_service.constantize.call(order: line_item.order, line_item: line_item)
+        Spree.cart_remove_line_item_service.call(order: line_item.order, line_item: line_item)
       end
     end
   end

--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -157,7 +157,7 @@ module Spree
     end
 
     def current_ability
-      @current_ability ||= Spree::Dependencies.ability_class.constantize.new(user, { store: store })
+      @current_ability ||= Spree.ability_class.new(user, { store: store })
     end
 
     # eg. Spree::Exports::Products => products-store-my-store-code-20241030133348.csv

--- a/core/app/models/spree/import.rb
+++ b/core/app/models/spree/import.rb
@@ -217,7 +217,7 @@ module Spree
     # Returns the current ability for the import
     # @return [Spree::Ability]
     def current_ability
-      @current_ability ||= Spree::Dependencies.ability_class.constantize.new(user, { store: store })
+      @current_ability ||= Spree.ability_class.new(user, { store: store })
     end
 
     class << self

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -349,7 +349,7 @@ module Spree
     end
 
     def updater
-      @updater ||= Spree::Dependencies.order_updater.constantize.new(self)
+      @updater ||= Spree.order_updater.new(self)
     end
 
     def update_with_updater!
@@ -407,7 +407,7 @@ module Spree
     def find_line_item_by_variant(variant, options = {})
       line_items.detect do |line_item|
         line_item.variant_id == variant.id &&
-          Spree::Dependencies.cart_compare_line_items_service.constantize.new.call(order: self, line_item: line_item, options: options).value
+          Spree.cart_compare_line_items_service.new.call(order: self, line_item: line_item, options: options).value
       end
     end
 
@@ -578,7 +578,7 @@ module Spree
     def empty!
       raise Spree.t(:cannot_empty_completed_order) if completed?
 
-      result = Spree::Dependencies.cart_empty_service.constantize.call(order: self)
+      result = Spree.cart_empty_service.call(order: self)
       result.value
     end
 
@@ -957,7 +957,7 @@ module Spree
       if gift_card.present?
         recalculate_gift_card
       elsif using_store_credit?
-        Spree::Dependencies.checkout_add_store_credit_service.constantize.call(order: self)
+        Spree.checkout_add_store_credit_service.call(order: self)
       end
     end
   end

--- a/core/app/models/spree/order/gift_card.rb
+++ b/core/app/models/spree/order/gift_card.rb
@@ -25,13 +25,13 @@ module Spree
       # @param gift_card [Spree::GiftCard] the gift card to apply
       # @return [Spree::Order] the order with the gift card applied
       def apply_gift_card(gift_card)
-        Spree::Dependencies.gift_card_apply_service.constantize.call(gift_card: gift_card, order: self)
+        Spree.gift_card_apply_service.call(gift_card: gift_card, order: self)
       end
 
       # Removes a gift card from the order
       # @return [Spree::Order] the order with the gift card removed
       def remove_gift_card
-        Spree::Dependencies.gift_card_remove_service.constantize.call(order: self)
+        Spree.gift_card_remove_service.call(order: self)
       end
 
       def recalculate_gift_card
@@ -44,7 +44,7 @@ module Spree
       def redeem_gift_card
         return unless gift_card.present?
 
-        Spree::Dependencies.gift_card_redeem_service.constantize.call(gift_card: gift_card)
+        Spree.gift_card_redeem_service.call(gift_card: gift_card)
       end
     end
   end

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -2,11 +2,11 @@ module Spree
   class Order < Spree.base_class
     module StoreCredit
       def add_store_credit_payments(amount = nil)
-        Spree::Dependencies.checkout_add_store_credit_service.constantize.call(order: self, amount: amount)
+        Spree.checkout_add_store_credit_service.call(order: self, amount: amount)
       end
 
       def remove_store_credit_payments
-        Spree::Dependencies.checkout_remove_store_credit_service.constantize.call(order: self)
+        Spree.checkout_remove_store_credit_service.call(order: self)
       end
 
       def covered_by_store_credit?

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -7,17 +7,17 @@ module Spree
     end
 
     def add(variant, quantity = 1, options = {})
-      Spree::Dependencies.cart_add_item_service.constantize.call(order: order,
-                                                                 variant: variant,
-                                                                 quantity: quantity,
-                                                                 options: options).value
+      Spree.cart_add_item_service.call(order: order,
+                                       variant: variant,
+                                       quantity: quantity,
+                                       options: options).value
     end
 
     def remove(variant, quantity = 1, options = {})
-      Spree::Dependencies.cart_remove_item_service.constantize.call(order: order,
-                                                                    variant: variant,
-                                                                    quantity: quantity,
-                                                                    options: options).value
+      Spree.cart_remove_item_service.call(order: order,
+                                          variant: variant,
+                                          quantity: quantity,
+                                          options: options).value
     end
 
     def remove_line_item(line_item, options = {})
@@ -25,7 +25,7 @@ module Spree
     end
 
     def update_cart(params)
-      Spree::Dependencies.cart_update_service.constantize.call(order: order, params: params).value
+      Spree.cart_update_service.call(order: order, params: params).value
     end
   end
 end

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -35,9 +35,9 @@ module Spree
     def find_matching_line_item(other_order_line_item)
       order.line_items.detect do |my_li|
         my_li.variant == other_order_line_item.variant &&
-          Spree::Dependencies.cart_compare_line_items_service.constantize.new.call(order: order,
-                                                                                   line_item: my_li,
-                                                                                   options: other_order_line_item.serializable_hash).value
+          Spree.cart_compare_line_items_service.new.call(order: order,
+                                                         line_item: my_li,
+                                                         options: other_order_line_item.serializable_hash).value
       end
     end
 

--- a/core/app/models/spree/page_sections/featured_taxon.rb
+++ b/core/app/models/spree/page_sections/featured_taxon.rb
@@ -61,8 +61,7 @@ module Spree
             sort_by: 'default'
           }
 
-          products_finder = Spree::Dependencies.products_finder.constantize
-          products_finder.new(scope: store.products, params: finder_params).execute.limit(preferred_max_products_to_show)
+          Spree.products_finder.new(scope: store.products, params: finder_params).execute.limit(preferred_max_products_to_show)
         end
       end
 

--- a/core/app/models/spree/promotion/actions/create_line_items.rb
+++ b/core/app/models/spree/promotion/actions/create_line_items.rb
@@ -47,9 +47,9 @@ module Spree
             current_quantity = order.quantity_of(item.variant)
             next unless current_quantity < item.quantity && item_available?(item)
 
-            line_item = Spree::Dependencies.cart_add_item_service.constantize.call(order: order,
-                                                                                   variant: item.variant,
-                                                                                   quantity: item.quantity - current_quantity).value
+            line_item = Spree.cart_add_item_service.call(order: order,
+                                                         variant: item.variant,
+                                                         quantity: item.quantity - current_quantity).value
             action_taken = true if line_item.try(:valid?)
           end
           action_taken
@@ -68,9 +68,9 @@ module Spree
             line_item = order.find_line_item_by_variant(item.variant)
             next unless line_item.present?
 
-            Spree::Dependencies.cart_remove_item_service.constantize.call(order: order,
-                                                                          variant: item.variant,
-                                                                          quantity: (item.quantity || 1))
+            Spree.cart_remove_item_service.call(order: order,
+                                                variant: item.variant,
+                                                quantity: (item.quantity || 1))
             action_taken = true
           end
 

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -133,7 +133,7 @@ module Spree
           line_item = order.find_line_item_by_variant(item.variant)
           next if line_item.blank?
 
-          Spree::Dependencies.cart_remove_item_service.constantize.call(order: order, variant: item.variant, quantity: item.quantity)
+          Spree.cart_remove_item_service.call(order: order, variant: item.variant, quantity: item.quantity)
         end
       end
 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -77,7 +77,7 @@ module Spree
 
     # your shipping method subclasses can override this method to provide a custom tracking number service
     def tracking_number_service(tracking)
-      @tracking_number_service ||= Spree::Dependencies.tracking_number_service.constantize.new(tracking)
+      @tracking_number_service ||= Spree.tracking_number_service.new(tracking)
     end
 
     def self.calculators

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -210,7 +210,7 @@ module Spree
 
     def self.current(url = nil)
       if url.present?
-        Spree::Dependencies.current_store_finder.constantize.new(url: url).execute
+        Spree.current_store_finder.new(url: url).execute
       else
         Spree::Current.store
       end

--- a/core/app/services/spree/cart/add_item.rb
+++ b/core/app/services/spree/cart/add_item.rb
@@ -6,7 +6,7 @@ module Spree
       def call(order:, variant:, quantity: nil, public_metadata: {}, private_metadata: {}, options: {})
         ApplicationRecord.transaction do
           run :add_to_line_item
-          run Spree::Dependencies.cart_recalculate_service.constantize
+          run Spree.cart_recalculate_service
         end
       end
 
@@ -18,7 +18,7 @@ module Spree
 
         return failure(variant, "#{variant.name} is not available in #{order.currency}") if variant.amount_in(order.currency).nil?
 
-        line_item = Spree::Dependencies.line_item_by_variant_finder.constantize.new.execute(order: order, variant: variant, options: options)
+        line_item = Spree.line_item_by_variant_finder.new.execute(order: order, variant: variant, options: options)
 
         line_item_created = line_item.nil?
         if line_item.nil?

--- a/core/app/services/spree/cart/remove_item.rb
+++ b/core/app/services/spree/cart/remove_item.rb
@@ -9,9 +9,9 @@ module Spree
 
         ActiveRecord::Base.transaction do
           line_item = remove_from_line_item(order: order, variant: variant, quantity: quantity, options: options)
-          Spree::Dependencies.cart_recalculate_service.constantize.call(line_item: line_item,
-                                                                        order: order,
-                                                                        options: options)
+          Spree.cart_recalculate_service.call(line_item: line_item,
+                                              order: order,
+                                              options: options)
           success(line_item)
         end
       end
@@ -19,7 +19,7 @@ module Spree
       private
 
       def remove_from_line_item(order:, variant:, quantity:, options:)
-        line_item = Spree::Dependencies.line_item_by_variant_finder.constantize.new.execute(order: order, variant: variant, options: options)
+        line_item = Spree.line_item_by_variant_finder.new.execute(order: order, variant: variant, options: options)
 
         raise ActiveRecord::RecordNotFound if line_item.nil?
 

--- a/core/app/services/spree/cart/remove_line_item.rb
+++ b/core/app/services/spree/cart/remove_line_item.rb
@@ -7,9 +7,9 @@ module Spree
         options ||= {}
         ActiveRecord::Base.transaction do
           order.line_items.destroy(line_item)
-          Spree::Dependencies.cart_recalculate_service.constantize.new.call(order: order,
-                                                                            line_item: line_item,
-                                                                            options: options)
+          Spree.cart_recalculate_service.new.call(order: order,
+                                                  line_item: line_item,
+                                                  options: options)
         end
         success(line_item)
       end

--- a/core/app/services/spree/cart/remove_out_of_stock_items.rb
+++ b/core/app/services/spree/cart/remove_out_of_stock_items.rb
@@ -49,7 +49,7 @@ module Spree
       end
 
       def cart_remove_line_item_service
-        Spree::Dependencies.cart_remove_line_item_service.constantize
+        Spree.cart_remove_line_item_service
       end
     end
   end

--- a/core/app/services/spree/cart/set_quantity.rb
+++ b/core/app/services/spree/cart/set_quantity.rb
@@ -6,7 +6,7 @@ module Spree
       def call(order:, line_item:, quantity: nil)
         ActiveRecord::Base.transaction do
           run :change_item_quantity
-          run Spree::Dependencies.cart_recalculate_service.constantize
+          run Spree.cart_recalculate_service
         end
       end
 

--- a/core/app/services/spree/checkout/advance.rb
+++ b/core/app/services/spree/checkout/advance.rb
@@ -15,7 +15,7 @@ module Spree
         transitions_count = 0
 
         until cannot_make_transition?(order, state)
-          next_result = Spree::Dependencies.checkout_next_service.constantize.call(order: order)
+          next_result = Spree.checkout_next_service.call(order: order)
           return failure(order, order.errors) if next_result.failure? && (transitions_count.zero? || state.present?)
 
           transitions_count +=1

--- a/core/app/services/spree/checkout/complete.rb
+++ b/core/app/services/spree/checkout/complete.rb
@@ -4,7 +4,7 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call(order:)
-        Spree::Dependencies.checkout_next_service.constantize.call(order: order) until cannot_make_transition?(order)
+        Spree.checkout_next_service.call(order: order) until cannot_make_transition?(order)
 
         if order.reload.complete?
           success(order)

--- a/core/app/services/spree/data_feeds/google/rss.rb
+++ b/core/app/services/spree/data_feeds/google/rss.rb
@@ -87,19 +87,19 @@ module Spree
         end
 
         def optional_attributes
-          Spree::Dependencies.data_feeds_google_optional_attributes_service.constantize.new
+          Spree.data_feeds_google_optional_attributes_service.new
         end
 
         def required_attributes
-          Spree::Dependencies.data_feeds_google_required_attributes_service.constantize.new
+          Spree.data_feeds_google_required_attributes_service.new
         end
 
         def optional_sub_attributes
-          Spree::Dependencies.data_feeds_google_optional_sub_attributes_service.constantize.new
+          Spree.data_feeds_google_optional_sub_attributes_service.new
         end
 
         def products_list
-          Spree::Dependencies.data_feeds_google_products_list.constantize.new
+          Spree.data_feeds_google_products_list.new
         end
       end
     end

--- a/core/app/services/spree/line_items/helper.rb
+++ b/core/app/services/spree/line_items/helper.rb
@@ -4,7 +4,7 @@ module Spree
       protected
 
       def recalculate_service
-        Spree::Dependencies.cart_recalculate_service.constantize
+        Spree.cart_recalculate_service
       end
     end
   end

--- a/core/app/services/spree/shipments/helper.rb
+++ b/core/app/services/spree/shipments/helper.rb
@@ -12,11 +12,11 @@ module Spree
       end
 
       def add_item_service
-        Spree::Dependencies.cart_add_item_service.constantize
+        Spree.cart_add_item_service
       end
 
       def remove_item_service
-        Spree::Dependencies.cart_remove_item_service.constantize
+        Spree.cart_remove_item_service
       end
     end
   end

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -17,7 +17,7 @@ module Spree
 
         # Needs to be overridden so that we use Spree's Ability rather than anyone else's.
         def current_ability
-          @current_ability ||= Spree::Dependencies.ability_class.constantize.new(try_spree_current_user, { store: current_store })
+          @current_ability ||= Spree.ability_class.new(try_spree_current_user, { store: current_store })
         end
 
         def redirect_back_or_default(default)

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -64,7 +64,7 @@ module Spree
         end
 
         def current_store_finder
-          Spree::Dependencies.current_store_finder.constantize
+          Spree.current_store_finder
         end
 
         def raise_record_not_found_if_store_is_not_found

--- a/core/lib/spree/core/dependencies.rb
+++ b/core/lib/spree/core/dependencies.rb
@@ -97,8 +97,8 @@ module Spree
         # finders
         address_finder: 'Spree::Addresses::Find',
         country_finder: 'Spree::Countries::Find',
-        cms_page_finder: 'Spree::CmsPages::Find', # LEGACY
-        menu_finder: 'Spree::Menus::Find', # LEGACY
+        cms_page_finder: nil, # LEGACY
+        menu_finder: nil, # LEGACY
         current_order_finder: 'Spree::Orders::FindCurrent',
         current_store_finder: 'Spree::Stores::FindCurrent',
         completed_order_finder: 'Spree::Orders::FindComplete',

--- a/core/lib/spree/core/dependencies_helper.rb
+++ b/core/lib/spree/core/dependencies_helper.rb
@@ -78,7 +78,9 @@ module Spree
           name: point,
           current: current,
           default: default_val,
-          overridden: current != default_val,
+          # Use overridden? to check if setter was called, not value comparison
+          # Value comparison fails for proc-based defaults that reference other dependencies
+          overridden: overridden?(point),
           override_info: overrides[point]
         }
       end

--- a/core/lib/spree/core/dependencies_helper.rb
+++ b/core/lib/spree/core/dependencies_helper.rb
@@ -1,21 +1,95 @@
 module Spree
+  class DependencyError < StandardError; end
+
   module DependenciesHelper
     def self.included(base)
       injection_points = base::INJECTION_POINTS_WITH_DEFAULTS.keys.freeze
       base.const_set(:INJECTION_POINTS, injection_points)
-      base.attr_accessor(*injection_points)
+
+      injection_points.each do |point|
+        # Original getter - returns raw value (string, class, or proc result)
+        # BACKWARDS COMPATIBLE: Spree::Dependencies.foo.constantize still works
+        base.attr_reader(point)
+
+        # Setter with override tracking
+        # BACKWARDS COMPATIBLE: Spree::Dependencies.foo = "MyClass" still works
+        base.define_method("#{point}=") do |value|
+          @overrides ||= {}
+          @overrides[point] = {
+            value: value,
+            source: caller_locations(1, 1).first.to_s,
+            set_at: Time.current
+          }
+          # Clear memoized class when value changes
+          remove_instance_variable("@#{point}_resolved") if instance_variable_defined?("@#{point}_resolved")
+          instance_variable_set("@#{point}", value)
+        end
+
+        # Returns resolved class with memoization
+        # Usage: Spree::Dependencies.foo_class or Spree.foo
+        base.define_method("#{point}_class") do
+          return instance_variable_get("@#{point}_resolved") if instance_variable_defined?("@#{point}_resolved")
+
+          value = send(point)
+          resolved = case value
+                     when String then value.constantize
+                     when Proc then value.call.then { |v| v.is_a?(String) ? v.constantize : v }
+                     else value
+                     end
+          instance_variable_set("@#{point}_resolved", resolved)
+          resolved
+        end
+      end
     end
 
     def initialize
       set_default_values
     end
 
+    # Returns hash of all overridden dependencies with metadata
+    def overrides
+      @overrides || {}
+    end
+
+    # Check if a specific dependency has been overridden
+    def overridden?(name)
+      overrides.key?(name.to_sym)
+    end
+
+    # Get override info for a specific dependency
+    def override_info(name)
+      overrides[name.to_sym]
+    end
+
+    # Returns array of all dependencies with current values and metadata
     def current_values
-      values = []
-      self.class::INJECTION_POINTS.each do |injection_point|
-        values << { injection_point.to_s => instance_variable_get("@#{injection_point}") }
+      self.class::INJECTION_POINTS.map do |point|
+        default = self.class::INJECTION_POINTS_WITH_DEFAULTS[point]
+        default_val = default.respond_to?(:call) ? default.call : default
+        current = send(point)
+
+        {
+          name: point,
+          current: current,
+          default: default_val,
+          overridden: current != default_val,
+          override_info: overrides[point]
+        }
       end
-      values
+    end
+
+    # Validate all dependencies can be resolved to classes
+    # Raises Spree::DependencyError if any dependency is invalid
+    def validate!
+      errors = []
+      self.class::INJECTION_POINTS.each do |point|
+        send("#{point}_class")
+      rescue NameError => e
+        errors << { name: point, value: send(point), error: e.message }
+      end
+      raise Spree::DependencyError, "Invalid dependencies: #{errors.map { |e| e[:name] }.join(', ')}" if errors.any?
+
+      true
     end
 
     private

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -32,7 +32,7 @@ module Spree
         def extended_base_scope
           base_scope = current_store.products.spree_base_scopes
           base_scope = get_products_conditions_for(base_scope, keywords)
-          base_scope = Spree::Dependencies.products_finder.constantize.new(**product_finder_params(base_scope)).execute
+          base_scope = Spree.products_finder.new(**product_finder_params(base_scope)).execute
           base_scope = add_search_scopes(base_scope)
           add_eagerload_scopes(base_scope)
         end

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -30,7 +30,7 @@ module Spree
 
         def stub_authorization!
           ability = build_ability
-          ability_class = Spree::Dependencies.ability_class.constantize
+          ability_class = Spree.ability_class
 
           after(:all) do
             ability_class.remove_ability(ability)
@@ -51,7 +51,7 @@ module Spree
 
         def custom_authorization!(&block)
           ability = build_ability(&block)
-          ability_class = Spree::Dependencies.ability_class.constantize
+          ability_class = Spree.ability_class
 
           after(:all) do
             ability_class.remove_ability(ability)

--- a/core/lib/tasks/dependencies.rake
+++ b/core/lib/tasks/dependencies.rake
@@ -1,0 +1,76 @@
+namespace :spree do
+  namespace :dependencies do
+    desc 'List all Spree dependencies with their current values'
+    task list: :environment do
+      print_dependencies('CORE', Spree::Dependencies)
+      print_dependencies('API', Spree::Api::Dependencies) if defined?(Spree::Api::Dependencies)
+    end
+
+    desc 'Show only overridden dependencies'
+    task overrides: :environment do
+      core_overrides = Spree::Dependencies.current_values.select { |d| d[:overridden] }
+      api_overrides = if defined?(Spree::Api::Dependencies)
+                        Spree::Api::Dependencies.current_values.select { |d| d[:overridden] }
+                      else
+                        []
+                      end
+
+      if core_overrides.empty? && api_overrides.empty?
+        puts 'No dependencies have been overridden.'
+      else
+        print_overrides('Core', core_overrides) if core_overrides.any?
+        print_overrides('API', api_overrides) if api_overrides.any?
+      end
+    end
+
+    desc 'Validate all dependencies resolve to valid classes'
+    task validate: :environment do
+      errors = validate_dependencies('Core', Spree::Dependencies)
+      errors += validate_dependencies('API', Spree::Api::Dependencies) if defined?(Spree::Api::Dependencies)
+
+      puts "\n"
+      if errors.any?
+        puts "\n\e[31m#{errors.size} invalid dependencies:\e[0m"
+        errors.each { |err| puts "  [#{err[:source]}] #{err[:name]}: #{err[:error]}" }
+        exit 1
+      else
+        puts "\e[32mAll dependencies valid\e[0m"
+      end
+    end
+
+    def print_dependencies(name, deps)
+      puts "\n[#{name}]"
+
+      # Calculate max width for alignment
+      max_name_width = deps.class::INJECTION_POINTS.map(&:length).max
+
+      deps.current_values.each do |dep|
+        status = dep[:overridden] ? ' [OVERRIDDEN]' : ''
+        puts "#{dep[:name].to_s.ljust(max_name_width)}  #{dep[:current]}#{status}"
+      end
+    end
+
+    def print_overrides(name, overrides)
+      puts "\n[#{name} OVERRIDES]"
+
+      max_name_width = overrides.map { |d| d[:name].length }.max
+
+      overrides.each do |dep|
+        source = dep[:override_info] ? " (#{dep[:override_info][:source]})" : ''
+        puts "#{dep[:name].to_s.ljust(max_name_width)}  #{dep[:default]} -> #{dep[:current]}#{source}"
+      end
+    end
+
+    def validate_dependencies(name, deps)
+      errors = []
+      deps.class::INJECTION_POINTS.each do |point|
+        deps.send("#{point}_class")
+        print "\e[32m.\e[0m"
+      rescue NameError => e
+        errors << { source: name, name: point, error: e.message }
+        print "\e[31mF\e[0m"
+      end
+      errors
+    end
+  end
+end

--- a/core/spec/models/spree/app_dependencies_spec.rb
+++ b/core/spec/models/spree/app_dependencies_spec.rb
@@ -161,9 +161,10 @@ describe 'Spree module dependency accessors' do
     let(:original_value) { Spree::Dependencies.cart_add_item_service }
 
     after do
-      # Restore original value
-      Spree::Dependencies.instance_variable_set(:@cart_add_item_service, original_value)
-      Spree::Dependencies.instance_variable_set(:@overrides, {})
+      # Restore original value using setter (which clears memoization)
+      Spree::Dependencies.cart_add_item_service = original_value
+      # Clear override tracking for this test
+      Spree::Dependencies.instance_variable_get(:@overrides)&.delete(:cart_add_item_service)
     end
 
     it 'sets the dependency via Spree module' do

--- a/core/spec/models/spree/app_dependencies_spec.rb
+++ b/core/spec/models/spree/app_dependencies_spec.rb
@@ -176,5 +176,14 @@ describe 'Spree module dependency accessors' do
       Spree.cart_add_item_service = MyCustomAddItemService
       expect(Spree.cart_add_item_service).to eq MyCustomAddItemService
     end
+
+    it 'tracks override source correctly (not internal routing code)' do
+      Spree.cart_add_item_service = MyCustomAddItemService
+      info = Spree::Dependencies.override_info(:cart_add_item_service)
+
+      # Should point to this spec file, not core.rb method_missing
+      expect(info[:source]).to include('app_dependencies_spec.rb')
+      expect(info[:source]).not_to include('lib/spree/core.rb')
+    end
   end
 end

--- a/core/spec/models/spree/app_dependencies_spec.rb
+++ b/core/spec/models/spree/app_dependencies_spec.rb
@@ -158,9 +158,11 @@ describe 'Spree module dependency accessors' do
   end
 
   describe 'Spree.<dependency>=' do
-    let(:original_value) { Spree::Dependencies.cart_add_item_service }
-
-    after do
+    # Use around hook with ensure to guarantee cleanup even if test fails
+    around do |example|
+      original_value = Spree::Dependencies.cart_add_item_service
+      example.run
+    ensure
       # Restore original value using setter (which clears memoization)
       Spree::Dependencies.cart_add_item_service = original_value
       # Clear override tracking for this test

--- a/core/spec/models/spree/app_dependencies_spec.rb
+++ b/core/spec/models/spree/app_dependencies_spec.rb
@@ -3,15 +3,177 @@ require 'spec_helper'
 class MyCustomCreateService
 end
 
-describe Spree::Core::Dependencies, type: :model do
-  let (:deps) { described_class.new }
+class MyCustomAddItemService
+end
 
-  it 'returns the default value' do
-    expect(deps.cart_create_service).to eq('Spree::Cart::Create')
+describe Spree::Core::Dependencies, type: :model do
+  let(:deps) { described_class.new }
+
+  describe 'backwards compatibility' do
+    it 'returns the default value as string' do
+      expect(deps.cart_create_service).to eq('Spree::Cart::Create')
+    end
+
+    it 'allows to overwrite the value with a class' do
+      deps.cart_create_service = MyCustomCreateService
+      expect(deps.cart_create_service).to eq MyCustomCreateService
+    end
+
+    it 'allows to overwrite the value with a string' do
+      deps.cart_create_service = 'MyCustomCreateService'
+      expect(deps.cart_create_service).to eq 'MyCustomCreateService'
+    end
+
+    it 'works with constantize for string values' do
+      expect(deps.cart_create_service.constantize).to eq Spree::Cart::Create
+    end
   end
 
-  it 'allows to overwrite the value' do
-    deps.cart_create_service = MyCustomCreateService
-    expect(deps.cart_create_service).to eq MyCustomCreateService
+  describe '#<dependency>_class' do
+    it 'returns the constantized class for string values' do
+      expect(deps.cart_create_service_class).to eq Spree::Cart::Create
+    end
+
+    it 'returns the class directly when set as class' do
+      deps.cart_create_service = MyCustomCreateService
+      expect(deps.cart_create_service_class).to eq MyCustomCreateService
+    end
+
+    it 'memoizes the resolved class' do
+      deps.cart_create_service_class
+      expect(deps.instance_variable_get(:@cart_create_service_resolved)).to eq Spree::Cart::Create
+    end
+
+    it 'clears memoization when value changes' do
+      deps.cart_create_service_class
+      deps.cart_create_service = MyCustomCreateService
+      expect(deps.instance_variable_defined?(:@cart_create_service_resolved)).to be false
+    end
+  end
+
+  describe '#overrides' do
+    it 'returns empty hash when no overrides' do
+      expect(deps.overrides).to eq({})
+    end
+
+    it 'tracks overridden dependencies' do
+      deps.cart_create_service = MyCustomCreateService
+      expect(deps.overrides).to have_key(:cart_create_service)
+    end
+
+    it 'includes override metadata' do
+      deps.cart_create_service = MyCustomCreateService
+      override = deps.overrides[:cart_create_service]
+
+      expect(override[:value]).to eq MyCustomCreateService
+      expect(override[:source]).to be_a(String)
+      expect(override[:set_at]).to be_a(Time)
+    end
+  end
+
+  describe '#overridden?' do
+    it 'returns false for non-overridden dependencies' do
+      expect(deps.overridden?(:cart_create_service)).to be false
+    end
+
+    it 'returns true for overridden dependencies' do
+      deps.cart_create_service = MyCustomCreateService
+      expect(deps.overridden?(:cart_create_service)).to be true
+    end
+
+    it 'works with string argument' do
+      deps.cart_create_service = MyCustomCreateService
+      expect(deps.overridden?('cart_create_service')).to be true
+    end
+  end
+
+  describe '#override_info' do
+    it 'returns nil for non-overridden dependencies' do
+      expect(deps.override_info(:cart_create_service)).to be_nil
+    end
+
+    it 'returns override info for overridden dependencies' do
+      deps.cart_create_service = MyCustomCreateService
+      info = deps.override_info(:cart_create_service)
+
+      expect(info[:value]).to eq MyCustomCreateService
+      expect(info[:source]).to include('app_dependencies_spec.rb')
+    end
+  end
+
+  describe '#current_values' do
+    it 'returns all dependencies with metadata' do
+      values = deps.current_values
+      expect(values).to be_an(Array)
+      expect(values.first).to include(:name, :current, :default, :overridden)
+    end
+
+    it 'marks non-overridden dependencies correctly' do
+      cart_create = deps.current_values.find { |v| v[:name] == :cart_create_service }
+      expect(cart_create[:overridden]).to be false
+      expect(cart_create[:current]).to eq cart_create[:default]
+    end
+
+    it 'marks overridden dependencies correctly' do
+      deps.cart_create_service = MyCustomCreateService
+      cart_create = deps.current_values.find { |v| v[:name] == :cart_create_service }
+
+      expect(cart_create[:overridden]).to be true
+      expect(cart_create[:current]).to eq MyCustomCreateService
+      expect(cart_create[:default]).to eq 'Spree::Cart::Create'
+    end
+  end
+
+  describe '#validate!' do
+    it 'raises Spree::DependencyError for invalid dependencies' do
+      deps.cart_create_service = 'NonExistentClass'
+      expect { deps.validate! }.to raise_error(Spree::DependencyError)
+    end
+
+    it 'includes dependency names in error message' do
+      deps.cart_create_service = 'NonExistentClass'
+      deps.cart_add_item_service = 'AnotherNonExistentClass'
+      expect { deps.validate! }.to raise_error(Spree::DependencyError, /cart_create_service/)
+    end
+  end
+end
+
+describe 'Spree module dependency accessors' do
+  # These tests use the global Spree::Dependencies instance
+  # We need to be careful to restore original values after tests
+
+  describe 'Spree.<dependency>' do
+    it 'returns the resolved class' do
+      expect(Spree.cart_create_service).to eq Spree::Cart::Create
+    end
+
+    it 'responds to dependency methods' do
+      expect(Spree.respond_to?(:cart_create_service)).to be true
+      expect(Spree.respond_to?(:cart_create_service=)).to be true
+    end
+
+    it 'does not respond to non-dependency methods' do
+      expect(Spree.respond_to?(:non_existent_dependency)).to be false
+    end
+  end
+
+  describe 'Spree.<dependency>=' do
+    let(:original_value) { Spree::Dependencies.cart_add_item_service }
+
+    after do
+      # Restore original value
+      Spree::Dependencies.instance_variable_set(:@cart_add_item_service, original_value)
+      Spree::Dependencies.instance_variable_set(:@overrides, {})
+    end
+
+    it 'sets the dependency via Spree module' do
+      Spree.cart_add_item_service = MyCustomAddItemService
+      expect(Spree::Dependencies.cart_add_item_service).to eq MyCustomAddItemService
+    end
+
+    it 'returns the new class via Spree module' do
+      Spree.cart_add_item_service = MyCustomAddItemService
+      expect(Spree.cart_add_item_service).to eq MyCustomAddItemService
+    end
   end
 end

--- a/docs/developer/customization/dependencies.mdx
+++ b/docs/developer/customization/dependencies.mdx
@@ -5,7 +5,7 @@ section: customization
 
 ## Overview
 
-With Dependencies, you can easily replace parts of Spree core with your custom code. You can replace [Services](https://github.com/spree/spree/tree/master/core/app/services/spree), CanCanCan Abilities (user for [Permissions](permissions)), and [API Serializers](https://github.com/spree/spree/tree/master/api/app/serializers/spree/v2) (used for generating JSON API responses).
+With Dependencies, you can easily replace parts of Spree core with your custom code. You can replace [Services](https://github.com/spree/spree/tree/master/core/app/services/spree), CanCanCan Abilities (used for [Permissions](permissions)), and [API Serializers](https://github.com/spree/spree/tree/master/api/app/serializers/spree/v2) (used for generating JSON API responses).
 
 ## Application (global) customization
 
@@ -14,31 +14,31 @@ This will change every aspect of the application (both APIs, Admin Panel, and St
 In your `config/initializers/spree.rb` file, you can set the following:
 
 ```ruby
-Spree::Dependencies.cart_add_item_service = 'MyAddToCartService'
+Spree.cart_add_item_service = MyAddToCartService
 ```
 
-or
+or using the block syntax:
 
 ```ruby
 Spree.dependencies do |dependencies|
-  dependencies.cart_add_item_service = 'MyAddToCartService'
+  dependencies.cart_add_item_service = MyAddToCartService
 end
 ```
 
 Now let's create your custom service.
 
 ```bash
-mkdir app/services -f && touch app/services/my_add_to_cart_service.rb
+mkdir -p app/services && touch app/services/my_add_to_cart_service.rb
 ```
 
 And add the following code to it:
 
 ```ruby
-module MyAddToCartService < Spree::Cart::AddItem
+class MyAddToCartService < Spree::Cart::AddItem
   def call(order:, variant:, quantity: nil, public_metadata: {}, private_metadata: {}, options: {})
     ApplicationRecord.transaction do
       run :add_to_line_item
-      run Spree::Dependencies.cart_recalculate_service.constantize
+      run Spree.cart_recalculate_service
       run :update_in_external_system
     end
   end
@@ -56,19 +56,27 @@ This code will:
 1. Inherit from `Spree::Cart::AddItem`
 2. Override the `call` method to add your custom logic
 3. Call `run :add_to_line_item` to add the item to the cart
-4. Call `run Spree::Dependencies.cart_recalculate_service.constantize` to recalculate the cart
+4. Call `run Spree.cart_recalculate_service` to recalculate the cart (returns the resolved class)
 5. Call `run :update_in_external_system` to execute your custom logic, eg. updating Order in an external system such as ERP
 
-<Warning>
-Values set in the initializer have to be strings, eg. `'MyNewAwesomeAddItemToCart'`
-</Warning>
+## Using dependencies in your code
+
+When you need to use a dependency in your code, you can access it directly via the `Spree` module:
+
+```ruby
+# Returns the resolved class (not a string)
+Spree.cart_add_item_service.call(order: order, variant: variant, quantity: 1)
+
+# For API dependencies, use the Spree.api accessor
+Spree.api.storefront_cart_serializer.new(order).serializable_hash
+```
 
 ## Controller level customization
 
 If you need to replace [serializers](https://github.com/jsonapi-serializer/jsonapi-serializer) or Services in a specific API endpoint you can create a [code decorator](/developer/customization/decorators):
 
 ```bash
-mkdir app/controllers/spree -f && touch app/controllers/spree/cart_controller_decorator.rb
+mkdir -p app/controllers/spree && touch app/controllers/spree/cart_controller_decorator.rb
 ```
 
 and add the following code to it:
@@ -100,8 +108,8 @@ Storefront API and Platform API have separate Dependencies injection points so y
 In your Spree initializer (`config/initializers/spree.rb`) please add:
 
 ```ruby
-Spree::Api::Dependencies.storefront_cart_serializer = 'MyNewAwesomeCartSerializer'
-Spree::Api::Dependencies.storefront_cart_add_item_service = 'MyNewAwesomeAddItemToCart'
+Spree.api.storefront_cart_serializer = MyNewAwesomeCartSerializer
+Spree.api.storefront_cart_add_item_service = MyNewAwesomeAddItemToCart
 ```
 
 This will swap the default Cart serializer and Add Item to Cart service for your custom ones within all Storefront API endpoints that use those classes.
@@ -109,15 +117,116 @@ This will swap the default Cart serializer and Add Item to Cart service for your
 You can mix and match both global and API-level customizations:
 
 ```ruby
-Spree::Dependencies.cart_add_item_service = 'MyNewAwesomeAddItemToCart'
-Spree::Api::Dependencies.storefront_cart_add_item_service = 'AnotherAddItemToCart'
+Spree.cart_add_item_service = MyNewAwesomeAddItemToCart
+Spree.api.storefront_cart_add_item_service = AnotherAddItemToCart
 ```
 
-The second line will have precedence over the first one, and the Storefront API will use `AnotherAddItemToCart` and the rest of the application will use `MyNewAwesomeAddItemToCart`
+The second line will have precedence over the first one, and the Storefront API will use `AnotherAddItemToCart` and the rest of the application will use `MyNewAwesomeAddItemToCart`.
+
+## Debugging dependencies
+
+Spree provides rake tasks to help you debug and inspect dependencies:
+
+### List all dependencies
+
+```bash
+bin/rake spree:dependencies:list
+```
+
+This will output all dependencies with their current values:
+
+```
+[CORE]
+cart_add_item_service           Spree::Cart::AddItem
+cart_create_service             Spree::Cart::Create
+cart_recalculate_service        Spree::Cart::Recalculate [OVERRIDDEN]
+...
+
+[API]
+storefront_cart_serializer      Spree::V2::Storefront::CartSerializer
+storefront_cart_add_item_service  MyApp::CartAddItem [OVERRIDDEN]
+...
+```
+
+You can use `grep` to filter results:
+
+```bash
+bin/rake spree:dependencies:list | grep cart
+```
+
+### Show only overridden dependencies
+
+```bash
+bin/rake spree:dependencies:overrides
+```
+
+This shows only the dependencies that have been customized, along with their original and current values:
+
+```
+[Core OVERRIDES]
+cart_recalculate_service  Spree::Cart::Recalculate -> MyApp::CartRecalculate (config/initializers/spree.rb:15)
+
+[API OVERRIDES]
+storefront_cart_add_item_service  Spree::Cart::AddItem -> MyApp::CartAddItem (config/initializers/spree.rb:20)
+```
+
+### Validate all dependencies
+
+```bash
+bin/rake spree:dependencies:validate
+```
+
+This validates that all dependencies can be resolved to valid classes. If any dependency points to a non-existent class, it will report an error:
+
+```
+..........F.........
+1 invalid dependencies:
+  [Core] cart_add_item_service: uninitialized constant NonExistentClass
+```
+
+## Programmatic introspection
+
+You can also inspect dependencies programmatically:
+
+```ruby
+# Check all current values
+Spree::Dependencies.current_values
+# => [{name: :cart_add_item_service, current: MyApp::CartAddItem, default: 'Spree::Cart::AddItem', overridden: true}, ...]
+
+# Check if a specific dependency is overridden
+Spree::Dependencies.overridden?(:cart_add_item_service)
+# => true
+
+# Get override information (where it was set)
+Spree::Dependencies.override_info(:cart_add_item_service)
+# => {value: MyApp::CartAddItem, source: "config/initializers/spree.rb:15", set_at: 2024-01-15 10:30:00}
+
+# Validate all dependencies resolve to valid classes
+Spree::Dependencies.validate!
+# => true (or raises Spree::DependencyError)
+```
+
+## Backwards compatibility
+
+The legacy string-based syntax is still supported for backwards compatibility:
+
+```ruby
+# Legacy syntax (still works)
+Spree::Dependencies.cart_add_item_service = 'MyAddToCartService'
+result = Spree::Dependencies.cart_add_item_service.constantize
+
+# New syntax (recommended)
+Spree.cart_add_item_service = MyAddToCartService
+result = Spree.cart_add_item_service
+```
+
+Both syntaxes can coexist, but the new syntax is recommended as it's more concise and provides better error messages at assignment time.
 
 ## Default values
 
-By default values can be easily checked by looking at the source code of Dependencies classes:
+Default values can be easily checked by:
 
-* [Application (global) dependencies](https://github.com/spree/spree/blob/main/core/lib/spree/core/dependencies.rb)
-* [API level dependencies](https://github.com/spree/spree/blob/main/api/lib/spree/api/dependencies.rb)
+1. Using the rake task: `bin/rake spree:dependencies:list`
+2. Looking at the source code:
+   * [Application (global) dependencies](https://github.com/spree/spree/blob/main/core/lib/spree/core/dependencies.rb)
+   * [API level dependencies](https://github.com/spree/spree/blob/main/api/lib/spree/api/dependencies.rb)


### PR DESCRIPTION
* Unified DSL to use dependency injection
* rake tasks to check/validate dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce unified Spree/Spree.api dependency accessors, refactor call sites to use them, add override tracking/validation with rake tasks, tests, and docs.
> 
> - **Dependencies DSL (Core + API)**:
>   - Add dynamic accessors on `Spree` and `Spree.api` that return resolved classes and support assignment (eg. `Spree.cart_add_item_service`, `Spree.api.storefront_cart_serializer`).
>   - Enhance `DependenciesHelper`: override tracking with source metadata, memoized `<dep>_class`, `current_values`, `overridden?`, `override_info`, and `validate!` (raises `Spree::DependencyError`).
>   - Mark legacy injection points (`cms_page_finder`, `menu_finder`, related serializers) as `nil`.
> - **Refactors (Core)**:
>   - Replace `Spree::Dependencies.*.constantize` with `Spree.*` accessors across models/services/jobs/finders (cart, checkout, orders, shipments, promotions, data feeds, search, store lookup, tracking numbers, abilities, etc.).
> - **API**:
>   - Add `Spree.api` accessor and use new dependency patterns; keep raw `Spree::Api::Dependencies` for BC.
> - **Tooling**:
>   - New rake tasks: `spree:dependencies:list`, `spree:dependencies:overrides`, `spree:dependencies:validate`.
> - **Tests**:
>   - Expand specs for core and API dependencies, accessor behavior, override tracking, memoization, and validation.
> - **Docs**:
>   - Update customization guide to new accessor syntax, usage examples, debugging tasks, and BC notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 838cb135f3200730eb1eada882b53531355e31ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->