### PR TITLE
Fixed issue #13437 - Promotion rule caching issue when editing rules …

### DIFF
--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -100,6 +100,9 @@ module Spree
             )
           end
 
+          # Invalidate cache after bulk operations
+          touch
+
           # Clear memoized values
           @eligible_product_ids = nil
         end

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -61,6 +61,9 @@ module Spree
             )
           end
 
+          # Invalidate cache after bulk operations
+          touch
+
           # Clear memoized values
           @eligible_user_ids = nil
         end

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -178,5 +178,17 @@ describe Spree::Promotion::Rules::Product, type: :model do
       rule.save!
       expect(rule.reload.eligible_product_ids).to match_array(products.map(&:id))
     end
+
+    it 'touches the record to invalidate cache' do
+      rule.product_ids_to_add = [products.first.id]
+      rule.save!
+      original_updated_at = rule.updated_at
+
+      rule.update_column(:updated_at, 1.day.ago)
+      rule.product_ids_to_add = [products.second.id]
+      rule.save!
+
+      expect(rule.reload.updated_at).to be > original_updated_at
+    end
   end
 end

--- a/core/spec/models/spree/promotion/rules/user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_spec.rb
@@ -63,5 +63,17 @@ describe Spree::Promotion::Rules::User, type: :model do
       rule.save!
       expect(rule.users).to include(random_user, user_placing_order)
     end
+
+    it 'touches the record to invalidate cache' do
+      rule.user_ids_to_add = [random_user.id]
+      rule.save!
+      original_updated_at = rule.updated_at
+
+      rule.update_column(:updated_at, 1.day.ago)
+      rule.user_ids_to_add = [user_placing_order.id]
+      rule.save!
+
+      expect(rule.reload.updated_at).to be > original_updated_at
+    end
   end
 end


### PR DESCRIPTION
…with associated users or products.

  Problem: The add_users and add_products methods in Spree::Promotion::Rules::User and Spree::Promotion::Rules::Product used bulk SQL operations (delete_all and insert_all) that bypass
  ActiveRecord callbacks, preventing the parent record's updated_at timestamp from being refreshed. This caused Rails to serve stale cached HTML after saving changes.

  Solution: Added a touch call after the bulk operations in both methods to invalidate the cache:

  - core/app/models/spree/promotion/rules/user.rb:65 - Added touch in add_users
  - core/app/models/spree/promotion/rules/product.rb:104 - Added touch in add_products