### PR TITLE
FIX preserve search, filters, and sort across admin table forms

### DIFF
--- a/spree/admin/app/helpers/spree/admin/table_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/table_helper.rb
@@ -394,8 +394,11 @@ module Spree
       end
 
       def sort_dropdown_item(label, sort_value, is_active, current_q)
+        url_params = { q: current_q.merge(s: sort_value) }
+        url_params[:query_state] = params[:query_state] if params[:query_state].present?
+
         link_to(
-          url_for(q: current_q.merge(s: sort_value)),
+          url_for(url_params),
           class: "dropdown-item flex items-center justify-between #{'active' if is_active}",
           data: { turbo_action: 'advance' }
         ) do

--- a/spree/admin/app/views/spree/admin/tables/_query_builder.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/_query_builder.html.erb
@@ -24,6 +24,23 @@
          class="grow flex flex-col justify-between">
 
       <%= form_with url: url_for, method: :get, html: { class: 'grow flex flex-col justify-between' }, data: { turbo_frame: frame_name, turbo_action: 'advance', query_builder_target: 'form', action: 'submit->query-builder#submitForm' } do |f| %>
+        <%# Preserve search and date range state when applying filters %>
+        <% search_param = table.respond_to?(:search_param) ? table.search_param : :name_cont %>
+        <% if params.dig(:q, search_param).present? %>
+          <%= hidden_field_tag "q[#{search_param}]", params.dig(:q, search_param) %>
+        <% end %>
+        <% date_range_param = table.date_range_param %>
+        <% if date_range_param.present? %>
+          <% if params.dig(:q, :"#{date_range_param}_gt").present? %>
+            <%= hidden_field_tag "q[#{date_range_param}_gt]", params.dig(:q, :"#{date_range_param}_gt") %>
+          <% end %>
+          <% if params.dig(:q, :"#{date_range_param}_lt").present? %>
+            <%= hidden_field_tag "q[#{date_range_param}_lt]", params.dig(:q, :"#{date_range_param}_lt") %>
+          <% end %>
+        <% end %>
+        <% if params.dig(:q, :s).present? %>
+          <%= hidden_field_tag "q[s]", params.dig(:q, :s) %>
+        <% end %>
         <div class="drawer-body">
           <div class="mb-4 flex items-center gap-2 flex-wrap">
             <span class="text-sm text-gray-600">

--- a/spree/admin/app/views/spree/admin/tables/_table.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/_table.html.erb
@@ -27,6 +27,23 @@
                 <%= icon 'x', class: 'w-4 h-4' %>
               </button>
             </div>
+            <%# Preserve query builder filter state when submitting search %>
+            <% if params[:query_state].present? %>
+              <%= hidden_field_tag :query_state, params[:query_state] %>
+            <% end %>
+            <%# Preserve date range filter state when submitting search %>
+            <% if date_range_param.present? %>
+              <% if params.dig(:q, :"#{date_range_param}_gt").present? %>
+                <%= hidden_field_tag "q[#{date_range_param}_gt]", params.dig(:q, :"#{date_range_param}_gt") %>
+              <% end %>
+              <% if params.dig(:q, :"#{date_range_param}_lt").present? %>
+                <%= hidden_field_tag "q[#{date_range_param}_lt]", params.dig(:q, :"#{date_range_param}_lt") %>
+              <% end %>
+            <% end %>
+            <%# Preserve sort order when submitting search %>
+            <% if params.dig(:q, :s).present? %>
+              <%= hidden_field_tag "q[s]", params.dig(:q, :s) %>
+            <% end %>
           <% end %>
         </div>
 
@@ -39,6 +56,16 @@
                          date_from_value: params.dig(:q, :"#{date_range_param}_gt"),
                          date_to_value: params.dig(:q, :"#{date_range_param}_lt"),
                          css_classes: "btn-light btn-sm dropdown-toggle h-[2.125rem]" %>
+              <%# Preserve search and filter state when submitting date range %>
+              <% if params.dig(:q, search_param).present? %>
+                <%= hidden_field_tag "q[#{search_param}]", params.dig(:q, search_param) %>
+              <% end %>
+              <% if params[:query_state].present? %>
+                <%= hidden_field_tag :query_state, params[:query_state] %>
+              <% end %>
+              <% if params.dig(:q, :s).present? %>
+                <%= hidden_field_tag "q[s]", params.dig(:q, :s) %>
+              <% end %>
             <% end %>
           <% end %>
           <%= render 'spree/admin/tables/query_builder', table: table, table_key: table_key, frame_name: frame_name %>

--- a/spree/admin/spec/features/spree/admin/products/products_spec.rb
+++ b/spree/admin/spec/features/spree/admin/products/products_spec.rb
@@ -27,6 +27,47 @@ describe 'Products', type: :feature do
     end
 
     context 'listing products' do
+      # Regression test for #13789
+      context 'search preserves filters', js: true do
+        let!(:active_cap) { create(:product, name: 'apache baseball cap', status: 'active') }
+        let!(:active_shirt) { create(:product, name: 'zomg shirt', status: 'active') }
+        let!(:draft_product) { create(:product, name: 'apache draft hat', status: 'draft') }
+
+        it 'preserves query_state filters when searching' do
+          query_state = { combinator: 'and', filters: [{ id: '1', field: 'status', operator: 'eq', value: 'active' }], groups: [] }.to_json
+          visit spree.admin_products_path(query_state: query_state)
+
+          # Only active products should be visible
+          expect(page).to have_content('apache baseball cap')
+          expect(page).to have_content('zomg shirt')
+          expect(page).not_to have_content('apache draft hat')
+
+          # Type in search box — filters should be preserved
+          fill_in 'products-table-search-input', with: 'apache'
+          wait_for_turbo
+
+          # Should show only active products matching search
+          expect(page).to have_content('apache baseball cap')
+          expect(page).not_to have_content('zomg shirt')
+          expect(page).not_to have_content('apache draft hat')
+
+          # Verify query_state is still present in the page
+          expect(page).to have_css('input[name="query_state"]', visible: :all)
+        end
+
+        it 'preserves search text when applying filters' do
+          visit spree.admin_products_path(q: { search: 'apache' })
+
+          # Only products matching search should be visible
+          expect(page).to have_content('apache baseball cap')
+          expect(page).to have_content('apache draft hat')
+          expect(page).not_to have_content('zomg shirt')
+
+          # Verify search text is still in the hidden field within the query builder form
+          expect(page).to have_css('input[name="q[search]"][value="apache"]', visible: :all)
+        end
+      end
+
       context 'sorting' do
         before do
           create(:product, name: 'apache baseball cap', price: 10)


### PR DESCRIPTION
## Summary

Fixes #13789

- Admin table has separate `<form>` elements for search input, date range picker, and query builder filters. When any form submits, it only sends its own inputs — dropping state from the other forms (e.g. typing in search removes active filters, applying filters removes search text).
- Add hidden fields to each form to carry over params from the other forms (query_state, search text, date range, sort order), so all table state is preserved regardless of which control the user interacts with.
- Also fix sort dropdown links to include `query_state` param so sorting doesn't drop filters.

## Test plan

- [ ] Go to admin products index, set status filter to "active", then type in search — verify filter badge persists and results are filtered by both
- [ ] Apply filters, then change sort order — verify filters are preserved
- [ ] Set search text, then apply date range (on orders page) — verify search text persists
- [ ] Clear search text while filters are active — verify filters remain
- [ ] Test pagination with active filters + search — verify all state persists across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)