### PR TITLE
FIX gift card overspend race condition vulnerability

### DIFF
--- a/spree/core/app/services/spree/gift_cards/apply.rb
+++ b/spree/core/app/services/spree/gift_cards/apply.rb
@@ -25,15 +25,16 @@ module Spree
           return failure(:gift_card_mismatched_customer) if gift_card.user != order.user
         end
 
-        amount = [gift_card.amount_remaining, order.total].min
         store = order.store
-
-        return failure(:gift_card_no_amount_remaining) unless amount.positive? || order.total.zero?
 
         payment_method = ensure_store_credit_payment_method!(store)
 
-        gift_card.lock!
         order.with_lock do
+          gift_card.lock!
+          amount = [gift_card.amount_remaining, order.total].min
+
+          return failure(:gift_card_no_amount_remaining) unless amount.positive? || order.total.zero?
+
           store_credit = gift_card.store_credits.create!(
             store: store,
             user: order.user,

--- a/spree/core/spec/services/spree/gift_cards/apply_spec.rb
+++ b/spree/core/spec/services/spree/gift_cards/apply_spec.rb
@@ -105,6 +105,33 @@ RSpec.describe Spree::GiftCards::Apply do
     end
   end
 
+  context 'when applied concurrently to multiple orders' do
+    let(:gift_card) { create(:gift_card, amount: 100, store: store) }
+    let(:users) { Array.new(5) { create(:user) } }
+    let(:orders) do
+      users.map do |user|
+        order = create(:order, store: store, user: user)
+        order.update_columns(total: 80, item_total: 80)
+        order
+      end
+    end
+
+    it 'does not generate store credits exceeding the gift card value' do
+      threads = orders.map do |order|
+        Thread.new do
+          described_class.call(gift_card: gift_card, order: order)
+        end
+      end
+      threads.each(&:join)
+
+      gift_card.reload
+      total_credits = Spree::StoreCredit.where(originator: gift_card).sum(:amount)
+
+      expect(total_credits).to be <= gift_card.amount
+      expect(gift_card.amount_used).to be <= gift_card.amount
+    end
+  end
+
   context 'when the gift card has no amount remaining' do
     before { gift_card.update!(amount_used: gift_card.amount) }
 


### PR DESCRIPTION
After FIX script will still put race condition error but it is false positive as it's triggered on successes of requests rather than spent amount. 

<img width="528" height="228" alt="Zrzut ekranu 2026-03-5 o 15 26 19" src="https://github.com/user-attachments/assets/f259141f-e6ed-4ec3-ab85-42686176bf06" />
