### PR TITLE
Fix string mutation bug in Google Merchant feed title generation

### DIFF
--- a/core/app/services/spree/data_feeds/google/required_attributes.rb
+++ b/core/app/services/spree/data_feeds/google/required_attributes.rb
@@ -26,11 +26,11 @@ module Spree
         def format_title(product, variant)
           # Title of a variant is created by joining title of a product and variant's option_values, as they are
           # what differentiates it from other variants.
-          title = product.name
+          parts = [product.name]
           variant.option_values.find_each do |option_value|
-            title << " - #{option_value.name}"
+            parts << option_value.name
           end
-          title
+          parts.join(' - ')
         end
 
         def get_description(product, variant)

--- a/core/spec/services/spree/data_feeds/google/required_attributes_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/required_attributes_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Spree
+  describe DataFeeds::Google::RequiredAttributes do
+    subject { described_class.new }
+
+    let(:store) { @default_store }
+    let(:product) { create(:product, name: 'Test Product', stores: [store]) }
+
+    describe '#call' do
+      it 'does not mutate product name when generating titles for multiple variants' do
+        option_type = create(:option_type)
+        option_a = create(:option_value, name: 'option-a', option_type: option_type)
+        option_b = create(:option_value, name: 'option-b', option_type: option_type)
+
+        variant_a = create(:with_image_variant, product: product, option_values: [option_a])
+        variant_b = create(:with_image_variant, product: product, option_values: [option_b])
+
+        result_a = subject.call(product: product, variant: variant_a, store: store)
+        result_b = subject.call(product: product, variant: variant_b, store: store)
+
+        expect(result_a.value[:information]['title']).not_to include('option-b')
+        expect(result_b.value[:information]['title']).not_to include('option-a')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## The Bug
The `format_title` method in `Spree::DataFeeds::Google::RequiredAttributes` mutates the `product.name` string using `<<.` Since `product.name` returns the same string object across calls, each variant's title accumulates all previous variants' option values.

## How to Reproduce
Check in your console, using something like this

```
product = Spree::Product.joins(:variants).group('spree_products.id').having('COUNT(spree_variants.id) >= 3').first
store = Spree::Store.default
variants = product.variants.includes(:option_values).limit(3).to_a
service = Spree::DataFeeds::Google::RequiredAttributes.new

variants.each_with_index do |variant, i|
  result = service.call(product: product, variant: variant, store: store)
  puts "Variant #{i + 1}: #{result.value[:information]['title']}"
end; nil
```

Expected output:
```
Variant 1: Apple iPhone 16 - black - 128-gb
Variant 2: Apple iPhone 16 - white - 128-gb
Variant 3: Apple iPhone 16 - pink - 128-gb
```
Actual output (bug):
```
Variant 1: Apple iPhone 16 - black - 128-gb
Variant 2: Apple iPhone 16 - black - 128-gb - white - 128-gb
Variant 3: Apple iPhone 16 - black - 128-gb - white - 128-gb - pink - 128-gb
```

Should also be apparent in your feed at `/api/v2/data_feeds/google/products`

## The Fix
Changed format_title to use an array and join instead of mutating the product name string with <<:

## Test
Added a spec that verifies variant titles don't accumulate option values from other variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents cross-variant title contamination in Google Merchant feed.
> 
> - Refactors `format_title` to build titles with an array (`parts`) and `join(' - ')` instead of mutating `product.name` with `<<` in `required_attributes.rb`
> - Adds spec in `required_attributes_spec.rb` verifying titles for multiple variants remain independent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f70c531412de81ccc4847cbcc4cc417571315a5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->