### PR TITLE
Add customer imports to admin UI

### DIFF
--- a/backend/engines/admin/app/views/spree/admin/import_rows/_customer.html.erb
+++ b/backend/engines/admin/app/views/spree/admin/import_rows/_customer.html.erb
@@ -1,0 +1,10 @@
+<%= link_to spree.admin_user_path(item), class: 'flex items-center gap-2 no-underline', data: { turbo_frame: :_top } do %>
+  <%= render_avatar(item, width: 32, height: 32) %>
+  <div>
+    <strong><%= customer_full_name(item) || item.email %></strong>
+    <% if customer_full_name(item) %>
+      <br />
+      <span class="text-gray-600 text-sm"><%= item.email %></span>
+    <% end %>
+  </div>
+<% end %>

--- a/backend/engines/admin/app/views/spree/admin/imports/_row.html.erb
+++ b/backend/engines/admin/app/views/spree/admin/imports/_row.html.erb
@@ -19,7 +19,7 @@
     <% if row.status == 'failed' %>
       <div class="text-danger"><%= row.validation_errors %></div>
     <% elsif row.status == 'completed' && row.item.present? %>
-      <%= render "spree/admin/import_rows/#{row.item_type.demodulize.underscore}", item: row.item %>
+      <%= render "spree/admin/import_rows/#{import.item_partial_name}", item: row.item %>
     <% else %>
       <div class="flex items-center gap-2">
         <div class="inline-block w-5 h-5 border-2 border-current border-r-transparent rounded-full animate-spin text-gray-600" role="status">

--- a/backend/engines/admin/app/views/spree/admin/users/index.html.erb
+++ b/backend/engines/admin/app/views/spree/admin/users/index.html.erb
@@ -4,6 +4,7 @@
 
 <% content_for :page_actions do %>
   <%= render_admin_partials(:users_actions_partials) %>
+  <%= link_to_with_icon 'table-import', Spree.t(:import), spree.new_admin_import_path(type: 'Spree::Imports::Customers'), class: 'btn btn-light', data: { action: 'drawer#open', turbo_frame: :drawer } if can?(:create, Spree::Import) %>
   <%= link_to_export_modal %>
   <%= link_to_with_icon 'plus', Spree.t(:new_customer), spree.new_admin_user_path, class: "btn btn-primary" if can? :create, Spree::user_class %>
 <% end %>

--- a/backend/engines/admin/spec/controllers/spree/admin/imports_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/imports_controller_spec.rb
@@ -112,6 +112,18 @@ RSpec.describe Spree::Admin::ImportsController, type: :controller do
         expect(response.body).to include(variant.name)
       end
     end
+
+    context 'when rows have customer items' do
+      let(:import) { create(:customer_import, status: :completed_mapping) }
+      let(:customer) { create(:user, email: 'imported@example.com', first_name: 'John', last_name: 'Doe') }
+      let!(:row) { create(:import_row, import: import, status: :completed, item: customer) }
+
+      it 'renders the customer partial' do
+        get :show, params: { id: import.to_param }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(customer.email)
+      end
+    end
   end
 
   describe 'PUT #complete_mapping' do

--- a/backend/engines/core/app/models/spree/import.rb
+++ b/backend/engines/core/app/models/spree/import.rb
@@ -110,6 +110,13 @@ module Spree
       "Spree::ImportSchemas::#{type.demodulize}".safe_constantize.new
     end
 
+    # Returns the partial name used to render an import row item in admin views
+    # Override in subclasses for custom item types (e.g. configurable user class)
+    # @return [String]
+    def item_partial_name
+      model_class.to_s.demodulize.underscore
+    end
+
     # Returns the row processor class for the import
     # @return [Class]
     def row_processor_class

--- a/backend/engines/core/app/models/spree/imports/customers.rb
+++ b/backend/engines/core/app/models/spree/imports/customers.rb
@@ -4,6 +4,10 @@ module Spree
       def row_processor_class
         Spree::Imports::RowProcessors::Customer
       end
+
+      def item_partial_name
+        'customer'
+      end
     end
   end
 end

--- a/backend/engines/core/app/models/spree/imports/products.rb
+++ b/backend/engines/core/app/models/spree/imports/products.rb
@@ -4,6 +4,10 @@ module Spree
       def row_processor_class
         Spree::Imports::RowProcessors::ProductVariant
       end
+
+      def item_partial_name
+        'variant'
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Exposes the existing customer import functionality in the Admin UI, following the same pattern as product imports. Users can now import customer data via CSV with automatic field mapping and validation.

## Changes

- Add import button to Customers admin index page
- Create flexible `item_partial_name` method in Import classes to handle item rendering
- Add `_customer.html.erb` partial for displaying imported customers
- Add test coverage for customer import row rendering

## Test Plan

- ✓ Verify import button appears on Customers admin page
- ✓ Test that customer imports can be created and mapped
- ✓ Verify customer rows render with email and name display
- ✓ All admin and core specs pass