### PR TITLE
fix mobile nav initial transform

### DIFF
--- a/admin/app/views/layouts/spree/admin.html.erb
+++ b/admin/app/views/layouts/spree/admin.html.erb
@@ -13,7 +13,7 @@
 
     <%= render "spree/admin/shared/header" %>
     <%= render "spree/admin/shared/sidebar" %>
-    <main id="content" data-controller=" export-dialog">
+    <main id="content" data-controller="export-dialog">
       <%= render "spree/admin/shared/content_header" %>
       <%= render "spree/admin/shared/page_tabs" %>
       <%= render "spree/admin/shared/page_alerts" %>

--- a/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/nav/_mobile.html.erb
@@ -1,5 +1,5 @@
 <div class="bg-background border-default border-t overflow-x-hidden h-full w-screen overflow-y-hidden">
-  <div class="h-full flex transform has-[.currency-and-locale-modal:not(.hidden)]:transform-none relative transition-transform duration-300" data-controller="mobile-nav">
+  <div class="h-full flex transform translate-x-0 has-[.currency-and-locale-modal:not(.hidden)]:transform-none relative transition-transform duration-300" data-controller="mobile-nav">
     <div class="w-screen shrink-0 flex flex-col h-full grow-0">
       <div class="flex-grow overflow-y-scroll">
         <% if section.blocks.any? %>


### PR DESCRIPTION
## Problem/Solution
This PR fixes an issue where the mobile navigation submenu wouldn’t position correctly after tapping a menu item. The nav container’s transform state wasn’t explicitly initialized, so the transition could start from an unexpected computed value.

- Adds an explicit translate-x-0 on the mobile nav wrapper to define a consistent initial transform state
- Ensures submenu transitions start from the correct position, so the submenu slides in and aligns properly after click/tap
- No behavior changes beyond mobile nav positioning/transition stability

## How to verify
- On mobile (or responsive mode), open the hamburger menu
- Tap an item that opens a submenu
- Confirm the submenu slides in and is positioned correctly every time (including repeated open/close cycles)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small view-only changes to CSS classes/data attributes; low likelihood of regressions beyond mobile nav animation behavior.
> 
> **Overview**
> Stabilizes storefront mobile navigation submenu transitions by explicitly setting the wrapper’s initial transform state (`translate-x-0`), preventing inconsistent slide-in positioning.
> 
> Also fixes a minor typo/whitespace in the admin layout’s `data-controller` attribute for `export-dialog`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6db2dab6af1f9f774b6c7203922662cb02f6f2b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->