### PR TITLE
FIX reports date picker and scopes

### DIFF
--- a/admin/app/views/spree/admin/reports/new.html.erb
+++ b/admin/app/views/spree/admin/reports/new.html.erb
@@ -28,8 +28,8 @@
 
     <div class="flex gap-2">
       <%= render 'spree/admin/shared/calendar_range_picker',
-        date_from_value: @report.date_from,
-        date_to_value: @report.date_to %>
+        date_from_value: params.dig(:q, :completed_at_gt),
+        date_to_value: params.dig(:q, :completed_at_lt) %>
 
       <div class="form-group">
         <%= select_tag :currency,

--- a/admin/app/views/spree/admin/reports/new.html.erb
+++ b/admin/app/views/spree/admin/reports/new.html.erb
@@ -28,8 +28,8 @@
 
     <div class="flex gap-2">
       <%= render 'spree/admin/shared/calendar_range_picker',
-        date_from_value: params.dig(:q, :completed_at_gt),
-        date_to_value: params.dig(:q, :completed_at_lt) %>
+        date_from_value: params[:date_from],
+        date_to_value: params[:date_to] %>
 
       <div class="form-group">
         <%= select_tag :currency,

--- a/admin/app/views/spree/admin/reports/new.html.erb
+++ b/admin/app/views/spree/admin/reports/new.html.erb
@@ -28,8 +28,8 @@
 
     <div class="flex gap-2">
       <%= render 'spree/admin/shared/calendar_range_picker',
-        date_from_value: params[:date_from],
-        date_to_value: params[:date_to] %>
+        date_from_value: params[:date_from] || 1.month.ago.in_time_zone(current_store.preferred_timezone).beginning_of_day,
+        date_to_value: params[:date_to] || Time.current.in_time_zone(current_store.preferred_timezone).end_of_day %>
 
       <div class="form-group">
         <%= select_tag :currency,

--- a/core/app/models/spree/reports/products_performance.rb
+++ b/core/app/models/spree/reports/products_performance.rb
@@ -17,7 +17,7 @@ module Spree
                                currency: currency
                              },
                              spree_orders: {
-                               completed_at: (date_from.to_time.beginning_of_day)..(date_to.to_time.end_of_day)
+                               completed_at: date_from..date_to
                              }
                            )
 

--- a/core/app/models/spree/reports/sales_total.rb
+++ b/core/app/models/spree/reports/sales_total.rb
@@ -5,7 +5,7 @@ module Spree
         scope = store.line_items.where(
           order: Spree::Order.complete.where(
             currency: currency,
-            completed_at: (date_from.to_time.beginning_of_day)..(date_to.to_time.end_of_day)
+            completed_at: date_from..date_to
           )
         ).includes(:order, shipments: :inventory_units, variant: :product)
 

--- a/core/spec/models/spree/report_line_items/products_performance_spec.rb
+++ b/core/spec/models/spree/report_line_items/products_performance_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Spree::ReportLineItems::ProductsPerformance do
   let!(:product) { order.line_items.first.product }
   let!(:variant) { order.line_items.first.variant }
 
+  before { order.update(completed_at: report.date_from + 1.day) }
+
   subject { report.line_items.first }
 
   describe '#vendor' do

--- a/core/spec/models/spree/reports/products_performance_spec.rb
+++ b/core/spec/models/spree/reports/products_performance_spec.rb
@@ -36,6 +36,42 @@ RSpec.describe Spree::Reports::ProductsPerformance do
       end
     end
 
+    context 'date range boundary conditions' do
+      before { line_item.save! }
+
+      context 'when order completed exactly at date_from' do
+        before { order.update(completed_at: report.date_from) }
+
+        it 'includes products' do
+          expect(report.line_items_scope).not_to be_empty
+        end
+      end
+
+      context 'when order completed exactly at date_to' do
+        before { order.update(completed_at: report.date_to) }
+
+        it 'includes products' do
+          expect(report.line_items_scope).not_to be_empty
+        end
+      end
+
+      context 'when order completed 1 minute before date_from' do
+        before { order.update(completed_at: report.date_from - 1.minute) }
+
+        it 'excludes products' do
+          expect(report.line_items_scope).to be_empty
+        end
+      end
+
+      context 'when order completed 1 minute after date_to' do
+        before { order.update(completed_at: report.date_to + 1.minute) }
+
+        it 'excludes products' do
+          expect(report.line_items_scope).to be_empty
+        end
+      end
+    end
+
     context 'when order has different currency' do
       before do
         order.update(currency: 'EUR')

--- a/core/spec/models/spree/reports/sales_total_spec.rb
+++ b/core/spec/models/spree/reports/sales_total_spec.rb
@@ -27,6 +27,40 @@ RSpec.describe Spree::Reports::SalesTotal do
       end
     end
 
+    context 'date range boundary conditions' do
+      context 'when order completed exactly at date_from' do
+        before { order.update(completed_at: report.date_from) }
+
+        it 'includes line items' do
+          expect(report.line_items_scope).to include(line_item)
+        end
+      end
+
+      context 'when order completed exactly at date_to' do
+        before { order.update(completed_at: report.date_to) }
+
+        it 'includes line items' do
+          expect(report.line_items_scope).to include(line_item)
+        end
+      end
+
+      context 'when order completed 1 minute before date_from' do
+        before { order.update(completed_at: report.date_from - 1.minute) }
+
+        it 'excludes line items' do
+          expect(report.line_items_scope).not_to include(line_item)
+        end
+      end
+
+      context 'when order completed 1 minute after date_to' do
+        before { order.update(completed_at: report.date_to + 1.minute) }
+
+        it 'excludes line items' do
+          expect(report.line_items_scope).not_to include(line_item)
+        end
+      end
+    end
+
     context 'when order has different currency' do
       before do
         order.update(currency: 'EUR')
@@ -50,6 +84,8 @@ RSpec.describe Spree::Reports::SalesTotal do
 
   describe '#return_line_items' do
     let(:return_line_item) { report.line_items.first }
+
+    before { order.update(completed_at: report.date_from + 1.day) }
 
     it 'returns line items' do
       expect(return_line_item).to be_a(Spree::ReportLineItems::SalesTotal)


### PR DESCRIPTION
Fixes:
1. Use dates from params instead of dates from report which is parsed with database timezone
2. Deleted beginning_of_day and end_of_day as date_from and date_to are already prepared: https://github.com/spree/spree/blob/09ce5f7a11a74ce527f9c748c8fc9a6003873075/admin/app/controllers/spree/admin/reports_controller.rb#L42

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns report date handling with inclusive ranges and timezone-aware defaults.
> 
> - Admin reports UI now uses `params[:date_from]`/`params[:date_to]` with store timezone defaults for the calendar picker
> - `SalesTotal` and `ProductsPerformance` filter scopes updated to `completed_at: date_from..date_to` (removed `beginning_of_day`/`end_of_day` conversions)
> - Specs added/updated to verify inclusive boundary behavior (exact `date_from`/`date_to` included) and ensure orders fall within range where required
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 275a6f8ba3aed97e4196128be5fb24b56efa5f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->