### PR TITLE
Fix SDK Trusted Publishing with npm upgrade

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - 'sdk/**'
+      - '.github/workflows/sdk.yml'
   pull_request:
     paths:
       - 'sdk/**'
+      - '.github/workflows/sdk.yml'
 
 permissions:
   contents: read
@@ -58,6 +60,10 @@ jobs:
           cache-dependency-path: sdk/package-lock.json
 
       - run: npm ci
+
+      - name: Upgrade npm for Trusted Publishing support
+        run: npm install -g npm@latest
+        working-directory: .
 
       - name: Check if version is published
         id: check

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/sdk
 
+## 0.1.4
+
+### Patch Changes
+
+- Fix automated release with npm Trusted Publishing
+
 ## 0.1.3
 
 ### Patch Changes

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Official TypeScript SDK for Spree Commerce API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Upgrade npm to latest in release job for OIDC Trusted Publishing auth support (Node 20's bundled npm is too old)
- Add `.github/workflows/sdk.yml` to path triggers so workflow changes also trigger CI
- Bump `@spree/sdk` to v0.1.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)