### PR TITLE
Change server startup command in README

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -27,7 +27,7 @@ Then run the setup script:
 ```bash
 cd server
 bin/setup
-bin/rails server
+bin/dev
 ```
 
 `bin/setup` handles everything: installs Ruby (via [mise](https://mise.jdx.dev) if available, otherwise uses your system Ruby), system packages (libpq, vips), gems, and prepares the database.

--- a/server/bin/setup
+++ b/server/bin/setup
@@ -50,4 +50,4 @@ step "Cleaning up" bin/rails log:clear tmp:clear
 echo
 echo "✓ Done (${SECONDS}s)"
 echo
-echo "Run 'bin/dev server' to start the app."
+echo "Run 'bin/dev' to start the app."

--- a/server/bin/setup
+++ b/server/bin/setup
@@ -50,4 +50,4 @@ step "Cleaning up" bin/rails log:clear tmp:clear
 echo
 echo "✓ Done (${SECONDS}s)"
 echo
-echo "Run 'bin/rails server' to start the app."
+echo "Run 'bin/dev server' to start the app."


### PR DESCRIPTION
Updated server startup command in README from 'bin/rails server' to 'bin/dev'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/script output change only; no runtime logic or data handling is modified.
> 
> **Overview**
> Updates local development startup guidance to use `bin/dev` instead of `bin/rails server`, in both `server/README.md` and the final message printed by `server/bin/setup`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 630510a15d4a1a229578898dfad5cfc162bbd3bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->