### PR TITLE
Add deprecation warnings to legacy functionality (Spree 5.5)

### DIFF
--- a/backend/engines/core/app/models/spree/ability.rb
+++ b/backend/engines/core/app/models/spree/ability.rb
@@ -30,11 +30,21 @@ module Spree
     # modify the default +Ability+ of an application.  The +ability+ argument must be a class that includes
     # the +CanCan::Ability+ module.  The registered ability should behave properly as a stand-alone class
     # and therefore should be easy to test in isolation.
+    # @deprecated Use Spree::PermissionSets instead. Will be removed in Spree 5.5.
     def self.register_ability(ability)
+      Spree::Deprecation.warn(
+        'Spree::Ability.register_ability is deprecated and will be removed in Spree 5.5. ' \
+        'Please use Spree::PermissionSets instead. See Spree::PermissionSets::Base for details.'
+      )
       abilities.add(ability)
     end
 
+    # @deprecated Use Spree::PermissionSets instead. Will be removed in Spree 5.5.
     def self.remove_ability(ability)
+      Spree::Deprecation.warn(
+        'Spree::Ability.remove_ability is deprecated and will be removed in Spree 5.5. ' \
+        'Please use Spree::PermissionSets instead. See Spree::PermissionSets::Base for details.'
+      )
       abilities.delete(ability)
     end
 

--- a/backend/engines/core/app/models/spree/store.rb
+++ b/backend/engines/core/app/models/spree/store.rb
@@ -204,14 +204,17 @@ module Spree
       end
     end
 
-    # FIXME: we need to drop `or_initialize` in v5
-    # this behaviour is very buggy and unpredictable
+    # @deprecated The or_initialize behavior will be removed in Spree 5.5.
     def self.default
       Rails.cache.fetch('default_store') do
         # workaround for Mobility bug with first_or_initialize
         if where(default: true).any?
           where(default: true).first
         else
+          Spree::Deprecation.warn(
+            'Spree::Store.default returning a new unpersisted store when no default store exists is deprecated ' \
+            'and will be removed in Spree 5.5. Please ensure a default store is created before calling Store.default.'
+          )
           new(default: true)
         end
       end

--- a/backend/engines/core/app/models/spree/taxon.rb
+++ b/backend/engines/core/app/models/spree/taxon.rb
@@ -38,7 +38,8 @@ module Spree
     has_one :store, through: :taxonomy
     has_many :classifications, -> { order(:position) }, dependent: :destroy_async, inverse_of: :taxon
     has_many :products, through: :classifications
-    has_one :icon, as: :viewable, dependent: :destroy, class_name: 'Spree::TaxonImage' # TODO: remove this as this is deprecated
+    # @deprecated Use Spree::Taxon#image (Active Storage) instead. Will be removed in Spree 5.5.
+    has_one :icon, as: :viewable, dependent: :destroy, class_name: 'Spree::TaxonImage'
 
     has_many :prototype_taxons, class_name: 'Spree::PrototypeTaxon', dependent: :destroy
     has_many :prototypes, through: :prototype_taxons, class_name: 'Spree::Prototype'

--- a/backend/engines/core/app/models/spree/taxon_image.rb
+++ b/backend/engines/core/app/models/spree/taxon_image.rb
@@ -1,8 +1,16 @@
 module Spree
+  # @deprecated Use Spree::Taxon#image (Active Storage) instead. Will be removed in Spree 5.5.
   class TaxonImage < Asset
     include Spree::TaxonImage::Configuration::ActiveStorage
     include Rails.application.routes.url_helpers
     include Spree::ImageMethods
+
+    after_initialize do
+      Spree::Deprecation.warn(
+        'Spree::TaxonImage is deprecated and will be removed in Spree 5.5. ' \
+        'Please use Spree::Taxon#image (Active Storage) instead.'
+      )
+    end
 
     def styles
       self.class.styles.map do |_, size|

--- a/backend/engines/core/lib/spree/webhooks.rb
+++ b/backend/engines/core/lib/spree/webhooks.rb
@@ -1,7 +1,7 @@
 module Spree
   module Webhooks
     def self.disable_webhooks
-      Spree::Deprecation.warn('Spree::Webhooks.disable_webhooks is deprecated. Use Spree::LegacyWebhooks.disable_webhooks instead.')
+      Spree::Deprecation.warn('Spree::Webhooks.disable_webhooks is deprecated and will be removed in Spree 5.5. Use Spree::LegacyWebhooks.disable_webhooks instead.')
       prev_value = disabled?
       RequestStore.store[:disable_spree_legacy_webhooks] = true
       yield
@@ -10,12 +10,12 @@ module Spree
     end
 
     def self.disabled?
-      Spree::Deprecation.warn('Spree::Webhooks.disabled? is deprecated. Use Spree::LegacyWebhooks.disabled? instead.')
+      Spree::Deprecation.warn('Spree::Webhooks.disabled? is deprecated and will be removed in Spree 5.5. Use Spree::LegacyWebhooks.disabled? instead.')
       RequestStore.fetch(:disable_spree_legacy_webhooks) { false }
     end
 
     def self.disabled=(value)
-      Spree::Deprecation.warn('Spree::Webhooks.disabled= is deprecated. Use Spree::LegacyWebhooks.disabled= instead.')
+      Spree::Deprecation.warn('Spree::Webhooks.disabled= is deprecated and will be removed in Spree 5.5. Use Spree::LegacyWebhooks.disabled= instead.')
       RequestStore.store[:disable_spree_legacy_webhooks] = value
     end
   end


### PR DESCRIPTION
## Summary

Add `Spree::Deprecation.warn` calls to four pieces of overdue legacy code that developers need to migrate away from before Spree 5.5. These were either explicitly marked for removal in earlier versions or have had long-standing FIXME comments.

**Changes:**
- `Spree::Ability.register_ability/remove_ability` — legacy permission system, use `Spree::PermissionSets` instead
- `Spree::Store.default` — unpersisted store fallback behavior, ensure default store exists before calling
- `Spree::Taxon#icon` and `Spree::TaxonImage` — use Active Storage `image`/`square_image` attachments instead
- `Spree::Webhooks` module — use `Spree::LegacyWebhooks` instead

Developers will now see clear deprecation warnings with migration guidance when using these features.

## Test Plan

- [x] All existing tests pass
- [x] Deprecation warnings are triggered when the deprecated code paths are used
- [x] Warning messages provide clear migration guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)