### PR TITLE
FIX validation error on admin address for not persisted address

### DIFF
--- a/admin/app/controllers/spree/admin/addresses_controller.rb
+++ b/admin/app/controllers/spree/admin/addresses_controller.rb
@@ -15,14 +15,8 @@ module Spree
 
         @address = @object = result.value
 
-        if result.success?
-          set_current_store
-
-          flash[:success] = flash_message_for(@address, :successfully_created)
-          redirect_to location_after_save, status: :see_other
-        else
-          render action: :edit, status: :unprocessable_entity
-        end
+        set_current_store if result.success?
+        flash.now[:success] = flash_message_for(@address, :successfully_created) if result.success?
       end
 
       def update
@@ -37,14 +31,8 @@ module Spree
 
         @address = @object = result.value
 
-        if result.success?
-          set_current_store
-
-          flash[:success] = flash_message_for(@address, :successfully_updated)
-          redirect_to location_after_save, status: :see_other
-        else
-          render action: :edit, status: :unprocessable_entity
-        end
+        set_current_store if result.success?
+        flash.now[:success] = flash_message_for(@address, :successfully_updated) if result.success?
       end
 
       private

--- a/admin/app/views/spree/admin/addresses/_edit_form.html.erb
+++ b/admin/app/views/spree/admin/addresses/_edit_form.html.erb
@@ -1,0 +1,13 @@
+<%= turbo_frame_tag "edit_address_#{params[:type]}" do %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
+
+  <%= form_for [:admin, @address], as: :address, url: spree.admin_address_path(@address), method: :put do |f| %>
+    <%= render 'spree/addresses/form',
+                   address_name: 'address',
+                   address_form: f,
+                   address_type: 'shipping',
+                   address: @address %>
+    <%= hidden_field_tag :type, params[:type] %>
+    <%= render 'spree/admin/shared/edit_resource_links', f: f %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/_new_form.html.erb
+++ b/admin/app/views/spree/admin/addresses/_new_form.html.erb
@@ -1,4 +1,8 @@
 <% frame_id = local_assigns.fetch(:frame_id, "new_address_#{params[:type]}") %>
+<% user_id_value = local_assigns.fetch(:user_id, params[:user_id]) %>
+<% default_shipping_value = local_assigns.fetch(:default_shipping, params[:default_shipping]) %>
+<% default_billing_value = local_assigns.fetch(:default_billing, params[:default_billing]) %>
+
 <%= turbo_frame_tag frame_id do %>
   <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
 
@@ -8,9 +12,9 @@
       address_form: f,
       address_type: 'shipping',
       address: @address %>
-    <%= hidden_field_tag :user_id, params[:user_id] %>
-    <%= hidden_field_tag :default_shipping, params[:default_shipping] %>
-    <%= hidden_field_tag :default_billing, params[:default_billing] %>
+    <%= hidden_field_tag :user_id, user_id_value %>
+    <%= hidden_field_tag :default_shipping, default_shipping_value %>
+    <%= hidden_field_tag :default_billing, default_billing_value %>
     <%= hidden_field_tag :type, params[:type] %>
 
     <%= render 'spree/admin/shared/new_resource_links', f: f %>

--- a/admin/app/views/spree/admin/addresses/_new_form.html.erb
+++ b/admin/app/views/spree/admin/addresses/_new_form.html.erb
@@ -1,0 +1,18 @@
+<% frame_id = local_assigns.fetch(:frame_id, "new_address_#{params[:type]}") %>
+<%= turbo_frame_tag frame_id do %>
+  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
+
+  <%= form_for [:admin, @address], as: :address, url: spree.admin_addresses_path, method: :post do |f| %>
+    <%= render 'spree/addresses/form',
+      address_name: 'address',
+      address_form: f,
+      address_type: 'shipping',
+      address: @address %>
+    <%= hidden_field_tag :user_id, params[:user_id] %>
+    <%= hidden_field_tag :default_shipping, params[:default_shipping] %>
+    <%= hidden_field_tag :default_billing, params[:default_billing] %>
+    <%= hidden_field_tag :type, params[:type] %>
+
+    <%= render 'spree/admin/shared/new_resource_links', f: f %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/create.turbo_stream.erb
+++ b/admin/app/views/spree/admin/addresses/create.turbo_stream.erb
@@ -1,0 +1,21 @@
+<% @user = @address.user %>
+
+<% if @address.valid? %>
+  <%= turbo_render_alerts %>
+
+  <% if params[:default_shipping].to_b %>
+    <%= turbo_stream.replace 'user-ship-address' do %>
+      <%= render 'spree/admin/users/shipping' %>
+    <% end %>
+  <% end %>
+
+  <% if params[:default_billing].to_b %>
+    <%= turbo_stream.replace 'user-bill-address' do %>
+      <%= render 'spree/admin/users/billing' %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.replace "new_address_#{params[:type]}" do %>
+    <%= render 'spree/admin/addresses/new_form' %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/edit.html.erb
+++ b/admin/app/views/spree/admin/addresses/edit.html.erb
@@ -1,12 +1,1 @@
-<%= turbo_frame_tag "edit_address_#{params[:type]}" do %>
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
-
-  <%= form_for [:admin, @address], as: :address, url: spree.admin_address_path(@address), method: :put, data: { turbo_frame: '_top' } do |f| %>
-    <%= render 'spree/addresses/form',
-                   address_name: 'address',
-                   address_form: f,
-                   address_type: 'shipping',
-                   address: @address %>
-    <%= render 'spree/admin/shared/edit_resource_links', f: f, turbo_frame: '_top' %>
-  <% end %>
-<% end %>
+<%= render 'spree/admin/addresses/edit_form' %>

--- a/admin/app/views/spree/admin/addresses/new.html.erb
+++ b/admin/app/views/spree/admin/addresses/new.html.erb
@@ -1,16 +1,1 @@
-<%= turbo_frame_tag "new_address_#{params[:type]}" do %>
-  <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @address } %>
-
-  <%= form_for [:admin, @address], as: :address, url: spree.admin_addresses_path, method: :post, data: { turbo_frame: '_top' } do |f| %>
-    <%= render 'spree/addresses/form',
-      address_name: 'address',
-      address_form: f,
-      address_type: 'shipping',
-      address: @address %>
-    <%= hidden_field_tag :user_id, params[:user_id] %>
-    <%= hidden_field_tag :default_shipping, params[:default_shipping] %>
-    <%= hidden_field_tag :default_billing, params[:default_billing] %>
-
-    <%= render 'spree/admin/shared/new_resource_links', f: f %>
-  <% end %>
-<% end %>
+<%= render 'spree/admin/addresses/new_form' %>

--- a/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
@@ -16,7 +16,11 @@
     <% if @address.persisted? %>
       <%= render 'spree/admin/addresses/edit_form' %>
     <% else %>
-      <%= render 'spree/admin/addresses/new_form', frame_id: "edit_address_#{params[:type]}" %>
+      <%= render 'spree/admin/addresses/new_form',
+            frame_id: "edit_address_#{params[:type]}",
+            user_id: @user.id,
+            default_shipping: params[:type] == 'shipping',
+            default_billing: params[:type] == 'billing' %>
     <% end %>
   <% end %>
 <% end %>

--- a/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
@@ -1,0 +1,22 @@
+<% @user = @address.user %>
+
+<% if @address.valid? %>
+  <%= turbo_render_alerts %>
+
+  <%= turbo_stream.replace 'user-ship-address' do %>
+    <%= render 'spree/admin/users/shipping' %>
+  <% end %>
+
+  <%= turbo_stream.replace 'user-bill-address' do %>
+    <%= render 'spree/admin/users/billing' %>
+  <% end %>
+<% else %>
+  <%# Update service may return a new address without ID when original isn't editable %>
+  <%= turbo_stream.replace "edit_address_#{params[:type]}" do %>
+    <% if @address.persisted? %>
+      <%= render 'spree/admin/addresses/edit_form' %>
+    <% else %>
+      <%= render 'spree/admin/addresses/new_form', frame_id: "edit_address_#{params[:type]}" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
+++ b/admin/app/views/spree/admin/addresses/update.turbo_stream.erb
@@ -18,7 +18,7 @@
     <% else %>
       <%= render 'spree/admin/addresses/new_form',
             frame_id: "edit_address_#{params[:type]}",
-            user_id: @user.id,
+            user_id: @user&.id,
             default_shipping: params[:type] == 'shipping',
             default_billing: params[:type] == 'billing' %>
     <% end %>


### PR DESCRIPTION
Fixed case when address is not editable and new not persisted record didn't pass validation. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View-only change to how hidden form values are populated/re-rendered; low blast radius but could affect which user/default flags are submitted if locals/params are incorrect.
> 
> **Overview**
> Fixes the admin address update failure path where an uneditable address can be replaced by a *non-persisted* record and the form is re-rendered.
> 
> The `new_form` partial now accepts `user_id` and default shipping/billing values via locals (falling back to `params`), and `update.turbo_stream.erb` explicitly passes these locals when re-rendering the new form so hidden fields stay populated and validation errors can be corrected without losing context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f1f8a303abfe1908d53f4d990938f35e6542f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->