### PR TITLE
Revert "Fixed: store `return_to` session for all admin controllers, eg. Order…"

### DIFF
--- a/admin/app/controllers/spree/admin/base_controller.rb
+++ b/admin/app/controllers/spree/admin/base_controller.rb
@@ -14,7 +14,6 @@ module Spree
       helper 'spree/integrations'
 
       before_action :authorize_admin
-      after_action :set_return_to, only: [:index]
 
       protected
 

--- a/admin/app/controllers/spree/admin/resource_controller.rb
+++ b/admin/app/controllers/spree/admin/resource_controller.rb
@@ -6,6 +6,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url, :model_class
   before_action :load_resource
   before_action :set_currency, :set_current_store, only: [:new, :create]
+  after_action :set_return_to, only: [:index]
 
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
 


### PR DESCRIPTION
Reverts spree/spree#13251

All of the controllers, such as Orders, and so on inherit now from ResourceController so we can move it back and fix #13541 13541