### PR TITLE
Preprocess product images in background job to create their variations

### DIFF
--- a/admin/app/views/spree/admin/shared/_product_image.html.erb
+++ b/admin/app/views/spree/admin/shared/_product_image.html.erb
@@ -1,11 +1,12 @@
 <% width ||= 50 %>
 <% height ||= 50 %>
+<% variant ||= :mini %>
 <% image ||= object.default_image %>
 
 <% if image.present? && image.attached? && image.variable? %>
   <% alt ||= image.alt || object.name %>
   <div class="admin-product-image-container">
-    <%= spree_image_tag(image, width: width, height: height, alt: alt) %>
+    <%= spree_image_tag(image, variant: variant, alt: alt, width: width, height: height) %>
   </div>
 <% else %>
   <%= render 'spree/admin/shared/no_image', width: width, height: height %>

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -12,9 +12,33 @@ module Spree
     belongs_to :viewable, polymorphic: true, touch: true
     acts_as_list scope: [:viewable_id, :viewable_type]
 
-    delegate :key, :attached?, :variant, :variable?, :blob, :filename, to: :attachment
+    delegate :key, :attached?, :variant, :variable?, :blob, :filename, :variation, to: :attachment
 
-    has_one_attached :attachment, service: Spree.public_storage_service_name
+    WEBP_SAVER_OPTIONS = {
+      strip: true,
+      quality: 75,
+      lossless: false,
+      alpha_q: 85,
+      reduction_effort: 6,
+      smart_subsample: true
+    }.freeze
+
+    has_one_attached :attachment, service: Spree.public_storage_service_name do |attachable|
+      # Note: Key order matters for variation digest matching.
+      # Active Storage reorders keys alphabetically when calling variant(:name),
+      # so we must define them in alphabetical order: format, resize_to_fill, saver
+      #
+      # IMPORTANT: Use string values (not symbols) for format because the variation key
+      # is JSON-encoded in URLs. JSON converts symbols to strings, so "webp" != :webp
+      # after round-tripping, which causes digest mismatches.
+      Spree::Config.product_image_variant_sizes.each do |name, (width, height)|
+        attachable.variant name,
+                           format: "webp",
+                           resize_to_fill: [width, height],
+                           saver: WEBP_SAVER_OPTIONS,
+                           preprocessed: true
+      end
+    end
 
     default_scope { includes(attachment_attachment: :blob) }
 

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -51,7 +51,8 @@ module Spree
     end
 
     def plp_url
-      generate_url(size: self.class.styles[:plp_and_carousel])
+      Spree::Deprecation.warn "Image#plp_url is deprecated. Use variant(:large) instead."
+      generate_url(size: self.class.styles[:large])
     end
 
     private

--- a/core/app/models/spree/image/configuration/active_storage.rb
+++ b/core/app/models/spree/image/configuration/active_storage.rb
@@ -7,25 +7,16 @@ module Spree
         included do
           validates :attachment, attached: true, content_type: Rails.application.config.active_storage.web_image_content_types
 
+          # Returns image styles derived from Spree::Config.product_image_variant_sizes
+          # Format: { variant_name: 'WxH>' } for API compatibility
           def self.styles
-            @styles ||= {
-              mini: '48x48>',
-              small: '100x100>',
-              product: '240x240>',
-              pdp_thumbnail: '160x200>',
-              plp_and_carousel: '448x600>',
-              plp_and_carousel_xs: '254x340>',
-              plp_and_carousel_sm: '350x468>',
-              plp_and_carousel_md: '222x297>',
-              plp_and_carousel_lg: '278x371>',
-              large: '600x600>',
-              plp: '278x371>',
-              zoomed: '650x870>'
-            }
+            @styles ||= Spree::Config.product_image_variant_sizes.transform_values do |dimensions|
+              "#{dimensions[0]}x#{dimensions[1]}>"
+            end
           end
 
           def default_style
-            :product
+            :small
           end
         end
       end

--- a/core/app/models/spree/themes/default.rb
+++ b/core/app/models/spree/themes/default.rb
@@ -85,10 +85,13 @@ module Spree
       preference :border_shadow_blur, :integer, default: 5
 
       # PRODUCT IMAGES
-      preference :product_listing_image_height, :integer, default: 300
-      preference :product_listing_image_width, :integer, default: 300
-      preference :product_listing_image_height_mobile, :integer, default: 190
-      preference :product_listing_image_width_mobile, :integer, default: 190
+      # These defaults match preprocessed variant sizes for optimal performance:
+      # Desktop (360x360) → large variant (720x720 at 2x)
+      # Mobile (200x200) → medium variant (400x400 at 2x)
+      preference :product_listing_image_height, :integer, default: 360
+      preference :product_listing_image_width, :integer, default: 360
+      preference :product_listing_image_height_mobile, :integer, default: 200
+      preference :product_listing_image_width_mobile, :integer, default: 200
     end
   end
 end

--- a/core/lib/spree/core/configuration.rb
+++ b/core/lib/spree/core/configuration.rb
@@ -46,6 +46,36 @@ module Spree
       preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
       preference :geocode_addresses, :boolean, default: true
       preference :images_save_from_url_job_attempts, :integer, default: 5
+
+      # Preprocessed product image variant sizes at 2x retina resolution.
+      # These variants are generated on upload to reduce runtime processing.
+      # When using spree_image_tag, pass half these values (e.g., width: 64 for mini).
+      #
+      # Default sizes:
+      #   mini (128x128)     - admin thumbnails, checkout line items
+      #   small (256x256)    - cart/order items, gallery thumbnails
+      #   medium (400x400)   - mobile listing, admin media
+      #   large (720x720)    - product listing, mobile gallery
+      #   xlarge (2000x2000) - gallery main, lightbox
+      #
+      # To customize, override in your initializer:
+      #   Spree::Config.product_image_variant_sizes = {
+      #     mini: [128, 128],
+      #     small: [256, 256],
+      #     # ... your custom sizes
+      #   }
+      attr_writer :product_image_variant_sizes
+
+      def product_image_variant_sizes
+        @product_image_variant_sizes ||= {
+          mini: [128, 128],
+          small: [256, 256],
+          medium: [400, 400],
+          large: [720, 720],
+          xlarge: [2000, 2000],
+          og_image: [1200, 630]
+        }
+      end
       preference :layout, :string, deprecated: 'Please use Spree::Frontend::Config[:layout] instead'
       preference :logo, :string, deprecated: true
       preference :mailer_logo, :string, deprecated: true

--- a/core/spec/models/spree/asset_spec.rb
+++ b/core/spec/models/spree/asset_spec.rb
@@ -3,6 +3,25 @@ require 'spec_helper'
 describe Spree::Asset, type: :model do
   it_behaves_like 'metadata'
 
+  describe 'named variants' do
+    let(:reflection) { described_class.attachment_reflections['attachment'] }
+
+    it 'defines preprocessed variants based on config' do
+      expected_variants = Spree::Config.product_image_variant_sizes.keys
+      expect(reflection.named_variants.keys).to match_array(expected_variants)
+    end
+
+    Spree::Config.product_image_variant_sizes.each do |name, (width, height)|
+      it "defines :#{name} variant with correct options" do
+        named_variant = reflection.named_variants[name]
+        expect(named_variant).to be_present
+        expect(named_variant.transformations[:resize_to_fill]).to eq([width, height])
+        expect(named_variant.transformations[:format]).to eq("webp")
+        expect(named_variant.instance_variable_get(:@preprocessed)).to eq(true)
+      end
+    end
+  end
+
   describe '#product' do
     it 'returns the product for the asset' do
       variant = create(:variant)

--- a/storefront/app/views/spree/checkout/_line_item.html.erb
+++ b/storefront/app/views/spree/checkout/_line_item.html.erb
@@ -5,7 +5,7 @@
     </span>
     <% image = line_item.variant.default_image %>
     <% if image.present? && image.attached? && image.variable? %>
-      <%= spree_image_tag(image, class: 'rounded-sm border border-default bg-transparent object-cover object-center', loading: :lazy, width: 64, height: 64) %>
+      <%= spree_image_tag(image, class: 'rounded-sm border border-default bg-transparent object-cover object-center', loading: :lazy, variant: :mini, width: 64, height: 64) %>
     <% else %>
       <div class="w-16 h-16 bg-accent border border-default rounded-sm"></div>
     <% end %>

--- a/storefront/app/views/themes/default/spree/orders/_line_item.html.erb
+++ b/storefront/app/views/themes/default/spree/orders/_line_item.html.erb
@@ -5,7 +5,7 @@
         <% image = line_item.variant.default_image %>
         <% if image.present? && image.attached? && image.variable? %>
           <%= link_to spree_storefront_resource_url(line_item.product), data: { 'turbo-frame': '_top' } do %>
-            <%= spree_image_tag(image, width: 128, height: 128, class: 'object-cover', loading: :lazy) %>
+            <%= spree_image_tag(image, width: 128, height: 128, variant: :small, class: 'object-cover', loading: :lazy) %>
           <% end %>
         <% else %>
           <div class="w-32 h-32 bg-accent"></div>

--- a/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
@@ -12,10 +12,10 @@
     <% image_hover_class = object.secondary_image.present? && object.secondary_image.attached? ? 
          "w-full group-hover:opacity-0 transition-opacity duration-500 z-10 relative h-full bg-background product-card !max-h-full #{object_class}" :
          "w-full h-full !max-h-full #{object_class}" %>
-    <%= spree_image_tag(object.default_image, width: width, height: height, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.primary_image', default: 'primary image')}", class: image_hover_class) %>
+    <%= spree_image_tag(object.default_image, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.primary_image', default: 'primary image')}", class: image_hover_class) %>
     <% if object.secondary_image.present? && object.secondary_image.attached? %>
       <% secondary_image_class = "w-full absolute top-0 left-0 opacity-100 h-full !max-h-full #{object_class}" %>
-      <%= spree_image_tag(object.secondary_image, width: width, height: height, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.secondary_image', default: 'secondary image')}", class: secondary_image_class) %>
+      <%= spree_image_tag(object.secondary_image, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.secondary_image', default: 'secondary image')}", class: secondary_image_class) %>
     <% end %>
   </figure>
 <% else %>

--- a/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
@@ -7,7 +7,7 @@
     "url": <%= spree.product_url(product, host: current_store.url_or_custom_domain).to_json.html_safe %>,
   <% if product.featured_image %>
     "image": [
-      <%= spree_image_url(product.featured_image, width: 630, height: 630).to_json.html_safe %>
+      <%= spree_image_url(product.featured_image, variant: :large).to_json.html_safe %>
     ],
   <% end %>
   <% if product.description.present? %>

--- a/storefront/app/views/themes/default/spree/products/_media_gallery.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_media_gallery.html.erb
@@ -21,7 +21,7 @@
                     class="relative aspect-1 w-full block "
                     id="thumb-desktop-product-image-<%= image.id %>"
                     data-turbo-permanent>
-                    <%= spree_image_tag(image, width: 100, height: 100, alt: image_alt(image), class: 'w-full h-full') %>
+                    <%= spree_image_tag(image, variant: :small, alt: image_alt(image), class: 'w-full h-full') %>
                   </div>
                 </div>
               <% end %>
@@ -39,11 +39,11 @@
                   class="product-image relative w-full aspect-1"
                   id="main-desktop-product-image-<%= image.id %>"
                   data-turbo-permanent>
-                  <%= link_to spree_image_url(image, width: 1000, height: 1000), data: { pswp_width: "2000", pswp_height: "2000" } do %>
+                  <%= link_to spree_image_url(image, variant: :xlarge), data: { pswp_width: "2000", pswp_height: "2000" } do %>
                     <div class="zoom-icon hidden absolute bottom-2 right-2 p-4 bg-background rounded-full opacity-75 hover:opacity-100">
                       <%= render 'spree/shared/icons/zoom' %>
                     </div>
-                    <%= spree_image_tag(image, width: 1000, height: 1000, alt: image_alt(image), class: 'w-full h-full') %>
+                    <%= spree_image_tag(image, variant: :xlarge, alt: image_alt(image), class: 'w-full h-full') %>
                   <% end %>
                 </div>
               </div>
@@ -70,11 +70,11 @@
         <div class="swiper-wrapper">
           <% images.each do |image| %>
             <div class="swiper-slide aspect-1" id="swiper-slide-<%= image.id %>">
-              <%= link_to spree_image_url(image, width: 2000, height: 2000), class: "absolute top-2 right-2 p-2 bg-background rounded-full opacity-75 hover:opacity-100", data: { pswp_width: "2000", pswp_height: "2000" } do %>
+              <%= link_to spree_image_url(image, variant: :xlarge), class: "absolute top-2 right-2 p-2 bg-background rounded-full opacity-75 hover:opacity-100", data: { pswp_width: "2000", pswp_height: "2000" } do %>
                 <%= render 'spree/shared/icons/zoom' %>
               <% end %>
               <%= render 'spree/products/label', product: product, mobile_pdp: true %>
-              <%= spree_image_tag(image, width: 360, height: 360, alt: image_alt(image), class: 'h-full w-full object-cover object-center', style: 'min-height: 358px') %>
+              <%= spree_image_tag(image, variant: :large, alt: image_alt(image), class: 'h-full w-full object-cover object-center', style: 'min-height: 358px') %>
             </div>
           <% end %>
         </div>

--- a/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
@@ -22,7 +22,11 @@
 <meta property="og:description" content="<%= h(og_description) %>">
 
 <% if page_image.present? && page_image.attached? && page_image.variable? %>
-  <% image_url = spree_image_url(page_image, width: 1200, height: 630) %>
+  <% if @product %>
+    <% image_url = spree_image_url(page_image, variant: :og_image) %>
+  <% else %>
+    <% image_url = spree_image_url(page_image, width: 1200, height: 630) %>
+  <% end %>
 
   <meta property="og:image" content="<%= image_url %>">
   <meta property="og:image:secure_url" content="<%= image_url %>">

--- a/storefront/app/views/themes/default/spree/shared/_order_line_item.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_line_item.html.erb
@@ -6,7 +6,7 @@
       <% image = line_item.variant.default_image %>
       <% if image.present? && image.attached? && image.variable? %>
         <%= link_to spree_storefront_resource_url(line_item.product, relative: true) do %>
-          <%= spree_image_tag(image, width: 128, height: 128, loading: :lazy) %>
+          <%= spree_image_tag(image, width: 128, height: 128, variant: :small, loading: :lazy) %>
         <% end %>
       <% else %>
         <div class="w-32 h-32 bg-accent"></div>

--- a/storefront/lib/generators/spree/storefront/theme/templates/model.rb.tt
+++ b/storefront/lib/generators/spree/storefront/theme/templates/model.rb.tt
@@ -84,10 +84,13 @@ module Spree
       preference :border_shadow_blur, :integer, default: 5
 
       # PRODUCT IMAGES
-      preference :product_listing_image_height, :integer, default: 300
-      preference :product_listing_image_width, :integer, default: 300
-      preference :product_listing_image_height_mobile, :integer, default: 190
-      preference :product_listing_image_width_mobile, :integer, default: 190
+      # These defaults match preprocessed variant sizes for optimal performance:
+      # Desktop (360x360) → large variant (720x720 at 2x)
+      # Mobile (200x200) → medium variant (400x400 at 2x)
+      preference :product_listing_image_height, :integer, default: 360
+      preference :product_listing_image_width, :integer, default: 360
+      preference :product_listing_image_height_mobile, :integer, default: 200
+      preference :product_listing_image_width_mobile, :integer, default: 200
 
       # Returns an array of available layout section classes for the theme, eg. header, footer, newsletter, etc.
       #


### PR DESCRIPTION
This massively speeds up product listing pages and reduces web load. Usually images are served from CDN but the first time you hit them, they were need to be reprocessed in the web process, which is a lengthy process we should avoid.