### PR TITLE
Fix link to Developer Guides in user documentation

### DIFF
--- a/docs/user/what-is-spree-commerce.mdx
+++ b/docs/user/what-is-spree-commerce.mdx
@@ -35,7 +35,7 @@ So what sets both versions apart? Here's a [feature comparison](https://spreecom
 
 This Spree user documentation is intended for business owners and site administrators of Spree e-commerce sites. Everything you need to know to configure and manage your Spree store can be found here.
 
-If you are a Spree developer, you may find the [Developer Guides](/docs/developer) to be of benefit to you, though we strongly urge you to read through both sets of guides.
+If you are a Spree developer, you may find the [Developer Guides](/developer) to be of benefit to you, though we strongly urge you to read through both sets of guides.
 
 BTW Give Spree a [GitHub Star](https://github.com/spree/spree)<Icon icon="star" iconType="solid" color="#FFD43B" />, why dont't ya?
 


### PR DESCRIPTION
Updated link to Developer Guides for accuracy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates user docs to point the Developer Guides link to `(/developer)` instead of `(/docs/developer)`.
> 
> - In `docs/user/what-is-spree-commerce.mdx`, corrected the Developer Guides URL and added a trailing newline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ebee4e5d0565e9748658a491041326b33c451a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->