### PR TITLE
Fix flaky array assertions in tests by using match_array

### DIFF
--- a/backend/engines/admin/spec/controllers/spree/admin/orders/user_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/orders/user_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Spree::Admin::Orders::UserController, type: :controller do
         expect(existing_user.reload.first_name).to eq(user_params[:first_name])
         expect(existing_user.last_name).to eq(user_params[:last_name])
         expect(existing_user.email).to eq(user_params[:email])
-        expect(existing_user.tag_list).to eq(user_params[:tag_list])
+        expect(existing_user.tag_list).to match_array(user_params[:tag_list])
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe Spree::Admin::Orders::UserController, type: :controller do
         expect(new_user.reload.first_name).to eq(user_params[:first_name])
         expect(new_user.last_name).to eq(user_params[:last_name])
         expect(new_user.email).to eq(user_params[:email])
-        expect(new_user.tag_list).to eq(user_params[:tag_list])
+        expect(new_user.tag_list).to match_array(user_params[:tag_list])
       end
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/posts_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/posts_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Spree::Admin::PostsController, type: :controller do
       expect(post.image).to be_attached
       expect(post.meta_title).to eq('New Post for SEO')
       expect(post.meta_description).to eq('This is a new post for SEO')
-      expect(post.tag_list).to eq(['SEO', 'VIP'])
+      expect(post.tag_list).to match_array(['SEO', 'VIP'])
       expect(post.slug).to eq("my-new-post")
       expect(post.post_category).to eq(post_category)
     end
@@ -130,7 +130,7 @@ RSpec.describe Spree::Admin::PostsController, type: :controller do
       expect(post.image).to be_attached
       expect(post.meta_title).to eq('Updated Post for SEO')
       expect(post.meta_description).to eq('This is an updated post for SEO')
-      expect(post.tag_list).to eq(['Updated', 'VIP'])
+      expect(post.tag_list).to match_array(['Updated', 'VIP'])
       expect(post.post_category).to eq(post_category)
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -1017,7 +1017,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         it 'removes the variant' do
           send_request
 
-          expect(product.reload.variant_ids).to eq([variant2.id, variant3.id])
+          expect(product.reload.variant_ids).to match_array([variant2.id, variant3.id])
         end
       end
 
@@ -1300,8 +1300,8 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
 
     it 'adds tags to products' do
       send_request
-      expect(product.reload.tag_list).to eq(['tag1', 'tag2', 'tag3'])
-      expect(product2.reload.tag_list).to eq(['tag1', 'tag2', 'tag3'])
+      expect(product.reload.tag_list).to match_array(['tag1', 'tag2', 'tag3'])
+      expect(product2.reload.tag_list).to match_array(['tag1', 'tag2', 'tag3'])
       expect(response).to redirect_to('/admin/products')
     end
   end

--- a/backend/engines/core/spec/models/spree/property_spec.rb
+++ b/backend/engines/core/spec/models/spree/property_spec.rb
@@ -75,7 +75,7 @@ describe Spree::Property, type: :model do
       create(:product_property, property: property, value: 'Another 10% Value')
     end
 
-    it { expect(property.uniq_values).to eq([['some-value', 'Some Value'], ['another-10-value', 'Another 10% Value']]) }
+    it { expect(property.uniq_values).to match_array([['some-value', 'Some Value'], ['another-10-value', 'Another 10% Value']]) }
 
     context 'when narrowing the scope of product properties' do
       let!(:product_property_1) { create(:product_property, property: property, value: 'Some 10% Value') }
@@ -91,12 +91,12 @@ describe Spree::Property, type: :model do
         ]
       end
 
-      it { expect(property.uniq_values(product_properties_scope: scope)).to eq(scope_uniq_values) }
+      it { expect(property.uniq_values(product_properties_scope: scope)).to match_array(scope_uniq_values) }
     end
 
     context 'when caching' do
       it 'correctly returns uniq values' do
-        expect(property.uniq_values).to eq([['some-value', 'Some Value'], ['another-10-value', 'Another 10% Value']])
+        expect(property.uniq_values).to match_array([['some-value', 'Some Value'], ['another-10-value', 'Another 10% Value']])
 
         product_property_1 = create(:product_property, property: property, value: 'Some 20% Value')
         expect(property.uniq_values).to match_array(

--- a/backend/engines/core/spec/presenters/spree/filters/property_presenter_spec.rb
+++ b/backend/engines/core/spec/presenters/spree/filters/property_presenter_spec.rb
@@ -17,7 +17,7 @@ module Spree
       subject(:uniq_values) { property.uniq_values }
 
       it 'returns unique Product Properties values for a given list of Product Properties' do
-        expect(uniq_values).to eq([['alpha', 'Alpha'], ['beta', 'Beta']])
+        expect(uniq_values).to match_array([['alpha', 'Alpha'], ['beta', 'Beta']])
       end
     end
   end

--- a/backend/engines/core/spec/services/spree/products/duplicator_spec.rb
+++ b/backend/engines/core/spec/services/spree/products/duplicator_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Spree::Products::Duplicator do
     end
 
     it 'copies tags' do
-      expect(new_product.tag_list).to eq(['tag1', 'tag2'])
+      expect(new_product.tag_list).to match_array(['tag1', 'tag2'])
     end
 
     it 'clones barcode' do


### PR DESCRIPTION
## Summary
Replaced `.to eq([...])` with `.to match_array([...])` for unordered collections in test assertions. This fixes flaky tests that fail when array element order is non-deterministic due to database row ordering or query result ordering.

## Changes
- **Tag list assertions**: Fixed 6 test cases comparing `tag_list` values
- **Association IDs**: Fixed variant_ids comparison 
- **Query results**: Fixed `uniq_values` property assertions that depend on non-deterministic DB ordering

## Test Plan
- Run the affected test suites to confirm they no longer fail intermittently:
  - `products/duplicator_spec.rb`
  - `products_controller_spec.rb`
  - `posts_controller_spec.rb`
  - `orders/user_controller_spec.rb`
  - `property_spec.rb`
  - `property_presenter_spec.rb`