### PR TITLE
Fix locale-aware formatting for variants price inputs (admin)

### DIFF
--- a/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -1136,6 +1136,7 @@ export default class extends CheckboxSelectAll {
 
   formatNumber(value) {
     if (value === null) return ''
+    if (typeof value === 'string' && value.trim() === '') return ''
 
     const number = Number(value)
     if (!Number.isFinite(number)) return ''

--- a/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -416,7 +416,7 @@ export default class extends CheckboxSelectAll {
     pricesVariation.delete(null)
 
     if (pricesVariation.size === 0) {
-      parentPriceEl.value = this.priceForVariant(variantName, currency).amount?.toLocaleString(this.localeValue) || ''
+      parentPriceEl.value = this.formatNumber(this.priceForVariant(variantName, currency).amount)
       parentPriceEl.placeholder = ''
       return
     }
@@ -425,9 +425,10 @@ export default class extends CheckboxSelectAll {
 
     if (minPrice !== maxPrice) {
       parentPriceEl.value = null
-      parentPriceEl.placeholder = `${minPrice} - ${maxPrice}`
+      parentPriceEl.placeholder = `${this.formatNumber(minPrice)} - ${this.formatNumber(maxPrice)}`
     } else {
-      parentPriceEl.value = minPrice
+      parentPriceEl.value = this.formatNumber(minPrice)
+      parentPriceEl.placeholder = ''
     }
   }
 
@@ -712,7 +713,7 @@ export default class extends CheckboxSelectAll {
       }
 
       const existingPrice = this.priceForVariant(internalName, currency)
-      priceInput.value = existingPrice.amount?.toLocaleString(this.localeValue) || ''
+      priceInput.value = this.formatNumber(existingPrice.amount)
       currencyInput.value = currency
       if (existingPrice.id) {
         idInput.value = existingPrice.id
@@ -1131,5 +1132,14 @@ export default class extends CheckboxSelectAll {
     } else {
       el.classList.add('hidden')
     }
+  }
+
+  formatNumber(value) {
+    if (value === null) return ''
+
+    const number = Number(value)
+    if (!Number.isFinite(number)) return ''
+
+    return number.toLocaleString(this.localeValue)
   }
 }


### PR DESCRIPTION
## Problem

In the admin variants form, prices were formatted inconsistently under some locales (e.g. Greek). Parent/summary price values could show `5.50` while nested variant price inputs showed `5,50`.

## Root cause

Different code paths wrote price values to inputs. Some used raw numbers/strings while others used locale-aware formatting.

## Changes

Centralized all UI price formatting through `formatNumber()` and used it consistently for both parent price/range display and nested variant price inputs.

> [!NOTE]
> Why `formatNumber` looks like this:
> - `if (value === null) return ''` prevents null being coerced to `0` `Number(null) === 0`
> - `Number.isFinite(number)` prevents rendering `NaN/Infinity` into the UI.
> - No `try/catch`: we assume `this.localeValue` is valid for our app; if it isn’t, we prefer failing fast rather than hiding it.

How to verify: Open an admin product with variants, use a Greek locale browser/session, and confirm both parent price range/placeholder and nested variant inputs use the same decimal separator/format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent, locale-aware price rendering across the variants form.
> 
> - Introduces `formatNumber()` and uses it for parent price values, range placeholders, and nested variant price inputs
> - Replaces direct `toLocaleString` calls and raw assignments with `formatNumber()` to avoid `null/NaN` issues and inconsistent separators
> - Clears parent price placeholder when a single value is present for clarity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 295e576fc5c42ba5770ef5751ade77718f8871f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->