### PR TITLE
Fix indentation in product details template

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/_product_details.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_product_details.html.erb
@@ -70,7 +70,8 @@
                       <%= render 'spree/products/metafields', product: product, block: block, section: section %>
                     <% end %>
                   </div>
-              <% end %>
+                <% end %>
+              </div>
             <% end %>
 
             <%= render 'spree/products/add_to_waitlist', variant: current_variant if show_waitlist_modal %>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes misplaced ERB `end` and adds a missing closing `</div>` in the product details section to ensure proper structure.
> 
> - **Views**:
>   - `storefront/app/views/themes/default/spree/page_sections/_product_details.html.erb`:
>     - Move misplaced ERB `end` to properly close the blocks loop.
>     - Add missing closing `</div>` for the `productDetails` wrapper to fix layout/structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9659183e9bdbb673f80f8d30d93e5653121d3707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->