### PR TITLE
Add `item_group_id` to required_attributes for Google data feed

### DIFF
--- a/core/app/services/spree/data_feeds/google/required_attributes.rb
+++ b/core/app/services/spree/data_feeds/google/required_attributes.rb
@@ -10,6 +10,7 @@ module Spree
           return failure(nil, error: 'No image link') if get_image_link(input[:variant], input[:product]).nil?
 
           information['id'] = input[:variant].id
+          information['item_group_id'] = input[:product].id
           information['title'] = format_title(input[:product], input[:variant])
           information['description'] = get_description(input[:product], input[:variant])
           information['link'] = "#{input[:store].url}/products/#{input[:product].slug}"

--- a/core/spec/services/spree/data_feeds/google/rss_spec.rb
+++ b/core/spec/services/spree/data_feeds/google/rss_spec.rb
@@ -37,6 +37,10 @@ module Spree
         expect(result.value[:file]).to include("<g:id>#{variant.id}</g:id>").once
       end
 
+      it 'includes product id as item_group_id' do
+        expect(result.value[:file]).to include("<g:item_group_id>#{product.id}</g:item_group_id>").once
+      end
+
       it 'includes title' do
         expect(result.value[:file]).to include("<g:title>#{product.name} - #{variant.option_values.first.name}</g:title>").once
       end


### PR DESCRIPTION
This PR is about adding `<g:item_group_id>` to google data feed.

> Use the item group ID [item_group_id] attribute to group product variants in your product data. Variants are a group of similar products that only differ from one another by product details like [size [size]](https://support.google.com/merchants/answer/6324492), [color [color]](https://support.google.com/merchants/answer/6324487), [material [material]](https://support.google.com/merchants/answer/6324410), [pattern [pattern]](https://support.google.com/merchants/answer/6324483), [age group [age_group]](https://support.google.com/merchants/answer/6324463), and [gender [gender]](https://support.google.com/merchants/answer/6324479).
> 
> When you use an item group ID [item_group_id] to group your products, you can ensure that your product and its variants are shown to customers as a group, instead of separately.

https://support.google.com/merchants/answer/6324507?hl=en

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to feed output plus a test; low likelihood of regressions beyond consumers that strictly validate the XML schema.
> 
> **Overview**
> Adds Google Merchant Center variant grouping support by emitting `item_group_id` (set to the parent product ID) in the required attributes for each RSS feed item.
> 
> Updates the RSS spec to assert `<g:item_group_id>` is present alongside the existing `<g:id>` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2adf5e96d531fb1359a126f75e74a78e9aaf873e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->