### PR TITLE
Fix flaky FulfilmentChanger test by correcting quantity reduction logic

### DIFF
--- a/backend/engines/core/app/models/spree/fulfilment_changer.rb
+++ b/backend/engines/core/app/models/spree/fulfilment_changer.rb
@@ -85,8 +85,14 @@ module Spree
 
     def reduce_units_quantities(reduced_quantity, units)
       units.each do |unit|
-        unit.quantity > reduced_quantity ? unit.update(quantity: unit.quantity - reduced_quantity) : unit.destroy!
-        reduced_quantity -= unit.quantity
+        if unit.quantity > reduced_quantity
+          unit.update(quantity: unit.quantity - reduced_quantity)
+          reduced_quantity = 0
+        else
+          reduced_quantity -= unit.quantity
+          unit.destroy!
+        end
+        break if reduced_quantity.zero?
       end
       reduced_quantity
     end

--- a/backend/engines/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/backend/engines/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -212,7 +212,7 @@ describe Spree::FulfilmentChanger do
               new_unit.update!(quantity: 5)
             end
 
-            it 'reduces the backordered items first', retry: 3 do
+            it 'reduces the backordered items first' do
               expect(current_shipment.inventory_units.on_hand.count).to eq(2)
               expect(current_shipment.inventory_units.on_hand.sum(:quantity)).to eq(6)
               expect(current_shipment.inventory_units.backordered.count).to eq(1)


### PR DESCRIPTION
## Summary
Fixed a bug in `FulfilmentChanger#reduce_units_quantities` where the quantity reduction logic was incorrectly calculating remaining quantities when units were partially reduced. This caused the test to fail non-deterministically when inventory units were returned from the database in certain orders.

## Changes
- Rewrote `reduce_units_quantities` to properly track consumed quantity
- When partially reducing a unit, set `reduced_quantity = 0` instead of subtracting the already-reduced quantity
- Added early `break` when all quantity has been consumed
- Removed `retry: 3` workaround from the test that was masking the underlying bug

## Testing
All 42 specs in the FulfilmentChanger test suite pass consistently across multiple runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)