### PR TITLE
Optimize core gem FactoryBot factories for performance

### DIFF
--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -2,7 +2,7 @@ require 'factory_bot'
 
 Spree::Zone.class_eval do
   def self.global
-    find_by(name: 'GlobalZone') || FactoryBot.create(:global_zone)
+    find_by(name: 'GlobalZone') || FactoryBot.create(:global_zone, name: 'GlobalZone')
   end
 end
 

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :calculator, class: Spree::Calculator::FlatRate do
-    after(:create) { |c| c.set_preference(:amount, 10.0) }
+    preferred_amount { 10.0 }
   end
 
   factory :no_amount_calculator, class: Spree::Calculator::FlatRate do
-    after(:create) { |c| c.set_preference(:amount, 0) }
+    preferred_amount { 0 }
   end
 
   factory :default_tax_calculator, class: Spree::Calculator::DefaultTax do
@@ -27,10 +27,10 @@ FactoryBot.define do
   end
 
   factory :non_free_shipping_calculator, class: Spree::Calculator::Shipping::FlatRate do
-    after(:create) { |c| c.set_preference(:amount, 20.0) }
+    preferred_amount { 20.0 }
   end
 
   factory :digital_shipping_calculator, class: Spree::Calculator::Shipping::DigitalDelivery do
-    after(:create) { |c| c.set_preference(:amount, 0) }
+    preferred_amount { 0 }
   end
 end

--- a/core/lib/spree/testing_support/factories/custom_domain_factory.rb
+++ b/core/lib/spree/testing_support/factories/custom_domain_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :custom_domain, class: Spree::CustomDomain do
     url { FFaker::Internet.domain_name }
-    store { create(:store) }
+    association :store, factory: :store
     default { true }
   end
 end

--- a/core/lib/spree/testing_support/factories/customer_group_user_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_group_user_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :customer_group_user, class: Spree::CustomerGroupUser do
     customer_group
-    user { create(:user) }
+    user
   end
 end

--- a/core/lib/spree/testing_support/factories/export_factory.rb
+++ b/core/lib/spree/testing_support/factories/export_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :export, class: 'Spree::Export' do
-    store { create(:store) }
-    user { create(:admin_user) }
+    association :store, factory: :store
+    association :user, factory: :admin_user
     type { 'Spree::Exports::Products' }
     format { 'csv' }
 

--- a/core/lib/spree/testing_support/factories/google_data_feed_factory.rb
+++ b/core/lib/spree/testing_support/factories/google_data_feed_factory.rb
@@ -1,8 +1,7 @@
 FactoryBot.define do
   factory :google_data_feed, class: Spree::DataFeed::Google do
-    id             { 1 }
     active         { true }
-    store          { create(:store) }
+    association :store, factory: :store
     name           { 'test' }
   end
 end

--- a/core/lib/spree/testing_support/factories/import_factory.rb
+++ b/core/lib/spree/testing_support/factories/import_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :import, class: 'Spree::Import' do
     owner { Spree::Store.default || create(:store) }
-    user { create(:admin_user) }
+    association :user, factory: :admin_user
     type { 'Spree::Imports::Products' }
 
     factory :product_import, class: 'Spree::Imports::Products', parent: :import do

--- a/core/lib/spree/testing_support/factories/invitation_factory.rb
+++ b/core/lib/spree/testing_support/factories/invitation_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :invitation, class: Spree::Invitation do
     email { FFaker::Internet.email }
-    inviter { create(:admin_user) }
+    association :inviter, factory: :admin_user
   end
 end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -4,13 +4,18 @@ FactoryBot.define do
     quantity { 1 }
     price    { BigDecimal('10.00') }
     currency { order.currency }
-    product do
-      if order&.store&.present?
-        create(:product, stores: [order.store])
-      else
-        create(:product)
-      end
+    transient do
+      product { nil }
     end
-    variant { product.master }
+    variant do
+      resolved_product = product || begin
+        if order&.store&.present?
+          create(:product, stores: [order.store])
+        else
+          create(:product)
+        end
+      end
+      resolved_product.master
+    end
   end
 end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -13,10 +13,11 @@ FactoryBot.define do
 
     before(:create) do |order|
       unless order.store.present?
-        default_store = Spree::Store.default.persisted? ? Spree::Store.default : nil
-        store = default_store || create(:store)
-
-        order.store = store
+        store = begin
+          default = Spree::Store.default
+          default&.persisted? ? default : nil
+        end
+        order.store = store || create(:store)
       end
     end
 
@@ -42,7 +43,6 @@ FactoryBot.define do
     end
 
     factory :order_with_line_items do
-      bill_address
       ship_address
 
       transient do

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
   factory :check_payment, class: Spree::Payment do
     amount { 45.75 }
-    order  { create(:order, total: 45.75) }
+    order  { create(:order, total: amount) }
 
     association(:payment_method, factory: :check_payment_method)
   end

--- a/core/lib/spree/testing_support/factories/post_factory.rb
+++ b/core/lib/spree/testing_support/factories/post_factory.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :post, class: Spree::Post do
-    post_category { create(:post_category, store: Spree::Store.default || create(:store)) }
+    store { Spree::Store.default || create(:store) }
+    post_category { association(:post_category, store: store) }
     title { FFaker::Lorem.sentence }
     content { FFaker::Lorem.paragraph }
     published_at { Time.current }
-    author { create(:admin_user) }
-    store { Spree::Store.default || create(:store) }
+    association :author, factory: :admin_user
 
     trait :with_image do
       image { Rack::Test::UploadedFile.new(Spree::Core::Engine.root.join('spec/fixtures/thinking-cat.jpg'), 'image/jpeg') }

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -19,7 +19,10 @@ FactoryBot.define do
       create(:store, default: true) unless Spree::Store.any?
     end
     after(:create) do |product|
-      Spree::StockLocation.all.each { |stock_location| stock_location.propagate_variant(product.master) unless stock_location.stock_items.exists?(variant: product.master) }
+      existing_location_ids = product.master.stock_items.pluck(:stock_location_id)
+      Spree::StockLocation.where.not(id: existing_location_ids).find_each do |stock_location|
+        stock_location.propagate_variant(product.master)
+      end
     end
 
     factory :custom_product do
@@ -49,8 +52,8 @@ FactoryBot.define do
       end
       factory :product_with_properties do
         after(:create) do |product|
-          create(:property, :brand, id: 10)
-          create(:product_property, product: product, property_id: 10, value: 'Epsilon')
+          property = create(:property, :brand)
+          create(:product_property, product: product, property: property, value: 'Epsilon')
         end
       end
 

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product_property, class: Spree::ProductProperty do
-    product { create(:product, stores: [Spree::Store.default]) }
+    product
     value { "val-#{rand(50)}" }
     property
   end

--- a/core/lib/spree/testing_support/factories/prototype_factory.rb
+++ b/core/lib/spree/testing_support/factories/prototype_factory.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :prototype, class: Spree::Prototype do
     name       { 'Baseball Cap' }
-    properties { [create(:property)] }
+    properties { [build(:property)] }
   end
   factory :prototype_with_option_types, class: Spree::Prototype do
     name         { 'Baseball Cap' }
-    properties   { [create(:property)] }
-    option_types { [create(:option_type)] }
+    properties   { [build(:property)] }
+    option_types { [build(:option_type)] }
   end
 end

--- a/core/lib/spree/testing_support/factories/report_factory.rb
+++ b/core/lib/spree/testing_support/factories/report_factory.rb
@@ -14,8 +14,8 @@
 #
 FactoryBot.define do
   factory :report, class: 'Spree::Reports::SalesTotal' do
-    store { create(:store) }
-    user { create(:admin_user) }
+    association :store, factory: :store
+    association :user, factory: :admin_user
     type { 'Spree::Reports::SalesTotal' }
     currency { 'USD' }
     date_from { 1.month.ago }
@@ -23,8 +23,8 @@ FactoryBot.define do
   end
 
   factory :products_performance_report, class: 'Spree::Reports::ProductsPerformance' do
-    store { create(:store) }
-    user { create(:admin_user) }
+    association :store, factory: :store
+    association :user, factory: :admin_user
     type { 'Spree::Reports::ProductsPerformance' }
     currency { 'USD' }
     date_from { 1.month.ago }

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :store_credit_auth_event, class: Spree::StoreCreditEvent do
-    store_credit       { create(:store_credit) }
+    association :store_credit, factory: :store_credit
     action             { Spree::StoreCredit::AUTHORIZE_ACTION }
     amount             { 100.00 }
     authorization_code { "#{store_credit.id}-SC-20140602164814476128" }

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
 
   factory :store_credit, class: Spree::StoreCredit do
     user
-    created_by { create(:admin_user) }
-    category { create(:store_credit_category) }
+    association :created_by, factory: :admin_user
+    association :category, factory: :store_credit_category
     amount { 150.00 }
     currency { 'USD' }
-    credit_type { create(:primary_credit_type) }
+    association :credit_type, factory: :primary_credit_type
     store { Spree::Store.default || create(:store) }
   end
 

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -13,11 +13,9 @@ FactoryBot.define do
 
     factory :user_with_addresses, aliases: [:user_with_addreses] do
       after(:create) do |user|
-        user.ship_address = create(:address, user: user)
-        user.bill_address = create(:address, user: user)
-        user.addresses << user.ship_address
-        user.addresses << user.bill_address
-        user.save
+        ship_address = create(:address, user: user)
+        bill_address = create(:address, user: user)
+        user.update_columns(ship_address_id: ship_address.id, bill_address_id: bill_address.id)
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     track_inventory { true }
 
     product       { |p| p.association(:base_product, stores: [Spree::Store.default]) }
-    option_values { [create(:option_value)] }
+    option_values { [build(:option_value)] }
 
     transient do
       create_stock { true }
@@ -26,9 +26,8 @@ FactoryBot.define do
 
     after(:create) do |variant, evaluator|
       if evaluator.create_stock
-        Spree::StockLocation.all.each do |stock_location|
-          next if stock_location.stock_item(variant).present?
-
+        existing_location_ids = variant.stock_items.pluck(:stock_location_id)
+        Spree::StockLocation.where.not(id: existing_location_ids).find_each do |stock_location|
           stock_location.propagate_variant(variant)
         end
       end


### PR DESCRIPTION
Replace explicit create() calls in attribute blocks with association/build across 13 factories to respect build strategy and avoid unnecessary DB writes.

Fix N+1 stock propagation in product and variant factories by using a single pluck query for existing locations instead of iterating all stock locations with individual existence checks.

Replace global_zone factory's per-country first_or_create N+1 pattern with bulk insert_all. Remove redundant bill_address from order_with_line_items (already inherited from parent). Use preferred_amount attribute instead of after(:create) set_preference in calculator factories. Remove hardcoded IDs from google_data_feed and product_with_properties factories. Simplify user_with_addresses to use update_columns instead of redundant save.