### PR TITLE
fix[v-3325]: order_refunded? fix

### DIFF
--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -309,9 +309,9 @@ module Spree
     # @return [Boolean]
     def order_refunded?
       return false if item_count.zero?
+      return false if refunds_total.zero?
 
-      (payment_state.in?(%w[void failed]) && refunds_total.positive?) ||
-        refunds_total == total_minus_store_credits - additional_tax_total.abs
+      payment_state.in?(%w[void failed]) || refunds_total == total_minus_store_credits - additional_tax_total.abs
     end
 
     def refunds_total

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -2418,7 +2418,18 @@ describe Spree::Order, type: :model do
     end
 
     context 'when order does not have refunds' do
-      let!(:order) { create(:order_ready_to_ship) }
+      let(:order) { create(:order_with_line_items, total: 100, store: store) }
+
+      context 'when order is fully paid by store credit' do
+        before do
+          create(:store_credit_payment_method, stores: [order.store])
+          create(:store_credit_payment, amount: order.total, order: order)
+        end
+
+        it 'returns false' do
+          expect(subject).to be(false)
+        end
+      end
 
       it 'returns false' do
         expect(subject).to be(false)


### PR DESCRIPTION
## issue description
- orders are incorectly marked as refunded when fully paid by store credits

## solution
- update condition in Spree::Order#order_refunded?
- udpate specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches refund-status logic in `Spree::Order#order_refunded?`, which can affect order state/reporting; change is small and covered by an added regression spec but impacts financial semantics.
> 
> **Overview**
> Fixes `Spree::Order#order_refunded?` to **require a non-zero `refunds_total`** before an order can be considered refunded, preventing store-credit-only orders (with no refunds) from being incorrectly flagged as refunded.
> 
> Updates model specs to add a regression case for an order fully paid via store credit and to align the existing “no refunds” expectations with the new guard condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd0d3c3893947ffc71936d87730578fb12cf21b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->