### PR TITLE
Fix incorrect indefinite articles (a → an) across docs and specs

### DIFF
--- a/docs/api-reference/platform/authentication.mdx
+++ b/docs/api-reference/platform/authentication.mdx
@@ -16,7 +16,7 @@ To generate a valid token for the Platform API, you'll first need to create an a
 
     <img src="/images/Platform API 3.png"/>
 
-4. Save your Client ID and Secret - you'll later use it to generate a OAuth token to access the platform API
+4. Save your Client ID and Secret - you'll later use it to generate an OAuth token to access the platform API
 
     <img src="/images/Platform API 4.png"/>
 

--- a/docs/api-reference/storefront.yaml
+++ b/docs/api-reference/storefront.yaml
@@ -171,7 +171,7 @@ paths:
                 address:
                   $ref: "#/components/schemas/AddressPayload"
             examples:
-              Create a Address:
+              Create an Address:
                 value:
                   address:
                     firstname: Mark

--- a/docs/user/manage-products/export-products.mdx
+++ b/docs/user/manage-products/export-products.mdx
@@ -15,7 +15,7 @@ Click on **Export** in the top right corner. 
 
 ![](/docs/images/user/products/export-products/2.export_type.png)
 
-This opens a export modal that gives you two options to choose from:
+This opens an export modal that gives you two options to choose from:
 
 - **Filtered Records**: Export only filtered records matching the search criteria
 - **All**: Export all records (can be slow for large datasets)

--- a/spree/core/app/models/spree/order/checkout.rb
+++ b/spree/core/app/models/spree/order/checkout.rb
@@ -317,7 +317,7 @@ module Spree
           # attributes for a single payment and its source, discarding attributes
           # for payment methods other than the one selected
           #
-          # In case a existing credit card is provided it needs to build the payment
+          # In case an existing credit card is provided it needs to build the payment
           # attributes from scratch so we can set the amount. example payload:
           #
           #   {

--- a/spree/core/app/models/spree/order/checkout.rb
+++ b/spree/core/app/models/spree/order/checkout.rb
@@ -317,8 +317,8 @@ module Spree
           # attributes for a single payment and its source, discarding attributes
           # for payment methods other than the one selected
           #
-          # In case an existing credit card is provided it needs to build the payment
-          # attributes from scratch so we can set the amount. example payload:
+          # If an existing credit card is provided, build the payment attributes
+          # from scratch so the amount can be set. Example payload:
           #
           #   {
           #     "order": {

--- a/spree/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/spree/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -59,7 +59,7 @@ describe Spree::Core::ControllerHelpers::Store, type: :controller do
       end
     end
 
-    context 'on a object that accepts a single store' do
+    context 'on an object that accepts a single store' do
       before { allow(controller).to receive(:current_store).and_return(store) }
 
       context 'when no store is present' do

--- a/spree/core/spec/models/spree/calculator_spec.rb
+++ b/spree/core/spec/models/spree/calculator_spec.rb
@@ -28,7 +28,7 @@ describe Spree::Calculator, type: :model do
         end
       end
 
-      context 'with a arbitrary object' do
+      context 'with an arbitrary object' do
         it 'calls the correct compute' do
           s = 'Calculator can all'
           expect(subject).to receive(:compute_string).with(s)
@@ -56,7 +56,7 @@ describe Spree::Calculator, type: :model do
         end
       end
 
-      context 'with a arbitrary object' do
+      context 'with an arbitrary object' do
         it 'raises NotImplementedError' do
           s = 'Calculator can all'
           expect { subject.compute(s) }.to raise_error NotImplementedError, /Please implement \'compute_string\(string\)\' in your calculator/

--- a/spree/core/spec/models/spree/gateway_spec.rb
+++ b/spree/core/spec/models/spree/gateway_spec.rb
@@ -58,7 +58,7 @@ describe Spree::Gateway, type: :model do
       create(:payment, order: order, source: cc, payment_method: has_card)
     end
 
-    it 'finds credit cards associated on an order completed' do
+    it 'finds credit cards associated with a completed order' do
       allow(payment.order).to receive_messages completed?: true
 
       expect(no_card.reusable_sources(payment.order)).to be_empty

--- a/spree/core/spec/models/spree/gateway_spec.rb
+++ b/spree/core/spec/models/spree/gateway_spec.rb
@@ -58,7 +58,7 @@ describe Spree::Gateway, type: :model do
       create(:payment, order: order, source: cc, payment_method: has_card)
     end
 
-    it 'finds credit cards associated on a order completed' do
+    it 'finds credit cards associated on an order completed' do
       allow(payment.order).to receive_messages completed?: true
 
       expect(no_card.reusable_sources(payment.order)).to be_empty

--- a/spree/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/spree/core/spec/models/spree/preferences/preferable_spec.rb
@@ -116,7 +116,7 @@ describe Spree::Preferences::Preferable, type: :model do
                                            color: 'green')
     end
 
-    it 'builds a array of deprecated preferences' do
+    it 'builds an array of deprecated preferences' do
       expect(@b.deprecated_preferences).to eq([{ name: :color,
                                                  message: 'Please use colour instead' }])
     end

--- a/spree/core/spec/models/spree/product/scopes_spec.rb
+++ b/spree/core/spec/models/spree/product/scopes_spec.rb
@@ -502,7 +502,7 @@ describe 'Product scopes', type: :model do
     describe '.with_option' do
       subject(:with_option) { Spree::Product.method(:with_option) }
 
-      it "finds by a option type's name" do
+      it "finds by an option type's name" do
         expect(with_option.call(option_type.name).count).to eq(1)
       end
 
@@ -510,7 +510,7 @@ describe 'Product scopes', type: :model do
         expect(with_option.call('fake').count).to eq(0)
       end
 
-      it 'finds by a option type' do
+      it 'finds by an option type' do
         expect(with_option.call(option_type).count).to eq(1)
       end
 
@@ -526,7 +526,7 @@ describe 'Product scopes', type: :model do
     describe '.with_option_value' do
       subject(:with_option) { Spree::Product.method(:with_option_value) }
 
-      it "finds by a option type's name" do
+      it "finds by an option type's name" do
         expect(with_option.call(option_type.name, option_value.name).count).to eq({ product.id => 1 })
       end
 
@@ -534,7 +534,7 @@ describe 'Product scopes', type: :model do
         expect(with_option.call('fake', 'fake').count).to eq({})
       end
 
-      it 'finds by a option type' do
+      it 'finds by an option type' do
         expect(with_option.call(option_type, option_value.name).count).to eq({ product.id => 1 })
       end
 


### PR DESCRIPTION
## Summary
- Fix "a" → "an" before vowel-sound words (address, arbitrary, array, export, existing, object, order, option, OAuth) across docs and specs
- 9 files, 13 occurrences total
- No functional changes — text/comment/test description fixes only

## Test plan
- [x] All affected spec files pass (136 examples, 0 failures)
- [x] Changes limited to string literals in comments, test descriptions, and documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)