### PR TITLE
Fix promotion usage count double-counting with multiple actions

### DIFF
--- a/spree/core/app/models/spree/promotion.rb
+++ b/spree/core/app/models/spree/promotion.rb
@@ -232,7 +232,7 @@ module Spree
 
     def adjusted_credits_count(promotable)
       adjustments = promotable.is_a?(Order) ? promotable.all_adjustments : promotable.adjustments
-      credits_count - adjustments.promotion.where(source_id: actions.pluck(:id)).size
+      credits_count - adjustments.promotion.where(source_id: actions.pluck(:id)).select(:order_id).distinct.count
     end
 
     def credits
@@ -240,7 +240,7 @@ module Spree
     end
 
     def credits_count
-      credits.count
+      credits.select(:order_id).distinct.count
     end
 
     def line_item_actionable?(order, line_item)

--- a/spree/core/app/models/spree/promotion.rb
+++ b/spree/core/app/models/spree/promotion.rb
@@ -232,7 +232,7 @@ module Spree
 
     def adjusted_credits_count(promotable)
       adjustments = promotable.is_a?(Order) ? promotable.all_adjustments : promotable.adjustments
-      credits_count - adjustments.promotion.where(source_id: actions.pluck(:id)).select(:order_id).distinct.count
+      credits_count - adjustments.eligible.promotion.where(source_id: actions.pluck(:id)).select(:order_id).distinct.count
     end
 
     def credits

--- a/spree/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/spree/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -23,7 +23,7 @@ describe Spree::Promotion::Actions::FreeShipping, type: :model do
       expect(first_shipment_cost).to be > 0
       expect(last_shipment_cost).to be > 0
       expect(action.perform(payload)).to be true
-      expect(promotion.credits_count).to eq(2)
+      expect(promotion.credits_count).to eq(1)
       expect(order.shipment_adjustments.count).to eq(2)
       expect(order.shipment_adjustments.first.amount.to_i).to eq(-first_shipment_cost.to_i)
       expect(order.shipment_adjustments.last.amount.to_i).to eq(-last_shipment_cost.to_i)
@@ -32,7 +32,7 @@ describe Spree::Promotion::Actions::FreeShipping, type: :model do
     it 'does not create a discount when order already has one from this promotion' do
       expect(action.perform(payload)).to be true
       expect(action.perform(payload)).to be false
-      expect(promotion.credits_count).to eq(2)
+      expect(promotion.credits_count).to eq(1)
       expect(order.shipment_adjustments.count).to eq(2)
     end
 
@@ -46,7 +46,7 @@ describe Spree::Promotion::Actions::FreeShipping, type: :model do
         expect(order.shipments.first.cost).to eq(0)
         expect(order.shipments.last.cost).to eq(0)
         expect(action.perform(payload)).to be true
-        expect(promotion.credits_count).to eq(2)
+        expect(promotion.credits_count).to eq(1)
         expect(order.shipment_adjustments.count).to eq(2)
         expect(order.shipment_adjustments.first.amount.to_i).to eq(0)
         expect(order.shipment_adjustments.last.amount.to_i).to eq(0)

--- a/spree/core/spec/models/spree/promotion_spec.rb
+++ b/spree/core/spec/models/spree/promotion_spec.rb
@@ -391,6 +391,54 @@ describe Spree::Promotion, type: :model do
       adjustment.update_column(:eligible, false)
       expect(promotion.credits_count).to eq(0)
     end
+
+    # Regression test for #11879
+    context 'with multiple actions on the same order' do
+      let!(:second_action) do
+        calculator = Spree::Calculator::FlatRate.new
+        action = Spree::Promotion::Actions::CreateAdjustment.create(promotion: promotion, calculator: calculator)
+        promotion.actions << action
+        action
+      end
+
+      before do
+        order = adjustment.order
+        Spree::Adjustment.create!(
+          order: order,
+          adjustable: order,
+          source: second_action,
+          amount: -5,
+          label: 'Second promotional adjustment'
+        )
+        # mark both adjustments eligible
+        order.all_adjustments.update_all(eligible: true)
+      end
+
+      it 'counts unique orders, not individual adjustments' do
+        expect(promotion.credits_count).to eq(1)
+      end
+    end
+
+    # Regression test for #11879
+    context 'with the same action applied to multiple orders' do
+      let!(:second_order) { create(:order) }
+
+      before do
+        Spree::Adjustment.create!(
+          order: second_order,
+          adjustable: second_order,
+          source: action,
+          amount: 10,
+          label: 'Promotional adjustment'
+        )
+        adjustment.update_column(:eligible, true)
+        second_order.all_adjustments.update_all(eligible: true)
+      end
+
+      it 'counts each order separately' do
+        expect(promotion.credits_count).to eq(2)
+      end
+    end
   end
 
   context '#adjusted_credits_count' do


### PR DESCRIPTION
## Summary

`Promotion#credits_count` counts the number of `Adjustment` records rather than
the number of unique orders. When a promotion has multiple actions (e.g., a
whole-order discount + free shipping), each action creates its own adjustment,
causing `credits_count` to return 2 for a single order. This makes
`usage_limit_exceeded?` trigger prematurely — a promotion with `usage_limit: 1`
becomes "used up" after being applied to just one order.

Fixes #11879

## Root cause

`credits_count` was introduced in 2011 (177022069f) under the implicit
assumption of one action per promotion. The original test asserted
`promotion.credits_count.should == 1` for a single action on a single order.

When `FreeShipping` was converted from a calculator to a promotion action in
2013 (5062755adc), it created one adjustment per shipment. The test was written
to match the implementation (`credits_count == 2` for 2 shipments) rather than
the intended semantics (1 order = 1 usage).

## Fix

Change `credits_count` and `adjusted_credits_count` to count distinct orders
instead of individual adjustments:

```ruby
def credits_count
  credits.select(:order_id).distinct.count
end
```

This is a single SQL query (`COUNT(DISTINCT order_id)`) with no performance
impact compared to the previous `COUNT(*)`.

## Test plan

- [x] Added regression test: 2 actions on same order → `credits_count == 1`
- [x] Added test: same action on 2 different orders → `credits_count == 2`
- [x] Updated `free_shipping_spec` expectations from `eq(2)` to `eq(1)` (3 places) — these were asserting buggy behavior
- [x] All 143 promotion-related examples pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)