### PR TITLE
Optimize several Order model methods

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -568,8 +568,7 @@ module Spree
     # Check to see if any line item variants are discontinued.
     # If so add error and restart checkout.
     def ensure_line_item_variants_are_not_discontinued
-      has_discontinued = line_items.where(variant_id: nil).exists? ||
-        line_items.joins(:variant).merge(Spree::Variant.discontinued).exists?
+      has_discontinued = line_items.joins(:variant).merge(Spree::Variant.discontinued).exists?
       if has_discontinued
         restart_checkout_flow
         errors.add(:base, Spree.t(:discontinued_variants_present))

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -664,7 +664,7 @@ module Spree
     #
     # @return [BigDecimal] the total weight of the inventory units in the order
     def total_weight
-      @total_weight ||= line_items.joins(:variant).sum('spree_variants.weight * spree_line_items.quantity')
+      @total_weight ||= line_items.joins(:variant).sum("#{Variant.table_name}.weight * #{LineItem.table_name}.quantity")
     end
 
     # Returns line items that have no shipping rates

--- a/core/app/models/spree/order/webhooks.rb
+++ b/core/app/models/spree/order/webhooks.rb
@@ -1,3 +1,5 @@
+# Thus module is only needed for Legacy Webhooks
+# new webhook system doens't use this module
 module Spree
   class Order < Spree.base_class
     module Webhooks

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -110,6 +110,10 @@ module Spree
       )
     end
 
+    scope :discontinued, -> do
+      where(arel_table[:discontinue_on].lt(Time.current))
+    end
+
     scope :not_deleted, -> { where("#{Spree::Variant.quoted_table_name}.deleted_at IS NULL") }
 
     scope :for_currency_and_available_price_amount, ->(currency = nil) do

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -50,10 +50,9 @@ describe Spree::Order, type: :model do
     end
 
     it 'freezes all adjustments' do
-      adjustments = [double]
-      expect(order).to receive(:all_adjustments).and_return(adjustments)
-      expect(adjustments).to all(receive(:close))
+      adjustment = create(:adjustment, order: order, adjustable: order, state: 'open')
       order.finalize!
+      expect(adjustment.reload.state).to eq('closed')
     end
 
     context 'order is considered risky' do

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -114,6 +114,7 @@ describe Spree::Order, type: :model do
       allow(shipments).to receive_messages ready: []
       allow(shipments).to receive_messages pending: []
       allow(shipments).to receive_messages shipped: []
+      allow(shipments).to receive_messages not_canceled: [shipment]
       allow(shipments).to receive_message_chain(:to_a, :sum).and_return(shipment.cost)
 
       allow_any_instance_of(Spree::OrderUpdater).to receive(:update_adjustment_total).and_return(10)


### PR DESCRIPTION
Fixed N+1s, reduced memory footprint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Spree::Order` calculation and checkout/cancel/finalize logic while swapping Ruby iteration for SQL/AR queries; behavior should be equivalent but edge cases around loaded associations and SQL sums/state checks could regress.
> 
> **Overview**
> Improves performance of several `Spree::Order` methods by replacing Ruby iteration with SQL/ActiveRecord queries (e.g., `amount`, `confirmation_required?`, backorder/shipped/returned checks, `total_weight`, `fully_discounted?`, `line_items_without_shipping_rates`, and `to_csv` metafield lookups) to reduce N+1s and memory usage.
> 
> Adjusts order finalization to bulk-close open adjustments via `update_all`, refines cancellation to only cancel `shipments.not_canceled`, and adds `Spree::Variant.discontinued` to support a more efficient discontinued-variant check. Specs are updated to assert persisted DB behavior (creating real records/stock) instead of stubbing arrays and doubles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b2a40c5a21273322fe864311da85d4148e23f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->