### PR TITLE
Fix: Implement `allowed_file_types` option for `spree_file_field`

### DIFF
--- a/admin/app/models/spree/admin/form_builder.rb
+++ b/admin/app/models/spree/admin/form_builder.rb
@@ -234,13 +234,13 @@ module Spree
       #
       # @param method [Symbol] the field name
       # @param options [Hash] field options
-      # @option options [Boolean] :crop whether to crop the image
-      # @option options [Boolean] :auto_submit whether to auto-submit the form when the file is uploaded
-      # @option options [Boolean] :can_delete whether to show the delete button
-      # @option options [Boolean] :inline whether to display the uploader inline
-      # @option options [Integer] :height the height of the uploader
-      # @option options [Integer] :width the width of the uploader
-      # @option options [Array] :allowed_file_types the allowed file types, defaults to image types
+      # @option options [Integer] :width Width of the image preview in pixels
+      # @option options [Integer] :height Height of the image preview in pixels
+      # @option options [Boolean] :crop Enable image cropping with recommended size indicator
+      # @option options [Boolean] :auto_submit Automatically submit form when file is selected
+      # @option options [Boolean] :can_delete Show delete button for removing uploaded image
+      # @option options [String] :css Additional CSS classes for the upload placeholder area
+      # @option options [Array] :allowed_file_types Specify the allowed file types
       # @return [String] HTML string containing the complete form group with direct file upload field
       def spree_file_field(method, options = {})
         @template.content_tag(:div, class: 'form-group') do

--- a/admin/app/views/active_storage/_upload_form.html.erb
+++ b/admin/app/views/active_storage/_upload_form.html.erb
@@ -2,6 +2,7 @@
 <% height ||= 300 %>
 <% crop ||= false unless defined?(crop) %>
 <% auto_submit ||= false %>
+<% allowed_file_types ||= Rails.application.config.active_storage.web_image_content_types %>
 <% show_delete_button = defined?(can_delete) ? can_delete : true %>
 <% css ||= '' %>
 
@@ -12,7 +13,7 @@
       data-active-storage-upload-crop-value="<%= crop.presence || false %>"
       data-active-storage-upload-auto-submit-value="<%= auto_submit %>"
       data-active-storage-upload-field-name-value="<%= form.object_name %>[<%= field_name %>]"
-      data-active-storage-upload-allowed-file-types-value="<%= Rails.application.config.active_storage.web_image_content_types %>"
+      data-active-storage-upload-allowed-file-types-value="<%= allowed_file_types %>"
       class="flex flex-col justify-center w-full relative">
     <div class="upload-area"
          data-action="click->active-storage-upload#open"

--- a/docs/developer/admin/form-builder.mdx
+++ b/docs/developer/admin/form-builder.mdx
@@ -289,7 +289,7 @@ All common FormBuilder options (`:label`, `:required`, `:help`, `:help_bubble`) 
 <%= f.spree_file_field :hero_video_background,
     width: 1200,
     height: 630,
-    crop: true,
+    crop: false,
     auto_submit: false,
     can_delete: true,
     help_bubble: "This video will loop in the background",

--- a/docs/developer/admin/form-builder.mdx
+++ b/docs/developer/admin/form-builder.mdx
@@ -272,6 +272,7 @@ Creates a file upload field with image preview, drag-and-drop support, and optio
 | `:auto_submit` | Boolean | `false` | Automatically submit form when file is selected |
 | `:can_delete` | Boolean | `true` | Show delete button for removing uploaded image |
 | `:css` | String | `''` | Additional CSS classes for the upload placeholder area |
+| `:allowed_file_types` | Array | Image types | Specify the allowed file types |
 
 All common FormBuilder options (`:label`, `:required`, `:help`, `:help_bubble`) are also supported.
 
@@ -285,12 +286,15 @@ All common FormBuilder options (`:label`, `:required`, `:help`, `:help_bubble`) 
 **Example with all options:**
 
 ```erb
-<%= f.spree_file_field :social_image,
+<%= f.spree_file_field :hero_video_background,
     width: 1200,
     height: 630,
     crop: true,
-    label: 'Preview image',
-    help_bubble: "This image will be used when shared on social media" %>
+    auto_submit: false,
+    can_delete: true,
+    help_bubble: "This video will loop in the background",
+    label: 'Hero video background',
+    allowed_file_types: %w[video/mp4 video/webm video/ogg] %>
 ```
 
 ## Complete Form Example


### PR DESCRIPTION
The `spree_file_field` method includes [a note about `allowed_file_types`](https://github.com/spree/spree/blob/fb51e27e06fffff3c84fa68670b4e03a160107bc/admin/app/models/spree/admin/form_builder.rb#L243), but I discovered that it wasn't actually implemented as I was building a new custom page section that requires a video file upload.

This PR fixes that by implementing `allowed_file_types` for the `spree_file_field` method, and updates the associated comment notes to match with the developer docs. There are no associated specs for this method, and the specs are passing. I was able to test that it works in the sandbox environment outlined in the dev docs for contribution.

I did also try to find an [Issue](https://github.com/spree/spree/issues?q=is%3Aissue%20spree%20file%20field%20file%20types) that referenced this bug, but couldn't find one, apologies if I missed it.

I have read the CLA Document and I hereby sign the CLA


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements configurable `:allowed_file_types` for `spree_file_field` and wires it through the Active Storage upload form.
> 
> - Updates `spree_file_field` docs in `FormBuilder` to include `:allowed_file_types`
> - `_upload_form.html.erb` now accepts `allowed_file_types` (defaulting to `Rails.application.config.active_storage.web_image_content_types`) and passes it via `data-active-storage-upload-allowed-file-types-value`
> - Developer docs updated to document the option and add a video upload example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c83ee105797ec6d85a38ff16cd0c85124d5155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->