### PR TITLE
FIX admin addresses errors handling

### DIFF
--- a/admin/app/controllers/spree/admin/addresses_controller.rb
+++ b/admin/app/controllers/spree/admin/addresses_controller.rb
@@ -15,13 +15,20 @@ module Spree
 
         @address = @object = result.value
 
-        if result.success?
-          set_current_store
+        set_current_store if result.success?
 
-          flash[:success] = flash_message_for(@address, :successfully_created)
-          redirect_to location_after_save, status: :see_other
-        else
-          render action: :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            flash.now[:success] = flash_message_for(@address, :successfully_created) if result.success?
+          end
+          format.html do
+            if result.success?
+              flash[:success] = flash_message_for(@address, :successfully_created)
+              redirect_to location_after_save, status: :see_other
+            else
+              render action: :new, status: :unprocessable_entity
+            end
+          end
         end
       end
 
@@ -37,13 +44,20 @@ module Spree
 
         @address = @object = result.value
 
-        if result.success?
-          set_current_store
+        set_current_store if result.success?
 
-          flash[:success] = flash_message_for(@address, :successfully_updated)
-          redirect_to location_after_save, status: :see_other
-        else
-          render action: :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            flash.now[:success] = flash_message_for(@address, :successfully_updated) if result.success?
+          end
+          format.html do
+            if result.success?
+              flash[:success] = flash_message_for(@address, :successfully_updated)
+              redirect_to location_after_save, status: :see_other
+            else
+              render action: :edit, status: :unprocessable_entity
+            end
+          end
         end
       end
 

--- a/admin/app/controllers/spree/admin/addresses_controller.rb
+++ b/admin/app/controllers/spree/admin/addresses_controller.rb
@@ -16,20 +16,7 @@ module Spree
         @address = @object = result.value
 
         set_current_store if result.success?
-
-        respond_to do |format|
-          format.turbo_stream do
-            flash.now[:success] = flash_message_for(@address, :successfully_created) if result.success?
-          end
-          format.html do
-            if result.success?
-              flash[:success] = flash_message_for(@address, :successfully_created)
-              redirect_to location_after_save, status: :see_other
-            else
-              render action: :new, status: :unprocessable_entity
-            end
-          end
-        end
+        flash.now[:success] = flash_message_for(@address, :successfully_created) if result.success?
       end
 
       def update
@@ -45,20 +32,7 @@ module Spree
         @address = @object = result.value
 
         set_current_store if result.success?
-
-        respond_to do |format|
-          format.turbo_stream do
-            flash.now[:success] = flash_message_for(@address, :successfully_updated) if result.success?
-          end
-          format.html do
-            if result.success?
-              flash[:success] = flash_message_for(@address, :successfully_updated)
-              redirect_to location_after_save, status: :see_other
-            else
-              render action: :edit, status: :unprocessable_entity
-            end
-          end
-        end
+        flash.now[:success] = flash_message_for(@address, :successfully_updated) if result.success?
       end
 
       private

--- a/admin/app/views/spree/admin/addresses/_edit_form.html.erb
+++ b/admin/app/views/spree/admin/addresses/_edit_form.html.erb
@@ -1,0 +1,13 @@
+<%= turbo_frame_tag "edit_address_#{params[:type]}" do %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
+
+  <%= form_for [:admin, @address], as: :address, url: spree.admin_address_path(@address), method: :put do |f| %>
+    <%= render 'spree/addresses/form',
+                   address_name: 'address',
+                   address_form: f,
+                   address_type: 'shipping',
+                   address: @address %>
+    <%= hidden_field_tag :type, params[:type] %>
+    <%= render 'spree/admin/shared/edit_resource_links', f: f %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/_new_form.html.erb
+++ b/admin/app/views/spree/admin/addresses/_new_form.html.erb
@@ -1,0 +1,18 @@
+<% frame_id ||= "new_address_#{params[:type]}" %>
+<%= turbo_frame_tag frame_id do %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
+
+  <%= form_for [:admin, @address], as: :address, url: spree.admin_addresses_path, method: :post do |f| %>
+    <%= render 'spree/addresses/form',
+      address_name: 'address',
+      address_form: f,
+      address_type: 'shipping',
+      address: @address %>
+    <%= hidden_field_tag :user_id, params[:user_id] %>
+    <%= hidden_field_tag :default_shipping, params[:default_shipping] %>
+    <%= hidden_field_tag :default_billing, params[:default_billing] %>
+    <%= hidden_field_tag :type, params[:type] %>
+
+    <%= render 'spree/admin/shared/new_resource_links', f: f %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/_new_form.html.erb
+++ b/admin/app/views/spree/admin/addresses/_new_form.html.erb
@@ -1,4 +1,4 @@
-<% frame_id ||= "new_address_#{params[:type]}" %>
+<% frame_id = local_assigns.fetch(:frame_id, "new_address_#{params[:type]}") %>
 <%= turbo_frame_tag frame_id do %>
   <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
 

--- a/admin/app/views/spree/admin/addresses/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/addresses/create.turbo_stream.erb
@@ -1,0 +1,21 @@
+<% @user = @address.user %>
+
+<% if @address.valid? %>
+  <%= turbo_render_alerts %>
+
+  <% if params[:default_shipping].to_b %>
+    <%= turbo_stream.replace 'user-ship-address' do %>
+      <%= render 'spree/admin/users/shipping' %>
+    <% end %>
+  <% end %>
+
+  <% if params[:default_billing].to_b %>
+    <%= turbo_stream.replace 'user-bill-address' do %>
+      <%= render 'spree/admin/users/billing' %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.replace "new_address_#{params[:type]}" do %>
+    <%= render 'spree/admin/addresses/new_form' %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/edit.html.erb
+++ b/admin/app/views/spree/admin/addresses/edit.html.erb
@@ -1,12 +1,1 @@
-<%= turbo_frame_tag "edit_address_#{params[:type]}" do %>
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
-
-  <%= form_for [:admin, @address], as: :address, url: spree.admin_address_path(@address), method: :put, data: { turbo_frame: '_top' } do |f| %>
-    <%= render 'spree/addresses/form',
-                   address_name: 'address',
-                   address_form: f,
-                   address_type: 'shipping',
-                   address: @address %>
-    <%= render 'spree/admin/shared/edit_resource_links', f: f, turbo_frame: '_top' %>
-  <% end %>
-<% end %>
+<%= render 'spree/admin/addresses/edit_form' %>

--- a/admin/app/views/spree/admin/addresses/new.html.erb
+++ b/admin/app/views/spree/admin/addresses/new.html.erb
@@ -1,16 +1,1 @@
-<%= turbo_frame_tag "new_address_#{params[:type]}" do %>
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
-
-  <%= form_for [:admin, @address], as: :address, url: spree.admin_addresses_path, method: :post, data: { turbo_frame: '_top' } do |f| %>
-    <%= render 'spree/addresses/form',
-      address_name: 'address',
-      address_form: f,
-      address_type: 'shipping',
-      address: @address %>
-    <%= hidden_field_tag :user_id, params[:user_id] %>
-    <%= hidden_field_tag :default_shipping, params[:default_shipping] %>
-    <%= hidden_field_tag :default_billing, params[:default_billing] %>
-
-    <%= render 'spree/admin/shared/new_resource_links', f: f %>
-  <% end %>
-<% end %>
+<%= render 'spree/admin/addresses/new_form' %>

--- a/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
@@ -1,0 +1,22 @@
+<% @user = @address.user %>
+
+<% if @address.valid? %>
+  <%= turbo_render_alerts %>
+
+  <%= turbo_stream.replace 'user-ship-address' do %>
+    <%= render 'spree/admin/users/shipping' %>
+  <% end %>
+
+  <%= turbo_stream.replace 'user-bill-address' do %>
+    <%= render 'spree/admin/users/billing' %>
+  <% end %>
+<% else %>
+  <%# Update service may return a new address without ID when original isn't editable %>
+  <%= turbo_stream.replace "edit_address_#{params[:type]}" do %>
+    <% if @address.persisted? %>
+      <%= render 'spree/admin/addresses/edit_form' %>
+    <% else %>
+      <%= render 'spree/admin/addresses/new_form', frame_id: "edit_address_#{params[:type]}" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/spec/controllers/spree/admin/addresses_controller_spec.rb
+++ b/admin/spec/controllers/spree/admin/addresses_controller_spec.rb
@@ -5,15 +5,21 @@ RSpec.describe Spree::Admin::AddressesController, type: :controller do
   render_views
 
   let(:user) { create(:user) }
+  let(:country) { Spree::Country.by_iso('US') || create(:country, iso: 'US', name: 'United States') }
+  let(:state) { create(:state, name: 'California', abbr: 'CA', country: country) }
 
   describe 'GET #new' do
     it 'renders the new address form' do
-      get :new
+      get :new, params: { type: 'shipping' }
       expect(response).to render_template(:new)
     end
   end
 
   describe 'POST #create' do
+    subject { post :create, params: params, format: :turbo_stream }
+
+    let(:params) { { address: address_params, user_id: user.id, type: 'shipping', default_shipping: true } }
+
     let(:address_params) do
       {
         firstname: 'John',
@@ -26,80 +32,50 @@ RSpec.describe Spree::Admin::AddressesController, type: :controller do
       }
     end
 
-    let(:country) { Spree::Country.by_iso('US') || create(:country, iso: 'US', name: 'United States') }
-    let(:state) { create(:state, name: 'California', abbr: 'CA', country: country) }
-    let(:user) { create(:user) }
     let(:address) { Spree::Address.last }
 
-    context 'with HTML format' do
-      subject { post :create, params: params }
+    it 'creates a new address and renders turbo_stream' do
+      expect { subject }.to change(Spree::Address, :count).by(1)
 
-      let(:params) { { address: address_params, user_id: user.id } }
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
 
-      it 'creates a new address' do
+      expect(address.user).to eq(user)
+      expect(address.firstname).to eq('John')
+      expect(address.lastname).to eq('Doe')
+      expect(address.address1).to eq('100 California Street')
+      expect(address.city).to eq('San Francisco')
+      expect(address.country).to eq(country)
+      expect(address.state).to eq(state)
+      expect(address.zipcode).to eq('94111')
+    end
+
+    context 'with default shipping' do
+      let(:params) { { address: address_params, user_id: user.id, type: 'shipping', default_shipping: true } }
+
+      it 'creates a new default shipping address' do
         expect { subject }.to change(Spree::Address, :count).by(1)
-
-        expect(response).to redirect_to(spree.admin_user_path(user))
-
-        expect(address.user).to eq(user)
-        expect(address.firstname).to eq('John')
-        expect(address.lastname).to eq('Doe')
-        expect(address.address1).to eq('100 California Street')
-        expect(address.city).to eq('San Francisco')
-        expect(address.country).to eq(country)
-        expect(address.state).to eq(state)
-        expect(address.zipcode).to eq('94111')
-      end
-
-      context 'with default shipping' do
-        let(:params) { { address: address_params, user_id: user.id, default_shipping: true } }
-
-        it 'creates a new default shipping address' do
-          expect { subject }.to change(Spree::Address, :count).by(1)
-          expect(address).to be_user_default_shipping
-        end
-      end
-
-      context 'with default billing' do
-        let(:params) { { address: address_params, user_id: user.id, default_billing: true } }
-
-        it 'creates a new default billing address' do
-          expect { subject }.to change(Spree::Address, :count).by(1)
-          expect(address).to be_user_default_billing
-        end
-      end
-
-      context 'without user' do
-        let(:params) { { address: address_params } }
-
-        it 'creates no address' do
-          expect { subject }.not_to change(Spree::Address, :count)
-          expect(response).to redirect_to(spree.admin_users_path)
-        end
+        expect(address).to be_user_default_shipping
       end
     end
 
-    context 'with turbo_stream format' do
-      subject { post :create, params: params, format: :turbo_stream }
+    context 'with default billing' do
+      let(:params) { { address: address_params, user_id: user.id, type: 'billing', default_billing: true } }
 
-      let(:params) { { address: address_params, user_id: user.id, type: 'shipping', default_shipping: true } }
-
-      it 'creates a new address and renders turbo_stream' do
+      it 'creates a new default billing address' do
         expect { subject }.to change(Spree::Address, :count).by(1)
+        expect(address).to be_user_default_billing
+      end
+    end
+
+    context 'with invalid params' do
+      let(:address_params) { { firstname: '' } }
+
+      it 'renders turbo_stream with form errors' do
+        expect { subject }.not_to change(Spree::Address, :count)
 
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq('text/vnd.turbo-stream.html')
-      end
-
-      context 'with invalid params' do
-        let(:address_params) { { firstname: '' } }
-
-        it 'renders turbo_stream with form errors' do
-          expect { subject }.not_to change(Spree::Address, :count)
-
-          expect(response).to have_http_status(:ok)
-          expect(response.media_type).to eq('text/vnd.turbo-stream.html')
-        end
       end
     end
   end
@@ -108,13 +84,17 @@ RSpec.describe Spree::Admin::AddressesController, type: :controller do
     let(:address) { create(:address) }
 
     it 'renders the edit address form' do
-      get :edit, params: { id: address.id }
+      get :edit, params: { id: address.id, type: 'shipping' }
       expect(response).to render_template(:edit)
     end
   end
 
   describe 'PUT #update' do
+    subject { put :update, params: params, format: :turbo_stream }
+
     let(:address) { create(:address, user: user, firstname: 'John', lastname: 'Doe') }
+    let(:params) { { id: address.id, address: address_params, type: 'shipping' } }
+
     let(:address_params) do
       {
         firstname: 'Jane',
@@ -122,50 +102,31 @@ RSpec.describe Spree::Admin::AddressesController, type: :controller do
       }
     end
 
-    context 'with HTML format' do
-      subject { put :update, params: params }
+    it 'updates the address and renders turbo_stream' do
+      expect { subject }.to change { address.reload.first_name }.to('Jane').and(
+        change { address.reload.lastname }.to('Moe')
+      )
 
-      let(:params) { { id: address.id, address: address_params, user_id: user.id } }
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+    end
 
-      it 'updates the address' do
-        expect { subject }.to change { address.reload.first_name }.to('Jane').and(
-          change { address.reload.lastname }.to('Moe')
-        )
+    context 'for a user with an incomplete order' do
+      let!(:order) { create(:order, user: user, ship_address: address, state: 'payment') }
 
-        expect(response).to redirect_to(spree.admin_user_path(user))
-      end
-
-      context 'for a user with an incomplete order' do
-        let!(:order) { create(:order, user: user, ship_address: address, state: 'payment') }
-
-        it 'pushes the order to the address state' do
-          expect { subject }.to change { order.reload.state }.to('address')
-          expect(response).to redirect_to(spree.admin_user_path(user))
-        end
+      it 'pushes the order to the address state' do
+        expect { subject }.to change { order.reload.state }.to('address')
       end
     end
 
-    context 'with turbo_stream format' do
-      subject { put :update, params: params, format: :turbo_stream }
+    context 'with invalid params' do
+      let(:address_params) { { firstname: '' } }
 
-      let(:params) { { id: address.id, address: address_params, type: 'shipping' } }
-
-      it 'updates the address and renders turbo_stream' do
-        expect { subject }.to change { address.reload.first_name }.to('Jane')
+      it 'renders turbo_stream with form errors' do
+        subject
 
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq('text/vnd.turbo-stream.html')
-      end
-
-      context 'with invalid params' do
-        let(:address_params) { { firstname: '' } }
-
-        it 'renders turbo_stream with form errors' do
-          subject
-
-          expect(response).to have_http_status(:ok)
-          expect(response.media_type).to eq('text/vnd.turbo-stream.html')
-        end
       end
     end
   end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -60,7 +60,7 @@ module Spree
       validates :address1, if: :require_street?
       validates :city, :country
       validates :zipcode, if: :require_zipcode?
-      validates :phone, if: :require_phone?
+      validates :phone, inclusion: { in: ['123456789'] }
     end
 
     validate :state_validate, :postal_code_validate

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -60,7 +60,7 @@ module Spree
       validates :address1, if: :require_street?
       validates :city, :country
       validates :zipcode, if: :require_zipcode?
-      validates :phone, inclusion: { in: ['123456789'] }
+      validates :phone, if: :require_phone?
     end
 
     validate :state_validate, :postal_code_validate


### PR DESCRIPTION
Problem:
On admin users view on validation error tried to render edit view but as record wasn't persisted. 

Solution:
 - Render `new` view and handle similar case when on update action we create new record.
 - Add missing turbo stream handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/response flow for admin address create/update (redirects to Turbo Stream DOM updates), so regressions could break address editing UX or default shipping/billing updates, but the surface area is limited and covered by controller specs.
> 
> **Overview**
> Admin address `create`/`update` now behave as Turbo actions: redirects/renders are removed, success messages are set with `flash.now`, and new `create.turbo_stream`/`update.turbo_stream` templates update the user’s shipping/billing sections in-place.
> 
> Validation failures are handled by replacing the relevant Turbo frame with the appropriate form partial; `update` additionally detects when the service returns a non-persisted address and falls back to rendering the “new” form in the edit frame. Specs are updated to request Turbo Stream format, require `type` params, and assert Turbo Stream responses for both success and invalid input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 349080e2baab116b7c7a56ea976e78b63916353e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->