### PR TITLE
Fixed:  [PAGY] the :client_max_limit option is deprecated: use :max_l…

### DIFF
--- a/spree/api/config/initializers/pagy.rb
+++ b/spree/api/config/initializers/pagy.rb
@@ -5,4 +5,4 @@
 Pagy::OPTIONS[:limit] = 25
 
 # Maximum number of items per page
-Pagy::OPTIONS[:client_max_limit] = 100
+Pagy::OPTIONS[:max_limit] = 100


### PR DESCRIPTION
…imit instead