### PR TITLE
Fix deleting products w/o translations on non-default locale

### DIFF
--- a/backend/engines/core/app/models/spree/product/slugs.rb
+++ b/backend/engines/core/app/models/spree/product/slugs.rb
@@ -103,7 +103,7 @@ module Spree
         translations.with_deleted.each { |rec| rec.update_columns(slug: new_slug.call(rec)) }
         slugs.with_deleted.each { |rec| rec.update_column(:slug, new_slug.call(rec)) }
 
-        translations.find_by!(locale: I18n.locale).update_column(:slug, slug) if Spree.use_translations?
+        translations.find_by(locale: I18n.locale)&.update_column(:slug, slug) if Spree.use_translations?
       end
     end
   end


### PR DESCRIPTION
Deleting a product stops when trying to remove it on a store's non-default locale and the translations for current locale doesn't exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to slug-updating during destroy plus test coverage; low risk aside from subtle slug-history behavior during deletion.
> 
> **Overview**
> Fixes a product-deletion edge case where `punch_slugs` would raise when `Spree.use_translations?` is enabled but the current locale has no translation row.
> 
> This makes the current-locale translation slug update nil-safe and adds specs covering deletion on a non-default locale both when a translation exists (slug is renamed) and when it does not (deletion proceeds without creating translations).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26f861470f5cb2113c7a2968f1e2fc7eaaf0f588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->