### PR TITLE
Fix toggle menu

### DIFF
--- a/storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js
@@ -44,18 +44,10 @@ export default class ToggleMenu extends Toggle {
   updateDynamicHeight() {
     if (!this.hasContentTarget) return
     
-    const navElement = this.element.querySelector('nav[aria-label="Top"]')
-    const navPaddingBottom = navElement ? 
-      parseInt(getComputedStyle(navElement).paddingBottom, 10) || 0 : 0
-    
     const contentTopDistance = this.contentTarget.getBoundingClientRect().top
     const calculatedHeight = `calc(100dvh - ${contentTopDistance}px)`
     
     this.contentTarget.style.height = calculatedHeight
-    const firstChild = this.contentTarget.firstElementChild
-    if (firstChild) {
-      firstChild.style.marginTop = `${navPaddingBottom}px`
-    }
   }
 
   setupObservers() {

--- a/storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js
+++ b/storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js
@@ -7,6 +7,12 @@ export default class ToggleMenu extends Toggle {
 
   connect() {
     super.connect()
+    this.setupDynamicHeight()
+  }
+
+  disconnect() {
+    super.disconnect()
+    this.cleanupObservers()
   }
 
   hide(e) {
@@ -17,6 +23,7 @@ export default class ToggleMenu extends Toggle {
   }
 
   toggle(e) {
+    this.updateDynamicHeight()
     super.toggle(e)
     if (this.openValue) {
       this.buttonTarget.classList.add('menu-open')
@@ -28,4 +35,55 @@ export default class ToggleMenu extends Toggle {
       unlockScroll()
     }
   }
+
+  setupDynamicHeight() {
+    this.updateDynamicHeight()
+    this.setupObservers()
+  }
+
+  updateDynamicHeight() {
+    if (!this.hasContentTarget) return
+    
+    const navElement = this.element.querySelector('nav[aria-label="Top"]')
+    const navPaddingBottom = navElement ? 
+      parseInt(getComputedStyle(navElement).paddingBottom, 10) || 0 : 0
+    
+    const contentTopDistance = this.contentTarget.getBoundingClientRect().top
+    const calculatedHeight = `calc(100dvh - ${contentTopDistance}px)`
+    
+    this.contentTarget.style.height = calculatedHeight
+    const firstChild = this.contentTarget.firstElementChild
+    if (firstChild) {
+      firstChild.style.marginTop = `${navPaddingBottom}px`
+    }
+  }
+
+  setupObservers() {
+    const debouncedUpdate = () => {
+      clearTimeout(this.updateTimeout)
+      this.updateTimeout = setTimeout(() => this.updateDynamicHeight(), 16)
+    }
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(debouncedUpdate)
+      const navElement = this.element.querySelector('nav[aria-label="Top"]')
+      if (navElement) {
+        this.resizeObserver.observe(navElement)
+      }
+    }
+
+    this.windowResizeHandler = debouncedUpdate
+    window.addEventListener('resize', this.windowResizeHandler)
+  }
+
+  cleanupObservers() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect()
+    }
+    if (this.windowResizeHandler) {
+      window.removeEventListener('resize', this.windowResizeHandler)
+    }
+    clearTimeout(this.updateTimeout)
+  }
+
 }

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -143,7 +143,7 @@
       aria-modal='true'
     >
       <div
-        class='flex justify-between flex-col lg:hidden w-full transition-transform translate-x-[-50%] has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
+        class='flex justify-between flex-col lg:hidden w-full transition-transform has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
         data-toggle-menu-target='content'
         style='background-color: <%= section.preferred_background_color %>;'
         >

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -149,6 +149,7 @@
         >
         <%= render 'spree/page_sections/nav/mobile', section: section %>
       </div>
+    </div>
 
     <%= render 'spree/shared/cart_pane', section: section %>
     <% if show_account_pane? %>

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -137,18 +137,17 @@
       </div>
     </nav>
     <div
-        class='h-0 opacity-0 pointer-events-none hide-on-load'
-        data-toggle-menu-target='toggleable'
-        role='dialog'
-        aria-modal='true'
-      >
-        <div
-          class='flex justify-between flex-col lg:hidden w-full transition-transform has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
-          data-toggle-menu-target='content'
-          style='background-color: <%= section.preferred_background_color %>; height: calc(100dvh - 58px - 36px);'
-          >
-          <%= render 'spree/page_sections/nav/mobile', section: section %>
-        </div>
+      class='h-0 opacity-0 pointer-events-none hide-on-load'
+      data-toggle-menu-target='toggleable'
+      role='dialog'
+      aria-modal='true'
+    >
+      <div
+        class='flex justify-between flex-col lg:hidden w-full transition-transform translate-x-[-50%] has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'
+        data-toggle-menu-target='content'
+        style='background-color: <%= section.preferred_background_color %>;'
+        >
+        <%= render 'spree/page_sections/nav/mobile', section: section %>
       </div>
 
     <%= render 'spree/shared/cart_pane', section: section %>


### PR DESCRIPTION
Currently, the height of the toggle menu is hardcoded.
We do not anticipate a situation in which the user changes, for example, the header padding or the height of the announcement bar.

The introduced controller modification will handle this automatically. It will check the distance between the open menu and the device and set the appropriate height of the open menu.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the mobile menu height dynamic via controller logic and observers, removing hardcoded height from the header template.
> 
> - **Storefront JS** (`storefront/app/javascript/spree/storefront/controllers/toggle_menu_controller.js`):
>   - Add dynamic height calculation for `content` (`calc(100dvh - contentTop)`), invoked on connect and toggle.
>   - Introduce observers: `ResizeObserver` on `nav[aria-label="Top"]` and window `resize` with debounced updates; clean up on disconnect.
> - **View** (`storefront/app/views/themes/default/spree/page_sections/_header.html.erb`):
>   - Remove hardcoded inline height from mobile menu container; keep background color style only, relying on controller-set height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4170dbe65ebfae2da867c787a3ec56fab914e3ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->