### PR TITLE
Feature/v 3334 fix rails storefront compatibility with spree 54

### DIFF
--- a/spree/common_spree_dependencies.rb
+++ b/spree/common_spree_dependencies.rb
@@ -3,6 +3,8 @@
 # the one component of Spree.
 source 'https://rubygems.org'
 
+# https://github.com/shioyama/mobility/issues/678
+gem 'mobility', github: 'StephenVNelson/mobility', branch: 'stephenvnelson/fix_ar_8_querying'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'rails', ENV.fetch('RAILS_VERSION', '~> 8.1.0'), require: false
 

--- a/spree/core/app/models/concerns/spree/product_scopes.rb
+++ b/spree/core/app/models/concerns/spree/product_scopes.rb
@@ -334,16 +334,22 @@ module Spree
       # @return [ActiveRecord::Relation]
       add_search_scope :by_best_selling do |order_direction = :desc|
         store_id = Spree::Current.store&.id
-        sp_table = StoreProduct.arel_table
+        sp_table = StoreProduct.arel_table.alias('sps_best_selling')
         products_table = Product.arel_table
 
-        conditions = sp_table[:product_id].eq(products_table[:id]).and(sp_table[:store_id].eq(store_id))
+        join_condition = sp_table[:product_id].eq(products_table[:id]).and(sp_table[:store_id].eq(store_id))
+        join_node = Arel::Nodes::OuterJoin.new(sp_table, Arel::Nodes::On.new(join_condition))
 
-        units_sold = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table.project(sp_table[:units_sold_count]).where(conditions), 0])
-        revenue = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table.project(sp_table[:revenue]).where(conditions), 0])
-
+        zero = Arel::Nodes::Quoted.new(0)
+        best_selling_units = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table[:units_sold_count], zero]).as('best_selling_units')
+        best_selling_revenue = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table[:revenue], zero]).as('best_selling_revenue')
         order_dir = order_direction == :desc ? :desc : :asc
-        order(units_sold.send(order_dir)).order(revenue.send(order_dir))
+        order_units = Arel.sql('best_selling_units')
+        order_revenue = Arel.sql('best_selling_revenue')
+
+        joins(join_node).
+          select(products_table[Arel.star], best_selling_units, best_selling_revenue).
+          order(order_units.public_send(order_dir)).order(order_revenue.public_send(order_dir))
       end
 
       # .search_by_name

--- a/spree/core/app/models/concerns/spree/product_scopes.rb
+++ b/spree/core/app/models/concerns/spree/product_scopes.rb
@@ -341,15 +341,17 @@ module Spree
         join_node = Arel::Nodes::OuterJoin.new(sp_table, Arel::Nodes::On.new(join_condition))
 
         zero = Arel::Nodes::Quoted.new(0)
-        best_selling_units = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table[:units_sold_count], zero]).as('best_selling_units')
-        best_selling_revenue = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table[:revenue], zero]).as('best_selling_revenue')
+        best_selling_units = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table[:units_sold_count], zero])
+                                                       .as('best_selling_units')
+        best_selling_revenue = Arel::Nodes::NamedFunction.new('COALESCE', [sp_table[:revenue], zero])
+                                                         .as('best_selling_revenue')
         order_dir = order_direction == :desc ? :desc : :asc
         order_units = Arel.sql('best_selling_units')
         order_revenue = Arel.sql('best_selling_revenue')
 
-        joins(join_node).
-          select(products_table[Arel.star], best_selling_units, best_selling_revenue).
-          order(order_units.public_send(order_dir)).order(order_revenue.public_send(order_dir))
+        joins(join_node)
+          .select(products_table[Arel.star], best_selling_units, best_selling_revenue)
+          .order(order_units.public_send(order_dir)).order(order_revenue.public_send(order_dir))
       end
 
       # .search_by_name

--- a/spree/core/spec/finders/spree/products/find_spec.rb
+++ b/spree/core/spec/finders/spree/products/find_spec.rb
@@ -415,19 +415,6 @@ module Spree
         end
       end
 
-
-      # module Spree
-      #   describe Products::Find do
-      #     let(:store)                      { @default_store }
-      #     let!(:product)                   { create(:product, name: 'Product 1', price: 15.99, stores: [store]) }
-      #     let!(:product_2)                 { create(:product, name: 'Product 2', discontinue_on: Time.current + 1.day, price: 23.99, stores: [store]) }
-      #     let!(:product_3)                 { create(:product, name: 'Product 3', stores: [store]) }
-      #     let!(:option_value)              { create(:option_value) }
-      #     let!(:deleted_product)           { create(:product, name: 'Deleted Product', deleted_at: Time.current - 1.day) }
-      #     let!(:discontinued_product)      { create(:product, name: 'Discontinued Product', status: 'archived') }
-      #     let!(:in_stock_product)          { create(:product_in_stock, name: 'In Stock Product') }
-      #     let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product') }
-
       context 'when sorting by newest-first' do
         let(:params) { { sort_by: 'newest-first' } }
 

--- a/spree/core/spec/finders/spree/products/find_spec.rb
+++ b/spree/core/spec/finders/spree/products/find_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 module Spree
   describe Products::Find do
     let(:store)                      { @default_store }
-    let!(:product)                   { create(:product, price: 15.99, stores: [store]) }
-    let!(:product_2)                 { create(:product, discontinue_on: Time.current + 1.day, price: 23.99, stores: [store]) }
-    let!(:product_3)                 { create(:product, stores: [store]) }
+    let!(:product)                   { create(:product, name: 'Product 1', price: 15.99, stores: [store]) }
+    let!(:product_2)                 { create(:product, name: 'Product 2', discontinue_on: Time.current + 1.day, price: 23.99, stores: [store]) }
+    let!(:product_3)                 { create(:product, name: 'Product 3', stores: [store]) }
     let!(:option_value)              { create(:option_value) }
-    let!(:deleted_product)           { create(:product, deleted_at: Time.current - 1.day) }
-    let!(:discontinued_product)      { create(:product, status: 'archived') }
-    let!(:in_stock_product)          { create(:product_in_stock) }
-    let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder) }
+    let!(:deleted_product)           { create(:product, name: 'Deleted Product', deleted_at: Time.current - 1.day) }
+    let!(:discontinued_product)      { create(:product, name: 'Discontinued Product', status: 'archived') }
+    let!(:in_stock_product)          { create(:product_in_stock, name: 'In Stock Product') }
+    let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product') }
 
     context 'include discontinued' do
       it 'returns products with discontinued' do
@@ -377,7 +377,7 @@ module Spree
         described_class.new(
           scope: Spree::Product.all,
           params: params
-        ).execute
+        ).execute.to_a
       end
 
       context 'default' do
@@ -385,7 +385,7 @@ module Spree
           let(:params) { { sort_by: 'default' } }
 
           it 'returns products in default order' do
-            expect(products.ids).to match_array Spree::Product.available.ids
+            expect(products).to match_array Spree::Product.available.to_a
           end
         end
 
@@ -415,11 +415,24 @@ module Spree
         end
       end
 
+
+      # module Spree
+      #   describe Products::Find do
+      #     let(:store)                      { @default_store }
+      #     let!(:product)                   { create(:product, name: 'Product 1', price: 15.99, stores: [store]) }
+      #     let!(:product_2)                 { create(:product, name: 'Product 2', discontinue_on: Time.current + 1.day, price: 23.99, stores: [store]) }
+      #     let!(:product_3)                 { create(:product, name: 'Product 3', stores: [store]) }
+      #     let!(:option_value)              { create(:option_value) }
+      #     let!(:deleted_product)           { create(:product, name: 'Deleted Product', deleted_at: Time.current - 1.day) }
+      #     let!(:discontinued_product)      { create(:product, name: 'Discontinued Product', status: 'archived') }
+      #     let!(:in_stock_product)          { create(:product_in_stock, name: 'In Stock Product') }
+      #     let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product') }
+
       context 'when sorting by newest-first' do
         let(:params) { { sort_by: 'newest-first' } }
 
         it 'returns products in newest-first order' do
-          expect(products).to match_array([product_2, product_3, product, in_stock_product, not_backorderable_product])
+          expect(products.to_a).to eq([not_backorderable_product, in_stock_product, product_3, product_2, product])
         end
       end
 
@@ -427,7 +440,7 @@ module Spree
         let(:params) { { sort_by: 'price-high-to-low' } }
 
         it 'returns products in price-high-to-low order' do
-          expect(products).to match_array([product_2, product_3, product, in_stock_product, not_backorderable_product])
+          expect(products).to eq([product_2, not_backorderable_product, in_stock_product, product_3, product])
         end
       end
 
@@ -435,7 +448,7 @@ module Spree
         let(:params) { { sort_by: 'price-low-to-high' } }
 
         it 'returns products in price-low-to-high order' do
-          expect(products).to match_array([product, product_3, product_2, in_stock_product, not_backorderable_product])
+          expect(products).to eq([product, product_3, in_stock_product, not_backorderable_product, product_2])
         end
       end
 
@@ -443,7 +456,7 @@ module Spree
         let(:params) { { sort_by: 'name-a-z' } }
 
         it 'returns products in name-a-z order' do
-          expect(products).to match_array([product, product_2, product_3, in_stock_product, not_backorderable_product])
+          expect(products).to eq([in_stock_product, not_backorderable_product, product, product_2, product_3])
         end
       end
 
@@ -451,7 +464,7 @@ module Spree
         let(:params) { { sort_by: 'name-z-a' } }
 
         it 'returns products in name-z-a order' do
-          expect(products).to match_array([product_3, product_2, product, in_stock_product, not_backorderable_product])
+          expect(products).to eq([product_3, product_2, product, not_backorderable_product, in_stock_product])
         end
       end
 
@@ -459,13 +472,13 @@ module Spree
         let(:params) { { sort_by: 'best-selling' } }
 
         before do
-          create(:store_product, product: product, units_sold_count: 10, revenue: 100)
-          create(:store_product, product: product_2, units_sold_count: 20, revenue: 200)
-          create(:store_product, product: product_3, units_sold_count: 30, revenue: 300)
+          product.store_products.find_by(store: store).update(units_sold_count: 10, revenue: 100)
+          product_2.store_products.find_by(store: store).update(units_sold_count: 30, revenue: 200)
+          product_3.store_products.find_by(store: store).update(units_sold_count: 30, revenue: 300)
         end
 
         it 'returns products in best-selling order' do
-          expect(products).to match_array([product_3, product_2, product, in_stock_product, not_backorderable_product])
+          expect(products).to eq([product_3, product_2, product, in_stock_product, not_backorderable_product])
         end
       end
     end

--- a/spree/core/spec/finders/spree/products/find_spec.rb
+++ b/spree/core/spec/finders/spree/products/find_spec.rb
@@ -5,12 +5,12 @@ module Spree
     let(:store)                      { @default_store }
     let!(:product)                   { create(:product, name: 'Product 1', price: 15.99, stores: [store]) }
     let!(:product_2)                 { create(:product, name: 'Product 2', discontinue_on: Time.current + 1.day, price: 23.99, stores: [store]) }
-    let!(:product_3)                 { create(:product, name: 'Product 3', stores: [store]) }
+    let!(:product_3)                 { create(:product, name: 'Product 3', price: 16.99, stores: [store]) }
     let!(:option_value)              { create(:option_value) }
     let!(:deleted_product)           { create(:product, name: 'Deleted Product', deleted_at: Time.current - 1.day) }
     let!(:discontinued_product)      { create(:product, name: 'Discontinued Product', status: 'archived') }
-    let!(:in_stock_product)          { create(:product_in_stock, name: 'In Stock Product') }
-    let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product') }
+    let!(:in_stock_product)          { create(:product_in_stock, name: 'In Stock Product', price: 17.99) }
+    let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product', price: 18.99) }
 
     context 'include discontinued' do
       it 'returns products with discontinued' do

--- a/spree/core/spec/finders/spree/products/find_spec.rb
+++ b/spree/core/spec/finders/spree/products/find_spec.rb
@@ -373,14 +373,14 @@ module Spree
     end
 
     context 'ordered' do
-      context 'default' do
-        subject(:products) do
-          described_class.new(
-            scope: Spree::Product.all,
-            params: params
-          ).execute
-        end
+      subject(:products) do
+        described_class.new(
+          scope: Spree::Product.all,
+          params: params
+        ).execute
+      end
 
+      context 'default' do
         context 'when not filtering by taxons' do
           let(:params) { { sort_by: 'default' } }
 
@@ -415,69 +415,58 @@ module Spree
         end
       end
 
-      it 'returns products in newest-first order' do
-        params = {
-          sort_by: 'newest-first'
-        }
+      context 'when sorting by newest-first' do
+        let(:params) { { sort_by: 'newest-first' } }
 
-        product_ids = described_class.new(
-          scope: Spree::Product.all,
-          params: params
-        ).execute.map(&:id)
-
-        expect(product_ids).to eq Spree::Product.available.order(make_active_at: :desc).map(&:id)
+        it 'returns products in newest-first order' do
+          expect(products).to match_array([product_2, product_3, product, in_stock_product, not_backorderable_product])
+        end
       end
 
-      it 'returns products in price-high-to-low order' do
-        params = {
-          sort_by: 'price-high-to-low'
-        }
+      context 'when sorting by price-high-to-low' do
+        let(:params) { { sort_by: 'price-high-to-low' } }
 
-        products = described_class.new(
-          scope: Spree::Product.all,
-          params: params
-        ).execute.to_a
-
-        expect(products).to match_array([product_2, product_3, product, in_stock_product, not_backorderable_product])
+        it 'returns products in price-high-to-low order' do
+          expect(products).to match_array([product_2, product_3, product, in_stock_product, not_backorderable_product])
+        end
       end
 
-      it 'returns products in price-low-to-high order' do
-        params = {
-          sort_by: 'price-low-to-high'
-        }
+      context 'when sorting by price-low-to-high' do
+        let(:params) { { sort_by: 'price-low-to-high' } }
 
-        products = described_class.new(
-          scope: Spree::Product.all,
-          params: params
-        ).execute
-
-        expect(products).to match_array([product, product_3, product_2, in_stock_product, not_backorderable_product])
+        it 'returns products in price-low-to-high order' do
+          expect(products).to match_array([product, product_3, product_2, in_stock_product, not_backorderable_product])
+        end
       end
 
-      it 'returns products in name-a-z order' do
-        params = {
-          sort_by: 'name-a-z'
-        }
+      context 'when sorting by name-a-z' do
+        let(:params) { { sort_by: 'name-a-z' } }
 
-        products = described_class.new(
-          scope: Spree::Product.all,
-          params: params
-        ).execute
-
-        expect(products).to match_array([product, product_2, product_3, in_stock_product, not_backorderable_product])
+        it 'returns products in name-a-z order' do
+          expect(products).to match_array([product, product_2, product_3, in_stock_product, not_backorderable_product])
+        end
       end
 
-      it 'returns products in name-z-a order' do
-        params = {
-          sort_by: 'name-z-a'
-        }
+      context 'when sorting by name-z-a' do
+        let(:params) { { sort_by: 'name-z-a' } }
 
-        products = described_class.new(
-          scope: Spree::Product.all,
-          params: params
-        ).execute
+        it 'returns products in name-z-a order' do
+          expect(products).to match_array([product_3, product_2, product, in_stock_product, not_backorderable_product])
+        end
+      end
 
-        expect(products).to match_array([product_3, product_2, product, in_stock_product, not_backorderable_product])
+      context 'when sorting by best-selling' do
+        let(:params) { { sort_by: 'best-selling' } }
+
+        before do
+          create(:store_product, product: product, units_sold_count: 10, revenue: 100)
+          create(:store_product, product: product_2, units_sold_count: 20, revenue: 200)
+          create(:store_product, product: product_3, units_sold_count: 30, revenue: 300)
+        end
+
+        it 'returns products in best-selling order' do
+          expect(products).to match_array([product_3, product_2, product, in_stock_product, not_backorderable_product])
+        end
       end
     end
 

--- a/spree/core/spec/finders/spree/products/find_spec.rb
+++ b/spree/core/spec/finders/spree/products/find_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 module Spree
   describe Products::Find do
     let(:store)                      { @default_store }
-    let!(:product)                   { create(:product, name: 'Product 1', price: 15.99, stores: [store]) }
-    let!(:product_2)                 { create(:product, name: 'Product 2', discontinue_on: Time.current + 1.day, price: 23.99, stores: [store]) }
-    let!(:product_3)                 { create(:product, name: 'Product 3', price: 16.99, stores: [store]) }
+    let!(:product)                   { Timecop.travel(5.days.ago) { create(:product, name: 'Product 1', price: 15.99, stores: [store]) } }
+    let!(:product_2)                 { Timecop.travel(4.days.ago) { create(:product, name: 'Product 2', discontinue_on: Time.current + 5.day, price: 23.99, stores: [store]) } }
+    let!(:product_3)                 { Timecop.travel(3.days.ago) { create(:product, name: 'Product 3', price: 16.99, stores: [store]) } }
     let!(:option_value)              { create(:option_value) }
-    let!(:deleted_product)           { create(:product, name: 'Deleted Product', deleted_at: Time.current - 1.day) }
-    let!(:discontinued_product)      { create(:product, name: 'Discontinued Product', status: 'archived') }
-    let!(:in_stock_product)          { create(:product_in_stock, name: 'In Stock Product', price: 17.99) }
-    let!(:not_backorderable_product) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product', price: 18.99) }
+    let!(:deleted_product)           { Timecop.travel(2.days.ago) { create(:product, name: 'Deleted Product', deleted_at: Time.current - 1.day) } }
+    let!(:discontinued_product)      { Timecop.travel(1.day.ago) { create(:product, name: 'Discontinued Product', status: 'archived') } }
+    let!(:in_stock_product)          { Timecop.travel(1.hour.ago) { create(:product_in_stock, name: 'In Stock Product', price: 17.99) } }
+    let!(:not_backorderable_product) { Timecop.travel(1.minute.ago) { create(:product_in_stock, :without_backorder, name: 'Not Backorderable Product', price: 18.99) } }
 
     context 'include discontinued' do
       it 'returns products with discontinued' do
@@ -419,7 +419,7 @@ module Spree
         let(:params) { { sort_by: 'newest-first' } }
 
         it 'returns products in newest-first order' do
-          expect(products.to_a).to eq([not_backorderable_product, in_stock_product, product_3, product_2, product])
+          expect(products.to_a.map(&:name)).to eq([not_backorderable_product.name, in_stock_product.name, product_3.name, product_2.name, product.name])
         end
       end
 

--- a/spree/core/spec/finders/spree/products/find_spec.rb
+++ b/spree/core/spec/finders/spree/products/find_spec.rb
@@ -462,6 +462,7 @@ module Spree
           product.store_products.find_by(store: store).update(units_sold_count: 10, revenue: 100)
           product_2.store_products.find_by(store: store).update(units_sold_count: 30, revenue: 200)
           product_3.store_products.find_by(store: store).update(units_sold_count: 30, revenue: 300)
+          in_stock_product.store_products.find_by(store: store).update(units_sold_count: 1, revenue: 400)
         end
 
         it 'returns products in best-selling order' do


### PR DESCRIPTION
## issue

- product finder was raising `ActiveRecord::StatementInvalid: PG::InvalidColumnReference` when using `sort-by: best-selling` option

## solution

- use join and select instead of subquery in order by clause
- add specs

## other fixes
- after using custom select in best_selling scope, pagy failed with undefined method .right error. (rails 8 compability issue). to fix the issue mobility gem has been updated with fork that fixes the issue (new gem version has been not released yet)
- ` 'ordered' context` of finder test was using `match_array` in most test cases which... ignores order. 🙈  changed to `eq`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query generation for a user-facing sort and pins a core dependency to an unreleased fork, which could affect result ordering/performance or introduce upgrade friction.
> 
> **Overview**
> Fixes `best-selling` product sorting by rewriting `ProductScopes.by_best_selling` to use a `LEFT OUTER JOIN` against `spree_products_stores` with `COALESCE`d, selected alias columns, avoiding Postgres `InvalidColumnReference` errors caused by ordering via subqueries.
> 
> Updates `Products::Find` specs to use deterministic timestamps/names and to assert *actual ordering* (switching many cases from `match_array` to `eq`), and adds coverage for `best-selling` sorting.
> 
> Pins `mobility` to a GitHub fork/branch to work around a Rails 8 querying issue affecting custom selects/pagination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05f32cc413781b91b387b43f0ed71af2cca89d51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->