### PR TITLE
Add password reset with AllowedOrigin validation and email support

### DIFF
--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -661,16 +661,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjAwNTcxZWNiLTYyYmQtNGQ3Ni1iNDUxLTk0MTJmYmU3NDZiZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNDExNjYzfQ.U0J-BFqzSLcYAN1TB-OXwLVV4tORyWxlmEYphCop3gA
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjNhMTQzMTZlLTQxN2MtNDRkNS05MWIzLTQ3YWRjZGY1YWFlMiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNTcyMTkyfQ.-nJLamwDUlgW3KPN_OY0S9-3u9muXVzpYSPnBJKjpBE
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Bridget
-                  last_name: Monahan
+                  first_name: Emilia
+                  last_name: Wehner
                   phone:
                   accepts_email_marketing: false
-                  created_at: '2026-03-13T13:21:03.567Z'
-                  updated_at: '2026-03-13T13:21:03.567Z'
+                  created_at: '2026-03-15T09:56:32.161Z'
+                  updated_at: '2026-03-15T09:56:32.161Z'
                   addresses: []
                   default_billing_address:
                   default_shipping_address:
@@ -747,16 +747,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImNjY2EzYTVmLTEzZWMtNDk3Mi05MTU1LWEwOGVhZTQ3ZjAzMyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNDExNjY0fQ.hoJNlCD_ZK4ILNfVUT441Gc2rdZtFRuAyzXXnGTnEhs
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImMxNjEwNDNjLWI1NjItNDU3YS05YjIwLTkwNTNhODJjNjZkMCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNTcyMTkzfQ.0D4-S9NJHJF-W2YtiqshpVkEY4kiM7loXp-79cy-9pc
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Tad
-                  last_name: Oberbrunner
+                  first_name: Tracey
+                  last_name: Koss
                   phone:
                   accepts_email_marketing: false
-                  created_at: '2026-03-13T13:21:04.921Z'
-                  updated_at: '2026-03-13T13:21:04.921Z'
+                  created_at: '2026-03-15T09:56:33.527Z'
+                  updated_at: '2026-03-15T09:56:33.527Z'
                   addresses: []
                   default_billing_address:
                   default_shipping_address:
@@ -814,9 +814,9 @@ paths:
               example:
                 data:
                 - id: cart_gbHJdmfrXB
-                  number: R194031828
-                  token: sHscmM8PQHRueCo4JEYG1WPZpCyqcMnHvRt
-                  email: waltraud@denesik.ca
+                  number: R272337197
+                  token: U9HRYmYTNAj3n1kngD1MupUfU1LT1GiKrrG
+                  email: noble@effertz.com
                   special_instructions:
                   currency: USD
                   locale: en
@@ -837,8 +837,8 @@ paths:
                   display_additional_tax_total: "$0.00"
                   total: '110.0'
                   display_total: "$110.00"
-                  created_at: '2026-03-13T13:21:05.630Z'
-                  updated_at: '2026-03-13T13:21:05.674Z'
+                  created_at: '2026-03-15T09:56:34.274Z'
+                  updated_at: '2026-03-15T09:56:34.328Z'
                   current_step: address
                   completed_steps: []
                   requirements:
@@ -851,8 +851,8 @@ paths:
                     variant_id: variant_gbHJdmfrXB
                     quantity: 1
                     currency: USD
-                    name: Product 24428
-                    slug: product-24428
+                    name: Product 21424
+                    slug: product-21424
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -871,23 +871,23 @@ paths:
                     discounted_amount: '10.0'
                     display_discounted_amount: "$10.00"
                     display_compare_at_amount: "$0.00"
-                    created_at: '2026-03-13T13:21:05.656Z'
-                    updated_at: '2026-03-13T13:21:05.656Z'
+                    created_at: '2026-03-15T09:56:34.306Z'
+                    updated_at: '2026-03-15T09:56:34.306Z'
                     compare_at_amount:
                     thumbnail_url:
                     option_values: []
                     digital_links: []
                   shipments:
                   - id: ship_gbHJdmfrXB
-                    number: H10059463813
+                    number: H07549026034
                     state: pending
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
                     display_cost: "$100.00"
                     shipped_at:
-                    created_at: '2026-03-13T13:21:05.663Z'
-                    updated_at: '2026-03-13T13:21:05.672Z'
+                    created_at: '2026-03-15T09:56:34.314Z'
+                    updated_at: '2026-03-15T09:56:34.326Z'
                     shipping_method:
                       id: shpm_gbHJdmfrXB
                       name: UPS Ground
@@ -895,7 +895,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: STATE_ABBR_37
-                      name: Lakendra Kuhic
+                      name: Caryl Feeney
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -950,9 +950,9 @@ paths:
                     state_name: STATE_NAME_42
                   payment_methods: []
                 - id: cart_UkLWZg9DAJ
-                  number: R647029618
-                  token: cNy8Chg1zgewJZJFgDnB7McHDs52ufsgquv
-                  email: waltraud@denesik.ca
+                  number: R741612804
+                  token: 1Wnd3pNEjwU19G8iipANmeJ1ihP7n3j5pe3
+                  email: noble@effertz.com
                   special_instructions:
                   currency: USD
                   locale: en
@@ -973,8 +973,8 @@ paths:
                   display_additional_tax_total: "$0.00"
                   total: '110.0'
                   display_total: "$110.00"
-                  created_at: '2026-03-13T13:21:05.477Z'
-                  updated_at: '2026-03-13T13:21:05.625Z'
+                  created_at: '2026-03-15T09:56:34.100Z'
+                  updated_at: '2026-03-15T09:56:34.268Z'
                   current_step: address
                   completed_steps: []
                   requirements:
@@ -987,8 +987,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 12727
-                    slug: product-12727
+                    name: Product 15258
+                    slug: product-15258
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1007,23 +1007,23 @@ paths:
                     discounted_amount: '10.0'
                     display_discounted_amount: "$10.00"
                     display_compare_at_amount: "$0.00"
-                    created_at: '2026-03-13T13:21:05.567Z'
-                    updated_at: '2026-03-13T13:21:05.567Z'
+                    created_at: '2026-03-15T09:56:34.204Z'
+                    updated_at: '2026-03-15T09:56:34.204Z'
                     compare_at_amount:
                     thumbnail_url:
                     option_values: []
                     digital_links: []
                   shipments:
                   - id: ship_UkLWZg9DAJ
-                    number: H66582748732
+                    number: H33942229319
                     state: pending
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
                     display_cost: "$100.00"
                     shipped_at:
-                    created_at: '2026-03-13T13:21:05.583Z'
-                    updated_at: '2026-03-13T13:21:05.621Z'
+                    created_at: '2026-03-15T09:56:34.220Z'
+                    updated_at: '2026-03-15T09:56:34.263Z'
                     shipping_method:
                       id: shpm_UkLWZg9DAJ
                       name: UPS Ground
@@ -1031,7 +1031,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: STATE_ABBR_37
-                      name: Lakendra Kuhic
+                      name: Caryl Feeney
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1159,8 +1159,8 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R150042985
-                token: RX5k4MQCQ3FWumvA3dYpKYWwPfWKowf2ndX
+                number: R820921292
+                token: 9YbrGXVaCKW3nXiUVZyzLCkzSGYyJomFZap
                 email:
                 special_instructions:
                 currency: USD
@@ -1182,8 +1182,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '0.0'
                 display_total: "$0.00"
-                created_at: '2026-03-13T13:21:06.188Z'
-                updated_at: '2026-03-13T13:21:06.188Z'
+                created_at: '2026-03-15T09:56:34.825Z'
+                updated_at: '2026-03-15T09:56:34.825Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -1290,9 +1290,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R251834326
-                token: huGoDXVzxPrUnMbr1J71cmzYMtvbdarN2ag
-                email: nidia@faheyrohan.us
+                number: R274060221
+                token: UfvdA4eYrAv2zSSFpookDap37GdR3pk51xh
+                email: nakia_stokes@bauch.ca
                 special_instructions:
                 currency: USD
                 locale: en
@@ -1313,8 +1313,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:06.462Z'
-                updated_at: '2026-03-13T13:21:06.507Z'
+                created_at: '2026-03-15T09:56:35.105Z'
+                updated_at: '2026-03-15T09:56:35.160Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -1327,8 +1327,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 53889
-                  slug: product-53889
+                  name: Product 52481
+                  slug: product-52481
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1347,23 +1347,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:06.488Z'
-                  updated_at: '2026-03-13T13:21:06.488Z'
+                  created_at: '2026-03-15T09:56:35.136Z'
+                  updated_at: '2026-03-15T09:56:35.136Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H34714733825
+                  number: H88293867577
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:06.493Z'
-                  updated_at: '2026-03-13T13:21:06.505Z'
+                  created_at: '2026-03-15T09:56:35.141Z'
+                  updated_at: '2026-03-15T09:56:35.158Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1371,7 +1371,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_47
-                    name: Junko Hoppe
+                    name: Florentino Kuhn
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1506,9 +1506,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R682773628
-                token: syPcDnJ9wmzkHAMTfoyDPrVmJ2WfYDPKjJy
-                email: libbie@bauch.name
+                number: R321260229
+                token: 7xXrFbBGu8uGBWPEWtmfyctkZmBmG7VWsym
+                email: otelia.morar@greenruecker.biz
                 special_instructions: Leave at door
                 currency: USD
                 locale: en
@@ -1529,8 +1529,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '29.99'
                 display_total: "$29.99"
-                created_at: '2026-03-13T13:21:07.077Z'
-                updated_at: '2026-03-13T13:21:07.194Z'
+                created_at: '2026-03-15T09:56:35.810Z'
+                updated_at: '2026-03-15T09:56:36.017Z'
                 current_step: payment
                 completed_steps:
                 - address
@@ -1545,8 +1545,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 63492
-                  slug: product-63492
+                  name: Product 65837
+                  slug: product-65837
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -1565,23 +1565,23 @@ paths:
                   discounted_amount: '19.99'
                   display_discounted_amount: "$19.99"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:07.103Z'
-                  updated_at: '2026-03-13T13:21:07.155Z'
+                  created_at: '2026-03-15T09:56:35.853Z'
+                  updated_at: '2026-03-15T09:56:35.964Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_gbHJdmfrXB
-                  number: H34187027622
+                  number: H35789928369
                   state: pending
                   tracking:
                   tracking_url:
                   cost: '10.0'
                   display_cost: "$10.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:07.170Z'
-                  updated_at: '2026-03-13T13:21:07.181Z'
+                  created_at: '2026-03-15T09:56:35.983Z'
+                  updated_at: '2026-03-15T09:56:35.999Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1589,7 +1589,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_49
-                    name: Reina Wyman
+                    name: Luana Schuppe
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1811,9 +1811,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R578197857
-                token: fmJR2omwuHJsU73xbVa7KLQ3unN7K4nijox
-                email: sixta@bins.ca
+                number: R055833456
+                token: KQNMFNmjDq1ksBnKMPLyyN2fERN9FkT4EMX
+                email: peggy.hyatt@considine.com
                 special_instructions:
                 currency: USD
                 locale: en
@@ -1834,8 +1834,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:07.849Z'
-                updated_at: '2026-03-13T13:21:07.892Z'
+                created_at: '2026-03-15T09:56:36.714Z'
+                updated_at: '2026-03-15T09:56:36.780Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -1848,8 +1848,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 89039
-                  slug: product-89039
+                  name: Product 84030
+                  slug: product-84030
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1868,23 +1868,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:07.874Z'
-                  updated_at: '2026-03-13T13:21:07.874Z'
+                  created_at: '2026-03-15T09:56:36.755Z'
+                  updated_at: '2026-03-15T09:56:36.755Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H25082741006
+                  number: H87986565781
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:07.879Z'
-                  updated_at: '2026-03-13T13:21:07.890Z'
+                  created_at: '2026-03-15T09:56:36.761Z'
+                  updated_at: '2026-03-15T09:56:36.778Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -1892,7 +1892,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_57
-                    name: Jonell Dibbert
+                    name: Emilee Osinski
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2011,8 +2011,8 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R407488498
-                email: patience.sawayn@sipes.info
+                number: R792302214
+                email: shakia.gleason@cronin.name
                 special_instructions:
                 currency: USD
                 locale: en
@@ -2035,17 +2035,17 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '29.99'
                 display_total: "$29.99"
-                completed_at: '2026-03-13T13:21:09.257Z'
-                created_at: '2026-03-13T13:21:09.030Z'
-                updated_at: '2026-03-13T13:21:09.257Z'
+                completed_at: '2026-03-15T09:56:38.225Z'
+                created_at: '2026-03-15T09:56:37.947Z'
+                updated_at: '2026-03-15T09:56:38.225Z'
                 promotions: []
                 items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 105978
-                  slug: product-105978
+                  name: Product 106099
+                  slug: product-106099
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -2064,23 +2064,23 @@ paths:
                   discounted_amount: '19.99'
                   display_discounted_amount: "$19.99"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:09.055Z'
-                  updated_at: '2026-03-13T13:21:09.097Z'
+                  created_at: '2026-03-15T09:56:37.981Z'
+                  updated_at: '2026-03-15T09:56:38.230Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_gbHJdmfrXB
-                  number: H92081014808
+                  number: H94144915344
                   state: pending
                   tracking:
                   tracking_url:
                   cost: '10.0'
                   display_cost: "$10.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:09.123Z'
-                  updated_at: '2026-03-13T13:21:09.251Z'
+                  created_at: '2026-03-15T09:56:38.071Z'
+                  updated_at: '2026-03-15T09:56:38.219Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -2088,7 +2088,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_63
-                    name: Chante Treutel
+                    name: Darnell Weissnat
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2111,11 +2111,11 @@ paths:
                   payment_method_id: pm_UkLWZg9DAJ
                   state: completed
                   response_code: '12345'
-                  number: P934Q2WO
+                  number: PKB74RGB
                   amount: '29.99'
                   display_amount: "$29.99"
-                  created_at: '2026-03-13T13:21:09.211Z'
-                  updated_at: '2026-03-13T13:21:09.238Z'
+                  created_at: '2026-03-15T09:56:38.171Z'
+                  updated_at: '2026-03-15T09:56:38.197Z'
                   source_type: credit_card
                   source_id: card_UkLWZg9DAJ
                   source:
@@ -2247,8 +2247,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 1
-                  created_at: '2026-03-13T13:21:09.944Z'
-                  updated_at: '2026-03-13T13:21:09.998Z'
+                  created_at: '2026-03-15T09:56:38.892Z'
+                  updated_at: '2026-03-15T09:56:38.957Z'
                   parent_id:
                   description: ''
                   description_html: ''
@@ -2266,8 +2266,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 1
-                  created_at: '2026-03-13T13:21:09.954Z'
-                  updated_at: '2026-03-13T13:21:09.998Z'
+                  created_at: '2026-03-15T09:56:38.902Z'
+                  updated_at: '2026-03-15T09:56:38.957Z'
                   parent_id: ctg_UkLWZg9DAJ
                   description: ''
                   description_html: ''
@@ -2285,8 +2285,8 @@ paths:
                   meta_description:
                   meta_keywords:
                   children_count: 0
-                  created_at: '2026-03-13T13:21:09.964Z'
-                  updated_at: '2026-03-13T13:21:09.969Z'
+                  created_at: '2026-03-15T09:56:38.916Z'
+                  updated_at: '2026-03-15T09:56:38.924Z'
                   parent_id: ctg_gbHJdmfrXB
                   description: ''
                   description_html: ''
@@ -2387,8 +2387,8 @@ paths:
                 meta_description:
                 meta_keywords:
                 children_count: 1
-                created_at: '2026-03-13T13:21:10.352Z'
-                updated_at: '2026-03-13T13:21:10.384Z'
+                created_at: '2026-03-15T09:56:39.323Z'
+                updated_at: '2026-03-15T09:56:39.369Z'
                 parent_id: ctg_UkLWZg9DAJ
                 description: ''
                 description_html: ''
@@ -2515,20 +2515,16 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 196920
-                  description: |-
-                    Doloribus optio voluptas ratione veniam quisquam. Autem asperiores id itaque dolore. Iste rem officia fugiat corporis dolores libero architecto asperiores.
-                    Quam placeat labore voluptatem inventore dignissimos atque adipisci fugiat. Doloribus autem quo neque exercitationem earum molestiae. Blanditiis modi dicta esse iusto cupiditate velit fuga exercitationem. Labore fugiat iusto in sequi dolorum nemo atque delectus. Incidunt sed adipisci nobis aliquid voluptas.
-                    Accusantium distinctio nostrum harum ipsum quo eius corrupti. Sunt facere similique consequuntur officia dolorum. Itaque odio facere maiores provident asperiores. Minima iusto soluta aliquid quis velit blanditiis necessitatibus. Dolorum ipsa unde omnis quaerat.
-                    Tenetur sapiente facere non quo doloremque animi suscipit. Fugit est ducimus esse accusamus excepturi sint expedita. Inventore fugit quos optio labore. Eum sit voluptatum quas veniam ut quaerat excepturi laudantium. Aperiam velit non enim soluta impedit.
-                    Soluta dolorum possimus placeat asperiores. Eaque neque quod ipsum ducimus quaerat voluptate modi. Eius incidunt sit dignissimos mollitia.
-                  slug: product-196920
+                  name: Product 19398
+                  description: Minus similique repellat atque nobis. Fugiat placeat
+                    repudiandae hic quam. Omnis error aperiam officiis repellat.
+                  slug: product-19398
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-03-13T13:21:10.789Z'
-                  created_at: '2026-03-13T13:21:10.804Z'
-                  updated_at: '2026-03-13T13:21:10.817Z'
+                  available_on: '2025-03-15T09:56:39.966Z'
+                  created_at: '2026-03-15T09:56:39.981Z'
+                  updated_at: '2026-03-15T09:56:39.998Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -2798,9 +2794,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R040292129
-                token: He9gx8vMbT5pV9ikJxSgZ5mAF8XgFNEvq1A
-                email: rhona@dickiwolf.com
+                number: R239512747
+                token: DG7zZrtiYGCSVPJ265jT1Tiv5nsrR5etsk7
+                email: randy.stark@quitzon.ca
                 special_instructions:
                 currency: USD
                 locale: en
@@ -2821,8 +2817,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:12.564Z'
-                updated_at: '2026-03-13T13:21:12.654Z'
+                created_at: '2026-03-15T09:56:41.865Z'
+                updated_at: '2026-03-15T09:56:41.983Z'
                 current_step: address
                 completed_steps: []
                 requirements: []
@@ -2832,8 +2828,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 23937
-                  slug: product-23937
+                  name: Product 23971
+                  slug: product-23971
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -2852,23 +2848,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:12.591Z'
-                  updated_at: '2026-03-13T13:21:12.591Z'
+                  created_at: '2026-03-15T09:56:41.903Z'
+                  updated_at: '2026-03-15T09:56:41.903Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H38039362532
+                  number: H11031309423
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:12.596Z'
-                  updated_at: '2026-03-13T13:21:12.608Z'
+                  created_at: '2026-03-15T09:56:41.909Z'
+                  updated_at: '2026-03-15T09:56:41.924Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -2876,7 +2872,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_85
-                    name: Tari Kuhn
+                    name: Aliza Bednar
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2898,12 +2894,12 @@ paths:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
-                  response_code: 1-SC-20260313132112648182
-                  number: PZEHJYWD
+                  response_code: 1-SC-20260315095641975501
+                  number: P7HJEX3A
                   amount: '50.0'
                   display_amount: "$50.00"
-                  created_at: '2026-03-13T13:21:12.649Z'
-                  updated_at: '2026-03-13T13:21:12.649Z'
+                  created_at: '2026-03-15T09:56:41.977Z'
+                  updated_at: '2026-03-15T09:56:41.977Z'
                   source_type: store_credit
                   source_id: credit_UkLWZg9DAJ
                   source:
@@ -3046,9 +3042,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R862449861
-                token: dETVM3kH24DZZpY3SUWSGxaREf2DFpHQhYj
-                email: charlyn@kuhlman.info
+                number: R737368305
+                token: hxLpj3PmQJveF8goUcH6yJ5g9fpNf3vwBwa
+                email: andra@gleasonbuckridge.ca
                 special_instructions:
                 currency: USD
                 locale: en
@@ -3069,8 +3065,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:13.817Z'
-                updated_at: '2026-03-13T13:21:13.912Z'
+                created_at: '2026-03-15T09:56:43.255Z'
+                updated_at: '2026-03-15T09:56:43.376Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -3083,8 +3079,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 255306
-                  slug: product-255306
+                  name: Product 254999
+                  slug: product-254999
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3103,23 +3099,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:13.845Z'
-                  updated_at: '2026-03-13T13:21:13.907Z'
+                  created_at: '2026-03-15T09:56:43.290Z'
+                  updated_at: '2026-03-15T09:56:43.369Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H42733531071
+                  number: H55998223093
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:13.849Z'
-                  updated_at: '2026-03-13T13:21:13.861Z'
+                  created_at: '2026-03-15T09:56:43.296Z'
+                  updated_at: '2026-03-15T09:56:43.311Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -3127,7 +3123,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_93
-                    name: Shante Parisian
+                    name: Kimberly Rolfson
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3476,6 +3472,177 @@ paths:
                   message: Valid API key required
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customer/password_resets":
+    post:
+      summary: Request a password reset
+      tags:
+      - Password Resets
+      security:
+      - api_key: []
+      description: Sends a password reset email if an account exists for the given
+        email address. Always returns 202 Accepted to prevent email enumeration.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          await client.customer.passwordResets.create({
+            email: 'customer@example.com',
+            redirect_url: 'https://myshop.com/reset-password',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          description: email not found (same response to prevent enumeration)
+          content:
+            application/json:
+              example:
+                message: If an account exists for that email, password reset instructions
+                  have been sent.
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '401':
+          description: missing API key
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: customer@example.com
+                  description: Email address of the account to reset
+                redirect_url:
+                  type: string
+                  format: uri
+                  example: https://myshop.com/reset-password
+                  description: URL to redirect the user to after clicking the reset
+                    link. Validated against the store's allowed origins.
+              required:
+              - email
+  "/api/v3/store/customer/password_resets/{token}":
+    patch:
+      summary: Reset password with token
+      tags:
+      - Password Resets
+      security:
+      - api_key: []
+      description: Resets the password using a token received via email. Returns a
+        JWT token on success (auto-login).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const auth = await client.customer.passwordResets.update(
+            'reset-token-from-email',
+            {
+              password: 'newsecurepassword',
+              password_confirmation: 'newsecurepassword',
+            }
+          )
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: token
+        in: path
+        required: true
+        description: Password reset token from the email
+        schema:
+          type: string
+      responses:
+        '200':
+          description: password reset successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImJiMzViNzEzLThkMmEtNGU5Ni04MzI0LThlZmJjMDNhOGFjYSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNTcyMjA4fQ.lvT_KdvwjKK9epprdnp52TsqSGzg1LG1J4Q9Tn8Bjsk
+                user:
+                  id: cus_UkLWZg9DAJ
+                  email: customer@example.com
+                  first_name: Evelina
+                  last_name: Herman
+                  phone:
+                  accepts_email_marketing: false
+                  created_at: '2026-03-15T09:56:48.256Z'
+                  updated_at: '2026-03-15T09:56:48.531Z'
+                  addresses: []
+                  default_billing_address:
+                  default_shipping_address:
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '422':
+          description: password confirmation mismatch
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Password confirmation doesn't match Password
+                  details:
+                    password_confirmation:
+                    - doesn't match Password
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '401':
+          description: missing API key
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  minLength: 6
+                  example: newsecurepassword
+                password_confirmation:
+                  type: string
+                  example: newsecurepassword
+              required:
+              - password
+              - password_confirmation
   "/api/v3/store/customer/orders":
     get:
       summary: List orders
@@ -3519,8 +3686,8 @@ paths:
               example:
                 data:
                 - id: or_UkLWZg9DAJ
-                  number: R076106998
-                  email: eula@monahanstracke.ca
+                  number: R351447625
+                  email: isreal@weissnat.name
                   special_instructions:
                   currency: USD
                   locale: en
@@ -3543,17 +3710,17 @@ paths:
                   display_additional_tax_total: "$0.00"
                   total: '110.0'
                   display_total: "$110.00"
-                  completed_at: '2026-03-13T13:21:18.430Z'
-                  created_at: '2026-03-13T13:21:18.386Z'
-                  updated_at: '2026-03-13T13:21:18.430Z'
+                  completed_at: '2026-03-15T09:56:49.440Z'
+                  created_at: '2026-03-15T09:56:49.382Z'
+                  updated_at: '2026-03-15T09:56:49.440Z'
                   promotions: []
                   items:
                   - id: li_UkLWZg9DAJ
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 277849
-                    slug: product-277849
+                    name: Product 276901
+                    slug: product-276901
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -3572,23 +3739,23 @@ paths:
                     discounted_amount: '10.0'
                     display_discounted_amount: "$10.00"
                     display_compare_at_amount: "$0.00"
-                    created_at: '2026-03-13T13:21:18.411Z'
-                    updated_at: '2026-03-13T13:21:18.411Z'
+                    created_at: '2026-03-15T09:56:49.416Z'
+                    updated_at: '2026-03-15T09:56:49.416Z'
                     compare_at_amount:
                     thumbnail_url:
                     option_values: []
                     digital_links: []
                   shipments:
                   - id: ship_UkLWZg9DAJ
-                    number: H34713708304
+                    number: H42845699184
                     state: pending
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
                     display_cost: "$100.00"
                     shipped_at:
-                    created_at: '2026-03-13T13:21:18.416Z'
-                    updated_at: '2026-03-13T13:21:18.428Z'
+                    created_at: '2026-03-15T09:56:49.421Z'
+                    updated_at: '2026-03-15T09:56:49.437Z'
                     shipping_method:
                       id: shpm_UkLWZg9DAJ
                       name: UPS Ground
@@ -3596,7 +3763,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: STATE_ABBR_113
-                      name: Verline Ziemann
+                      name: Carli Roob
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -3716,8 +3883,8 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R933833301
-                email: penelope_tremblay@conroy.co.uk
+                number: R913804901
+                email: ruthe.lowe@davis.info
                 special_instructions:
                 currency: USD
                 locale: en
@@ -3740,17 +3907,17 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                completed_at: '2026-03-13T13:21:19.106Z'
-                created_at: '2026-03-13T13:21:19.062Z'
-                updated_at: '2026-03-13T13:21:19.106Z'
+                completed_at: '2026-03-15T09:56:50.133Z'
+                created_at: '2026-03-15T09:56:50.077Z'
+                updated_at: '2026-03-15T09:56:50.132Z'
                 promotions: []
                 items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 294225
-                  slug: product-294225
+                  name: Product 293199
+                  slug: product-293199
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3769,23 +3936,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:19.088Z'
-                  updated_at: '2026-03-13T13:21:19.088Z'
+                  created_at: '2026-03-15T09:56:50.109Z'
+                  updated_at: '2026-03-15T09:56:50.109Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H04363751482
+                  number: H53393663228
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:19.092Z'
-                  updated_at: '2026-03-13T13:21:19.104Z'
+                  created_at: '2026-03-15T09:56:50.115Z'
+                  updated_at: '2026-03-15T09:56:50.130Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -3793,7 +3960,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_119
-                    name: Lisa Klein
+                    name: Halina Larson
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3899,7 +4066,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjAzZmJlMGNiLTdkYjktNDY3ZS04Y2Y2LTQxZDNlNmU1NjExNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNDExNjgwfQ.bFdiMDIP7T7Qrr2p2aELskwIO4lUfaTgqHBMYgDF7Ko
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjEyMjRiMWQ0LWM5ODEtNDBhZC1iOWI5LTQxNTU2NmQ5NjY2MCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzczNTcyMjExfQ.p1jhTIxt8zTeAy51FvCRmLJ9QNkr8A135crtZ-BTvxw
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
@@ -3907,8 +4074,8 @@ paths:
                   last_name: Doe
                   phone: "+1234567890"
                   accepts_email_marketing: true
-                  created_at: '2026-03-13T13:21:20.268Z'
-                  updated_at: '2026-03-13T13:21:20.268Z'
+                  created_at: '2026-03-15T09:56:51.359Z'
+                  updated_at: '2026-03-15T09:56:51.359Z'
                   addresses: []
                   default_billing_address:
                   default_shipping_address:
@@ -4012,13 +4179,13 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: regina_gottlieb@aufderhar.ca
-                first_name: Darcey
-                last_name: Gleichner
+                email: laurette_kessler@wisozk.name
+                first_name: Millie
+                last_name: Jerde
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                created_at: '2026-03-13T13:21:20.819Z'
-                updated_at: '2026-03-13T13:21:21.085Z'
+                created_at: '2026-03-15T09:56:51.908Z'
+                updated_at: '2026-03-15T09:56:52.178Z'
                 addresses:
                 - id: addr_gbHJdmfrXB
                   firstname: John
@@ -4142,13 +4309,13 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: taylor_abernathy@langbeer.us
+                email: lauralee@thielcartwright.com
                 first_name: Updated
                 last_name: Name
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                created_at: '2026-03-13T13:21:21.372Z'
-                updated_at: '2026-03-13T13:21:21.648Z'
+                created_at: '2026-03-15T09:56:52.468Z'
+                updated_at: '2026-03-15T09:56:52.749Z'
                 addresses:
                 - id: addr_gbHJdmfrXB
                   firstname: John
@@ -4372,7 +4539,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: 22365A5081A193DC
+                  code: B608F79E2170A577
                   state: active
                   currency: USD
                   amount: '10.0'
@@ -4386,8 +4553,8 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-03-13T13:21:24.650Z'
-                  updated_at: '2026-03-13T13:21:24.650Z'
+                  created_at: '2026-03-15T09:56:55.879Z'
+                  updated_at: '2026-03-15T09:56:55.879Z'
                 meta:
                   page: 1
                   limit: 25
@@ -4470,7 +4637,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: A0FBB3022A8B673A
+                code: 531FE0239DCE4448
                 state: active
                 currency: USD
                 amount: '10.0'
@@ -4484,8 +4651,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-03-13T13:21:25.764Z'
-                updated_at: '2026-03-13T13:21:25.764Z'
+                created_at: '2026-03-15T09:56:56.987Z'
+                updated_at: '2026-03-15T09:56:56.987Z'
               schema:
                 "$ref": "#/components/schemas/GiftCard"
         '404':
@@ -4562,9 +4729,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R699842518
-                token: H5coEmtKEyoCkJEgUi1wSnRaHdebgLXeXhp
-                email: karyl.huel@sawayn.info
+                number: R503264262
+                token: dt5Bn5EmpZZwYARF7WnTrRu92yV5nrkpvDX
+                email: christine@oreillystoltenberg.biz
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4585,8 +4752,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '29.99'
                 display_total: "$29.99"
-                created_at: '2026-03-13T13:21:27.529Z'
-                updated_at: '2026-03-13T13:21:27.622Z'
+                created_at: '2026-03-15T09:56:58.847Z'
+                updated_at: '2026-03-15T09:56:58.972Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -4605,8 +4772,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 398702
-                  slug: product-398702
+                  name: Product 398150
+                  slug: product-398150
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4625,8 +4792,8 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:27.561Z'
-                  updated_at: '2026-03-13T13:21:27.561Z'
+                  created_at: '2026-03-15T09:56:58.883Z'
+                  updated_at: '2026-03-15T09:56:58.883Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
@@ -4635,8 +4802,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 409042
-                  slug: product-409042
+                  name: Product 402535
+                  slug: product-402535
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -4655,8 +4822,8 @@ paths:
                   discounted_amount: '19.99'
                   display_discounted_amount: "$19.99"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:27.602Z'
-                  updated_at: '2026-03-13T13:21:27.602Z'
+                  created_at: '2026-03-15T09:56:58.928Z'
+                  updated_at: '2026-03-15T09:56:58.928Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
@@ -4776,9 +4943,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R024060063
-                token: RbvDoZVLo8Dupvhs2KiLHcsQLYijfBwMABG
-                email: erma.baumbach@lemkesipes.com
+                number: R774166219
+                token: JMrytsemQpzmg8h11vACQazS7fyvTta8pBJ
+                email: lester_veum@macejkovic.us
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4799,8 +4966,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '0.0'
                 display_total: "$0.00"
-                created_at: '2026-03-13T13:21:29.364Z'
-                updated_at: '2026-03-13T13:21:29.391Z'
+                created_at: '2026-03-15T09:57:00.741Z'
+                updated_at: '2026-03-15T09:57:00.791Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -4816,8 +4983,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 439289
-                  slug: product-439289
+                  name: Product 434622
+                  slug: product-434622
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4836,8 +5003,8 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:29.391Z'
-                  updated_at: '2026-03-13T13:21:29.406Z'
+                  created_at: '2026-03-15T09:57:00.791Z'
+                  updated_at: '2026-03-15T09:57:00.820Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
@@ -4937,9 +5104,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R731372091
-                token: a4Cm7DywhFEdTBdH2VhbrieuR1AU5bQwTXb
-                email: vernita@keebler.us
+                number: R315470094
+                token: 1Q4v5MBRVvdkfVV2CVDKkEji6cMcgZ7UCjK
+                email: bulah_blanda@ledner.ca
                 special_instructions:
                 currency: USD
                 locale: en
@@ -4960,8 +5127,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '0.0'
                 display_total: "$0.00"
-                created_at: '2026-03-13T13:21:29.949Z'
-                updated_at: '2026-03-13T13:21:30.000Z'
+                created_at: '2026-03-15T09:57:01.391Z'
+                updated_at: '2026-03-15T09:57:01.475Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -5513,7 +5680,7 @@ paths:
             application/json:
               example:
                 id: or_UkLWZg9DAJ
-                number: R677424154
+                number: R431379959
                 email: guest@example.com
                 special_instructions:
                 currency: USD
@@ -5537,17 +5704,17 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                completed_at: '2026-03-13T13:21:31.708Z'
-                created_at: '2026-03-13T13:21:31.661Z'
-                updated_at: '2026-03-13T13:21:31.707Z'
+                completed_at: '2026-03-15T09:57:03.285Z'
+                created_at: '2026-03-15T09:57:03.226Z'
+                updated_at: '2026-03-15T09:57:03.285Z'
                 promotions: []
                 items:
                 - id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 476008
-                  slug: product-476008
+                  name: Product 471096
+                  slug: product-471096
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5566,23 +5733,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:31.689Z'
-                  updated_at: '2026-03-13T13:21:31.689Z'
+                  created_at: '2026-03-15T09:57:03.259Z'
+                  updated_at: '2026-03-15T09:57:03.259Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H05832068772
+                  number: H99381335009
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:31.693Z'
-                  updated_at: '2026-03-13T13:21:31.706Z'
+                  created_at: '2026-03-15T09:57:03.265Z'
+                  updated_at: '2026-03-15T09:57:03.282Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -5590,7 +5757,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_178
-                    name: Kina Hilpert
+                    name: Eliseo Anderson
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5795,13 +5962,13 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_d67b5c07bff7cdf650e215fd
+                external_id: bogus_a0977e1348c050bfa16b4ec0
                 external_data:
-                  client_secret: bogus_secret_634d05a921d1ece1
+                  client_secret: bogus_secret_5361e4eb9f61beb5
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-13T13:21:34.113Z'
-                updated_at: '2026-03-13T13:21:34.113Z'
+                created_at: '2026-03-15T09:57:05.798Z'
+                updated_at: '2026-03-15T09:57:05.798Z'
                 amount: '110.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -5896,13 +6063,13 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_64576a8fec060ad0cc7411b3
+                external_id: bogus_cf57445d529c06574c445f2b
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-13T13:21:34.708Z'
-                updated_at: '2026-03-13T13:21:34.708Z'
+                created_at: '2026-03-15T09:57:06.471Z'
+                updated_at: '2026-03-15T09:57:06.471Z'
                 amount: '110.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -5959,13 +6126,13 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_c1ef0c0f51eb4329b72d06ac
+                external_id: bogus_2558128ec996a5f552ea55e3
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-13T13:21:36.043Z'
-                updated_at: '2026-03-13T13:21:36.056Z'
+                created_at: '2026-03-15T09:57:07.733Z'
+                updated_at: '2026-03-15T09:57:07.747Z'
                 amount: '50.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -6062,13 +6229,13 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_963ea6aad5fc1e8e28cafc53
+                external_id: bogus_f6e3add7f8155fd60a723dac
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
                 expires_at:
-                created_at: '2026-03-13T13:21:36.647Z'
-                updated_at: '2026-03-13T13:21:36.659Z'
+                created_at: '2026-03-15T09:57:08.350Z'
+                updated_at: '2026-03-15T09:57:08.363Z'
                 amount: '110.0'
                 payment_method_id: pm_UkLWZg9DAJ
                 order_id: or_UkLWZg9DAJ
@@ -6148,11 +6315,11 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_037e7344b6c9d46b6fb1da78
-                external_client_secret: bogus_seti_secret_733e3a63a5c2f02e
+                external_id: bogus_seti_35831340b9be1dda0dc879b7
+                external_client_secret: bogus_seti_secret_645160465b56014d
                 external_data: {}
-                created_at: '2026-03-13T13:21:37.880Z'
-                updated_at: '2026-03-13T13:21:37.880Z'
+                created_at: '2026-03-15T09:57:09.547Z'
+                updated_at: '2026-03-15T09:57:09.547Z'
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
                 payment_source_type:
@@ -6249,12 +6416,12 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_84a3c4192c8b459ac83ab5a0
-                external_client_secret: seti_secret_2f916dce76c86ac5b5fd0737
+                external_id: seti_test_2e9ef45b42d7fb1b4e5fac91
+                external_client_secret: seti_secret_4165488a7c42172d41e2e0fb
                 external_data:
                   client_secret: secret_123
-                created_at: '2026-03-13T13:21:39.502Z'
-                updated_at: '2026-03-13T13:21:39.502Z'
+                created_at: '2026-03-15T09:57:11.198Z'
+                updated_at: '2026-03-15T09:57:11.198Z'
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
                 payment_source_type:
@@ -6327,12 +6494,12 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_bda76724663a5c773cefc43e
-                external_client_secret: seti_secret_df879275fcfcee1521b84767
+                external_id: seti_test_e65035e9af9ec10297b861e1
+                external_client_secret: seti_secret_4abb4347ff85b4dac427a0de
                 external_data:
                   client_secret: secret_123
-                created_at: '2026-03-13T13:21:40.600Z'
-                updated_at: '2026-03-13T13:21:40.616Z'
+                created_at: '2026-03-15T09:57:12.306Z'
+                updated_at: '2026-03-15T09:57:12.323Z'
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id: card_UkLWZg9DAJ
                 payment_source_type: Spree::CreditCard
@@ -6420,11 +6587,11 @@ paths:
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
                   response_code: '12345'
-                  number: PEOHBCTD
+                  number: PE69K01S
                   amount: '110.0'
                   display_amount: "$110.00"
-                  created_at: '2026-03-13T13:21:41.769Z'
-                  updated_at: '2026-03-13T13:21:41.769Z'
+                  created_at: '2026-03-15T09:57:13.516Z'
+                  updated_at: '2026-03-15T09:57:13.516Z'
                   source_type: credit_card
                   source_id: card_UkLWZg9DAJ
                   source:
@@ -6511,11 +6678,11 @@ paths:
                 payment_method_id: pm_UkLWZg9DAJ
                 state: checkout
                 response_code:
-                number: PNV26FB9
+                number: P95WC0IE
                 amount: '110.0'
                 display_amount: "$110.00"
-                created_at: '2026-03-13T13:21:42.385Z'
-                updated_at: '2026-03-13T13:21:42.385Z'
+                created_at: '2026-03-15T09:57:14.154Z'
+                updated_at: '2026-03-15T09:57:14.154Z'
                 source_type:
                 source_id:
                 source:
@@ -6672,20 +6839,19 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 59677
-                  description: |-
-                    Ipsam accusantium quae quibusdam expedita accusamus. Dolorum a vitae sapiente suscipit magni eveniet accusantium. Possimus veniam aperiam animi nisi nihil. Possimus sed velit sit sequi neque est.
-                    Eius aliquid eaque dignissimos rem sed incidunt earum. Similique rerum voluptatem repellat rem. Possimus dignissimos at qui sequi.
-                    Deserunt nam ut temporibus voluptatem odit eaque recusandae. Pariatur nemo molestias atque maxime debitis quia inventore deserunt. Reiciendis similique illum laborum animi repellendus accusantium. Occaecati consectetur magnam quo cumque quibusdam. Quisquam facere esse voluptas unde ipsam saepe.
-                    Aliquid porro quidem tempore omnis corrupti. Possimus dignissimos maxime ipsam deleniti quisquam delectus similique illum. Velit quasi dignissimos optio qui laudantium. Consequatur vero deleniti doloremque magnam repellat repellendus expedita.
-                    Alias commodi natus eum non eligendi dolor. Perspiciatis atque iste amet consectetur. Sit natus quo ex vero illum provident error nesciunt.
-                  slug: product-59677
+                  name: Product 594464
+                  description: Pariatur quae consequatur quo rerum modi magnam. Facilis
+                    sint nam temporibus quas officia vero nobis. Reprehenderit nam
+                    possimus numquam consectetur rerum. Temporibus quo inventore culpa
+                    expedita fugiat. Repudiandae voluptatum vero natus incidunt cupiditate
+                    nemo.
+                  slug: product-594464
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-03-13T13:21:43.204Z'
-                  created_at: '2026-03-13T13:21:43.218Z'
-                  updated_at: '2026-03-13T13:21:43.267Z'
+                  available_on: '2025-03-15T09:57:14.832Z'
+                  created_at: '2026-03-15T09:57:14.852Z'
+                  updated_at: '2026-03-15T09:57:14.903Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -6705,18 +6871,18 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 602460
-                  description: |-
-                    Repellendus enim sunt rerum pariatur laboriosam ducimus harum nihil. Officiis ratione nisi dolorem cum dicta neque. Nulla itaque maxime eum voluptate.
-                    Porro quis quisquam dolorum fugiat iusto possimus neque. Sit deserunt iste veritatis corporis. Alias tempora quas repellendus libero aliquam odit.
-                    Quisquam vel ullam molestias optio dolores illum. Necessitatibus ex est beatae quibusdam. Laudantium odio commodi culpa quisquam quam incidunt. Magni accusantium atque architecto rem ut sit nobis ipsa. Maiores doloremque tenetur totam cumque.
-                  slug: product-602460
+                  name: Product 607834
+                  description: Autem reiciendis minima aspernatur quaerat qui repudiandae.
+                    Inventore libero vero adipisci recusandae iste expedita veniam
+                    deserunt. Cum dicta distinctio harum ea nesciunt sequi eveniet
+                    modi.
+                  slug: product-607834
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-03-13T13:21:43.274Z'
-                  created_at: '2026-03-13T13:21:43.285Z'
-                  updated_at: '2026-03-13T13:21:43.300Z'
+                  available_on: '2025-03-15T09:57:14.911Z'
+                  created_at: '2026-03-15T09:57:14.922Z'
+                  updated_at: '2026-03-15T09:57:14.936Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -6822,18 +6988,18 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 712884
-                description: Tenetur nam neque possimus est. Atque saepe sapiente
-                  architecto explicabo placeat magnam. Expedita eveniet neque suscipit
-                  id pariatur maxime facere. Consequatur quo explicabo nostrum possimus
-                  laborum dignissimos nulla minus. Minus debitis provident quasi impedit.
-                slug: product-712884
+                name: Product 719274
+                description: |-
+                  Doloremque cupiditate cumque porro dolor. Veritatis perferendis dolor expedita ipsum tempore nulla iusto nemo. Eveniet voluptate impedit voluptatem voluptates.
+                  Accusamus facilis at soluta vero quibusdam natus cum vitae. Ex sequi pariatur laboriosam nisi molestias labore. Rem odio pariatur earum labore saepe consectetur ullam. Ad eius dolorem minus nulla. Aperiam illum veritatis sed eaque itaque.
+                  Quibusdam commodi at distinctio deleniti incidunt. Minus soluta esse fugiat saepe unde molestias. Ullam asperiores rem laboriosam a.
+                slug: product-719274
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-03-13T13:21:43.932Z'
-                created_at: '2026-03-13T13:21:43.951Z'
-                updated_at: '2026-03-13T13:21:43.998Z'
+                available_on: '2025-03-15T09:57:15.553Z'
+                created_at: '2026-03-15T09:57:15.580Z'
+                updated_at: '2026-03-15T09:57:15.645Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -7051,15 +7217,15 @@ paths:
               example:
                 data:
                 - id: ship_UkLWZg9DAJ
-                  number: H89258927496
+                  number: H69528152229
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:46.270Z'
-                  updated_at: '2026-03-13T13:21:46.292Z'
+                  created_at: '2026-03-15T09:57:17.857Z'
+                  updated_at: '2026-03-15T09:57:17.873Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -7067,7 +7233,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_250
-                    name: Renna Steuber
+                    name: Ludie Grant
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7149,9 +7315,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R568091676
-                token: H9vBXxvGZLrW62oFGDiNxcPDhVVmSvG6war
-                email: jim@gislasonchristiansen.biz
+                number: R905508813
+                token: 9NzoeWMT2z8be7kife1xnWDAbiZTWnACkNG
+                email: billye@collins.com
                 special_instructions:
                 currency: USD
                 locale: en
@@ -7172,8 +7338,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:46.898Z'
-                updated_at: '2026-03-13T13:21:46.992Z'
+                created_at: '2026-03-15T09:57:18.433Z'
+                updated_at: '2026-03-15T09:57:18.531Z'
                 current_step: payment
                 completed_steps:
                 - address
@@ -7188,8 +7354,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1002307
-                  slug: product-1002307
+                  name: Product 1003603
+                  slug: product-1003603
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7208,23 +7374,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:46.930Z'
-                  updated_at: '2026-03-13T13:21:46.930Z'
+                  created_at: '2026-03-15T09:57:18.467Z'
+                  updated_at: '2026-03-15T09:57:18.467Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H79690374982
+                  number: H28170725534
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:46.936Z'
-                  updated_at: '2026-03-13T13:21:46.974Z'
+                  created_at: '2026-03-15T09:57:18.473Z'
+                  updated_at: '2026-03-15T09:57:18.514Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -7232,7 +7398,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_254
-                    name: Michal Towne
+                    name: Benjamin Beier
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7368,9 +7534,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R891292364
-                token: 2mrYZVbiiG82arRbRZSxDpjmcgrftSc3iQ8
-                email: melba.stracke@predovicshanahan.us
+                number: R002787829
+                token: 642ULnFDFXNEANAEZoa4Hx8NFhF5JmmxJ39
+                email: beulah_treutel@beattybecker.co.uk
                 special_instructions:
                 currency: USD
                 locale: en
@@ -7391,8 +7557,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:48.144Z'
-                updated_at: '2026-03-13T13:21:48.194Z'
+                created_at: '2026-03-15T09:57:19.784Z'
+                updated_at: '2026-03-15T09:57:19.869Z'
                 current_step: address
                 completed_steps: []
                 requirements: []
@@ -7402,8 +7568,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1021030
-                  slug: product-1021030
+                  name: Product 1026200
+                  slug: product-1026200
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7422,23 +7588,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:48.175Z'
-                  updated_at: '2026-03-13T13:21:48.175Z'
+                  created_at: '2026-03-15T09:57:19.839Z'
+                  updated_at: '2026-03-15T09:57:19.839Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H91139349253
+                  number: H72079528401
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:48.180Z'
-                  updated_at: '2026-03-13T13:21:48.192Z'
+                  created_at: '2026-03-15T09:57:19.847Z'
+                  updated_at: '2026-03-15T09:57:19.866Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -7446,7 +7612,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_262
-                    name: Concetta Reilly
+                    name: Henriette Larkin
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7468,12 +7634,12 @@ paths:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   state: checkout
-                  response_code: 1-SC-20260313132148499600
-                  number: PIO7TOSZ
+                  response_code: 1-SC-20260315095720181607
+                  number: PGSET0HH
                   amount: '10.0'
                   display_amount: "$10.00"
-                  created_at: '2026-03-13T13:21:48.503Z'
-                  updated_at: '2026-03-13T13:21:48.503Z'
+                  created_at: '2026-03-15T09:57:20.185Z'
+                  updated_at: '2026-03-15T09:57:20.185Z'
                   source_type: store_credit
                   source_id: credit_UkLWZg9DAJ
                   source:
@@ -7604,9 +7770,9 @@ paths:
             application/json:
               example:
                 id: cart_UkLWZg9DAJ
-                number: R870356661
-                token: xsDmHKcwqxzvb3hf4ymM3cE3d5fxLehbhDf
-                email: larissa.baumbach@williamson.us
+                number: R153268950
+                token: RE7XHmBaKZBWVbEsynYnqQ56xZPNk3Uyepm
+                email: serena.keeling@nolan.us
                 special_instructions:
                 currency: USD
                 locale: en
@@ -7627,8 +7793,8 @@ paths:
                 display_additional_tax_total: "$0.00"
                 total: '110.0'
                 display_total: "$110.00"
-                created_at: '2026-03-13T13:21:49.718Z'
-                updated_at: '2026-03-13T13:21:49.781Z'
+                created_at: '2026-03-15T09:57:21.371Z'
+                updated_at: '2026-03-15T09:57:21.432Z'
                 current_step: address
                 completed_steps: []
                 requirements:
@@ -7641,8 +7807,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1043142
-                  slug: product-1043142
+                  name: Product 1044733
+                  slug: product-1044733
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7661,23 +7827,23 @@ paths:
                   discounted_amount: '10.0'
                   display_discounted_amount: "$10.00"
                   display_compare_at_amount: "$0.00"
-                  created_at: '2026-03-13T13:21:49.753Z'
-                  updated_at: '2026-03-13T13:21:49.753Z'
+                  created_at: '2026-03-15T09:57:21.406Z'
+                  updated_at: '2026-03-15T09:57:21.406Z'
                   compare_at_amount:
                   thumbnail_url:
                   option_values: []
                   digital_links: []
                 shipments:
                 - id: ship_UkLWZg9DAJ
-                  number: H59385608469
+                  number: H94443388943
                   state: pending
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
                   display_cost: "$100.00"
                   shipped_at:
-                  created_at: '2026-03-13T13:21:49.760Z'
-                  updated_at: '2026-03-13T13:21:49.778Z'
+                  created_at: '2026-03-15T09:57:21.412Z'
+                  updated_at: '2026-03-15T09:57:21.429Z'
                   shipping_method:
                     id: shpm_UkLWZg9DAJ
                     name: UPS Ground
@@ -7685,7 +7851,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: STATE_ABBR_270
-                    name: Viva Schinner
+                    name: Damion Crist
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7801,9 +7967,9 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: NGD91Ra2KyTGmH4ugDqQdrEE
-                  created_at: '2026-03-13T13:21:50.379Z'
-                  updated_at: '2026-03-13T13:21:50.379Z'
+                  token: Q7WVpKPerdP728LP2cTyre52
+                  created_at: '2026-03-15T09:57:22.003Z'
+                  updated_at: '2026-03-15T09:57:22.003Z'
                   is_default: false
                   is_private: true
                 meta:
@@ -7879,9 +8045,9 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: d1hkbCQ7oTRkKxJ9UaeMTJpY
-                created_at: '2026-03-13T13:21:51.592Z'
-                updated_at: '2026-03-13T13:21:51.592Z'
+                token: v9F5QMgvHgcV1s7jkH7YKV6W
+                created_at: '2026-03-15T09:57:23.219Z'
+                updated_at: '2026-03-15T09:57:23.219Z'
                 is_default: false
                 is_private: true
               schema:
@@ -7977,9 +8143,9 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: MGENAcmuamfV8pjBDbqDx3xb
-                created_at: '2026-03-13T13:21:52.711Z'
-                updated_at: '2026-03-13T13:21:52.711Z'
+                token: ksKtAtTwXqPMvcoNpX3sSBi9
+                created_at: '2026-03-15T09:57:24.339Z'
+                updated_at: '2026-03-15T09:57:24.339Z'
                 is_default: false
                 is_private: true
               schema:
@@ -8041,9 +8207,9 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: MsvKUK8GJMVjYsMoPknvqTXu
-                created_at: '2026-03-13T13:21:53.853Z'
-                updated_at: '2026-03-13T13:21:53.896Z'
+                token: Y9zmnLuTSR9iY1HLtHeDYW9o
+                created_at: '2026-03-15T09:57:25.494Z'
+                updated_at: '2026-03-15T09:57:25.542Z'
                 is_default: false
                 is_private: true
               schema:
@@ -8155,8 +8321,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 wishlist_id: wl_UkLWZg9DAJ
                 quantity: 1
-                created_at: '2026-03-13T13:21:55.101Z'
-                updated_at: '2026-03-13T13:21:55.101Z'
+                created_at: '2026-03-15T09:57:26.730Z'
+                updated_at: '2026-03-15T09:57:26.730Z'
                 variant:
                   id: variant_gbHJdmfrXB
                   product_id: prod_gbHJdmfrXB
@@ -8165,8 +8331,8 @@ paths:
                   options_text: ''
                   track_inventory: true
                   image_count: 0
-                  created_at: '2026-03-13T13:21:55.073Z'
-                  updated_at: '2026-03-13T13:21:55.083Z'
+                  created_at: '2026-03-15T09:57:26.705Z'
+                  updated_at: '2026-03-15T09:57:26.716Z'
                   thumbnail:
                   purchasable: true
                   in_stock: false

--- a/docs/developer/core-concepts/customers.mdx
+++ b/docs/developer/core-concepts/customers.mdx
@@ -116,6 +116,68 @@ curl -X POST 'https://api.mystore.com/api/v3/store/auth/refresh' \
 
 </CodeGroup>
 
+## Password Reset
+
+Password reset is a two-step flow. First, request a reset email. Then, use the token from the email to set a new password.
+
+### Step 1: Request Reset
+
+<CodeGroup>
+
+```typescript SDK
+await client.customer.passwordResets.create({
+  email: 'john@example.com',
+  redirect_url: 'https://myshop.com/reset-password',
+})
+// Always returns { message: "..." } — even if the email doesn't exist
+// This prevents email enumeration
+```
+
+```bash cURL
+curl -X POST 'https://api.mystore.com/api/v3/store/customer/password_resets' \
+  -H 'X-Spree-Api-Key: spree_pk_xxx' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "email": "john@example.com",
+    "redirect_url": "https://myshop.com/reset-password"
+  }'
+```
+
+</CodeGroup>
+
+The optional `redirect_url` parameter specifies where the password reset link in the email should point to. The token will be appended as a query parameter (e.g., `https://myshop.com/reset-password?token=...`). If the store has [Allowed Origins](/developer/core-concepts/allowed-origins) configured, the `redirect_url` must match one of them.
+
+This fires a `customer.password_reset_requested` event with the reset token in the payload. If you're using the `spree_emails` package, the email is sent automatically. Otherwise, subscribe to this event to send the reset email yourself (see [Events](/developer/core-concepts/events)).
+
+### Step 2: Reset Password
+
+<CodeGroup>
+
+```typescript SDK
+const { token, user } = await client.customer.passwordResets.update(
+  'reset-token-from-email',
+  {
+    password: 'newsecurepassword',
+    password_confirmation: 'newsecurepassword',
+  }
+)
+// Returns JWT token + user (auto-login)
+```
+
+```bash cURL
+curl -X PATCH 'https://api.mystore.com/api/v3/store/customer/password_resets/RESET_TOKEN' \
+  -H 'X-Spree-Api-Key: spree_pk_xxx' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "password": "newsecurepassword",
+    "password_confirmation": "newsecurepassword"
+  }'
+```
+
+</CodeGroup>
+
+On success, the user is automatically logged in and a JWT token is returned. The reset token expires after 15 minutes (configurable via `Spree::Config.customer_password_reset_expires_in`) and is single-use (changing the password invalidates it).
+
 ## Customer Profile
 
 <CodeGroup>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,119 @@
+{
+  "name": "spree",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spree",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "turbo": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/turbo": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.17.tgz",
+      "integrity": "sha512-YwPsNSqU2f/RXU/+Kcb7cPkPZARxom4+me7LKEdN5jsvy2tpfze3zDZ4EiGrJnvOm9Avu9rK0aaYsP7qZ3iz7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.8.17",
+        "turbo-darwin-arm64": "2.8.17",
+        "turbo-linux-64": "2.8.17",
+        "turbo-linux-arm64": "2.8.17",
+        "turbo-windows-64": "2.8.17",
+        "turbo-windows-arm64": "2.8.17"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.17.tgz",
+      "integrity": "sha512-ZFkv2hv7zHpAPEXBF6ouRRXshllOavYc+jjcrYyVHvxVTTwJWsBZwJ/gpPzmOKGvkSjsEyDO5V6aqqtZzwVF+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.17.tgz",
+      "integrity": "sha512-5DXqhQUt24ycEryXDfMNKEkW5TBHs+QmU23a2qxXwwFDaJsWcPo2obEhBxxdEPOv7qmotjad+09RGeWCcJ9JDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.17.tgz",
+      "integrity": "sha512-KLUbz6w7F73D/Ihh51hVagrKR0/CTsPEbRkvXLXvoND014XJ4BCrQUqSxlQ4/hu+nqp1v5WlM85/h3ldeyujuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.17.tgz",
+      "integrity": "sha512-pJK67XcNJH40lTAjFu7s/rUlobgVXyB3A3lDoq+/JccB3hf+SysmkpR4Itlc93s8LEaFAI4mamhFuTV17Z6wOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.17.tgz",
+      "integrity": "sha512-EijeQ6zszDMmGZLP2vT2RXTs/GVi9rM0zv2/G4rNu2SSRSGFapgZdxgW4b5zUYLVaSkzmkpWlGfPfj76SW9yUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.17.tgz",
+      "integrity": "sha512-crpfeMPkfECd4V1PQ/hMoiyVcOy04+bWedu/if89S15WhOalHZ2BYUi6DOJhZrszY+mTT99OwpOsj4wNfb/GHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/next
 
+## 0.10.5
+
+### Patch Changes
+
+- Add optional `redirectUrl` parameter to `requestPasswordReset` server action for password reset flow with custom redirect URL support.
+
 ## 0.10.4
 
 ### Patch Changes

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -172,6 +172,21 @@ const customer = await getCustomer();
 await updateCustomer({ first_name: 'John' });
 ```
 
+### Password Reset
+
+```typescript
+import { requestPasswordReset, resetPassword } from '@spree/next';
+
+// Request a password reset email — returns { message: string }
+await requestPasswordReset(email);
+
+// With redirect URL (validated against store's allowed origins)
+await requestPasswordReset(email, 'https://myshop.com/reset-password');
+
+// Reset password and auto-login — returns { success: boolean; error?: string }
+await resetPassword(token, password, password_confirmation);
+```
+
 ### Addresses
 
 ```typescript

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/next",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Next.js integration for Spree Commerce — server actions, caching, and cookie-based auth",
   "type": "module",
   "main": "./dist/index.js",
@@ -62,7 +62,7 @@
     "url": "https://github.com/spree/spree/issues"
   },
   "peerDependencies": {
-    "@spree/sdk": ">=0.10.0",
+    "@spree/sdk": ">=0.10.1",
     "next": ">=15.0.0",
     "react": ">=19.0.0"
   },

--- a/packages/next/src/actions/auth.ts
+++ b/packages/next/src/actions/auth.ts
@@ -120,6 +120,50 @@ export async function getCustomer(): Promise<Customer | null> {
 }
 
 /**
+ * Request a password reset email.
+ * Always succeeds to prevent email enumeration.
+ *
+ * @param email - The email address of the account
+ * @param redirectUrl - Optional URL to redirect the user to after clicking the reset link.
+ *                      Must match one of the store's allowed origins.
+ */
+export async function requestPasswordReset(
+  email: string,
+  redirectUrl?: string
+): Promise<{ message: string }> {
+  return getClient().customer.passwordResets.create({
+    email,
+    ...(redirectUrl && { redirect_url: redirectUrl }),
+  });
+}
+
+/**
+ * Reset password using a token from the password reset email.
+ * On success, the user is automatically logged in.
+ */
+export async function resetPassword(
+  token: string,
+  password: string,
+  password_confirmation: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await getClient().customer.passwordResets.update(token, {
+      password,
+      password_confirmation,
+    });
+    await setAccessToken(result.token);
+    revalidateTag('customer');
+    revalidateTag('cart');
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Password reset failed',
+    };
+  }
+}
+
+/**
  * Update the current customer's profile.
  */
 export async function updateCustomer(

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -33,6 +33,8 @@ export {
   logout,
   getCustomer,
   updateCustomer,
+  requestPasswordReset,
+  resetPassword,
 } from './actions/auth';
 
 export {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/sdk
 
+## 0.10.1
+
+### Patch Changes
+
+- Add optional `redirect_url` parameter to `requestPasswordReset` for password reset flow. The URL is validated against the store's allowed origins on the server side.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -468,6 +468,25 @@ await client.customer.addresses.markAsDefault('addr_xxx', 'billing', options);
 await client.customer.addresses.markAsDefault('addr_xxx', 'shipping', options);
 ```
 
+### Customer Password Resets
+
+```typescript
+// Request a password reset email
+// Always returns { message: string } (202 status) — prevents email enumeration
+await client.customer.passwordResets.create({
+  email: 'customer@example.com',
+  redirect_url: 'https://myshop.com/reset-password', // optional, validated against store's allowed origins
+});
+
+// Reset password with token from email
+// Returns AuthTokens (JWT + user) — auto-login on success
+// Token expires in 15 minutes
+const { token, user } = await client.customer.passwordResets.update('reset_token_xxx', {
+  password: 'newPassword123',
+  password_confirmation: 'newPassword123',
+});
+```
+
 ### Customer Credit Cards
 
 ```typescript
@@ -545,6 +564,7 @@ The SDK uses a resource builder pattern for nested resources:
 | `carts` | `paymentSessions` | `create`, `get`, `update`, `complete` |
 | `carts` | `storeCredits` | `apply`, `remove` |
 | `customer` | `addresses` | `list`, `get`, `create`, `update`, `delete`, `markAsDefault` |
+| `customer` | `passwordResets` | `create`, `update` |
 | `customer` | `creditCards` | `list`, `get`, `delete` |
 | `customer` | `giftCards` | `list`, `get` |
 | `customer` | `orders` | `list`, `get` |

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Official TypeScript SDK for Spree Commerce Store API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/src/store-client.ts
+++ b/packages/sdk/src/store-client.ts
@@ -25,6 +25,8 @@ import type {
   CompletePaymentSessionParams,
   CreatePaymentSetupSessionParams,
   CompletePaymentSetupSessionParams,
+  RequestPasswordResetParams,
+  ResetPasswordParams,
   Cart,
   CreditCard,
   GiftCard,
@@ -882,6 +884,35 @@ export class StoreClient {
           'PATCH',
           `/customer/payment_setup_sessions/${id}/complete`,
           { ...options, body: params }
+        ),
+    },
+
+    /**
+     * Password reset
+     */
+    passwordResets: {
+      /**
+       * Request a password reset email.
+       * Always succeeds (202) to prevent email enumeration.
+       */
+      create: (params: RequestPasswordResetParams): Promise<{ message: string }> =>
+        this.request<{ message: string }>('POST', '/customer/password_resets', {
+          body: params,
+        }),
+
+      /**
+       * Reset password using the token from the email.
+       * Returns a JWT token on success (auto-login).
+       * @param token - Password reset token from the email
+       */
+      update: (
+        token: string,
+        params: ResetPasswordParams
+      ): Promise<AuthTokens> =>
+        this.request<AuthTokens>(
+          'PATCH',
+          `/customer/password_resets/${token}`,
+          { body: params }
         ),
     },
   };

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -146,6 +146,16 @@ export interface LoginCredentials {
   password: string;
 }
 
+export interface RequestPasswordResetParams {
+  email: string;
+  redirect_url?: string;
+}
+
+export interface ResetPasswordParams {
+  password: string;
+  password_confirmation: string;
+}
+
 export interface RegisterParams {
   email: string;
   password: string;

--- a/packages/sdk/tests/mocks/handlers.ts
+++ b/packages/sdk/tests/mocks/handlers.ts
@@ -519,6 +519,18 @@ export const handlers = [
     })
   ),
 
+  // Customer > Password Resets
+  http.post(`${API_PREFIX}/customer/password_resets`, () =>
+    HttpResponse.json(
+      { message: 'If an account exists for that email, password reset instructions have been sent.' },
+      { status: 202 }
+    )
+  ),
+
+  http.patch(`${API_PREFIX}/customer/password_resets/:token`, () =>
+    HttpResponse.json({ token: 'new-jwt-token', user: fixtures.user })
+  ),
+
   // Wishlists
   http.get(`${API_PREFIX}/wishlists`, () =>
     HttpResponse.json({ data: [fixtures.wishlist], meta: paginationMeta })

--- a/packages/sdk/tests/password-resets.test.ts
+++ b/packages/sdk/tests/password-resets.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { server } from './mocks/server';
+import { http, HttpResponse } from 'msw';
+import { createTestClient, TEST_BASE_URL } from './helpers';
+
+const API_PREFIX = `${TEST_BASE_URL}/api/v3/store`;
+
+describe('customer.passwordResets', () => {
+  describe('create (request password reset)', () => {
+    it('returns a message on success', async () => {
+      const client = createTestClient();
+      const result = await client.customer.passwordResets.create({
+        email: 'test@example.com',
+      });
+
+      expect(result.message).toBeDefined();
+    });
+
+    it('sends email in request body', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`${API_PREFIX}/customer/password_resets`, async ({ request }) => {
+          capturedBody = await request.json() as Record<string, unknown>;
+          return HttpResponse.json(
+            { message: 'If an account exists for that email, password reset instructions have been sent.' },
+            { status: 202 }
+          );
+        })
+      );
+
+      const client = createTestClient();
+      await client.customer.passwordResets.create({ email: 'test@example.com' });
+
+      expect(capturedBody.email).toBe('test@example.com');
+    });
+  });
+
+  describe('update (reset password with token)', () => {
+    it('returns auth tokens on successful reset', async () => {
+      const client = createTestClient();
+      const result = await client.customer.passwordResets.update(
+        'valid-reset-token',
+        {
+          password: 'newsecurepassword',
+          password_confirmation: 'newsecurepassword',
+        }
+      );
+
+      expect(result.token).toBe('new-jwt-token');
+      expect(result.user.email).toBe('test@example.com');
+    });
+
+    it('sends token in URL path', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.patch(`${API_PREFIX}/customer/password_resets/:token`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ token: 'new-jwt-token', user: { id: 'user_1', email: 'test@example.com', first_name: null, last_name: null } });
+        })
+      );
+
+      const client = createTestClient();
+      await client.customer.passwordResets.update('my-reset-token', {
+        password: 'newsecurepassword',
+        password_confirmation: 'newsecurepassword',
+      });
+
+      expect(capturedUrl).toContain('/customer/password_resets/my-reset-token');
+    });
+
+    it('throws SpreeError on invalid token', async () => {
+      server.use(
+        http.patch(`${API_PREFIX}/customer/password_resets/:token`, () =>
+          HttpResponse.json(
+            { error: { code: 'password_reset_token_invalid', message: 'Password reset token is invalid or has expired.' } },
+            { status: 422 }
+          )
+        )
+      );
+
+      const client = createTestClient();
+      try {
+        await client.customer.passwordResets.update('expired-token', {
+          password: 'newsecurepassword',
+          password_confirmation: 'newsecurepassword',
+        });
+        expect.unreachable('Should have thrown');
+      } catch (error: any) {
+        expect(error.code).toBe('password_reset_token_invalid');
+        expect(error.status).toBe(422);
+      }
+    });
+  });
+});

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_081642) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_15_144027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -151,6 +151,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_081642) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_spree_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_spree_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "spree_allowed_origins", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "origin", null: false
+    t.bigint "store_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id", "origin"], name: "index_spree_allowed_origins_on_store_id_and_origin", unique: true
+    t.index ["store_id"], name: "index_spree_allowed_origins_on_store_id"
   end
 
   create_table "spree_api_keys", force: :cascade do |t|

--- a/spree/admin/app/controllers/spree/admin/allowed_origins_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/allowed_origins_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class AllowedOriginsController < ResourceController
+      include Spree::Admin::SettingsConcern
+      include Spree::Admin::TableConcern
+
+      private
+
+      def model_class
+        Spree::AllowedOrigin
+      end
+
+      def scope
+        current_store.allowed_origins
+      end
+
+      def object_name
+        'allowed_origin'
+      end
+
+      def permitted_resource_params
+        params.require(:allowed_origin).permit(permitted_allowed_origin_attributes)
+      end
+
+      def location_after_save
+        spree.admin_allowed_origins_path
+      end
+
+      def location_after_destroy
+        spree.admin_allowed_origins_path
+      end
+    end
+  end
+end

--- a/spree/admin/app/views/spree/admin/allowed_origins/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/allowed_origins/_form.html.erb
@@ -1,0 +1,9 @@
+<div class="card mb-6">
+  <div class="card-header">
+    <h5 class="card-title"><%= Spree.t('admin.allowed_origins.origin_settings') %></h5>
+  </div>
+  <div class="card-body">
+    <%= f.spree_text_field :origin, required: true, autofocus: f.object.new_record?, placeholder: 'https://myshop.com' %>
+    <p class="text-sm text-gray-500 mt-1"><%= Spree.t('admin.allowed_origins.origin_help') %></p>
+  </div>
+</div>

--- a/spree/admin/app/views/spree/admin/allowed_origins/edit.html.erb
+++ b/spree/admin/app/views/spree/admin/allowed_origins/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/admin/shared/edit_resource' %>

--- a/spree/admin/app/views/spree/admin/allowed_origins/index.html.erb
+++ b/spree/admin/app/views/spree/admin/allowed_origins/index.html.erb
@@ -1,0 +1,9 @@
+<%= render 'spree/admin/shared/developers_nav' %>
+
+<%= content_for(:title, Spree.t(:allowed_origins)) %>
+
+<% content_for :page_actions do %>
+  <%= link_to_with_icon 'plus', Spree.t(:new_allowed_origin), new_object_url, class: "btn btn-primary" if can? :create, Spree::AllowedOrigin %>
+<% end %>
+
+<%= render_table @collection, :allowed_origins %>

--- a/spree/admin/app/views/spree/admin/allowed_origins/new.html.erb
+++ b/spree/admin/app/views/spree/admin/allowed_origins/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/admin/shared/new_resource' %>

--- a/spree/admin/app/views/spree/admin/orders/_payments.html.erb
+++ b/spree/admin/app/views/spree/admin/orders/_payments.html.erb
@@ -21,7 +21,7 @@
             <%= link_to_with_icon 'send', Spree.t('admin.send_payment_link'), spree.admin_order_payment_links_path(@order), data: { turbo_method: :post }, class: 'btn btn-light', title: Spree.t(:send_payment_link_title) %>
 
             <div data-controller="clipboard" data-clipboard-success-content-value="<%= Spree.t('admin.copied') %>">
-              <input type="hidden" value="<%= spree.checkout_state_url(@order.token, :payment, host: current_store.url_or_custom_domain) %>" readonly data-clipboard-target="source">
+              <input type="hidden" value="<%= spree.checkout_state_url(@order.token, :payment, host: current_store.storefront_url) %>" readonly data-clipboard-target="source">
               <button class="btn btn-light" type="button" data-clipboard-target="button" data-action="click->clipboard#copy">
                 <%= icon('copy') %>
                 <%= Spree.t('admin.copy_payment_link') %>

--- a/spree/admin/app/views/spree/admin/shared/_seo.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_seo.html.erb
@@ -9,7 +9,7 @@
         <%= meta_title.presence || title %>
       </div>
       <div class="seo__preview__link">
-        <%= current_store.formatted_url_or_custom_domain %>/<%= slug_path %>/<span data-seo-form-target="slugPreview"><%= slug %></span>
+        <%= current_store.storefront_url %>/<%= slug_path %>/<span data-seo-form-target="slugPreview"><%= slug %></span>
       </div>
       <div class="seo__preview__description break-words" data-seo-form-target="descriptionPreview"></div>
     </div>

--- a/spree/admin/app/views/spree/admin/shared/sidebar/_store_dropdown.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/sidebar/_store_dropdown.html.erb
@@ -7,7 +7,7 @@
       </span>
     <% end %>
     <%= dropdown_menu do %>
-      <%= link_to current_store.formatted_url_or_custom_domain, class: 'dropdown-item', target: '_blank' do %>
+      <%= link_to current_store.storefront_url, class: 'dropdown-item', target: '_blank' do %>
         <%= icon 'eye' %>
         <%= Spree.t(:view_store) %>
       <% end %>

--- a/spree/admin/config/initializers/spree_admin_navigation.rb
+++ b/spree/admin/config/initializers/spree_admin_navigation.rb
@@ -334,7 +334,7 @@ Rails.application.config.after_initialize do
           url: :admin_api_keys_path,
           icon: 'terminal',
           position: 150,
-          active: -> { %w[oauth_applications api_keys webhooks_subscribers webhook_endpoints webhook_deliveries].include?(controller_name) },
+          active: -> { %w[oauth_applications api_keys webhooks_subscribers webhook_endpoints webhook_deliveries allowed_origins].include?(controller_name) },
           if: -> { can?(:manage, Spree::ApiKey) }
 
   # Edit Profile
@@ -455,6 +455,13 @@ Rails.application.config.after_initialize do
           position: 20,
           active: -> { %w[webhook_endpoints webhook_deliveries].include?(controller_name) },
           if: -> { can?(:manage, Spree::WebhookEndpoint) }
+
+  developers_tabs_nav.add :allowed_origins,
+          label: :allowed_origins,
+          url: :admin_allowed_origins_path,
+          position: 30,
+          active: -> { controller_name == 'allowed_origins' },
+          if: -> { can?(:manage, Spree::AllowedOrigin) }
 
   # Audit Tab Navigation
   audit_tabs_nav = Spree.admin.navigation.audit_tabs

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -1998,4 +1998,23 @@ Rails.application.config.after_initialize do
                                           default: true,
                                           position: 60,
                                           method: ->(sm) { sm.display_on.presence || 'both' }
+
+  # Register Allowed Origins table
+  Spree.admin.tables.register(:allowed_origins, model_class: Spree::AllowedOrigin, search_param: :origin_cont)
+
+  Spree.admin.tables.allowed_origins.add :origin,
+                                         label: :origin,
+                                         type: :string,
+                                         sortable: true,
+                                         filterable: true,
+                                         default: true,
+                                         position: 10
+
+  Spree.admin.tables.allowed_origins.add :created_at,
+                                         label: :created_at,
+                                         type: :datetime,
+                                         sortable: true,
+                                         filterable: true,
+                                         default: true,
+                                         position: 20
 end

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -5,6 +5,9 @@ en:
       not_found: Can't embed a video using the provided URL
   spree:
     admin:
+      allowed_origins:
+        origin_settings: Origin Settings
+        origin_help: "Enter the full origin URL of your storefront (e.g. https://myshop.com). Do not include paths or query strings."
       amount_spent: Amount spent
       api_keys:
         example_request: Example Request

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -6,8 +6,8 @@ en:
   spree:
     admin:
       allowed_origins:
+        origin_help: Enter the full origin URL of your storefront (e.g. https://myshop.com). Do not include paths or query strings.
         origin_settings: Origin Settings
-        origin_help: "Enter the full origin URL of your storefront (e.g. https://myshop.com). Do not include paths or query strings."
       amount_spent: Amount spent
       api_keys:
         example_request: Example Request

--- a/spree/admin/config/routes.rb
+++ b/spree/admin/config/routes.rb
@@ -258,6 +258,7 @@ Spree::Core::Engine.add_routes do
     resources :webhook_endpoints do
       resources :webhook_deliveries, only: [:index, :show]
     end
+    resources :allowed_origins, except: :show
 
     # errors
     get '/forbidden', to: 'errors#show', code: 403, as: :forbidden

--- a/spree/admin/spec/controllers/spree/admin/allowed_origins_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/allowed_origins_controller_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::AllowedOriginsController, type: :controller do
+  stub_authorization!
+  render_views
+
+  let(:store) { @default_store }
+
+  describe 'GET #index' do
+    subject(:index) { get :index }
+
+    let!(:allowed_origins) { create_list(:allowed_origin, 3, store: store) }
+    let!(:other_store_origins) { create_list(:allowed_origin, 2, store: create(:store)) }
+
+    it 'renders the index template' do
+      index
+
+      expect(response).to render_template(:index)
+    end
+
+    it 'assigns allowed origins for current store only' do
+      index
+
+      expect(assigns[:collection]).to contain_exactly(*allowed_origins)
+    end
+  end
+
+  describe 'GET #new' do
+    subject(:new_action) { get :new }
+
+    it 'renders the new template' do
+      new_action
+
+      expect(response).to render_template(:new)
+    end
+
+    it 'assigns a new allowed origin' do
+      new_action
+
+      expect(assigns[:allowed_origin]).to be_a_new(Spree::AllowedOrigin)
+    end
+  end
+
+  describe 'POST #create' do
+    subject(:create_origin) { post :create, params: { allowed_origin: origin_params } }
+
+    let(:origin_params) do
+      { origin: 'https://myshop.example.com' }
+    end
+
+    it 'creates a new allowed origin' do
+      expect { create_origin }.to change(Spree::AllowedOrigin, :count).by(1)
+    end
+
+    it 'sets the attributes correctly' do
+      create_origin
+
+      allowed_origin = Spree::AllowedOrigin.last
+      expect(allowed_origin.origin).to eq('https://myshop.example.com')
+      expect(allowed_origin.store).to eq(store)
+    end
+
+    it 'redirects to index' do
+      create_origin
+
+      expect(response).to redirect_to(spree.admin_allowed_origins_path)
+    end
+
+    context 'with invalid params' do
+      let(:origin_params) { { origin: '' } }
+
+      it 'does not create an allowed origin' do
+        expect { create_origin }.not_to change(Spree::AllowedOrigin, :count)
+      end
+
+      it 'renders the new template' do
+        create_origin
+
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    subject(:edit) { get :edit, params: { id: allowed_origin.to_param } }
+
+    let(:allowed_origin) { create(:allowed_origin, store: store) }
+
+    it 'renders the edit template' do
+      edit
+
+      expect(response).to render_template(:edit)
+    end
+
+    it 'assigns the allowed origin' do
+      edit
+
+      expect(assigns[:allowed_origin]).to eq(allowed_origin)
+    end
+  end
+
+  describe 'PATCH #update' do
+    subject(:update_origin) { patch :update, params: { id: allowed_origin.to_param, allowed_origin: origin_params } }
+
+    let!(:allowed_origin) { create(:allowed_origin, store: store, origin: 'https://old.example.com') }
+
+    let(:origin_params) do
+      { origin: 'https://new.example.com' }
+    end
+
+    it 'updates the allowed origin' do
+      update_origin
+
+      allowed_origin.reload
+      expect(allowed_origin.origin).to eq('https://new.example.com')
+    end
+
+    it 'redirects to index' do
+      update_origin
+
+      expect(response).to redirect_to(spree.admin_allowed_origins_path)
+    end
+
+    context 'with invalid params' do
+      let(:origin_params) { { origin: '' } }
+
+      it 'does not update the allowed origin' do
+        update_origin
+
+        allowed_origin.reload
+        expect(allowed_origin.origin).to eq('https://old.example.com')
+      end
+
+      it 'renders the edit template' do
+        update_origin
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    subject(:destroy_origin) { delete :destroy, params: { id: allowed_origin.to_param } }
+
+    let!(:allowed_origin) { create(:allowed_origin, store: store) }
+
+    it 'deletes the allowed origin' do
+      expect { destroy_origin }.to change(Spree::AllowedOrigin, :count).by(-1)
+    end
+
+    it 'redirects to index' do
+      destroy_origin
+
+      expect(response).to redirect_to(spree.admin_allowed_origins_path)
+    end
+  end
+end

--- a/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
@@ -13,6 +13,8 @@ module Spree
           invalid_token: 'invalid_token',
           invalid_provider: 'invalid_provider',
           current_password_invalid: 'current_password_invalid',
+          password_reset_token_invalid: 'password_reset_token_invalid',
+          redirect_url_not_allowed: 'redirect_url_not_allowed',
 
           # Resource errors
           record_not_found: 'record_not_found',

--- a/spree/api/app/controllers/spree/api/v3/store/customer/password_resets_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/customer/password_resets_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module V3
+      module Store
+        module Customer
+          class PasswordResetsController < Store::BaseController
+            rate_limit to: Spree::Api::Config[:rate_limit_password_reset],
+                       within: Spree::Api::Config[:rate_limit_window].seconds,
+                       store: Rails.cache,
+                       with: RATE_LIMIT_RESPONSE
+
+            skip_before_action :authenticate_user
+
+            # POST /api/v3/store/customer/password_resets
+            def create
+              redirect_url = params[:redirect_url]
+
+              # Validate redirect_url against allowed origins if store has any configured
+              if redirect_url.present? && current_store.allowed_origins.any?
+                unless current_store.allowed_origin?(redirect_url)
+                  return render_error(
+                    code: ERROR_CODES[:redirect_url_not_allowed],
+                    message: Spree.t(:redirect_url_not_allowed, scope: :api),
+                    status: :unprocessable_content
+                  )
+                end
+              end
+
+              user = Spree.user_class.find_by(email: params[:email])
+
+              if user
+                token = user.generate_token_for(:password_reset)
+                event_payload = { reset_token: token, email: user.email }
+                event_payload[:redirect_url] = redirect_url if redirect_url.present?
+                user.publish_event('customer.password_reset_requested', event_payload)
+              end
+
+              # Always return 202 to prevent email enumeration
+              render json: { message: Spree.t(:password_reset_requested, scope: :api) }, status: :accepted
+            end
+
+            # PATCH /api/v3/store/customer/password_resets/:id
+            def update
+              user = Spree.user_class.find_by_password_reset_token(params[:id])
+
+              unless user
+                return render_error(
+                  code: ERROR_CODES[:password_reset_token_invalid],
+                  message: Spree.t(:password_reset_token_invalid, scope: :api),
+                  status: :unprocessable_content
+                )
+              end
+
+              if user.update(password: params[:password], password_confirmation: params[:password_confirmation])
+                jwt = generate_jwt(user)
+                user.publish_event('customer.password_reset')
+
+                render json: {
+                  token: jwt,
+                  user: serializer_class.new(user, params: serializer_params).to_h
+                }
+              else
+                render_errors(user.errors)
+              end
+            end
+
+            protected
+
+            def serializer_class
+              Spree.api.customer_serializer
+            end
+
+            def serializer_params
+              {
+                store: current_store,
+                locale: current_locale,
+                currency: current_currency,
+                user: nil,
+                includes: []
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spree/api/app/controllers/spree/api/v3/store/customer/password_resets_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/customer/password_resets_controller.rb
@@ -17,14 +17,14 @@ module Spree
             def create
               redirect_url = params[:redirect_url]
 
-              # Validate redirect_url against allowed origins if store has any configured
-              if redirect_url.present? && current_store.allowed_origins.any?
-                unless current_store.allowed_origin?(redirect_url)
-                  return render_error(
-                    code: ERROR_CODES[:redirect_url_not_allowed],
-                    message: Spree.t(:redirect_url_not_allowed, scope: :api),
-                    status: :unprocessable_content
-                  )
+              # Validate redirect_url against allowed origins (secure by default).
+              # If no allowed origins are configured, redirect_url is silently ignored
+              # to prevent open redirect / token exfiltration attacks.
+              if redirect_url.present?
+                if current_store.allowed_origins.exists? && current_store.allowed_origin?(redirect_url)
+                  # redirect_url is valid — keep it
+                else
+                  redirect_url = nil
                 end
               end
 

--- a/spree/api/app/serializers/spree/api/v3/admin/allowed_origin_serializer.rb
+++ b/spree/api/app/serializers/spree/api/v3/admin/allowed_origin_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module V3
+      module Admin
+        class AllowedOriginSerializer < V3::BaseSerializer
+          typelize store_id: :string
+
+          attributes :id, :origin
+
+          attribute :store_id do |allowed_origin|
+            allowed_origin.store&.prefixed_id
+          end
+
+          attributes created_at: :iso8601, updated_at: :iso8601
+        end
+      end
+    end
+  end
+end

--- a/spree/api/config/locales/en.yml
+++ b/spree/api/config/locales/en.yml
@@ -7,6 +7,9 @@ en:
       invalid_resource: Invalid resource. Please fix errors and try again.
       invalid_taxonomy_id: Invalid taxonomy id.
       current_password_invalid: Current password is invalid or missing
+      password_reset_requested: If an account exists for that email, password reset instructions have been sent.
+      password_reset_token_invalid: Password reset token is invalid or has expired.
+      redirect_url_not_allowed: The redirect URL is not from an allowed origin for this store.
       must_specify_api_key: You must specify an API key.
       negative_quantity: quantity is negative
       order:

--- a/spree/api/config/routes.rb
+++ b/spree/api/config/routes.rb
@@ -59,6 +59,8 @@ Spree::Core::Engine.add_routes do
 
         # Customer nested resources
         namespace :customer, path: 'customer' do
+          resources :password_resets, only: [:create, :update]
+
           resources :orders, only: [:index, :show]
           resources :addresses, only: [:index, :show, :create, :update, :destroy] do
             member do

--- a/spree/api/lib/spree/api/configuration.rb
+++ b/spree/api/lib/spree/api/configuration.rb
@@ -19,6 +19,7 @@ module Spree
       preference :rate_limit_register, :integer, default: 3 # per IP
       preference :rate_limit_refresh, :integer, default: 10 # per IP
       preference :rate_limit_oauth, :integer, default: 5 # per IP
+      preference :rate_limit_password_reset, :integer, default: 3 # per IP
 
       # Request body size limit in bytes
       preference :max_request_body_size, :integer, default: 102_400 # 100KB

--- a/spree/api/spec/controllers/spree/api/v3/store/customer/password_resets_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/customer/password_resets_controller_spec.rb
@@ -62,16 +62,21 @@ RSpec.describe Spree::Api::V3::Store::Customer::PasswordResetsController, type: 
           post :create, params: { email: user.email, redirect_url: 'https://myshop.com/reset-password' }
         end
 
-        it 'returns 422 when redirect_url does not match allowed origin' do
+        it 'silently drops redirect_url when it does not match allowed origin' do
+          expect_any_instance_of(Spree.user_class).to receive(:publish_event)
+            .with('customer.password_reset_requested', hash_not_including(:redirect_url))
+
           post :create, params: { email: user.email, redirect_url: 'https://evil.com/phishing' }
 
-          expect(response).to have_http_status(:unprocessable_content)
-          expect(json_response['error']['code']).to eq('redirect_url_not_allowed')
+          expect(response).to have_http_status(:accepted)
         end
       end
 
       context 'when store has no allowed origins' do
-        it 'returns 202 without validating redirect_url' do
+        it 'silently drops redirect_url to prevent open redirect' do
+          expect_any_instance_of(Spree.user_class).to receive(:publish_event)
+            .with('customer.password_reset_requested', hash_not_including(:redirect_url))
+
           post :create, params: { email: user.email, redirect_url: 'https://anything.com/reset' }
 
           expect(response).to have_http_status(:accepted)

--- a/spree/api/spec/controllers/spree/api/v3/store/customer/password_resets_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/customer/password_resets_controller_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Store::Customer::PasswordResetsController, type: :controller do
+  render_views
+
+  include_context 'API v3 Store'
+
+  before do
+    request.headers['X-Spree-Api-Key'] = api_key.token
+  end
+
+  describe 'POST #create' do
+    context 'with a valid email' do
+      it 'returns 202 accepted' do
+        post :create, params: { email: user.email }
+
+        expect(response).to have_http_status(:accepted)
+        expect(json_response['message']).to be_present
+      end
+
+      it 'publishes customer.password_reset_requested event' do
+        expect_any_instance_of(Spree.user_class).to receive(:publish_event)
+          .with('customer.password_reset_requested', hash_including(:reset_token))
+
+        post :create, params: { email: user.email }
+      end
+    end
+
+    context 'with an unknown email' do
+      it 'returns 202 accepted (prevents email enumeration)' do
+        post :create, params: { email: 'nonexistent@example.com' }
+
+        expect(response).to have_http_status(:accepted)
+        expect(json_response['message']).to be_present
+      end
+    end
+
+    context 'with no email' do
+      it 'returns 202 accepted (prevents email enumeration)' do
+        post :create, params: {}
+
+        expect(response).to have_http_status(:accepted)
+      end
+    end
+
+    context 'with redirect_url' do
+      context 'when store has allowed origins' do
+        let!(:allowed_origin) { create(:allowed_origin, store: store, origin: 'https://myshop.com') }
+
+        it 'returns 202 when redirect_url matches allowed origin' do
+          post :create, params: { email: user.email, redirect_url: 'https://myshop.com/reset-password' }
+
+          expect(response).to have_http_status(:accepted)
+        end
+
+        it 'includes redirect_url in event payload' do
+          expect_any_instance_of(Spree.user_class).to receive(:publish_event)
+            .with('customer.password_reset_requested', hash_including(redirect_url: 'https://myshop.com/reset-password'))
+
+          post :create, params: { email: user.email, redirect_url: 'https://myshop.com/reset-password' }
+        end
+
+        it 'returns 422 when redirect_url does not match allowed origin' do
+          post :create, params: { email: user.email, redirect_url: 'https://evil.com/phishing' }
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(json_response['error']['code']).to eq('redirect_url_not_allowed')
+        end
+      end
+
+      context 'when store has no allowed origins' do
+        it 'returns 202 without validating redirect_url' do
+          post :create, params: { email: user.email, redirect_url: 'https://anything.com/reset' }
+
+          expect(response).to have_http_status(:accepted)
+        end
+      end
+
+      context 'without redirect_url' do
+        it 'does not include redirect_url in event payload' do
+          expect_any_instance_of(Spree.user_class).to receive(:publish_event)
+            .with('customer.password_reset_requested', hash_not_including(:redirect_url))
+
+          post :create, params: { email: user.email }
+        end
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:reset_token) { user.generate_token_for(:password_reset) }
+
+    context 'with a valid token and matching passwords' do
+      it 'resets the password and returns JWT' do
+        patch :update, params: {
+          id: reset_token,
+          password: 'newsecurepassword',
+          password_confirmation: 'newsecurepassword'
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['token']).to be_present
+        expect(json_response['user']).to be_present
+        expect(json_response['user']['email']).to eq(user.email)
+      end
+
+      it 'publishes customer.password_reset event' do
+        expect_any_instance_of(Spree.user_class).to receive(:publish_event)
+          .with('customer.password_reset')
+
+        patch :update, params: {
+          id: reset_token,
+          password: 'newsecurepassword',
+          password_confirmation: 'newsecurepassword'
+        }
+      end
+
+      it 'invalidates the token after use' do
+        patch :update, params: {
+          id: reset_token,
+          password: 'newsecurepassword',
+          password_confirmation: 'newsecurepassword'
+        }
+
+        expect(response).to have_http_status(:ok)
+
+        # Reusing the same token should fail because password salt changed
+        patch :update, params: {
+          id: reset_token,
+          password: 'anotherpassword',
+          password_confirmation: 'anotherpassword'
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['error']['code']).to eq('password_reset_token_invalid')
+      end
+    end
+
+    context 'with an invalid token' do
+      it 'returns error' do
+        patch :update, params: {
+          id: 'invalid-token',
+          password: 'newsecurepassword',
+          password_confirmation: 'newsecurepassword'
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['error']['code']).to eq('password_reset_token_invalid')
+      end
+    end
+
+    context 'with mismatched passwords' do
+      it 'returns validation error' do
+        patch :update, params: {
+          id: reset_token,
+          password: 'newsecurepassword',
+          password_confirmation: 'differentpassword'
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['error']['code']).to eq('validation_error')
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/store/customer/password_resets_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/customer/password_resets_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Password Resets API', type: :request, swagger_doc: 'api-reference/store.yaml' do
+  include_context 'API v3 Store'
+
+  let(:existing_user) { create(:user, email: 'customer@example.com', password: 'password123') }
+
+  path '/api/v3/store/customer/password_resets' do
+    post 'Request a password reset' do
+      tags 'Password Resets'
+      consumes 'application/json'
+      produces 'application/json'
+      security [api_key: []]
+      description 'Sends a password reset email if an account exists for the given email address. Always returns 202 Accepted to prevent email enumeration.'
+
+      sdk_example <<~JS
+        await client.customer.passwordResets.create({
+          email: 'customer@example.com',
+          redirect_url: 'https://myshop.com/reset-password',
+        })
+      JS
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string, format: 'email', example: 'customer@example.com', description: 'Email address of the account to reset' },
+          redirect_url: { type: :string, format: 'uri', example: 'https://myshop.com/reset-password', description: 'URL to redirect the user to after clicking the reset link. Validated against the store\'s allowed origins.' }
+        },
+        required: %w[email]
+      }
+
+      response '202', 'password reset requested' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:body) { { email: existing_user.email } }
+
+        schema type: :object,
+               properties: {
+                 message: { type: :string }
+               }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['message']).to be_present
+        end
+      end
+
+      response '202', 'email not found (same response to prevent enumeration)' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:body) { { email: 'nonexistent@example.com' } }
+
+        schema type: :object,
+               properties: {
+                 message: { type: :string }
+               }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['message']).to be_present
+        end
+      end
+
+      response '401', 'missing API key' do
+        let(:'x-spree-api-key') { 'invalid' }
+        let(:body) { { email: existing_user.email } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/store/customer/password_resets/{token}' do
+    patch 'Reset password with token' do
+      tags 'Password Resets'
+      consumes 'application/json'
+      produces 'application/json'
+      security [api_key: []]
+      description 'Resets the password using a token received via email. Returns a JWT token on success (auto-login).'
+
+      sdk_example <<~JS
+        const auth = await client.customer.passwordResets.update(
+          'reset-token-from-email',
+          {
+            password: 'newsecurepassword',
+            password_confirmation: 'newsecurepassword',
+          }
+        )
+      JS
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+      parameter name: :token, in: :path, type: :string, required: true,
+                description: 'Password reset token from the email'
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          password: { type: :string, minLength: 6, example: 'newsecurepassword' },
+          password_confirmation: { type: :string, example: 'newsecurepassword' }
+        },
+        required: %w[password password_confirmation]
+      }
+
+      response '200', 'password reset successful' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:token) { existing_user.generate_token_for(:password_reset) }
+        let(:body) { { password: 'newsecurepassword', password_confirmation: 'newsecurepassword' } }
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data['user']).to be_present
+          expect(data['user']['email']).to eq(existing_user.email)
+        end
+      end
+
+      response '422', 'invalid or expired token' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:token) { 'invalid-token' }
+        let(:body) { { password: 'newsecurepassword', password_confirmation: 'newsecurepassword' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['error']['code']).to eq('password_reset_token_invalid')
+        end
+      end
+
+      response '422', 'password confirmation mismatch' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:token) { existing_user.generate_token_for(:password_reset) }
+        let(:body) { { password: 'newsecurepassword', password_confirmation: 'differentpassword' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+
+      response '401', 'missing API key' do
+        let(:'x-spree-api-key') { 'invalid' }
+        let(:token) { 'some-token' }
+        let(:body) { { password: 'newsecurepassword', password_confirmation: 'newsecurepassword' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/core/app/helpers/spree/base_helper.rb
+++ b/spree/core/app/helpers/spree/base_helper.rb
@@ -114,10 +114,8 @@ module Spree
 
       base_url = if options[:relative]
                    ''
-                 elsif store.respond_to?(:formatted_custom_domain) && store.formatted_custom_domain.present?
-                   store.formatted_custom_domain
                  else
-                   store.formatted_url
+                   store.storefront_url
                  end
 
       localize = if options[:locale].present?

--- a/spree/core/app/mailers/spree/base_mailer.rb
+++ b/spree/core/app/mailers/spree/base_mailer.rb
@@ -37,7 +37,7 @@ module Spree
     # this is only a fail-safe solution if developer didn't set this in environment files
     # http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
     def ensure_default_action_mailer_url_host(store_url = nil)
-      host_url = store_url.presence || current_store.try(:url_or_custom_domain)
+      host_url = store_url.presence || current_store.try(:storefront_url)
 
       return if host_url.blank?
 

--- a/spree/core/app/models/concerns/spree/user_methods.rb
+++ b/spree/core/app/models/concerns/spree/user_methods.rb
@@ -18,6 +18,13 @@ module Spree
       # Enable lifecycle events for user models
       publishes_lifecycle_events
 
+      # Password reset token (Rails 7.1+ signed token, no DB column needed)
+      # Token auto-invalidates when password changes (salt changes)
+      # Expiration is configurable via Spree::Config.customer_password_reset_expires_in (in minutes)
+      generates_token_for :password_reset, expires_in: Spree::Config.customer_password_reset_expires_in.minutes do
+        password_salt&.last(10) || encrypted_password&.last(10)
+      end
+
       # we need to have this callback before any dependent: :destroy associations
       # https://github.com/rails/rails/issues/3458
       before_validation :clone_billing_address, if: :use_billing?
@@ -58,6 +65,14 @@ module Spree
       # Attributes
       #
       attr_accessor :confirm_email, :terms_of_service
+
+      def self.find_by_password_reset_token(token)
+        find_by_token_for(:password_reset, token)
+      end
+
+      def self.find_by_password_reset_token!(token)
+        find_by_token_for!(:password_reset, token)
+      end
 
       def self.multi_search(query)
         sanitized_query = sanitize_query_for_multi_search(query)

--- a/spree/core/app/models/spree/allowed_origin.rb
+++ b/spree/core/app/models/spree/allowed_origin.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Spree
+  class AllowedOrigin < Spree.base_class
+    has_prefix_id :ao
+
+    include Spree::SingleStoreResource
+
+    belongs_to :store, class_name: 'Spree::Store'
+
+    validates :store, :origin, presence: true
+    validates :origin, uniqueness: { scope: [:store_id, *spree_base_uniqueness_scope] }
+    validate :origin_must_be_valid_http_url
+
+    private
+
+    def origin_must_be_valid_http_url
+      return if origin.blank?
+
+      uri = URI.parse(origin)
+
+      unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+        errors.add(:origin, :invalid)
+        return
+      end
+
+      if uri.host.blank?
+        errors.add(:origin, :invalid)
+        return
+      end
+
+      # Origins must not have a path, query, or fragment
+      if uri.path.present? && uri.path != '/'
+        errors.add(:origin, :must_be_origin_only)
+      end
+
+      if uri.query.present? || uri.fragment.present?
+        errors.add(:origin, :must_be_origin_only)
+      end
+    rescue URI::InvalidURIError
+      errors.add(:origin, :invalid)
+    end
+  end
+end

--- a/spree/core/app/models/spree/legacy_user.rb
+++ b/spree/core/app/models/spree/legacy_user.rb
@@ -12,6 +12,7 @@ module Spree
     attr_accessor :password, :password_confirmation
 
     validates :email, presence: true, uniqueness: { case_sensitive: false }
+    validates :password, confirmation: true, if: :password
 
     before_save :encrypt_password, if: :password
 

--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -109,6 +109,7 @@ module Spree
     has_many :customer_groups, class_name: 'Spree::CustomerGroup', dependent: :destroy, inverse_of: :store
 
     has_many :api_keys, class_name: 'Spree::ApiKey', dependent: :destroy
+    has_many :allowed_origins, class_name: 'Spree::AllowedOrigin', dependent: :destroy
 
     #
     # Validations
@@ -250,6 +251,23 @@ module Spree
 
     def formatted_url_or_custom_domain
       formatted_url
+    end
+
+    # Returns true if the given URL's origin matches one of the store's allowed origins.
+    # Used to validate redirect_url parameters in password reset and similar flows.
+    #
+    # @param url [String] the full URL to check
+    # @return [Boolean]
+    def allowed_origin?(url)
+      return false if url.blank?
+
+      uri = URI.parse(url)
+      request_origin = "#{uri.scheme}://#{uri.host}"
+      request_origin += ":#{uri.port}" unless [80, 443].include?(uri.port)
+
+      allowed_origins.exists?(origin: request_origin)
+    rescue URI::InvalidURIError
+      false
     end
 
     # Returns the states available for checkout for the store

--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -253,6 +253,14 @@ module Spree
       formatted_url
     end
 
+    # Returns the storefront origin URL for use in customer-facing emails and links.
+    # Uses the first allowed origin if configured, otherwise falls back to formatted_url.
+    #
+    # @return [String] e.g. "https://myshop.com"
+    def storefront_url
+      allowed_origins.order(:created_at).pick(:origin) || formatted_url
+    end
+
     # Returns true if the given URL's origin matches one of the store's allowed origins.
     # Used to validate redirect_url parameters in password reset and similar flows.
     #

--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -262,7 +262,8 @@ module Spree
     end
 
     # Returns true if the given URL's origin matches one of the store's allowed origins.
-    # Used to validate redirect_url parameters in password reset and similar flows.
+    # Comparison is port-less: only scheme + host are matched, so storing
+    # `http://localhost` will match `http://localhost:3000`, `http://localhost:4000`, etc.
     #
     # @param url [String] the full URL to check
     # @return [Boolean]
@@ -271,9 +272,13 @@ module Spree
 
       uri = URI.parse(url)
       request_origin = "#{uri.scheme}://#{uri.host}"
-      request_origin += ":#{uri.port}" unless [80, 443].include?(uri.port)
 
-      allowed_origins.exists?(origin: request_origin)
+      allowed_origins.pluck(:origin).any? do |stored|
+        stored_uri = URI.parse(stored)
+        "#{stored_uri.scheme}://#{stored_uri.host}" == request_origin
+      rescue URI::InvalidURIError
+        false
+      end
     rescue URI::InvalidURIError
       false
     end

--- a/spree/core/app/services/spree/seeds/all.rb
+++ b/spree/core/app/services/spree/seeds/all.rb
@@ -28,6 +28,7 @@ module Spree
           # add store resources
           PaymentMethods.call
           ApiKeys.call
+          AllowedOrigins.call
         end
       end
     end

--- a/spree/core/app/services/spree/seeds/allowed_origins.rb
+++ b/spree/core/app/services/spree/seeds/allowed_origins.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Seeds
+    class AllowedOrigins
+      prepend Spree::ServiceModule::Base
+
+      def call
+        store = Spree::Store.default
+        return unless store&.persisted?
+
+        store.allowed_origins.find_or_create_by!(origin: 'http://localhost')
+      end
+    end
+  end
+end

--- a/spree/core/app/views/spree/shared/_mailer_logo.html.erb
+++ b/spree/core/app/views/spree/shared/_mailer_logo.html.erb
@@ -2,7 +2,7 @@
 <% height ||= 64 %>
 <% logo_css ||= '' %>
 
-<%= link_to current_store.url_or_custom_domain, id: 'site-logo', style: "text-decoration: none;" do %>
+<%= link_to current_store.storefront_url, id: 'site-logo', style: "text-decoration: none;" do %>
   <span style="display: none;"><%= current_store.name %></span>
   <% if logo.present? && logo.attached? && logo.variable? %>
     <% aspect_ratio = spree_asset_aspect_ratio(logo) %>

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -240,6 +240,10 @@ en:
       messages:
         blank: can't be blank
       models:
+        spree/allowed_origin:
+          attributes:
+            origin:
+              must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
@@ -294,10 +298,6 @@ en:
             country:
               already_in_market: is already assigned to another market in this store
               not_in_shipping_zone: is not covered by any shipping zone. Please set up a shipping zone first.
-        spree/allowed_origin:
-          attributes:
-            origin:
-              must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment
         spree/payment:
           attributes:
             amount:
@@ -746,6 +746,8 @@ en:
     all_products: All products
     all_rights_reserved: All rights reserved
     all_time: All time
+    allowed_origin: Allowed Origin
+    allowed_origins: Allowed Origins
     already_have_account: Already have an account?
     alt_text: Alternative Text
     alternative_phone: Alternative Phone
@@ -755,8 +757,6 @@ en:
     and_n_more:
       one: "...and %{count} more"
       other: "...and %{count} more"
-    allowed_origin: Allowed Origin
-    allowed_origins: Allowed Origins
     api_key: API Key
     api_keys: API Keys
     apis:
@@ -978,18 +978,18 @@ en:
     customer_could_not_be_removed_from_group: Customer could not be removed from group
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated
-    customer_mailer:
-      password_reset_email:
-        subject: Password Reset
-        greeting: "Hi %{name},"
-        instructions: We received a request to reset your password. Click the button below to choose a new password.
-        action: Reset Password
-        expiry_notice: This password reset link will expire shortly. If you did not request this, no action is needed.
-        ignore_notice: If you did not request a password reset, you can safely ignore this email. Your password will not be changed.
     customer_group: Customer Group
     customer_group_rule:
       choose_customer_groups: 'Select the customer group(s) to which this promotion should apply:'
     customer_groups: Customer Groups
+    customer_mailer:
+      password_reset_email:
+        action: Reset Password
+        expiry_notice: This password reset link will expire shortly. If you did not request this, no action is needed.
+        greeting: Hi %{name},
+        ignore_notice: If you did not request a password reset, you can safely ignore this email. Your password will not be changed.
+        instructions: We received a request to reset your password. Click the button below to choose a new password.
+        subject: Password Reset
     customer_removed_from_group: Customer removed from group
     customer_return: Customer Return
     customer_returns: Customer Returns
@@ -1118,8 +1118,8 @@ en:
         blank: can't be blank
         cannot_remove_icon: Cannot remove image
         could_not_create_taxon: Could not create taxon
-        no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.
         must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment
+        no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.
         store_association_can_not_be_changed: The store association can not be changed
         store_is_already_set: Store is already set
       services:

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -294,6 +294,10 @@ en:
             country:
               already_in_market: is already assigned to another market in this store
               not_in_shipping_zone: is not covered by any shipping zone. Please set up a shipping zone first.
+        spree/allowed_origin:
+          attributes:
+            origin:
+              must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment
         spree/payment:
           attributes:
             amount:
@@ -751,6 +755,8 @@ en:
     and_n_more:
       one: "...and %{count} more"
       other: "...and %{count} more"
+    allowed_origin: Allowed Origin
+    allowed_origins: Allowed Origins
     api_key: API Key
     api_keys: API Keys
     apis:
@@ -972,6 +978,14 @@ en:
     customer_could_not_be_removed_from_group: Customer could not be removed from group
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated
+    customer_mailer:
+      password_reset_email:
+        subject: Password Reset
+        greeting: "Hi %{name},"
+        instructions: We received a request to reset your password. Click the button below to choose a new password.
+        action: Reset Password
+        expiry_notice: This password reset link will expire shortly. If you did not request this, no action is needed.
+        ignore_notice: If you did not request a password reset, you can safely ignore this email. Your password will not be changed.
     customer_group: Customer Group
     customer_group_rule:
       choose_customer_groups: 'Select the customer group(s) to which this promotion should apply:'
@@ -1105,6 +1119,7 @@ en:
         cannot_remove_icon: Cannot remove image
         could_not_create_taxon: Could not create taxon
         no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.
+        must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment
         store_association_can_not_be_changed: The store association can not be changed
         store_is_already_set: Store is already set
       services:
@@ -1418,6 +1433,7 @@ en:
     new: New
     new_address: New address
     new_adjustment: New Adjustment
+    new_allowed_origin: New Allowed Origin
     new_api_key: New API Key
     new_balance: New balance
     new_billing_address: New Billing Address

--- a/spree/core/db/migrate/20260315000000_create_spree_allowed_origins.rb
+++ b/spree/core/db/migrate/20260315000000_create_spree_allowed_origins.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSpreeAllowedOrigins < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spree_allowed_origins do |t|
+      t.references :store, null: false
+      t.string :origin, null: false
+      t.timestamps
+    end
+
+    add_index :spree_allowed_origins, [:store_id, :origin], unique: true,
+              name: 'index_spree_allowed_origins_on_store_id_and_origin'
+  end
+end

--- a/spree/core/lib/spree/core/configuration.rb
+++ b/spree/core/lib/spree/core/configuration.rb
@@ -107,6 +107,9 @@ module Spree
       preference :coupon_codes_web_limit, :integer, default: 500 # number of coupon codes to be generated in the web process, more than this will be generated in a background job
       preference :coupon_codes_total_limit, :integer, default: 5000 # the maximum number of coupon codes to be generated
 
+      # password reset
+      preference :customer_password_reset_expires_in, :integer, default: 15 # password reset token expiration time in minutes
+
       # gift cards
       preference :gift_card_batch_web_limit, :integer, default: 500 # number of gift card codes to be generated in the web process, more than this will be generated in a background job
       preference :gift_card_batch_limit, :integer, default: 50_000

--- a/spree/core/lib/spree/permitted_attributes.rb
+++ b/spree/core/lib/spree/permitted_attributes.rb
@@ -2,6 +2,7 @@ module Spree
   module PermittedAttributes
     ATTRIBUTES = [
       :address_attributes,
+      :allowed_origin_attributes,
       :api_key_attributes,
       :asset_attributes,
       :checkout_attributes,
@@ -86,6 +87,8 @@ module Spree
       { country: [:iso, :name, :iso3, :iso_name],
         state: [:name, :abbr] }
     ]
+
+    @@allowed_origin_attributes = [:origin]
 
     @@api_key_attributes = [:name, :key_type]
 

--- a/spree/core/lib/spree/testing_support/factories/allowed_origin_factory.rb
+++ b/spree/core/lib/spree/testing_support/factories/allowed_origin_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :allowed_origin, class: Spree::AllowedOrigin do
+    store
+    sequence(:origin) { |n| "https://storefront#{n}.example.com" }
+  end
+end

--- a/spree/core/spec/models/spree/allowed_origin_spec.rb
+++ b/spree/core/spec/models/spree/allowed_origin_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::AllowedOrigin, type: :model do
+  let(:store) { create(:store) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:store).class_name('Spree::Store').without_validating_presence }
+  end
+
+  describe 'validations' do
+    subject { build(:allowed_origin, store: store) }
+
+    it { is_expected.to validate_presence_of(:store) }
+    it { is_expected.to validate_presence_of(:origin) }
+
+    it 'validates uniqueness of origin scoped to store' do
+      create(:allowed_origin, store: store, origin: 'https://example.com')
+      duplicate = build(:allowed_origin, store: store, origin: 'https://example.com')
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:origin]).to include('has already been taken')
+    end
+
+    it 'allows same origin for different stores' do
+      other_store = create(:store, code: 'other')
+      create(:allowed_origin, store: store, origin: 'https://example.com')
+      other = build(:allowed_origin, store: other_store, origin: 'https://example.com')
+      expect(other).to be_valid
+    end
+  end
+
+  describe 'origin format validation' do
+    it 'accepts valid HTTPS origin' do
+      origin = build(:allowed_origin, store: store, origin: 'https://myshop.com')
+      expect(origin).to be_valid
+    end
+
+    it 'accepts valid HTTP origin' do
+      origin = build(:allowed_origin, store: store, origin: 'http://localhost')
+      expect(origin).to be_valid
+    end
+
+    it 'accepts origin with port' do
+      origin = build(:allowed_origin, store: store, origin: 'http://localhost:3000')
+      expect(origin).to be_valid
+    end
+
+    it 'accepts origin with trailing slash' do
+      origin = build(:allowed_origin, store: store, origin: 'https://myshop.com/')
+      expect(origin).to be_valid
+    end
+
+    it 'rejects origin with path' do
+      origin = build(:allowed_origin, store: store, origin: 'https://myshop.com/reset-password')
+      expect(origin).not_to be_valid
+      expect(origin.errors[:origin]).to include('must be an origin (scheme and host) without path, query, or fragment')
+    end
+
+    it 'rejects origin with query string' do
+      origin = build(:allowed_origin, store: store, origin: 'https://myshop.com?foo=bar')
+      expect(origin).not_to be_valid
+      expect(origin.errors[:origin]).to include('must be an origin (scheme and host) without path, query, or fragment')
+    end
+
+    it 'rejects origin with fragment' do
+      origin = build(:allowed_origin, store: store, origin: 'https://myshop.com#section')
+      expect(origin).not_to be_valid
+      expect(origin.errors[:origin]).to include('must be an origin (scheme and host) without path, query, or fragment')
+    end
+
+    it 'rejects non-HTTP scheme' do
+      origin = build(:allowed_origin, store: store, origin: 'ftp://myshop.com')
+      expect(origin).not_to be_valid
+      expect(origin.errors[:origin]).to include('is invalid')
+    end
+
+    it 'rejects invalid URI' do
+      origin = build(:allowed_origin, store: store, origin: 'not a url at all')
+      expect(origin).not_to be_valid
+    end
+  end
+
+  describe 'SingleStoreResource' do
+    it 'prevents changing store after creation' do
+      origin = create(:allowed_origin, store: store)
+      other_store = create(:store, code: 'other2')
+      origin.store = other_store
+      expect(origin).not_to be_valid
+    end
+  end
+
+  describe 'prefix_id' do
+    it 'generates ao_ prefixed id' do
+      origin = create(:allowed_origin, store: store)
+      expect(origin.prefixed_id).to start_with('ao_')
+    end
+  end
+end

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -821,4 +821,30 @@ describe Spree::Store, type: :model, without_global_store: true do
       expect(store.url_or_custom_domain).to eq('mystore.mydomain.dev')
     end
   end
+
+  describe '#storefront_url' do
+    let(:store) { create(:store, url: 'backend.example.com') }
+
+    context 'when allowed origins exist' do
+      before do
+        create(:allowed_origin, store: store, origin: 'https://shop.example.com', created_at: 1.day.ago)
+      end
+
+      it 'returns the first allowed origin' do
+        expect(store.storefront_url).to eq('https://shop.example.com')
+      end
+
+      it 'returns the oldest allowed origin when multiple exist' do
+        create(:allowed_origin, store: store, origin: 'https://staging.example.com', created_at: Time.current)
+
+        expect(store.storefront_url).to eq('https://shop.example.com')
+      end
+    end
+
+    context 'when no allowed origins exist' do
+      it 'falls back to formatted_url' do
+        expect(store.storefront_url).to eq(store.formatted_url)
+      end
+    end
+  end
 end

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -822,6 +822,46 @@ describe Spree::Store, type: :model, without_global_store: true do
     end
   end
 
+  describe '#allowed_origin?' do
+    let(:store) { create(:store) }
+
+    before do
+      create(:allowed_origin, store: store, origin: 'https://myshop.com')
+      create(:allowed_origin, store: store, origin: 'http://localhost')
+    end
+
+    it 'matches exact origin' do
+      expect(store.allowed_origin?('https://myshop.com/reset-password')).to be true
+    end
+
+    it 'matches origin regardless of port (port-less matching)' do
+      expect(store.allowed_origin?('http://localhost:3000/reset-password')).to be true
+      expect(store.allowed_origin?('http://localhost:4000/anything')).to be true
+      expect(store.allowed_origin?('http://localhost:5173')).to be true
+    end
+
+    it 'matches production origin with non-standard port' do
+      expect(store.allowed_origin?('https://myshop.com:8080/checkout')).to be true
+    end
+
+    it 'does not match different scheme' do
+      expect(store.allowed_origin?('http://myshop.com/page')).to be false
+    end
+
+    it 'does not match different host' do
+      expect(store.allowed_origin?('https://evil.com/page')).to be false
+    end
+
+    it 'returns false for blank url' do
+      expect(store.allowed_origin?(nil)).to be false
+      expect(store.allowed_origin?('')).to be false
+    end
+
+    it 'returns false for invalid URI' do
+      expect(store.allowed_origin?('not a url')).to be false
+    end
+  end
+
   describe '#storefront_url' do
     let(:store) { create(:store, url: 'backend.example.com') }
 

--- a/spree/core/spec/services/spree/seeds/allowed_origins_spec.rb
+++ b/spree/core/spec/services/spree/seeds/allowed_origins_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Seeds::AllowedOrigins do
+  subject { described_class.call }
+
+  let(:store) { @default_store }
+
+  it 'creates a localhost allowed origin' do
+    expect { subject }.to change(Spree::AllowedOrigin, :count).by(1)
+
+    origin = store.allowed_origins.last
+    expect(origin.origin).to eq('http://localhost')
+  end
+
+  context 'when the allowed origin already exists' do
+    before do
+      create(:allowed_origin, store: store, origin: 'http://localhost')
+    end
+
+    it 'does not create a duplicate' do
+      expect { subject }.not_to change(Spree::AllowedOrigin, :count)
+    end
+  end
+
+  context 'when no default store exists' do
+    before do
+      Spree::Store.destroy_all
+    end
+
+    it 'does not raise an error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+end

--- a/spree/emails/app/mailers/spree/customer_mailer.rb
+++ b/spree/emails/app/mailers/spree/customer_mailer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Spree
+  class CustomerMailer < BaseMailer
+    def password_reset_email(user_id, store_id, reset_token, redirect_url = nil)
+      @user = Spree.user_class.find(user_id)
+      @current_store = Spree::Store.find(store_id)
+      @reset_token = reset_token
+      @reset_url = build_reset_url(redirect_url, reset_token)
+
+      subject = "#{@current_store.name} #{Spree.t('customer_mailer.password_reset_email.subject')}"
+      mail(
+        to: @user.email,
+        from: from_address,
+        subject: subject,
+        store_url: @current_store.url_or_custom_domain,
+        reply_to: reply_to_address
+      )
+    end
+
+    private
+
+    def build_reset_url(redirect_url, token)
+      return nil if redirect_url.blank?
+
+      uri = URI.parse(redirect_url)
+      params = URI.decode_www_form(uri.query || '')
+      params << ['token', token]
+      uri.query = URI.encode_www_form(params)
+      uri.to_s
+    end
+  end
+end

--- a/spree/emails/app/mailers/spree/customer_mailer.rb
+++ b/spree/emails/app/mailers/spree/customer_mailer.rb
@@ -13,7 +13,7 @@ module Spree
         to: @user.email,
         from: from_address,
         subject: subject,
-        store_url: @current_store.url_or_custom_domain,
+        store_url: @current_store.storefront_url,
         reply_to: reply_to_address
       )
     end

--- a/spree/emails/app/mailers/spree/newsletter_mailer.rb
+++ b/spree/emails/app/mailers/spree/newsletter_mailer.rb
@@ -2,7 +2,7 @@ module Spree
   class NewsletterMailer < BaseMailer
     def email_confirmation(subscriber)
       @subscriber = subscriber
-      @confirm_email_url = spree.verify_newsletter_subscribers_url(token: @subscriber.verification_token, host: Spree::Current.store.url_or_custom_domain)
+      @confirm_email_url = spree.verify_newsletter_subscribers_url(token: @subscriber.verification_token, host: Spree::Current.store.storefront_url)
       mail(to: @subscriber.email, from: from_address, subject: Spree.t('newsletter_mailer.email_confirmation.subject'))
     end
   end

--- a/spree/emails/app/mailers/spree/order_mailer.rb
+++ b/spree/emails/app/mailers/spree/order_mailer.rb
@@ -7,14 +7,14 @@ module Spree
       current_store = @order.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
     end
 
     def store_owner_notification_email(order)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       current_store = @order.store
       subject = Spree.t('order_mailer.store_owner_notification_email.subject', store_name: current_store.name)
-      mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
+      mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
     end
 
     def cancel_email(order, resend = false)
@@ -22,16 +22,16 @@ module Spree
       current_store = @order.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
     end
 
     def payment_link_email(order_id)
       @order = Spree::Order.incomplete.not_canceled.find(order_id)
       @current_store = @order.store
-      @checkout_payment_url = spree.checkout_state_url(@order.token, :payment, host: @current_store.url_or_custom_domain)
+      @checkout_payment_url = spree.checkout_state_url(@order.token, :payment, host: @current_store.storefront_url)
 
       mail(to: @order.email, from: from_address, subject: Spree.t('order_mailer.payment_link_email.subject', number: @order.number),
-           store_url: @current_store.url_or_custom_domain, reply_to: reply_to_address)
+           store_url: @current_store.storefront_url, reply_to: reply_to_address)
     end
   end
 end

--- a/spree/emails/app/mailers/spree/reimbursement_mailer.rb
+++ b/spree/emails/app/mailers/spree/reimbursement_mailer.rb
@@ -8,7 +8,7 @@ module Spree
       current_store = @reimbursement.store || Spree::Store.default
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
     end
   end
 end

--- a/spree/emails/app/mailers/spree/shipment_mailer.rb
+++ b/spree/emails/app/mailers/spree/shipment_mailer.rb
@@ -9,7 +9,7 @@ module Spree
       current_store = @shipment.store
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{current_store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@order.number}"
-      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.url_or_custom_domain, reply_to: reply_to_address)
+      mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
     end
   end
 end

--- a/spree/emails/app/subscribers/spree/customer_email_subscriber.rb
+++ b/spree/emails/app/subscribers/spree/customer_email_subscriber.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Spree
+  class CustomerEmailSubscriber < Spree::Subscriber
+    subscribes_to 'customer.password_reset_requested'
+
+    def handle(event)
+      email = event.payload['email']
+      return if email.blank?
+
+      user = Spree.user_class.find_by(email: email)
+      return unless user
+
+      store = find_store(event)
+      return unless store
+      return unless store.prefers_send_consumer_transactional_emails?
+
+      reset_token = event.payload['reset_token']
+      redirect_url = event.payload['redirect_url']
+
+      CustomerMailer.password_reset_email(
+        user.id,
+        store.id,
+        reset_token,
+        redirect_url
+      ).deliver_later
+    end
+
+    private
+
+    def find_store(event)
+      store_id = event.store_id
+      return Spree::Store.find(store_id) if store_id.present?
+
+      Spree::Current.store || Spree::Store.default
+    end
+  end
+end

--- a/spree/emails/app/views/spree/customer_mailer/password_reset_email.html.erb
+++ b/spree/emails/app/views/spree/customer_mailer/password_reset_email.html.erb
@@ -1,0 +1,26 @@
+<h1>
+  <%= Spree.t('customer_mailer.password_reset_email.greeting', name: @user.first_name.presence || @user.email) %>
+</h1>
+<p>
+  <%= Spree.t('customer_mailer.password_reset_email.instructions') %>
+</p>
+<% if @reset_url %>
+  <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+      <td align="center">
+        <a href="<%= @reset_url %>" class="button" target="_blank">
+          <%= Spree.t('customer_mailer.password_reset_email.action') %>
+        </a>
+      </td>
+    </tr>
+  </table>
+<% end %>
+<p>
+  <%= Spree.t('customer_mailer.password_reset_email.expiry_notice') %>
+</p>
+<p>
+  <%= Spree.t('customer_mailer.password_reset_email.ignore_notice') %>
+</p>
+<p>
+  <%= Spree.t('order_mailer.store_team', store_name: current_store.name) %>
+</p>

--- a/spree/emails/app/views/spree/customer_mailer/password_reset_email.text.erb
+++ b/spree/emails/app/views/spree/customer_mailer/password_reset_email.text.erb
@@ -1,0 +1,13 @@
+<%= Spree.t('customer_mailer.password_reset_email.greeting', name: @user.first_name.presence || @user.email) %>
+
+<%= Spree.t('customer_mailer.password_reset_email.instructions') %>
+
+<% if @reset_url %>
+<%= Spree.t('customer_mailer.password_reset_email.action') %>: <%= @reset_url %>
+<% end %>
+
+<%= Spree.t('customer_mailer.password_reset_email.expiry_notice') %>
+
+<%= Spree.t('customer_mailer.password_reset_email.ignore_notice') %>
+
+<%= Spree.t('order_mailer.store_team', store_name: current_store.name) %>

--- a/spree/emails/lib/spree/emails/engine.rb
+++ b/spree/emails/lib/spree/emails/engine.rb
@@ -15,7 +15,8 @@ module Spree
           Spree::OrderEmailSubscriber,
           Spree::ShipmentEmailSubscriber,
           Spree::ReimbursementEmailSubscriber,
-          Spree::NewsletterSubscriberEmailSubscriber
+          Spree::NewsletterSubscriberEmailSubscriber,
+          Spree::CustomerEmailSubscriber
         ]
       end
     end

--- a/spree/emails/spec/mailers/spree/customer_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/customer_mailer_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'email_spec'
+
+describe Spree::CustomerMailer, type: :mailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+
+  let!(:store) { @default_store }
+  let(:user) { create(:user, email: 'customer@example.com', first_name: 'Jane') }
+  let(:reset_token) { 'test-reset-token-123' }
+  let(:redirect_url) { 'https://mystore.com/reset-password' }
+
+  describe '#password_reset_email' do
+    context 'with redirect_url' do
+      let(:email) { described_class.password_reset_email(user.id, store.id, reset_token, redirect_url) }
+
+      it 'sends to the correct email address' do
+        expect(email.to).to eq(['customer@example.com'])
+      end
+
+      it 'has correct subject with store name' do
+        expect(email.subject).to eq("#{store.name} Password Reset")
+      end
+
+      it 'uses store from_address' do
+        expect(email.from).to eq([store.mail_from_address])
+      end
+
+      it 'uses store reply_to address' do
+        expect(email.reply_to).to eq([store.mail_from_address])
+      end
+
+      it 'includes reset URL with token' do
+        expect(email).to have_body_text('https://mystore.com/reset-password?token=test-reset-token-123')
+      end
+
+      it 'includes the Reset Password button text' do
+        expect(email).to have_body_text('Reset Password')
+      end
+
+      it 'includes greeting with user first name' do
+        expect(email).to have_body_text('Hi Jane,')
+      end
+
+      it 'includes store team sign-off' do
+        expect(email).to have_body_text("#{store.name} Team")
+      end
+    end
+
+    context 'with redirect_url that has existing query params' do
+      let(:redirect_url_with_params) { 'https://mystore.com/reset-password?locale=en' }
+      let(:email) { described_class.password_reset_email(user.id, store.id, reset_token, redirect_url_with_params) }
+
+      it 'appends token to existing query params' do
+        expect(email).to have_body_text('https://mystore.com/reset-password?locale=en&token=test-reset-token-123')
+      end
+    end
+
+    context 'without redirect_url' do
+      let(:email) { described_class.password_reset_email(user.id, store.id, reset_token, nil) }
+
+      it 'does not include a reset URL link' do
+        expect(email).not_to have_body_text('mystore.com/reset-password')
+      end
+
+      it 'does not render the reset button' do
+        expect(email).not_to have_body_text('Reset Password')
+      end
+
+      it 'still sends the email successfully' do
+        expect(email.to).to eq(['customer@example.com'])
+      end
+    end
+
+    context 'when user has no first name' do
+      let(:user_no_name) { create(:user, email: 'anon@example.com', first_name: nil) }
+      let(:email) { described_class.password_reset_email(user_no_name.id, store.id, reset_token, redirect_url) }
+
+      it 'uses email in greeting' do
+        expect(email).to have_body_text('Hi anon@example.com,')
+      end
+    end
+
+    context 'with preference :send_core_emails set to false' do
+      it 'sends no email' do
+        Spree::Config.set(:send_core_emails, false)
+        message = described_class.password_reset_email(user.id, store.id, reset_token, redirect_url)
+        expect(message.body).to be_blank
+      end
+    end
+  end
+end

--- a/spree/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -300,12 +300,12 @@ describe Spree::OrderMailer, type: :mailer do
     it 'shows proper host url in email content' do
       ActionMailer::Base.default_url_options = { host: 'localhost' }
       described_class.confirm_email(order).deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq(order.store.url)
+      expect(ActionMailer::Base.default_url_options[:host]).to eq(order.store.storefront_url)
     end
 
     it 'shows proper host url in email content #2' do
       described_class.confirm_email(second_order).deliver_now
-      expect(ActionMailer::Base.default_url_options[:host]).to eq(second_order.store.url)
+      expect(ActionMailer::Base.default_url_options[:host]).to eq(second_order.store.storefront_url)
     end
 
   end

--- a/spree/emails/spec/subscribers/spree/customer_email_subscriber_spec.rb
+++ b/spree/emails/spec/subscribers/spree/customer_email_subscriber_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::CustomerEmailSubscriber do
+  let(:store) { create(:store) }
+  let(:user) { create(:user, email: 'customer@example.com') }
+  let(:subscriber) { described_class.new }
+  let(:reset_token) { 'test-reset-token-123' }
+  let(:redirect_url) { 'https://mystore.com/reset-password' }
+
+  def mock_event(payload = {}, store_id: store.id)
+    double('Event',
+      payload: payload.deep_stringify_keys,
+      store_id: store_id
+    )
+  end
+
+  before do
+    store.update!(preferences: store.preferences.merge(send_consumer_transactional_emails: true))
+  end
+
+  describe 'customer.password_reset_requested event' do
+    let(:event) do
+      mock_event(
+        { email: user.email, reset_token: reset_token, redirect_url: redirect_url },
+        store_id: store.id
+      )
+    end
+
+    it 'sends password reset email' do
+      expect(Spree::CustomerMailer).to receive(:password_reset_email)
+        .with(user.id, store.id, reset_token, redirect_url)
+        .and_return(double(deliver_later: true))
+
+      subscriber.handle(event)
+    end
+
+    it 'passes nil redirect_url when not in payload' do
+      event_without_redirect = mock_event(
+        { email: user.email, reset_token: reset_token },
+        store_id: store.id
+      )
+
+      expect(Spree::CustomerMailer).to receive(:password_reset_email)
+        .with(user.id, store.id, reset_token, nil)
+        .and_return(double(deliver_later: true))
+
+      subscriber.handle(event_without_redirect)
+    end
+
+    context 'when store disables transactional emails' do
+      before do
+        store.update!(preferences: store.preferences.merge(send_consumer_transactional_emails: false))
+      end
+
+      it 'does not send email' do
+        expect(Spree::CustomerMailer).not_to receive(:password_reset_email)
+
+        subscriber.handle(event)
+      end
+    end
+
+    context 'when email is blank' do
+      let(:event) { mock_event({ email: '', reset_token: reset_token }, store_id: store.id) }
+
+      it 'does not send email' do
+        expect(Spree::CustomerMailer).not_to receive(:password_reset_email)
+
+        subscriber.handle(event)
+      end
+    end
+
+    context 'when email is nil' do
+      let(:event) { mock_event({ reset_token: reset_token }, store_id: store.id) }
+
+      it 'does not send email' do
+        expect(Spree::CustomerMailer).not_to receive(:password_reset_email)
+
+        subscriber.handle(event)
+      end
+    end
+
+    context 'when user is not found' do
+      let(:event) do
+        mock_event(
+          { email: 'nonexistent@example.com', reset_token: reset_token },
+          store_id: store.id
+        )
+      end
+
+      it 'does not send email' do
+        expect(Spree::CustomerMailer).not_to receive(:password_reset_email)
+
+        subscriber.handle(event)
+      end
+    end
+
+    context 'when store_id is nil' do
+      let(:event) do
+        mock_event(
+          { email: user.email, reset_token: reset_token, redirect_url: redirect_url },
+          store_id: nil
+        )
+      end
+
+      it 'falls back to current store' do
+        allow(Spree::Current).to receive(:store).and_return(store)
+
+        expect(Spree::CustomerMailer).to receive(:password_reset_email)
+          .with(user.id, store.id, reset_token, redirect_url)
+          .and_return(double(deliver_later: true))
+
+        subscriber.handle(event)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **`Spree::AllowedOrigin` model** — store-scoped model for registering allowed storefront origins (e.g. `https://myshop.com`). Validates origin format (scheme + host, no path/query/fragment). Uses `has_prefix_id :ao` and `SingleStoreResource`. Includes admin UI under Settings → Developers alongside API Keys and Webhooks.
- **Password reset `redirect_url` support** — POST `/api/v3/store/customer/password_resets` now accepts optional `redirect_url`. When provided and store has allowed origins configured, validates against them (422 if not allowed). Backward compatible: skips validation if no origins configured.
- **Password reset email via `spree_emails`** — `CustomerMailer#password_reset_email` with HTML + text templates, triggered by `customer.password_reset_requested` event via `CustomerEmailSubscriber`. Includes reset link button when `redirect_url` is provided, gracefully omits it when not.
- **Configurable token expiration** — `Spree::Config.customer_password_reset_expires_in` preference (default: 15 minutes) for password reset token lifetime.
- **SDK + Next.js updates** — `redirect_url` parameter in `requestPasswordReset()`, updated types and docs.

## Test plan

- [x] Core: `bundle exec rspec spec/models/spree/allowed_origin_spec.rb` — 16 examples, 0 failures
- [x] API controller: `bundle exec rspec spec/controllers/.../password_resets_controller_spec.rb` — 14 examples, 0 failures
- [x] API integration: `bundle exec rspec spec/integration/.../password_resets_spec.rb` — 7 examples, 0 failures
- [x] Emails mailer + subscriber: `bundle exec rspec spec/mailers/... spec/subscribers/...` — 21 examples, 0 failures
- [x] Admin controller: `bundle exec rspec spec/controllers/.../allowed_origins_controller_spec.rb` — 17 examples, 0 failures
- [x] SDK: `pnpm test` — 140 tests, 0 failures
- [x] OpenAPI: `bundle exec rake rswag:specs:swaggerize` — 149 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)