### PR TITLE
ADD event for tags

### DIFF
--- a/spree/core/app/services/spree/tags/bulk_add.rb
+++ b/spree/core/app/services/spree/tags/bulk_add.rb
@@ -42,7 +42,7 @@ module Spree
 
         record_class.where(id: records.pluck(:id)).touch_all
 
-        Spree::Events.publish('tagging.bulk_created', { tagging_ids: tagging_ids })
+        Spree::Events.publish('tagging.bulk_created', { tagging_ids: tagging_ids }) if tagging_ids.any?
 
         tagging_ids
       end

--- a/spree/core/app/services/spree/tags/bulk_remove.rb
+++ b/spree/core/app/services/spree/tags/bulk_remove.rb
@@ -9,15 +9,24 @@ module Spree
         return if tag_ids.empty?
 
         record_class = records.first.class
+        record_ids = records.pluck(:id)
 
-        ActsAsTaggableOn::Tagging.where(
-          taggable_id: records.pluck(:id),
+        taggings_scope = ActsAsTaggableOn::Tagging.where(
+          taggable_id: record_ids,
           taggable_type: record_class.to_s,
           context: context,
           tag_id: tag_ids
-        ).delete_all
+        )
 
-        record_class.where(id: records.pluck(:id)).touch_all
+        taggings_data = taggings_scope.select(:id, :tag_id, :taggable_id, :taggable_type, :context).map do |t|
+          { id: t.id, tag_id: t.tag_id, taggable_id: t.taggable_id, taggable_type: t.taggable_type, context: t.context }
+        end
+
+        taggings_scope.delete_all
+
+        record_class.where(id: record_ids).touch_all
+
+        Spree::Events.publish('tagging.bulk_removed', { taggings: taggings_data }) if taggings_data.any?
       end
     end
   end

--- a/spree/core/spec/services/spree/tags/bulk_add_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_add_spec.rb
@@ -38,17 +38,6 @@ module Spree
         subject
       end
 
-      context 'when all taggings already exist' do
-        before do
-          described_class.call(tag_names: tag_names, records: products, context: context)
-        end
-
-        it 'does not publish event' do
-          expect(Spree::Events).not_to receive(:publish)
-          subject
-        end
-      end
-
       context 'when tag names are duplicated or have extra spaces' do
         let(:tag_names) { ['tag1', ' tag2 ', 'tag1', 'tag3'] }
 

--- a/spree/core/spec/services/spree/tags/bulk_add_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_add_spec.rb
@@ -38,6 +38,17 @@ module Spree
         subject
       end
 
+      context 'when all taggings already exist' do
+        before do
+          described_class.call(tag_names: tag_names, records: products, context: context)
+        end
+
+        it 'does not publish event' do
+          expect(Spree::Events).not_to receive(:publish)
+          subject
+        end
+      end
+
       context 'when tag names are duplicated or have extra spaces' do
         let(:tag_names) { ['tag1', ' tag2 ', 'tag1', 'tag3'] }
 

--- a/spree/core/spec/services/spree/tags/bulk_add_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_add_spec.rb
@@ -33,6 +33,11 @@ module Spree
         expect { subject }.to change { Spree::Product.where(id: products.pluck(:id)).pluck(:updated_at) }
       end
 
+      it 'publishes tagging.bulk_created event' do
+        expect(Spree::Events).to receive(:publish).with('tagging.bulk_created', hash_including(:tagging_ids))
+        subject
+      end
+
       context 'when tag names are duplicated or have extra spaces' do
         let(:tag_names) { ['tag1', ' tag2 ', 'tag1', 'tag3'] }
 

--- a/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
@@ -10,8 +10,7 @@ module Spree
       subject { described_class.call(tag_names: tag_names, records: products, context: context) }
 
       before do
-        # Add tags to products initially
-        Spree::Tags::BulkAdd.call(tag_names: tag_names, records: products, context: context)
+        Spree::Tags::BulkAdd.call(tag_names: ['tag1', 'tag2', 'tag3'], records: products, context: context)
       end
 
       it 'removes taggings for each product-tag pair' do

--- a/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
@@ -32,9 +32,20 @@ module Spree
       it 'touches all products' do
         expect { subject }.to change { Spree::Product.where(id: products.pluck(:id)).pluck(:updated_at) }
       end
+<<<<<<< Updated upstream:backend/engines/core/spec/services/spree/tags/bulk_remove_spec.rb
 
       it 'publishes tagging.bulk_removed event' do
         expect(Spree::Events).to receive(:publish).with('tagging.bulk_removed', hash_including(:taggings))
+=======
+<<<<<<< Updated upstream:core/spec/services/spree/tags/bulk_remove_spec.rb
+=======
+
+      it 'publishes tagging.bulk_removed event' do
+        expect(Spree::Events).to receive(:publish).with(
+          'tagging.bulk_removed',
+          hash_including(:taggings, :taggable_type, :context)
+        )
+>>>>>>> Stashed changes:core/spec/services/spree/tags/bulk_remove_spec.rb
         subject
       end
 
@@ -50,6 +61,10 @@ module Spree
           subject
         end
       end
+<<<<<<< Updated upstream:backend/engines/core/spec/services/spree/tags/bulk_remove_spec.rb
+=======
+>>>>>>> Stashed changes:backend/engines/core/spec/services/spree/tags/bulk_remove_spec.rb
+>>>>>>> Stashed changes:core/spec/services/spree/tags/bulk_remove_spec.rb
     end
   end
 end

--- a/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
@@ -32,20 +32,12 @@ module Spree
       it 'touches all products' do
         expect { subject }.to change { Spree::Product.where(id: products.pluck(:id)).pluck(:updated_at) }
       end
-<<<<<<< Updated upstream:backend/engines/core/spec/services/spree/tags/bulk_remove_spec.rb
-
-      it 'publishes tagging.bulk_removed event' do
-        expect(Spree::Events).to receive(:publish).with('tagging.bulk_removed', hash_including(:taggings))
-=======
-<<<<<<< Updated upstream:core/spec/services/spree/tags/bulk_remove_spec.rb
-=======
 
       it 'publishes tagging.bulk_removed event' do
         expect(Spree::Events).to receive(:publish).with(
           'tagging.bulk_removed',
           hash_including(:taggings, :taggable_type, :context)
         )
->>>>>>> Stashed changes:core/spec/services/spree/tags/bulk_remove_spec.rb
         subject
       end
 
@@ -61,10 +53,6 @@ module Spree
           subject
         end
       end
-<<<<<<< Updated upstream:backend/engines/core/spec/services/spree/tags/bulk_remove_spec.rb
-=======
->>>>>>> Stashed changes:backend/engines/core/spec/services/spree/tags/bulk_remove_spec.rb
->>>>>>> Stashed changes:core/spec/services/spree/tags/bulk_remove_spec.rb
     end
   end
 end

--- a/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
+++ b/spree/core/spec/services/spree/tags/bulk_remove_spec.rb
@@ -32,6 +32,24 @@ module Spree
       it 'touches all products' do
         expect { subject }.to change { Spree::Product.where(id: products.pluck(:id)).pluck(:updated_at) }
       end
+
+      it 'publishes tagging.bulk_removed event' do
+        expect(Spree::Events).to receive(:publish).with('tagging.bulk_removed', hash_including(:taggings))
+        subject
+      end
+
+      context 'when tags do not exist' do
+        let(:tag_names) { ['nonexistent_tag'] }
+
+        it 'does not remove any taggings' do
+          expect { subject }.not_to change { ActsAsTaggableOn::Tagging.count }
+        end
+
+        it 'does not publish event' do
+          expect(Spree::Events).not_to receive(:publish)
+          subject
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core tagging write paths and introduces event side effects; incorrect scoping/deduping could lead to missed events or unexpected tagging persistence.
> 
> **Overview**
> Bulk tag operations now emit events: `Spree::Tags::BulkAdd` publishes `tagging.bulk_created` with newly created tagging IDs, and `Spree::Tags::BulkRemove` publishes `tagging.bulk_removed` with details of deleted taggings (plus `taggable_type`/`context`).
> 
> `BulkAdd` is updated to pre-check existing taggings for the target records/tags and only `insert_all` missing pairs (skipping duplicates), while still touching affected records; specs are expanded to cover event emission and no-op/partial-add scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50eca868bfe887a30dd89bf91a82b2082e9ee213. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->