### PR TITLE
Move `publishes_lifecycle_events` directly into models

### DIFF
--- a/admin/app/helpers/spree/admin/webhook_endpoints_helper.rb
+++ b/admin/app/helpers/spree/admin/webhook_endpoints_helper.rb
@@ -3,16 +3,49 @@
 module Spree
   module Admin
     module WebhookEndpointsHelper
+      # Models that have publishes_lifecycle_events enabled
+      # These models publish created/updated/deleted events
+      EVENTABLE_MODELS = %w[
+        asset
+        customer_return
+        digital
+        digital_link
+        export
+        gift_card
+        gift_card_batch
+        import
+        line_item
+        newsletter_subscriber
+        order
+        payment
+        post
+        post_category
+        price
+        product
+        promotion
+        refund
+        report
+        return_authorization
+        shipment
+        stock_item
+        stock_movement
+        stock_transfer
+        store_credit
+        user
+        variant
+        wished_item
+        wishlist
+      ].freeze
+
       def available_webhook_events
         @available_webhook_events ||= begin
           events = []
 
           # Add lifecycle events from eventable models
-          Spree.eventable_models.each do |model_class|
-            base_name = model_class.name.demodulize.underscore
-            events << "#{base_name}.created"
-            events << "#{base_name}.updated"
-            events << "#{base_name}.deleted"
+          EVENTABLE_MODELS.each do |model_name|
+            events << "#{model_name}.created"
+            events << "#{model_name}.updated"
+            events << "#{model_name}.deleted"
           end
 
           # Add custom events

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -4,6 +4,8 @@ module Spree
     include Spree::Metafields
     include Spree::Metadata
 
+    publishes_lifecycle_events
+
     EXTERNAL_URL_METAFIELD_KEY = 'external.url'
 
     belongs_to :viewable, polymorphic: true, touch: true

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -5,6 +5,8 @@ module Spree
     include Spree::Metafields
     include Spree::Metadata
 
+    publishes_lifecycle_events
+
     belongs_to :stock_location
     belongs_to :store, class_name: 'Spree::Store', inverse_of: :customer_returns
 

--- a/core/app/models/spree/digital.rb
+++ b/core/app/models/spree/digital.rb
@@ -1,5 +1,7 @@
 module Spree
   class Digital < Spree.base_class
+    publishes_lifecycle_events
+
     belongs_to :variant
     has_many :digital_links, dependent: :destroy
 

--- a/core/app/models/spree/digital_link.rb
+++ b/core/app/models/spree/digital_link.rb
@@ -1,5 +1,7 @@
 module Spree
   class DigitalLink < Spree.base_class
+    publishes_lifecycle_events
+
     if Rails::VERSION::STRING >= '7.1.0'
       has_secure_token on: :save
     else

--- a/core/app/models/spree/export.rb
+++ b/core/app/models/spree/export.rb
@@ -11,6 +11,8 @@ module Spree
 
     include Spree::Core::NumberGenerator.new(prefix: 'EF')
 
+    publishes_lifecycle_events
+
     # Set event prefix for all Export subclasses
     # This ensures Spree::Exports::Products publishes 'export.create' not 'products.create'
     self.event_prefix = 'export'

--- a/core/app/models/spree/gift_card.rb
+++ b/core/app/models/spree/gift_card.rb
@@ -5,6 +5,8 @@ module Spree
     include Spree::Metafields
     include Spree::Security::GiftCards if defined?(Spree::Security::GiftCards)
 
+    publishes_lifecycle_events
+
     #
     # State machine
     #

--- a/core/app/models/spree/gift_card_batch.rb
+++ b/core/app/models/spree/gift_card_batch.rb
@@ -3,6 +3,8 @@ module Spree
     extend DisplayMoney
     include Spree::SingleStoreResource
 
+    publishes_lifecycle_events
+
     #
     # Associations
     #

--- a/core/app/models/spree/import.rb
+++ b/core/app/models/spree/import.rb
@@ -7,6 +7,8 @@ module Spree
 
     include Spree::Core::NumberGenerator.new(prefix: 'IM')
 
+    publishes_lifecycle_events
+
     # Set event prefix for all Import subclasses
     # This ensures Spree::Imports::Products publishes 'import.create' not 'products.create'
     self.event_prefix = 'import'

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -3,6 +3,8 @@ module Spree
     include Spree::Metafields
     include Spree::Metadata
 
+    publishes_lifecycle_events
+
     attribute :quantity, :integer, default: 1
 
     before_validation :ensure_valid_quantity

--- a/core/app/models/spree/newsletter_subscriber.rb
+++ b/core/app/models/spree/newsletter_subscriber.rb
@@ -5,6 +5,8 @@ module Spree
     include Spree::NewsletterSubscriber::Emails
     include Spree::Metafields
 
+    publishes_lifecycle_events
+
     has_secure_token :verification_token
 
     #

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -28,6 +28,8 @@ module Spree
     include Spree::NumberIdentifier
     include Spree::NumberAsParam
     include Spree::SingleStoreResource
+
+    publishes_lifecycle_events
     include Spree::MemoizedData
     include Spree::Metafields
     include Spree::Metadata

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -17,6 +17,8 @@ module Spree
     include Spree::Payment::Webhooks
     include Spree::Payment::CustomEvents
 
+    publishes_lifecycle_events
+
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
     RISKY_AVS_CODES     = ['A', 'C', 'E', 'F', 'G', 'I', 'K', 'L', 'N', 'O', 'P', 'R', 'S', 'U', 'W', 'Z'].freeze
     INVALID_STATES      = %w(failed invalid void).freeze

--- a/core/app/models/spree/post.rb
+++ b/core/app/models/spree/post.rb
@@ -4,6 +4,8 @@ module Spree
     include Spree::Metafields
     extend FriendlyId
 
+    publishes_lifecycle_events
+
     friendly_id :slug_candidates, use: %i[slugged scoped history], scope: %i[store_id deleted?]
     acts_as_paranoid
     acts_as_taggable_on :tags

--- a/core/app/models/spree/post_category.rb
+++ b/core/app/models/spree/post_category.rb
@@ -4,6 +4,8 @@ module Spree
     include Spree::Metafields
     extend FriendlyId
 
+    publishes_lifecycle_events
+
     friendly_id :slug_candidates, use: %i[slugged scoped history], scope: %i[store_id]
 
     #

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -2,6 +2,8 @@ module Spree
   class Price < Spree.base_class
     include Spree::VatPriceCalculation
 
+    publishes_lifecycle_events
+
     acts_as_paranoid
 
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -36,6 +36,8 @@ module Spree
       include Spree::VendorConcern
     end
 
+    publishes_lifecycle_events
+
     MEMOIZED_METHODS = %w[total_on_hand taxonomy_ids taxon_and_ancestors category
                           default_variant_id tax_category default_variant
                           default_image secondary_image

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -7,6 +7,8 @@ module Spree
       include Spree::Security::Promotions
     end
 
+    publishes_lifecycle_events
+
     MATCH_POLICIES = %w(all any)
     UNACTIVATABLE_ORDER_STATES = ['complete', 'awaiting_return', 'returned']
 

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -6,6 +6,8 @@ module Spree
       include Spree::Security::Refunds
     end
 
+    publishes_lifecycle_events
+
     with_options inverse_of: :refunds do
       belongs_to :payment
       belongs_to :reimbursement, optional: true

--- a/core/app/models/spree/report.rb
+++ b/core/app/models/spree/report.rb
@@ -3,6 +3,8 @@ module Spree
     include Spree::SingleStoreResource
     include Spree::VendorConcern if defined?(Spree::VendorConcern)
 
+    publishes_lifecycle_events
+
     # Set event prefix for all Report subclasses
     # This ensures Spree::Reports::SalesTotal publishes 'report.create' not 'sales_total.create'
     self.event_prefix = 'report'

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -3,6 +3,8 @@ module Spree
     include Spree::Core::NumberGenerator.new(prefix: 'RA', length: 9)
     include Spree::NumberIdentifier
 
+    publishes_lifecycle_events
+
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations
 
     has_many :return_items, inverse_of: :return_authorization, dependent: :destroy

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -17,6 +17,8 @@ module Spree
     include Spree::Shipment::Webhooks
     include Spree::Shipment::CustomEvents
 
+    publishes_lifecycle_events
+
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'
       belongs_to :order, class_name: 'Spree::Order', touch: true

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -6,6 +6,8 @@ module Spree
     include Spree::Metadata
     include Spree::StockItem::Webhooks
 
+    publishes_lifecycle_events
+
     with_options inverse_of: :stock_items do
       belongs_to :stock_location, class_name: 'Spree::StockLocation'
       belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -8,6 +8,8 @@ module Spree
     include Spree::StockMovement::Webhooks
     include Spree::StockMovement::CustomEvents
 
+    publishes_lifecycle_events
+
     belongs_to :stock_item, class_name: 'Spree::StockItem', inverse_of: :stock_movements
     belongs_to :originator, polymorphic: true
 

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -6,6 +6,8 @@ module Spree
     include Spree::Metafields
     include Spree::Metadata
 
+    publishes_lifecycle_events
+
     has_many :stock_movements, as: :originator
     accepts_nested_attributes_for :stock_movements, reject_if: proc { |attributes|
       attributes[:quantity] = attributes[:quantity].to_i

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -4,6 +4,8 @@ module Spree
     include Spree::Metafields
     include Spree::Metadata
 
+    publishes_lifecycle_events
+
     acts_as_paranoid
 
     VOID_ACTION       = 'void'.freeze

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -8,6 +8,8 @@ module Spree
     include Spree::Metadata
     include Spree::Variant::Webhooks
 
+    publishes_lifecycle_events
+
     MEMOIZED_METHODS = %w(purchasable in_stock on_sale backorderable tax_category options_text compare_at_price)
 
     DIMENSION_UNITS = %w[mm cm in ft]

--- a/core/app/models/spree/wished_item.rb
+++ b/core/app/models/spree/wished_item.rb
@@ -3,6 +3,8 @@ module Spree
     extend DisplayMoney
     money_methods :total, :price
 
+    publishes_lifecycle_events
+
     belongs_to :variant, class_name: 'Spree::Variant'
     belongs_to :wishlist, class_name: 'Spree::Wishlist'
 

--- a/core/app/models/spree/wishlist.rb
+++ b/core/app/models/spree/wishlist.rb
@@ -2,6 +2,8 @@ module Spree
   class Wishlist < Spree.base_class
     include Spree::SingleStoreResource
 
+    publishes_lifecycle_events
+
     if Rails::VERSION::STRING >= '7.1.0'
       has_secure_token on: :save
     else

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -306,17 +306,6 @@ module Spree
     Rails.application.config.spree.integrations = value
   end
 
-  # Models that automatically emit lifecycle events (create, update, destroy)
-  # @example Adding a custom model to emit events
-  #   Spree.eventable_models << MyCustomModel
-  def self.eventable_models
-    Rails.application.config.spree.eventable_models
-  end
-
-  def self.eventable_models=(value)
-    Rails.application.config.spree.eventable_models = value
-  end
-
   # Event subscribers that handle lifecycle and custom events
   # @example Adding a custom subscriber
   #   Spree.subscribers << MyApp::OrderNotificationSubscriber

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -28,7 +28,6 @@ module Spree
                                :analytics_events,
                                :analytics_event_handlers,
                                :integrations,
-                               :eventable_models,
                                :subscribers)
       SpreeCalculators = Struct.new(:shipping_methods, :tax_rates, :promotion_actions_create_adjustments, :promotion_actions_create_item_adjustments)
       PromoEnvironment = Struct.new(:rules, :actions)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -276,44 +276,6 @@ module Spree
           Spree::Addresses::PhoneValidator
         ]
 
-        # Models that automatically emit lifecycle events (create, update, destroy)
-        # Developers can add/remove models from this list in their initializers
-        Rails.application.config.spree.eventable_models = [
-          Spree::Asset,
-          Spree::CustomerReturn,
-          Spree::Digital,
-          Spree::DigitalLink,
-          Spree::Export,
-          Spree::GiftCard,
-          Spree::GiftCardBatch,
-          Spree::Import,
-          Spree::LineItem,
-          Spree::NewsletterSubscriber,
-          Spree::Order,
-          Spree::Payment,
-          Spree::Post,
-          Spree::PostCategory,
-          Spree::Price,
-          Spree::Product,
-          Spree::Promotion,
-          Spree::Refund,
-          Spree::Report,
-          Spree::ReturnAuthorization,
-          Spree::Shipment,
-          Spree::StockItem,
-          Spree::StockMovement,
-          Spree::StockTransfer,
-          Spree::StoreCredit,
-          Spree::Variant,
-          Spree::WishedItem,
-          Spree::Wishlist
-        ]
-
-        # Enable lifecycle events for configured models
-        Rails.application.config.spree.eventable_models.each do |model|
-          model.publishes_lifecycle_events if model.respond_to?(:publishes_lifecycle_events)
-        end
-
         # Attach event log subscriber if enabled
         if Spree::Config.events_log_enabled
           Spree::EventLogSubscriber.attach_to_notifications
@@ -384,24 +346,6 @@ module Spree
         # Load application's model / class decorators
         Dir.glob(File.join(File.dirname(__FILE__), '../../../app/**/*_decorator*.rb')) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)
-        end
-
-        # Re-enable lifecycle events for configured models after code reload
-        # This is needed because after_commit callbacks are lost when classes are reloaded
-        # We must resolve the constants fresh because Zeitwerk creates new class objects
-        Rails.application.config.spree.eventable_models&.each do |model|
-          # Resolve the model constant fresh to handle code reload
-          resolved_model = begin
-            model.is_a?(String) ? model.constantize : model.name.constantize
-          rescue NameError
-            nil
-          end
-
-          next unless resolved_model
-
-          # Reset lifecycle_events_enabled so callbacks can be re-registered
-          resolved_model.lifecycle_events_enabled = false if resolved_model.respond_to?(:lifecycle_events_enabled=)
-          resolved_model.publishes_lifecycle_events if resolved_model.respond_to?(:publishes_lifecycle_events)
         end
 
         # Reset and re-activate event subscribers on code reload


### PR DESCRIPTION
Cleaner, safer, less magic, we already did that for `UserMethods`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves lifecycle event wiring from engine config to models themselves for consistency and reliability.
> 
> - Add `publishes_lifecycle_events` to many core models (e.g., `Order`, `Payment`, `Product`, `Variant`, `Shipment`, `StockItem`, `StockMovement`, `StoreCredit`, `Price`, `LineItem`, `Import/Export/Report`, `GiftCard/GiftCardBatch`, `CustomerReturn`, `ReturnAuthorization`, `Digital/DigitalLink`, `NewsletterSubscriber`, `Post/PostCategory`, `StockTransfer`, `Wishlist/WishedItem`, `Refund`, `Asset`)
> - Remove `Spree.eventable_models` config and related initialization/reload logic from `core/lib/spree/core.rb` and `core/lib/spree/core/engine.rb`
> - Update admin `WebhookEndpointsHelper` to use a fixed `EVENTABLE_MODELS` list (strings) to generate `*.created/updated/deleted` events instead of reading from config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4cf2ade7368b92069bef1ab5665e21f0ad38841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->