### PR TITLE
Pagespeed insights adjustments

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/_footer.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_footer.html.erb
@@ -12,9 +12,9 @@
           </div>
           <div class="grid grid-cols-1 lg:grid-cols-4 grow w-full">
             <% section.blocks.includes(:links).each do |block| %>
-              <div class="flex-grow gap-1 flex flex-col py-6 md:py-0 border-b md:border-none border-default lg:mb-6">
+              <nav class="flex-grow gap-1 flex flex-col py-6 md:py-0 border-b md:border-none border-default lg:mb-6" aria-label="<%= block.preferred_label %>">
                 <div <%= block_attributes(block) %>>
-                  <h3 class="text-sm py-2"><%= block.preferred_label %></h3>
+                  <div class="text-sm py-2"><%= block.preferred_label %></div>
                   <ul class="uppercase text-sm tracking-wider !leading-4 flex flex-col gap-1">
                     <% block.links.each do |link| %>
                       <li class='py-2'>
@@ -25,12 +25,12 @@
                     <% end %>
                   </ul>
                 </div>
-              </div>
+              </nav>
             <% end %>
           </div>
-          <div class="flex-grow gap-4 flex flex-col justify-between lg:w-60">
+          <nav class="flex-grow gap-4 flex flex-col justify-between lg:w-60" aria-label="<%= Spree.t(:follow_us) %>">
             <div class="gap-1 flex flex-col py-6 md:py-0">
-              <h3 class="text-sm py-2"><%= Spree.t(:follow_us) %></h3>
+              <div class="text-sm py-2"><%= Spree.t(:follow_us) %></div>
               <div class="flex flex-wrap gap-2 max-w-48 py-2">
                 <% cache spree_storefront_base_cache_scope.call(current_store) do %>
                   <% Spree::Store::SUPPORTED_SOCIAL_NETWORKS.each do |media| %>
@@ -44,7 +44,7 @@
                 <% end %>
               </div>
             </div>
-          </div>
+          </nav>
         </div>
         <div class="flex justify-end w-full"></div>
       </div>

--- a/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_header.html.erb
@@ -103,11 +103,12 @@
               <% if show_account_pane? %>
                 <button
                   data-action='click->slideover-account#toggle click@window->slideover-account#hide click->toggle-menu#hide touch->toggle-menu#hide'
+                  aria-label='Open account panel'
                   >
                   <%= render 'spree/shared/icons/account', color: section.preferred_text_color, section: section %>
                 </button>
               <% else %>
-                <%= link_to spree.account_path do %>
+                <%= link_to spree.account_path, 'aria-label': 'Open account panel' do %>
                   <%= render 'spree/shared/icons/account', color: section.preferred_text_color, section: section %>
                 <% end %>
               <% end %>
@@ -117,12 +118,13 @@
                 <button
                   type="submit"
                   id="wishlist-icon"
+                  aria-label='Open wishlist'
                   class="flex items-end">
                   <%= render 'spree/shared/wishlist_icon', wishlist: current_wishlist, background_color: section.preferred_background_color %>
                 </button>
               <% end %>
             <% else %>
-              <%= link_to spree.account_wishlist_path, id: "wishlist-icon" do %>
+              <%= link_to spree.account_wishlist_path, id: "wishlist-icon", 'aria-label': 'Open wishlist' do %>
                 <%= render 'spree/shared/wishlist_icon', background_color: section.preferred_background_color %>
               <% end %>
             <% end %>
@@ -141,6 +143,7 @@
       data-toggle-menu-target='toggleable'
       role='dialog'
       aria-modal='true'
+      aria-label='Mobile menu'
     >
       <div
         class='flex justify-between flex-col lg:hidden w-full transition-transform has-[.currency-and-locale-modal:not(.hidden)]:transform-none body header--mobile-menu'

--- a/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
@@ -5,19 +5,21 @@
     <%= button_tag class: 'decrease-quantity',
                      type: 'button',
                      data: { action: 'click->quantity-picker#decrease',
-                            'quantity-picker-target': 'decrease' } do %>
+                            'quantity-picker-target': 'decrease' },
+                    aria: { label: Spree.t(:decrease_quantity) } do %>
       <%= render 'spree/shared/icons/minus' %>
     <% end %>
     <%= number_field_tag :quantity, 1,
                           min: 1,
                           max: selected_variant&.backorderable? ? nil : selected_variant&.total_on_hand,
                           class: 'quantity-input',
-                          'aria-label': 'Quantity',
-                          data: { 'quantity-picker-target': 'quantity' } %>
+                          data: { 'quantity-picker-target': 'quantity' },
+                          aria: { label: Spree.t(:quantity) } %>
     <%= button_tag class: 'increase-quantity',
                      type: 'button',
                      data: { action: 'click->quantity-picker#increase',
-                            'quantity-picker-target': 'increase' } do %>
+                            'quantity-picker-target': 'increase' },
+                     aria: { label: Spree.t(:increase_quantity) } do %>
       <%= render 'spree/shared/icons/plus' %>
     <% end %>
   </div>

--- a/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
@@ -6,7 +6,7 @@
                      type: 'button',
                      data: { action: 'click->quantity-picker#decrease',
                             'quantity-picker-target': 'decrease' },
-                    aria: { label: Spree.t(:decrease_quantity) } do %>
+                    aria: { label: Spree.t('storefront.products.decrease_quantity') } do %>
       <%= render 'spree/shared/icons/minus' %>
     <% end %>
     <%= number_field_tag :quantity, 1,
@@ -14,12 +14,12 @@
                           max: selected_variant&.backorderable? ? nil : selected_variant&.total_on_hand,
                           class: 'quantity-input',
                           data: { 'quantity-picker-target': 'quantity' },
-                          aria: { label: Spree.t(:quantity) } %>
+                          aria: { label: Spree.t('storefront.products.quantity') } %>
     <%= button_tag class: 'increase-quantity',
                      type: 'button',
                      data: { action: 'click->quantity-picker#increase',
                             'quantity-picker-target': 'increase' },
-                     aria: { label: Spree.t(:increase_quantity) } do %>
+                     aria: { label: Spree.t('storefront.products.increase_quantity') } do %>
       <%= render 'spree/shared/icons/plus' %>
     <% end %>
   </div>

--- a/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
@@ -19,7 +19,7 @@
                      type: 'button',
                      data: { action: 'click->quantity-picker#increase',
                             'quantity-picker-target': 'increase' },
-                     aria: { label: Spree.t('storefront.products.increase_quantity') } do %>
+                     aria: { label: Spree.t(:quantity) } do %>
       <%= render 'spree/shared/icons/plus' %>
     <% end %>
   </div>

--- a/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
@@ -14,7 +14,7 @@
                           max: selected_variant&.backorderable? ? nil : selected_variant&.total_on_hand,
                           class: 'quantity-input',
                           data: { 'quantity-picker-target': 'quantity' },
-                          aria: { label: Spree.t('storefront.products.quantity') } %>
+                          aria: { label: Spree.t(:quantity) } %>
     <%= button_tag class: 'increase-quantity',
                      type: 'button',
                      data: { action: 'click->quantity-picker#increase',

--- a/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_quantity_selector.html.erb
@@ -19,7 +19,7 @@
                      type: 'button',
                      data: { action: 'click->quantity-picker#increase',
                             'quantity-picker-target': 'increase' },
-                     aria: { label: Spree.t(:quantity) } do %>
+                     aria: { label: Spree.t('storefront.products.increase_quantity') } do %>
       <%= render 'spree/shared/icons/plus' %>
     <% end %>
   </div>

--- a/storefront/app/views/themes/default/spree/products/_swiper.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_swiper.html.erb
@@ -75,10 +75,10 @@
         <% end %>
       </div>
     </div>
-    <%= button_tag class: "absolute p-2 bg-white rounded-full z-10 border border-accent left-0 disabled:hidden hover:border-primary ml-2 lg:ml-0 swiper-custom-button-prev-#{section.id} block #{arrows_on_top ? '' : 'md:hidden'} top-(--top) lg:top-(--desktop-top)", aria: { hidden: true }, style: "--top: calc(#{theme_setting('product_listing_image_height_mobile')}px/2); --desktop-top: calc(#{theme_setting('product_listing_image_height')}px/2); transform: translate(-50%, -50%);" do %>
+    <%= button_tag class: "absolute p-2 bg-white rounded-full z-10 border border-accent left-0 disabled:hidden hover:border-primary ml-2 lg:ml-0 swiper-custom-button-prev-#{section.id} block #{arrows_on_top ? '' : 'md:hidden'} top-(--top) lg:top-(--desktop-top)", style: "--top: calc(#{theme_setting('product_listing_image_height_mobile')}px/2); --desktop-top: calc(#{theme_setting('product_listing_image_height')}px/2); transform: translate(-50%, -50%);" do %>
       <%= render 'spree/shared/icons/chevron' %>
     <% end %>
-    <%= button_tag class: "absolute p-2 bg-white rounded-full z-10 border border-accent right-0 disabled:hidden hover:border-primary mr-2 lg:mr-0 swiper-custom-button-next-#{section.id} block #{arrows_on_top ? '' : 'md:hidden'} top-(--top) lg:top-(--desktop-top)", aria: { hidden: true }, style: "--top: calc(#{theme_setting('product_listing_image_height_mobile')}px/2); --desktop-top: calc(#{theme_setting('product_listing_image_height')}px/2); transform: translate(50%, -50%);" do %>
+    <%= button_tag class: "absolute p-2 bg-white rounded-full z-10 border border-accent right-0 disabled:hidden hover:border-primary mr-2 lg:mr-0 swiper-custom-button-next-#{section.id} block #{arrows_on_top ? '' : 'md:hidden'} top-(--top) lg:top-(--desktop-top)", style: "--top: calc(#{theme_setting('product_listing_image_height_mobile')}px/2); --desktop-top: calc(#{theme_setting('product_listing_image_height')}px/2); transform: translate(50%, -50%);" do %>
       <%= render 'spree/shared/icons/chevron_right' %>
     <% end %>
   </div>

--- a/storefront/app/views/themes/default/spree/products/_variant_options.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_variant_options.html.erb
@@ -56,10 +56,14 @@
         option_id: option_type.id
       },
       name: option_type.presentation,
+      role: 'menuitemradio',
+      aria: { label: value.presentation },
       id: "product-option-#{product.id}-#{position}-#{index}"
     %>
     <label
       for='product-option-<%= product.id %>-<%= position %>-<%= index %>'
+      role="menuitem"
+      aria-label="<%= value.presentation %>"
       class='text-sm cursor-pointer flex items-center justify-between px-4 py-2.5 hover:bg-accent focus:outline-hidden focus:bg-accent transition duration-150 ease-in-out <%= option_disabled ? "opacity-50 cursor-not-allowed" : "hover:bg-accent" %>'
     >
       <p><%=h value.presentation %></p>

--- a/storefront/app/views/themes/default/spree/products/_variant_options.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_variant_options.html.erb
@@ -32,8 +32,8 @@
     <% end %>
   <% end %>
   <% if option_type.color? %>
-    <li>
-      <label class="cursor-pointer">
+    <li role="option" aria-label="<%= value.presentation %>">
+      <label class="cursor-pointer"  aria-label="<%= value.presentation %>">
         <%= radio_button_tag option_type.presentation, value.name, selected_option == value,
           name: option_type.presentation,
           id: "product-option-#{product.id}-#{position}-#{index}",

--- a/storefront/app/views/themes/default/spree/products/_variant_picker.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_variant_picker.html.erb
@@ -20,7 +20,7 @@
                 type='button'
                 class='text-sm uppercase tracking-widest flex gap-2 items-center border border-default py-2 px-4 rounded-input dropdown-button'
                 data-dropdown-target="button"
-                aria-label="<%= option_type.presentation %>">
+                aria-label="<%= selected_option ? option_type.presentation+":"+selected_option.presentation : Spree.t('storefront.variant_picker.please_choose', option_type: option_type.presentation) %>">
                 <legend class="mr-2" id="option-<%= option_type.id %>-value">
                   <% if selected_option %>
                     <%= option_type.presentation %>: <span class="option-value-text"><%= selected_option.presentation %></span>

--- a/storefront/app/views/themes/default/spree/products/_variant_picker.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_variant_picker.html.erb
@@ -7,19 +7,20 @@
         <%= option_type_colors_preview_styles(option_type).html_safe %>
         <fieldset data-option-id="<%= option_type.id %>" class="flex flex-col gap-y-2">
           <span class="text-sm leading-4 uppercase tracking-widest"><%= option_type.presentation %>: <%= selected_option.presentation %></span>
-          <ul class="flex items-center flex-wrap gap-1">
+          <ul class="flex items-center flex-wrap gap-1" role="listbox" aria-label="<%= option_type.presentation %>">
             <%= render 'spree/products/variant_options', product: product, option_type: option_type, position: index, selected_variant: selected_variant, options_param_name: options_param_name %>
           </ul>
         </fieldset>
       <% else %>
         <fieldset data-option-id="<%= option_type.id %>">
-          <div data-controller="dropdown" class="relative mb-2">
+          <div data-controller="dropdown" class="relative mb-2" role="group" aria-label="<%= option_type.presentation %>">
             <div class="flex items-center justify-between">
               <button
                 data-action="click->dropdown#toggle click@window->dropdown#hide"
                 type='button'
                 class='text-sm uppercase tracking-widest flex gap-2 items-center border border-default py-2 px-4 rounded-input dropdown-button'
-                data-dropdown-target="button">
+                data-dropdown-target="button"
+                aria-label="<%= option_type.presentation %>">
                 <legend class="mr-2" id="option-<%= option_type.id %>-value">
                   <% if selected_option %>
                     <%= option_type.presentation %>: <span class="option-value-text"><%= selected_option.presentation %></span>
@@ -37,6 +38,7 @@
                 data-transition-leave="transition ease-in"
                 data-transition-leave-from="opacity-100 translate-y-0"
                 data-transition-leave-to="opacity-0 translate-y-1"
+                role="menu"
                 class="hidden absolute top-11 left-0 z-[9999] flex w-screen max-w-max shadow-xs">
               <div class="bg-background border-default border overflow-hidden w-72">
                 <%= render 'spree/products/variant_options', product: product, option_type: option_type, position: index, selected_variant: selected_variant, options_param_name: options_param_name %>

--- a/storefront/app/views/themes/default/spree/shared/_custom_head.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_custom_head.html.erb
@@ -1,0 +1,7 @@
+<link rel="preconnect" href="https://esm.sh" crossorigin>
+<link rel="dns-prefetch" href="https://esm.sh">
+
+<link rel="preload" href="https://esm.sh/swiper@11.2.2/swiper-bundle.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://esm.sh/swiper@11.2.2/swiper-bundle.min.css"></noscript>
+<link rel="preload" href="https://esm.sh/flag-icons@7.3.2/css/flag-icons.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://esm.sh/flag-icons@7.3.2/css/flag-icons.min.css"></noscript>

--- a/storefront/app/views/themes/default/spree/shared/_search.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_search.html.erb
@@ -1,4 +1,4 @@
-<div id="search-suggestions" role="dialog" aria-modal="true">
+<div id="search-suggestions" role="dialog" aria-label="Search suggestions" aria-modal="true">
   <div class='w-full flex flex-col border-b border-default' data-controller="search-suggestions" data-show-class="h-screen min-h-screen" data-search-suggestions-url-value="<%= spree.search_suggestions_path %>">
     <div class='hidden lg:flex justify-center w-full mt-4 mb-3' id="header-logo">
       <%= render 'spree/shared/logo', logo: logo, height: logo_height %>

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -61,9 +61,9 @@ en:
       products:
         decrease_quantity: Decrease quantity
         increase_quantity: Increase quantity
-        quantity: Quantity
         pinch_to_zoom_html: Pinch to<br>zoom
         primary_image: primary image
+        quantity: Quantity
         secondary_image: secondary image
       refund_action_not_required_message:
         order_canceled:

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -63,7 +63,6 @@ en:
         increase_quantity: Increase quantity
         pinch_to_zoom_html: Pinch to<br>zoom
         primary_image: primary image
-        quantity: Quantity
         secondary_image: secondary image
       refund_action_not_required_message:
         order_canceled:

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -59,6 +59,9 @@ en:
         join: Email me about new products, sales, and more. You can unsubscribe at any time.
         status: You are currently %{status} to the newsletters.
       products:
+        decrease_quantity: Decrease quantity
+        increase_quantity: Increase quantity
+        quantity: Quantity
         pinch_to_zoom_html: Pinch to<br>zoom
         primary_image: primary image
         secondary_image: secondary image

--- a/storefront/lib/generators/spree/storefront/install/templates/application.css
+++ b/storefront/lib/generators/spree/storefront/install/templates/application.css
@@ -1,6 +1,3 @@
-@import url('https://esm.sh/swiper@11.2.2/swiper-bundle.min.css');
-@import url('https://esm.sh/flag-icons@7.3.2/css/flag-icons.min.css');
-
 @import 'tailwindcss';
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/forms";


### PR DESCRIPTION
Fixed PageSpeed Insights errors on the home page:
[Raport before chages](https://github.com/user-attachments/files/24498473/Lighthouse-raport-before.pdf)
[Raport after changes](https://github.com/user-attachments/files/24498419/Lighthouse-raport-after.pdf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves performance and accessibility across storefront templates.
> 
> - **Performance:** Adds `preconnect`/`dns-prefetch` and preloaded styles for `swiper` and `flag-icons` in `shared/_custom_head.html.erb`; removes blocking `@import` lines from `application.css` template.
> - **Accessibility:**
>   - Footer/Header/Search: wrap sections in `nav` with `aria-label`s; add descriptive `aria-label`s to account, wishlist, and mobile menu; label search dialog.
>   - Product variant picker/options: add proper roles (`listbox`, `menu`, `menuitemradio`) and `aria-label`s; label color options.
>   - Quantity selector: add `aria-label`s for increase/decrease and input; introduces i18n keys for these labels.
>   - Swiper controls: expose prev/next buttons (remove `aria-hidden`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a281778656deb77a4c2b2356af8a9fdf7060cc4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->