### PR TITLE
Fix handling Store mobility-powered associations during store creation

### DIFF
--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -38,6 +38,15 @@ module Spree
     #
     scope :with_body,    -> { joins(:rich_text_body).distinct }
     scope :without_body, -> { where.missing(:rich_text_body) }
+    scope :with_matching_name, ->(name_to_match) do
+      value = name_to_match.to_s.strip.downcase
+
+      if Spree.use_translations?
+        i18n { name.lower.eq(value) }
+      else
+        where(arel_table[:name].lower.eq(value))
+      end
+    end
 
     #
     #  Ransack

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -471,41 +471,76 @@ module Spree
     end
 
     def ensure_default_taxonomies_are_created
-      taxonomies.find_or_create_by(name: I18n.t('spree.taxonomy_categories_name', default: I18n.t('spree.taxonomy_categories_name', locale: :en)))
-      taxonomies.find_or_create_by(name: I18n.t('spree.taxonomy_brands_name', default: I18n.t('spree.taxonomy_brands_name', locale: :en)))
-      taxonomies.find_or_create_by(name: I18n.t('spree.taxonomy_collections_name', default: I18n.t('spree.taxonomy_collections_name', locale: :en)))
-    rescue ActiveRecord::NotNullViolation
+      [
+        translate_with_store_locale_fallback('spree.taxonomy_categories_name'),
+        translate_with_store_locale_fallback('spree.taxonomy_brands_name'),
+        translate_with_store_locale_fallback('spree.taxonomy_collections_name')
+      ].each do |taxonomy_name|
+        # Manual exists?/create to work around Mobility bug with find_or_create_by
+        next if taxonomies.with_matching_name(taxonomy_name).exists?
+
+        taxonomies.create(name: taxonomy_name)
+      end
     end
 
     def ensure_default_automatic_taxons
-      collections_taxonomy = taxonomies.find_by(name: Spree.t(:taxonomy_collections_name))
+      # Use Mobility-safe lookup for taxonomy
+      collections_taxonomy = taxonomies.with_matching_name(translate_with_store_locale_fallback('spree.taxonomy_collections_name')).first
+      return unless collections_taxonomy.present?
 
-      if collections_taxonomy.present?
-        on_sale_taxon = collections_taxonomy.taxons.automatic.where(name: Spree.t('automatic_taxon_names.on_sale')).first_or_create! do |taxon|
-          taxon.parent = collections_taxonomy.root
-          taxon.rules.new(type: 'Spree::TaxonRules::Sale', value: 'true')
+      automatic_taxons_config = [
+        { name: translate_with_store_locale_fallback('spree.automatic_taxon_names.on_sale'), rule_type: 'Spree::TaxonRules::Sale', rule_value: 'true' },
+        { name: translate_with_store_locale_fallback('spree.automatic_taxon_names.new_arrivals'), rule_type: 'Spree::TaxonRules::AvailableOn', rule_value: 30 }
+      ]
+
+      automatic_taxons_config.map do |config|
+        # Manual exists?/create to work around Mobility bug with first_or_create
+        taxon_scope = collections_taxonomy.taxons.automatic.with_matching_name(config[:name])
+
+        if taxon_scope.exists?
+          taxon_scope.first
+        else
+          collections_taxonomy.taxons.create!(
+            name: config[:name],
+            automatic: true,
+            parent: collections_taxonomy.root,
+            taxon_rules: [TaxonRule.new(type: config[:rule_type], value: config[:rule_value])]
+          )
         end
-
-        new_arrivals_taxon = collections_taxonomy.taxons.automatic.where(name: Spree.t('automatic_taxon_names.new_arrivals')).first_or_create! do |taxon|
-          taxon.parent = collections_taxonomy.root
-          taxon.rules.new(type: 'Spree::TaxonRules::AvailableOn', value: 30)
-        end
-
-        [on_sale_taxon, new_arrivals_taxon]
       end
     end
 
     def ensure_default_post_categories_are_created
-      post_categories.find_or_create_by(title: Spree.t('default_post_categories.resources'))
-      post_categories.find_or_create_by(title: Spree.t('default_post_categories.articles'))
-      post_categories.find_or_create_by(title: Spree.t('default_post_categories.news'))
+      [
+        translate_with_store_locale_fallback('spree.default_post_categories.resources'),
+        translate_with_store_locale_fallback('spree.default_post_categories.articles'),
+        translate_with_store_locale_fallback('spree.default_post_categories.news')
+      ].each do |category_title|
+        # Use exists?/create pattern for safety
+        next if post_categories.where(title: category_title).exists?
+
+        post_categories.create(title: category_title)
+      end
     end
 
     def create_default_policies
-      policies.find_or_create_by(name: Spree.t('terms_of_service'))
-      policies.find_or_create_by(name: Spree.t('privacy_policy'))
-      policies.find_or_create_by(name: Spree.t('returns_policy'))
-      policies.find_or_create_by(name: Spree.t('shipping_policy'))
+      [
+        translate_with_store_locale_fallback('spree.terms_of_service'),
+        translate_with_store_locale_fallback('spree.privacy_policy'),
+        translate_with_store_locale_fallback('spree.returns_policy'),
+        translate_with_store_locale_fallback('spree.shipping_policy')
+      ].each do |policy_name|
+        # Manual exists?/create to work around Mobility bug with find_or_create_by
+        next if policies.with_matching_name(policy_name).exists?
+
+        policies.create(name: policy_name)
+      end
+    end
+
+    # Translates a key using the store's default locale with fallback to :en
+    def translate_with_store_locale_fallback(key)
+      locale = default_locale.presence&.to_sym || :en
+      I18n.t(key, locale: locale, default: I18n.t(key, locale: :en))
     end
 
     # code is slug, so we don't want to generate new slug when code changes

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -96,5 +96,28 @@ RSpec.describe Spree::Policy, type: :model do
         end
       end
     end
+
+    describe '.with_matching_name' do
+      let!(:privacy_policy) { create(:policy, name: 'Privacy Policy', owner: store) }
+      let!(:terms_policy) { create(:policy, name: 'Terms of Service', owner: store) }
+
+      it 'finds policy by exact name match (case insensitive)' do
+        expect(described_class.with_matching_name('Privacy Policy')).to include(privacy_policy)
+        expect(described_class.with_matching_name('privacy policy')).to include(privacy_policy)
+        expect(described_class.with_matching_name('PRIVACY POLICY')).to include(privacy_policy)
+      end
+
+      it 'does not find policy with partial match' do
+        expect(described_class.with_matching_name('Privacy')).not_to include(privacy_policy)
+      end
+
+      it 'strips whitespace from search term' do
+        expect(described_class.with_matching_name('  Privacy Policy  ')).to include(privacy_policy)
+      end
+
+      it 'returns empty when no match found' do
+        expect(described_class.with_matching_name('Non Existent Policy')).to be_empty
+      end
+    end
   end
 end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -159,6 +159,48 @@ describe Spree::Store, type: :model, without_global_store: true do
 
         it 'creates default policies' do
           expect { store.save! }.to change(Spree::Policy, :count).by(4)
+
+          expect(store.policies.count).to eq(4)
+          expect(store.policies.pluck(:name)).to contain_exactly(
+            Spree.t('terms_of_service'),
+            Spree.t('privacy_policy'),
+            Spree.t('returns_policy'),
+            Spree.t('shipping_policy')
+          )
+        end
+
+        it 'is idempotent - does not create duplicates when called multiple times' do
+          store.save!
+
+          expect { store.send(:create_default_policies) }.not_to change(Spree::Policy, :count)
+          expect(store.policies.count).to eq(4)
+        end
+
+        context 'with non-English store locale' do
+          let(:store) { build(:store, default_locale: 'de') }
+
+          before do
+            I18n.backend.store_translations(:de, {
+              spree: {
+                terms_of_service: 'Nutzungsbedingungen',
+                privacy_policy: 'Datenschutzrichtlinie',
+                returns_policy: 'Rückgaberecht',
+                shipping_policy: 'Versandrichtlinie'
+              }
+            })
+          end
+
+          it 'creates policies with translated names in store locale' do
+            store.save!
+
+            # Policies are created with the translated name in the base column
+            expect(store.policies.pluck(:name)).to contain_exactly(
+              'Nutzungsbedingungen',
+              'Datenschutzrichtlinie',
+              'Rückgaberecht',
+              'Versandrichtlinie'
+            )
+          end
         end
       end
     end
@@ -198,11 +240,52 @@ describe Spree::Store, type: :model, without_global_store: true do
           Spree.t(:taxonomy_collections_name)
         )
       end
+
+      it 'is idempotent - does not create duplicates when called multiple times' do
+        store.save!
+
+        expect { store.send(:ensure_default_taxonomies_are_created) }.not_to change(Spree::Taxonomy, :count)
+        expect(store.taxonomies.count).to eq(3)
+      end
+
+      context 'with non-English store locale' do
+        let(:store) { build(:store, default_locale: 'de') }
+
+        before do
+          # Add German translations for taxonomy names
+          I18n.backend.store_translations(:de, {
+            spree: {
+              taxonomy_categories_name: 'Kategorien',
+              taxonomy_brands_name: 'Marken',
+              taxonomy_collections_name: 'Kollektionen'
+            }
+          })
+        end
+
+        it 'creates taxonomies with translated names in store locale' do
+          store.save!
+
+          # Taxonomies are created with the translated name in the base column
+          expect(store.taxonomies.pluck(:name)).to contain_exactly('Kategorien', 'Marken', 'Kollektionen')
+        end
+
+        it 'falls back to English when translation is missing' do
+          # Remove the German translation for categories
+          I18n.backend.store_translations(:de, { spree: { taxonomy_categories_name: nil } })
+
+          store.save!
+
+          # Categories falls back to English, others use German
+          expect(store.taxonomies.pluck(:name)).to include('Categories') # fallback to English
+          expect(store.taxonomies.pluck(:name)).to include('Marken')
+          expect(store.taxonomies.pluck(:name)).to include('Kollektionen')
+        end
+      end
     end
 
     describe '#ensure_default_automatic_taxons' do
       let(:store) { build(:store) }
-      let(:collections_taxonomy) { store.taxonomies.find_by(name: Spree.t(:taxonomy_collections_name)) }
+      let(:collections_taxonomy) { store.taxonomies.with_matching_name(Spree.t(:taxonomy_collections_name)).first }
 
       it 'creates automatic taxons on the collections taxonomy' do
         expect { store.save! }.to change(Spree::Taxon.automatic, :count).by(2)
@@ -210,6 +293,35 @@ describe Spree::Store, type: :model, without_global_store: true do
         expect(store.reload.taxons.automatic.count).to eq(2)
         expect(store.taxons.automatic.pluck(:name)).to contain_exactly('New arrivals', 'On sale')
         expect(store.taxons.automatic.pluck(:taxonomy_id).uniq).to contain_exactly(collections_taxonomy.id)
+      end
+
+      it 'is idempotent - does not create duplicates when called multiple times' do
+        store.save!
+
+        expect { store.send(:ensure_default_automatic_taxons) }.not_to change(Spree::Taxon.automatic, :count)
+        expect(store.taxons.automatic.count).to eq(2)
+      end
+    end
+
+    describe '#ensure_default_post_categories_are_created' do
+      let(:store) { build(:store) }
+
+      it 'creates default post categories' do
+        expect { store.save! }.to change(Spree::PostCategory, :count).by(3)
+
+        expect(store.post_categories.count).to eq(3)
+        expect(store.post_categories.pluck(:title)).to contain_exactly(
+          Spree.t('default_post_categories.resources'),
+          Spree.t('default_post_categories.articles'),
+          Spree.t('default_post_categories.news')
+        )
+      end
+
+      it 'is idempotent - does not create duplicates when called multiple times' do
+        store.save!
+
+        expect { store.send(:ensure_default_post_categories_are_created) }.not_to change(Spree::PostCategory, :count)
+        expect(store.post_categories.count).to eq(3)
       end
     end
 
@@ -259,7 +371,7 @@ describe Spree::Store, type: :model, without_global_store: true do
     let!(:store) { create(:store, name: 'Store EN') }
 
     before do
-      Mobility.with_locale(:pl) do
+      ::Mobility.with_locale(:pl) do
         store.update!(
           name: 'Store PL',
           description: 'PL description'


### PR DESCRIPTION
There's a bug / feature limit in Mobility (library for storing/fetching translations we use) that find_or_create_by

Records are created with the translated name directly in the base column (not using Mobility.with_locale), because:
  1. Mobility with column_fallback: true expects values in the base column
  2. Creating inside Mobility.with_locale would write to the translations table, leaving the base column NULL and causing NOT NULL constraint violations

  This means a German store will have taxonomies with German names like "Kategorien", "Marken", "Kollektionen" stored in the name column directly.