### PR TITLE
Fixed flaky test doing mocking of dependencies

### DIFF
--- a/core/spec/jobs/spree/variants/remove_line_item_job_spec.rb
+++ b/core/spec/jobs/spree/variants/remove_line_item_job_spec.rb
@@ -4,13 +4,11 @@ module Spree
   describe Variants::RemoveLineItemJob, :job do
     let!(:order) { create(:order_with_line_items) }
     let!(:line_item) { order.line_items.take }
-    let(:remove_line_item_service_double) { double('RemoveLineItemService') }
 
-    it 'calls the cart_remove_item_service service' do
-      expect(Spree::Dependencies.cart_remove_line_item_service).to receive(:constantize).and_return(remove_line_item_service_double)
-      expect(remove_line_item_service_double).to receive(:call).with(order: order, line_item: line_item)
-
-      described_class.perform_now(line_item: line_item)
+    it 'removes the line item from the order' do
+      expect {
+        described_class.perform_now(line_item: line_item)
+      }.to change { order.reload.line_items.count }.by(-1)
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update the job spec to verify a line item is removed from the order instead of mocking the dependency.
> 
> - **Tests**:
>   - Update `core/spec/jobs/spree/variants/remove_line_item_job_spec.rb` to assert that `Variants::RemoveLineItemJob.perform_now` decreases `order.line_items.count` by 1, removing previous mocking of `Spree::Dependencies.cart_remove_line_item_service`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7047264ff6d9494ad345d5c1ae4d6b80aab3e4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->