### PR TITLE
user ID instead of slug in admin edit policy path

### DIFF
--- a/backend/engines/admin/app/controllers/spree/admin/policies_controller.rb
+++ b/backend/engines/admin/app/controllers/spree/admin/policies_controller.rb
@@ -27,6 +27,11 @@ module Spree
         target = object || @object
         spree.admin_policy_url(target&.id, options)
       end
+
+      def edit_object_url(object = nil, options = {})
+        target = object || @object
+        spree.edit_admin_policy_url(target&.id, options)
+      end
     end
   end
 end


### PR DESCRIPTION
We must have edit policy URL with ID, not slug, because having two policies with same slug but different owner can result with creating URL to invalid resource.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized routing change affecting only admin policy edit URL generation; low likelihood of side effects beyond redirects/links.
> 
> **Overview**
> Admin policy edit URL generation is changed by overriding `edit_object_url` in `Spree::Admin::PoliciesController` to call `spree.edit_admin_policy_url(target&.id, ...)`.
> 
> This aligns edit redirects/links with the existing `object_url` override and avoids collisions when multiple policies share the same slug under different owners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 389cf8314a069d7e92edc844047db5f7c5f25afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->