### PR TITLE
Fix flaky by_best_selling scope test with tied products

### DIFF
--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -548,8 +548,9 @@ describe 'Product scopes', type: :model do
         products = Spree::Product.where(id: test_product_ids).by_best_selling
         # Product 1: 2 units sold (first)
         # Product 3: 1 unit sold (second)
-        # Product 2 & 4: 0 units sold (last, but Product 2 still included despite having pending orders)
-        expect(products.map(&:name)).to eq(['Product 1', 'Product 3', 'Product 2', 'Product 4'])
+        # Product 2 & 4: 0 units sold (last, order between them is non-deterministic)
+        expect(products.first(2).map(&:name)).to eq(['Product 1', 'Product 3'])
+        expect(products.last(2).map(&:name)).to contain_exactly('Product 2', 'Product 4')
       end
     end
   end


### PR DESCRIPTION
## Summary

Products 2 and 4 both have 0 units sold, so their relative ordering from the database is non-deterministic. The test was asserting a specific order for these tied products. Changed to use `contain_exactly` for the tied pair while still asserting the deterministic ordering of Products 1 and 3.

## Test plan

- The flaky test should now pass consistently regardless of database ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)