### PR TITLE
Drop `activemerchant`

### DIFF
--- a/docs/developer/upgrades/5.3-to-5.4.mdx
+++ b/docs/developer/upgrades/5.3-to-5.4.mdx
@@ -135,6 +135,67 @@ zone = current_store.checkout_zone
 zone = Spree::Zone.default_tax
 ```
 
+### ActiveMerchant removed from Spree Core
+
+Spree 5.4 no longer depends on the `activemerchant` gem. All internal usages have been replaced with lightweight Spree-native classes:
+
+| ActiveMerchant class | Spree replacement |
+|---|---|
+| `ActiveMerchant::Billing::Response` | `Spree::PaymentResponse` |
+| `ActiveMerchant::ConnectionError` | `Spree::PaymentConnectionError` |
+
+`Spree::PaymentResponse` is a drop-in replacement with the same constructor signature:
+
+```ruby
+Spree::PaymentResponse.new(success, message, params = {}, options = {})
+```
+
+It supports the same methods: `success?`, `message`, `params`, `authorization`, `avs_result`, `cvv_result`, `test?`, and YAML serialization (for log entries).
+
+#### Updating custom payment methods
+
+If you have a custom payment method (gateway) that returns `ActiveMerchant::Billing::Response`, update it to return `Spree::PaymentResponse` instead:
+
+```ruby
+# Before
+def authorize(money, source, options = {})
+  # ...
+  ActiveMerchant::Billing::Response.new(true, 'Success', {},
+    authorization: transaction_id, test: test?)
+end
+
+# After
+def authorize(money, source, options = {})
+  # ...
+  Spree::PaymentResponse.new(true, 'Success', {},
+    authorization: transaction_id, test: test?)
+end
+```
+
+If your gateway rescues `ActiveMerchant::ConnectionError`, update it to rescue `Spree::PaymentConnectionError`:
+
+```ruby
+# Before
+rescue ActiveMerchant::ConnectionError => e
+
+# After
+rescue Spree::PaymentConnectionError => e
+```
+
+#### Using `spree_gateway` or other ActiveMerchant-based extensions
+
+If you use the [`spree_gateway`](https://github.com/spree/spree_gateway) gem or another extension that depends on ActiveMerchant, add `activemerchant` directly to your application's `Gemfile`:
+
+```ruby
+gem 'activemerchant'
+```
+
+These extensions will continue to work — Spree's `LogEntry#parsed_details` still deserializes `ActiveMerchant::Billing::Response` objects when the gem is present.
+
+#### Address hash method renamed
+
+`Spree::Address#active_merchant_hash` has been renamed to `#gateway_hash`. A backwards-compatible alias is provided, so existing code continues to work without changes.
+
 ### (Optional) Install API v2
 
 Spree 5.4 ships with API v3, which marks deprecation of API v2. API v2 is still available but you need to install it separately. If you currently use API v2, you can do this by running the following command:

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -49,7 +49,6 @@ PATH
       typelizer (~> 0.8)
     spree_core (5.4.0.beta)
       active_storage_validations (= 1.3.0)
-      activemerchant (~> 1.67)
       acts-as-taggable-on
       acts_as_list (>= 0.8)
       any_ascii (~> 0.3.2)
@@ -148,12 +147,6 @@ GEM
     activejob (8.1.2)
       activesupport (= 8.1.2)
       globalid (>= 0.3.6)
-    activemerchant (1.137.0)
-      activesupport (>= 4.2)
-      builder (>= 2.1.2, < 4.0.0)
-      i18n (>= 0.6.9)
-      nokogiri (~> 1.4)
-      rexml (~> 3.3, >= 3.3.4)
     activemodel (8.1.2)
       activesupport (= 8.1.2)
     activerecord (8.1.2)
@@ -867,7 +860,6 @@ CHECKSUMS
   active_link_to (1.0.5) sha256=4830847b3d14589df1e9fc62038ceec015257fce975ec1c2a77836c461b139ba
   active_storage_validations (1.3.0) sha256=788e4189d51c7b55049bf2825ede964baa2fe531e22a31c59f67a962ebf8d71e
   activejob (8.1.2) sha256=908dab3713b101859536375819f4156b07bdf4c232cc645e7538adb9e302f825
-  activemerchant (1.137.0) sha256=fdf5e33f5c94d1981bd632d72e282c0a5afaf06bac6df3f933c08a95e98bd5ce
   activemodel (8.1.2) sha256=e21358c11ce68aed3f9838b7e464977bc007b4446c6e4059781e1d5c03bcf33e
   activerecord (8.1.2) sha256=acfbe0cadfcc50fa208011fe6f4eb01cae682ebae0ef57145ba45380c74bcc44
   activestorage (8.1.2) sha256=8a63a48c3999caeee26a59441f813f94681fc35cc41aba7ce1f836add04fba76

--- a/spree/admin/app/views/spree/admin/payment_methods/descriptions/_gateway.html.erb
+++ b/spree/admin/app/views/spree/admin/payment_methods/descriptions/_gateway.html.erb
@@ -1,1 +1,1 @@
-Classic ActiveMerchant gateway provided by community.
+Classic payment gateway provided by community.

--- a/spree/core/app/models/spree/address.rb
+++ b/spree/core/app/models/spree/address.rb
@@ -175,8 +175,8 @@ module Spree
       attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
     end
 
-    # Generates an ActiveMerchant compatible address hash
-    def active_merchant_hash
+    # Generates an address hash for payment gateway options
+    def gateway_hash
       {
         name: full_name,
         address1: address1,
@@ -188,6 +188,7 @@ module Spree
         phone: phone
       }
     end
+    alias_method :active_merchant_hash, :gateway_hash
 
     def require_phone?
       # We want to collect phone number for quick checkout but not to validate it

--- a/spree/core/app/models/spree/gateway.rb
+++ b/spree/core/app/models/spree/gateway.rb
@@ -20,9 +20,6 @@ module Spree
     def provider
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?
-      if gateway_options[:server]
-        ActiveMerchant::Billing::Base.mode = gateway_options[:server].to_sym
-      end
       @provider ||= provider_class.new(gateway_options)
     end
 

--- a/spree/core/app/models/spree/gateway/bogus.rb
+++ b/spree/core/app/models/spree/gateway/bogus.rb
@@ -32,39 +32,39 @@ module Spree
     def authorize(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id&.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id&.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
       end
     end
 
     def credit(_money, _credit_card, _response_code, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 
     def capture(_money, authorization, _gateway_options)
       if authorization == '12345'
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true)
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true)
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
+        Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
       end
     end
 
     def void(_response_code, _credit_card, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: 'void-12345')
+      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: 'void-12345')
     end
 
     def cancel(_response_code, _payment = nil)
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 
     def test?

--- a/spree/core/app/models/spree/gateway/bogus_simple.rb
+++ b/spree/core/app/models/spree/gateway/bogus_simple.rb
@@ -7,17 +7,17 @@ module Spree
 
     def authorize(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
       end
     end
   end

--- a/spree/core/app/models/spree/log_entry.rb
+++ b/spree/core/app/models/spree/log_entry.rb
@@ -17,11 +17,14 @@ module Spree
     end
 
     def parsed_details
-      @details ||= if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-                     YAML.safe_load(details, permitted_classes: [ActiveMerchant::Billing::Response])
-                   else
-                     YAML.safe_load(details, [ActiveMerchant::Billing::Response])
-                   end
+      @details ||= YAML.safe_load(
+        details,
+        permitted_classes: [
+          Spree::PaymentResponse,
+          ActiveSupport::HashWithIndifferentAccess,
+          (ActiveMerchant::Billing::Response if defined?(ActiveMerchant::Billing::Response))
+        ].compact
+      )
     end
   end
 end

--- a/spree/core/app/models/spree/payment.rb
+++ b/spree/core/app/models/spree/payment.rb
@@ -348,7 +348,7 @@ module Spree
       return if source.respond_to?(:imported) && source.imported
 
       payment_method.create_profile(self)
-    rescue ActiveMerchant::ConnectionError => e
+    rescue Spree::PaymentConnectionError => e
       gateway_error e
     end
 

--- a/spree/core/app/models/spree/payment/gateway_options.rb
+++ b/spree/core/app/models/spree/payment/gateway_options.rb
@@ -51,11 +51,11 @@ module Spree
       end
 
       def billing_address
-        order.bill_address.try(:active_merchant_hash)
+        order.bill_address.try(:gateway_hash)
       end
 
       def shipping_address
-        order.ship_address.try(:active_merchant_hash)
+        order.ship_address.try(:gateway_hash)
       end
 
       def hash_methods

--- a/spree/core/app/models/spree/payment/processing.rb
+++ b/spree/core/app/models/spree/payment/processing.rb
@@ -48,7 +48,7 @@ module Spree
         amount ||= money.amount_in_cents
         started_processing!
         protect_from_connection_error do
-          # Standard ActiveMerchant capture usage
+          # Capture the payment amount
           response = payment_method.capture(
             amount,
             response_code,
@@ -71,7 +71,7 @@ module Spree
             # so supply the authorization itself as well as the credit card, rather than just the authorization code
             response = payment_method.void(response_code, source, gateway_options)
           else
-            # Standard ActiveMerchant void usage
+            # Standard void usage
             response = payment_method.void(response_code, gateway_options)
           end
           record_response(response)
@@ -165,15 +165,15 @@ module Spree
 
       def protect_from_connection_error
         yield
-      rescue ActiveMerchant::ConnectionError => e
+      rescue Spree::PaymentConnectionError => e
         failure!
         gateway_error(e)
       end
 
       def gateway_error(error)
-        text = if error.is_a? ActiveMerchant::Billing::Response
+        text = if error.is_a? Spree::PaymentResponse
                  error.params['message'] || error.params['response_reason_text'] || error.message
-               elsif error.is_a? ActiveMerchant::ConnectionError
+               elsif error.is_a? Spree::PaymentConnectionError
                  Spree.t(:unable_to_connect_to_gateway)
                else
                  error.to_s

--- a/spree/core/app/models/spree/payment_connection_error.rb
+++ b/spree/core/app/models/spree/payment_connection_error.rb
@@ -1,0 +1,3 @@
+module Spree
+  class PaymentConnectionError < StandardError; end
+end

--- a/spree/core/app/models/spree/payment_method/check.rb
+++ b/spree/core/app/models/spree/payment_method/check.rb
@@ -37,7 +37,7 @@ module Spree
     private
 
     def simulated_successful_billing_response
-      ActiveMerchant::Billing::Response.new(true, '', {}, {})
+      Spree::PaymentResponse.new(true, '', {}, {})
     end
   end
 end

--- a/spree/core/app/models/spree/payment_method/store_credit.rb
+++ b/spree/core/app/models/spree/payment_method/store_credit.rb
@@ -22,7 +22,7 @@ module Spree
 
     def authorize(amount_in_cents, store_credit, gateway_options = {})
       if store_credit.nil?
-        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit_payment_method.unable_to_find'), {}, {})
+        Spree::PaymentResponse.new(false, Spree.t('store_credit_payment_method.unable_to_find'), {}, {})
       else
         action = lambda do |store_credit|
           store_credit.authorize(
@@ -58,7 +58,7 @@ module Spree
       end
 
       if event.blank?
-        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit_payment_method.unable_to_find'), {}, {})
+        Spree::PaymentResponse.new(false, Spree.t('store_credit_payment_method.unable_to_find'), {}, {})
       else
         capture(amount_in_cents, event.authorization_code, gateway_options)
       end
@@ -111,14 +111,14 @@ module Spree
       store_credit.with_lock do
         if response = action.call(store_credit)
           # note that we only need to return the auth code on an 'auth', but it's innocuous to always return
-          ActiveMerchant::Billing::Response.new(
+          Spree::PaymentResponse.new(
             true,
             Spree.t('store_credit_payment_method.successful_action', action: action_name),
             {},
             authorization: auth_code || response
           )
         else
-          ActiveMerchant::Billing::Response.new(false, store_credit.errors.full_messages.to_sentence, {}, {})
+          Spree::PaymentResponse.new(false, store_credit.errors.full_messages.to_sentence, {}, {})
         end
       end
     end
@@ -128,7 +128,7 @@ module Spree
       store_credit = StoreCreditEvent.find_by(authorization_code: auth_code).try(:store_credit)
 
       if store_credit.nil?
-        ActiveMerchant::Billing::Response.new(
+        Spree::PaymentResponse.new(
           false,
           Spree.t('store_credit_payment_method.unable_to_find_for_action', auth_code: auth_code, action: action_name),
           {},

--- a/spree/core/app/models/spree/payment_response.rb
+++ b/spree/core/app/models/spree/payment_response.rb
@@ -1,9 +1,48 @@
 module Spree
-  # Lightweight value object for payment gateway responses.
-  # Drop-in replacement for ActiveMerchant::Billing::Response.
+  # Lightweight value object representing a payment gateway response.
+  #
+  # This is Spree's native replacement for +ActiveMerchant::Billing::Response+.
+  # It carries the same interface so existing payment method implementations
+  # (Bogus, Check, StoreCredit, and third-party gateways) can return it without
+  # any callers needing to change.
+  #
+  # @example Successful authorization
+  #   Spree::PaymentResponse.new(true, 'Transaction approved', {},
+  #     authorization: 'ch_abc123',
+  #     avs_result:    { code: 'D' },
+  #     cvv_result:    { code: 'M', message: 'Match' },
+  #     test:          true)
+  #
+  # @example Failed charge
+  #   Spree::PaymentResponse.new(false, 'Card declined', { message: 'Insufficient funds' })
+  #
   class PaymentResponse
-    attr_reader :params, :message, :test
+    # @return [HashWithIndifferentAccess] raw gateway params
+    attr_reader :params
 
+    # @return [String] human-readable result message
+    attr_reader :message
+
+    # @return [Boolean] whether the response came from a test/sandbox environment
+    attr_reader :test
+
+    # @return [String, nil] gateway authorization / transaction reference
+    attr_reader :authorization
+
+    # @return [Hash] AVS (Address Verification System) result with +"code"+ key
+    attr_reader :avs_result
+
+    # @return [Hash] CVV result with +"code"+ and +"message"+ keys
+    attr_reader :cvv_result
+
+    # @param success [Boolean] whether the gateway action succeeded
+    # @param message [String]  human-readable result message
+    # @param params  [Hash]    raw key/value pairs returned by the gateway
+    # @param options [Hash]    additional metadata
+    # @option options [String]  :authorization  gateway transaction reference
+    # @option options [Hash]    :avs_result     must contain +:code+
+    # @option options [Hash]    :cvv_result     may contain +:code+ and +:message+
+    # @option options [Boolean] :test           sandbox/test flag
     def initialize(success, message, params = {}, options = {})
       @success = success
       @message = message
@@ -18,24 +57,14 @@ module Spree
                     end
     end
 
+    # @return [Boolean] whether the gateway action succeeded
     def success?
       @success
     end
 
+    # @return [Boolean] whether the response came from a test/sandbox environment
     def test?
       @test
-    end
-
-    def authorization
-      @authorization
-    end
-
-    def avs_result
-      @avs_result
-    end
-
-    def cvv_result
-      @cvv_result
     end
   end
 end

--- a/spree/core/app/models/spree/payment_response.rb
+++ b/spree/core/app/models/spree/payment_response.rb
@@ -1,0 +1,41 @@
+module Spree
+  # Lightweight value object for payment gateway responses.
+  # Drop-in replacement for ActiveMerchant::Billing::Response.
+  class PaymentResponse
+    attr_reader :params, :message, :test
+
+    def initialize(success, message, params = {}, options = {})
+      @success = success
+      @message = message
+      @params = params.with_indifferent_access
+      @test = options[:test] || false
+      @authorization = options[:authorization]
+      @avs_result = options[:avs_result] ? { 'code' => options[:avs_result][:code] } : { 'code' => nil }
+      @cvv_result = if options[:cvv_result]
+                      { 'code' => options[:cvv_result][:code], 'message' => options[:cvv_result][:message] }
+                    else
+                      { 'code' => nil, 'message' => nil }
+                    end
+    end
+
+    def success?
+      @success
+    end
+
+    def test?
+      @test
+    end
+
+    def authorization
+      @authorization
+    end
+
+    def avs_result
+      @avs_result
+    end
+
+    def cvv_result
+      @cvv_result
+    end
+  end
+end

--- a/spree/core/app/models/spree/refund.rb
+++ b/spree/core/app/models/spree/refund.rb
@@ -83,7 +83,7 @@ module Spree
       update_order
     end
 
-    # return an activemerchant response object if successful or else raise an error
+    # return a payment response object if successful or else raise an error
     def process!(credit_cents)
       refund_total_in_cents = calculate_refund_amount(credit_cents)
 
@@ -102,7 +102,7 @@ module Spree
       end
 
       response
-    rescue ActiveMerchant::ConnectionError => e
+    rescue Spree::PaymentConnectionError => e
       Rails.logger.error(Spree.t(:gateway_error) + "  #{e.inspect}")
       raise Core::GatewayError, Spree.t(:unable_to_connect_to_gateway)
     end

--- a/spree/core/lib/spree/core.rb
+++ b/spree/core/lib/spree/core.rb
@@ -11,7 +11,7 @@ require 'action_cable/engine'
 require 'mail'
 require 'action_mailer/railtie'
 
-require 'active_merchant'
+
 require 'acts_as_list'
 require 'acts-as-taggable-on'
 require 'awesome_nested_set'

--- a/spree/core/spec/models/spree/credit_card_spec.rb
+++ b/spree/core/spec/models/spree/credit_card_spec.rb
@@ -22,10 +22,6 @@ describe Spree::CreditCard, type: :model do
     Spree::Payment.state_machine.states.keys
   end
 
-  it 'responds to track_data' do
-    expect(credit_card.respond_to?(:track_data)).to be true
-  end
-
   describe '#can_capture?' do
     shared_examples 'can be captured' do
       it 'can be captured' do
@@ -322,26 +318,6 @@ describe Spree::CreditCard, type: :model do
 
     it 'extracts the last name' do
       expect(credit_card.last_name).to eq 'van Beethoven'
-    end
-  end
-
-  describe '#to_active_merchant' do
-    before do
-      credit_card.number = '4111111111111111'
-      credit_card.year = Time.current.year
-      credit_card.month = Time.current.month
-      credit_card.name = 'Ludwig van Beethoven'
-      credit_card.verification_value = 123
-    end
-
-    it 'converts to an ActiveMerchant::Billing::CreditCard object' do
-      am_card = credit_card.to_active_merchant
-      expect(am_card.number).to eq('4111111111111111')
-      expect(am_card.year).to eq(Time.current.year)
-      expect(am_card.month).to eq(Time.current.month)
-      expect(am_card.first_name).to eq('Ludwig')
-      expect(am_card.last_name).to eq('van Beethoven')
-      expect(am_card.verification_value).to eq('123')
     end
   end
 

--- a/spree/core/spec/models/spree/log_entry_spec.rb
+++ b/spree/core/spec/models/spree/log_entry_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Spree::LogEntry, type: :model do
   let(:log_entry) { create(:log_entry, details: details) }
-  let(:details) { "--- !ruby/object:ActiveMerchant::Billing::Response\nparams: {}\nmessage: 'Bogus Gateway: Forced success'\nsuccess: true\ntest: true\nauthorization: \nfraud_review: \nerror_code: \nemv_authorization: \nnetwork_transaction_id: \navs_result:\n  code: \n  message: \n  street_match: \n  postal_match: \ncvv_result:\n  code: \n  message: \n" }
+  let(:details) { Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true).to_yaml }
 
   describe '#parsed_details' do
     subject { log_entry.parsed_details }
 
-    it 'deserializes log entry with billing response' do
-      expect(subject).to be_instance_of(ActiveMerchant::Billing::Response)
+    it 'deserializes log entry with payment response' do
+      expect(subject).to be_instance_of(Spree::PaymentResponse)
       expect(subject.message).to eq('Bogus Gateway: Forced success')
     end
   end

--- a/spree/core/spec/models/spree/payment/gateway_options_spec.rb
+++ b/spree/core/spec/models/spree/payment/gateway_options_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe Spree::Payment::GatewayOptions, type: :model do
   end
 
   let(:bill_address) do
-    double Spree::Address, active_merchant_hash: { bill: :address }
+    double Spree::Address, gateway_hash: { bill: :address }
   end
 
   let(:ship_address) do
-    double Spree::Address, active_merchant_hash: { ship: :address }
+    double Spree::Address, gateway_hash: { ship: :address }
   end
 
   describe '#order' do

--- a/spree/core/spec/models/spree/payment/store_credit_spec.rb
+++ b/spree/core/spec/models/spree/payment/store_credit_spec.rb
@@ -22,7 +22,7 @@ describe 'Payment' do
       end
 
       let(:successful_response) do
-        ActiveMerchant::Billing::Response.new(
+        Spree::PaymentResponse.new(
           true,
           Spree.t('store_credit_payment_method.successful_action', action: :cancel),
           {},
@@ -31,7 +31,7 @@ describe 'Payment' do
       end
 
       let(:failed_response) do
-        ActiveMerchant::Billing::Response.new(
+        Spree::PaymentResponse.new(
           false,
           Spree.t('store_credit_payment_method.unable_to_find_for_action', action: :cancel,
                                                                            auth_code: payment.response_code),

--- a/spree/core/spec/models/spree/payment_response_spec.rb
+++ b/spree/core/spec/models/spree/payment_response_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe Spree::PaymentResponse do
+  describe '#initialize' do
+    context 'with minimal arguments' do
+      subject { described_class.new(true, 'Success') }
+
+      it 'sets success, message and defaults' do
+        expect(subject).to be_success
+        expect(subject.message).to eq('Success')
+        expect(subject.params).to eq({})
+        expect(subject.test).to be false
+        expect(subject.authorization).to be_nil
+        expect(subject.avs_result).to eq('code' => nil)
+        expect(subject.cvv_result).to eq('code' => nil, 'message' => nil)
+      end
+    end
+
+    context 'with all options' do
+      subject do
+        described_class.new(
+          true,
+          'Approved',
+          { 'transaction_id' => 'tx_1' },
+          authorization: 'auth_123',
+          avs_result: { code: 'D' },
+          cvv_result: { code: 'M', message: 'Match' },
+          test: true
+        )
+      end
+
+      it 'stores authorization' do
+        expect(subject.authorization).to eq('auth_123')
+      end
+
+      it 'stores avs_result with string keys' do
+        expect(subject.avs_result).to eq('code' => 'D')
+      end
+
+      it 'stores cvv_result with string keys' do
+        expect(subject.cvv_result).to eq('code' => 'M', 'message' => 'Match')
+      end
+
+      it 'stores test flag' do
+        expect(subject).to be_test
+      end
+
+      it 'stores params with indifferent access' do
+        expect(subject.params[:transaction_id]).to eq('tx_1')
+        expect(subject.params['transaction_id']).to eq('tx_1')
+      end
+    end
+  end
+
+  describe '#success?' do
+    it 'returns true for a successful response' do
+      expect(described_class.new(true, 'ok')).to be_success
+    end
+
+    it 'returns false for a failed response' do
+      expect(described_class.new(false, 'fail')).not_to be_success
+    end
+  end
+
+  describe '#test?' do
+    it 'returns true when test option is set' do
+      expect(described_class.new(true, '', {}, test: true)).to be_test
+    end
+
+    it 'returns false by default' do
+      expect(described_class.new(true, '')).not_to be_test
+    end
+  end
+
+  describe 'YAML serialization' do
+    it 'round-trips through YAML.safe_load' do
+      original = described_class.new(true, 'Captured', { 'ref' => '42' },
+                                     authorization: 'auth_1', test: true,
+                                     avs_result: { code: 'Y' },
+                                     cvv_result: { code: 'M', message: 'Match' })
+
+      yaml = original.to_yaml
+      restored = YAML.safe_load(yaml, permitted_classes: [described_class, ActiveSupport::HashWithIndifferentAccess])
+
+      expect(restored).to be_a(described_class)
+      expect(restored).to be_success
+      expect(restored.message).to eq('Captured')
+      expect(restored.authorization).to eq('auth_1')
+      expect(restored.params['ref']).to eq('42')
+      expect(restored.avs_result['code']).to eq('Y')
+      expect(restored.cvv_result['code']).to eq('M')
+    end
+  end
+end

--- a/spree/core/spec/models/spree/refund_spec.rb
+++ b/spree/core/spec/models/spree/refund_spec.rb
@@ -25,7 +25,7 @@ describe Spree::Refund, type: :model do
     let(:refund_reason) { create(:refund_reason) }
 
     let(:gateway_response) do
-      ActiveMerchant::Billing::Response.new(
+      Spree::PaymentResponse.new(
         gateway_response_success,
         gateway_response_message,
         gateway_response_params,
@@ -146,15 +146,15 @@ describe Spree::Refund, type: :model do
       end
     end
 
-    context 'with an activemerchant gateway connection error' do
+    context 'with a gateway connection error' do
       before do
-        message = double('gateway_error')
+        message = 'gateway_error'
         expect(payment.payment_method).to receive(:credit).with(
           amount_in_cents,
           payment.source,
           payment.transaction_id,
           originator: an_instance_of(Spree::Refund)
-        ).and_raise(ActiveMerchant::ConnectionError.new(message, nil))
+        ).and_raise(Spree::PaymentConnectionError.new(message))
       end
 
       it 'raises Spree::Core::GatewayError' do

--- a/spree/core/spree_core.gemspec
+++ b/spree/core/spree_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 7.2', '< 8.2'
 
-  s.add_dependency 'activemerchant', '~> 1.67'
+
   s.add_dependency 'acts_as_list', '>= 0.8'
   s.add_dependency 'acts-as-taggable-on'
   s.add_dependency 'awesome_nested_set', '~> 3.3', '>= 3.3.1'


### PR DESCRIPTION
Spree 5.4 introduced a modern payment architecture (PaymentSession-based, native gateway SDKs like Stripe/Adyen/PayPal). ActiveMerchant is a legacy dependency that encourages         │
│ server-side card handling — incompatible with modern PCI compliance. It's a large gem (~1.137.0) with many transitive dependencies.