### PR TITLE
Replace rails runner with rake tasks in CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-beta.2",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/api-key.ts
+++ b/packages/cli/src/commands/api-key.ts
@@ -3,7 +3,7 @@ import * as p from '@clack/prompts'
 import pc from 'picocolors'
 import { printTable } from 'console-table-printer'
 import { detectProject } from '../context.js'
-import { railsRunner, escapeRubyString } from '../docker.js'
+import { rakeTask } from '../docker.js'
 
 export function registerApiKeyCommand(program: Command): void {
   const apiKey = program
@@ -59,16 +59,10 @@ export function registerApiKeyCommand(program: Command): void {
       const s = p.spinner()
       s.start('Creating API key...')
 
-      const safeName = escapeRubyString(name)
-      const script = [
-        `key = Spree::Store.default.api_keys.create!(`,
-        `name: '${safeName}',`,
-        `key_type: '${keyType}'`,
-        `);`,
-        `print key.plaintext_token`,
-      ].join(' ')
-
-      const stdout = await railsRunner(script, ctx.projectDir)
+      const stdout = await rakeTask('spree:cli:create_api_key', ctx.projectDir, {
+        NAME: name,
+        KEY_TYPE: keyType,
+      })
 
       const tokenPrefix = keyType === 'publishable' ? 'pk_' : 'sk_'
       const match = stdout.match(new RegExp(`${tokenPrefix}[A-Za-z0-9_-]+`))
@@ -99,15 +93,7 @@ export function registerApiKeyCommand(program: Command): void {
       const s = p.spinner()
       s.start('Fetching API keys...')
 
-      const script = [
-        `Spree::Store.default.api_keys.order(created_at: :desc).each { |k|`,
-        `status = k.revoked_at ? 'revoked' : 'active';`,
-        `token = k.secret? ? k.token_prefix : k.token;`,
-        `puts [k.prefixed_id, k.name, k.key_type, token, k.created_at.strftime('%Y-%m-%d %H:%M'), status].join('|')`,
-        `}`,
-      ].join(' ')
-
-      const stdout = await railsRunner(script, ctx.projectDir)
+      const stdout = await rakeTask('spree:cli:list_api_keys', ctx.projectDir)
       s.stop('')
 
       const lines = stdout.trim().split('\n').filter(Boolean)
@@ -142,15 +128,9 @@ export function registerApiKeyCommand(program: Command): void {
       const s = p.spinner()
       s.start('Revoking API key...')
 
-      const safeId = escapeRubyString(id)
-
-      const script = [
-        `key = Spree::Store.default.api_keys.find_by_prefix_id!('${safeId}');`,
-        `key.revoke!;`,
-        `print key.name`,
-      ].join(' ')
-
-      const stdout = await railsRunner(script, ctx.projectDir)
+      const stdout = await rakeTask('spree:cli:revoke_api_key', ctx.projectDir, {
+        ID: id,
+      })
       const name = stdout.trim()
 
       s.stop(`API key "${name}" revoked.`)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import pc from 'picocolors'
 import { execaCommand } from 'execa'
 import { platform } from 'node:os'
 import { detectProject } from '../context.js'
-import { dockerCompose, railsRunner } from '../docker.js'
+import { dockerCompose, rakeTask } from '../docker.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 
 const HEALTH_CHECK_INTERVAL_MS = 3000
@@ -34,10 +34,7 @@ export function registerInitCommand(program: Command): void {
 
       if (flags.sampleData) {
         s.start('Loading sample data...')
-        await dockerCompose(
-          ['exec', '-T', 'web', 'bin/rails', 'spree:load_sample_data'],
-          ctx.projectDir,
-        )
+        await rakeTask('spree:load_sample_data', ctx.projectDir)
         s.stop('Sample data loaded.')
       }
 
@@ -81,14 +78,7 @@ async function waitForHealthy(port: number): Promise<void> {
 }
 
 async function fetchApiKey(projectDir: string): Promise<string> {
-  const script = [
-    'store = Spree::Store.default;',
-    'key = store.api_keys.active.publishable.first ||',
-    "  store.api_keys.create!(name: 'Default', key_type: 'publishable');",
-    'print key.plaintext_token',
-  ].join(' ')
-
-  const stdout = await railsRunner(script, projectDir)
+  const stdout = await rakeTask('spree:cli:ensure_api_key', projectDir)
 
   const match = stdout.match(/pk_[A-Za-z0-9_-]+/)
   if (!match) {

--- a/packages/cli/src/commands/sample-data.ts
+++ b/packages/cli/src/commands/sample-data.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander'
 import * as p from '@clack/prompts'
 import { detectProject } from '../context.js'
-import { dockerCompose } from '../docker.js'
+import { rakeTask } from '../docker.js'
 
 export function registerSampleDataCommand(program: Command): void {
   program
@@ -12,10 +12,7 @@ export function registerSampleDataCommand(program: Command): void {
 
       const s = p.spinner()
       s.start('Loading sample data...')
-      await dockerCompose(
-        ['exec', '-T', 'web', 'bin/rails', 'spree:load_sample_data'],
-        ctx.projectDir,
-      )
+      await rakeTask('spree:load_sample_data', ctx.projectDir)
       s.stop('Sample data loaded.')
     })
 }

--- a/packages/cli/src/commands/seed.ts
+++ b/packages/cli/src/commands/seed.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander'
 import * as p from '@clack/prompts'
 import { detectProject } from '../context.js'
-import { dockerCompose } from '../docker.js'
+import { rakeTask } from '../docker.js'
 
 export function registerSeedCommand(program: Command): void {
   program
@@ -12,10 +12,7 @@ export function registerSeedCommand(program: Command): void {
 
       const s = p.spinner()
       s.start('Seeding database...')
-      await dockerCompose(
-        ['exec', '-T', 'web', 'bin/rails', 'db:seed'],
-        ctx.projectDir,
-      )
+      await rakeTask('db:seed', ctx.projectDir)
       s.stop('Database seeded.')
     })
 }

--- a/packages/cli/src/commands/user.ts
+++ b/packages/cli/src/commands/user.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander'
 import * as p from '@clack/prompts'
 import pc from 'picocolors'
 import { detectProject } from '../context.js'
-import { railsRunner, escapeRubyString } from '../docker.js'
+import { rakeTask } from '../docker.js'
 
 export function registerUserCommand(program: Command): void {
   const user = program
@@ -55,20 +55,10 @@ export function registerUserCommand(program: Command): void {
       const s = p.spinner()
       s.start('Creating admin user...')
 
-      const safeEmail = escapeRubyString(email)
-      const safePassword = escapeRubyString(password)
-
-      const script = [
-        `admin = Spree.admin_user_class.create!(`,
-        `email: '${safeEmail}',`,
-        `password: '${safePassword}',`,
-        `password_confirmation: '${safePassword}'`,
-        `);`,
-        `admin.add_role('admin', Spree::Store.default);`,
-        `print admin.email`,
-      ].join(' ')
-
-      await railsRunner(script, ctx.projectDir)
+      await rakeTask('spree:cli:create_admin', ctx.projectDir, {
+        EMAIL: email,
+        PASSWORD: password,
+      })
 
       s.stop('Admin user created.')
       p.log.success(`Email: ${pc.cyan(email)}`)

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -1,10 +1,5 @@
 import { execa, type Options as ExecaOptions } from 'execa'
 
-/** Escape a string for safe interpolation into a Ruby single-quoted string. */
-export function escapeRubyString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
-}
-
 export async function dockerCompose(
   args: string[],
   projectDir: string,
@@ -16,15 +11,22 @@ export async function dockerCompose(
   })
 }
 
-export async function railsRunner(
-  script: string,
+export async function rakeTask(
+  task: string,
   projectDir: string,
+  env?: Record<string, string>,
 ): Promise<string> {
-  const { stdout } = await execa(
-    'docker',
-    ['compose', 'exec', '-T', 'web', 'bin/rails', 'runner', script],
-    { cwd: projectDir },
-  )
+  const args = ['compose', 'exec', '-T']
+
+  if (env) {
+    for (const [key, value] of Object.entries(env)) {
+      args.push('-e', `${key}=${value}`)
+    }
+  }
+
+  args.push('web', 'bin/rails', task)
+
+  const { stdout } = await execa('docker', args, { cwd: projectDir })
 
   // Rails boot prints noise to stdout (e.g. "[Spree Events] ...") — strip it
   return stdout

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ import { registerSampleDataCommand } from './commands/sample-data.js'
 const program = new Command()
   .name('spree')
   .description('CLI for managing Spree Commerce projects')
-  .version('2.0.0-beta')
+  .version('2.0.0-beta.2')
 
 registerInitCommand(program)
 registerDevCommand(program)

--- a/packages/create-spree-app/src/templates/package-json.ts
+++ b/packages/create-spree-app/src/templates/package-json.ts
@@ -14,7 +14,7 @@ export function rootPackageJsonContent(name: string): string {
       console: 'spree console',
     },
     dependencies: {
-      '@spree/cli': '2.0.0-beta',
+      '@spree/cli': '2.0.0-beta.2',
     },
   }
 

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: ../spree/admin
   specs:
-    spree_admin (5.4.0.beta2)
+    spree_admin (5.4.0.beta3)
       active_link_to
       breadcrumbs_on_rails (~> 4.1)
       chartkick (~> 5.0)
@@ -23,7 +23,7 @@ PATH
       mapkick-rb (~> 0.1)
       pagy (~> 43.0)
       ruby-oembed (~> 0.18)
-      spree (>= 5.4.0.beta2)
+      spree (>= 5.4.0.beta3)
       stimulus-rails
       tailwindcss-rails (>= 4.0)
       tailwindcss-ruby (>= 4.0)
@@ -33,22 +33,22 @@ PATH
 PATH
   remote: ../spree/emails
   specs:
-    spree_emails (5.4.0.beta2)
-      spree (>= 5.4.0.beta2)
+    spree_emails (5.4.0.beta3)
+      spree (>= 5.4.0.beta3)
 
 PATH
   remote: ../spree
   specs:
-    spree (5.4.0.beta2)
-      spree_api (= 5.4.0.beta2)
-      spree_core (= 5.4.0.beta2)
-    spree_api (5.4.0.beta2)
+    spree (5.4.0.beta3)
+      spree_api (= 5.4.0.beta3)
+      spree_core (= 5.4.0.beta3)
+    spree_api (5.4.0.beta3)
       alba (~> 3.0)
       oj (~> 3.16)
       pagy (~> 43.0)
-      spree_core (= 5.4.0.beta2)
+      spree_core (= 5.4.0.beta3)
       typelizer (~> 0.9)
-    spree_core (5.4.0.beta2)
+    spree_core (5.4.0.beta3)
       active_storage_validations (= 1.3.0)
       acts-as-taggable-on
       acts_as_list (>= 0.8)
@@ -1117,12 +1117,12 @@ CHECKSUMS
   simplecov-cobertura (3.1.0) sha256=6d7f38aa32c965ca2174b2e5bd88cb17138eaf629518854976ac50e628925dc5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
-  spree (5.4.0.beta2)
-  spree_admin (5.4.0.beta2)
-  spree_api (5.4.0.beta2)
-  spree_core (5.4.0.beta2)
+  spree (5.4.0.beta3)
+  spree_admin (5.4.0.beta3)
+  spree_api (5.4.0.beta3)
+  spree_core (5.4.0.beta3)
   spree_dev_tools (0.5.3) sha256=64ae7b215ac5d5c5f5890f6fc0dbcb12882b9af305a860f36f95f564ec240a75
-  spree_emails (5.4.0.beta2)
+  spree_emails (5.4.0.beta3)
   spree_extension (0.1.0) sha256=b648327f4787295e051be4ea0c0a47baec47c2e245bca9c93ecf73605fc3a051
   spree_i18n (5.3.2) sha256=03b805235ca156644951f6bc3d07cbe43d0aa01134c4a27e3f3304011956f79b
   spree_stripe (1.5.1)

--- a/spree/core/lib/spree/core/version.rb
+++ b/spree/core/lib/spree/core/version.rb
@@ -1,5 +1,5 @@
 module Spree
-  VERSION = '5.4.0.beta2'.freeze
+  VERSION = '5.4.0.beta3'.freeze
 
   def self.version
     VERSION

--- a/spree/core/lib/tasks/cli.rake
+++ b/spree/core/lib/tasks/cli.rake
@@ -1,0 +1,50 @@
+namespace :spree do
+  namespace :cli do
+    desc 'Ensure a default publishable API key exists and print its token'
+    task ensure_api_key: :environment do
+      store = Spree::Store.default
+      key = store.api_keys.active.publishable.first ||
+            store.api_keys.create!(name: 'Default', key_type: 'publishable')
+      print key.plaintext_token
+    end
+
+    desc 'Create an API key'
+    task create_api_key: :environment do
+      name = ENV.fetch('NAME')
+      key_type = ENV.fetch('KEY_TYPE')
+      store = Spree::Store.default
+      key = store.api_keys.create!(name: name, key_type: key_type)
+      print key.plaintext_token
+    end
+
+    desc 'List API keys (pipe-delimited)'
+    task list_api_keys: :environment do
+      Spree::Store.default.api_keys.order(created_at: :desc).each do |k|
+        status = k.revoked_at ? 'revoked' : 'active'
+        token = k.secret? ? k.token_prefix : k.token
+        puts [k.prefixed_id, k.name, k.key_type, token, k.created_at.strftime('%Y-%m-%d %H:%M'), status].join('|')
+      end
+    end
+
+    desc 'Revoke an API key by prefixed ID'
+    task revoke_api_key: :environment do
+      id = ENV.fetch('ID')
+      key = Spree::Store.default.api_keys.find_by_prefix_id!(id)
+      key.revoke!
+      print key.name
+    end
+
+    desc 'Create an admin user'
+    task create_admin: :environment do
+      email = ENV.fetch('EMAIL')
+      password = ENV.fetch('PASSWORD')
+      admin = Spree.admin_user_class.create!(
+        email: email,
+        password: password,
+        password_confirmation: password
+      )
+      admin.add_role('admin', Spree::Store.default)
+      print admin.email
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replace all `rails runner` calls in `@spree/cli` with dedicated rake tasks under `spree:cli:` namespace — fixes shell escaping issues with `!` in Ruby methods (`create!`, `revoke!`) when invoked via `docker compose exec`
- Add `spree/core/lib/tasks/cli.rake` with 5 tasks that receive parameters via env vars
- Bump Spree to `5.4.0.beta3` (new Docker image needed for rake tasks)
- Bump `@spree/cli` to `2.0.0-beta.2`
- Fix npm publish CI for pre-release versions (`--tag beta`)

## Test plan

- [x] All 5 rake tasks tested manually against local Docker image
- [x] `spree init` end-to-end tested successfully
- [x] CLI tests pass (9/9)
- [x] create-spree-app tests pass (51/51)
- [x] Build and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)