### PR TITLE
Fix Rails 8.1 ActiveRecord::EagerLoadPolymorphicError

### DIFF
--- a/page_builder/app/jobs/spree/themes/duplicate_components_job.rb
+++ b/page_builder/app/jobs/spree/themes/duplicate_components_job.rb
@@ -43,7 +43,7 @@ module Spree
 
         all_parent_ids = all_section_ids + all_page_blocks.ids
         all_page_links = Spree::PageLink.
-                          includes(:linkable, parent: :pageable).
+                          preload(:linkable, parent: :pageable).
                           where(linkable_type: 'Spree::Page').
                           where(parent_id: all_parent_ids, linkable_id: theme.pages)
 

--- a/page_builder/app/models/concerns/spree/has_page_links.rb
+++ b/page_builder/app/models/concerns/spree/has_page_links.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :links, -> { order(:position).includes(:linkable) }, class_name: 'Spree::PageLink', as: :parent, dependent: :destroy, inverse_of: :parent
+      has_many :links, -> { order(:position) }, class_name: 'Spree::PageLink', as: :parent, dependent: :destroy, inverse_of: :parent
       alias page_links links
 
       after_create :create_default_links, unless: :do_not_create_links


### PR DESCRIPTION
Rails 8.1 raises EagerLoadPolymorphicError when using includes() on polymorphic associations. This affects the :linkable association on PageLink which is polymorphic (can be Page, Product, Taxon, etc.).

Changes:
- Remove includes(:linkable) from has_many :links default scope
- Use preload() instead of includes() in DuplicateComponentsJob

preload() uses separate queries per type which works with polymorphic associations, while includes() attempts a JOIN which fails.