### PR TITLE
Fixed OptionType/OptionValue `label` alias translations

### DIFF
--- a/spree/core/app/models/spree/option_type.rb
+++ b/spree/core/app/models/spree/option_type.rb
@@ -35,7 +35,15 @@ module Spree
     has_many :prototypes, through: :option_type_prototypes, class_name: 'Spree::Prototype'
 
     # 5.5 API naming bridge (DB column rename in 6.0)
-    alias_attribute :label, :presentation
+    # NOTE: alias_attribute bypasses Mobility's locale-aware reader/writer,
+    # so we define explicit delegating methods instead.
+    def label(*args)
+      presentation(*args)
+    end
+
+    def label=(value)
+      self.presentation = value
+    end
 
     #
     # Validations

--- a/spree/core/app/models/spree/option_value.rb
+++ b/spree/core/app/models/spree/option_value.rb
@@ -34,7 +34,15 @@ module Spree
     has_many :products, through: :variants, class_name: 'Spree::Product'
 
     # 5.5 API naming bridge (DB column rename in 6.0)
-    alias_attribute :label, :presentation
+    # NOTE: alias_attribute bypasses Mobility's locale-aware reader/writer,
+    # so we define explicit delegating methods instead.
+    def label(*args)
+      presentation(*args)
+    end
+
+    def label=(value)
+      self.presentation = value
+    end
 
     #
     # Validations

--- a/spree/core/spec/models/spree/option_type_spec.rb
+++ b/spree/core/spec/models/spree/option_type_spec.rb
@@ -37,6 +37,26 @@ describe Spree::OptionType, type: :model do
       expect(option_type_pl_translation.presentation).to eq('Rozmiar')
     end
 
+    describe '#label alias' do
+      it 'returns the translated presentation for the current locale' do
+        expect(option_type.label).to eq('Size')
+      end
+
+      it 'returns the translated presentation for a different locale' do
+        Mobility.with_locale(:pl) do
+          expect(option_type.label).to eq('Rozmiar')
+        end
+      end
+
+      it 'sets the translated presentation via label=' do
+        Mobility.with_locale(:pl) do
+          option_type.label = 'Nowy Rozmiar'
+          option_type.save!
+          expect(option_type.presentation).to eq('Nowy Rozmiar')
+        end
+      end
+    end
+
     context 'with always_use_translations enabled' do
       before do
         Spree::Config.always_use_translations = true

--- a/spree/core/spec/models/spree/option_value_spec.rb
+++ b/spree/core/spec/models/spree/option_value_spec.rb
@@ -115,5 +115,25 @@ describe Spree::OptionValue, type: :model do
       expect(option_value_pl_translation).to be_present
       expect(option_value_pl_translation.presentation).to eq('Czerwony')
     end
+
+    describe '#label alias' do
+      it 'returns the translated presentation for the current locale' do
+        expect(option_value.label).to eq('Red')
+      end
+
+      it 'returns the translated presentation for a different locale' do
+        Mobility.with_locale(:pl) do
+          expect(option_value.label).to eq('Czerwony')
+        end
+      end
+
+      it 'sets the translated presentation via label=' do
+        Mobility.with_locale(:pl) do
+          option_value.label = 'Nowy Czerwony'
+          option_value.save!
+          expect(option_value.presentation).to eq('Nowy Czerwony')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
alias_attribute bypasses Mobility's locale-aware reader/writer