### PR TITLE
Fix: Replace deprecated Image#plp_url with cdn_image_url variant(:xlarge)

### DIFF
--- a/spree/core/app/services/spree/data_feeds/google/required_attributes.rb
+++ b/spree/core/app/services/spree/data_feeds/google/required_attributes.rb
@@ -41,15 +41,10 @@ module Spree
         end
 
         def get_image_link(variant, product)
-          # try getting image from variant
-          img = variant.images.first&.plp_url
+          image = variant.thumbnail || product.thumbnail
+          return if image.nil?
 
-          # if no image specified for variant try getting product image
-          if img.nil?
-            img = product.images.first&.plp_url
-          end
-
-          img
+          Rails.application.routes.url_helpers.cdn_image_url(image.attachment.variant(:xlarge))
         end
 
         def format_price(variant)

--- a/spree/core/spec/services/spree/data_feeds/google/rss_spec.rb
+++ b/spree/core/spec/services/spree/data_feeds/google/rss_spec.rb
@@ -54,7 +54,9 @@ module Spree
       end
 
       it 'includes image link' do
-        expect(result.value[:file]).to include("<g:image_link>#{variant.images.first.plp_url}</g:image_link>").once
+        image = variant.images.first
+        expected_url = Rails.application.routes.url_helpers.cdn_image_url(image.attachment.variant(:xlarge))
+        expect(result.value[:file]).to include("<g:image_link>#{expected_url}</g:image_link>").once
       end
 
       it 'includes price' do


### PR DESCRIPTION
## Summary

Fixed deprecation warning by replacing `Image#plp_url` with `cdn_image_url(image.attachment.variant(:xlarge))` in the Google data feed service. This uses the modern preprocessed xlarge variant (2000x2000) which provides high-resolution images for Google Shopping feeds and follows the same pattern used in API serializers.

Also improved performance by using `variant.thumbnail || product.thumbnail` instead of querying `images.first`.