### PR TITLE
Change icon name from 'h2' to 'h-2'

### DIFF
--- a/packages/page_builder/app/models/spree/page_blocks/subheading.rb
+++ b/packages/page_builder/app/models/spree/page_blocks/subheading.rb
@@ -6,7 +6,7 @@ module Spree
       preference :text_color, :string
 
       def icon_name
-        'h2'
+        'h-2'
       end
 
       def display_name


### PR DESCRIPTION
## Problem

I was using the `Subheading` page block in a custom page section I was building and I noticed it didn't have a nice icon like all of the other blocks:

<img width="328" height="174" alt="image" src="https://github.com/user-attachments/assets/9d23fb93-ba44-40fa-80fc-ac746f5c6ccd" />

## Solution: `h-2`

In [tabler's icon set](https://tabler.io/icons), there is no `h2`, only `h-2`. With this fix, the icon now looks like:

<img width="327" height="171" alt="image" src="https://github.com/user-attachments/assets/4fcc3cd2-d768-4942-9315-9c1a8efb3b3f" />

After exploring various options (see below), I figured perhaps just the comparison of `H` to `H2` is sufficient enough for a block that probably few are using anyway.

### Other option I tried: `letter-h-small`

Because this might not always be implemented as an `<h2>` element, I thought I'd take a look at some other icons that might be better suited. I particularly was interested in `letter-h-small`, however it's much more tiny than I was expecting:

<img width="325" height="171" alt="image" src="https://github.com/user-attachments/assets/e817d440-75b5-44e8-bed7-51170eb0a041" />

### Other option I tried: `letter-h`

and for the curious/overthinking, here it is as just `letter-h` which doesn't look very different from the `heading` H:

<img width="324" height="172" alt="image" src="https://github.com/user-attachments/assets/6ccd7a03-a77d-4aa3-bebc-f23f7665d970" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes incorrect icon reference for Subheading block**
> 
> - Updates `icon_name` in `packages/page_builder/app/models/spree/page_blocks/subheading.rb` to return `"h-2"` instead of `"h2"`
> - Ensures the Subheading block uses a valid Tabler icon
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65908aa5e488bc6514e02fb6090e2aa865b7a8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->