### PR TITLE
Prevent NoMethodError in StoreProduct#refresh_metrics!

### DIFF
--- a/core/app/models/spree/store_product.rb
+++ b/core/app/models/spree/store_product.rb
@@ -9,6 +9,8 @@ module Spree
     validates :store_id, uniqueness: { scope: :product_id }
 
     def refresh_metrics!
+      return if product.nil?
+
       completed_order_ids = product.completed_orders.where(store_id: store_id).select(:id)
       variant_ids = product.variants_including_master.ids
 


### PR DESCRIPTION
## Fix: Handle nil product in StoreProduct#refresh_metrics!

### Problem
The `refresh_metrics!` method in `StoreProduct` was throwing a `NoMethodError` when the associated `product` was `nil`:

```ruby
NoMethodError: undefined method 'completed_orders' for nil:NilClass
```


### Solution
Added a nil guard clause at the beginning of `refresh_metrics!` method in StoreProduct


All existing functionality remains intact. The fix only affects the error case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change isolated to metrics refresh logic plus additional test coverage; minimal behavioral impact beyond avoiding errors on invalid data.
> 
> **Overview**
> Prevents `StoreProduct#refresh_metrics!` from raising when the associated `product` is missing by adding an early return when `product` is `nil`.
> 
> Expands model specs to cover nil/missing product scenarios (explicit `product: nil`, invalid `product_id`, and product deleted after association) and asserts metrics are not updated and no exceptions are thrown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0ac7b358e53f468e44ab901da2205f2d1a7a29d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->