### PR TITLE
Add /products/ path to Google Merchant feed links

### DIFF
--- a/core/app/services/spree/data_feeds/google/required_attributes.rb
+++ b/core/app/services/spree/data_feeds/google/required_attributes.rb
@@ -12,7 +12,7 @@ module Spree
           information['id'] = input[:variant].id
           information['title'] = format_title(input[:product], input[:variant])
           information['description'] = get_description(input[:product], input[:variant])
-          information['link'] = "#{input[:store].url}/#{input[:product].slug}"
+          information['link'] = "#{input[:store].url}/products/#{input[:product].slug}"
           information['image_link'] = get_image_link(input[:variant], input[:product])
           information['price'] = format_price(input[:variant])
           information['availability'] = get_availability(input[:product])

--- a/core/spec/services/spree/data_feeds/google/rss_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/rss_spec.rb
@@ -46,7 +46,7 @@ module Spree
       end
 
       it 'includes link' do
-        expect(result.value[:file]).to include("<g:link>#{store.url}/#{product.slug}</g:link>").once
+        expect(result.value[:file]).to include("<g:link>#{store.url}/products/#{product.slug}</g:link>").once
       end
 
       it 'includes image link' do


### PR DESCRIPTION
Product links are missing the `/products/` path segment, generating URLs like `example.com/product-slug` instead of `example.com/products/product-slug`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects product URL construction in Google Merchant feed.
> 
> - In `RequiredAttributes`, builds `link` as `"#{store.url}/products/#{product.slug}"` instead of `"#{store.url}/#{product.slug}"`
> - Updates `rss_spec` to assert the new `<g:link>` format
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 167f7db92c3867c7a5364f46f1d088d0f83f567a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->