### PR TITLE
Revert "Added `CalculatedAdjustments#cached_calculator`"

### DIFF
--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -6,7 +6,7 @@ module Spree
       has_one :calculator, class_name: 'Spree::Calculator', as: :calculable, inverse_of: :calculable, dependent: :destroy, autosave: true
       accepts_nested_attributes_for :calculator
       validates :calculator, presence: true
-      delegate :compute, to: :cached_calculator
+      delegate :compute, to: :calculator
 
       scope :with_calculator, ->(calculator) { joins(:calculator).where(calculator: { type: calculator.to_s }) }
 
@@ -15,22 +15,12 @@ module Spree
       end
 
       def calculator_type
-        cached_calculator.class.to_s if cached_calculator
+        calculator.class.to_s if calculator
       end
 
       def calculator_type=(calculator_type)
         klass = calculator_type.constantize if calculator_type
         self.calculator = klass.new if klass && !calculator.instance_of?(klass)
-      end
-
-      # Returns the calculator using Rails.cache to avoid repeated database lookups.
-      #
-      # @return [Object, nil] The calculator object (TaxRate, PromotionAction, etc.)
-      def cached_calculator
-        Rails.cache.fetch("#{cache_key_with_version}/calculator") { calculator }
-      rescue TypeError
-        # Handle objects that can't be serialized (e.g., mock objects in tests)
-        calculator
       end
 
       private


### PR DESCRIPTION
Reverts spree/spree#13400

This optimization is great when using Redis/Memcached caching solutions, but it's not performant when using the default Rails Solid Cache (database-powered), as it's just swapping one SQL call for another