### PR TITLE
Deprecate `DefaultPrice` concern

### DIFF
--- a/spree/core/app/models/concerns/spree/default_price.rb
+++ b/spree/core/app/models/concerns/spree/default_price.rb
@@ -2,24 +2,112 @@ module Spree
   module DefaultPrice
     extend ActiveSupport::Concern
 
+    DEPRECATION_MSG = 'Spree::DefaultPrice is deprecated and will be removed in Spree 6.0. ' \
+      'Use variant.set_price(currency, amount) and variant.price_in(currency) instead.'
+
     included do
       has_one :default_price,
               -> { with_deleted.where(currency: Spree::Store.default.default_currency) },
               class_name: 'Spree::Price',
               dependent: :destroy
 
-      delegate :display_price, :display_amount, :price, :currency, :price=,
-               :price_including_vat_for, :currency=, :display_compare_at_price,
-               :compare_at_price, :compare_at_price=, to: :find_or_build_default_price
+      after_save :save_default_price, if: -> { Spree::Config.enable_legacy_default_price }
 
-      after_save :save_default_price
+      def price
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.price
+        else
+          price_in(Spree::Store.default.default_currency).amount
+        end
+      end
+
+      def price=(value)
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.price = value
+        else
+          set_price(Spree::Store.default.default_currency, value)
+        end
+      end
+
+      def currency
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.currency
+        else
+          Spree::Store.default.default_currency
+        end
+      end
+
+      def currency=(value)
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        find_or_build_default_price.currency = value
+      end
+
+      def display_price
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.display_price
+        else
+          price_in(Spree::Store.default.default_currency).display_amount
+        end
+      end
+
+      def display_amount
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.display_amount
+        else
+          price_in(Spree::Store.default.default_currency).display_amount
+        end
+      end
+
+      def compare_at_price
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.compare_at_price
+        else
+          price_in(Spree::Store.default.default_currency).compare_at_amount
+        end
+      end
+
+      def compare_at_price=(value)
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        find_or_build_default_price.compare_at_price = value
+      end
+
+      def display_compare_at_price
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          find_or_build_default_price.display_compare_at_price
+        else
+          price_in(Spree::Store.default.default_currency).display_compare_at_amount
+        end
+      end
+
+      def price_including_vat_for(price_options)
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        find_or_build_default_price.price_including_vat_for(price_options)
+      end
 
       def has_default_price?
-        !default_price.nil?
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          !default_price.nil?
+        else
+          prices.base_prices.any? { |p| p.currency == Spree::Store.default.default_currency }
+        end
       end
 
       def find_or_build_default_price
-        default_price || build_default_price
+        Spree::Deprecation.warn(Spree::DefaultPrice::DEPRECATION_MSG)
+        if Spree::Config.enable_legacy_default_price
+          default_price || build_default_price
+        else
+          prices.base_prices.find { |p| p.currency == Spree::Store.default.default_currency } ||
+            prices.build(currency: Spree::Store.default.default_currency)
+        end
       end
 
       private

--- a/spree/core/app/models/spree/product.rb
+++ b/spree/core/app/models/spree/product.rb
@@ -673,11 +673,12 @@ module Spree
       values = option_values_hash.values
       values = values.inject(values.shift) { |memo, value| memo.product(value).map(&:flatten) }
 
+      default_currency = stores.first&.default_currency || Spree::Store.default.default_currency
+      master_price = master.price_in(default_currency).amount
+
       values.each do |ids|
-        variants.create(
-          option_value_ids: ids,
-          price: master.price
-        )
+        variant = variants.create!(option_value_ids: ids)
+        variant.set_price(default_currency, master_price) if master_price.present?
       end
       save
     end
@@ -711,6 +712,7 @@ module Spree
         master.new_record? ||
         master.changed? ||
         (
+          Spree::Config.enable_legacy_default_price &&
           master.default_price &&
           (
             master.default_price.new_record? ||
@@ -733,9 +735,13 @@ module Spree
     # If the master cannot be saved, the Product object will get its errors
     # and will be destroyed
     def validate_master
-      # We call master.default_price here to ensure price is initialized.
-      # Required to avoid Variant#check_price validation failing on create.
-      unless master.default_price && master.valid?
+      if Spree::Config.enable_legacy_default_price
+        # We call master.default_price here to ensure price is initialized.
+        # Required to avoid Variant#check_price validation failing on create.
+        master.default_price
+      end
+
+      unless master.valid?
         master.errors.map { |error| { field: error.attribute, message: error&.message } }.each do |err|
           next if err[:field].blank? || err[:message].blank?
 

--- a/spree/core/app/models/spree/variant.rb
+++ b/spree/core/app/models/spree/variant.rb
@@ -62,14 +62,13 @@ module Spree
 
     before_validation :set_cost_currency
 
-    validate :check_price
+    validate :check_price, if: -> { Spree::Config.enable_legacy_default_price }
 
     validates :option_value_variants, presence: true, unless: :is_master?
 
-    with_options numericality: { greater_than_or_equal_to: 0, allow_nil: true } do
-      validates :cost_price
-      validates :price
-    end
+    validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+    validates :price, numericality: { greater_than_or_equal_to: 0, allow_nil: true },
+                      if: -> { Spree::Config.enable_legacy_default_price }
     validates :sku, uniqueness: { conditions: -> { where(deleted_at: nil) }, case_sensitive: false, scope: spree_base_uniqueness_scope },
                     allow_blank: true, unless: :disable_sku_validation?
 
@@ -448,7 +447,7 @@ module Spree
       price = prices.base_prices.find_or_initialize_by(currency: currency)
       price.amount = amount
       price.compare_at_amount = compare_at_amount if compare_at_amount.present?
-      price.save!
+      price.save! if persisted?
     end
 
     # Returns the price for the given context or options.
@@ -607,18 +606,21 @@ module Spree
 
     # Ensures a new variant takes the product master price when price is not supplied
     def check_price
-      return if (has_default_price? && default_price.valid?) || prices.any?
+      return if prices.any?
 
       infer_price_from_default_variant_if_needed
-      self.currency = Spree::Store.default.default_currency if price.present? && currency.nil?
     end
 
     def infer_price_from_default_variant_if_needed
-      if price.nil?
+      default_currency = Spree::Store.default.default_currency
+      current_price = price_in(default_currency).amount
+
+      if current_price.nil?
         return errors.add(:base, :no_master_variant_found_to_infer_price) unless product&.master
 
         # At this point, master can have or have no price, so let's use price from the default variant
-        self.price = product.default_variant.price
+        inferred_price = product.default_variant.price_in(default_currency).amount
+        set_price(default_currency, inferred_price) if inferred_price.present?
       end
     end
 

--- a/spree/core/lib/spree/core/configuration.rb
+++ b/spree/core/lib/spree/core/configuration.rb
@@ -40,6 +40,7 @@ module Spree
       preference :currency, :string, default: 'USD', deprecated: true
       preference :credit_to_new_allocation, :boolean, default: false
       preference :disable_migration_check, :boolean, default: false # when turned on disables the startup warning about missing engine migrations
+      preference :enable_legacy_default_price, :boolean, default: false # when enabled, keeps the legacy DefaultPrice concern active (has_one :default_price, variant.price= delegation, check_price validation). Disable (default) to use set_price exclusively.
       preference :disable_sku_validation, :boolean, default: false # when turned off disables the built-in SKU uniqueness validation
       preference :disable_store_presence_validation, :boolean, default: false # when turned off disables Store presence validation for Products and Payment Methods
       preference :events_log_enabled, :boolean, default: true # Log all Spree events to Rails logger

--- a/spree/core/lib/spree/core/controller_helpers/order.rb
+++ b/spree/core/lib/spree/core/controller_helpers/order.rb
@@ -168,18 +168,20 @@ module Spree
         end
 
         def order_includes
+          variant_includes = [
+            :images,
+            :prices,
+            :stock_items,
+            :stock_locations,
+            { option_values: :option_type },
+            { stock_items: :stock_location },
+            { product: :master }
+          ]
+          variant_includes << :default_price if Spree::Config.enable_legacy_default_price
+
           {
             line_items: {
-              variant: [
-                :images,
-                :prices,
-                :default_price,
-                :stock_items,
-                :stock_locations,
-                { option_values: :option_type },
-                { stock_items: :stock_location },
-                { product: :master }
-              ]
+              variant: variant_includes
             }
           }
         end

--- a/spree/core/lib/spree/core/pricing/resolver.rb
+++ b/spree/core/lib/spree/core/pricing/resolver.rb
@@ -106,11 +106,13 @@ module Spree
         context.variant.prices
       end
 
-      # Builds an empty price for the variant
+      # Returns an empty price placeholder for the variant.
+      # Uses Price.new instead of prices.build to avoid polluting the association
+      # with an unsaved record that would fail validation on variant save.
       # @return [Spree::Price]
       def build_empty_price
-        context.variant.prices.build(
-          variant: context.variant,
+        Spree::Price.new(
+          variant_id: context.variant.id,
           currency: context.currency,
           amount: nil,
           price_list_id: nil

--- a/spree/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/spree/core/lib/spree/testing_support/factories/product_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :base_product, class: Spree::Product do
     sequence(:name)   { |n| "Product #{n}#{Kernel.rand(9999)}" }
     description       { generate(:random_description) }
-    price             { 19.99 }
     cost_price        { 17.00 }
     sku               { generate(:sku) }
     available_on      { 1.year.ago }
@@ -12,16 +11,26 @@ FactoryBot.define do
     status            { 'active' }
     stores            { [Spree::Store.default] }
 
+    transient do
+      price { 19.99 }
+      currency { nil }
+    end
+
     # ensure stock item will be created for this products master
     # also attach this product to the default store if no stores are passed in
     before(:create) do |_product|
       create(:stock_location) unless Spree::StockLocation.any?
       create(:store, default: true) unless Spree::Store.any?
     end
-    after(:create) do |product|
+    after(:create) do |product, evaluator|
       existing_location_ids = product.master.stock_items.pluck(:stock_location_id)
       Spree::StockLocation.where.not(id: existing_location_ids).find_each do |stock_location|
         stock_location.propagate_variant(product.master)
+      end
+
+      if evaluator.price.present?
+        price_currency = evaluator.currency || product.stores.first&.default_currency || 'USD'
+        product.master.set_price(price_currency, evaluator.price)
       end
     end
 

--- a/spree/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/spree/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }
 
   factory :base_variant, class: Spree::Variant do
-    price           { 19.99 }
     cost_price      { 17.00 }
     sku             { generate(:sku) }
     weight          { generate(:random_float) }
@@ -16,6 +15,8 @@ FactoryBot.define do
     option_values { [build(:option_value)] }
 
     transient do
+      price { 19.99 }
+      currency { nil }
       create_stock { true }
     end
 
@@ -31,6 +32,11 @@ FactoryBot.define do
           stock_location.propagate_variant(variant)
         end
       end
+
+      if evaluator.price.present?
+        price_currency = evaluator.currency || variant.product&.stores&.first&.default_currency || 'USD'
+        variant.set_price(price_currency, evaluator.price)
+      end
     end
 
     factory :variant do
@@ -44,7 +50,6 @@ FactoryBot.define do
       trait :with_no_price do
         price { nil }
         cost_price { nil }
-        currency { nil }
       end
     end
 

--- a/spree/core/spec/models/concerns/spree/default_price_spec.rb
+++ b/spree/core/spec/models/concerns/spree/default_price_spec.rb
@@ -1,0 +1,170 @@
+require 'spec_helper'
+
+RSpec.describe Spree::DefaultPrice do
+  let(:store) { Spree::Store.default }
+  let(:product) { create(:product, stores: [store]) }
+  let(:variant) { product.master }
+
+  describe 'with enable_legacy_default_price disabled (default)' do
+    before do
+      allow(Spree::Config).to receive(:enable_legacy_default_price).and_return(false)
+    end
+
+    describe '#price' do
+      it 'returns amount from price_in for the default currency' do
+        variant.set_price('USD', 29.99)
+        expect(variant.price).to eq(29.99)
+      end
+
+      it 'returns nil when no price exists for the default currency' do
+        variant.prices.destroy_all
+        expect(variant.price).to be_nil
+      end
+    end
+
+    describe '#price=' do
+      it 'sets price via set_price' do
+        variant.price = 19.99
+        expect(variant.price_in('USD').amount).to eq(19.99)
+      end
+    end
+
+    describe '#currency' do
+      it 'returns the default store currency' do
+        expect(variant.currency).to eq(store.default_currency)
+      end
+    end
+
+    describe '#display_price' do
+      it 'returns display amount for the default currency' do
+        variant.set_price('USD', 10.55)
+        expect(variant.display_price.to_s).to eq('$10.55')
+      end
+    end
+
+    describe '#has_default_price?' do
+      it 'returns true when a base price exists in the default currency' do
+        variant.set_price('USD', 10)
+        expect(variant.has_default_price?).to be true
+      end
+
+      it 'returns false when no base price exists in the default currency' do
+        variant.prices.destroy_all
+        expect(variant.has_default_price?).to be false
+      end
+    end
+
+    describe '#set_price' do
+      it 'persists the price when variant is persisted' do
+        variant.set_price('USD', 42.00)
+        expect(variant.price_in('USD').amount).to eq(42.00)
+        expect(variant.price_in('USD')).to be_persisted
+      end
+
+      it 'builds price in-memory when variant is not persisted' do
+        new_variant = Spree::Variant.new(product: product)
+        new_variant.set_price('USD', 15.00)
+        price = new_variant.prices.detect { |p| p.currency == 'USD' }
+        expect(price.amount).to eq(15.00)
+        expect(price).not_to be_persisted
+      end
+
+      it 'supports multiple currencies' do
+        variant.set_price('USD', 29.99)
+        variant.set_price('EUR', 27.99)
+        expect(variant.price_in('USD').amount).to eq(29.99)
+        expect(variant.price_in('EUR').amount).to eq(27.99)
+      end
+    end
+
+    describe 'variant save without price' do
+      it 'allows saving a variant without any price' do
+        new_product = create(:product, stores: [store])
+        master = new_product.master
+        master.prices.destroy_all
+        expect { master.save! }.not_to raise_error
+      end
+    end
+
+    describe 'save_default_price callback' do
+      it 'does not run' do
+        variant.set_price('USD', 50.00)
+        expect(variant).not_to receive(:save_default_price)
+        variant.save!
+      end
+    end
+  end
+
+  describe 'with enable_legacy_default_price enabled' do
+    before do
+      allow(Spree::Config).to receive(:enable_legacy_default_price).and_return(true)
+    end
+
+    describe '#price' do
+      it 'returns price from the default price record' do
+        expect(variant.price).to eq(variant.default_price.amount)
+      end
+    end
+
+    describe '#price=' do
+      it 'sets price on the default price record' do
+        variant.price = 25.00
+        expect(variant.default_price.amount).to eq(25.00)
+      end
+    end
+
+    describe '#has_default_price?' do
+      it 'returns true when default_price exists' do
+        expect(variant.has_default_price?).to be true
+      end
+    end
+
+    describe 'save_default_price callback' do
+      it 'saves the default price when it has changed' do
+        variant.reload
+        variant.default_price.price = 99.99
+        expect(variant.default_price).to receive(:save)
+        variant.save!
+      end
+    end
+
+    describe 'check_price validation' do
+      it 'runs the check_price validation' do
+        new_variant = build(:variant, product: product)
+        expect(new_variant).to be_valid
+      end
+    end
+  end
+
+  describe 'deprecation warnings' do
+    it 'warns on #price' do
+      expect(Spree::Deprecation).to receive(:warn).with(Spree::DefaultPrice::DEPRECATION_MSG).at_least(:once)
+      variant.price
+    end
+
+    it 'warns on #price=' do
+      expect(Spree::Deprecation).to receive(:warn).with(Spree::DefaultPrice::DEPRECATION_MSG).at_least(:once)
+      variant.price = 10
+    end
+
+    it 'warns on #display_price' do
+      expect(Spree::Deprecation).to receive(:warn).with(Spree::DefaultPrice::DEPRECATION_MSG).at_least(:once)
+      variant.display_price
+    end
+
+    it 'warns on #currency' do
+      expect(Spree::Deprecation).to receive(:warn).with(Spree::DefaultPrice::DEPRECATION_MSG).at_least(:once)
+      variant.currency
+    end
+
+    it 'warns on #has_default_price?' do
+      expect(Spree::Deprecation).to receive(:warn).with(Spree::DefaultPrice::DEPRECATION_MSG).at_least(:once)
+      variant.has_default_price?
+    end
+
+    it 'warns on #find_or_build_default_price' do
+      expect(Spree::Deprecation).to receive(:warn).with(Spree::DefaultPrice::DEPRECATION_MSG).at_least(:once)
+      variant.find_or_build_default_price
+    end
+  end
+end

--- a/spree/core/spec/models/spree/product_spec.rb
+++ b/spree/core/spec/models/spree/product_spec.rb
@@ -164,12 +164,13 @@ describe Spree::Product, type: :model do
         end
       end
 
-      context 'when master default price changed' do
+      context 'when master default price changed', enable_legacy_default_price: true do
         before do
-          master = product.master
+          allow(Spree::Config).to receive(:enable_legacy_default_price).and_return(true)
+          master = product.master.reload
           master.default_price.price = 11
           master.save!
-          product.master.default_price.price = 12
+          product.master.reload.default_price.price = 12
         end
 
         it 'saves the master' do
@@ -244,13 +245,11 @@ describe Spree::Product, type: :model do
 
       context 'with currency set to JPY' do
         before do
-          product.master.default_price.currency = 'JPY'
-          product.master.default_price.save!
-          Spree::Config[:currency] = 'JPY'
+          product.master.set_price('JPY', 11)
         end
 
         it 'displays the currency in yen' do
-          expect(product.display_price.to_s).to eq('¥11')
+          expect(product.master.price_in('JPY').display_amount.to_s).to eq('¥11')
         end
       end
     end

--- a/spree/core/spec/models/spree/variant_spec.rb
+++ b/spree/core/spec/models/spree/variant_spec.rb
@@ -17,6 +17,7 @@ describe Spree::Variant, type: :model do
 
   context 'validations' do
     it 'validates price is greater than 0' do
+      allow(Spree::Config).to receive(:enable_legacy_default_price).and_return(true)
       variant.price = -1
       expect(variant).to be_invalid
     end
@@ -240,7 +241,10 @@ describe Spree::Variant, type: :model do
     let(:master) { product.master }
 
     it 'removes prices from master when variant with price is created' do
-      expect { variant.save! }.to change(product.master.prices, :count).from(1).to(0)
+      expect(product.master.prices.count).to eq(1)
+      variant.save!
+      variant.set_price(store.default_currency, 19.99)
+      expect(product.master.prices.reload.count).to eq(0)
     end
   end
 
@@ -1250,24 +1254,24 @@ describe Spree::Variant, type: :model do
   describe 'validate :check_price' do
     subject { variant.save }
 
+    before do
+      allow(Spree::Config).to receive(:enable_legacy_default_price).and_return(true)
+    end
+
     let(:currency) { store.default_currency }
 
     context 'when variant has a default price' do
-      let(:variant) { build(:variant, product: product, default_price: default_price) }
+      let(:variant) { build(:variant, product: product) }
 
-      let(:product) { create(:product, master: master) }
-      let(:master) { create(:master_variant, price: 11.11, currency: currency) }
-
-      let(:default_price) { build(:price, amount: 12.34, currency: currency) }
+      let(:product) { create(:product, price: 11.11) }
 
       it 'keeps the default price' do
+        variant.set_price(currency, 12.34)
         expect(subject).to be(true)
         expect(variant.price_in(currency).amount).to eq(12.34)
       end
 
       context 'when the default price is invalid' do
-        let(:default_price) { build(:price, amount: nil, currency: currency) }
-
         it 'infers price from the default variant' do
           expect(subject).to be(true)
           expect(variant.price_in(currency).amount).to eq(11.11)
@@ -1289,8 +1293,7 @@ describe Spree::Variant, type: :model do
     context 'when variant has no default price' do
       let(:variant) { build(:variant, :with_no_price, product: product) }
 
-      let(:product) { create(:product, master: master) }
-      let(:master) { create(:master_variant, price: 11.11, currency: currency) }
+      let(:product) { create(:product, price: 11.11) }
 
       it 'infers price from the default variant' do
         expect(subject).to be(true)

--- a/spree/core/spec/support/concerns/default_price.rb
+++ b/spree/core/spec/support/concerns/default_price.rb
@@ -1,7 +1,15 @@
 shared_examples_for 'default_price' do
-  subject(:instance) { FactoryBot.build(model.name.demodulize.downcase.to_sym) }
+  subject(:instance) do
+    obj = FactoryBot.create(model.name.demodulize.downcase.to_sym)
+    obj.reload
+    obj
+  end
 
   let(:model) { described_class }
+
+  before do
+    allow(Spree::Config).to receive(:enable_legacy_default_price).and_return(true)
+  end
 
   describe '.has_one :default_price' do
     let(:default_price_association) { model.reflect_on_association(:default_price) }
@@ -28,8 +36,8 @@ shared_examples_for 'default_price' do
     end
 
     it 'delegates price_including_vat_for' do
-      expect(instance.default_price).to receive(:price_including_vat_for)
-      instance.price_including_vat_for
+      expect(instance.default_price).to receive(:price_including_vat_for).with({})
+      instance.price_including_vat_for({})
     end
   end
 


### PR DESCRIPTION
It finally happened. We're getting rid of this concern as its very buggy and doesnt align well with multi-currency environments.

Added `enable_legacy_default_price` confguration to allow to enable this