### PR TITLE
Fix markets:migrate_checkout_zones failing with validation error

### DIFF
--- a/spree/core/lib/tasks/markets.rake
+++ b/spree/core/lib/tasks/markets.rake
@@ -27,12 +27,9 @@ namespace :spree do
           name: primary_country&.name || 'Default',
           currency: iso_country&.currency_code || store.read_attribute(:default_currency) || 'USD',
           default_locale: iso_country&.languages_official&.first || store.read_attribute(:default_locale) || 'en',
-          default: true
+          default: true,
+          country_ids: countries.map(&:id)
         )
-
-        countries.each do |country|
-          market.market_countries.build(country: country).save!(validate: false)
-        end
 
         store.update_column(:checkout_zone_id, nil) if checkout_zone_id
 


### PR DESCRIPTION
**Bug (on v5.4):** `rake spree:markets:migrate_checkout_zones` fails with `ActiveRecord::RecordInvalid: Validation failed: Countries can't be blank`

**Cause:** `Spree::Market` validates `countries` presence, but the task calls `create!` without `country_ids` and tries to add countries afterwards via `market_countries.build` — which never executes because the validation fails first.

**Fix:** Pass `country_ids: countries.map(&:id)` directly to `create!` and remove the now-unnecessary `market_countries.build` loop.