### PR TITLE
Deprecate Spree::Classifications::Reposition for Spree 5.5

### DIFF
--- a/spree/core/app/services/spree/classifications/reposition.rb
+++ b/spree/core/app/services/spree/classifications/reposition.rb
@@ -1,9 +1,14 @@
 module Spree
   module Classifications
+    # @deprecated This service is deprecated and will be removed in Spree 5.5.
     class Reposition
       prepend Spree::ServiceModule::Base
 
       def call(classification:, position:)
+        Spree::Deprecation.warn(
+          "#{self.class.name} is deprecated and will be removed in Spree 5.5.",
+          caller_locations(2)
+        )
         if position.is_a?(String) && !position.match(/^\d+$/)
           return failure(nil, I18n.t('errors.messages.not_a_number'))
         end


### PR DESCRIPTION
Add deprecation notice to `Spree::Classifications::Reposition` service indicating it will be removed in Spree 5.5. The deprecation is communicated both via YARD documentation and a runtime warning using `Spree::Deprecation.warn`.

This aligns with the project's deprecation pattern used in other services.