### PR TITLE
Fix flaky product sorting test

### DIFF
--- a/backend/engines/admin/app/controllers/spree/admin/products_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/products_controller.rb
@@ -209,6 +209,10 @@ module Spree
       end
 
       # These includes are not picked automatically by ar_lazy_preload gem so we need to specify them manually.
+      def collection_default_sort
+        'name asc'
+      end
+
       def collection_includes
         {
           thumbnail: [attachment_attachment: :blob],


### PR DESCRIPTION
## Summary

Fix flaky admin products listing test by setting a default sort order. The test was failing non-deterministically because the controller had no default sort, causing the database to return products in undefined order.

## Changes

Added `collection_default_sort` method to `ProductsController` returning `'name asc'` to ensure consistent alphabetical ordering by product name.

## Test

Verified the previously flaky sorting test now passes consistently across multiple runs.