### PR TITLE
FIX void payment

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -63,6 +63,7 @@ module Spree
 
       def void_transaction!
         return true if void?
+        return void if response_code.blank?
 
         protect_from_connection_error do
           if payment_method.payment_profiles_supported?

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -694,6 +694,19 @@ describe Spree::Payment, type: :model do
           payment.void_transaction!
         end
       end
+
+      context 'if response_code is blank' do
+        before do
+          payment.response_code = nil
+          payment.state = 'pending'
+        end
+
+        it 'voids the payment without calling the gateway' do
+          expect(payment.payment_method).not_to receive(:void)
+          payment.void_transaction!
+          expect(payment.state).to eq('void')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Initialized payments might not have response_code from provider but still we need to void them: https://github.com/spree/spree/blob/main/core/app/models/spree/order.rb#L941