### PR TITLE
Updated user docs menu items

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -639,40 +639,6 @@
             ]
           },
           {
-            "group": "Storefront",
-            "pages": [
-              {
-                "group": "Storefront Themes",
-                "pages": [
-                  "user/storefront/theme-editor",
-                  "user/storefront/create-new-theme",
-                  "user/storefront/delete-theme",
-                  "user/storefront/product-details-page",
-                  "user/storefront/product-listing-page"
-                ]
-              },
-              {
-                "group": "Storefront Pages",
-                "pages": [
-                  "user/storefront/create-page",
-                  "user/storefront/edit-page",
-                  "user/storefront/delete-page"
-                ]
-              },
-              "user/storefront/storefront-settings",
-              "user/storefront/create-new-store"
-            ]
-          },
-          {
-            "group": "Posts",
-            "pages": [
-              "user/storefront/create-post",
-              "user/storefront/edit-post",
-              "user/storefront/search-posts",
-              "user/storefront/delete-post"
-            ]
-          },
-          {
             "group": "Settings",
             "pages": [
               "user/settings/store-details",

--- a/docs/user/how-to/multi-currency-pricing.mdx
+++ b/docs/user/how-to/multi-currency-pricing.mdx
@@ -7,8 +7,7 @@ When you sell to customers in different countries, you'll want each customer to 
 
 In this guide, we'll walk through a common scenario — a US-based store adding a German market so customers in Germany can browse and buy in EUR.
 
-<Note>This guide covers multi-currency pricing — different currencies for different regions. If you need different prices within the same currency across regions (e.g., separate EUR prices for Germany, France, and Spain), see [<u>Set Up Multi-Region Pricing</u>](https://spreecommerce.org/docs/user/how-to/multi-region-pricing) instead.
-</Note>
+<Note>This guide covers multi-currency pricing — different currencies for different regions. If you need different prices within the same currency across regions (e.g., separate EUR prices for Germany, France, and Spain), see [<u>Set Up Multi-Region Pricing</u>](https://spreecommerce.org/docs/user/how-to/multi-region-pricing) instead.</Note>
 
 ## Prerequisites
 


### PR DESCRIPTION
Update includes:
- Fixed closing </Note> tag that was causing 404 on docs/user/how-to/multi-currency-pricing
- Removed Storefront and Posts menu sections