### PR TITLE
Improve prefix_ids:backfill rake task scalability

### DIFF
--- a/docs/developer/upgrades/5.3-to-5.4.mdx
+++ b/docs/developer/upgrades/5.3-to-5.4.mdx
@@ -31,7 +31,20 @@ However this requires a one-time backfill of IDs for existing records. This can 
   bin/rails spree:prefix_ids:backfill
   ```
 
-Length of this process can vary depending on the size of your database. Both new API and Admin Dashboard will use these IDs. `spree_storefront` still uses the old IDs so this update won't disrupt your existing storefront.
+For large databases, you can backfill a single model at a time, which allows you to run multiple backfills in parallel across separate terminals:
+
+  ```bash
+  bin/rails spree:prefix_ids:backfill MODEL=Spree::Order
+  bin/rails spree:prefix_ids:backfill MODEL=Spree::LineItem
+  ```
+
+To check progress at any time:
+
+  ```bash
+  bin/rails spree:prefix_ids:status
+  ```
+
+Both new API and Admin Dashboard will use these IDs. `spree_storefront` still uses the old IDs so this update won't disrupt your existing storefront.
 
 ### Backfill Image Thumbnail IDs
 


### PR DESCRIPTION
Rewrote the `spree:prefix_ids:backfill` task to handle large databases efficiently:

- **Auto-discover models** via `_prefix_id_prefix` instead of hardcoded 85-model list
- **Add `MODEL=` filter** for per-model backfill, enabling parallelization across terminals
- **Batch SQL updates** instead of row-by-row (100x fewer queries)
- **Progress reporting** with elapsed time per model
- **New `prefix_ids:status` task** to check remaining counts anytime

Updated upgrade docs to show the new `MODEL=` and `status` options.