### PR TITLE
Update CLI extension generator to follow new principles

### DIFF
--- a/backend/engines/cli/lib/spree_cli/extension.rb
+++ b/backend/engines/cli/lib/spree_cli/extension.rb
@@ -21,12 +21,11 @@ module SpreeCli
 
       empty_directory "#{file_name}/app/models/#{file_name}"
       empty_directory "#{file_name}/app/views/spree"
-      empty_directory "#{file_name}/app/views/#{file_name}"
       empty_directory "#{file_name}/app/controllers/spree/admin"
       empty_directory "#{file_name}/app/controllers/#{file_name}"
       empty_directory "#{file_name}/app/services/#{file_name}"
-      empty_directory "#{file_name}/app/serializers/spree/v2/storefront"
-      empty_directory "#{file_name}/app/serializers/spree/api/v2/platform"
+      empty_directory "#{file_name}/app/serializers/spree/api/v3"
+      empty_directory "#{file_name}/app/serializers/spree/api/v3/admin"
       empty_directory "#{file_name}/vendor/javascript"
       empty_directory "#{file_name}/vendor/stylesheets"
 

--- a/backend/engines/cli/lib/spree_cli/templates/extension/LICENSE.md
+++ b/backend/engines/cli/lib/spree_cli/templates/extension/LICENSE.md
@@ -1,14 +1,9 @@
 # LICENSE
 
 Copyright (c) <%= Time.now.year %> [name of plugin creator]
-All rights reserved.
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see [https://www.gnu.org/licenses/](https://www.gnu.org/licenses/).
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/engines/cli/lib/spree_cli/templates/extension/app/views/%file_name%/_head.html.erb.tt
+++ b/backend/engines/cli/lib/spree_cli/templates/extension/app/views/%file_name%/_head.html.erb.tt
@@ -1,1 +1,0 @@
-<%%= javascript_import_module_tag 'application-<%= file_name.gsub('_', '-') %>' %>

--- a/backend/engines/cli/lib/spree_cli/templates/extension/config/i18n-tasks.yml
+++ b/backend/engines/cli/lib/spree_cli/templates/extension/config/i18n-tasks.yml
@@ -34,7 +34,6 @@ data:
     ## Example (replace %#= with %=):
     # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
     - "<%= %x[bundle info spree_core --path].chomp %>/config/locales/%{locale}.yml"
-    - "<%= %x[bundle info spree_storefront --path].chomp %>/config/locales/%{locale}.yml"
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router
 

--- a/backend/engines/cli/lib/spree_cli/templates/extension/extension.gemspec
+++ b/backend/engines/cli/lib/spree_cli/templates/extension/extension.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.author    = 'You'
   s.email     = 'you@example.com'
   s.homepage  = 'https://github.com/your-github-handle/<%= file_name %>'
-  s.license = 'AGPL-3.0-or-later'
+  s.license = 'MIT'
 
   s.files        = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.md", "Rakefile", "README.md"].reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'
@@ -22,7 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree', '>= <%= Gem.loaded_specs['spree_cli'].version %>'
   s.add_dependency 'spree_admin', '>= <%= Gem.loaded_specs['spree_cli'].version %>'
-  s.add_dependency 'spree_extension'
-
   s.add_development_dependency 'spree_dev_tools'
 end

--- a/backend/engines/cli/lib/spree_cli/templates/extension/lib/%file_name%.rb.tt
+++ b/backend/engines/cli/lib/spree_cli/templates/extension/lib/%file_name%.rb.tt
@@ -1,5 +1,4 @@
 require 'spree'
-require 'spree_extension'
 require '<%=file_name%>/engine'
 require '<%=file_name%>/version'
 require '<%=file_name%>/configuration'


### PR DESCRIPTION
## Summary
Updated the CLI extension generator to align with the new Spree development principles:

- Changed generated extensions from AGPL to MIT license
- Removed `spree_extension` dependency (no longer needed)
- Removed storefront-related files and references (`_head.html.erb.tt`, `app/views/{extension}` directory)
- Updated serializer paths from v2 to v3 API (v3 for Store API, v3/admin for Platform API)
- Removed `spree_storefront` locale reference from i18n-tasks configuration

## Compliance Checklist
- ✅ GitHub Actions (already in use)
- ✅ MIT license (updated)
- ✅ Removed spree_extension (updated)
- ✅ Uses propshaft (already in use)
- ✅ Only spree and spree_admin dependencies (already the case)
- ✅ No storefront code (updated)

🚀 Generated with Claude Code