### PR TITLE
Mark ProductFilters as deprecated for removal in Spree 5.5

### DIFF
--- a/spree/core/app/models/spree/taxon.rb
+++ b/spree/core/app/models/spree/taxon.rb
@@ -312,8 +312,8 @@ module Spree
       end
     end
 
-    # indicate which filters should be used for a taxon
-    # this method should be customized to your own site
+    # @deprecated This method is deprecated and will be removed in Spree 5.5.
+    #   Use Spree::Api::V3::FiltersAggregator instead.
     def applicable_filters
       Spree::Deprecation.warn('applicable_filters is deprecated and will be removed in Spree 5.5')
       fs = []

--- a/spree/core/lib/spree/core/product_filters.rb
+++ b/spree/core/lib/spree/core/product_filters.rb
@@ -61,7 +61,9 @@ module Spree
       # If user checks off three different price ranges then the argument passed to
       # below scope would be something like ["$10 - $15", "$15 - $18", "$18 - $20"]
       #
+      # @deprecated This scope is deprecated and will be removed in Spree 5.5.
       Spree::Product.add_search_scope :price_range_any do |*opts|
+        deprecated_warning
         conds = opts.map { |o| Spree::Core::ProductFilters.price_filter[:conds][o] }.reject(&:nil?)
         scope = conds.shift
         conds.each do |new_scope|
@@ -70,10 +72,13 @@ module Spree
         Spree::Product.joins(master: :default_price).where(scope)
       end
 
+      # @deprecated This method is deprecated and will be removed in Spree 5.5.
       def self.format_price(amount)
         Spree::Money.new(amount)
       end
 
+      # @deprecated This method is deprecated and will be removed in Spree 5.5.
+      #   Use Spree::Api::V3::FiltersAggregator instead.
       def self.price_filter
         deprecated_warning
         v = Spree::Price.arel_table
@@ -102,7 +107,9 @@ module Spree
       #   the (uniquely named) field "p_brand.value". There's also a test for brand info
       #   being blank: note that this relies on with_property doing a left outer join
       #   rather than an inner join.
+      # @deprecated This scope is deprecated and will be removed in Spree 5.5.
       Spree::Product.add_search_scope :brand_any do |*opts|
+        deprecated_warning
         conds = opts.map { |o| ProductFilters.brand_filter[:conds][o] }.reject(&:nil?)
         scope = conds.shift
         conds.each do |new_scope|
@@ -116,6 +123,8 @@ module Spree
         end
       end
 
+      # @deprecated This method is deprecated and will be removed in Spree 5.5.
+      #   Use Spree::Api::V3::FiltersAggregator instead.
       def self.brand_filter
         deprecated_warning
         brand_property = Spree::Property.find_by(name: 'brand')
@@ -154,10 +163,14 @@ module Spree
       #
       #   The brand-finding code can be simplified if a few more named scopes were added to
       #   the product properties model.
+      # @deprecated This scope is deprecated and will be removed in Spree 5.5.
       Spree::Product.add_search_scope :selective_brand_any do |*opts|
+        deprecated_warning
         Spree::Product.brand_any(*opts)
       end
 
+      # @deprecated This method is deprecated and will be removed in Spree 5.5.
+      #   Use Spree::Api::V3::FiltersAggregator instead.
       def self.selective_brand_filter(taxon = nil)
         deprecated_warning
         taxon ||= Spree::Taxonomy.first.root
@@ -185,6 +198,8 @@ module Spree
       #
       # This scope selects products in any of the active taxons or their children.
       #
+      # @deprecated This method is deprecated and will be removed in Spree 5.5.
+      #   Use Spree::Api::V3::FiltersAggregator instead.
       def self.taxons_below(taxon)
         deprecated_warning
         return Spree::Core::ProductFilters.all_taxons if taxon.nil?
@@ -203,6 +218,8 @@ module Spree
       # it uses one of the auto-generated scopes from Ransack.
       #
       # idea: expand the format to allow nesting of labels?
+      # @deprecated This method is deprecated and will be removed in Spree 5.5.
+      #   Use Spree::Api::V3::FiltersAggregator instead.
       def self.all_taxons
         deprecated_warning
         taxons = Spree::Taxonomy.all.map { |t| [t.root] + t.root.descendants }.flatten


### PR DESCRIPTION
## Summary

- Added `@deprecated` YARD tags to `Spree::Core::ProductFilters` module, all its methods, and search scopes
- Added `deprecated_warning` calls to the three search scopes (`:price_range_any`, `:brand_any`, `:selective_brand_any`)
- Updated `Taxon#applicable_filters` documentation with proper deprecation notice
- All deprecated APIs are replaced by `Spree::Api::V3::FiltersAggregator` in the Store API

These changes provide clear migration guidance for users and prepare the codebase for removal in Spree 5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)