### PR TITLE
Fix price parsing for non-English locales

### DIFF
--- a/backend/engines/admin/app/javascript/spree/admin/controllers/money_field_controller.js
+++ b/backend/engines/admin/app/javascript/spree/admin/controllers/money_field_controller.js
@@ -4,11 +4,10 @@ import { Controller } from '@hotwired/stimulus'
  * MoneyFieldController
  *
  * A Stimulus controller for locale-aware money/price input fields.
- * Handles formatting for display and normalizing values before form submission.
+ * Handles formatting values for display in the user's locale format.
  *
  * Features:
  * - Displays amounts in the user's locale format (e.g., "1.234,56" for German, "1,234.56" for English)
- * - Normalizes values to standard decimal format (with "." as decimal separator) before form submission
  * - Supports optional currency symbol display
  *
  * Usage:
@@ -32,21 +31,8 @@ export default class extends Controller {
   }
 
   connect() {
-    this.form = this.element.closest('form')
-
-    if (this.form) {
-      this.boundNormalizeBeforeSubmit = this.normalizeBeforeSubmit.bind(this)
-      this.form.addEventListener('submit', this.boundNormalizeBeforeSubmit)
-    }
-
     // Format the initial value for display
     this.formatForDisplay()
-  }
-
-  disconnect() {
-    if (this.form && this.boundNormalizeBeforeSubmit) {
-      this.form.removeEventListener('submit', this.boundNormalizeBeforeSubmit)
-    }
   }
 
   /**
@@ -139,12 +125,4 @@ export default class extends Controller {
     return stringValue
   }
 
-  /**
-   * Normalizes the value before form submission
-   * @param {Event} event - The form submit event
-   */
-  normalizeBeforeSubmit(event) {
-    const normalizedValue = this.normalizeValue(this.element.value)
-    this.element.value = normalizedValue
-  }
 }

--- a/backend/engines/admin/spec/features/spree/admin/products/products_spec.rb
+++ b/backend/engines/admin/spec/features/spree/admin/products/products_spec.rb
@@ -208,6 +208,23 @@ describe 'Products', type: :feature do
         expect(product.master.stock_items.first.count_on_hand).to eq(10)
       end
 
+      context 'with non-English locale using comma as decimal separator', js: true do
+        before do
+          I18n.backend.store_translations(:de, number: { currency: { format: { separator: ',', delimiter: '.' } } })
+          allow(store).to receive(:default_locale).and_return('de')
+        end
+
+        it 'correctly saves price without multiplying by 100' do
+          visit spree.edit_admin_product_path(product)
+
+          fill_in 'product_master_attributes_prices_attributes_0_amount', with: '123,00'
+          within('#page-header') { click_button 'Update' }
+
+          expect(page).to have_content('successfully updated')
+          expect(product.reload.price_in('USD').amount).to eq(123.0)
+        end
+      end
+
       it 'allows adding new options', js: true do
         # Add the first option - Color
         find('span', text: Spree.t('admin.variants_form.add_option.empty')).click

--- a/backend/engines/core/spec/lib/spree/localized_number_spec.rb
+++ b/backend/engines/core/spec/lib/spree/localized_number_spec.rb
@@ -51,5 +51,16 @@ describe Spree::LocalizedNumber do
         expect(subject.class.parse('')).to be 0
       end
     end
+
+    context 'when input uses the locale decimal separator (as sent by money_field_controller.js)' do
+      it 'correctly parses comma-decimal values with German locale' do
+        allow(I18n).to receive(:locale).and_return(:de)
+        allow(I18n.config).to receive(:locale).and_return(:de)
+
+        # money_field_controller.js strips thousands separators but keeps the locale's decimal separator
+        expect(subject.class.parse('123,00')).to eq(123.0)
+        expect(subject.class.parse('1599,99')).to eq(1599.99)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #13626

## Problem

After upgrading to Spree 5.3.0, prices entered in non-English locales using comma as the decimal separator (German, Danish, French, etc.) were being multiplied by 100.

Example: Entering `123,00` in German admin saved as `12300.00` instead of `123.00`.

## Root Cause

The `money_field_controller.js` and `bulk_editor_controller.js` were normalizing all price input to English format (period as decimal separator) before form submission. However, the backend's `Spree::LocalizedNumber.parse()` expects locale-formatted input and uses `I18n.locale` to determine the decimal separator. This mismatch caused it to misinterpret `123.00` as `12300` when the locale was German.

## Solution

Remove the redundant JS normalization. Forms now submit values in the user's locale format, allowing `LocalizedNumber.parse` to handle them correctly. The backend already does all necessary parsing — locale detection, thousands separator stripping, and decimal conversion.

## Testing

- Added unit test: `LocalizedNumber.parse('123,00')` with German locale returns `123.0`
- Added feature test: Product edit with German locale, enter `123,00`, verify saved as `123.0`