### PR TITLE
fix[v-3311]: gift cards - add user validation to Apply class

### DIFF
--- a/core/app/services/spree/gift_cards/apply.rb
+++ b/core/app/services/spree/gift_cards/apply.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Applies a gift card to an order
 # under the hood it creates a store credit payment record and updates the gift card amount used
 # @param gift_card [Spree::GiftCard] the gift card to apply
@@ -15,6 +16,14 @@ module Spree
 
         # we shouldn't allow a gift card to be applied to an order with a different currency
         return failure(:gift_card_mismatched_currency) if gift_card.currency != order.currency
+
+        # gift card requires logged user
+        if gift_card.user.present?
+          # user must be logged in
+          return failure(:gift_card_customer_not_logged_in) if order.user.blank?
+          # user must be the same as the gift card user
+          return failure(:gift_card_mismatched_customer) if gift_card.user != order.user
+        end
 
         amount = [gift_card.amount_remaining, order.total].min
         store = order.store

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1190,7 +1190,10 @@ en:
     gift_card_already_redeemed: The Gift Card has already been redeemed.
     gift_card_applied: The Gift Card was successfully applied to your order!
     gift_card_batch: Gift Card Batch
+    gift_card_customer_not_logged_in: Gift Card cannot be applied with guest user.
     gift_card_expired: The Gift Card has expired.
+    gift_card_mismatched_currency: Gift Card cannot be applied with current currency.
+    gift_card_mismatched_customer: This gift card is associated with another user.
     gift_card_removed: The Gift Card was successfully removed from your order
     gift_card_using_store_credit_error: You can't apply the Gift Card after you applied the store credit.
     gift_cards: Gift Cards


### PR DESCRIPTION
## problem description:
- a user can redeem a gift card that is assigned to another user if they know the gift card code.

## solution:
add user validation:
if gift card is associated with a user:
- check if it is guest checkout - if yes - ask user to log in
- otherwise check if user associated with an order is user from a gift card

minor changes:
- add missing specs and locale for mismatched_currency error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout/payment application rules for gift cards, which could block some redemptions if user/order associations are mis-set or if guest checkout relies on user-assigned cards; behavior is covered by new specs.
> 
> **Overview**
> Tightens `Spree::GiftCards::Apply` validation to prevent redeeming a gift card that’s tied to another customer: if a gift card has a `user`, the order must be logged in and match that user, otherwise the service returns new failure codes.
> 
> Adds/ensures locale strings for the new errors (and currency mismatch messaging) and expands `apply_spec` to cover user-assigned gift cards (valid user/guest/other user) plus mismatched-currency behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d225edccfeec1ae441522bdba753ea29625c06c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->