### PR TITLE
SDK v0.1.2 - Fix release workflow for Trusted Publishing

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -59,12 +60,16 @@ jobs:
 
       - run: npm ci
 
-      - name: Create Release PR or Publish
-        uses: changesets/action@v1
-        with:
-          publish: npm run release
-          version: npm run version
-          cwd: sdk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Check if version is published
+        id: check
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if npm view @spree/sdk@$PACKAGE_VERSION version 2>/dev/null; then
+            echo "published=true" >> $GITHUB_OUTPUT
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and Publish
+        if: steps.check.outputs.published == 'false'
+        run: npm run build && npm publish --provenance --access public

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/sdk
 
+## 0.1.2
+
+### Patch Changes
+
+- Fix release workflow for npm Trusted Publishing
+
 ## 0.1.1
 
 ### Patch Changes

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Official TypeScript SDK for Spree Commerce API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Fix SDK release workflow: replace `changesets/action@v1` (failed to find `.changeset` in subdirectory) with manual publish steps
- Use npm Trusted Publishing (OIDC provenance) instead of `NPM_TOKEN`
- Bump `@spree/sdk` to v0.1.2

## Changes
- Added `id-token: write` permission for OIDC provenance
- Release step checks if version is already on npm before publishing
- Uses `npm publish --provenance --access public` for supply chain security
- Removed dependency on `NPM_TOKEN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)