### PR TITLE
Add missing helper Spree::MailHelper to InvitationMailer

### DIFF
--- a/spree/core/app/mailers/spree/invitation_mailer.rb
+++ b/spree/core/app/mailers/spree/invitation_mailer.rb
@@ -1,5 +1,7 @@
 module Spree
   class InvitationMailer < BaseMailer
+    helper Spree::ImagesHelper
+
     # invitation email, sending email to the invited to let them know they have been invited to join a store/account/vendor
     def invitation_email(invitation)
       @invitation = invitation

--- a/spree/core/app/mailers/spree/invitation_mailer.rb
+++ b/spree/core/app/mailers/spree/invitation_mailer.rb
@@ -1,6 +1,6 @@
 module Spree
   class InvitationMailer < BaseMailer
-    helper Spree::ImagesHelper
+    helper Spree::MailHelper
 
     # invitation email, sending email to the invited to let them know they have been invited to join a store/account/vendor
     def invitation_email(invitation)

--- a/spree/core/app/mailers/spree/invitation_mailer.rb
+++ b/spree/core/app/mailers/spree/invitation_mailer.rb
@@ -1,6 +1,6 @@
 module Spree
   class InvitationMailer < BaseMailer
-    helper Spree::MailHelper
+    helper Spree::ImagesHelper
 
     # invitation email, sending email to the invited to let them know they have been invited to join a store/account/vendor
     def invitation_email(invitation)


### PR DESCRIPTION
We need this helper for invitation emails to i.e properly display store logo in email.