### PR TITLE
Fixes GHSA-3ghg-3787-w2xr Unauthenticated IDOR - Guest Address

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -143,7 +143,8 @@ module Spree
       can :update, ::Spree::Order do |order, token|
         !order.completed? && (order.user == user || order.token && token == order.token)
       end
-      can :manage, ::Spree::Address, user_id: user.id
+      # Address management - only for persisted users with matching user_id
+      can :manage, ::Spree::Address, user_id: user.id if user.persisted?
       can [:read, :destroy], ::Spree::CreditCard, user_id: user.id
       can :read, ::Spree::Product
       can :read, ::Spree::ProductProperty

--- a/core/app/models/spree/permission_sets/default_customer.rb
+++ b/core/app/models/spree/permission_sets/default_customer.rb
@@ -43,8 +43,8 @@ module Spree
         can :create, Spree.user_class
         can [:show, :update, :destroy], Spree.user_class, id: user.id
 
-        # Address management
-        can :manage, Spree::Address, user_id: user.id
+        # Address management - only for persisted users with matching user_id
+        can :manage, Spree::Address, user_id: user.id if user.persisted?
 
         # Credit card management
         can [:read, :destroy], Spree::CreditCard, user_id: user.id

--- a/core/spec/models/spree/permission_sets/default_customer_spec.rb
+++ b/core/spec/models/spree/permission_sets/default_customer_spec.rb
@@ -123,6 +123,32 @@ RSpec.describe Spree::PermissionSets::DefaultCustomer do
       it 'prevents managing other user address' do
         expect(ability.can?(:manage, other_address)).to be false
       end
+
+      context 'with guest user (non-persisted)' do
+        let(:guest_user) { Spree.user_class.new }
+        let(:guest_ability) { Spree::Ability.new(guest_user) }
+        let(:guest_permission_set) { described_class.new(guest_ability) }
+        let(:guest_address) { build(:address, user_id: nil) }
+        let(:other_guest_address) { create(:address, user_id: nil) }
+
+        before { guest_permission_set.activate! }
+
+        it 'prevents guest user from managing addresses with nil user_id (IDOR protection)' do
+          expect(guest_ability.can?(:manage, guest_address)).to be false
+        end
+
+        it 'prevents guest user from editing other guest addresses (IDOR protection)' do
+          expect(guest_ability.can?(:edit, other_guest_address)).to be false
+        end
+
+        it 'prevents guest user from updating other guest addresses (IDOR protection)' do
+          expect(guest_ability.can?(:update, other_guest_address)).to be false
+        end
+
+        it 'prevents guest user from reading other guest addresses (IDOR protection)' do
+          expect(guest_ability.can?(:read, other_guest_address)).to be false
+        end
+      end
     end
 
     context 'credit card permissions' do

--- a/storefront/app/controllers/spree/addresses_controller.rb
+++ b/storefront/app/controllers/spree/addresses_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   class AddressesController < Spree::StoreController
     helper Spree::AddressesHelper
+    before_action :require_user
     before_action :load_and_authorize_address, except: [:index]
 
     def create

--- a/storefront/spec/controllers/spree/addresses_controller_spec.rb
+++ b/storefront/spec/controllers/spree/addresses_controller_spec.rb
@@ -312,4 +312,156 @@ describe Spree::AddressesController, type: :controller do
       end
     end
   end
+
+end
+
+# Separate describe block for security tests - without mocked authorization
+describe Spree::AddressesController, 'security', type: :controller do
+  let(:store) { @default_store }
+  let(:country) { store.default_country || create(:country_us) }
+  let(:state) { create(:state, country: country, name: 'New York', abbr: 'NY') }
+  let(:user) { create(:user) }
+
+  render_views
+
+  context 'authentication requirement (IDOR vulnerability fix)' do
+    let(:guest_address) { create(:address, user_id: nil, country: country, state: state) }
+
+    before do
+      allow(controller).to receive_messages try_spree_current_user: nil
+      allow(controller).to receive_messages spree_current_user: nil
+    end
+
+    describe '#edit' do
+      it 'requires authentication and redirects to login' do
+        get :edit, params: { id: guest_address.id }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe '#update' do
+      let(:address_params) { guest_address.attributes.symbolize_keys.merge(firstname: 'Hacker') }
+
+      it 'requires authentication and redirects to login' do
+        put :update, params: { id: guest_address.id, address: address_params }
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it 'does not update the address when not authenticated' do
+        original_firstname = guest_address.firstname
+        put :update, params: { id: guest_address.id, address: address_params }
+        expect(guest_address.reload.firstname).to eq(original_firstname)
+      end
+    end
+
+    describe '#destroy' do
+      it 'requires authentication and redirects to login' do
+        delete :destroy, params: { id: guest_address.id }
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it 'does not destroy the address when not authenticated' do
+        delete :destroy, params: { id: guest_address.id }
+        expect(Spree::Address.find_by(id: guest_address.id)).to be_present
+      end
+    end
+
+    describe '#new' do
+      it 'requires authentication and redirects to login' do
+        get :new
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    describe '#create' do
+      let(:address_params) do
+        build(:address, country: country, state: state).attributes.except('created_at', 'updated_at')
+      end
+
+      it 'requires authentication and redirects to login' do
+        post :create, params: { address: address_params }
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  context 'when authenticated user tries to access another users address' do
+    let(:other_user) { create(:user) }
+    let(:other_user_address) { create(:address, user: other_user, country: country, state: state) }
+
+    before do
+      allow(controller).to receive_messages try_spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
+    end
+
+    describe '#edit' do
+      it 'denies access to other users address' do
+        get :edit, params: { id: other_user_address.id }
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(spree.forbidden_path)
+      end
+    end
+
+    describe '#update' do
+      let(:address_params) { other_user_address.attributes.symbolize_keys.merge(firstname: 'Hacker') }
+
+      it 'denies update to other users address' do
+        put :update, params: { id: other_user_address.id, address: address_params }
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(spree.forbidden_path)
+      end
+
+      it 'does not update the address when denied' do
+        original_firstname = other_user_address.firstname
+        put :update, params: { id: other_user_address.id, address: address_params }
+        expect(other_user_address.reload.firstname).to eq(original_firstname)
+      end
+    end
+
+    describe '#destroy' do
+      it 'denies destroy of other users address' do
+        delete :destroy, params: { id: other_user_address.id }
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(spree.forbidden_path)
+      end
+
+      it 'does not destroy the address when denied' do
+        delete :destroy, params: { id: other_user_address.id }
+        expect(Spree::Address.find_by(id: other_user_address.id)).to be_present
+      end
+    end
+  end
+
+  context 'when authenticated user accesses their own address' do
+    let(:own_address) { create(:address, user: user, country: country, state: state) }
+
+    before do
+      allow(controller).to receive_messages try_spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
+    end
+
+    describe '#edit' do
+      it 'allows access to own address' do
+        get :edit, params: { id: own_address.id }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe '#update' do
+      let(:address_params) { own_address.attributes.symbolize_keys.merge(firstname: 'Updated') }
+
+      it 'allows update to own address' do
+        put :update, params: { id: own_address.id, address: address_params }
+        expect(response).to have_http_status(:redirect)
+        expect(response).not_to redirect_to(spree.forbidden_path)
+      end
+    end
+
+    describe '#destroy' do
+      it 'allows destroy of own address' do
+        delete :destroy, params: { id: own_address.id }
+        expect(response).to have_http_status(:see_other)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixed ability check for address management in storefront exposing ability for guest users to edit/view other guest users addresses. This required knowing Address ID and internal Spree Address Book URLs.