### PR TITLE
eplace giget with `git clone --depth 1` for downloading storefront te…

### DIFF
--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,17 @@
 # create-spree-app
 
+## 0.2.2
+
+### Patch Changes
+
+- Replace giget with `git clone --depth 1` for downloading storefront template — fixes EACCES cache permission errors and reduces bundle size by 75%
+
+## 0.2.1
+
+### Patch Changes
+
+- Fix EACCES permission error when downloading storefront template by pre-creating the giget cache directory
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",
@@ -47,7 +47,6 @@
     "commander": "^13.1.0",
     "execa": "^9.5.2",
     "get-port": "^7.1.0",
-    "giget": "^2.0.0",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/create-spree-app/src/constants.ts
+++ b/packages/create-spree-app/src/constants.ts
@@ -6,7 +6,7 @@ export const STOREFRONT_PORT = 3001
 export const HEALTH_CHECK_INTERVAL_MS = 3000
 export const HEALTH_CHECK_TIMEOUT_MS = 120_000
 
-export const STOREFRONT_REPO = 'github:spree/nextjs-starter-spree'
+export const STOREFRONT_REPO = 'https://github.com/spree/nextjs-starter-spree.git'
 
 export const DEFAULT_ADMIN_EMAIL = 'spree@example.com'
 export const DEFAULT_ADMIN_PASSWORD = 'spree123'

--- a/packages/create-spree-app/src/storefront.ts
+++ b/packages/create-spree-app/src/storefront.ts
@@ -1,4 +1,3 @@
-import { downloadTemplate } from 'giget'
 import fs from 'node:fs'
 import path from 'node:path'
 import { execa } from 'execa'
@@ -9,7 +8,8 @@ import type { PackageManager } from './types.js'
 
 export async function downloadStorefront(projectDir: string): Promise<void> {
   const storefrontDir = path.join(projectDir, 'apps', 'storefront')
-  await downloadTemplate(STOREFRONT_REPO, { dir: storefrontDir, force: true })
+  await execa('git', ['clone', '--depth', '1', STOREFRONT_REPO, storefrontDir], { stdio: 'ignore' })
+  fs.rmSync(path.join(storefrontDir, '.git'), { recursive: true, force: true })
 }
 
 export async function installStorefrontDeps(projectDir: string, pm: PackageManager): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
-      giget:
-        specifier: ^2.0.0
-        version: 2.0.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -917,12 +914,6 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
-  citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
-
-  citty@0.2.1:
-    resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
-
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -978,9 +969,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1094,10 +1082,6 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
-
-  giget@2.0.0:
-    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
-    hasBin: true
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1301,9 +1285,6 @@ packages:
       sass:
         optional: true
 
-  node-fetch-native@1.6.7:
-    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -1316,11 +1297,6 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
-
-  nypm@0.6.5:
-    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2563,12 +2539,6 @@ snapshots:
 
   ci-info@3.9.0: {}
 
-  citty@0.1.6:
-    dependencies:
-      consola: 3.4.2
-
-  citty@0.2.1: {}
-
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -2608,8 +2578,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  defu@6.1.4: {}
 
   detect-indent@6.1.0: {}
 
@@ -2749,15 +2717,6 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  giget@2.0.0:
-    dependencies:
-      citty: 0.1.6
-      consola: 3.4.2
-      defu: 6.1.4
-      node-fetch-native: 1.6.7
-      nypm: 0.6.5
-      pathe: 2.0.3
 
   glob-parent@5.1.2:
     dependencies:
@@ -2950,8 +2909,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-fetch-native@1.6.7: {}
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -2960,12 +2917,6 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
-
-  nypm@0.6.5:
-    dependencies:
-      citty: 0.2.1
-      pathe: 2.0.3
-      tinyexec: 1.0.2
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
…mplate — fixes EACCES cache permission errors and reduces bundle size by 75%