### PR TITLE
Fix API v2 legacy links on intro page

### DIFF
--- a/docs/api-reference/v2/introduction.mdx
+++ b/docs/api-reference/v2/introduction.mdx
@@ -10,11 +10,11 @@ Spree Commerce open-source comes with a fully-featured Ecommerce API enabling a 
 Currently Spree includes 2 modern REST APIs:
 
 <CardGroup cols={2}>
-  <Card title="Storefront API" href="storefront">
+  <Card title="Storefront API" href="/api-reference/storefront/authentication">
     Designed to allow customers to interact with the store via external applications (e.g. Next.js storefront or a dedicated mobile app)
   </Card>
 
-  <Card title="Platform API" href="platform">
+  <Card title="Platform API" href="/api-reference/platform/authentication">
     Provides management capabilities, allowing third party apps to perform actions otherwise available via the admin panel.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Currently it's 404:

https://github.com/user-attachments/assets/828d9c04-1f1f-4072-a009-90a968ca0874

