### PR TITLE
Version Packages - @spree/sdk v0.1.3

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/sdk
 
+## 0.1.3
+
+### Patch Changes
+
+- Fix release workflow for npm Trusted Publishing (OIDC)
+
 ## 0.1.2
 
 ### Patch Changes

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Official TypeScript SDK for Spree Commerce API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump `@spree/sdk` to v0.1.3 to trigger release with fixed Trusted Publishing workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)