### PR TITLE
Hide already-selected option values from variant dropdowns

### DIFF
--- a/spree/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
     this.element.reset = this.reset.bind(this)
     this.element.values = this.values.bind(this)
     this.element.setValues = this.setValues.bind(this)
+    this.element.addEventListener('tomSelectInitialized', () => this.refreshAvailableOptions())
 
     this.setValues(this.preloadedValuesValue)
   }
@@ -48,6 +49,8 @@ export default class extends Controller {
       const inputContainer = event.target.closest('[data-multi-tom-select-target="select"]')
       this.removeSelect(inputContainer)
     }
+
+    this.refreshAvailableOptions()
   }
 
   removeSelect(container) {
@@ -56,6 +59,29 @@ export default class extends Controller {
       select.tomselect?.destroy()
       container.remove()
     }
+  }
+
+  refreshAvailableOptions() {
+    const selected = this.selectTargets.map((target) => {
+      const ts = target.querySelector('select')?.tomselect
+      return ts ? ts.getValue() : (target.getAttribute('data-select-active-option-value') || '')
+    }).filter(Boolean)
+
+    this.selectTargets.forEach((target) => {
+      const ts = target.querySelector('select')?.tomselect
+      if (!ts) return
+
+      const currentValue = ts.getValue()
+      this.preloadedOptionsValue.forEach((opt) => {
+        const optId = String(opt.id)
+        if (selected.includes(optId) && optId !== currentValue) {
+          ts.removeOption(optId, true)
+        } else if (!ts.options[optId]) {
+          ts.addOption(opt)
+        }
+      })
+      ts.refreshOptions(false)
+    })
   }
 
   addSelect(value = null) {

--- a/spree/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/multi_tom_select_controller.js
@@ -12,9 +12,14 @@ export default class extends Controller {
     this.element.reset = this.reset.bind(this)
     this.element.values = this.values.bind(this)
     this.element.setValues = this.setValues.bind(this)
-    this.element.addEventListener('tomSelectInitialized', () => this.refreshAvailableOptions())
+    this.boundRefresh = this.refreshAvailableOptions.bind(this)
+    this.element.addEventListener('tomSelectInitialized', this.boundRefresh)
 
     this.setValues(this.preloadedValuesValue)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('tomSelectInitialized', this.boundRefresh)
   }
 
   reset(addBlankSelect = true) {

--- a/spree/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -768,14 +768,12 @@ export default class extends CheckboxSelectAll {
     if (this.lastOptionNameId) {
       const response = await get(`${this.adminPathValue}/option_types/${this.lastOptionNameId}/option_values/select_options`)
 
-      if (response.ok) {
-        this.currentOptionValues[this.lastOptionNameId] = await response.json
+      this.currentOptionValues[this.lastOptionNameId] = response.ok ? await response.json : []
 
-        const optionsCreatorContainer = targetInput.closest('.options-creator__option')
-        const newOptionValuesSelects = optionsCreatorContainer.querySelectorAll('[data-variants-form-target="newOptionValuesSelect"]')
+      const optionsCreatorContainer = targetInput.closest('.options-creator__option')
+      const newOptionValuesSelects = optionsCreatorContainer.querySelectorAll('[data-variants-form-target="newOptionValuesSelect"]')
 
-        newOptionValuesSelects.forEach((select) => this.replaceSelectOptions(select))
-      }
+      newOptionValuesSelects.forEach((select) => this.replaceSelectOptions(select))
     }
   }
 


### PR DESCRIPTION
https://linear.app/vendo/issue/V-3161/product-form-option-values-can-select-already-added-values

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c0480856cf442ca10f1fbb7e1601e424e15d5d52. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->