### PR TITLE
API & SDK documentation fixes

### DIFF
--- a/docs/api-reference/store-api/authentication.mdx
+++ b/docs/api-reference/store-api/authentication.mdx
@@ -69,7 +69,7 @@ const { token, user } = await client.store.auth.login({
 })
 
 // Use the token for authenticated requests
-const orders = await client.store.orders.list({}, { token })
+const orders = await client.store.customer.orders.list({}, { token })
 ```
 
 ```bash cURL

--- a/docs/api-reference/store-api/monetary-amounts.mdx
+++ b/docs/api-reference/store-api/monetary-amounts.mdx
@@ -1,0 +1,69 @@
+---
+title: "Monetary Amounts"
+sidebarTitle: "Monetary Amounts"
+description: "How monetary values are represented in API responses"
+---
+
+All monetary values in the Store API are returned as **strings** (e.g., `"29.99"`, `"0.0"`), not numbers. This preserves decimal precision and avoids floating-point rounding issues common with JSON numbers.
+
+## Response Format
+
+Every monetary field has a corresponding `display_` field that includes currency formatting:
+
+```json
+{
+  "total": "129.99",
+  "display_total": "$129.99",
+  "item_total": "99.99",
+  "display_item_total": "$99.99",
+  "ship_total": "10.00",
+  "display_ship_total": "$10.00",
+  "tax_total": "20.00",
+  "display_tax_total": "$20.00"
+}
+```
+
+## Affected Types
+
+This convention applies to all monetary fields across all resources:
+
+| Resource | Monetary Fields |
+|----------|----------------|
+| **Order** | `total`, `item_total`, `ship_total`, `tax_total`, `adjustment_total`, `promo_total`, `included_tax_total`, `additional_tax_total` |
+| **Line Item** | `price`, `total`, `adjustment_total`, `promo_total`, `pre_tax_amount`, `discounted_amount`, `compare_at_amount` |
+| **Shipment** | `cost` |
+| **Payment** | `amount` |
+| **Gift Card** | `amount`, `amount_used`, `amount_authorized`, `amount_remaining` |
+| **Store Credit** | `amount`, `amount_used`, `amount_remaining` |
+| **Price** | `amount`, `compare_at_amount` |
+
+## Working with Amounts
+
+<CodeGroup>
+
+```typescript SDK
+const order = await client.store.orders.get('or_abc123', {}, { token });
+
+// Raw string values
+order.total;         // "129.99"
+order.display_total; // "$129.99"
+
+// Convert to number for calculations
+const total = parseFloat(order.total);
+```
+
+```javascript JavaScript
+const data = await response.json();
+
+// Use display fields for rendering
+element.textContent = data.display_total; // "$129.99"
+
+// Use raw fields for calculations
+const total = parseFloat(data.total);
+```
+
+</CodeGroup>
+
+<Tip>
+Use `display_*` fields for rendering prices in the UI — they are pre-formatted with the correct currency symbol and decimal places based on the order's currency. Use the raw string fields when you need to perform calculations.
+</Tip>

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -647,14 +647,14 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImQ3ZTVhMjljLTU1Y2UtNDAxNi1hZDZmLWRiMmU5ZjY3NTA4MSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzcyNzQyODY5fQ.ZRet-XBHnlKp9eLnyY25uU3yerCNZ5j4HtUQRU8duwk
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjNjNWFhOTQ5LTIyZmItNGE3ZS1iOWIxLTA1ZmE0NGI2OTE0YSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzcyNzQ0MjUxfQ.ZDKbjjOPp5UnbimtOHlZGVXDyGUsKLFH1Xr1-YHzHCw
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Rachel
-                  last_name: McGlynn
-                  created_at: '2026-03-05T19:34:29.189Z'
-                  updated_at: '2026-03-05T19:34:29.189Z'
+                  first_name: Krista
+                  last_name: Morar
+                  created_at: '2026-03-05T19:57:31.501Z'
+                  updated_at: '2026-03-05T19:57:31.501Z'
                   addresses: []
                   default_billing_address:
                   default_shipping_address:
@@ -727,14 +727,14 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjVkODAwMWI2LThmYTItNGM3Yy1iYzg0LTEzYzUxZDRmOGQyMiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzcyNzQyODcwfQ.-bZMS2MquOp_XWdBB3PcZej1HR58csH_36d2KSPSA9Y
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijg0YTdhMzcxLTI2YWItNDg4ZC1iOTIwLWFiMDcyNWEyNjhkZSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzcyNzQ0MjUyfQ.ZmAW9hmi61YhXZCCRwynbzUi8D7PNKGhHH-BYR4qRFo
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
                   first_name: John
                   last_name: Doe
-                  created_at: '2026-03-05T19:34:30.609Z'
-                  updated_at: '2026-03-05T19:34:30.609Z'
+                  created_at: '2026-03-05T19:57:32.933Z'
+                  updated_at: '2026-03-05T19:57:32.933Z'
                   addresses: []
                   default_billing_address:
                   default_shipping_address:
@@ -820,14 +820,14 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImFiN2IxMzg1LTJkYTYtNDQ2Yy1hZGFlLTVkYWM3YzEzZWQ0OSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzcyNzQyODcxfQ.fK1h_EEvHr82Cvm2ZUWVlaTEy39uciPhvyeHbQH8OZk
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImI3ZjIyYWFjLWY5ZTUtNGZiZi04NTc2LWFkODMyNmZkYTE2ZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzcyNzQ0MjUzfQ.5N4KKvawJm9F3AHlB6oELyYRua4FOArUCDqlOVDma-E
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Ethelyn
-                  last_name: Dach
-                  created_at: '2026-03-05T19:34:31.174Z'
-                  updated_at: '2026-03-05T19:34:31.174Z'
+                  first_name: Necole
+                  last_name: McDermott
+                  created_at: '2026-03-05T19:57:33.519Z'
+                  updated_at: '2026-03-05T19:57:33.519Z'
                   addresses: []
                   default_billing_address:
                   default_shipping_address:
@@ -891,13 +891,13 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R475457113
+                number: R423698003
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - complete
-                token: fYkadPtBLE5WUtgNo87V2A1772739271810
+                token: "-McWPHH7a9HPW6DVLgdIuA1772740654176"
                 email:
                 special_instructions:
                 currency: USD
@@ -923,8 +923,8 @@ paths:
                 total: '0.0'
                 display_total: "$0.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:31.811Z'
-                updated_at: '2026-03-05T19:34:31.811Z'
+                created_at: '2026-03-05T19:57:34.178Z'
+                updated_at: '2026-03-05T19:57:34.178Z'
                 order_promotions: []
                 line_items: []
                 shipments: []
@@ -1030,15 +1030,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R594344076
+                number: R326298422
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: P3hU3WdubZQdKZ8sk8bAaU2dtLdqk8fypps
-                email: sherie_nader@christiansenprosacco.us
+                token: WjWNEf7ezSpHGvwbPZBexm1mts3WHk19RCC
+                email: royce.schinner@huel.ca
                 special_instructions:
                 currency: USD
                 locale: en
@@ -1063,16 +1063,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:32.855Z'
-                updated_at: '2026-03-05T19:34:32.909Z'
+                created_at: '2026-03-05T19:57:35.235Z'
+                updated_at: '2026-03-05T19:57:35.292Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 28640
-                  slug: product-28640
+                  name: Product 26083
+                  slug: product-26083
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1091,23 +1091,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:32.886Z'
-                  updated_at: '2026-03-05T19:34:32.886Z'
+                  created_at: '2026-03-05T19:57:35.270Z'
+                  updated_at: '2026-03-05T19:57:35.270Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H16418260736
+                  number: H68721556501
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:34:32.892Z'
-                  updated_at: '2026-03-05T19:34:32.907Z'
+                  created_at: '2026-03-05T19:57:35.275Z'
+                  updated_at: '2026-03-05T19:57:35.288Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1115,7 +1115,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_41
-                    name: Edythe Streich
+                    name: Sarita Hegmann
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1233,15 +1233,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R549110979
+                number: R967116876
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: tHAvReKQMRLyg8wq2RgURRQDuHHjqQhRZg8
-                email: hugh.hessel@ryan.com
+                token: hui94gHxTu76huYx3HCGMu2uC6u4QrDZe9P
+                email: lizzie@hahn.info
                 special_instructions:
                 currency: USD
                 locale: en
@@ -1266,16 +1266,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:33.516Z'
-                updated_at: '2026-03-05T19:34:33.571Z'
+                created_at: '2026-03-05T19:57:35.879Z'
+                updated_at: '2026-03-05T19:57:35.933Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 3613
-                  slug: product-3613
+                  name: Product 31685
+                  slug: product-31685
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1294,23 +1294,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:33.549Z'
-                  updated_at: '2026-03-05T19:34:33.549Z'
+                  created_at: '2026-03-05T19:57:35.909Z'
+                  updated_at: '2026-03-05T19:57:35.909Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H65042707991
+                  number: H48511535939
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:34:33.555Z'
-                  updated_at: '2026-03-05T19:34:33.568Z'
+                  created_at: '2026-03-05T19:57:35.915Z'
+                  updated_at: '2026-03-05T19:57:35.930Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1318,7 +1318,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_45
-                    name: Monserrate Lakin
+                    name: Collette Schiller
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1593,15 +1593,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R241156833
+                number: R299619364
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: Z77bRNqvXpUYgs4tdKc1B2zy3W2r12RmdV7
-                email: lottie@hodkiewiczdamore.biz
+                token: yREKEGUwxbihqQFANqz3dEAcL8Md4Tnx3zo
+                email: richie@grant.com
                 special_instructions:
                 currency: USD
                 locale: en
@@ -1626,16 +1626,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:37.389Z'
-                updated_at: '2026-03-05T19:34:37.517Z'
+                created_at: '2026-03-05T19:57:39.602Z'
+                updated_at: '2026-03-05T19:57:39.723Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 82228
-                  slug: product-82228
+                  name: Product 86724
+                  slug: product-86724
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1654,23 +1654,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:37.424Z'
-                  updated_at: '2026-03-05T19:34:37.424Z'
+                  created_at: '2026-03-05T19:57:39.642Z'
+                  updated_at: '2026-03-05T19:57:39.642Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H51146050064
+                  number: H05607878929
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:34:37.429Z'
-                  updated_at: '2026-03-05T19:34:37.445Z'
+                  created_at: '2026-03-05T19:57:39.648Z'
+                  updated_at: '2026-03-05T19:57:39.662Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1678,7 +1678,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_65
-                    name: Felton Jast
+                    name: Rosenda Mitchell
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1700,12 +1700,12 @@ paths:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
-                  response_code: 1-SC-20260305193437505334
-                  number: PF68Z57F
+                  response_code: 1-SC-20260305195739714100
+                  number: P2T6SH1I
                   amount: '50.0'
                   display_amount: "$50.00"
-                  created_at: '2026-03-05T19:34:37.510Z'
-                  updated_at: '2026-03-05T19:34:37.510Z'
+                  created_at: '2026-03-05T19:57:39.718Z'
+                  updated_at: '2026-03-05T19:57:39.718Z'
                   source_type: store_credit
                   source_id: credit_UkLWZg9DAJ
                   source:
@@ -1857,15 +1857,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R409972656
+                number: R418108292
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: tjq8gAjv6yDfPNx567VTuY7fRU55FwPVQJD
-                email: buena@fadelbechtelar.name
+                token: UMsYpMt99JP7ird1aaYURJhLALqquEktiKX
+                email: shakia@mann.biz
                 special_instructions:
                 currency: USD
                 locale: en
@@ -1890,16 +1890,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:39.412Z'
-                updated_at: '2026-03-05T19:34:39.561Z'
+                created_at: '2026-03-05T19:57:41.478Z'
+                updated_at: '2026-03-05T19:57:41.592Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 112162
-                  slug: product-112162
+                  name: Product 112933
+                  slug: product-112933
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1918,23 +1918,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:39.452Z'
-                  updated_at: '2026-03-05T19:34:39.554Z'
+                  created_at: '2026-03-05T19:57:41.511Z'
+                  updated_at: '2026-03-05T19:57:41.586Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H84508037593
+                  number: H96356725536
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:34:39.460Z'
-                  updated_at: '2026-03-05T19:34:39.476Z'
+                  created_at: '2026-03-05T19:57:41.517Z'
+                  updated_at: '2026-03-05T19:57:41.531Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1942,7 +1942,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_77
-                    name: Dawn Keebler
+                    name: Keisha Jacobson
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2337,15 +2337,15 @@ paths:
               example:
                 data:
                 - id: or_UkLWZg9DAJ
-                  number: R664706640
+                  number: R474484394
                   state: cart
                   checkout_steps:
                   - address
                   - delivery
                   - payment
                   - complete
-                  token: DGLiUqJH8ZD6LGs8NUxDUU8VE4ZoPmw7CPR
-                  email: rachele_abernathy@wizamcdermott.info
+                  token: 1ZJWRNLjpzKAHNxpaigugmaxQng6XbGign7
+                  email: berniece.cummerata@green.co.uk
                   special_instructions:
                   currency: USD
                   locale: en
@@ -2370,16 +2370,16 @@ paths:
                   total: '110.0'
                   display_total: "$110.00"
                   completed_at:
-                  created_at: '2026-03-05T19:34:44.529Z'
-                  updated_at: '2026-03-05T19:34:44.637Z'
+                  created_at: '2026-03-05T19:57:46.161Z'
+                  updated_at: '2026-03-05T19:57:46.212Z'
                   order_promotions: []
                   line_items:
                   - id: li_UkLWZg9DAJ
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 132459
-                    slug: product-132459
+                    name: Product 137762
+                    slug: product-137762
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -2398,23 +2398,23 @@ paths:
                     discounted_amount: '10.0'
                     display_discounted_amount: "$10.00"
                     display_compare_at_amount: "$0.00"
-                    created_at: '2026-03-05T19:34:44.595Z'
-                    updated_at: '2026-03-05T19:34:44.595Z'
+                    created_at: '2026-03-05T19:57:46.192Z'
+                    updated_at: '2026-03-05T19:57:46.192Z'
                     compare_at_amount:
                     thumbnail_url:
                     option_values: []
                     digital_links: []
                   shipments:
                   - id: ship_UkLWZg9DAJ
-                    number: H69602176809
+                    number: H48343233939
                     state: pending
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
                     display_cost: "$100.00"
                     shipped_at:
-                    created_at: '2026-03-05T19:34:44.605Z'
-                    updated_at: '2026-03-05T19:34:44.633Z'
+                    created_at: '2026-03-05T19:57:46.196Z'
+                    updated_at: '2026-03-05T19:57:46.210Z'
                     shipping_method:
                       id: shpm_UkLWZg9DAJ
                       name: UPS Ground
@@ -2422,7 +2422,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: STATE_ABBR_100
-                      name: Manuel Kessler
+                      name: Leon Gerhold
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -2547,11 +2547,11 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: sibyl@robelgoodwin.info
-                first_name: Irene
-                last_name: Fritsch
-                created_at: '2026-03-05T19:34:45.676Z'
-                updated_at: '2026-03-05T19:34:45.975Z'
+                email: vita.stoltenberg@feeneymcclure.name
+                first_name: Lincoln
+                last_name: Corkery
+                created_at: '2026-03-05T19:57:47.088Z'
+                updated_at: '2026-03-05T19:57:47.355Z'
                 addresses:
                 - id: addr_gbHJdmfrXB
                   firstname: John
@@ -2674,11 +2674,11 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: carmella_zboncak@nicolas.name
+                email: tesha@kemmerstroman.co.uk
                 first_name: Updated
                 last_name: Name
-                created_at: '2026-03-05T19:34:46.301Z'
-                updated_at: '2026-03-05T19:34:46.790Z'
+                created_at: '2026-03-05T19:57:47.654Z'
+                updated_at: '2026-03-05T19:57:47.933Z'
                 addresses:
                 - id: addr_gbHJdmfrXB
                   firstname: John
@@ -2891,7 +2891,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: E33CCC319BA77576
+                  code: 39F7481530B6E007
                   state: active
                   currency: USD
                   amount: '10.0'
@@ -2905,8 +2905,8 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-03-05T19:34:51.173Z'
-                  updated_at: '2026-03-05T19:34:51.173Z'
+                  created_at: '2026-03-05T19:57:51.001Z'
+                  updated_at: '2026-03-05T19:57:51.001Z'
                 meta:
                   page: 1
                   limit: 25
@@ -2982,7 +2982,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 65A22C3E1596C48E
+                code: 7B9CB917F7162ECC
                 state: active
                 currency: USD
                 amount: '10.0'
@@ -2996,8 +2996,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-03-05T19:34:52.314Z'
-                updated_at: '2026-03-05T19:34:52.314Z'
+                created_at: '2026-03-05T19:57:52.079Z'
+                updated_at: '2026-03-05T19:57:52.079Z'
               schema:
                 "$ref": "#/components/schemas/StoreGiftCard"
         '404':
@@ -3075,15 +3075,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R769301163
+                number: R993777998
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: 9fo7RYTAHqUuaDtGqTe8G6vMSRoBkmQL6u7
-                email: sheilah.keebler@thielblanda.com
+                token: WTF3gVveGRUh7Y7xYiE7NyZXzvYbKSpnDxN
+                email: oralia@howell.com
                 special_instructions:
                 currency: USD
                 locale: en
@@ -3108,16 +3108,16 @@ paths:
                 total: '29.99'
                 display_total: "$29.99"
                 completed_at:
-                created_at: '2026-03-05T19:34:54.118Z'
-                updated_at: '2026-03-05T19:34:54.230Z'
+                created_at: '2026-03-05T19:57:53.833Z'
+                updated_at: '2026-03-05T19:57:53.926Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 237632
-                  slug: product-237632
+                  name: Product 233579
+                  slug: product-233579
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3136,8 +3136,8 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:54.155Z'
-                  updated_at: '2026-03-05T19:34:54.155Z'
+                  created_at: '2026-03-05T19:57:53.861Z'
+                  updated_at: '2026-03-05T19:57:53.861Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
@@ -3146,8 +3146,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 249766
-                  slug: product-249766
+                  name: Product 249825
+                  slug: product-249825
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -3166,8 +3166,8 @@ paths:
                   discounted_amount: '19.99'
                   display_discounted_amount: "$19.99"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:54.205Z'
-                  updated_at: '2026-03-05T19:34:54.205Z'
+                  created_at: '2026-03-05T19:57:53.902Z'
+                  updated_at: '2026-03-05T19:57:53.902Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
@@ -3287,14 +3287,14 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R376886314
+                number: R176051424
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - complete
-                token: XegcG7bcayaFKJwAn7zsjbYhXGZYRAc7MGx
-                email: juan@feest.com
+                token: J7cqBNmtDQtnCUQkLcAxK4YvoWBHJnVtWkk
+                email: rocky@purdyhowell.co.uk
                 special_instructions:
                 currency: USD
                 locale: en
@@ -3319,16 +3319,16 @@ paths:
                 total: '0.0'
                 display_total: "$0.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:56.757Z'
-                updated_at: '2026-03-05T19:34:56.787Z'
+                created_at: '2026-03-05T19:57:56.243Z'
+                updated_at: '2026-03-05T19:57:56.275Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 281107
-                  slug: product-281107
+                  name: Product 282532
+                  slug: product-282532
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3347,8 +3347,8 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:56.787Z'
-                  updated_at: '2026-03-05T19:34:56.803Z'
+                  created_at: '2026-03-05T19:57:56.274Z'
+                  updated_at: '2026-03-05T19:57:56.290Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
@@ -3447,14 +3447,14 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R364273558
+                number: R796797841
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - complete
-                token: pTZg39v66xmCodQazRSPVLK1x9889Q88Wfx
-                email: adolph.pacocha@hagenes.us
+                token: TWmayfCxcFJox9uRdNDpX3fvtcXUGLfZSV8
+                email: dedra_senger@reilly.us
                 special_instructions:
                 currency: USD
                 locale: en
@@ -3479,8 +3479,8 @@ paths:
                 total: '0.0'
                 display_total: "$0.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:57.377Z'
-                updated_at: '2026-03-05T19:34:57.449Z'
+                created_at: '2026-03-05T19:57:56.834Z'
+                updated_at: '2026-03-05T19:57:56.888Z'
                 order_promotions: []
                 line_items: []
                 shipments: []
@@ -3985,14 +3985,14 @@ paths:
             application/json:
               example:
                 id: or_gbHJdmfrXB
-                number: R304888371
+                number: R511103264
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: f8uR7Ep3Bzds1QBBwj2a6NanYpgEzMPAkV2
+                token: ExiEnuA3Ux1qgi27JJQ1CDZuNjLcqf2VGYR
                 email:
                 special_instructions:
                 currency: USD
@@ -4018,16 +4018,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:34:59.824Z'
-                updated_at: '2026-03-05T19:34:59.884Z'
+                created_at: '2026-03-05T19:57:59.153Z'
+                updated_at: '2026-03-05T19:57:59.206Z'
                 order_promotions: []
                 line_items:
                 - id: li_gbHJdmfrXB
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 336747
-                  slug: product-336747
+                  name: Product 33318
+                  slug: product-33318
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4046,23 +4046,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:34:59.862Z'
-                  updated_at: '2026-03-05T19:34:59.862Z'
+                  created_at: '2026-03-05T19:57:59.185Z'
+                  updated_at: '2026-03-05T19:57:59.185Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_gbHJdmfrXB
-                  number: H47595143173
+                  number: H21406756833
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:34:59.870Z'
-                  updated_at: '2026-03-05T19:34:59.882Z'
+                  created_at: '2026-03-05T19:57:59.192Z'
+                  updated_at: '2026-03-05T19:57:59.203Z'
                   shipping_method:
                     id: shpm_gbHJdmfrXB
                     name: UPS Ground
@@ -4070,7 +4070,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_159
-                    name: Ralph Lindgren
+                    name: Rosario Smitham
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4205,15 +4205,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R222155112
+                number: R367519376
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: 7yzitew4SQycNSiHXPEZJWdUFk5B6UsgS4F
-                email: jesica@white.us
+                token: VBijCnhnMHAwtNrE1qpktsSMTdvnBwNarvq
+                email: sheba@roberts.biz
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4238,16 +4238,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:35:02.574Z'
-                updated_at: '2026-03-05T19:35:02.639Z'
+                created_at: '2026-03-05T19:58:01.841Z'
+                updated_at: '2026-03-05T19:58:01.910Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 372901
-                  slug: product-372901
+                  name: Product 372657
+                  slug: product-372657
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4266,23 +4266,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:02.605Z'
-                  updated_at: '2026-03-05T19:35:02.605Z'
+                  created_at: '2026-03-05T19:58:01.874Z'
+                  updated_at: '2026-03-05T19:58:01.874Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H94374952613
+                  number: H55085931047
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:02.610Z'
-                  updated_at: '2026-03-05T19:35:02.623Z'
+                  created_at: '2026-03-05T19:58:01.879Z'
+                  updated_at: '2026-03-05T19:58:01.893Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -4290,7 +4290,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_178
-                    name: Stella Metz
+                    name: Evon Ondricka
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4501,15 +4501,15 @@ paths:
             application/json:
               example:
                 id: or_gbHJdmfrXB
-                number: R594040326
+                number: R416495846
                 state: address
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: 3Md1cjUPKzCJypAWM1r5VJsfSU556MfUmHX
-                email: oma@mcglynn.name
+                token: KmbjZRU955ZXJWSPz2hpPDKoQeFYfJ2kYdN
+                email: renato@kleinfarrell.info
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4534,16 +4534,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:35:03.964Z'
-                updated_at: '2026-03-05T19:35:04.025Z'
+                created_at: '2026-03-05T19:58:03.177Z'
+                updated_at: '2026-03-05T19:58:03.248Z'
                 order_promotions: []
                 line_items:
                 - id: li_gbHJdmfrXB
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 414759
-                  slug: product-414759
+                  name: Product 418814
+                  slug: product-418814
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4562,23 +4562,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:03.990Z'
-                  updated_at: '2026-03-05T19:35:03.990Z'
+                  created_at: '2026-03-05T19:58:03.203Z'
+                  updated_at: '2026-03-05T19:58:03.203Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_gbHJdmfrXB
-                  number: H25120892261
+                  number: H33502902897
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:03.996Z'
-                  updated_at: '2026-03-05T19:35:04.007Z'
+                  created_at: '2026-03-05T19:58:03.210Z'
+                  updated_at: '2026-03-05T19:58:03.221Z'
                   shipping_method:
                     id: shpm_gbHJdmfrXB
                     name: UPS Ground
@@ -4586,7 +4586,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_188
-                    name: Marisha O'Reilly
+                    name: Donella Morissette
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4711,15 +4711,15 @@ paths:
             application/json:
               example:
                 id: or_gbHJdmfrXB
-                number: R625291768
+                number: R821573763
                 state: payment
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: yJAMyEvDaAMDGzhYyubN3Wze5CKJxk35SNM
-                email: rafaela@spinka.us
+                token: wL9s8xjqdqMGV6hLfrefx7jgViKVpHyXxgt
+                email: luba@dietrich.co.uk
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4744,16 +4744,16 @@ paths:
                 total: '29.99'
                 display_total: "$29.99"
                 completed_at:
-                created_at: '2026-03-05T19:35:05.328Z'
-                updated_at: '2026-03-05T19:35:05.475Z'
+                created_at: '2026-03-05T19:58:04.471Z'
+                updated_at: '2026-03-05T19:58:04.694Z'
                 order_promotions: []
                 line_items:
                 - id: li_gbHJdmfrXB
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 448391
-                  slug: product-448391
+                  name: Product 444640
+                  slug: product-444640
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -4772,23 +4772,23 @@ paths:
                   discounted_amount: '19.99'
                   display_discounted_amount: "$19.99"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:05.356Z'
-                  updated_at: '2026-03-05T19:35:05.413Z'
+                  created_at: '2026-03-05T19:58:04.505Z'
+                  updated_at: '2026-03-05T19:58:04.617Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_EfhxLZ9ck8
-                  number: H64219554110
+                  number: H42539203453
                   state: pending
                   tracking:
                   tracking_url:
                   cost: '10.0'
                   display_cost: "$10.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:05.432Z'
-                  updated_at: '2026-03-05T19:35:05.445Z'
+                  created_at: '2026-03-05T19:58:04.650Z'
+                  updated_at: '2026-03-05T19:58:04.665Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -4796,7 +4796,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_198
-                    name: Rudy Senger
+                    name: Jonathon Robel
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4920,15 +4920,15 @@ paths:
             application/json:
               example:
                 id: or_gbHJdmfrXB
-                number: R989711655
+                number: R361062581
                 state: complete
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: zDJat8Xk4PMaSdZQW8RZKequC7ztmq4ipTd
-                email: lucina@hahn.co.uk
+                token: 2iQzb2x5zDjuo46Gd6HCsB2x6osWxxAHuR7
+                email: harriett_wolff@rodriguez.biz
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4952,17 +4952,17 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '29.99'
                 display_total: "$29.99"
-                completed_at: '2026-03-05T19:35:06.366Z'
-                created_at: '2026-03-05T19:35:06.112Z'
-                updated_at: '2026-03-05T19:35:06.366Z'
+                completed_at: '2026-03-05T19:58:05.469Z'
+                created_at: '2026-03-05T19:58:05.298Z'
+                updated_at: '2026-03-05T19:58:05.469Z'
                 order_promotions: []
                 line_items:
                 - id: li_gbHJdmfrXB
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 467503
-                  slug: product-467503
+                  name: Product 461029
+                  slug: product-461029
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -4981,23 +4981,23 @@ paths:
                   discounted_amount: '19.99'
                   display_discounted_amount: "$19.99"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:06.161Z'
-                  updated_at: '2026-03-05T19:35:06.241Z'
+                  created_at: '2026-03-05T19:58:05.324Z'
+                  updated_at: '2026-03-05T19:58:05.369Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_EfhxLZ9ck8
-                  number: H55487054549
+                  number: H49423776470
                   state: pending
                   tracking:
                   tracking_url:
                   cost: '10.0'
                   display_cost: "$10.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:06.264Z'
-                  updated_at: '2026-03-05T19:35:06.356Z'
+                  created_at: '2026-03-05T19:58:05.386Z'
+                  updated_at: '2026-03-05T19:58:05.462Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -5005,7 +5005,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_204
-                    name: Lavonia Hoppe
+                    name: Kim Gulgowski
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5038,11 +5038,11 @@ paths:
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
                   response_code: '12345'
-                  number: PH6XN3I2
+                  number: P921GXLM
                   amount: '29.99'
                   display_amount: "$29.99"
-                  created_at: '2026-03-05T19:35:06.328Z'
-                  updated_at: '2026-03-05T19:35:06.328Z'
+                  created_at: '2026-03-05T19:58:05.439Z'
+                  updated_at: '2026-03-05T19:58:05.439Z'
                   source_type: credit_card
                   source_id: card_UkLWZg9DAJ
                   source:
@@ -5275,13 +5275,13 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_e33048fec691d8a43ce399d1
+                external_id: bogus_bff3b803518984b8c176fd93
                 external_data:
-                  client_secret: bogus_secret_4bb4044d1d6130d9
+                  client_secret: bogus_secret_503a70deded891f4
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-05T19:35:08.868Z'
-                updated_at: '2026-03-05T19:35:08.868Z'
+                created_at: '2026-03-05T19:58:07.869Z'
+                updated_at: '2026-03-05T19:58:07.869Z'
                 amount: '110.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -5386,13 +5386,13 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_cfcf9456dd0fcf0a03c25b0c
+                external_id: bogus_57fb6547fe9187a1e8ceec44
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-05T19:35:10.152Z'
-                updated_at: '2026-03-05T19:35:10.152Z'
+                created_at: '2026-03-05T19:58:09.084Z'
+                updated_at: '2026-03-05T19:58:09.084Z'
                 amount: '110.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -5449,13 +5449,13 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_58166e989d1599d09a5dd019
+                external_id: bogus_2ed7885834fc465e915f15ff
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-05T19:35:11.450Z'
-                updated_at: '2026-03-05T19:35:11.466Z'
+                created_at: '2026-03-05T19:58:10.286Z'
+                updated_at: '2026-03-05T19:58:10.299Z'
                 amount: '50.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -5553,13 +5553,13 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_d8d689f3af2489fd072fc024
+                external_id: bogus_4b7138c3ee0d6139a635e609
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-05T19:35:12.122Z'
-                updated_at: '2026-03-05T19:35:12.137Z'
+                created_at: '2026-03-05T19:58:10.905Z'
+                updated_at: '2026-03-05T19:58:10.920Z'
                 amount: '110.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -5639,11 +5639,11 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_3f6527e24ac88aaa9ebaf4ee
-                external_client_secret: bogus_seti_secret_b44fd04ca9b2f3f7
+                external_id: bogus_seti_33f9b074e3bceca0bdd1ecd6
+                external_client_secret: bogus_seti_secret_5d1fd977f2f246c8
                 external_data: {}
-                created_at: '2026-03-05T19:35:13.408Z'
-                updated_at: '2026-03-05T19:35:13.408Z'
+                created_at: '2026-03-05T19:58:12.086Z'
+                updated_at: '2026-03-05T19:58:12.086Z'
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
                 payment_source_type:
@@ -5740,12 +5740,12 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_c065c0b5df30cfa99ce9c81e
-                external_client_secret: seti_secret_5b83c1a6cf8cabc0173c87d2
+                external_id: seti_test_5b6dbd34e1b8229a4478b381
+                external_client_secret: seti_secret_fb77f15d45800a48c4913814
                 external_data:
                   client_secret: secret_123
-                created_at: '2026-03-05T19:35:15.113Z'
-                updated_at: '2026-03-05T19:35:15.113Z'
+                created_at: '2026-03-05T19:58:13.707Z'
+                updated_at: '2026-03-05T19:58:13.707Z'
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
                 payment_source_type:
@@ -5818,12 +5818,12 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_bd348254083cc194c30d73d0
-                external_client_secret: seti_secret_e78523730c6dca96a6f5cf79
+                external_id: seti_test_050a4fbdf2f1904cd5f745e2
+                external_client_secret: seti_secret_074a9565fcfd50e7faba9f8f
                 external_data:
                   client_secret: secret_123
-                created_at: '2026-03-05T19:35:16.303Z'
-                updated_at: '2026-03-05T19:35:16.318Z'
+                created_at: '2026-03-05T19:58:14.806Z'
+                updated_at: '2026-03-05T19:58:14.822Z'
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id: card_UkLWZg9DAJ
                 payment_source_type: Spree::CreditCard
@@ -5906,11 +5906,11 @@ paths:
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
                   response_code: '12345'
-                  number: PSMKMW11
+                  number: PP04TICB
                   amount: '110.0'
                   display_amount: "$110.00"
-                  created_at: '2026-03-05T19:35:17.630Z'
-                  updated_at: '2026-03-05T19:35:17.630Z'
+                  created_at: '2026-03-05T19:58:15.973Z'
+                  updated_at: '2026-03-05T19:58:15.973Z'
                   source_type: credit_card
                   source_id: card_UkLWZg9DAJ
                   source:
@@ -6004,11 +6004,11 @@ paths:
                 payment_method_id: pm_UkLWZg9DAJ
                 state: checkout
                 response_code: '12345'
-                number: PQKCJB6T
+                number: PL3NR1H4
                 amount: '110.0'
                 display_amount: "$110.00"
-                created_at: '2026-03-05T19:35:18.921Z'
-                updated_at: '2026-03-05T19:35:18.921Z'
+                created_at: '2026-03-05T19:58:17.226Z'
+                updated_at: '2026-03-05T19:58:17.226Z'
                 source_type: credit_card
                 source_id: card_UkLWZg9DAJ
                 source:
@@ -6145,17 +6145,18 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 634595
-                  description: Esse repellat consequatur saepe similique corporis.
-                    Vero quos repellendus esse impedit cum beatae dolore nam. Veritatis
-                    eaque dolores atque reprehenderit porro sint adipisci.
-                  slug: product-634595
+                  name: Product 637899
+                  description: |-
+                    Saepe inventore illo atque occaecati tenetur impedit doloribus optio. Quisquam odit fuga consectetur aliquam minus. Nobis aliquid unde sint repellendus quisquam debitis occaecati cumque. Esse fugit distinctio corporis ab soluta quis eaque. Eius debitis voluptate ab eaque.
+                    Id expedita dolorem voluptatibus molestiae dignissimos doloribus quisquam repellendus. Veniam commodi consequatur quaerat non eos inventore distinctio. Ratione officiis beatae itaque minus. Iusto error mollitia temporibus atque corporis deleniti dolore.
+                    Odit nemo quo nostrum laboriosam in. Rerum doloremque labore quis vero. Ipsa voluptatem ratione debitis nostrum harum odio quia animi. Quasi maxime ex dolor odit recusandae adipisci quisquam nihil. Praesentium velit numquam accusamus sequi.
+                  slug: product-637899
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-03-05T19:35:19.615Z'
-                  created_at: '2026-03-05T19:35:19.634Z'
-                  updated_at: '2026-03-05T19:35:19.687Z'
+                  available_on: '2025-03-05T19:58:17.894Z'
+                  created_at: '2026-03-05T19:58:17.909Z'
+                  updated_at: '2026-03-05T19:58:17.955Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -6175,18 +6176,20 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 646744
+                  name: Product 645192
                   description: |-
-                    Veritatis sapiente natus cum alias laboriosam quos. Tempore possimus rem nostrum placeat culpa temporibus libero magni. Quae blanditiis aut itaque accusamus culpa. Autem incidunt nihil hic nemo.
-                    Libero doloremque odit atque cupiditate temporibus molestiae architecto eum. Quos quidem maxime ex qui distinctio. Aperiam officia voluptates distinctio dolor veniam exercitationem asperiores. Quisquam laboriosam quas velit incidunt consectetur aliquam ex. Dolore culpa nam numquam magnam qui autem voluptatibus ipsum.
-                    Magnam cumque cum occaecati praesentium. Cumque dolorem quae maiores aspernatur deserunt eveniet voluptate inventore. Nobis laboriosam quos natus facilis officiis cum aut. Vitae blanditiis dolore ad reprehenderit quibusdam mollitia quis. Dolores et sequi molestias qui blanditiis.
-                  slug: product-646744
+                    Libero dicta doloremque laudantium sunt commodi assumenda aperiam neque. Iste quasi deserunt harum consectetur earum quis eligendi. Cupiditate magnam quas ullam soluta. Aut rem voluptatibus temporibus similique. Unde magni iusto commodi officiis omnis accusantium earum.
+                    Unde dignissimos quia doloremque iusto corrupti quaerat. Optio impedit asperiores dicta ad voluptate. Quia a nihil velit dolores maxime quos quo.
+                    Cupiditate quibusdam rem libero ut. Quaerat eius beatae tempore illo iste repudiandae corporis dolores. Rem id fugit nisi vero voluptatem sequi placeat. Veritatis ratione reiciendis quasi velit mollitia commodi.
+                    Quibusdam veniam iusto est nemo laborum nisi dolorum. Optio reiciendis vel pariatur quae eaque. Velit illum mollitia ducimus molestias ex porro. Aspernatur corrupti soluta voluptatibus excepturi error.
+                    Aperiam iusto temporibus aliquam excepturi veniam sint illo. Ipsa rerum ullam repudiandae quae qui. Dicta dolore saepe mollitia ab earum illo. A expedita excepturi recusandae placeat id.
+                  slug: product-645192
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-03-05T19:35:19.702Z'
-                  created_at: '2026-03-05T19:35:19.714Z'
-                  updated_at: '2026-03-05T19:35:19.731Z'
+                  available_on: '2025-03-05T19:58:17.960Z'
+                  created_at: '2026-03-05T19:58:17.968Z'
+                  updated_at: '2026-03-05T19:58:17.980Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -6285,18 +6288,20 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 75189
+                name: Product 758073
                 description: |-
-                  Amet laboriosam reprehenderit est ut iusto tempore illum. Deserunt molestiae alias aspernatur eligendi est accusantium. Odit totam dolores provident exercitationem. Nam voluptas architecto voluptatibus necessitatibus harum ducimus. Qui debitis distinctio illo fuga praesentium omnis.
-                  Amet ipsum recusandae distinctio tenetur dolorum ex ipsam. Dolore necessitatibus fuga eaque quibusdam. Ad excepturi molestias sit placeat delectus tenetur.
-                  Fuga beatae quos debitis provident molestiae. Eveniet impedit ut facere architecto. Corporis quibusdam id similique mollitia ipsa fugiat aperiam cumque. Asperiores ratione praesentium quis iure corporis debitis.
-                slug: product-75189
+                  Vel cum accusantium nisi adipisci nostrum. Fugiat hic perspiciatis odio vero debitis. Voluptates ipsam expedita quo tempora rem voluptatibus maxime nobis. Nobis dolorem culpa molestias aut tenetur quasi. Velit quasi nam laudantium iusto mollitia a.
+                  Ratione rerum aperiam architecto incidunt. Praesentium eum similique adipisci neque nemo commodi ex nisi. Laborum odit quos totam placeat voluptas itaque. Nesciunt rerum dolore tenetur voluptate maxime ullam voluptatem ab.
+                  Laboriosam aperiam autem possimus quidem. Consequatur enim odit veritatis adipisci animi aut. Eum a magni in numquam mollitia dolorem delectus. Delectus omnis ad quae vel animi.
+                  Explicabo laboriosam quibusdam ea temporibus repudiandae. Dicta doloribus porro veniam alias. Laboriosam temporibus nam nulla maxime atque vero quod dolores.
+                  Ex aliquid quis sapiente sint quisquam. Eveniet nulla commodi incidunt ducimus. Sed culpa distinctio libero sunt nam alias. Cum molestiae autem animi amet.
+                slug: product-758073
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-03-05T19:35:20.550Z'
-                created_at: '2026-03-05T19:35:20.571Z'
-                updated_at: '2026-03-05T19:35:20.618Z'
+                available_on: '2025-03-05T19:58:18.730Z'
+                created_at: '2026-03-05T19:58:18.745Z'
+                updated_at: '2026-03-05T19:58:18.777Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -6513,15 +6518,15 @@ paths:
               example:
                 data:
                 - id: ship_UkLWZg9DAJ
-                  number: H35146875600
+                  number: H02432309319
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:23.282Z'
-                  updated_at: '2026-03-05T19:35:23.297Z'
+                  created_at: '2026-03-05T19:58:21.248Z'
+                  updated_at: '2026-03-05T19:58:21.261Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -6529,7 +6534,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_290
-                    name: Amelia Mayert
+                    name: Terrance Murray
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -6626,15 +6631,15 @@ paths:
             application/json:
               example:
                 id: ship_UkLWZg9DAJ
-                number: H18565636390
+                number: H54933939929
                 state: pending
                 tracking: U10000
                 tracking_url:
                 cost: '100.0'
                 display_cost: "$100.00"
                 shipped_at:
-                created_at: '2026-03-05T19:35:24.570Z'
-                updated_at: '2026-03-05T19:35:24.585Z'
+                created_at: '2026-03-05T19:58:22.485Z'
+                updated_at: '2026-03-05T19:58:22.502Z'
                 shipping_method:
                   id: shpm_UkLWZg9DAJ
                   name: UPS Ground
@@ -6642,7 +6647,7 @@ paths:
                 stock_location:
                   id: sloc_UkLWZg9DAJ
                   state_abbr: STATE_ABBR_298
-                  name: Candida Reinger
+                  name: Youlanda Green
                   address1: 1600 Pennsylvania Ave NW
                   city: Washington
                   zipcode: '20500'
@@ -6731,15 +6736,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R975563241
+                number: R411976954
                 state: delivery
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: CJbm6rkYdJWdTVRMopGtyJtbdFmBD7DSa2B
-                email: joi@huels.name
+                token: TdzwAsDnfzYtQtKqL1eqzwpSHz7r75GA8ET
+                email: siu@robel.biz
                 special_instructions:
                 currency: USD
                 locale: en
@@ -6764,16 +6769,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:35:25.899Z'
-                updated_at: '2026-03-05T19:35:25.981Z'
+                created_at: '2026-03-05T19:58:23.720Z'
+                updated_at: '2026-03-05T19:58:23.850Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1078604
-                  slug: product-1078604
+                  name: Product 1076368
+                  slug: product-1076368
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6792,23 +6797,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:25.936Z'
-                  updated_at: '2026-03-05T19:35:25.936Z'
+                  created_at: '2026-03-05T19:58:23.752Z'
+                  updated_at: '2026-03-05T19:58:23.752Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H04841465046
+                  number: H51872864917
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:25.942Z'
-                  updated_at: '2026-03-05T19:35:25.979Z'
+                  created_at: '2026-03-05T19:58:23.765Z'
+                  updated_at: '2026-03-05T19:58:23.846Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -6816,7 +6821,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_306
-                    name: Diane Kozey
+                    name: Dylan Prohaska
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -6952,15 +6957,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R027138496
+                number: R518034414
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: NPyEiYXrLLfcT76bY6aeMLDToxLubZC71so
-                email: troy_rath@dooley.biz
+                token: DomjvQ2Pvz2dkRgWeDJNXf1tz9UMAh655V7
+                email: jeremiah@wardlynch.co.uk
                 special_instructions:
                 currency: USD
                 locale: en
@@ -6985,16 +6990,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:35:27.181Z'
-                updated_at: '2026-03-05T19:35:27.238Z'
+                created_at: '2026-03-05T19:58:25.030Z'
+                updated_at: '2026-03-05T19:58:25.085Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1093310
-                  slug: product-1093310
+                  name: Product 1094653
+                  slug: product-1094653
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7013,23 +7018,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:27.215Z'
-                  updated_at: '2026-03-05T19:35:27.215Z'
+                  created_at: '2026-03-05T19:58:25.063Z'
+                  updated_at: '2026-03-05T19:58:25.063Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H15680061140
+                  number: H33583535151
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:27.220Z'
-                  updated_at: '2026-03-05T19:35:27.236Z'
+                  created_at: '2026-03-05T19:58:25.068Z'
+                  updated_at: '2026-03-05T19:58:25.083Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -7037,7 +7042,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_314
-                    name: Betsey Metz
+                    name: Cletus Upton
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7059,12 +7064,12 @@ paths:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
-                  response_code: 1-SC-20260305193527550146
-                  number: PEQTEZ43
+                  response_code: 1-SC-20260305195825389794
+                  number: PPGR8S98
                   amount: '10.0'
                   display_amount: "$10.00"
-                  created_at: '2026-03-05T19:35:27.553Z'
-                  updated_at: '2026-03-05T19:35:27.553Z'
+                  created_at: '2026-03-05T19:58:25.393Z'
+                  updated_at: '2026-03-05T19:58:25.393Z'
                   source_type: store_credit
                   source_id: credit_UkLWZg9DAJ
                   source:
@@ -7194,15 +7199,15 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R408996788
+                number: R434847515
                 state: cart
                 checkout_steps:
                 - address
                 - delivery
                 - payment
                 - complete
-                token: jVpxcp9j8io6mvFXj23CstonrqjaZ4QSrKD
-                email: allie_dooley@dickijakubowski.info
+                token: PxLSVgGDwdqBGSu1Qy8ifLjgAySLCYMGtCX
+                email: stuart_morissette@romaguera.ca
                 special_instructions:
                 currency: USD
                 locale: en
@@ -7227,16 +7232,16 @@ paths:
                 total: '110.0'
                 display_total: "$110.00"
                 completed_at:
-                created_at: '2026-03-05T19:35:28.779Z'
-                updated_at: '2026-03-05T19:35:28.835Z'
+                created_at: '2026-03-05T19:58:26.561Z'
+                updated_at: '2026-03-05T19:58:26.612Z'
                 order_promotions: []
                 line_items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1115497
-                  slug: product-1115497
+                  name: Product 1119400
+                  slug: product-1119400
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7255,23 +7260,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-05T19:35:28.812Z'
-                  updated_at: '2026-03-05T19:35:28.812Z'
+                  created_at: '2026-03-05T19:58:26.593Z'
+                  updated_at: '2026-03-05T19:58:26.593Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H73241956459
+                  number: H74782414754
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-05T19:35:28.818Z'
-                  updated_at: '2026-03-05T19:35:28.832Z'
+                  created_at: '2026-03-05T19:58:26.598Z'
+                  updated_at: '2026-03-05T19:58:26.610Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -7279,7 +7284,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_322
-                    name: Amado Kutch
+                    name: Alina Veum
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7391,32 +7396,32 @@ paths:
                 - id: txnmy_UkLWZg9DAJ
                   name: Categories
                   position: 1
-                  created_at: '2026-03-05T19:34:21.741Z'
-                  updated_at: '2026-03-05T19:34:21.766Z'
+                  created_at: '2026-03-05T19:57:24.166Z'
+                  updated_at: '2026-03-05T19:57:24.187Z'
                   root_id: txn_UkLWZg9DAJ
                 - id: txnmy_gbHJdmfrXB
                   name: Brands
                   position: 2
-                  created_at: '2026-03-05T19:34:21.767Z'
-                  updated_at: '2026-03-05T19:34:21.778Z'
+                  created_at: '2026-03-05T19:57:24.188Z'
+                  updated_at: '2026-03-05T19:57:24.196Z'
                   root_id: txn_gbHJdmfrXB
                 - id: txnmy_EfhxLZ9ck8
                   name: Collections
                   position: 3
-                  created_at: '2026-03-05T19:34:21.779Z'
-                  updated_at: '2026-03-05T19:34:21.846Z'
+                  created_at: '2026-03-05T19:57:24.197Z'
+                  updated_at: '2026-03-05T19:57:24.280Z'
                   root_id: txn_EfhxLZ9ck8
                 - id: txnmy_VqXmZF31wY
                   name: taxonomy_11
                   position: 4
-                  created_at: '2026-03-05T19:35:28.871Z'
-                  updated_at: '2026-03-05T19:35:28.880Z'
+                  created_at: '2026-03-05T19:58:26.645Z'
+                  updated_at: '2026-03-05T19:58:26.654Z'
                   root_id: txn_OIJLhNcSbf
                 - id: txnmy_uw2YK1rnl0
                   name: taxonomy_12
                   position: 5
-                  created_at: '2026-03-05T19:35:28.881Z'
-                  updated_at: '2026-03-05T19:35:28.890Z'
+                  created_at: '2026-03-05T19:58:26.655Z'
+                  updated_at: '2026-03-05T19:58:26.663Z'
                   root_id: txn_AXs1igzRC6
                 meta:
                   page: 1
@@ -7496,8 +7501,8 @@ paths:
                 id: txnmy_VqXmZF31wY
                 name: taxonomy_17
                 position: 4
-                created_at: '2026-03-05T19:35:29.145Z'
-                updated_at: '2026-03-05T19:35:29.155Z'
+                created_at: '2026-03-05T19:58:26.890Z'
+                updated_at: '2026-03-05T19:58:26.898Z'
                 root_id: txn_OIJLhNcSbf
               schema:
                 "$ref": "#/components/schemas/StoreTaxonomy"
@@ -7573,8 +7578,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 0
-                  created_at: '2026-03-05T19:34:21.753Z'
-                  updated_at: '2026-03-05T19:34:21.764Z'
+                  created_at: '2026-03-05T19:57:24.177Z'
+                  updated_at: '2026-03-05T19:57:24.185Z'
                   parent_id:
                   taxonomy_id: txnmy_UkLWZg9DAJ
                   description: ''
@@ -7593,8 +7598,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 0
-                  created_at: '2026-03-05T19:34:21.771Z'
-                  updated_at: '2026-03-05T19:34:21.776Z'
+                  created_at: '2026-03-05T19:57:24.190Z'
+                  updated_at: '2026-03-05T19:57:24.194Z'
                   parent_id:
                   taxonomy_id: txnmy_gbHJdmfrXB
                   description: ''
@@ -7613,8 +7618,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 2
-                  created_at: '2026-03-05T19:34:21.782Z'
-                  updated_at: '2026-03-05T19:34:21.846Z'
+                  created_at: '2026-03-05T19:57:24.199Z'
+                  updated_at: '2026-03-05T19:57:24.280Z'
                   parent_id:
                   taxonomy_id: txnmy_EfhxLZ9ck8
                   description: ''
@@ -7633,8 +7638,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 0
-                  created_at: '2026-03-05T19:34:21.796Z'
-                  updated_at: '2026-03-05T19:34:21.798Z'
+                  created_at: '2026-03-05T19:57:24.212Z'
+                  updated_at: '2026-03-05T19:57:24.214Z'
                   parent_id: txn_EfhxLZ9ck8
                   taxonomy_id: txnmy_EfhxLZ9ck8
                   description: ''
@@ -7653,8 +7658,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 0
-                  created_at: '2026-03-05T19:34:21.810Z'
-                  updated_at: '2026-03-05T19:34:21.812Z'
+                  created_at: '2026-03-05T19:57:24.223Z'
+                  updated_at: '2026-03-05T19:57:24.224Z'
                   parent_id: txn_EfhxLZ9ck8
                   taxonomy_id: txnmy_EfhxLZ9ck8
                   description: ''
@@ -7673,8 +7678,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 1
-                  created_at: '2026-03-05T19:35:29.624Z'
-                  updated_at: '2026-03-05T19:35:29.672Z'
+                  created_at: '2026-03-05T19:58:27.244Z'
+                  updated_at: '2026-03-05T19:58:27.296Z'
                   parent_id:
                   taxonomy_id: txnmy_VqXmZF31wY
                   description: ''
@@ -7693,8 +7698,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 1
-                  created_at: '2026-03-05T19:35:29.632Z'
-                  updated_at: '2026-03-05T19:35:29.672Z'
+                  created_at: '2026-03-05T19:58:27.250Z'
+                  updated_at: '2026-03-05T19:58:27.296Z'
                   parent_id: txn_OIJLhNcSbf
                   taxonomy_id: txnmy_VqXmZF31wY
                   description: ''
@@ -7713,8 +7718,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 0
-                  created_at: '2026-03-05T19:35:29.642Z'
-                  updated_at: '2026-03-05T19:35:29.648Z'
+                  created_at: '2026-03-05T19:58:27.258Z'
+                  updated_at: '2026-03-05T19:58:27.268Z'
                   parent_id: txn_AXs1igzRC6
                   taxonomy_id: txnmy_VqXmZF31wY
                   description: ''
@@ -7809,8 +7814,8 @@ paths:
                 meta_description:
                 meta_keywords:
                 children_count: 1
-                created_at: '2026-03-05T19:35:30.222Z'
-                updated_at: '2026-03-05T19:35:30.262Z'
+                created_at: '2026-03-05T19:58:27.815Z'
+                updated_at: '2026-03-05T19:58:27.857Z'
                 parent_id: txn_OIJLhNcSbf
                 taxonomy_id: txnmy_VqXmZF31wY
                 description: ''
@@ -7931,19 +7936,17 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1193095
+                  name: Product 1197784
                   description: |-
-                    Enim assumenda incidunt aliquid eaque hic voluptatibus error. Iure suscipit similique consequatur nobis odit. Ipsam labore consectetur laudantium fugit iusto doloremque quos. Quam hic minima odio nobis quas tenetur harum eum.
-                    Quod asperiores debitis aliquam doloribus. Eligendi occaecati eveniet itaque tempore pariatur voluptates. Consectetur nobis ducimus magnam cupiditate totam fugit. Dolore temporibus odit expedita recusandae rerum.
-                    Laboriosam dolores aliquam tenetur excepturi sit. Ex cupiditate dolorum in consectetur sint. Quo vel eligendi ratione doloremque temporibus natus. Cum repudiandae odio eligendi incidunt laboriosam minus ad temporibus.
-                    Eos consequatur impedit reprehenderit animi repellendus quo est. Tenetur tempora pariatur incidunt quis quos. Laboriosam suscipit eius eveniet veritatis aliquid nostrum quidem. Sed natus sequi aliquam incidunt.
-                  slug: product-1193095
+                    Ratione architecto voluptatibus reiciendis repudiandae facere sequi dignissimos. Aliquam maxime quaerat aut incidunt. Velit corporis et alias officia dolor. Eaque voluptatem incidunt nostrum amet error vitae deserunt magni. Quos natus inventore quae nam praesentium quisquam quod hic.
+                    Maxime sit atque iure similique cum non. Maxime optio soluta nemo qui distinctio. Nemo aliquam voluptas sint deleniti.
+                  slug: product-1197784
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-03-05T19:35:31.096Z'
-                  created_at: '2026-03-05T19:35:31.110Z'
-                  updated_at: '2026-03-05T19:35:31.125Z'
+                  available_on: '2025-03-05T19:58:28.650Z'
+                  created_at: '2026-03-05T19:58:28.669Z'
+                  updated_at: '2026-03-05T19:58:28.686Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -8054,9 +8057,9 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: FKiQQ2QFPXmFZqUASBUCRQ3u
-                  created_at: '2026-03-05T19:35:32.216Z'
-                  updated_at: '2026-03-05T19:35:32.216Z'
+                  token: sETKKpXn8LhTis7Qu847GyVa
+                  created_at: '2026-03-05T19:58:29.762Z'
+                  updated_at: '2026-03-05T19:58:29.762Z'
                   is_default: false
                   is_private: true
                 meta:
@@ -8132,9 +8135,9 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: jsEaFQGuYmEXdsxo13YymUaQ
-                created_at: '2026-03-05T19:35:33.454Z'
-                updated_at: '2026-03-05T19:35:33.454Z'
+                token: qFT9r7SN2zP5Tk8mGumTYbTg
+                created_at: '2026-03-05T19:58:31.060Z'
+                updated_at: '2026-03-05T19:58:31.060Z'
                 is_default: false
                 is_private: true
               schema:
@@ -8223,9 +8226,9 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: rsFPPWayHbkswEFi2cUutMzH
-                created_at: '2026-03-05T19:35:34.618Z'
-                updated_at: '2026-03-05T19:35:34.618Z'
+                token: kvqMXVFcmUjgf7JapJwDXJUa
+                created_at: '2026-03-05T19:58:32.249Z'
+                updated_at: '2026-03-05T19:58:32.249Z'
                 is_default: false
                 is_private: true
               schema:
@@ -8287,9 +8290,9 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: K1EScQMC7wA7CsFdaRztftQW
-                created_at: '2026-03-05T19:35:35.813Z'
-                updated_at: '2026-03-05T19:35:35.857Z'
+                token: ViwVZJcZgAMPiXWjNL9mFsSW
+                created_at: '2026-03-05T19:58:33.436Z'
+                updated_at: '2026-03-05T19:58:33.480Z'
                 is_default: false
                 is_private: true
               schema:
@@ -8401,8 +8404,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 wishlist_id: wl_UkLWZg9DAJ
                 quantity: 1
-                created_at: '2026-03-05T19:35:37.071Z'
-                updated_at: '2026-03-05T19:35:37.071Z'
+                created_at: '2026-03-05T19:58:34.706Z'
+                updated_at: '2026-03-05T19:58:34.706Z'
                 variant:
                   id: variant_gbHJdmfrXB
                   product_id: prod_gbHJdmfrXB
@@ -8411,8 +8414,8 @@ paths:
                   options_text: ''
                   track_inventory: true
                   image_count: 0
-                  created_at: '2026-03-05T19:35:37.046Z'
-                  updated_at: '2026-03-05T19:35:37.056Z'
+                  created_at: '2026-03-05T19:58:34.675Z'
+                  updated_at: '2026-03-05T19:58:34.687Z'
                   thumbnail:
                   purchasable: true
                   in_stock: false
@@ -9725,7 +9728,6 @@ components:
           - credit_card
           - store_credit
           - payment_source
-          -
         source_id:
           type: string
           nullable: true

--- a/docs/developer/core-concepts/promotions.mdx
+++ b/docs/developer/core-concepts/promotions.mdx
@@ -284,8 +284,8 @@ const order = await client.store.orders.couponCodes.apply('or_abc123', 'SUMMER20
   orderToken: '<token>',
 })
 
-// Remove a coupon code
-await client.store.orders.couponCodes.remove('or_abc123', 'SUMMER20', {
+// Remove a promotion from the order
+await client.store.orders.couponCodes.remove('or_abc123', 'promo_abc123', {
   orderToken: '<token>',
 })
 ```

--- a/docs/developer/core-concepts/store-credits-gift-cards.mdx
+++ b/docs/developer/core-concepts/store-credits-gift-cards.mdx
@@ -258,7 +258,7 @@ Gift cards are applied using the same coupon codes endpoint as promotion codes. 
 ```typescript SDK
 // Apply gift card code to order (works for guests and registered customers)
 const order = await client.store.orders.couponCodes.apply('or_abc123', 'abc1234def', {
-  bearerToken: '<token>',
+  orderToken: '<token>',
 })
 ```
 

--- a/docs/developer/sdk/configuration.mdx
+++ b/docs/developer/sdk/configuration.mdx
@@ -52,6 +52,28 @@ const client = createSpreeClient({
 });
 ```
 
+## Monetary Amounts
+
+All monetary values in the API are returned as **strings** (e.g., `"29.99"`, `"0.0"`), not numbers. This preserves decimal precision and avoids floating-point rounding issues.
+
+```typescript
+const order = await client.store.orders.get('or_abc123', {}, { token });
+
+// Monetary fields are strings
+order.total;         // "129.99"
+order.item_total;    // "99.99"
+order.ship_total;    // "10.00"
+order.tax_total;     // "20.00"
+
+// Display fields include currency formatting
+order.display_total; // "$129.99"
+
+// Convert to number when needed for calculations
+const total = parseFloat(order.total);
+```
+
+This applies to all monetary fields across all types: `StoreOrder`, `StoreLineItem`, `StoreShipment`, `StorePayment`, `StoreGiftCard`, `StorePrice`, etc.
+
 ## TypeScript Support
 
 The SDK includes full TypeScript support with generated types from the API serializers:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -429,7 +429,8 @@
                   "api-reference/store-api/querying",
                   "api-reference/store-api/relations",
                   "api-reference/store-api/metadata",
-                  "api-reference/store-api/localization"
+                  "api-reference/store-api/localization",
+                  "api-reference/store-api/monetary-amounts"
                 ]
               },
               {

--- a/docs/snippets/store-api/auth-jwt-example.mdx
+++ b/docs/snippets/store-api/auth-jwt-example.mdx
@@ -6,5 +6,5 @@ const { token, user } = await client.store.auth.login({
 })
 
 // Use the token for authenticated requests
-const orders = await client.store.orders.list({}, { token })
+const orders = await client.store.customer.orders.list({}, { token })
 ```

--- a/spree/api/lib/spree/api/openapi/schema_helper.rb
+++ b/spree/api/lib/spree/api/openapi/schema_helper.rb
@@ -107,8 +107,23 @@ module Spree
           with_typelizer_enabled do
             schemas = Typelizer.openapi_schemas
             schemas = schemas.select { |key, _| key.to_s.start_with?('Store') }
-            schemas.each_value { |s| s[:'x-typelizer'] = true }
+            schemas.each_value do |s|
+              s[:'x-typelizer'] = true
+              strip_null_from_enums(s)
+            end
             schemas
+          end
+        end
+
+        # Typelizer adds nil to enum arrays for nullable fields.
+        # OpenAPI 3.0 handles nullability via `nullable: true`, so the nil entry is redundant
+        # and causes issues with code generators.
+        def strip_null_from_enums(schema)
+          properties = schema[:properties] || {}
+          properties.each_value do |prop|
+            next unless prop.is_a?(Hash) && prop[:enum].is_a?(Array)
+
+            prop[:enum].reject!(&:nil?)
           end
         end
 

--- a/spree/api/spree_api.gemspec
+++ b/spree/api/spree_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'alba', '~> 3.0'
   s.add_dependency 'oj', '~> 3.16'
   s.add_dependency 'pagy', '~> 43.0'
-  s.add_dependency 'typelizer', '~> 0.9'
+  s.add_dependency 'typelizer', '~> 0.10.0'
 
   s.add_dependency 'spree_core', s.version
 end


### PR DESCRIPTION
  1. client.store.orders.list() → client.store.customer.orders.list() — fixed in docs/snippets/store-api/auth-jwt-example.mdx and docs/api-reference/store-api/authentication.mdx
  2. couponCodes.remove wrong argument — fixed in docs/developer/core-concepts/promotions.mdx (changed 'SUMMER20' to 'promo_abc123' since remove takes a promotion prefixed ID, not a coupon code)
  3. bearerToken → orderToken — fixed in docs/developer/core-concepts/store-credits-gift-cards.mdx (invalid RequestOptions key)
  4. StorePayment.source_type empty enum entry — fixed via strip_null_from_enums post-processing in spree/api/lib/spree/api/openapi/schema_helper.rb. Enum now cleanly has 3 values without trailing null.
  5. Monetary amounts documentation — added to both:
    - docs/developer/sdk/configuration.mdx (SDK docs)
    - docs/api-reference/store-api/monetary-amounts.mdx (new API reference page, added to nav in docs.json)
  6. Typelizer bumped from ~> 0.9 to ~> 0.10.0 in spree_api.gemspec