### PR TITLE
Version Packages - @spree/sdk v0.1.1

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @spree/sdk
+
+## 0.1.1
+
+### Patch Changes
+
+- Fix package license to MIT
+
+- First public release with basic Product Catalog features, Customer account, Cart and Checkout

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Official TypeScript SDK for Spree Commerce API",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -56,7 +56,7 @@
     "headless"
   ],
   "author": "Vendo Connect Inc.",
-  "license": "BSD-3-Clause",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/spree/spree.git",


### PR DESCRIPTION
## Summary
- Fix package license from BSD-3-Clause to MIT
- First public release with basic Product Catalog features, Customer account, Cart and Checkout
- Bump `@spree/sdk` to v0.1.1

## Changeset
This is a version bump PR generated from changesets. Merging this will trigger the SDK release workflow to publish `@spree/sdk@0.1.1` to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)