### PR TITLE
Feature/v 3312 incorrect total applied store credit

### DIFF
--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -68,7 +68,7 @@ module Spree
         if payments.loaded?
           payments.
             find_all(&:store_credit?).
-            reject { |payment| payment.state.in?(Spree::Payment::INVALID_STATES) }.
+            reject { |payment| payment.has_invalid_state? }.
             sum(&:amount) || BigDecimal::ZERO
         else
           payments.store_credits.valid.sum(:amount)

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -68,7 +68,7 @@ module Spree
         if payments.loaded?
           payments.
             find_all(&:store_credit?).
-            reject { |payment| payment.has_invalid_state? }.
+            reject(&:has_invalid_state?).
             sum(&:amount) || BigDecimal::ZERO
         else
           payments.store_credits.valid.sum(:amount)

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -68,7 +68,7 @@ module Spree
         if payments.loaded?
           payments.
             find_all(&:store_credit?).
-            select { |payment| payment.state.in?(Spree::Payment::INVALID_STATES) }.
+            reject { |payment| payment.state.in?(Spree::Payment::INVALID_STATES) }.
             sum(&:amount) || BigDecimal::ZERO
         else
           payments.store_credits.valid.sum(:amount)

--- a/core/app/models/spree/order/store_credit.rb
+++ b/core/app/models/spree/order/store_credit.rb
@@ -66,7 +66,10 @@ module Spree
       # @return [BigDecimal] The total amount of store credits applied to the order.
       def total_applied_store_credit
         if payments.loaded?
-          payments.find_all(&:store_credit?).find_all(&:valid?).sum(&:amount) || BigDecimal::ZERO
+          payments.
+            find_all(&:store_credit?).
+            select { |payment| payment.state.in?(Spree::Payment::INVALID_STATES) }.
+            sum(&:amount) || BigDecimal::ZERO
         else
           payments.store_credits.valid.sum(:amount)
         end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -278,6 +278,10 @@ module Spree
       end
     end
 
+    def has_invalid_state?
+      INVALID_STATES.include?(state)
+    end
+
     private
 
     def set_amount
@@ -300,10 +304,6 @@ module Spree
 
     def publish_payment_voided_event
       publish_event('payment.voided')
-    end
-
-    def has_invalid_state?
-      INVALID_STATES.include?(state)
     end
 
     def validate_source

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -1296,6 +1296,23 @@ describe Spree::Payment, type: :model do
     end
   end
 
+  describe '#has_invalid_state?' do
+    let(:payment) { create(:payment, state: state) }
+    subject(:has_invalid_state?) { payment.has_invalid_state? }
+
+    context 'when the state is invalid' do
+      let(:state) { Spree::Payment::INVALID_STATES.first }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the state is valid' do
+      let(:state) { 'completed' }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe '#gateway_processing_error_messages' do
     before do
       payment.add_gateway_processing_error('Gateway processing error')


### PR DESCRIPTION
problem description:
total_applied_store_credit is using valid? which is ActiveRecord::Validations method.

solution:
move `order#has_invalid_state?` to public and add specs
replace `find_all(&:valid?)` with `reject(&:has_invalid_state?)`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to store-credit total calculation plus test coverage; low risk aside from potential behavior change for orders that previously counted `invalid/void/failed` payments.
> 
> **Overview**
> Fixes `Order#total_applied_store_credit` when `payments` are already loaded by filtering out payments in `INVALID_STATES` (instead of relying on ActiveRecord's `valid?`), aligning in-memory calculation with the `payments.valid` scope.
> 
> Promotes `Payment#has_invalid_state?` to a public method and adds/updates specs to cover invalid-state exclusion and parity between loaded vs unloaded associations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fb7e7a8fa437893d13d96dc264c4623866930c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->