### PR TITLE
FIX csv importer index

### DIFF
--- a/core/app/jobs/spree/imports/create_rows_job.rb
+++ b/core/app/jobs/spree/imports/create_rows_job.rb
@@ -31,7 +31,7 @@ module Spree
 
         upsert_options = {}
         if %w[PostgreSQL SQLite].include?(ActiveRecord::Base.connection.adapter_name)
-          upsert_options[:unique_by] = %i[import_id row_number]
+          upsert_options[:unique_by] = :index_spree_import_rows_on_import_id_and_row_number
         end
         # NOTE: Ensure a DB-level unique index on [:import_id, :row_number] for all adapters.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches upsert conflict target to the named unique index for import rows on PostgreSQL/SQLite during CSV row creation.
> 
> - **Backend – Imports**:
>   - Update `Spree::Imports::CreateRowsJob#create_rows_sequentially` to set `upsert_options[:unique_by]` to `:index_spree_import_rows_on_import_id_and_row_number` (instead of `[:import_id, :row_number]`) for PostgreSQL/SQLite `upsert_all`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fd088b5a6c52eff5a5c887115c46f738d080bf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->