### PR TITLE
Add CI skip logic for documentation and config-only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,41 @@ defaults: &defaults
     - image: &ruby_image cimg/ruby:4.0-browsers
 
 commands:
+  check_code_changes:
+    steps:
+      - run:
+          name: Check for code changes beyond docs/config
+          command: |
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
+              CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || echo "")
+            else
+              git fetch origin main --depth=1 2>/dev/null || true
+              CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null || echo "")
+            fi
+
+            if [ -z "$CHANGED_FILES" ]; then
+              echo "No changed files detected, proceeding with CI."
+              exit 0
+            fi
+
+            ONLY_EXCLUDED=true
+            for file in $CHANGED_FILES; do
+              case "$file" in
+                .github/*|docs/*|sdk/*|bin/*)
+                  ;;
+                *)
+                  ONLY_EXCLUDED=false
+                  break
+                  ;;
+              esac
+            done
+
+            if [ "$ONLY_EXCLUDED" = true ]; then
+              echo "Only changes in excluded directories (.github, docs, sdk, bin). Skipping CI."
+              circleci-agent step halt
+            else
+              echo "Code changes detected, proceeding with CI."
+            fi
   bundle_install:
     parameters:
       update:
@@ -78,6 +113,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - check_code_changes
       - bundle_install:
           update: true
           clean: true
@@ -94,6 +130,7 @@ jobs:
           POSTGRES_USER: postgres
     steps: &default_steps
       - checkout
+      - check_code_changes
       - attach_workspace:
           at: /tmp
       - bundle_install
@@ -197,6 +234,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - check_code_changes
       - bundle_install
       - run: bin/brakeman.sh
       - run:


### PR DESCRIPTION
## Summary
This PR adds a new CircleCI command that intelligently skips CI pipeline execution when only documentation, configuration, or non-code files are modified. This reduces unnecessary CI runs and speeds up the development workflow for documentation-only updates.

## Key Changes
- **New `check_code_changes` command**: Implements logic to detect if changes are limited to excluded directories (.github, docs, sdk, bin)
  - Compares against `main` branch for feature branches
  - Compares against previous commit for main branch
  - Uses `circleci-agent step halt` to gracefully skip CI when only excluded files are changed
  
- **Applied to three jobs**:
  - `setup` job
  - `test` job  
  - `brakeman` job (security scanning)

## Implementation Details
- The command safely handles cases where git operations may fail (e.g., shallow clones) by using `2>/dev/null || true`
- Uses a case statement to match excluded directory patterns
- Only halts CI if ALL changed files are in excluded directories; any code change triggers normal CI execution
- Provides clear console output indicating whether CI is being skipped or proceeding

https://claude.ai/code/session_01Tohc764MhNK18fjxCRofD9