### PR TITLE
Minor user documentation corrections

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1106,8 +1106,7 @@
                   "user/settings/payments",
                   "user/settings/zones",
                   "user/settings/shipping-methods",
-                  "user/settings/tax",
-                  "user/settings/returns-configuration"
+                  "user/settings/tax"
                 ]
               },
               {

--- a/docs/user/manage-products/product-taxonomies.mdx
+++ b/docs/user/manage-products/product-taxonomies.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Product Taxonomies"
-description: "How to manage product taxonomies in the Spree Commerce dashboard"
+title: "Taxonomies"
+description: "Learn how to create and manage product taxonomies in the Spree Commerce dashboard."
 ---
 
 Taxonomies let you organize products into groups like categories, brands, or collections.

--- a/docs/user/settings/returns-configuration.mdx
+++ b/docs/user/settings/returns-configuration.mdx
@@ -122,6 +122,6 @@ To delete a reimbursement type, simply open the Edit form as shown above and cli
 
 Now that you’ve defined all of your RMA reasons, refund reasons, and reimbursement types, you’ll be ready to process returns in the event that a customer requests them.
 
-To learn how to process returns, please refer to **Returns → Returns Processing**.
+To learn how to process returns, please refer to [Returns → Returns Processing](https://spreecommerce.org/docs/user/returns/returns-processing).
 
 

--- a/docs/user/settings/shipping-methods.mdx
+++ b/docs/user/settings/shipping-methods.mdx
@@ -85,7 +85,7 @@ This section determines how the shipping cost will be calculated for this method
 - **Flat Rate** - charges a fixed shipping amount, regardless of order size or value.
 - **Flexible Rate per package item** - charges a base rate plus an additional amount for each item in the package (ideal for variable-size orders).
 - **Flat Rate per package item** - Applies the same fixed fee to every item in the shipment.
-- **Price Sack** - offers tiered pricing based on the total order value (e.g., $5 for orders under $50, free over $100).
+- **Price Sack** - offers tiered pricing based on the total order value (e.g., \$5 for orders under \$50, free over \$100).
 - **Digital Delivery** - used for digital products that don’t require physical shipping (typically results in no shipping cost).
 
 Each calculator type may reveal different fields depending on its configuration. Choose the one that best aligns with your fulfillment strategy.
@@ -100,8 +100,6 @@ This optional setting allows you to display an estimated delivery time for the s
 
 While not required, showing delivery estimates can help build trust, reduce cart abandonment, and improve conversions by setting clear expectations about when customers will receive their orders.
 
-### Click Create
+### Create Shipping Method
 
 Once you’ve configured all of the above settings, simply click **Create** at the bottom of the page to save your new shipping method. It will become immediately available to customers provided the order details match the method’s configuration.
-
-Congratulations, you’ve just created your first shipping method!

--- a/docs/user/settings/store-details.mdx
+++ b/docs/user/settings/store-details.mdx
@@ -7,7 +7,7 @@ The Store Details section allows you to configure key settings that determine ho
 
 From your store’s name and logo to currency, locale, time zone, and units of measurement, this section is where you define your store’s identity and core operational preferences.
 
-To configure these settings, navigate to the Store Details tab of the Settings menu.
+To configure these settings, navigate to the **Settings → Store Details**.
 
 <img src="/images/user/settings/store-details/1.StoreDetails.png" />
 
@@ -16,7 +16,7 @@ To configure these settings, navigate to the Store Details tab of the Settings m
 <img src="/images/user/settings/store-details/2.NameandLogo.png" />
 
 - **Name**: This is the public-facing name of your store. It will appear in headers, footers, and other storefront areas.
-- **Logo**: Upload a store logo (recommended size: 240x240 px). This image is used only in the admin dashboard. For the storefront logo see Storefront Themes → Theme Editor.
+- **Logo**: Upload a store logo (recommended size: 240x240 px). This image is used only in the admin dashboard. To add a storefront logo, see [Storefront Themes → Theme Editor](https://spreecommerce.org/docs/user/storefront/theme-editor#page-header).
 
 ## Currencies & Countries
 

--- a/docs/user/storefront/theme-editor.mdx
+++ b/docs/user/storefront/theme-editor.mdx
@@ -76,17 +76,17 @@ Click on any page section or element to configure its content and appearance. Mo
 - **Content Settings** - Edit text, links, images, and other content 
 - **Design Settings** - Change padding, borders, alignment, color, and sometimes layouts
 
-### Global Page Sections
+## Global Page Sections
 
-Global sections appear across every page (besides checkout) and update everywhere when edited. Global page sections are as follows:
+Global sections appear across every page (besides checkout) and update everywhere when edited. They can be modified via the Side Navigation. Global page sections are as follows:
 
-#### Announcement Bar
+### Announcement Bar
 
 ![Configuring the announcement bar in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/10-announcement-bar.png)
 
 Add a message that appears at the very top of every page. Ideal for welcome messages and promos like free shipping or limited-time discounts.
 
-#### Page Header
+### Page Header
 
 ![Configuring the header in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/11-page-header.png)
 
@@ -98,11 +98,11 @@ The header includes your:
 - Cart icon
 - Account menu
 
-##### Add Logo
+#### Add Logo
 
 Click **Header** and upload your logo. You can resize its presentation in the **Design** tab.
 
-##### Add Links
+#### Add Links
 
 Click **Add Link** to add navigation items.
 
@@ -116,7 +116,7 @@ Link Types are as follows:
 
 You can also choose to have the link open in a new tab.
 
-##### Add Blocks
+#### Add Blocks
 
 ![Adding blocks to the header in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/12-add-blocks.png)
 
@@ -125,13 +125,13 @@ Click **Add Block** to configure a more advanced header layout. You can select f
 - **Mega Nav** - Manually add links to columns within a dropdown layout for full control over structure.
 - **Link** - A simple link to taxon, product, policy or any other page.
 
-#### Newsletter
+### Newsletter
 
 ![Configuring the newsletter sections in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/13-newsletter.png)
 
 A global email capture section to build your subscriber list. Customize text and styling as needed.
 
-#### Footer
+### Footer
 
 ![Configuring the footer section in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/14-footer.png)
 
@@ -143,11 +143,11 @@ Add:
 
 Organize content into blocks using **Add Block**, and add links as you did in the Header section.
 
-### Page-Specific Sections
+## Page-Specific Sections
 
 These only appear on the page they’re added to - ideal for storytelling, product discovery, and homepage content.
 
-#### Add Page Sections
+### Add Page Sections
 
 ![Adding more pages section in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/15-add-section.png)
 
@@ -168,17 +168,17 @@ Click **Add Section** in the sidebar, then choose a layout type from the followi
 
 The newly added section will appear at the bottom of the page, but above the footer and newsletter.
 
-#### Edit Page Sections and Elements
+### Edit Page Sections and Elements
 
 Click on a section in the sidebar or directly in the preview to update content or design. All changes reflect immediately in the editor preview.
 
-#### Rearrange Page Sections and Elements
+### Rearrange Page Sections and Elements
 
 ![Rearranging page sections in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/16-rearrange-sections.png)
 
 To move a page section or element, hover over it in the preview to reveal the actions menu, then use the up and down arrows to reposition it to the desired location on the page.
 
-#### Delete Sections and Elements
+### Delete Sections and Elements
 
 ![Deleting page sections in the Spree Commerce theme editor](/docs/images/user/storefront/themes/theme-editor/17-delete-section.png)
 


### PR DESCRIPTION
Made a few small corrections to the user docs:
- Changed the title of **Product Taxonomies** to **Taxonomies**
- Fixed a html bug in **Shipping Methods**, and updated a section title
- Adjusted header hierarchy in **Theme Editor** to stay within the supported H4 nesting limit. H5 headers were not rendering correctly or generating anchor links in the index.
- Added a link to **Returns Configuration** in the **Returns Processing** doc
- Removed duplicate menu item **Returns Configurations**, as it is already listed under the **Returns** section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits (navigation JSON and MDX formatting/links) with no runtime or data-handling impact; primary risk is minor broken links or nav ordering if paths are wrong.
> 
> **Overview**
> Updates Mintlify navigation to remove the duplicate `user/settings/returns-configuration` entry under *Settings* (leaving it only under *Returns*).
> 
> Polishes several user docs: renames the `product-taxonomies` page title/description to *Taxonomies*, fixes list/escaping and a section heading in `shipping-methods`, replaces plain text references with proper links in `returns-configuration` and `store-details`, and adjusts `theme-editor` heading levels so anchors/rendering work correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da3ebdfb600d78ce3142160edab6ce2e48648da6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->