### PR TITLE
Simplify Store API product visibility scope

### DIFF
--- a/backend/engines/api/app/controllers/spree/api/v3/store/products_controller.rb
+++ b/backend/engines/api/app/controllers/spree/api/v3/store/products_controller.rb
@@ -31,7 +31,7 @@ module Spree
           end
 
           def scope
-            super.available(Time.current, Spree::Current.currency)
+            super.active(Spree::Current.currency)
           end
 
           # these scopes are not automatically picked by ar_lazy_preload gem and we need to explicitly include them


### PR DESCRIPTION
## Summary
- Changed Store API product filtering from `available(Time.current, currency)` to `active(currency)`
- Removes the `available_on` date check from product visibility, eliminating duplicate scheduling logic
- Aligns Store API behavior with the old storefront approach

## Why
`available_on` created a redundant scheduling mechanism alongside `make_active_at`. A product could be `status: active` but invisible due to `available_on` being in the future, which is confusing. Now products are visible when they reach `status: active`, via the `make_active_at` → `active` transition.

## Test plan
- All 29 existing Store API products controller specs pass
- Products with `status: active` are returned
- Products with `status: draft` or `status: archived` are filtered out
- Currency filtering still works