### PR TITLE
Fix FindByVariant ignoring compare service result

### DIFF
--- a/spree/core/app/finders/spree/line_items/find_by_variant.rb
+++ b/spree/core/app/finders/spree/line_items/find_by_variant.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 module Spree
   module LineItems
     class FindByVariant
       def execute(order:, variant:, options: {})
         line_item = order.line_items.loaded? ? order.line_items.detect { |li| li.variant_id == variant.id } : order.line_items.find_by(variant_id: variant.id)
 
-        if line_item
-          Spree.cart_compare_line_items_service.call(order: order, line_item: line_item, options: options).value
-        end
+        return unless line_item
+        return unless Spree.cart_compare_line_items_service.call(order: order, line_item: line_item, options: options).value
 
         line_item
       end

--- a/spree/core/spec/finders/spree/line_items/find_by_variant_spec.rb
+++ b/spree/core/spec/finders/spree/line_items/find_by_variant_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  describe LineItems::FindByVariant do
+    subject { described_class.new }
+
+    let(:order) { create(:order_with_line_items, line_items_count: 1) }
+    let(:line_item) { order.line_items.first }
+    let(:variant) { line_item.variant }
+
+    context 'when line item exists and compare service returns true' do
+      it 'returns the line item' do
+        result = subject.execute(order: order, variant: variant)
+        expect(result).to eq(line_item)
+      end
+    end
+
+    context 'when line item exists but compare service returns false' do
+      before do
+        compare_service = double
+        allow(compare_service).to receive(:call).and_return(double(value: false))
+        allow(Spree).to receive(:cart_compare_line_items_service).and_return(compare_service)
+      end
+
+      it 'returns nil' do
+        result = subject.execute(order: order, variant: variant)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when line item does not exist' do
+      let(:other_variant) { create(:variant) }
+
+      it 'returns nil' do
+        result = subject.execute(order: order, variant: other_variant)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when line items are preloaded' do
+      before { order.line_items.load }
+
+      it 'returns the line item using detect' do
+        result = subject.execute(order: order, variant: variant)
+        expect(result).to eq(line_item)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fix `Spree::LineItems::FindByVariant#execute` to return `nil` when `cart_compare_line_items_service` returns false/nil, instead of always returning the line item
- Add dedicated spec for `FindByVariant` covering match, mismatch, missing, and preloaded scenarios

Closes #12970

## Test plan
- [x] `FindByVariant` returns `nil` when compare service returns `false`
- [x] `FindByVariant` returns line item when compare service returns `true`
- [x] `FindByVariant` returns `nil` when variant not in order
- [x] Works correctly with preloaded line items

🤖 Generated with [Claude Code](https://claude.com/claude-code)