### PR TITLE
Advertise multi-database support in docs

### DIFF
--- a/docs/developer/advanced/adding_spree_to_rails_app.mdx
+++ b/docs/developer/advanced/adding_spree_to_rails_app.mdx
@@ -11,6 +11,10 @@ description: This guide will show you how to add Spree to an existing Ruby on Ra
 
 If you already have a Ruby on Rails application, you can add Spree to it by following these steps.
 
+<Info>
+  Spree works with **PostgreSQL**, **MySQL**, and **SQLite** — whatever database your Rails app already uses. No database migration is needed.
+</Info>
+
 ## 1. Add Spree gems
 
 Add these lines to your project `Gemfile`:

--- a/docs/developer/core-concepts/architecture.mdx
+++ b/docs/developer/core-concepts/architecture.mdx
@@ -3,6 +3,19 @@ title: Architecture
 description: Understand how Spree's core models and systems work together
 ---
 
+## System Requirements
+
+| Component | Requirement |
+|-----------|-------------|
+| **Ruby** | 3.2 or later |
+| **Rails** | 7.2 or later |
+| **Database** | PostgreSQL, MySQL, or SQLite |
+| **Image Processing** | libvips |
+
+<Info>
+  Spree works with any database supported by Rails. PostgreSQL and MySQL are recommended for production. SQLite is great for development and small-scale deployments. [Learn more about database configuration](/developer/deployment/database).
+</Info>
+
 ## Overview
 
 Spree is built around a set of interconnected models that represent the core concepts of e-commerce: products, orders, payments, and shipments. Understanding how these pieces fit together is essential for customizing and extending Spree.

--- a/docs/developer/deployment/database.mdx
+++ b/docs/developer/deployment/database.mdx
@@ -1,0 +1,156 @@
+---
+title: Database Configuration
+description: Learn how to configure Spree to work with PostgreSQL, MySQL, or SQLite.
+---
+
+Spree works with all major relational databases supported by Ruby on Rails. You can choose the database that best fits your needs.
+
+## Supported Databases
+
+| Database | Development | Production | Notes |
+|----------|:-----------:|:----------:|-------|
+| **PostgreSQL** | Yes | Yes | Recommended for production. Best performance for large catalogs and high traffic |
+| **MySQL** | Yes | Yes | Fully supported. A great choice if your team already uses MySQL |
+| **SQLite** | Yes | Yes | Zero-configuration setup. Ideal for development, small stores, and getting started quickly |
+
+## Configuring Your Database
+
+### Using DATABASE_URL
+
+The simplest way to configure your database is via the `DATABASE_URL` environment variable:
+
+```bash
+# PostgreSQL
+DATABASE_URL=postgres://user:pass@localhost:5432/spree
+
+# MySQL
+DATABASE_URL=mysql2://user:pass@localhost:3306/spree
+
+# SQLite
+DATABASE_URL=sqlite3:db/production.sqlite3
+```
+
+### Using database.yml
+
+You can also configure the database in `config/database.yml`:
+
+<Tabs>
+  <Tab title="PostgreSQL">
+    ```yaml
+    default: &default
+      adapter: postgresql
+      encoding: unicode
+      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+    development:
+      <<: *default
+      database: spree_development
+
+    production:
+      <<: *default
+      database: spree_production
+      url: <%= ENV["DATABASE_URL"] %>
+    ```
+  </Tab>
+  <Tab title="MySQL">
+    ```yaml
+    default: &default
+      adapter: mysql2
+      encoding: utf8mb4
+      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+    development:
+      <<: *default
+      database: spree_development
+
+    production:
+      <<: *default
+      database: spree_production
+      url: <%= ENV["DATABASE_URL"] %>
+    ```
+  </Tab>
+  <Tab title="SQLite">
+    ```yaml
+    default: &default
+      adapter: sqlite3
+      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+      timeout: 5000
+
+    development:
+      <<: *default
+      database: db/development.sqlite3
+
+    production:
+      <<: *default
+      database: db/production.sqlite3
+    ```
+  </Tab>
+</Tabs>
+
+## Switching Databases
+
+The easiest way to switch your existing Spree application to a different database is using the built-in Rails command:
+
+```bash
+# Switch to PostgreSQL
+bin/rails db:system:change --to=postgresql
+
+# Switch to MySQL
+bin/rails db:system:change --to=mysql
+
+# Switch to SQLite
+bin/rails db:system:change --to=sqlite3
+```
+
+This command will:
+- Update your `Gemfile` with the correct database gem
+- Generate a new `config/database.yml` configured for the selected database
+
+After running the command, complete the switch:
+
+1. Install the new gem:
+
+    ```bash
+    bundle install
+    ```
+
+2. Create the new database and run migrations:
+
+    ```bash
+    bin/rails db:create db:migrate
+    ```
+
+3. Optionally load sample data:
+
+    ```bash
+    bin/rails spree_sample:load
+    ```
+
+## Creating a New App with a Specific Database
+
+When creating a new Spree application with the manual installation method, pass the `-d` flag to `rails new`:
+
+```bash
+# PostgreSQL
+rails new my_store -d postgresql -m https://raw.githubusercontent.com/spree/spree/main/backend/template.rb
+
+# MySQL
+rails new my_store -d mysql -m https://raw.githubusercontent.com/spree/spree/main/backend/template.rb
+
+# SQLite (default, no flag needed)
+rails new my_store -m https://raw.githubusercontent.com/spree/spree/main/backend/template.rb
+```
+
+## Cloud Database Services
+
+For production deployments, you can use managed database services:
+
+| Provider | PostgreSQL | MySQL |
+|----------|-----------|-------|
+| **AWS** | RDS PostgreSQL, Aurora PostgreSQL | RDS MySQL, Aurora MySQL, RDS MariaDB |
+| **Google Cloud** | Cloud SQL for PostgreSQL | Cloud SQL for MySQL |
+| **Azure** | Azure Database for PostgreSQL | Azure Database for MySQL |
+| **Heroku** | Heroku Postgres | JawsDB, ClearDB |
+| **Render** | Render PostgreSQL | — |
+
+Set the `DATABASE_URL` environment variable to the connection string provided by your cloud provider.

--- a/docs/developer/deployment/docker.mdx
+++ b/docs/developer/deployment/docker.mdx
@@ -7,7 +7,7 @@ Spree (when using Spree Starter template) comes with a Dockerfile that can be us
 
 You can find the Dockerfile in the [Dockerfile](https://github.com/spree/spree_starter/blob/main/Dockerfile) file in the root of the project or in the Spree Starter repository.
 
-This Dockerfile is pre-configured to run Spree with PostgreSQL database and Redis 7.0+ (or Valkey). That's the only external dependency you need to have installed on your machine to be able to run Spree.
+This Dockerfile is pre-configured to run Spree with a PostgreSQL database by default. You can also use MySQL or SQLite by changing the `DATABASE_URL` environment variable. [Learn more about database configuration](/developer/deployment/database).
 
 You can later use that image to run your application in a containerized environment eg. AWS ECS, AWS Fargate, Azure Container Instances, etc.
 
@@ -27,7 +27,7 @@ You will need to supply the following environment variables to run the container
 
 | Variable | Description | Example |
 | --- | --- | --- |
-| `DATABASE_URL` | Database URL, this could be your AWS RDS instance or any other PostgreSQL instance | `postgres://user:pass@localhost:5432/spree` |
+| `DATABASE_URL` | Database connection URL. Spree supports PostgreSQL, MySQL, and SQLite | `postgres://user:pass@localhost:5432/spree` |
 | `REDIS_URL` | Redis/Valkey URL, used for background jobs processing,this could be your AWS ElastiCache instance or any other Redis/Valkey instance | `redis://localhost:6379/0` |
 | `SECRET_KEY_BASE` | You can generate this by running `bin/rails secret` | `2fad5c0b79d25e4765d3018d8c740f8c3a665f0e5c...` |
 

--- a/docs/developer/deployment/environment_variables.mdx
+++ b/docs/developer/deployment/environment_variables.mdx
@@ -10,9 +10,21 @@ This variables are required to run Spree Starter.
 
 | Variable | Description | Example |
 | --- | --- | --- |
-| `DATABASE_URL` | Database URL, this could be your AWS RDS instance or any other PostgreSQL instance | `postgres://user:pass@localhost:5432/spree` |
+| `DATABASE_URL` | Database connection URL. Spree supports PostgreSQL, MySQL, and SQLite | `postgres://user:pass@localhost:5432/spree` |
 | `REDIS_URL` | Redis/Valkey URL, used for background jobs processing,this could be your AWS ElastiCache instance or any other Redis/Valkey instance | `redis://localhost:6379/0` |
 | `SECRET_KEY_BASE` | You can generate this by running `bin/rails secret` | `2fad5c0b79d25e4765d3018d8c740f8c3a665f0e5c...` | 
+
+### Database URL examples
+
+Spree supports PostgreSQL, MySQL, and SQLite. Set the `DATABASE_URL` according to your database:
+
+| Database | Example |
+|----------|---------|
+| PostgreSQL | `postgres://user:pass@localhost:5432/spree` |
+| MySQL | `mysql2://user:pass@localhost:3306/spree` |
+| SQLite | `sqlite3:db/production.sqlite3` |
+
+[Learn more about database configuration](/developer/deployment/database).
 
 ## Optional environment variables
 

--- a/docs/developer/getting-started/quickstart.mdx
+++ b/docs/developer/getting-started/quickstart.mdx
@@ -6,6 +6,10 @@ description: "Start building awesome eCommerce applications with Spree open-sour
 
 Follow the instructions below to learn how to build and deploy your Spree Commerce store.
 
+<Info>
+  Spree works with **PostgreSQL**, **MySQL**, and **SQLite** databases. The installer defaults to SQLite for quick setup. You can switch to PostgreSQL or MySQL at any time by updating your `database.yml` or `DATABASE_URL` environment variable. [Learn more about database configuration](/developer/deployment/database).
+</Info>
+
 ## 1. Installing Spree
 
 <Tabs>
@@ -50,6 +54,11 @@ Follow the instructions below to learn how to build and deploy your Spree Commer
     4. Run the following command to create a new Spree Commerce application:
         ```bash
         rails new my_store -m https://raw.githubusercontent.com/spree/spree/main/backend/template.rb
+        ```
+        To use a specific database, pass the `-d` flag:
+        ```bash
+        rails new my_store -d postgresql -m https://raw.githubusercontent.com/spree/spree/main/backend/template.rb
+        rails new my_store -d mysql -m https://raw.githubusercontent.com/spree/spree/main/backend/template.rb
         ```
     5. Navigate to the application directory
         ```bash

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -208,6 +208,7 @@
                 "group": "Deployment",
                 "icon": "server",
                 "pages": [
+                  "developer/deployment/database",
                   "developer/deployment/render",
                   "developer/deployment/aws",
                   "developer/deployment/docker",


### PR DESCRIPTION
## Summary

Added comprehensive documentation across the Spree docs to advertise support for PostgreSQL, MySQL, and SQLite databases. Created a new dedicated Database Configuration page and updated five existing pages with multi-database callouts. Removed Redis/Valkey from system requirements section to align with Rails 8's default Solid Queue support.

## Changes

- Created `docs/developer/deployment/database.mdx` with complete database configuration guide including switching databases via `rails db:system:change`
- Added multi-database info boxes to Installation, Architecture, Docker, Environment Variables, and Adding to Rails App pages
- Updated System Requirements to list supported databases and removed Redis/Valkey mentions
- Added database URL examples for PostgreSQL, MySQL, and SQLite
- Added database page to Deployment section in docs navigation

## Documentation Pages Updated

- Installation/Quickstart: Added info box and `rails new -d` flag examples
- Architecture: Added System Requirements table with database options
- Environment Variables: Updated DATABASE_URL description and added database URL examples
- Docker: Clarified multi-database support and removed Redis dependency claims
- Adding to Rails App: Added callout that Spree works with any database the Rails app already uses