### PR TITLE
Update sidebar-mobile styles to apply full translation when open

### DIFF
--- a/admin/app/assets/tailwind/spree/admin/components/_layout.css
+++ b/admin/app/assets/tailwind/spree/admin/components/_layout.css
@@ -552,7 +552,7 @@
   }
 
   .sidebar-mobile.sidebar-mobile-open .sidebar-panel {
-    @apply translate-x-0;
+    @apply translate-x-full;
   }
 
   /* Enterprise Edition Notice */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Tailwind/CSS transform tweak affecting only the mobile sidebar animation/positioning; no data or security impact.
> 
> **Overview**
> Adjusts the mobile admin sidebar open-state transform: `.sidebar-mobile.sidebar-mobile-open .sidebar-panel` now applies `translate-x-full` instead of `translate-x-0`, changing where the panel animates/lands when opened.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c22530e43ddf10224d462ad38d7dfbac8dd9ca17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->