### PR TITLE
Replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/backend/engines/admin/app/controllers/spree/admin/action_text/video_embeds_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/action_text/video_embeds_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
             render json: { sgid: video_embed.attachable_sgid, content: content }, status: :created
           else
-            render json: { error: video_embed.errors.full_messages.to_sentence }, status: :unprocessable_entity
+            render json: { error: video_embed.errors.full_messages.to_sentence }, status: :unprocessable_content
           end
         end
 

--- a/backend/engines/admin/app/controllers/spree/admin/admin_users_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/admin_users_controller.rb
@@ -56,7 +56,7 @@ module Spree
           end
           redirect_to spree.admin_path
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
 
@@ -74,7 +74,7 @@ module Spree
         if @admin_user.update(permitted_params)
           redirect_to spree.admin_admin_user_path(@admin_user), status: :see_other, notice: flash_message_for(@admin_user, :successfully_updated)
         else
-          render :edit, status: :unprocessable_entity
+          render :edit, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/assets_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/assets_controller.rb
@@ -14,7 +14,7 @@ module Spree
           store_uploaded_asset_in_session(@asset, @asset.viewable_type) if @asset.viewable.nil? || @asset.viewable.new_record?
         else
           flash.now[:error] = @asset.errors.full_messages.to_sentence
-          render :create, status: :unprocessable_entity
+          render :create, status: :unprocessable_content
         end
       end
 
@@ -27,7 +27,7 @@ module Spree
             format.json { render json: @asset }
           end
         else
-          head :unprocessable_entity
+          head :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/integrations_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/integrations_controller.rb
@@ -49,7 +49,7 @@ module Spree
 
         unless @integration.can_connect?
           @integration.errors.add(:base, :unable_to_connect, error_message: @integration.connection_error_message)
-          render action == :create ? :new : :edit, status: :unprocessable_entity
+          render action == :create ? :new : :edit, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/invitations_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/invitations_controller.rb
@@ -42,7 +42,7 @@ module Spree
             format.turbo_stream
           end
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/orders/adjustments_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/orders/adjustments_controller.rb
@@ -35,7 +35,7 @@ module Spree
             flash.now[:error] = @adjustment.errors.full_messages.to_sentence
             respond_to do |format|
               format.turbo_stream
-              format.html { render :new, status: :unprocessable_entity }
+              format.html { render :new, status: :unprocessable_content }
             end
           end
         end
@@ -58,7 +58,7 @@ module Spree
             end
           else
             flash.now[:error] = @adjustment.errors.full_messages.to_sentence
-            render :edit, status: :unprocessable_entity
+            render :edit, status: :unprocessable_content
           end
         end
 

--- a/backend/engines/admin/app/controllers/spree/admin/orders/billing_address_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/orders/billing_address_controller.rb
@@ -48,7 +48,7 @@ module Spree
             flash[:success] = Spree.t(:successfully_created, resource: Spree.t(:billing_address))
             redirect_to spree.edit_admin_order_path(@order)
           else
-            render :create, status: :unprocessable_entity
+            render :create, status: :unprocessable_content
           end
         end
 
@@ -88,7 +88,7 @@ module Spree
             flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:billing_address))
             redirect_to spree.edit_admin_order_path(@order)
           else
-            render :update, status: :unprocessable_entity
+            render :update, status: :unprocessable_content
           end
         end
 

--- a/backend/engines/admin/app/controllers/spree/admin/orders/shipping_address_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/orders/shipping_address_controller.rb
@@ -36,7 +36,7 @@ module Spree
 
             redirect_to spree.edit_admin_order_path(@order)
           else
-            render :create, status: :unprocessable_entity
+            render :create, status: :unprocessable_content
           end
         end
 
@@ -70,7 +70,7 @@ module Spree
 
             redirect_to spree.edit_admin_order_path(@order)
           else
-            render :update, status: :unprocessable_entity
+            render :update, status: :unprocessable_content
           end
         end
 

--- a/backend/engines/admin/app/controllers/spree/admin/orders/user_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/orders/user_controller.rb
@@ -29,11 +29,11 @@ module Spree
                 redirect_to spree.edit_admin_order_path(@order)
               else
                 flash[:error] = result.error.value.full_messages.to_sentence
-                redirect_to spree.new_admin_order_user_path(@order), status: :unprocessable_entity
+                redirect_to spree.new_admin_order_user_path(@order), status: :unprocessable_content
               end
             else
               flash[:error] = @user.errors.full_messages.to_sentence
-              redirect_to spree.new_admin_order_user_path(@order), status: :unprocessable_entity
+              redirect_to spree.new_admin_order_user_path(@order), status: :unprocessable_content
             end
           else
             @user = @order.build_user(user_params)
@@ -47,7 +47,7 @@ module Spree
               redirect_to spree.edit_admin_order_path(@order)
             else
               flash[:error] = @user.errors.full_messages.to_sentence
-              redirect_to spree.new_admin_order_user_path(@order), status: :unprocessable_entity
+              redirect_to spree.new_admin_order_user_path(@order), status: :unprocessable_content
             end
           end
         end

--- a/backend/engines/admin/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/orders_controller.rb
@@ -24,7 +24,7 @@ module Spree
           flash[:success] = flash_message_for(@order, :successfully_created)
           redirect_to spree.edit_admin_order_path(@order)
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/payments_controller.rb
@@ -48,13 +48,13 @@ module Spree
         invoke_callbacks(:create, :fails)
 
         flash[:error] = e.message.to_s
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       rescue ActiveRecord::RecordInvalid => _e
         @object.failure if defined?(@object) && @object.persisted?
         invoke_callbacks(:create, :fails)
 
         flash[:error] = @object.errors.full_messages.to_sentence
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
 
       def capture

--- a/backend/engines/admin/app/controllers/spree/admin/products_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/products_controller.rb
@@ -69,7 +69,7 @@ module Spree
           # update the product again
           @product.slug = @product.slug_was if @product.slug.blank?
           invoke_callbacks(:update, :fails)
-          render :edit, status: :unprocessable_entity
+          render :edit, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/profile_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/profile_controller.rb
@@ -19,7 +19,7 @@ module Spree
           flash[:success] = flash_message_for(@user, :successfully_updated)
           redirect_to spree.edit_admin_profile_path
         else
-          render :edit, status: :unprocessable_entity
+          render :edit, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/resource_controller.rb
@@ -51,7 +51,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
             flash.now[:error] = @object.errors.full_messages.join(', ')
           end
         end
-        format.html { render action: :edit, status: :unprocessable_entity }
+        format.html { render action: :edit, status: :unprocessable_content }
       end
     end
   end
@@ -82,7 +82,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
             flash.now[:error] = @object.errors.full_messages.join(', ')
           end
         end
-        format.html { render action: :new, status: :unprocessable_entity }
+        format.html { render action: :new, status: :unprocessable_content }
       end
     end
   end

--- a/backend/engines/admin/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/store_credits_controller.rb
@@ -26,7 +26,7 @@ module Spree
           redirect_to spree.admin_user_path(parent)
         else
           flash[:error] = Spree.t('store_credit.errors.unable_to_create')
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
 
@@ -38,7 +38,7 @@ module Spree
           redirect_to spree.admin_user_store_credit_path(parent, @store_credit)
         else
           flash[:error] = Spree.t('store_credit.errors.unable_to_update')
-          render :edit, status: :unprocessable_entity
+          render :edit, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/stores_controller.rb
@@ -30,7 +30,7 @@ module Spree
           flash[:success] = flash_message_for(@store, :successfully_created)
           redirect_to spree.admin_getting_started_url(host: @store.url), allow_other_host: true
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/taxons_controller.rb
@@ -38,7 +38,7 @@ module Spree
         if @taxon.move_to_child_with_index(new_parent, new_index)
           head :ok
         else
-          head :unprocessable_entity
+          head :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/app/controllers/spree/admin/users_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/users_controller.rb
@@ -58,7 +58,7 @@ module Spree
           flash[:success] = flash_message_for(@user, :successfully_created)
           redirect_to spree.admin_user_path(@user)
         else
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
         end
       end
 

--- a/backend/engines/admin/spec/controllers/spree/admin/admin_users_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/admin_users_controller_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
 
       it 'returns unprocessable entity status' do
         post :create, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -283,7 +283,7 @@ RSpec.describe Spree::Admin::AdminUsersController, type: :controller do
       end
 
       it 'returns unprocessable entity status' do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/custom_domains_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/custom_domains_controller_spec.rb
@@ -73,7 +73,7 @@ describe Spree::Admin::CustomDomainsController, type: :controller do
       it 'does not create a custom domain' do
         expect { subject }.not_to change(Spree::CustomDomain, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:new)
       end
     end
@@ -126,7 +126,7 @@ describe Spree::Admin::CustomDomainsController, type: :controller do
       it 'does not update the custom domain' do
         expect { subject }.not_to change { custom_domain.reload.url }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:edit)
       end
     end

--- a/backend/engines/admin/spec/controllers/spree/admin/gift_card_batches_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/gift_card_batches_controller_spec.rb
@@ -81,7 +81,7 @@ describe Spree::Admin::GiftCardBatchesController, type: :controller do
       it 'renders the new template' do
         subject
         expect(response).to render_template(:new)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/gift_cards_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/gift_cards_controller_spec.rb
@@ -205,7 +205,7 @@ describe Spree::Admin::GiftCardsController, type: :controller do
       it 'renders the new template' do
         subject
         expect(response).to render_template(:new)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -280,7 +280,7 @@ describe Spree::Admin::GiftCardsController, type: :controller do
       it 'renders the edit template' do
         subject
         expect(response).to render_template(:edit)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/imports_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/imports_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Spree::Admin::ImportsController, type: :controller do
           post :create, params: { import: import_params }
         }.not_to change(Spree::Import, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
 
       it 'returns unprocessable entity status' do
         post :create, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/backend/engines/admin/spec/controllers/spree/admin/metafield_definitions_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/metafield_definitions_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Spree::Admin::MetafieldDefinitionsController, type: :controller d
       it 'does not update and re-renders edit' do
         put :update, params: { id: metafield_definition.to_param, metafield_definition: { name: '' } }
         expect(response).to render_template(:edit)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(assigns(:object).reload.name).not_to eq('')
       end
     end

--- a/backend/engines/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -1206,7 +1206,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
 
         it 'renders the edit page' do
           expect(response).to render_template(:edit)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it 'renders the error' do

--- a/backend/engines/api/app/controllers/concerns/spree/api/v3/error_handler.rb
+++ b/backend/engines/api/app/controllers/concerns/spree/api/v3/error_handler.rb
@@ -87,13 +87,13 @@ module Spree
           render_error(
             code: code,
             message: message,
-            status: :unprocessable_entity,
+            status: :unprocessable_content,
             details: details
           )
         end
 
         # Convenience method for service result errors
-        def render_service_error(error, code: ERROR_CODES[:processing_error], status: :unprocessable_entity)
+        def render_service_error(error, code: ERROR_CODES[:processing_error], status: :unprocessable_content)
           if error.is_a?(ActiveModel::Errors)
             render_validation_error(error, code: code)
           elsif error.is_a?(String)
@@ -104,7 +104,7 @@ module Spree
         end
 
         # Legacy support - redirect to new error handling
-        def render_errors(errors, status = :unprocessable_entity)
+        def render_errors(errors, status = :unprocessable_content)
           code = infer_error_code(errors, status)
 
           if errors.is_a?(ActiveModel::Errors)
@@ -140,7 +140,7 @@ module Spree
           render_error(
             code: ERROR_CODES[:gateway_error],
             message: exception.message,
-            status: :unprocessable_entity
+            status: :unprocessable_content
           )
         end
 
@@ -182,7 +182,7 @@ module Spree
           render_error(
             code: ERROR_CODES[:order_cannot_transition],
             message: exception.message,
-            status: :unprocessable_entity
+            status: :unprocessable_content
           )
         end
 
@@ -204,7 +204,7 @@ module Spree
             ERROR_CODES[:access_denied]
           when :bad_request
             ERROR_CODES[:invalid_request]
-          when :unprocessable_entity
+          when :unprocessable_content
             errors.is_a?(ActiveModel::Errors) ? ERROR_CODES[:validation_error] : ERROR_CODES[:processing_error]
           else
             ERROR_CODES[:processing_error]

--- a/backend/engines/api/app/controllers/spree/api/v3/store/cart_controller.rb
+++ b/backend/engines/api/app/controllers/spree/api/v3/store/cart_controller.rb
@@ -45,7 +45,7 @@ module Spree
               render_error(
                 code: ERROR_CODES[:order_already_completed],
                 message: 'Cannot associate a completed order',
-                status: :unprocessable_entity
+                status: :unprocessable_content
               )
               return
             end

--- a/backend/engines/api/lib/spree/api/testing_support/v3/base.rb
+++ b/backend/engines/api/lib/spree/api/testing_support/v3/base.rb
@@ -90,7 +90,7 @@ end
 shared_examples 'returns 422 Unprocessable Entity' do
   it 'returns 422 status' do
     subject
-    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).to have_http_status(:unprocessable_content)
   end
 end
 

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
       it 'returns validation error for blank email' do
         post :register, params: { email: '', password: 'password123', password_confirmation: 'password123' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['email']).to be_present
       end
@@ -108,7 +108,7 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
         existing_user = create(:user)
         post :register, params: { email: existing_user.email, password: 'password123', password_confirmation: 'password123' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['email']).to be_present
       end

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/cart_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/cart_controller_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Spree::Api::V3::Store::CartController, type: :controller do
 
         patch :associate, params: { order_token: completed_order.token }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('order_already_completed')
       end
 

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/customer/account_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/customer/account_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Spree::Api::V3::Store::Customer::AccountController, type: :contro
       it 'returns errors for blank email' do
         patch :update, params: { email: '' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['email']).to be_present
       end
@@ -97,7 +97,7 @@ RSpec.describe Spree::Api::V3::Store::Customer::AccountController, type: :contro
         other_user = create(:user)
         patch :update, params: { email: other_user.email }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['email']).to be_present
       end

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/customer/addresses_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/customer/addresses_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Spree::Api::V3::Store::Customer::AddressesController, type: :cont
       it 'returns validation errors for missing firstname' do
         post :create, params: address_params.except(:firstname)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
       end
     end

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/orders/coupon_codes_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/orders/coupon_codes_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Spree::Api::V3::Store::Orders::CouponCodesController, type: :cont
       it 'returns error for invalid coupon code' do
         post :create, params: { order_id: order.to_param, code: 'INVALID' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']).to be_present
       end
 
@@ -43,7 +43,7 @@ RSpec.describe Spree::Api::V3::Store::Orders::CouponCodesController, type: :cont
 
         post :create, params: { order_id: order.to_param, code: 'SAVE10' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Spree::Api::V3::Store::Orders::CouponCodesController, type: :cont
 
         post :create, params: { order_id: order.to_param, code: 'giftcard123' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it 'returns error for redeemed gift card' do
@@ -90,7 +90,7 @@ RSpec.describe Spree::Api::V3::Store::Orders::CouponCodesController, type: :cont
 
         post :create, params: { order_id: order.to_param, code: 'giftcard123' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe Spree::Api::V3::Store::Orders::CouponCodesController, type: :cont
       it 'returns error' do
         post :create, params: { order_id: order.to_param, code: 'EXPIRED' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/orders/store_credits_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/orders/store_credits_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Spree::Api::V3::Store::Orders::StoreCreditsController, type: :con
         request.headers['Authorization'] = "Bearer #{jwt}"
         post :create, params: { order_id: order_without_credit.to_param, amount: 10 }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']).to be_present
       end
     end

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/wishlist_items_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/wishlist_items_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Spree::Api::V3::Store::WishlistItemsController, type: :controller
       it 'returns errors for missing variant_id' do
         post :create, params: { wishlist_id: wishlist.prefixed_id, quantity: 1 }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['message']).to be_present
       end
@@ -41,7 +41,7 @@ RSpec.describe Spree::Api::V3::Store::WishlistItemsController, type: :controller
       it 'returns errors for invalid variant_id' do
         post :create, params: { wishlist_id: wishlist.prefixed_id, variant_id: 0, quantity: 1 }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['variant']).to be_present
       end
@@ -92,7 +92,7 @@ RSpec.describe Spree::Api::V3::Store::WishlistItemsController, type: :controller
       it 'returns errors for invalid quantity' do
         patch :update, params: { wishlist_id: wishlist.prefixed_id, id: wished_item.prefixed_id, quantity: 0 }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['quantity']).to be_present
       end

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/wishlists_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/wishlists_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Spree::Api::V3::Store::WishlistsController, type: :controller do
       it 'returns errors for blank name' do
         post :create, params: { name: '' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['message']).to be_present
         expect(json_response['error']['details']['name']).to be_present
@@ -137,7 +137,7 @@ RSpec.describe Spree::Api::V3::Store::WishlistsController, type: :controller do
       it 'returns errors for blank name' do
         patch :update, params: { id: wishlist.prefixed_id, name: '' }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['error']['code']).to eq('validation_error')
         expect(json_response['error']['details']['name']).to be_present
       end

--- a/docs/developer/tutorial/testing.mdx
+++ b/docs/developer/tutorial/testing.mdx
@@ -278,7 +278,7 @@ RSpec.describe Spree::Admin::BrandsController, type: :controller do
 
       it 'returns unprocessable entity status' do
         post :create, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Replace all occurrences of `:unprocessable_entity` with `:unprocessable_content` across controllers and specs
- Aligns with RFC 9110 and modern Rack conventions where HTTP 422 was renamed
- Fixes deprecation warnings from Rack that `:unprocessable_entity` will be removed in a future version

## Changes
- 18 controller files updated with new status symbol
- 16 spec files updated with new HTTP status matcher
- 1 documentation file updated with example code
- Total: ~65 occurrences replaced

Both symbols resolve to HTTP 422, but `:unprocessable_content` is the current standard.