### PR TITLE
Fixed: Check payment method now properly transitions to pending/compl…

### DIFF
--- a/docs/developer/core-concepts/payments.mdx
+++ b/docs/developer/core-concepts/payments.mdx
@@ -248,7 +248,7 @@ sequenceDiagram
     Spree API-->>Frontend: Payment created
 
     Frontend->>Spree API: PATCH /orders/:id/complete
-    Spree API->>Spree API: process_payments! (no-op for manual methods)
+    Spree API->>Spree API: process_payments! (authorize succeeds immediately)
     Spree API->>Spree API: Payment → pending/completed
     Spree API-->>Frontend: Order completed
 ```
@@ -261,7 +261,7 @@ sequenceDiagram
     The frontend calls `POST /payments` with the `payment_method_id`. Spree creates a `Payment` record in `checkout` state. No external provider interaction is needed.
   </Step>
   <Step title="Complete order">
-    The frontend completes the order. Spree's `process_payments!` runs the payment method's authorize/purchase, which for manual methods is a no-op success. The payment transitions to `pending` (or `completed` with auto-capture) and the order completes.
+    The frontend completes the order. Spree's `process_payments!` runs the payment method's `authorize` (or `purchase` with auto-capture). For manual methods like Check, these return an immediate success — no external service is called. The payment transitions to `pending` (without auto-capture) or `completed` (with auto-capture) and the order completes. The merchant can later capture `pending` payments from the Admin Panel once the physical payment is received.
   </Step>
 </Steps>
 

--- a/spree/core/app/models/spree/payment/processing.rb
+++ b/spree/core/app/models/spree/payment/processing.rb
@@ -127,6 +127,8 @@ module Spree
           else
             raise Core::GatewayError, Spree.t(:payment_processing_failed)
           end
+        else
+          yield unless processing?
         end
       end
 

--- a/spree/core/app/models/spree/payment_method/check.rb
+++ b/spree/core/app/models/spree/payment_method/check.rb
@@ -4,6 +4,14 @@ module Spree
       %w{capture void}
     end
 
+    def authorize(*)
+      simulated_successful_billing_response
+    end
+
+    def purchase(*)
+      simulated_successful_billing_response
+    end
+
     # Indicates whether its possible to capture the payment
     def can_capture?(payment)
       ['checkout', 'pending'].include?(payment.state)

--- a/spree/core/spec/models/spree/payment_spec.rb
+++ b/spree/core/spec/models/spree/payment_spec.rb
@@ -731,14 +731,26 @@ describe Spree::Payment, type: :model do
   end
 
   context 'with source optional' do
-    context 'raises no error if source is not specified' do
+    context 'when payment method does not require source' do
+      let(:check_payment_method) { create(:check_payment_method, stores: [order.store], auto_capture: false) }
+
       before do
         payment.source = nil
-        allow(payment.payment_method).to receive_messages(source_required?: false)
+        payment.payment_method = check_payment_method
       end
 
-      specify do
+      it 'processes successfully and transitions to pending' do
         expect { payment.process! }.not_to raise_error
+        expect(payment.state).to eq('pending')
+      end
+
+      context 'with auto capture' do
+        let(:check_payment_method) { create(:check_payment_method, stores: [order.store], auto_capture: true) }
+
+        it 'processes successfully and transitions to completed' do
+          expect { payment.process! }.not_to raise_error
+          expect(payment.state).to eq('completed')
+        end
       end
     end
   end


### PR DESCRIPTION
…eted state

Previously, payments for non-session payment methods (Check, Cash on Delivery) stayed in `checkout` state because `handle_payment_preconditions` silently skipped processing when `source_required?` was false. Now:

- `handle_payment_preconditions` yields for sourceless payment methods
- `PaymentMethod::Check` implements `authorize` and `purchase` (immediate success)
- Without auto-capture: payment → pending (authorized, awaiting capture)
- With auto-capture: payment → completed (captured immediately)