### PR TITLE
Fixed admin table search field loosing focus after loading search res…

### DIFF
--- a/admin/app/views/spree/admin/tables/_table.html.erb
+++ b/admin/app/views/spree/admin/tables/_table.html.erb
@@ -22,7 +22,8 @@
                                    params.dig(:q, search_param),
                                    class: "outline-none border-0 h-full focus:border-0 focus:ring-0 p-0 text-base w-full",
                                    placeholder: search_placeholder,
-                                   data: { action: 'input->auto-submit#submit input->search-clear#toggleClearButton search->auto-submit#submit', search_clear_target: 'input' } %>
+                                   id: "table-search-input",
+                                   data: { "turbo-permanent": true, action: 'input->auto-submit#submit input->search-clear#toggleClearButton search->auto-submit#submit', search_clear_target: 'input' } %>
               <button type="button" class="<%= 'hidden' if params.dig(:q, search_param).blank? %> p-1 text-gray-400 hover:text-gray-600 shrink-0" data-search-clear-target="clear" data-action="search-clear#clear">
                 <%= icon 'x', class: 'w-4 h-4' %>
               </button>

--- a/admin/app/views/spree/admin/tables/_table.html.erb
+++ b/admin/app/views/spree/admin/tables/_table.html.erb
@@ -22,7 +22,7 @@
                                    params.dig(:q, search_param),
                                    class: "outline-none border-0 h-full focus:border-0 focus:ring-0 p-0 text-base w-full",
                                    placeholder: search_placeholder,
-                                   id: "table-search-input",
+                                   id: "#{frame_name}-table-search-input",
                                    data: { "turbo-permanent": true, action: 'input->auto-submit#submit input->search-clear#toggleClearButton search->auto-submit#submit', search_clear_target: 'input' } %>
               <button type="button" class="<%= 'hidden' if params.dig(:q, search_param).blank? %> p-1 text-gray-400 hover:text-gray-600 shrink-0" data-search-clear-target="clear" data-action="search-clear#clear">
                 <%= icon 'x', class: 'w-4 h-4' %>


### PR DESCRIPTION
…ults

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small view-only change that tweaks Turbo behavior for a single input; low chance of broader impact beyond potential DOM permanence quirks.
> 
> **Overview**
> Admin tables search input is now marked as `turbo-permanent` and given a stable `id` (`#{frame_name}-table-search-input`) so it persists across Turbo frame refreshes and no longer loses focus after search results load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd56f31a456302e2bbad5669a7afed58e5e4660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->