### PR TITLE
Fixed Price List Volume Rule not working during add to cart

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -244,7 +244,7 @@ module Spree
 
       # Only update if price or price list changed
       if new_price != price || new_price_list_id != price_list_id
-        update_columns(price: new_price, price_list_id: new_price_list_id)
+        update_columns(price: new_price, price_list_id: new_price_list_id, updated_at: Time.current)
       end
     end
 

--- a/core/app/services/spree/cart/add_item.rb
+++ b/core/app/services/spree/cart/add_item.rb
@@ -39,7 +39,7 @@ module Spree
 
         return failure(line_item) unless line_item.save
 
-        line_item.reload.update_price
+        line_item.reload.recalculate_price
 
         ::Spree::TaxRate.adjust(order, [line_item]) if line_item_created
         success(order: order, line_item: line_item, line_item_created: line_item_created, options: options)


### PR DESCRIPTION
 Problem: When adding an item to cart with a quantity that meets a volume-based pricing threshold, the volume price was not applied on initial creation. The volume price only worked when updating an existing line item's quantity.

  Root Cause: In Spree::Cart::AddItem service, after saving the line item, line_item.reload.update_price was called. However, update_price only sets the price/price_list_id attributes on the object without persisting them to the database. The changes were lost because there was no subsequent save.

  Fix: Changed the AddItem service to call recalculate_price instead of update_price. The recalculate_price method uses update_columns to persist the price changes directly to the database.