### PR TITLE
Fix available_on.nil? out of stock bug

### DIFF
--- a/core/app/services/spree/data_feeds/google/required_attributes.rb
+++ b/core/app/services/spree/data_feeds/google/required_attributes.rb
@@ -56,7 +56,7 @@ module Spree
         end
 
         def get_availability(product)
-          return 'in stock' if product.available? && product.available_on&.past?
+          return 'in stock' if product.available? && (product.available_on.nil? || product.available_on.past?)
           return 'backorder' if product.backorderable? && product.backordered? && product.available_on&.future?
 
           'out of stock'

--- a/core/spec/services/spree/data_feeds/google/required_attributes_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/required_attributes_spec.rb
@@ -22,15 +22,6 @@ module Spree
         expect(result_a.value[:information]['title']).not_to include('option-b')
         expect(result_b.value[:information]['title']).not_to include('option-a')
       end
-
-      it 'returns in stock for available products without available_on date' do
-        product = create(:product, available_on: nil, status: 'active', stores: [store])
-        variant = create(:with_image_variant, product: product)
-
-        result = subject.call(product: product, variant: variant, store: store)
-
-        expect(result.value[:information]['availability']).to eq('in stock')
-      end
     end
   end
 end

--- a/core/spec/services/spree/data_feeds/google/required_attributes_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/required_attributes_spec.rb
@@ -22,6 +22,15 @@ module Spree
         expect(result_a.value[:information]['title']).not_to include('option-b')
         expect(result_b.value[:information]['title']).not_to include('option-a')
       end
+
+      it 'returns in stock for available products without available_on date' do
+        product = create(:product, available_on: nil, status: 'active', stores: [store])
+        variant = create(:with_image_variant, product: product)
+
+        result = subject.call(product: product, variant: variant, store: store)
+
+        expect(result.value[:information]['availability']).to eq('in stock')
+      end
     end
   end
 end

--- a/core/spec/services/spree/data_feeds/google/rss_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/rss_spec.rb
@@ -78,8 +78,8 @@ module Spree
       context 'availability date is nil' do
         let(:product) { create(:product, stores: [store], available_on: nil) }
 
-        it 'shows that product is out of stock' do
-          expect(result.value[:file]).to include('<g:availability>out of stock</g:availability>')
+        it 'shows that product is in stock' do
+          expect(result.value[:file]).to include('<g:availability>in stock</g:availability>')
         end
 
         it 'shows that product availability date is nil' do


### PR DESCRIPTION
Products with `available_on == nil` are showing as out of stock in the feed, so if you are not using the `available_on` and `discontinue_on` features, every product shows as out of stock. This might be intended behaviour, but I find it unintuitive.

EDIT: Seems to be intended, since there is a test for it. I can't tell why though.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change: Google feed availability**
> 
> - Updates `get_availability` in `required_attributes.rb` to return `"in stock"` when `product.available?` and `available_on` is `nil` or in the past
> - Adds spec ensuring available products without `available_on` are reported as `"in stock"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef2f9342a5bc7ec31d3411cf0d8195ce950901d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->