### PR TITLE
Update products.mdx

### DIFF
--- a/docs/developer/core-concepts/products.mdx
+++ b/docs/developer/core-concepts/products.mdx
@@ -102,7 +102,7 @@ Products have the following attributes:
 | `status`          | The status of the product. Can be `draft`, `active`, `archived`. Defaults to `draft`. | No           |
 | `available_on`    | The first date the product becomes available for sale online in your shop                            | No           |
 | `discontinue_on`  | Date when the product will become unavailable for sale online in your shop                            | No           |
-| `deleted_at`      | The date the product is marked as deleted. We don't remove products entirely, only soft deleting them using a library called                                                              | No           |
+| `deleted_at`      | The date the product is marked as deleted. We don't remove products entirely, only soft deleting them using a library called `paranoia` | No           |
 | `meta_title`      | Optional title used for search engines instead of `name`                                              | Yes          |
 | `meta_description`| A description targeted at search engines for search engine optimization (SEO)                         | Yes          |
 | `meta_keywords`   | Several words and short phrases separated by commas, also targeted at search engines                  | Yes          |


### PR DESCRIPTION
Add missing gem name

<img width="1245" height="1573" alt="image" src="https://github.com/user-attachments/assets/a4bd2ff5-183c-4a2f-83c2-0b6877e9dd8c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies the soft-delete implementation detail; no runtime behavior is modified.
> 
> **Overview**
> Clarifies the `deleted_at` field description in `docs/developer/core-concepts/products.mdx` by explicitly naming the `paranoia` gem used for soft-deleting products.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9c08fb4ef496d313743425d44b915168962fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->