### PR TITLE
Fix admin taxonomies listing to link to taxon tree

### DIFF
--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -1865,7 +1865,7 @@ Rails.application.config.after_initialize do
   # ==========================================
   # Register Taxonomies table
   # ==========================================
-  Spree.admin.tables.register(:taxonomies, model_class: Spree::Taxonomy, search_param: :name_cont)
+  Spree.admin.tables.register(:taxonomies, model_class: Spree::Taxonomy, search_param: :name_cont, link_to_action: :show)
 
   Spree.admin.tables.taxonomies.add :name,
                                     label: :name,


### PR DESCRIPTION
## Changes

- Updated the taxonomies admin table configuration to link to the taxon tree view (`:show` action) instead of the edit form
- Modified `spree/admin/config/initializers/spree_admin_tables.rb` to add `link_to_action: :show` parameter to the taxonomies table registration

## Impact

Admins will now be directed to the taxon tree view when clicking on a taxonomy in the admin listing, providing a better interface for managing taxonomy structures.