### PR TITLE
Add changeset support for @spree/next

### DIFF
--- a/packages/next/.changeset/README.md
+++ b/packages/next/.changeset/README.md
@@ -1,0 +1,23 @@
+# Changesets
+
+This folder is used by [Changesets](https://github.com/changesets/changesets) to track @spree/next version bumps and changelog entries.
+
+## Adding a changeset
+
+After making changes to the package, run:
+
+```bash
+cd next
+npx changeset
+```
+
+This will prompt you to:
+1. Select the package (`@spree/next`)
+2. Choose the semver bump type (patch/minor/major)
+3. Write a summary of the changes
+
+A markdown file will be created in this directory describing the change.
+
+## Releasing
+
+When changeset files are merged to `main`, a "Version Packages" PR is automatically created. Merging that PR bumps the version, updates the CHANGELOG, and publishes to npm.

--- a/packages/next/.changeset/config.json
+++ b/packages/next/.changeset/config.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "spree/spree" }
+  ],
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @spree/next
+
+## 0.1.1
+
+### Patch Changes
+
+- Add changelog and changeset support for automated npm releases
+
+## 0.1.0
+
+### Minor Changes
+
+- First public release with Next.js server actions, caching, and cookie-based auth for Spree Commerce

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,0 +1,261 @@
+# @spree/next
+
+Next.js integration for Spree Commerce — server actions, caching, and cookie-based auth.
+
+## Installation
+
+```bash
+npm install @spree/next @spree/sdk
+# or
+yarn add @spree/next @spree/sdk
+# or
+pnpm add @spree/next @spree/sdk
+```
+
+## Quick Start
+
+### 1. Set environment variables
+
+```env
+SPREE_API_URL=https://api.mystore.com
+SPREE_API_KEY=your-publishable-api-key
+```
+
+The client auto-initializes from these env vars. Alternatively, initialize explicitly:
+
+```typescript
+// lib/storefront.ts
+import { initSpreeNext } from '@spree/next';
+
+initSpreeNext({
+  baseUrl: process.env.SPREE_API_URL!,
+  apiKey: process.env.SPREE_API_KEY!,
+});
+```
+
+### 2. Fetch data in Server Components
+
+```typescript
+import { listProducts, getProduct, listTaxons } from '@spree/next';
+
+export default async function ProductsPage() {
+  const products = await listProducts({ per_page: 12 });
+  const categories = await listTaxons({ 'q[depth_eq]': 1 });
+
+  return (
+    <div>
+      {products.data.map((product) => (
+        <div key={product.id}>{product.name}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+### 3. Use server actions for mutations
+
+```typescript
+import { addItem, removeItem, getCart } from '@spree/next';
+
+export default async function CartPage() {
+  const cart = await getCart();
+
+  async function handleAddItem(formData: FormData) {
+    'use server';
+    await addItem(formData.get('variantId') as string, 1);
+  }
+
+  return <form action={handleAddItem}>...</form>;
+}
+```
+
+## Configuration
+
+```typescript
+import { initSpreeNext } from '@spree/next';
+
+initSpreeNext({
+  baseUrl: 'https://api.mystore.com',
+  apiKey: 'your-publishable-api-key',
+  cartCookieName: '_spree_cart_token',     // default
+  accessTokenCookieName: '_spree_jwt',     // default
+  defaultLocale: 'en',
+  defaultCurrency: 'USD',
+});
+```
+
+## Data Functions
+
+Plain async functions for reading data in Server Components. Wrap with `"use cache"` in your app for caching.
+
+### Products
+
+```typescript
+import { listProducts, getProduct, getProductFilters } from '@spree/next';
+
+const products = await listProducts({ per_page: 25, includes: 'variants,images' });
+const product = await getProduct('ruby-on-rails-tote');
+const filters = await getProductFilters({ taxon_id: 'txn_123' });
+```
+
+### Categories
+
+```typescript
+import { listTaxons, getTaxon, listTaxonProducts } from '@spree/next';
+import { listTaxonomies, getTaxonomy } from '@spree/next';
+
+const taxons = await listTaxons({ 'q[depth_eq]': 1 });
+const taxon = await getTaxon('categories/clothing');
+const products = await listTaxonProducts('categories/clothing', { per_page: 12 });
+
+const taxonomies = await listTaxonomies({ includes: 'taxons' });
+const taxonomy = await getTaxonomy('tax_123');
+```
+
+### Store & Geography
+
+```typescript
+import { getStore, listCountries, getCountry } from '@spree/next';
+
+const store = await getStore();
+const countries = await listCountries();
+const usa = await getCountry('US');
+```
+
+## Server Actions
+
+Server actions handle mutations and auth-dependent reads. They automatically manage cookies for cart tokens and JWT authentication.
+
+### Cart
+
+```typescript
+import { getCart, getOrCreateCart, addItem, updateItem, removeItem, clearCart } from '@spree/next';
+
+const cart = await getCart();
+const cart = await getOrCreateCart();
+await addItem(variantId, quantity);
+await updateItem(lineItemId, quantity);
+await removeItem(lineItemId);
+await clearCart();
+```
+
+### Checkout
+
+```typescript
+import {
+  getCheckout,
+  updateAddresses,
+  advance,
+  next,
+  getShipments,
+  selectShippingRate,
+  applyCoupon,
+  removeCoupon,
+  complete,
+} from '@spree/next';
+
+const checkout = await getCheckout();
+await updateAddresses({ ship_address: { ... }, bill_address: { ... } });
+await advance();
+await next();
+const shipments = await getShipments();
+await selectShippingRate(shipmentId, rateId);
+await applyCoupon('SAVE20');
+await removeCoupon(promoId);
+await complete();
+```
+
+### Authentication
+
+```typescript
+import { login, register, logout, getCustomer, updateCustomer } from '@spree/next';
+
+await login(email, password);
+await register({ email, password, password_confirmation, first_name, last_name });
+await logout();
+const customer = await getCustomer();
+await updateCustomer({ first_name: 'John' });
+```
+
+### Addresses
+
+```typescript
+import { listAddresses, getAddress, createAddress, updateAddress, deleteAddress } from '@spree/next';
+
+const addresses = await listAddresses();
+const address = await getAddress(addressId);
+await createAddress({ firstname: 'John', address1: '123 Main St', ... });
+await updateAddress(addressId, { city: 'Brooklyn' });
+await deleteAddress(addressId);
+```
+
+### Orders
+
+```typescript
+import { listOrders, getOrder } from '@spree/next';
+
+const orders = await listOrders();
+const order = await getOrder(orderId);
+```
+
+### Credit Cards & Gift Cards
+
+```typescript
+import { listCreditCards, deleteCreditCard } from '@spree/next';
+import { listGiftCards, getGiftCard } from '@spree/next';
+
+const cards = await listCreditCards();
+await deleteCreditCard(cardId);
+
+const giftCards = await listGiftCards();
+const giftCard = await getGiftCard(giftCardId);
+```
+
+## Localization
+
+Pass locale and currency options to data functions:
+
+```typescript
+const products = await listProducts({ per_page: 10 }, { locale: 'fr', currency: 'EUR' });
+const taxon = await getTaxon('categories/clothing', {}, { locale: 'de', currency: 'EUR' });
+```
+
+## TypeScript
+
+All types are re-exported from `@spree/sdk` for convenience:
+
+```typescript
+import type {
+  StoreProduct,
+  StoreOrder,
+  StoreLineItem,
+  StoreTaxon,
+  PaginatedResponse,
+  SpreeError,
+} from '@spree/next';
+```
+
+## Development
+
+```bash
+cd packages/next
+pnpm install
+pnpm dev         # Build in watch mode
+pnpm typecheck   # Type-check
+pnpm test        # Run tests
+pnpm build       # Production build
+```
+
+### Releasing
+
+This package uses [Changesets](https://github.com/changesets/changesets) for version management.
+
+```bash
+npx changeset           # Add a changeset after making changes
+npx changeset version   # Bump version and update CHANGELOG
+pnpm release            # Build and publish to npm
+```
+
+## License
+
+MIT

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/next",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Next.js integration for Spree Commerce — server actions, caching, and cookie-based auth",
   "type": "module",
   "main": "./dist/index.js",
@@ -29,7 +29,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "release": "npm run build && changeset publish"
   },
   "keywords": [
     "spree",
@@ -57,6 +60,8 @@
     "react": ">=19.0.0"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.2",
+    "@changesets/cli": "^2.29.8",
     "@spree/sdk": "workspace:*",
     "@types/node": "^20.0.0",
     "@types/react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
 
   packages/next:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.2
+        version: 0.5.2
+      '@changesets/cli':
+        specifier: ^2.29.8
+        version: 2.29.8(@types/node@20.19.33)
       '@spree/sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
## Summary
- Add `.changeset/` config and README for `@spree/next` package (mirroring SDK setup)
- Add `CHANGELOG.md` with initial 0.1.0 and 0.1.1 entries
- Add changeset scripts (`changeset`, `version`, `release`) and devDependencies to `package.json`
- Version bumped to 0.1.1 (already published to npm)

## Test plan
- [x] `pnpm turbo typecheck build --filter=@spree/next` passes
- [x] `@spree/next@0.1.1` published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)