### PR TITLE
Deprecate unused utilities for 5.5 removal

### DIFF
--- a/backend/engines/core/app/helpers/spree/base_helper.rb
+++ b/backend/engines/core/app/helpers/spree/base_helper.rb
@@ -204,7 +204,8 @@ module Spree
     end
 
     def maximum_quantity
-      Spree::DatabaseTypeUtilities.maximum_value_for(:integer)
+      Spree::Deprecation.warn('BaseHelper#maximum_quantity is deprecated and will be removed in Spree 5.5')
+      Spree::DatabaseTypeUtilities::INTEGER_MAX
     end
 
     def payment_method_icon_tag(payment_method, opts = {})

--- a/backend/engines/core/app/models/spree/line_item.rb
+++ b/backend/engines/core/app/models/spree/line_item.rb
@@ -30,10 +30,12 @@ module Spree
 
     validates :variant, :order, presence: true
 
+    DB_INTEGER_MAX = (2**31) - 1
+
     # numericality: :less_than_or_equal_to validation is due to the restriction at the database level
     #   https://github.com/spree/spree/issues/2695#issuecomment-143314161
     validates :quantity, numericality: {
-      in: 0..DatabaseTypeUtilities.maximum_value_for(:integer),
+      in: 0..DB_INTEGER_MAX,
       only_integer: true, message: Spree.t('validation.must_be_int')
     }
 
@@ -226,7 +228,7 @@ module Spree
     #
     # @return [Integer]
     def maximum_quantity
-      @maximum_quantity ||= variant.backorderable? ? Spree::DatabaseTypeUtilities.maximum_value_for(:integer) : variant.total_on_hand
+      @maximum_quantity ||= variant.backorderable? ? DB_INTEGER_MAX : variant.total_on_hand
     end
 
     # Returns true if the line item variant has digital assets

--- a/backend/engines/core/lib/spree/core/controller_helpers/currency.rb
+++ b/backend/engines/core/lib/spree/core/controller_helpers/currency.rb
@@ -39,8 +39,13 @@ module Spree
         end
 
         # Returns the list of supported currencies for all stores.
+        # @deprecated This method will be removed in Spree 5.5.
         # @return [Array<String>] the list of supported currencies, eg. `["USD", "EUR"]`
         def supported_currencies_for_all_stores
+          Spree::Deprecation.warn(
+            'supported_currencies_for_all_stores is deprecated and will be removed in Spree 5.5.'
+          )
+
           @supported_currencies_for_all_stores ||= begin
             (
               Spree::Store.pluck(:supported_currencies).map { |c| c&.split(',') }.flatten + Spree::Store.pluck(:default_currency)

--- a/backend/engines/core/lib/spree/core/controller_helpers/order.rb
+++ b/backend/engines/core/lib/spree/core/controller_helpers/order.rb
@@ -15,8 +15,12 @@ module Spree
           @order_token ||= cookies.signed[:token] || params[:order_token]
         end
 
-        # Used in the link_to_cart helper.
+        # @deprecated Use `current_order` instead. This method will be removed in Spree 5.5.
         def simple_current_order
+          Spree::Deprecation.warn(
+            'simple_current_order is deprecated and will be removed in Spree 5.5. Use current_order instead.'
+          )
+
           return @simple_current_order if @simple_current_order
 
           @simple_current_order = find_order_by_token_or_user

--- a/backend/engines/core/lib/spree/database_type_utilities.rb
+++ b/backend/engines/core/lib/spree/database_type_utilities.rb
@@ -1,9 +1,16 @@
 module Spree
+  # @deprecated Use the integer constant directly instead, eg. `2_147_483_647` for 4-byte signed integer max.
+  #   This module will be removed in Spree 5.5.
   module DatabaseTypeUtilities
     # Maximum value for a 4-byte signed integer (default database integer type)
     INTEGER_MAX = (2**31) - 1
 
     def self.maximum_value_for(data_type)
+      Spree::Deprecation.warn(
+        'Spree::DatabaseTypeUtilities.maximum_value_for is deprecated and will be removed in Spree 5.5. ' \
+        'Use the integer constant directly instead, eg. 2_147_483_647 for 4-byte signed integer max.'
+      )
+
       case data_type
       when :integer
         INTEGER_MAX

--- a/backend/engines/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/backend/engines/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -28,14 +28,23 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
   let!(:store) { @default_store }
 
   describe '#simple_current_order' do
-    before { allow(controller).to receive_messages(try_spree_current_user: user) }
+    before do
+      allow(controller).to receive_messages(try_spree_current_user: user)
+      allow(Spree::Deprecation).to receive(:warn)
+    end
 
     it 'returns an empty order' do
       expect(controller.simple_current_order.item_count).to eq 0
     end
+
     it 'returns Spree::Order instance' do
       allow(controller).to receive_messages(cookies: double(signed: { token: order.token }))
       expect(controller.simple_current_order).to eq order
+    end
+
+    it 'emits a deprecation warning' do
+      controller.simple_current_order
+      expect(Spree::Deprecation).to have_received(:warn).with(/simple_current_order is deprecated/)
     end
   end
 


### PR DESCRIPTION
## Summary

Deprecates three unused utilities scheduled for removal in Spree 5.5:

- **DatabaseTypeUtilities.maximum_value_for**: Replaced with direct integer constants. Internal usages in LineItem now use a local DB_INTEGER_MAX constant.
- **supported_currencies_for_all_stores**: Unused helper method with no callers in the codebase.
- **simple_current_order**: Legacy method designed for a link_to_cart helper that no longer exists. Users should use `current_order` instead.

All deprecated methods emit Spree::Deprecation warnings to guide users toward alternatives.

## Test plan

- All existing tests pass with deprecation warnings properly emitted
- Added explicit test for simple_current_order deprecation warning