### PR TITLE
Next: Allow getCart() to accept an explicit cart ID

### DIFF
--- a/packages/next/.changeset/get-cart-explicit-id.md
+++ b/packages/next/.changeset/get-cart-explicit-id.md
@@ -1,0 +1,5 @@
+---
+"@spree/next": patch
+---
+
+Allow `getCart()` to accept an optional `explicitCartId` parameter. When provided, fetches that specific cart directly by ID instead of reading from cookies. Needed for the confirm-payment flow where the cart ID is known from the URL but cookies may have been cleared.

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/next
 
+## 0.10.4
+
+### Patch Changes
+
+- Allow `getCart()` to accept an optional `explicitCartId` parameter. When provided, fetches that specific cart directly by ID instead of reading from cookies. Needed for the confirm-payment flow where the cart ID is known from the URL but cookies may have been cleared.
+
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/next",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Next.js integration for Spree Commerce — server actions, caching, and cookie-based auth",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/next/src/actions/cart.ts
+++ b/packages/next/src/actions/cart.ts
@@ -12,11 +12,12 @@ import {
 
 /**
  * Get the current cart. Returns null if no cart exists.
+ * @param explicitCartId - Optional cart ID to fetch directly, bypassing cookie lookup.
  */
-export async function getCart(): Promise<Cart | null> {
+export async function getCart(explicitCartId?: string): Promise<Cart | null> {
   const spreeToken = await getCartToken();
   const token = await getAccessToken();
-  const cartId = await getCartId();
+  const cartId = explicitCartId ?? await getCartId();
 
   if (!cartId && !token) return null;
 
@@ -38,7 +39,9 @@ export async function getCart(): Promise<Cart | null> {
     return null;
   } catch {
     // Cart not found (e.g., order was completed) — clear stale cookies
-    await clearCartCookies();
+    if (!explicitCartId) {
+      await clearCartCookies();
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- `getCart()` now accepts an optional `explicitCartId` parameter that fetches a specific cart directly by ID, bypassing cookie lookup
- When an explicit ID is passed and the cart isn't found, stale cookies are **not** cleared (the missing cart doesn't mean the cookie cart is invalid)
- Bumps `@spree/next` to `0.10.4`

Needed for the confirm-payment flow where the cart ID is known from the URL but cookies may have been cleared after checkout.

## Test plan

- [ ] `getCart()` with no args still works via cookies (existing behavior)
- [ ] `getCart(cartId)` fetches the specific cart by ID
- [ ] `getCart(invalidId)` returns `null` without clearing cart cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)