### PR TITLE
Fix SDK Trusted Publishing OIDC auth

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -56,7 +56,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: sdk/package-lock.json
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` in the release job
- The `registry-url` option creates an `.npmrc` with an empty `NODE_AUTH_TOKEN` placeholder that overrides npm's automatic OIDC token exchange for Trusted Publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)