### PR TITLE
Fixed Taxon Products API scope

### DIFF
--- a/backend/engines/api/app/controllers/spree/api/v3/store/taxons/products_controller.rb
+++ b/backend/engines/api/app/controllers/spree/api/v3/store/taxons/products_controller.rb
@@ -13,14 +13,7 @@ module Spree
             end
 
             def scope
-              Spree::Product.
-                in_taxon(@taxon).
-                for_store(current_store).
-                accessible_by(current_ability, :show).
-                available(Time.current, Spree::Current.currency).
-                includes(scope_includes).
-                preload_associations_lazily.
-                i18n
+              super.in_taxon(@taxon)
             end
 
             private

--- a/backend/engines/api/spec/controllers/spree/api/v3/store/taxons/products_controller_spec.rb
+++ b/backend/engines/api/spec/controllers/spree/api/v3/store/taxons/products_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Spree::Api::V3::Store::Taxons::ProductsController, type: :control
   let!(:product_in_taxon) { create(:product, stores: [store], taxons: [taxon]) }
   let!(:product_in_child_taxon) { create(:product, stores: [store], taxons: [child_taxon]) }
   let!(:product_not_in_taxon) { create(:product, stores: [store]) }
+  let!(:inactive_product_in_taxon) { create(:product, stores: [store], taxons: [taxon], status: 'draft') }
 
   let!(:other_store) { create(:store) }
   let!(:other_taxonomy) { create(:taxonomy, store: other_store) }
@@ -23,12 +24,13 @@ RSpec.describe Spree::Api::V3::Store::Taxons::ProductsController, type: :control
 
   describe 'GET #index' do
     context 'finding taxon by permalink' do
-      it 'returns products belonging to the taxon' do
+      it 'returns active products belonging to the taxon' do
         get :index, params: { taxon_id: taxon.permalink }
 
         expect(response).to have_http_status(:ok)
         expect(json_response['data'].pluck('id')).to include(product_in_taxon.prefixed_id)
         expect(json_response['data'].pluck('id')).not_to include(product_not_in_taxon.prefixed_id)
+        expect(json_response['data'].pluck('id')).not_to include(inactive_product_in_taxon.prefixed_id)
       end
 
       it 'returns products from descendant taxons' do


### PR DESCRIPTION
We previously simplified the scope to fetch products in the main Products API https://github.com/spree/spree/commit/f5c0df48425bc28042ebf16c5297ff399e2b5818 but we forgot to do it in the Taxon Products endpoint, now it's fixed!