### PR TITLE
fix: Header overlay is misaligned in page builder

### DIFF
--- a/storefront/lib/generators/spree/storefront/install/templates/application.css
+++ b/storefront/lib/generators/spree/storefront/install/templates/application.css
@@ -135,7 +135,7 @@ html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-body .section-header {
+body:not(.page-builder) > div.section-header {
   @apply sticky top-0 z-50;
 }
 

--- a/storefront/lib/generators/spree/storefront/install/templates/application.css
+++ b/storefront/lib/generators/spree/storefront/install/templates/application.css
@@ -135,7 +135,7 @@ html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-body:not(.page-builder) > div.section-header {
+body:not(.inside-page-builder) > div.section-header {
   @apply sticky top-0 z-50;
 }
 


### PR DESCRIPTION
The section editing containers in the page builder try to refer to the top of the body container each time.
When the header has a sticky position, it becomes a relative component. For this reason, the editing container positions itself at the top of the page, but on the front end, it positions itself relative to the header. To easily fix this bug, the header will no longer be sticky in the page builder.

tldr:
A minor change fixing a header error in the page builder.  Header will no longer be sticky in the page builder.


Before:
<img width="3442" height="598" alt="image" src="https://github.com/user-attachments/assets/a8f13d7b-80d0-473c-961b-9ba56ae66f5b" />

After:
<img width="1836" height="423" alt="image" src="https://github.com/user-attachments/assets/768bf2fc-81f9-4b1c-9143-a35f77865aff" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents sticky header behavior inside the page builder to fix editing overlay alignment.
> 
> - Updates CSS selector from `body .section-header` to `body:not(.inside-page-builder) > div.section-header` so `sticky top-0 z-50` only applies outside the page builder
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c27ff268b00c510aa5ea15e6f6d480babc0f72e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->