### PR TITLE
fix info banner in address form

### DIFF
--- a/backend/engines/core/app/views/spree/addresses/_form.html.erb
+++ b/backend/engines/core/app/views/spree/addresses/_form.html.erb
@@ -45,8 +45,7 @@
       </div>
       <%= render "spree/addresses/suggestions_box" %>
     </div>
-    <span class="text-sm space-x-2 items-center hidden alert alert-info mt-2 align-items-center" data-address-autocomplete-target="addressWarning">
-      <%= heroicon "exclamation-circle", variant: :outline if defined?(heroicon) %>
+    <span class="text-sm space-x-2 hidden alert alert-info mt-2 static" data-address-autocomplete-target="addressWarning">
       <%= Spree.t('address_book.add_house_number') %>
     </span>
   </div>


### PR DESCRIPTION
Before:
<img width="500" height="500" alt="Screenshot 2026-02-18 at 22 08 24" src="https://github.com/user-attachments/assets/e8082833-f4f1-4d81-b4ea-46e0b7b9dac5" />

After:
<img width="300" height="300" alt="Screenshot 2026-02-18 at 22 09 49" src="https://github.com/user-attachments/assets/d7a00a59-064c-440a-a235-9135948d4bc9" />

Also placed info banner behind autocomplete.
Before:
<img width="300" height="300" alt="Screenshot 2026-02-18 at 22 18 41" src="https://github.com/user-attachments/assets/bbdce9df-6bbd-4a27-a850-4e4c4acc9a07" />
After:
<img width="300" height="300" alt="Screenshot 2026-02-19 at 09 15 39" src="https://github.com/user-attachments/assets/13c8d71d-346d-4796-9696-c1937617e1e7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small view-only change affecting CSS/markup for an informational banner; no data handling or business logic changes.
> 
> **Overview**
> Adjusts the address form’s `addressWarning` info banner markup used by the address autocomplete flow.
> 
> Removes the (optional) `heroicon` icon and tweaks CSS classes (including adding `static`) so the banner displays correctly when toggled by `address_autocomplete_controller.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa1d20d2af3f8ade13a2f14b721c376b84ae1939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->