### PR TITLE
-- Remove NOT NULL constraint from spree_policies.name to support Mobility translations

### DIFF
--- a/core/app/models/spree/policy.rb
+++ b/core/app/models/spree/policy.rb
@@ -36,7 +36,7 @@ module Spree
     #
     # Scopes
     #
-    scope :with_body,    -> { joins(:rich_text_body).distinct }
+    scope :with_body, -> { joins(:rich_text_body).distinct }
     scope :without_body, -> { where.missing(:rich_text_body) }
     scope :with_matching_name, ->(name_to_match) do
       value = name_to_match.to_s.strip.downcase

--- a/core/db/migrate/20260117140831_remove_not_null_constraint_from_policy_name.rb
+++ b/core/db/migrate/20260117140831_remove_not_null_constraint_from_policy_name.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromPolicyName < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :spree_policies, :name, true
+  end
+end

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe Spree::Policy, type: :model do
 
           expect(policy).to be_persisted
           expect(policy.name).to eq('Política de Privacidad')
-          expect(policy.read_attribute(:name)).to be_nil
         end
       end
     end

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe Spree::Policy, type: :model do
         expect(policy.body.to_plain_text).to eq('Política de Privacidad')
       end
     end
+
+    context 'when always_use_translations is enabled' do
+      before do
+        @original_setting = Spree::Config.always_use_translations
+        Spree::Config.always_use_translations = true
+      end
+
+      after do
+        Spree::Config.always_use_translations = @original_setting
+      end
+
+      it 'allows creating policies with translations' do
+        policy = create(:policy, owner: store, name: 'Privacy Policy')
+
+        expect(policy).to be_persisted
+        expect(policy.name).to eq('Privacy Policy')
+      end
+    end
   end
 
   describe 'Scopes' do

--- a/core/spec/models/spree/policy_spec.rb
+++ b/core/spec/models/spree/policy_spec.rb
@@ -81,10 +81,13 @@ RSpec.describe Spree::Policy, type: :model do
       end
 
       it 'allows creating policies with translations' do
-        policy = create(:policy, owner: store, name: 'Privacy Policy')
+        I18n.with_locale(:es) do
+          policy = create(:policy, owner: store, name: 'Política de Privacidad')
 
-        expect(policy).to be_persisted
-        expect(policy.name).to eq('Privacy Policy')
+          expect(policy).to be_persisted
+          expect(policy.name).to eq('Política de Privacidad')
+          expect(policy.read_attribute(:name)).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
**Problem:**
With always_use_translations enabled, Mobility stores translations in spree_policy_translations and sets the base name column to NULL. The database NOT NULL constraint causes a PG::NotNullViolation when creating policies.

**Solution:**
Removed the NOT NULL constraint from spree_policies.name to allow Mobility to work correctly when column_fallback: false.

**Safety:**
Data integrity is still enforced by the model-level validation validates :name, presence: true. This keeps validation at the application layer, which is compatible with Mobility’s translation behavior. The migration makes the column nullable, but policies still require a name through the model validation.

**Changes:**
Added migration to make spree_policies.name nullable
Added test to verify policy creation works when always_use_translations is enabled

**Fixes #13460**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows Mobility translations to persist when always_use_translations is enabled by removing the DB NOT NULL on `spree_policies.name` and adding a test to cover translated creation.
> 
> - Adds migration to make `spree_policies.name` nullable (`RemoveNotNullConstraintFromPolicyName`)
> - Adds spec ensuring policies can be created in a non-default locale when `always_use_translations` is true
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 210943db0611db684fb59a03b56f3045ae9ef75d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->