### PR TITLE
FIX admin mobile sidebar menu not opening (Tailwind v4 conflict)

### DIFF
--- a/spree/admin/app/assets/tailwind/spree/admin/components/_layout.css
+++ b/spree/admin/app/assets/tailwind/spree/admin/components/_layout.css
@@ -427,9 +427,8 @@
   }
 
   .sidebar-mobile .sidebar-panel {
-    @apply absolute left-0 top-0 bottom-0 bg-gray-25 overflow-y-auto flex flex-col shadow-lg transition-transform duration-500;
+    @apply absolute left-0 top-0 bottom-0 bg-gray-25 overflow-y-auto flex flex-col shadow-lg transition-transform duration-500 -translate-x-full;
     width: var(--spacing-sidebar-width);
-    transform: translateX(-100%);
   }
 
   .sidebar-mobile .sidebar-mobile-header {


### PR DESCRIPTION
## Summary

Fixes #13501

- Replace raw `transform: translateX(-100%)` with Tailwind's `@apply -translate-x-full` on the mobile sidebar panel
- In Tailwind v4, `translate-x-0` (used for the open state) sets the CSS `translate` property — **not** `transform`. Since these are different CSS properties, the open state's `translate-x-0` never overrode the hidden state's `transform: translateX(-100%)`, leaving the panel permanently off-screen while only the backdrop showed.

## Test plan

- [ ] Open admin panel in a mobile viewport (< 1024px)
- [ ] Click the hamburger menu button
- [ ] Verify the sidebar slides in from the left
- [ ] Click the backdrop to close — verify it slides back out
- [ ] Verify desktop sidebar toggle still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)