### PR TITLE
Add API v3 security hardening

### DIFF
--- a/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
@@ -46,6 +46,12 @@ module Spree
           digital_link_expired: 'digital_link_expired',
           download_limit_exceeded: 'download_limit_exceeded',
 
+          # Rate limiting errors
+          rate_limit_exceeded: 'rate_limit_exceeded',
+
+          # Request errors
+          request_too_large: 'request_too_large',
+
           # General errors
           processing_error: 'processing_error',
           invalid_request: 'invalid_request'

--- a/spree/api/app/controllers/concerns/spree/api/v3/security_headers.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/security_headers.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Api
+    module V3
+      module SecurityHeaders
+        extend ActiveSupport::Concern
+
+        included do
+          after_action :set_security_headers
+        end
+
+        private
+
+        def set_security_headers
+          response.headers['X-Content-Type-Options'] = 'nosniff'
+          response.headers['X-Frame-Options'] = 'DENY'
+          response.headers.delete('X-Powered-By')
+          response.headers.delete('Server')
+        end
+      end
+    end
+  end
+end

--- a/spree/api/app/controllers/spree/api/v3/base_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/base_controller.rb
@@ -11,6 +11,7 @@ module Spree
         include Spree::Api::V3::ApiKeyAuthentication
         include Spree::Api::V3::ErrorHandler
         include Spree::Api::V3::HttpCaching
+        include Spree::Api::V3::SecurityHeaders
         include Spree::Api::V3::ResourceSerializer
         include Pagy::Method
 

--- a/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
@@ -3,6 +3,12 @@ module Spree
     module V3
       module Store
         class AuthController < Store::BaseController
+          # Tighter rate limits for auth endpoints (per IP to prevent brute force)
+          rate_limit to: Spree::Api::Config[:rate_limit_login], within: 1.minute, only: :create, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_register], within: 1.minute, only: :register, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: 1.minute, only: :refresh, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_oauth], within: 1.minute, only: :oauth_callback, with: RATE_LIMIT_RESPONSE
+
           skip_before_action :authenticate_user, only: [:create, :register, :oauth_callback]
           prepend_before_action :require_authentication!, only: [:refresh]
 

--- a/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
@@ -4,10 +4,10 @@ module Spree
       module Store
         class AuthController < Store::BaseController
           # Tighter rate limits for auth endpoints (per IP to prevent brute force)
-          rate_limit to: Spree::Api::Config[:rate_limit_login], within: 1.minute, only: :create, with: RATE_LIMIT_RESPONSE
-          rate_limit to: Spree::Api::Config[:rate_limit_register], within: 1.minute, only: :register, with: RATE_LIMIT_RESPONSE
-          rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: 1.minute, only: :refresh, with: RATE_LIMIT_RESPONSE
-          rate_limit to: Spree::Api::Config[:rate_limit_oauth], within: 1.minute, only: :oauth_callback, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_login], within: 1.minute, store: Rails.cache, only: :create, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_register], within: 1.minute, store: Rails.cache, only: :register, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: 1.minute, store: Rails.cache, only: :refresh, with: RATE_LIMIT_RESPONSE
+          rate_limit to: Spree::Api::Config[:rate_limit_oauth], within: 1.minute, store: Rails.cache, only: :oauth_callback, with: RATE_LIMIT_RESPONSE
 
           skip_before_action :authenticate_user, only: [:create, :register, :oauth_callback]
           prepend_before_action :require_authentication!, only: [:refresh]

--- a/spree/api/app/controllers/spree/api/v3/store/base_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/base_controller.rb
@@ -3,6 +3,16 @@ module Spree
     module V3
       module Store
         class BaseController < Spree::Api::V3::BaseController
+          RATE_LIMIT_RESPONSE = -> {
+            body = { error: { code: 'rate_limit_exceeded', message: 'Too many requests. Please retry later.' } }
+            [429, { 'Content-Type' => 'application/json', 'Retry-After' => '60' }, [body.to_json]]
+          }
+
+          # Global rate limit per publishable API key
+          rate_limit to: Spree::Api::Config[:rate_limit_per_key], within: 1.minute,
+                     by: -> { request.headers['X-Spree-Api-Key'] || request.remote_ip },
+                     with: RATE_LIMIT_RESPONSE
+
           # Require publishable API key for all Store API requests
           before_action :authenticate_api_key!
         end

--- a/spree/api/app/controllers/spree/api/v3/store/base_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/base_controller.rb
@@ -10,6 +10,7 @@ module Spree
 
           # Global rate limit per publishable API key
           rate_limit to: Spree::Api::Config[:rate_limit_per_key], within: 1.minute,
+                     store: Rails.cache,
                      by: -> { request.headers['X-Spree-Api-Key'] || request.remote_ip },
                      with: RATE_LIMIT_RESPONSE
 

--- a/spree/api/lib/spree/api/configuration.rb
+++ b/spree/api/lib/spree/api/configuration.rb
@@ -9,6 +9,18 @@ module Spree
       preference :api_v2_content_type, :string, default: 'application/vnd.api+json'
       preference :api_v2_per_page_limit, :integer, default: 500
 
+      preference :jwt_expiration, :integer, default: 3600 # 1 hour in seconds
+
+      # Rate limiting (requests per minute)
+      preference :rate_limit_per_key, :integer, default: 300 # per publishable API key
+      preference :rate_limit_login, :integer, default: 5 # per IP
+      preference :rate_limit_register, :integer, default: 3 # per IP
+      preference :rate_limit_refresh, :integer, default: 10 # per IP
+      preference :rate_limit_oauth, :integer, default: 5 # per IP
+
+      # Request body size limit in bytes
+      preference :max_request_body_size, :integer, default: 102_400 # 100KB
+
       preference :webhooks_enabled, :boolean, default: true
       preference :webhooks_verify_ssl, :boolean, default: !Rails.env.development?
     end

--- a/spree/api/lib/spree/api/engine.rb
+++ b/spree/api/lib/spree/api/engine.rb
@@ -14,6 +14,11 @@ module Spree
         Spree::Api::Dependencies = Spree::Api::ApiDependencies.new
       end
 
+      initializer 'spree.api.request_size_limit' do |app|
+        require_relative 'middleware/request_size_limit'
+        app.middleware.insert_before Rack::Runtime, Spree::Api::Middleware::RequestSizeLimit
+      end
+
       # Add API event subscribers
       config.after_initialize do
         Spree.subscribers << Spree::WebhookEventSubscriber

--- a/spree/api/lib/spree/api/middleware/request_size_limit.rb
+++ b/spree/api/lib/spree/api/middleware/request_size_limit.rb
@@ -1,0 +1,36 @@
+module Spree
+  module Api
+    module Middleware
+      class RequestSizeLimit
+        def initialize(app, limit: nil)
+          @app = app
+          @limit = limit
+        end
+
+        def call(env)
+          if api_request?(env) && content_length_exceeded?(env)
+            body = { error: { code: 'request_too_large', message: 'Request body too large' } }
+            [413, { 'Content-Type' => 'application/json' }, [body.to_json]]
+          else
+            @app.call(env)
+          end
+        end
+
+        private
+
+        def api_request?(env)
+          env['PATH_INFO']&.start_with?('/api/v3/')
+        end
+
+        def content_length_exceeded?(env)
+          content_length = env['CONTENT_LENGTH'].to_i
+          content_length > max_body_size
+        end
+
+        def max_body_size
+          @limit || Spree::Api::Config[:max_request_body_size]
+        end
+      end
+    end
+  end
+end

--- a/spree/api/lib/spree/api/testing_support/v3/base.rb
+++ b/spree/api/lib/spree/api/testing_support/v3/base.rb
@@ -3,11 +3,14 @@ module Spree
   module Api
     module V3
       module TestingSupport
-        def self.generate_jwt(user, expiration: 24.hours.to_i)
+        def self.generate_jwt(user, expiration: 1.hour.to_i, audience: Spree::Api::V3::JwtAuthentication::JWT_AUDIENCE_STORE)
           user_type = user.is_a?(Spree.admin_user_class) ? 'admin' : 'customer'
           payload = {
             user_id: user.id,
             user_type: user_type,
+            jti: SecureRandom.uuid,
+            iss: Spree::Api::V3::JwtAuthentication::JWT_ISSUER,
+            aud: audience,
             exp: Time.current.to_i + expiration
           }
           secret = Rails.application.credentials.jwt_secret_key || ENV['JWT_SECRET_KEY'] || Rails.application.secret_key_base

--- a/spree/api/spec/controllers/concerns/spree/api/v3/jwt_authentication_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/jwt_authentication_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
+  render_views
+
+  include_context 'API v3 Store'
+
+  before do
+    request.headers['X-Spree-Api-Key'] = api_key.token
+  end
+
+  describe 'Spree::Api::V3::JwtAuthentication' do
+    let!(:existing_user) { create(:user, password: 'password123', password_confirmation: 'password123') }
+
+    describe 'JWT token claims' do
+      it 'includes jti, iss, and aud claims in generated token' do
+        post :create, params: { provider: 'email', email: existing_user.email, password: 'password123' }
+
+        token = json_response['token']
+        secret = Rails.application.credentials.jwt_secret_key || ENV['JWT_SECRET_KEY'] || Rails.application.secret_key_base
+        payload = JWT.decode(token, secret, true, algorithm: 'HS256').first
+
+        expect(payload['jti']).to be_present
+        expect(payload['iss']).to eq('spree')
+        expect(payload['aud']).to eq('store_api')
+        expect(payload['user_id']).to eq(existing_user.id)
+        expect(payload['user_type']).to eq('customer')
+        expect(payload['exp']).to be_present
+      end
+
+      it 'generates unique jti for each token' do
+        post :create, params: { provider: 'email', email: existing_user.email, password: 'password123' }
+        first_jti = JWT.decode(json_response['token'], nil, false).first['jti']
+
+        post :create, params: { provider: 'email', email: existing_user.email, password: 'password123' }
+        second_jti = JWT.decode(json_response['token'], nil, false).first['jti']
+
+        expect(first_jti).not_to eq(second_jti)
+      end
+    end
+
+    describe 'token verification' do
+      it 'rejects tokens with wrong issuer' do
+        bad_token = JWT.encode(
+          { user_id: user.id, user_type: 'customer', iss: 'wrong', aud: 'store_api', exp: 1.hour.from_now.to_i },
+          Rails.application.secret_key_base,
+          'HS256'
+        )
+        request.headers['Authorization'] = "Bearer #{bad_token}"
+
+        post :refresh
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'rejects tokens with wrong audience' do
+        bad_token = JWT.encode(
+          { user_id: user.id, user_type: 'customer', iss: 'spree', aud: 'wrong_api', exp: 1.hour.from_now.to_i },
+          Rails.application.secret_key_base,
+          'HS256'
+        )
+        request.headers['Authorization'] = "Bearer #{bad_token}"
+
+        post :refresh
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'rejects expired tokens' do
+        expired_token = Spree::Api::V3::TestingSupport.generate_jwt(user, expiration: -1.hour.to_i)
+        request.headers['Authorization'] = "Bearer #{expired_token}"
+
+        post :refresh
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe 'configurable expiration' do
+      it 'uses the configured jwt_expiration' do
+        original = Spree::Api::Config[:jwt_expiration]
+        Spree::Api::Config[:jwt_expiration] = 7200
+
+        post :create, params: { provider: 'email', email: existing_user.email, password: 'password123' }
+
+        token = json_response['token']
+        payload = JWT.decode(token, nil, false).first
+
+        # Token expiration should be approximately 2 hours from now
+        expected_exp = Time.current.to_i + 7200
+        expect(payload['exp']).to be_within(5).of(expected_exp)
+      ensure
+        Spree::Api::Config[:jwt_expiration] = original
+      end
+    end
+
+    describe 'token extraction' do
+      it 'extracts token from Authorization Bearer header' do
+        request.headers['Authorization'] = "Bearer #{jwt_token}"
+
+        post :refresh
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not extract token from query params on non-digitals controllers' do
+        post :refresh, params: { token: jwt_token }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spree/api/spec/controllers/concerns/spree/api/v3/rate_limiting_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/rate_limiting_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe 'Rate Limiting', type: :controller do
+  describe Spree::Api::V3::Store::StoresController do
+    controller(Spree::Api::V3::Store::StoresController) {}
+
+    render_views
+
+    include_context 'API v3 Store'
+
+    before do
+      request.headers['X-Spree-Api-Key'] = api_key.token
+    end
+
+    describe 'rate limit response format' do
+      it 'returns JSON error with rate_limit_exceeded code' do
+        response_proc = Spree::Api::V3::Store::BaseController::RATE_LIMIT_RESPONSE
+        status, headers, body = response_proc.call
+
+        expect(status).to eq(429)
+        expect(headers['Content-Type']).to eq('application/json')
+        expect(headers['Retry-After']).to eq('60')
+
+        parsed = JSON.parse(body.first)
+        expect(parsed['error']['code']).to eq('rate_limit_exceeded')
+        expect(parsed['error']['message']).to be_present
+      end
+    end
+  end
+
+  describe 'rate limit configuration' do
+    it 'exposes rate_limit_per_key as a configurable preference' do
+      expect(Spree::Api::Config[:rate_limit_per_key]).to eq(300)
+    end
+
+    it 'exposes rate_limit_login as a configurable preference' do
+      expect(Spree::Api::Config[:rate_limit_login]).to eq(5)
+    end
+
+    it 'exposes rate_limit_register as a configurable preference' do
+      expect(Spree::Api::Config[:rate_limit_register]).to eq(3)
+    end
+
+    it 'exposes rate_limit_refresh as a configurable preference' do
+      expect(Spree::Api::Config[:rate_limit_refresh]).to eq(10)
+    end
+
+    it 'exposes rate_limit_oauth as a configurable preference' do
+      expect(Spree::Api::Config[:rate_limit_oauth]).to eq(5)
+    end
+
+    it 'allows overriding rate limit values' do
+      original = Spree::Api::Config[:rate_limit_per_key]
+      Spree::Api::Config[:rate_limit_per_key] = 500
+      expect(Spree::Api::Config[:rate_limit_per_key]).to eq(500)
+    ensure
+      Spree::Api::Config[:rate_limit_per_key] = original
+    end
+  end
+end

--- a/spree/api/spec/controllers/concerns/spree/api/v3/security_headers_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/security_headers_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Store::StoresController, type: :controller do
+  render_views
+
+  include_context 'API v3 Store'
+
+  before do
+    request.headers['X-Spree-Api-Key'] = api_key.token
+  end
+
+  describe 'Spree::Api::V3::SecurityHeaders' do
+    it 'sets X-Content-Type-Options header' do
+      get :show
+
+      expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
+    end
+
+    it 'sets X-Frame-Options header' do
+      get :show
+
+      expect(response.headers['X-Frame-Options']).to eq('DENY')
+    end
+
+    it 'removes X-Powered-By header' do
+      get :show
+
+      expect(response.headers['X-Powered-By']).to be_nil
+    end
+
+    it 'removes Server header' do
+      get :show
+
+      expect(response.headers['Server']).to be_nil
+    end
+  end
+end

--- a/spree/api/spec/lib/spree/api/middleware/request_size_limit_spec.rb
+++ b/spree/api/spec/lib/spree/api/middleware/request_size_limit_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::Middleware::RequestSizeLimit do
+  let(:app) { ->(env) { [200, { 'Content-Type' => 'application/json' }, ['OK']] } }
+  let(:middleware) { described_class.new(app) }
+
+  def env_for(path, content_length: 0)
+    {
+      'PATH_INFO' => path,
+      'CONTENT_LENGTH' => content_length.to_s,
+      'REQUEST_METHOD' => 'POST'
+    }
+  end
+
+  describe '#call' do
+    context 'API v3 requests' do
+      it 'allows requests within the size limit' do
+        status, _headers, _body = middleware.call(env_for('/api/v3/store/cart', content_length: 1024))
+
+        expect(status).to eq(200)
+      end
+
+      it 'rejects requests exceeding the size limit' do
+        large_size = Spree::Api::Config[:max_request_body_size] + 1
+        status, headers, body = middleware.call(env_for('/api/v3/store/cart', content_length: large_size))
+
+        expect(status).to eq(413)
+        expect(headers['Content-Type']).to eq('application/json')
+
+        parsed = JSON.parse(body.first)
+        expect(parsed['error']['code']).to eq('request_too_large')
+        expect(parsed['error']['message']).to be_present
+      end
+
+      it 'allows requests exactly at the limit' do
+        exact_size = Spree::Api::Config[:max_request_body_size]
+        status, _headers, _body = middleware.call(env_for('/api/v3/store/cart', content_length: exact_size))
+
+        expect(status).to eq(200)
+      end
+
+      it 'respects custom limit passed via constructor' do
+        custom_middleware = described_class.new(app, limit: 500)
+
+        status, _headers, _body = custom_middleware.call(env_for('/api/v3/store/cart', content_length: 501))
+        expect(status).to eq(413)
+
+        status, _headers, _body = custom_middleware.call(env_for('/api/v3/store/cart', content_length: 500))
+        expect(status).to eq(200)
+      end
+    end
+
+    context 'non-API requests' do
+      it 'does not limit requests to other paths' do
+        status, _headers, _body = middleware.call(env_for('/admin/products', content_length: 10_000_000))
+
+        expect(status).to eq(200)
+      end
+    end
+
+    context 'requests without Content-Length' do
+      it 'allows requests with no Content-Length header' do
+        env = { 'PATH_INFO' => '/api/v3/store/cart', 'REQUEST_METHOD' => 'GET' }
+        status, _headers, _body = middleware.call(env)
+
+        expect(status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implement comprehensive security hardening for the Store API v3, addressing rate limiting, JWT improvements, security headers, and request size limits. All values are configurable via `Spree::Api::Config`.

**Rate Limiting (Rails built-in):**
- Global limit: 300 req/min per publishable API key
- Auth endpoints: login (5/min), register (3/min), refresh (10/min), oauth (5/min) per IP
- Brute force protection via per-IP auth endpoint limits
- Returns 429 with Stripe-style JSON error

**JWT Authentication:**
- Added `jti` (unique ID), `iss` (issuer), `aud` (audience) claims
- Verify issuer='spree' and audience='store_api' on decode
- Default expiration reduced to 1 hour (configurable via `jwt_expiration` preference)
- Restricted `params[:token]` fallback to digitals controller only
- Kept `secret_key_base` fallback for new app setups

**Security Headers:**
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- Removes `X-Powered-By` and `Server` headers

**Request Size Limits:**
- 100KB default (configurable via `max_request_body_size`)
- Rack middleware at API v3 request level
- Returns 413 with JSON error

**Configuration:**
All rate limits and body size available in `Spree::Api::Config`:
- `rate_limit_per_key` (default: 300)
- `rate_limit_login`, `rate_limit_register`, `rate_limit_refresh`, `rate_limit_oauth`
- `max_request_body_size` (default: 102400 bytes)
- `jwt_expiration` (default: 3600 seconds)

## Testing

- Added 25 new specs covering all security features
- All 820 API v3 specs pass
- No ordering issues or flaky tests