### PR TITLE
Fix race condition between saving invitation and sending email

### DIFF
--- a/backend/engines/core/app/models/spree/invitation.rb
+++ b/backend/engines/core/app/models/spree/invitation.rb
@@ -56,7 +56,7 @@ module Spree
     #
     after_initialize :set_defaults, if: :new_record?
     before_validation :set_invitee_from_email, on: :create
-    after_create :publish_invitation_created_event, unless: :skip_email
+    after_commit :publish_invitation_created_event, on: :create, unless: :skip_email
 
     # returns the store for the invitation
     # if the resource is a store, return the resource


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small callback timing change limited to invitation creation; risk is mainly around event timing/order changes for downstream subscribers.
> 
> **Overview**
> Fixes a race between invitation persistence and email delivery by moving the `invitation.created` publish hook from `after_create` to `after_commit` (on create), still respecting `skip_email`.
> 
> This ensures the `InvitationEmailSubscriber` only attempts to load and email newly-created invitations once the transaction is fully committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36b8713482e335bfef248f2476afaa4018a8f021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->