### PR TITLE
Fix admin export to apply filters correctly

### DIFF
--- a/backend/engines/admin/app/views/spree/admin/tables/_table.html.erb
+++ b/backend/engines/admin/app/views/spree/admin/tables/_table.html.erb
@@ -6,11 +6,10 @@
 <% search_placeholder = (table.respond_to?(:search_placeholder) && table.search_placeholder) || [Spree.t(:search), controller_name.humanize.downcase].join(' ') %>
 <% date_range_param = table.date_range_param %>
 
-<% if export_type.present? %>
-  <%= render 'spree/admin/shared/export_modal', export_type: export_type %>
-<% end %>
-
 <%= turbo_frame_tag frame_name, data: { turbo_action: 'advance' } do %>
+  <% if export_type.present? %>
+    <%= render 'spree/admin/shared/export_modal', export_type: export_type %>
+  <% end %>
   <div class="<%= local_assigns[:container_class] || 'card-lg' %>" data-controller="table" data-table-url-value="<%= request.path %>">
     <div class="p-3 border-b border-gray-200">
       <div class="flex flex-col lg:flex-row gap-3 items-start lg:items-center justify-between">

--- a/backend/engines/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/engines/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -75,6 +75,17 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
 
         expect(response).to be_successful
       end
+
+      it 'renders the export dialog inside the table turbo frame with search params' do
+        get :index, params: { q: { multi_search: 'test-filter' } }
+
+        doc = Nokogiri::HTML(response.body)
+        table_frame = doc.at_css('turbo-frame#products')
+        export_frame = table_frame&.at_css('turbo-frame#export_dialog')
+
+        expect(export_frame).to be_present
+        expect(CGI.unescape(export_frame['src'])).to include('test-filter')
+      end
     end
 
     describe 'sorting by price' do


### PR DESCRIPTION
## Summary
When exporting records from admin tables with filters applied, all records were exported instead of just the filtered ones.

## Root Cause
The export modal was rendered outside the table's turbo frame. When users applied filters (search, date range, query builder), only the turbo frame content was refreshed, leaving the export modal with stale search parameters from the initial page load.

## Solution
Moved the export modal rendering inside the turbo frame so it gets re-rendered with updated `params[:q]` whenever filters are applied.

## Test
Added a test that verifies the export dialog is rendered inside the turbo frame and contains current search parameters.

---
Generated by Claude Code