### PR TITLE
handle custom model class in exports#new

### DIFF
--- a/spree/admin/app/controllers/spree/admin/exports_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/exports_controller.rb
@@ -35,7 +35,9 @@ module Spree
       end
 
       def assign_params
-        @object.type = permitted_resource_params[:type] if available_types.map(&:to_s).include?(permitted_resource_params[:type])
+        if available_types.map(&:to_s).include?(permitted_resource_params[:type])
+          @object = @object.becomes!(permitted_resource_params[:type].constantize)
+        end
         @object.search_params = permitted_resource_params[:search_params]
       end
 

--- a/spree/admin/app/controllers/spree/admin/exports_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/exports_controller.rb
@@ -35,9 +35,8 @@ module Spree
       end
 
       def assign_params
-        if available_types.map(&:to_s).include?(permitted_resource_params[:type])
-          @object = @object.becomes!(permitted_resource_params[:type].constantize)
-        end
+        available_type =  available_types.map(&:to_s).find { |t| t == permitted_resource_params[:type] }
+        @object = @object.becomes!(available_type.constantize) if available_type.present?
         @object.search_params = permitted_resource_params[:search_params]
       end
 

--- a/spree/admin/app/views/spree/admin/exports/create.turbo_stream.erb
+++ b/spree/admin/app/views/spree/admin/exports/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_render_alerts %>
 
 <%= turbo_stream.replace 'export-dialog' do %>
-  <%= render 'spree/admin/shared/export_modal', export_type: @export.type %>
+  <%= render 'spree/admin/shared/export_modal', export_type: @object.type %>
 <% end %>

--- a/spree/admin/app/views/spree/admin/exports/new.html.erb
+++ b/spree/admin/app/views/spree/admin/exports/new.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :export_dialog do %>
-  <%= form_for @object, url: spree.admin_exports_path do |f| %>
+  <%= form_for @object, url: spree.admin_exports_path, as: :export do |f| %>
     <%= f.hidden_field :type %>
     <%= f.hidden_field :search_params %>
     <div class="dialog-header">

--- a/spree/admin/app/views/spree/admin/exports/new.html.erb
+++ b/spree/admin/app/views/spree/admin/exports/new.html.erb
@@ -1,15 +1,15 @@
 <%= turbo_frame_tag :export_dialog do %>
-  <%= form_for @export, url: spree.admin_exports_path do |f| %>
+  <%= form_for @object, url: spree.admin_exports_path do |f| %>
     <%= f.hidden_field :type %>
     <%= f.hidden_field :search_params %>
     <div class="dialog-header">
       <h5 class="dialog-title">
-        <%= Spree.t(:export) + ' ' + plural_resource_name(@export.model_class) %>
+        <%= Spree.t(:export) + ' ' + plural_resource_name(@object.model_class) %>
       </h5>
       <button type="button" class="btn-close" data-action="click->export-dialog#close" aria-label="Close"></button>
     </div>
     <div class="dialog-body">
-      <%= render 'spree/admin/shared/error_messages', target: @export %>
+      <%= render 'spree/admin/shared/error_messages', target: @object %>
       <div class="custom-control custom-radio hover:bg-gray-50 rounded-lg p-3">
         <%= f.radio_button :record_selection, 'filtered', class: 'custom-control-input' %>
         <%= f.label :record_selection, for: :export_record_selection_filtered, class: 'custom-control-label flex-col items-start' do %>

--- a/spree/admin/spec/controllers/spree/admin/exports_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/exports_controller_spec.rb
@@ -32,8 +32,9 @@ describe Spree::Admin::ExportsController, type: :controller do
 
     it 'assigns permitted params' do
       subject
-      expect(assigns(:export).type).to eq('Spree::Exports::Products')
-      expect(assigns(:export).search_params).to eq({ 'name_cont' => 'Product' }.to_json)
+      expect(assigns(:object)).to be_an_instance_of(Spree::Exports::Products)
+      expect(assigns(:object).type).to eq('Spree::Exports::Products')
+      expect(assigns(:object).search_params).to eq({ 'name_cont' => 'Product' }.to_json)
     end
   end
 
@@ -72,7 +73,7 @@ describe Spree::Admin::ExportsController, type: :controller do
 
       it 'does not assign search_params' do
         subject
-        expect(assigns(:export).search_params).to be_nil
+        expect(assigns(:object).search_params).to be_nil
       end
     end
   end


### PR DESCRIPTION
I need it to bring back stripe transfers page in spree_multi_vendor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the export model instance is typed/instantiated from user-supplied params and could affect export form rendering/creation for different export types.
> 
> **Overview**
> Fixes admin exports so the `type` param results in an instance of the selected export subclass (via `becomes!`) instead of only setting a string type, improving support for custom export model classes.
> 
> Updates the exports modal/new form views and controller specs to consistently use `@object` (and form `as: :export`) so Turbo-stream create and validation errors render against the correctly typed export instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd8ad90639f943aeb70dde318ca1ef1ffbf92334. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->