### PR TITLE
Fix Google feed excluding simple products without option variants

### DIFF
--- a/backend/engines/core/app/models/spree/variant.rb
+++ b/backend/engines/core/app/models/spree/variant.rb
@@ -95,12 +95,9 @@ module Spree
     scope :in_stock_or_backorderable, -> { in_stock.or(backorderable) }
 
     scope :eligible, lambda {
-      where(is_master: false).or(
-        where(
-          product_id: Spree::Variant.
-                      select(:product_id).
-                      group(:product_id).
-                      having("COUNT(#{Spree::Variant.table_name}.id) = 1")
+      joins(:product).where(
+        arel_table[:is_master].eq(false).or(
+          Spree::Product.arel_table[:variant_count].eq(0)
         )
       )
     }

--- a/backend/engines/core/app/services/spree/data_feeds/google/rss.rb
+++ b/backend/engines/core/app/services/spree/data_feeds/google/rss.rb
@@ -18,7 +18,9 @@ module Spree
                 result = products_list.call(store)
                 if result.success?
                   result.value[:products].find_each do |product|
-                    product.variants.active.find_each do |variant|
+                    product.variants_including_master.active.find_each do |variant|
+                      next if variant.is_master? && product.has_variants?
+
                       add_variant_information_to_xml(xml, product, variant)
                     end
                   end

--- a/backend/engines/core/spec/services/spree/data_feeds/google/rss_spec.rb
+++ b/backend/engines/core/spec/services/spree/data_feeds/google/rss_spec.rb
@@ -92,6 +92,24 @@ module Spree
       end
     end
 
+    context 'product with only master variant' do
+      let(:product) { create(:product, stores: [store]) }
+      let!(:variant) { nil }
+
+      before do
+        product.master.images << create(:image)
+        allow(subject).to receive(:store).and_return(store)
+      end
+
+      it 'includes master variant in feed' do
+        expect(result.value[:file]).to include("<g:id>#{product.master.id}</g:id>")
+      end
+
+      it 'includes product name as title' do
+        expect(result.value[:file]).to include("<g:title>#{product.name}</g:title>")
+      end
+    end
+
     context 'optional item attributes are generated correctly' do
       let(:product) { create(:product_with_properties, stores: [store]) }
 


### PR DESCRIPTION
## Summary

The Google Shopping feed was missing ~900 products because it only iterated over non-master variants, completely excluding simple products without option variants. Fixed to include master variants for simple products while properly filtering them out for products with real option variants.

Also optimized the `Variant.eligible` scope to use a JOIN with the counter cache instead of an expensive GROUP BY/HAVING subquery, improving query performance.

## Changes

- **rss.rb**: Changed from `product.variants.active` to `product.variants_including_master.active` with a guard clause (`next if variant.is_master? && product.has_variants?`) to skip dummy master variants only when real option variants exist
- **variant.rb**: Optimized `eligible` scope to use `joins(:product)` with `variant_count == 0` check instead of GROUP BY/HAVING subquery
- **rss_spec.rb**: Added test coverage for simple products with only master variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)