### PR TITLE
Added 'Shipping Calculators' user doc

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1097,6 +1097,7 @@
                   "user/settings/payments",
                   "user/settings/zones",
                   "user/settings/shipping-methods",
+                  "user/settings/shipping-calculators",
                   "user/settings/tax"
                 ]
               },

--- a/docs/user/settings/shipping-calculators.mdx
+++ b/docs/user/settings/shipping-calculators.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Shipping Calculators"
-description: "Learn how to cuse shipping calculators in Spree Commerce."
+description: "Learn how to use shipping calculators in Spree Commerce."
 ---
 
 Shipping calculators determine how the cost of a shipping method is calculated at checkout.
@@ -9,7 +9,7 @@ When creating or editing a shipping method, you’ll choose a **Calculator** typ
 
 Below is a breakdown of each available shipping calculator and how it works.
 
-## **Flat Percent**
+## Flat Percent
 
 Charges a percentage of the order total as the shipping cost.
 
@@ -27,7 +27,7 @@ If you set the percentage to **10%** and the order total is **\$200**, the shipp
 - Simple, scalable shipping rules
 - Stores where shipping cost should increase proportionally with order value
 
-## **Flat Rate**
+## Flat Rate
 
 Charges a fixed shipping cost based on weight and/or order total ranges.
 
@@ -64,7 +64,7 @@ Orders between \$0-\$100 will be charged \$10 shipping.
 - Heavy item pricing
 - Conditional flat pricing
 
-## **Flexible Rate per Package Item**
+## Flexible Rate per Package Item
 
 Charges one rate for the first item and a different rate for additional items in the shipment.
 
@@ -89,7 +89,7 @@ If a customer orders 3 items:
 - Small product stores
 - Per-item handling costs
 
-## **Flat Rate per Package Item**
+## Flat Rate per Package Item
 
 Charges the same fixed amount for each item in the shipment.
 
@@ -108,7 +108,7 @@ If the amount is **\$5 per item** and the order contains 4 items:
 - Uniform product sizes
 - Standardized packaging costs
 
-## **Price Sack**
+## Price Sack
 
 Applies one shipping amount below a minimum order value, and a discounted rate above it.
 
@@ -140,7 +140,7 @@ If the order is:
 - Incentivizing higher order values
 - “Spend \$100, get discounted shipping” promotions
 
-## **Digital Delivery**
+## Digital Delivery
 
 Used for digital products where shipping represents a processing or delivery fee.
 
@@ -161,7 +161,7 @@ If set to \$2, every order using this method will be charged \$2 for digital del
 - Downloadable media
 - Digital subscriptions
 
-# **Choosing the Right Calculator**
+# Choosing the Right Calculator
 
 Your choice depends on:
 

--- a/docs/user/settings/shipping-calculators.mdx
+++ b/docs/user/settings/shipping-calculators.mdx
@@ -1,0 +1,174 @@
+---
+title: "Shipping Calculators"
+description: "Learn how to cuse shipping calculators in Spree Commerce."
+---
+
+Shipping calculators determine how the cost of a shipping method is calculated at checkout.
+
+When creating or editing a shipping method, you’ll choose a **Calculator** type and configure its rules. Each calculator applies different pricing logic depending on weight, order value, or number of items.
+
+Below is a breakdown of each available shipping calculator and how it works.
+
+## **Flat Percent**
+
+Charges a percentage of the order total as the shipping cost.
+
+**Configuration:**
+
+- **Percentage** - The percent of the order total to charge
+
+**Example:**\
+If you set the percentage to **10%** and the order total is **\$200**, the shipping cost will be:
+
+\$200 × 10% = \$20 shipping
+
+**Best for:**
+
+- Simple, scalable shipping rules
+- Stores where shipping cost should increase proportionally with order value
+
+## **Flat Rate**
+
+Charges a fixed shipping cost based on weight and/or order total ranges.
+
+**Configuration:**
+
+- **Min Weight**
+- **Max Weight**
+- **Amount (cost)**
+- **Currency**
+- **Min Item Total**
+- **Max Item Total**
+
+The shipping cost applies only if the order falls within the defined weight and/or item total range.
+
+**Example 1 (Weight-based):**
+
+- Min weight: 0 kg
+- Max weight: 5 kg
+- Amount: \$15
+
+Orders weighing between 0-5 kg will be charged \$15 shipping.
+
+**Example 2 (Order total-based):**
+
+- Min item total: \$0
+- Max item total: \$100
+- Amount: \$10
+
+Orders between \$0-\$100 will be charged \$10 shipping.
+
+**Best for:**
+
+- Tiered shipping rules
+- Heavy item pricing
+- Conditional flat pricing
+
+## **Flexible Rate per Package Item**
+
+Charges one rate for the first item and a different rate for additional items in the shipment.
+
+**Configuration:**
+
+- **Max Items**
+- **Currency**
+- **First Item (cost)**
+- **Additional Items (cost)**
+
+**Example:**
+
+- First item: \$10
+- Additional items: \$3
+
+If a customer orders 3 items:
+
+\$10 (first item) + \$3 + \$3 = \$16 shipping
+
+**Best for:**
+
+- Small product stores
+- Per-item handling costs
+
+## **Flat Rate per Package Item**
+
+Charges the same fixed amount for each item in the shipment.
+
+**Configuration:**
+
+- **Amount**
+- **Currency**
+
+**Example:**\
+If the amount is **\$5 per item** and the order contains 4 items:
+
+4 × \$5 = \$20 shipping
+
+**Best for:**
+
+- Uniform product sizes
+- Standardized packaging costs
+
+## **Price Sack**
+
+Applies one shipping amount below a minimum order value, and a discounted rate above it.
+
+**Configuration:**
+
+- **Minimal Amount** - Order total threshold
+- **Normal Amount** - Shipping cost below threshold
+- **Discount Amount** - Shipping cost above threshold
+- **Currency**
+
+**How it works:**
+
+- If the order total is **below** the minimal amount → Normal Amount is charged
+- If the order total is **above** the minimal amount → Discount Amount is charged
+
+**Example:**
+
+- Minimal amount: \$100
+- Normal amount: \$15
+- Discount amount: \$5
+
+If the order is:
+
+- \$75 → Shipping = \$15
+- \$150 → Shipping = \$5
+
+**Best for:**
+
+- Incentivizing higher order values
+- “Spend \$100, get discounted shipping” promotions
+
+## **Digital Delivery**
+
+Used for digital products where shipping represents a processing or delivery fee.
+
+**Configuration:**
+
+- **Amount**
+- **Currency**
+
+In most cases, businesses selling digital products (such as e-books, software, or downloadable media) set this amount to 0, since no physical shipping is required. However, you may choose to apply a small processing fee if needed.
+
+**Example:**\
+If set to \$2, every order using this method will be charged \$2 for digital delivery.
+
+**Best for:**
+
+- E-books
+- Software licenses
+- Downloadable media
+- Digital subscriptions
+
+# **Choosing the Right Calculator**
+
+Your choice depends on:
+
+- Product weight variability
+- Average order value
+- Packaging costs
+- Geographic complexity
+- Whether you sell physical or digital goods
+
+For more advanced shipping logic, calculators can also be combined with [Shipping Categories](https://spreecommerce.org/docs/user/settings/shipping-methods#shipping-categories) and [Zones](https://spreecommerce.org/docs/user/settings/zones) to apply different pricing rules to different products or regions.

--- a/docs/user/settings/shipping-methods.mdx
+++ b/docs/user/settings/shipping-methods.mdx
@@ -57,8 +57,8 @@ Simply select the appropriate Zone(s) to ensure the method only appears for cust
 
 Shipping Categories are especially useful when your store includes products with very different delivery needs. For example:
 
-- Assigning a “Digital” category to non-physical products ensures they skip the shipping step during checkout.
-- Creating a “Heavy” category for large or heavy items allows you to limit specific shipping methods to those products.
+- Assigning a **Digital** category to non-physical products ensures they skip the shipping step during checkout.
+- Assigning a **Heavy** category to large or heavy items allows you to limit specific shipping methods to those products.
 
 ### Tax Category
 
@@ -90,7 +90,7 @@ This section determines how the shipping cost will be calculated for this method
 
 Each calculator type may reveal different fields depending on its configuration. Choose the one that best aligns with your fulfillment strategy.
 
-For a more detailed guide on shipping calculators, please refer to another support article.
+To learn more, please refer to our [**Shipping Calculators**](https://spreecommerce.org/docs/user/settings/shipping-calculators) support article.
 
 ### Estimated Transit Business Days
 


### PR DESCRIPTION
A new user doc covering shipping calculators plus some minor tweaks to the Shipping Methods doc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; the main risk is minor nav/link issues if the new page slug is incorrect.
> 
> **Overview**
> Adds a new **User Docs** page, `user/settings/shipping-calculators`, documenting the available shipping calculator types (configuration fields, examples, and suggested use cases).
> 
> Updates the `Shipping Methods` doc to fix list formatting in *Shipping Categories* and replaces the placeholder calculator reference with a direct link to the new **Shipping Calculators** article, and registers the new page in `docs.json` navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2063cd01ca6f310564d960e076db62d672980f4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->