### PR TITLE
Prevent NoMethodError in StoreProduct#refresh_metrics! when product is nil

### DIFF
--- a/core/app/models/spree/store_product.rb
+++ b/core/app/models/spree/store_product.rb
@@ -9,6 +9,8 @@ module Spree
     validates :store_id, uniqueness: { scope: :product_id }
 
     def refresh_metrics!
+      return if product.nil?
+
       completed_order_ids = product.completed_orders.where(store_id: store_id).select(:id)
       variant_ids = product.variants_including_master.ids
 


### PR DESCRIPTION
## Summary
- Adds a nil guard clause in `StoreProduct#refresh_metrics!` to prevent `NoMethodError` when the associated `product` is missing (e.g. orphaned join rows after product deletion)
- Adds specs covering nil/missing product scenarios
- Based on #13528 by @agnieszkajacek with Copilot review feedback addressed:
  - Removed trailing whitespace throughout the spec
  - Fixed double `refresh_metrics!` call — now captures result in a single invocation
  - Fixed `product_id: 999999` test to use `described_class.new` instead of factory `build` (which still assigns a product via association)
  - Collapsed two identical "error prevention" examples into the existing test coverage

## Test plan
- [ ] Verify `refresh_metrics!` returns nil and does not raise when `product` is nil
- [ ] Verify metrics are not updated when product is nil
- [ ] Verify orphaned `product_id` pointing to non-existent product is handled gracefully
- [ ] Verify destroyed product after store_product creation is handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)