### PR TITLE
Add return_quantity to permitted attributes for return items

### DIFF
--- a/spree/core/lib/spree/permitted_attributes.rb
+++ b/spree/core/lib/spree/permitted_attributes.rb
@@ -115,7 +115,7 @@ module Spree
 
     @@customer_return_attributes = [:stock_location_id, {
       return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount,
-                                :acceptance_status, :exchange_variant_id, :resellable]
+                                :acceptance_status, :exchange_variant_id, :resellable, :return_quantity]
     }]
 
     @@digital_attributes = [:attachment, :variant_id]
@@ -222,14 +222,14 @@ module Spree
           :id, :inventory_unit_id,
           :preferred_reimbursement_type_id,
           :return_authorization_id, :returned, :pre_tax_amount,
-          :acceptance_status, :exchange_variant_id, :resellable
+          :acceptance_status, :exchange_variant_id, :resellable, :return_quantity
         ]
       }
     ]
 
     @@return_authorization_reason_attributes = [:name, :active]
 
-    @@return_item_attributes = [:inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]
+    @@return_item_attributes = [:inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable, :return_quantity]
 
     @@role_attributes = [:name]
 

--- a/spree/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/spree/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -42,4 +42,17 @@ describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
       expect(controller.permitted_store_attributes.class).to eq Array
     end
   end
+
+  # Regression test for #13003
+  describe 'return_quantity in permitted attributes' do
+    it 'includes return_quantity in return_authorization nested return_items_attributes' do
+      nested = Spree::PermittedAttributes.return_authorization_attributes.find { |a| a.is_a?(Hash) && a.key?(:return_items_attributes) }
+      expect(nested[:return_items_attributes]).to include(:return_quantity)
+    end
+
+    it 'includes return_quantity in customer_return nested return_items_attributes' do
+      nested = Spree::PermittedAttributes.customer_return_attributes.find { |a| a.is_a?(Hash) && a.key?(:return_items_attributes) }
+      expect(nested[:return_items_attributes]).to include(:return_quantity)
+    end
+  end
 end

--- a/spree/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/spree/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -47,11 +47,13 @@ describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
   describe 'return_quantity in permitted attributes' do
     it 'includes return_quantity in return_authorization nested return_items_attributes' do
       nested = Spree::PermittedAttributes.return_authorization_attributes.find { |a| a.is_a?(Hash) && a.key?(:return_items_attributes) }
+      expect(nested).not_to be_nil
       expect(nested[:return_items_attributes]).to include(:return_quantity)
     end
 
     it 'includes return_quantity in customer_return nested return_items_attributes' do
       nested = Spree::PermittedAttributes.customer_return_attributes.find { |a| a.is_a?(Hash) && a.key?(:return_items_attributes) }
+      expect(nested).not_to be_nil
       expect(nested[:return_items_attributes]).to include(:return_quantity)
     end
   end


### PR DESCRIPTION
## Summary
- `return_quantity` was missing from `PermittedAttributes` in three places: `return_item_attributes`, `return_authorization_attributes`, and `customer_return_attributes`
- Rails strong parameters silently stripped the value, so partial returns (e.g. 2 of 3 items) always fell back to the full quantity

## Why
`ReturnItem#return_quantity` is a virtual attribute that controls inventory unit splitting during partial returns. The admin form submits it correctly, but strong parameters filtering discarded the value before it reached the model.

## Test plan
- [x] Added regression tests verifying `:return_quantity` is included in permitted attributes
- [x] Verified tests fail before fix and pass after
- [x] All existing strong_parameters specs pass

Fixes #13003

🤖 Generated with [Claude Code](https://claude.com/claude-code)