### PR TITLE
Fix duplicate HTML ids in variant template price and stock inputs

### DIFF
--- a/spree/admin/app/views/spree/admin/products/form/variants/_variant_template.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/variants/_variant_template.html.erb
@@ -21,18 +21,18 @@
     <div class="variants-table__body__cell column-price mr-2">
       <% supported_currencies.each_with_index do |currency, i| %>
         <div class="input-group price-input-container <%= current_currency != currency ? 'hidden' : 'flex' %>" <%= !can_manage_prices ? 'readonly' : '' %>>
-          <%= text_field_tag "product[variants_attributes][prices_attributes][#{i}][amount]", '',  class: 'border-0 focus:ring-0 focus:outline-none', data: { slot: "[prices_attributes][#{currency}][amount]_input", action: 'variants-form#updatePrice blur->variants-form#formatPrice', currency: currency.to_s }, readonly: !can_manage_prices %>
+          <%= text_field_tag "product[variants_attributes][prices_attributes][#{i}][amount]", '',  id: nil, class: 'border-0 focus:ring-0 focus:outline-none', data: { slot: "[prices_attributes][#{currency}][amount]_input", action: 'variants-form#updatePrice blur->variants-form#formatPrice', currency: currency.to_s }, readonly: !can_manage_prices %>
           <span class="px-3"><%= currency_symbol(currency) %></span>
         </div>
-        <%= hidden_field_tag "product[variants_attributes][prices_attributes][#{i}][currency]", currency, data: {slot: "[prices_attributes][#{currency}][currency]_input"} %>
-        <%= hidden_field_tag "product[variants_attributes][prices_attributes][#{i}][id]", "", data: {slot: "[prices_attributes][#{currency}][id]_input"} %>
+        <%= hidden_field_tag "product[variants_attributes][prices_attributes][#{i}][currency]", currency, id: nil, data: {slot: "[prices_attributes][#{currency}][currency]_input"} %>
+        <%= hidden_field_tag "product[variants_attributes][prices_attributes][#{i}][id]", "", id: nil, data: {slot: "[prices_attributes][#{currency}][id]_input"} %>
       <% end %>
     </div>
     <div class="variants-table__body__cell column-quantity">
       <% available_stock_locations_for_product(@product).ids.each_with_index do |id, i|  %>
-        <%= number_field_tag "product[variants_attributes][stock_items_attributes][#{i}][count_on_hand]", 0, class: class_names('form-input', default_stock_location.id == id ? 'block' : 'hidden'), data: {slot: "[stock_items_attributes][#{id}][count_on_hand]_input", stock_location_id: id, action: "variants-form#updateCountOnHand blur->variants-form#replaceBlankWithZero" }, readonly: !can_manage_stock %>
-        <%= hidden_field_tag "product[variants_attributes][stock_items_attributes][#{i}][stock_location_id]", id, data: { slot: "[stock_items_attributes][#{id}][stock_location_id]_input" } %>
-        <%= hidden_field_tag "product[variants_attributes][stock_items_attributes][#{i}][id]", "", data: { slot: "[stock_items_attributes][#{id}][id]_input" } %>
+        <%= number_field_tag "product[variants_attributes][stock_items_attributes][#{i}][count_on_hand]", 0, id: nil, class: class_names('form-input', default_stock_location.id == id ? 'block' : 'hidden'), data: {slot: "[stock_items_attributes][#{id}][count_on_hand]_input", stock_location_id: id, action: "variants-form#updateCountOnHand blur->variants-form#replaceBlankWithZero" }, readonly: !can_manage_stock %>
+        <%= hidden_field_tag "product[variants_attributes][stock_items_attributes][#{i}][stock_location_id]", id, id: nil, data: { slot: "[stock_items_attributes][#{id}][stock_location_id]_input" } %>
+        <%= hidden_field_tag "product[variants_attributes][stock_items_attributes][#{i}][id]", "", id: nil, data: { slot: "[stock_items_attributes][#{id}][id]_input" } %>
       <% end %>
     </div>
     <% if can?(:manage, @product.default_variant) %>

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -488,6 +488,27 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         get :edit, params: { id: product.to_param }
         expect(response).to render_template(:edit)
       end
+
+      it 'does not generate id attributes on variant template price and stock inputs' do
+        get :edit, params: { id: product.to_param }
+
+        template_html = response.body[/(<template data-variants-form-target="variantTemplate">)(.*?)(<\/template>)/m, 2]
+
+        expect(template_html).to be_present
+
+        doc = Nokogiri::HTML::DocumentFragment.parse(template_html)
+
+        price_inputs = doc.css('input[data-slot*="prices_attributes"]')
+        stock_inputs = doc.css('input[data-slot*="stock_items_attributes"]')
+        all_inputs = price_inputs + stock_inputs
+
+        expect(all_inputs).not_to be_empty
+
+        inputs_with_ids = all_inputs.select { |el| el['id'].present? }
+        expect(inputs_with_ids).to be_empty,
+          "Expected no id attributes on variant template inputs to avoid duplicates when cloned, " \
+          "but found: #{inputs_with_ids.map { |el| el['id'] }.join(', ')}"
+      end
     end
   end
 

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -492,19 +492,18 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
       it 'does not generate id attributes on variant template price and stock inputs' do
         get :edit, params: { id: product.to_param }
 
-        template_html = response.body[/(<template data-variants-form-target="variantTemplate">)(.*?)(<\/template>)/m, 2]
+        doc = Nokogiri::HTML(response.body)
+        template = doc.at_css('template[data-variants-form-target="variantTemplate"]')
 
-        expect(template_html).to be_present
+        expect(template).to be_present
 
-        doc = Nokogiri::HTML::DocumentFragment.parse(template_html)
-
-        price_inputs = doc.css('input[data-slot*="prices_attributes"]')
-        stock_inputs = doc.css('input[data-slot*="stock_items_attributes"]')
+        price_inputs = template.css('input[data-slot*="prices_attributes"]')
+        stock_inputs = template.css('input[data-slot*="stock_items_attributes"]')
         all_inputs = price_inputs + stock_inputs
 
         expect(all_inputs).not_to be_empty
 
-        inputs_with_ids = all_inputs.select { |el| el['id'].present? }
+        inputs_with_ids = all_inputs.select { |el| el.attribute('id').present? }
         expect(inputs_with_ids).to be_empty,
           "Expected no id attributes on variant template inputs to avoid duplicates when cloned, " \
           "but found: #{inputs_with_ids.map { |el| el['id'] }.join(', ')}"


### PR DESCRIPTION
## Summary
- The variant template partial (`_variant_template.html.erb`) generates `id` attributes on price and stock input elements via Rails tag helpers (`text_field_tag`, `number_field_tag`, `hidden_field_tag`)
- When the Stimulus controller clones this `<template>` for each variant row, it updates `name` attributes but not `id` attributes, producing duplicate HTML ids across all variant rows
- Added `id: nil` to all six field tag helpers in the template to suppress auto-generated ids — these inputs are selected by `data-slot` attributes in JavaScript, so `id` attributes are unnecessary

## Why
- Duplicate HTML ids violate the W3C HTML specification
- Can cause issues with accessibility tools (screen readers), browser `getElementById`, and `<label for="">` associations
- Affects any product with multiple variants in the Admin Panel

## Test plan
- [x] Added controller spec verifying variant template inputs have no `id` attributes
- [x] Confirmed test fails before fix (detects 15 duplicate ids) and passes after
- [x] All 78 existing `ProductsController` specs pass

Fixes #13453

🤖 Generated with [Claude Code](https://claude.com/claude-code)