### PR TITLE
Discontinue variants with completed orders, instead of destroying them

### DIFF
--- a/spree/admin/app/controllers/spree/admin/products_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/products_controller.rb
@@ -57,7 +57,17 @@ module Spree
       def update
         invoke_callbacks(:update, :before)
 
-        if @product.update(permitted_resource_params)
+        success = ActiveRecord::Base.transaction do
+          @prepare_params_service&.variants_to_discontinue&.each(&:discontinue!)
+
+          unless @product.update(permitted_resource_params)
+            raise ActiveRecord::Rollback
+          end
+
+          true
+        end
+
+        if success
           set_current_store
           invoke_callbacks(:update, :after)
           flash[:success] = flash_message_for(@product, :successfully_updated)
@@ -202,8 +212,8 @@ module Spree
       end
 
       def prepare_product_params
-        params_service = Spree::Products::PrepareNestedAttributes.new(@product, current_store, permitted_resource_params, current_ability)
-        params[:product] = params_service.call
+        @prepare_params_service = Spree::Products::PrepareNestedAttributes.new(@product, current_store, permitted_resource_params, current_ability)
+        params[:product] = @prepare_params_service.call
       end
 
       # These includes are not picked automatically by ar_lazy_preload gem so we need to specify them manually.

--- a/spree/core/app/services/spree/products/prepare_nested_attributes.rb
+++ b/spree/core/app/services/spree/products/prepare_nested_attributes.rb
@@ -159,6 +159,7 @@ module Spree
           product.variants
                  .joins(:orders)
                  .merge(Spree::Order.complete)
+                 .reorder(nil)
                  .distinct
                  .pluck(:id)
                  .map(&:to_s)

--- a/spree/core/app/services/spree/products/prepare_nested_attributes.rb
+++ b/spree/core/app/services/spree/products/prepare_nested_attributes.rb
@@ -78,13 +78,9 @@ module Spree
           params[:option_type_ids] = []
           params[:variants_attributes] = {}
 
-          next_index = 0
-          variants_to_remove.each do |variant_id|
-            removal_attrs = resolve_variant_removal(variant_id)
-            next unless removal_attrs
-
-            params[:variants_attributes][next_index.to_s] = removal_attrs
-            next_index += 1
+          populate_variants_to_discontinue
+          variant_ids_to_destroy.each_with_index do |variant_id, index|
+            params[:variants_attributes][index.to_s] = { id: variant_id, _destroy: '1' }
           end
 
           params[:variants_attributes].permit!
@@ -130,28 +126,24 @@ module Spree
       def removed_variants_attributes
         return {} unless can_remove_variants?
 
+        populate_variants_to_discontinue
+
         attributes = {}
         last_index = params[:variants_attributes].keys.map(&:to_i).max
-        next_index = last_index + 1
-        variants_to_remove.each do |variant_id|
-          removal_attrs = resolve_variant_removal(variant_id)
-          next unless removal_attrs
-
-          attributes[next_index.to_s] = removal_attrs
-          next_index += 1
+        variant_ids_to_destroy.each_with_index do |variant_id, index|
+          attributes[(last_index + 1 + index).to_s] = { id: variant_id, _destroy: '1' }
         end
 
         attributes
       end
 
-      def resolve_variant_removal(variant_id)
-        if variant_ids_with_completed_orders.include?(variant_id)
-          variant = product.variants.find_by(id: variant_id)
-          @variants_to_discontinue << variant if variant
-          nil
-        else
-          { id: variant_id, _destroy: '1' }
-        end
+      def populate_variants_to_discontinue
+        ids = variants_to_remove.select { |vid| variant_ids_with_completed_orders.include?(vid) }
+        @variants_to_discontinue = product.variants.where(id: ids).to_a if ids.any?
+      end
+
+      def variant_ids_to_destroy
+        variants_to_remove - variant_ids_with_completed_orders
       end
 
       def variant_ids_with_completed_orders

--- a/spree/core/app/services/spree/products/prepare_nested_attributes.rb
+++ b/spree/core/app/services/spree/products/prepare_nested_attributes.rb
@@ -17,11 +17,14 @@ module Spree
     #   prepared_params = service.call
     #
     class PrepareNestedAttributes
+      attr_reader :variants_to_discontinue
+
       def initialize(product, store, params, ability)
         @product = product
         @store = store
         @params = params
         @ability = ability
+        @variants_to_discontinue = []
       end
 
       def call
@@ -75,8 +78,13 @@ module Spree
           params[:option_type_ids] = []
           params[:variants_attributes] = {}
 
-          variants_to_remove.each_with_index do |variant_id, index|
-            params[:variants_attributes][index.to_s] = { id: variant_id, _destroy: '1' }
+          next_index = 0
+          variants_to_remove.each do |variant_id|
+            removal_attrs = resolve_variant_removal(variant_id)
+            next unless removal_attrs
+
+            params[:variants_attributes][next_index.to_s] = removal_attrs
+            next_index += 1
           end
 
           params[:variants_attributes].permit!
@@ -124,11 +132,36 @@ module Spree
 
         attributes = {}
         last_index = params[:variants_attributes].keys.map(&:to_i).max
-        variants_to_remove.each_with_index do |variant_id, index|
-          attributes[(index + last_index + 1).to_s] = { id: variant_id, _destroy: '1' }
+        next_index = last_index + 1
+        variants_to_remove.each do |variant_id|
+          removal_attrs = resolve_variant_removal(variant_id)
+          next unless removal_attrs
+
+          attributes[next_index.to_s] = removal_attrs
+          next_index += 1
         end
 
         attributes
+      end
+
+      def resolve_variant_removal(variant_id)
+        if variant_ids_with_completed_orders.include?(variant_id)
+          variant = product.variants.find_by(id: variant_id)
+          @variants_to_discontinue << variant if variant
+          nil
+        else
+          { id: variant_id, _destroy: '1' }
+        end
+      end
+
+      def variant_ids_with_completed_orders
+        @variant_ids_with_completed_orders ||=
+          product.variants
+                 .joins(:orders)
+                 .merge(Spree::Order.complete)
+                 .distinct
+                 .pluck(:id)
+                 .map(&:to_s)
       end
 
       def removed_product_option_types_attributes

--- a/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
+++ b/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Products::PrepareNestedAttributes do
-  subject(:prepared_params) { described_class.new(product, store, params, ability).call }
+  let(:service) { described_class.new(product, store, params, ability) }
+  subject(:prepared_params) { service.call }
 
   let(:ability) { Spree::Ability.new(nil) }
   let(:store) { @default_store }
@@ -214,6 +215,138 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
         it 'marks the price for destruction' do
           expect(prepared_params[:variants_attributes]['0'][:prices_attributes]['0']['_destroy']).to eq('1')
         end
+      end
+    end
+  end
+
+  describe 'variant removal handling' do
+    let(:option_type) { create(:option_type) }
+    let(:option_value) { create(:option_value, option_type: option_type) }
+    let(:variant) { create(:variant, product: product) }
+
+    context 'when variant has completed orders' do
+      before do
+        create(:completed_order_with_totals, variants: [variant])
+      end
+
+      context 'via variants_attributes' do
+        let(:new_option_value) { create(:option_value, option_type: option_type) }
+        let(:new_variant) { create(:variant, product: product) }
+        let(:raw_params) do
+          {
+            variants_attributes: {
+              '0' => {
+                id: new_variant.id.to_s,
+                options: [
+                  {
+                    id: option_type.id,
+                    name: option_type.name,
+                    position: '0',
+                    option_value_name: new_option_value.name,
+                    option_value_presentation: new_option_value.presentation
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        it 'collects the variant for discontinuation' do
+          prepared_params
+          expect(service.variants_to_discontinue).to include(variant)
+        end
+
+        it 'does not include the variant in removal attributes' do
+          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+          expect(removed).to be_nil
+        end
+      end
+
+      context 'via fallback removal (no variants_attributes)' do
+        let(:raw_params) { { name: 'Updated Product' } }
+
+        it 'collects the variant for discontinuation' do
+          prepared_params
+          expect(service.variants_to_discontinue).to include(variant)
+        end
+
+        it 'does not include the variant in destruction attributes' do
+          removed = prepared_params[:variants_attributes]&.values&.find { |v| v[:id] == variant.id.to_s }
+          expect(removed).to be_nil
+        end
+      end
+    end
+
+    context 'when variant has no completed orders' do
+      before { variant } # ensure variant exists before service runs
+
+      context 'via variants_attributes' do
+        let(:new_option_value) { create(:option_value, option_type: option_type) }
+        let(:new_variant) { create(:variant, product: product) }
+        let(:raw_params) do
+          {
+            variants_attributes: {
+              '0' => {
+                id: new_variant.id.to_s,
+                options: [
+                  {
+                    id: option_type.id,
+                    name: option_type.name,
+                    position: '0',
+                    option_value_name: new_option_value.name,
+                    option_value_presentation: new_option_value.presentation
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        it 'marks the variant for destruction' do
+          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+          expect(removed[:_destroy]).to eq('1')
+        end
+
+        it 'does not collect the variant for discontinuation' do
+          prepared_params
+          expect(service.variants_to_discontinue).not_to include(variant)
+        end
+      end
+
+      context 'via fallback removal (no variants_attributes)' do
+        let(:raw_params) { { name: 'Updated Product' } }
+
+        it 'marks the variant for destruction' do
+          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+          expect(removed[:_destroy]).to eq('1')
+        end
+      end
+    end
+
+    context 'when product has mix of variants with and without completed orders' do
+      let(:variant_with_order) { create(:variant, product: product) }
+      let(:variant_without_order) { create(:variant, product: product) }
+
+      before do
+        variant_without_order # ensure variant exists before service runs
+        create(:completed_order_with_totals, variants: [variant_with_order])
+      end
+
+      let(:raw_params) { { name: 'Updated Product' } }
+
+      it 'collects the variant with completed orders for discontinuation' do
+        prepared_params
+        expect(service.variants_to_discontinue).to include(variant_with_order)
+      end
+
+      it 'does not include the collected variant in removal attributes' do
+        removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant_with_order.id.to_s }
+        expect(removed).to be_nil
+      end
+
+      it 'marks the variant without completed orders for destruction' do
+        removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant_without_order.id.to_s }
+        expect(removed[:_destroy]).to eq('1')
       end
     end
   end


### PR DESCRIPTION
When adding new option types to a product, `PrepareNestedAttributes` marks existing variants for destruction. However, variants associated with completed orders cannot be destroyed due to the `ensure_not_in_complete_orders` callback, causing the entire product update to fail.

Instead of destroying these variants, discontinue them using the existing `discontinue!` mechanism. The `not_discontinued` scope already filters them from active listings. Variants without completed orders are still destroyed as before.

- Batch query `variant_ids_with_completed_orders` to identify variants with completed orders (avoids N+1)
- Partition variants into those to discontinue vs those to destroy
- Collect variants to discontinue instead of calling `discontinue!` inline in the service
- Wrap discontinuation + product update in a single transaction in the controller