### PR TITLE
Bump @spree/sdk and @spree/next to 0.2.1

### DIFF
--- a/packages/next/.changeset/add-payment-sessions.md
+++ b/packages/next/.changeset/add-payment-sessions.md
@@ -1,5 +1,0 @@
----
-"@spree/next": minor
----
-
-Add Payment Sessions server actions: `createPaymentSession`, `getPaymentSession`, `updatePaymentSession`, and `completePaymentSession`. Re-export `StorePaymentSession` and related param types from `@spree/sdk`.

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @spree/next
 
+## 0.2.1
+
+### Patch Changes
+
+- Add Payment Sessions server actions: `createPaymentSession`, `getPaymentSession`, `updatePaymentSession`, and `completePaymentSession`. Re-export `StorePaymentSession` and related param types from `@spree/sdk`.
+
+## 0.2.0
+
+### Minor Changes
+
+- Restructure to match @spree/sdk dual API namespace changes
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Next.js integration for Spree Commerce — server actions, caching, and cookie-based auth",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/.changeset/add-payment-sessions.md
+++ b/packages/sdk/.changeset/add-payment-sessions.md
@@ -1,5 +1,0 @@
----
-"@spree/sdk": minor
----
-
-Add Payment Sessions support: `client.store.orders.paymentSessions` with `create`, `get`, `update`, and `complete` methods. Add `session_required` field to `StorePaymentMethod` type. Add `CreatePaymentSessionParams`, `UpdatePaymentSessionParams`, and `CompletePaymentSessionParams` types.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/sdk
 
+## 0.2.1
+
+### Patch Changes
+
+- Add Payment Sessions support: `client.store.orders.paymentSessions` with `create`, `get`, `update`, and `complete` methods. Add `session_required` field to `StorePaymentMethod` type. Add `StorePaymentSession`, `CreatePaymentSessionParams`, `UpdatePaymentSessionParams`, and `CompletePaymentSessionParams` types.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Official TypeScript SDK for Spree Commerce API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Release Payment Sessions support in SDK (client.store.orders.paymentSessions) and Next.js server actions (createPaymentSession, getPaymentSession, etc.).