### PR TITLE
Add Greek country code mapping to svg_country_icon helper

### DIFF
--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -85,6 +85,7 @@ module Spree
 
     def svg_country_icon(country_code)
       language_to_country = {
+        'el' => 'gr',
         'en' => 'us',
         'ja' => 'jp',
         'uk' => 'ua'


### PR DESCRIPTION
Greek local code is "el" but as svg icon there is only for "gr". So, ive made this addition to the helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `el -> gr` mapping in `svg_country_icon` to display the Greek flag for Greek locale codes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 469bff0e23856d5728bb9bba41cca26c731c0cec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->