### PR TITLE
fix trailing backticks in testing tutorial code block

### DIFF
--- a/docs/developer/tutorial/testing.mdx
+++ b/docs/developer/tutorial/testing.mdx
@@ -34,7 +34,7 @@ This adds Spree-specific test helpers to your `spec/support/` directory, includi
 When writing tests that involve file attachments (like images, PDFs, etc.), you need fixture files that your factories can use. Here's how to set them up.
 
 ```bash
-mkdir -p spec/fixtures/files && printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82' > spec/fixtures/files/logo.png```
+mkdir -p spec/fixtures/files && printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82' > spec/fixtures/files/logo.png
 ```
 
 ### Step 4: Generate Test Files


### PR DESCRIPTION
The shell command for creating the PNG test fixture on the [Testing tutorial](https://spreecommerce.org/docs/developer/tutorial/testing) page includes trailing markdown backticks `(```)` that are not part of the actual command. When users copy-paste the command directly, the backticks cause the shell to open a command substitution prompt, requiring Ctrl+C to exit. This fix removes the trailing backticks so the command can be copied and run correctly.