### PR TITLE
Fix flaky tests caused by global state leaking between specs

### DIFF
--- a/backend/engines/core/spec/models/spree/ability_spec.rb
+++ b/backend/engines/core/spec/models/spree/ability_spec.rb
@@ -25,6 +25,12 @@ describe Spree::Ability, type: :model do
   let(:ability) { Spree::Ability.new(user) }
   let(:token) { nil }
 
+  before do
+    # Ensure permission sets are configured (may have been reset by other specs)
+    Spree.permissions.assign(:default, [Spree::PermissionSets::DefaultCustomer])
+    Spree.permissions.assign(:admin, [Spree::PermissionSets::SuperUser])
+  end
+
   after do
     Spree::Ability.abilities = Set.new
   end

--- a/backend/engines/core/spec/spec_helper.rb
+++ b/backend/engines/core/spec/spec_helper.rb
@@ -72,8 +72,12 @@ RSpec.configure do |config|
   end
 
   # Re-enable events for specs that need them
+  # Also re-activate subscribers in case another spec called Events.reset!
   config.around(:each, events: true) do |example|
-    Spree::Events.enable { example.run }
+    Spree::Events.enable do
+      Spree::Events.activate!
+      example.run
+    end
   end
 
   config.before(:each) do


### PR DESCRIPTION
## Summary

Fixes two flaky tests caused by global state leaking between specs due to test ordering:

- **Ability spec**: `ability_integration_spec` calls `Spree.permissions.reset!` in its `after` hook, clearing all permission set assignments. When the ability spec runs after it, `permission_sets_for_roles([:admin])` returns empty, falling into legacy permissions which fails the `is_a?(Spree.admin_user_class)` check. Fixed by ensuring permission sets are configured in the ability spec's `before` hook.

- **Order event spec**: `subscriber_spec` and `publishable_spec` call `Spree::Events.reset!` in their `after` hooks, destroying the event registry and all subscriber registrations. The `events: true` around hook only toggled the enabled flag without re-registering subscribers. Fixed by adding `Spree::Events.activate!` inside the events around hook.

## Test Plan
- [x] Ability spec: 85 examples, 0 failures across 5 random-seed runs
- [x] Order event spec: 299 examples, 0 failures across 3 random-seed runs