### PR TITLE
Include translations when fetching product breadcrumb taxons for json-ld

### DIFF
--- a/storefront/app/helpers/spree/products_helper.rb
+++ b/storefront/app/helpers/spree/products_helper.rb
@@ -176,7 +176,7 @@ module Spree
       return Spree::Taxon.none if product.main_taxon.blank?
 
       # using find_all as we already iterate over the taxons in #product_json_ld_breadcrumbs
-      product.main_taxon.self_and_ancestors.find_all { |taxon| taxon.depth != 0 }
+      product.main_taxon.self_and_ancestors.includes(:translations).find_all { |taxon| taxon.depth != 0 }
     end
 
     # Generates the JSON-LD elements for a list of products.


### PR DESCRIPTION
As bullet suggests - that association can be included to improve json-ld rendering performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes breadcrumb generation for product JSON-LD by preventing N+1 queries.
> 
> - Updates `product_breadcrumb_taxons` in `products_helper.rb` to call `self_and_ancestors.includes(:translations)` so taxon names are preloaded for localized rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f9264bd5daa5e17f18e61f998b45347c3d4b106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->