### PR TITLE
Add parallel_tests for local parallel spec execution

### DIFF
--- a/admin/spec/spec_helper.rb
+++ b/admin/spec/spec_helper.rb
@@ -56,7 +56,7 @@ require 'action_text/system_test_helper'
 
 RSpec.configure do |config|
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -64,7 +64,7 @@ end
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.raise_errors_for_deprecations!

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -18,6 +18,7 @@ platforms :ruby do
 end
 
 group :test do
+  gem 'parallel_tests'
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'capybara-select-2'

--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/spree_development.sqlite3
 test:
   adapter: sqlite3
-  database: db/spree_test.sqlite3
+  database: db/spree_test<%%= ENV['TEST_ENV_NUMBER'] %>.sqlite3
   timeout: 10000
 production:
   adapter: sqlite3
@@ -40,7 +40,7 @@ development:
   database: <%= database_prefix %><%= lib_name %>_spree_development
 test:
   <<: *mysql
-  database: <%= database_prefix %><%= lib_name %>_spree_test
+  database: <%= database_prefix %><%= lib_name %>_spree_test<%%= ENV['TEST_ENV_NUMBER'] %>
 production:
   <<: *mysql
   database: <%= database_prefix %><%= lib_name %>_spree_production
@@ -57,14 +57,14 @@ postgres: &postgres
   host: <%= db_host %>
   <% end %>
   min_messages: warning
-  pool: <%= ENV["DB_POOL"] || 50 %>
+  pool: <%%= ENV.fetch("DB_POOL", 50) %>
 
 development:
   <<: *postgres
   database: <%= database_prefix %><%= lib_name %>_spree_development
 test:
   <<: *postgres
-  database: <%= database_prefix %><%= lib_name %>_spree_test
+  database: <%= database_prefix %><%= lib_name %>_spree_test<%%= ENV['TEST_ENV_NUMBER'] %>
 production:
   <<: *postgres
   database: <%= database_prefix %><%= lib_name %>_spree_production
@@ -74,7 +74,7 @@ development:
   database: db/spree_development.sqlite3
 test:
   adapter: sqlite3
-  database: db/spree_test.sqlite3
+  database: db/spree_test<%%= ENV['TEST_ENV_NUMBER'] %>.sqlite3
 production:
   adapter: sqlite3
   database: db/spree_production.sqlite3

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -54,7 +54,7 @@ require 'spree/testing_support/next_instance_of'
 
 RSpec.configure do |config|
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/docs/developer/contributing/developing-spree.mdx
+++ b/docs/developer/contributing/developing-spree.mdx
@@ -129,6 +129,34 @@ If you want to run a particular line of spec
     bundle exec rspec spec/models/spree/state_spec.rb:7
     ```
 
+### Running tests in parallel
+
+You can run specs in parallel locally using the `parallel_tests` gem. This distributes spec files across multiple CPU cores for faster execution.
+
+After setting up the test app, create databases for parallel workers:
+
+    ```bash
+    cd core
+    bundle exec rake parallel_setup
+    ```
+
+Then run specs in parallel:
+
+    ```bash
+    bundle exec parallel_rspec spec
+    ```
+
+You can also specify the number of workers:
+
+    ```bash
+    bundle exec rake "parallel_setup[4]"
+    bundle exec parallel_rspec -n 4 spec
+    ```
+
+After schema changes, re-run `bundle exec rake parallel_setup` to update the worker databases.
+
+This works with both SQLite (default) and PostgreSQL. For PostgreSQL, set the `DB` environment variable when generating the test app as described above.
+
 ### Running integration tests on MacOS (only applicable for Admin Panel/Storefront)
 
 We use chromedriver to run integration tests. To install it please use this command:

--- a/emails/spec/spec_helper.rb
+++ b/emails/spec/spec_helper.rb
@@ -46,7 +46,7 @@ require 'spree/testing_support/rspec_retry_config'
 
 RSpec.configure do |config|
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/page_builder/spec/spec_helper.rb
+++ b/page_builder/spec/spec_helper.rb
@@ -41,7 +41,7 @@ require 'spree/page_builder/testing_support/factories'
 
 RSpec.configure do |config|
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require 'spree/testing_support/preferences'
 
 RSpec.configure do |config|
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/storefront/spec/spec_helper.rb
+++ b/storefront/spec/spec_helper.rb
@@ -55,7 +55,7 @@ require 'spree/core/controller_helpers/strong_parameters'
 
 RSpec.configure do |config|
   config.color = true
-  config.default_formatter = ENV['CI'] ? 'progress' : 'doc'
+  config.default_formatter = 'progress'
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec
@@ -110,7 +110,7 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
-  Capybara.server_port = 3000
+  Capybara.server_port = 3000 + ENV.fetch('TEST_ENV_NUMBER', 0).to_i
   Capybara.test_id = 'data-test-id'
 
   config.filter_run_including focus: true unless ENV['CI']


### PR DESCRIPTION
## Summary

- Add `parallel_tests` gem for running per-gem RSpec specs in parallel locally
- Update `database.yml` template to support `TEST_ENV_NUMBER` for per-worker database isolation (SQLite, PostgreSQL, MySQL)
- Add `parallel_setup` and `parallel_spec` rake tasks available in all gems
- Fix Capybara server port in storefront to avoid port conflicts between parallel workers
- Switch RSpec default formatter from `doc` to `progress` in all gems for cleaner output

## Usage

```bash
cd core
bundle exec rake test_app           # one-time setup
bundle exec rake parallel_setup     # create worker databases (auto-detects CPU count)
bundle exec parallel_rspec spec     # run specs in parallel

# or with explicit worker count
bundle exec rake "parallel_setup[4]"
bundle exec parallel_rspec -n 4 spec
```

Sequential `bundle exec rspec` continues to work unchanged.

## How it works

- **SQLite** (default): `parallel_setup` copies the primary `.sqlite3` file for each worker — fast and requires no Rails context
- **PostgreSQL/MySQL**: `parallel_setup` creates and migrates a separate database per worker
- `TEST_ENV_NUMBER` is embedded in the generated `database.yml` via escaped ERB (`<%%= %>`) so it's evaluated at Rails boot time
- Worker 1 uses the original database (backward compatible), workers 2+ get numbered databases

## Test plan

- [ ] `cd core && bundle exec rake test_app` generates `database.yml` with `<%= ENV['TEST_ENV_NUMBER'] %>` in test DB name
- [ ] `bundle exec rspec` still works (sequential, no `TEST_ENV_NUMBER` set)
- [ ] `bundle exec rake parallel_setup` creates worker database copies
- [ ] `bundle exec parallel_rspec spec` distributes specs across workers
- [ ] Repeat for `api/` gem

🤖 Generated with [Claude Code](https://claude.com/claude-code)