### PR TITLE
Use Spree Form builder in product form more

### DIFF
--- a/admin/app/views/spree/admin/products/form/_status.html.erb
+++ b/admin/app/views/spree/admin/products/form/_status.html.erb
@@ -2,47 +2,33 @@
   <div class="card-body">
     <div class="row mb-3">
       <div class="col-6">
-        <div class="form-group">
-          <%= f.label :status, Spree.t(:status) %>
-          <%= help_bubble(Spree.t('admin.products.status_form.status')) if show_product_status_help_bubble? %>
-          <% select_html = { 
-                            data: {
-                              controller: 'autocomplete-select',
-                              action: 'change->product-form#switchAvailabilityDatesFields',
-                              'product-form-target': 'status'
-                            } 
-          } %>
-          <%= f.select(:status, available_status_options(@product), { selected: @product.status }, select_html) %>
-          <%= f.error_message_on :status %>
-        </div>
+        <%= f.spree_select :status,
+                           available_status_options(@product),
+                           { selected: @product.status, help_bubble: show_product_status_help_bubble? ? Spree.t('admin.products.status_form.status') : nil },
+                           { data: {
+                               action: 'change->product-form#switchAvailabilityDatesFields',
+                               'product-form-target': 'status'
+                             }
+                           } %>
       </div>
-      <div class="col-6 <% if @product.active? %>d-none<% end %>" data-product-form-target="makeActiveAt">
+      <div class="col-6 <%= 'd-none' if @product.active? %>" data-product-form-target="makeActiveAt">
         <% if can?(:activate, @product) %>
-          <div class="form-group">
-            <%= f.label :make_active_at, Spree.t(:make_active_at) %>
-            <%= help_bubble(Spree.t('admin.products.status_form.make_active_at')) %>
-            <%= f.error_message_on :make_active_at %>
-            <%= f.datetime_field :make_active_at, class: 'form-control', max: @product.discontinue_on %>
-          </div>
+          <%= f.spree_datetime_field :make_active_at,
+                                     help_bubble: Spree.t('admin.products.status_form.make_active_at'),
+                                     max: @product.discontinue_on %>
         <% end %>
       </div>
     </div>
     <div class="row">
       <div data-product-form-target="availableOn" class="col-6">
-        <div class="form-group">
-          <%= f.label :available_on, Spree.t(:available_on) %>
-          <%= help_bubble(Spree.t('admin.products.status_form.available_on')) %>
-          <%= f.error_message_on :available_on %>
-          <%= f.datetime_field :available_on, class: 'form-control', max: @product.discontinue_on %>
-        </div>
+        <%= f.spree_datetime_field :available_on,
+                                   help_bubble: Spree.t('admin.products.status_form.available_on'),
+                                   max: @product.discontinue_on %>
       </div>
       <div data-product-form-target="discontinueOn" class="col-6">
-        <div class="form-group">
-          <%= f.label :discontinue_on, Spree.t(:discontinue_on) %>
-          <%= help_bubble(Spree.t('admin.products.status_form.discontinue_on')) %>
-          <%= f.error_message_on :discontinue_on %>
-          <%= f.datetime_field :discontinue_on, class: 'form-control', min: @product.make_active_at %>
-        </div>
+        <%= f.spree_datetime_field :discontinue_on,
+                                   help_bubble: Spree.t('admin.products.status_form.discontinue_on'),
+                                   min: @product.make_active_at %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces manual inputs with Spree form builder helpers for status and availability fields in the product form while preserving behaviors and data bindings.
> 
> - **Admin product form (`admin/app/views/spree/admin/products/form/_status.html.erb`)**:
>   - Replace manual inputs with Spree helpers:
>     - `f.spree_select :status` (with help bubble, `change->product-form#switchAvailabilityDatesFields`, and `product-form-target` data bindings).
>     - `f.spree_datetime_field :make_active_at`, `:available_on`, `:discontinue_on` (with help bubbles and min/max constraints).
>   - Simplify conditional class for `makeActiveAt` column: `"d-none" if @product.active?`.
>   - Remove explicit `form-group` wrappers and inline error helpers in favor of builder-provided UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fea58d2e679cb28eaaa4e4bbff218c9d9170426c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->