### PR TITLE
fix doubled order canceled event

### DIFF
--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -1013,7 +1013,6 @@ module Spree
 
       update_with_updater!
       send_order_canceled_webhook
-      publish_order_canceled_event
     end
 
     def after_resume
@@ -1092,10 +1091,6 @@ module Spree
 
     def publish_order_completed_event
       publish_event('order.completed')
-    end
-
-    def publish_order_canceled_event
-      publish_event('order.canceled')
     end
 
     def publish_order_resumed_event

--- a/spree/core/app/services/spree/orders/cancel.rb
+++ b/spree/core/app/services/spree/orders/cancel.rb
@@ -13,7 +13,6 @@ module Spree
           order.cancel!
         end
 
-        order.publish_event('order.canceled')
         success(order.reload)
       rescue ActiveRecord::Rollback, ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
         failure(order)

--- a/spree/core/app/services/spree/orders/cancel.rb
+++ b/spree/core/app/services/spree/orders/cancel.rb
@@ -13,6 +13,7 @@ module Spree
           order.cancel!
         end
 
+        order.publish_event('order.canceled')
         success(order.reload)
       rescue ActiveRecord::Rollback, ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
         failure(order)

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -358,15 +358,6 @@ describe Spree::Order, type: :model do
         end
       end
     end
-
-    context 'events', :events do
-      let(:order) { create(:completed_order_with_totals) }
-
-      it 'publishes order.canceled event' do
-        expect(order).to receive(:publish_event).with('order.canceled')
-        order.canceled_by(admin_user)
-      end
-    end
   end
 
   describe '#create' do

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -292,16 +292,6 @@ describe Spree::Order, type: :model do
         expect(order.payments.store_credits).to all(have_attributes(state: 'void'))
       end
     end
-
-    context 'events', :events do
-      let(:order) { create(:completed_order_with_totals, store: store) }
-
-      it 'publishes order.canceled event' do
-        expect(order).to receive(:publish_event).with('order.canceled').at_least(:once)
-        allow(order).to receive(:publish_event).with(anything)
-        order.cancel!
-      end
-    end
   end
 
   describe '#after_resume' do
@@ -356,6 +346,15 @@ describe Spree::Order, type: :model do
           order.canceled_by(admin_user, Time.current - 1.day)
           expect(order.reload.canceled_at.to_s).to eq (Time.current - 1.day).to_s
         end
+      end
+    end
+
+    context 'events', :events do
+      let(:order) { create(:completed_order_with_totals) }
+
+      it 'publishes order.canceled event' do
+        expect(order).to receive(:publish_event).with('order.canceled')
+        order.canceled_by(admin_user)
       end
     end
   end

--- a/spree/core/spec/services/spree/orders/cancel_spec.rb
+++ b/spree/core/spec/services/spree/orders/cancel_spec.rb
@@ -14,6 +14,11 @@ module Spree
         it { expect(result).to be_success }
         it { expect { result }.to change(order, :state).to('canceled') }
         it { expect(result.value).to eq(order) }
+
+        it 'publishes order.canceled event' do
+          expect(order).to receive(:publish_event).with('order.canceled')
+          result
+        end
       end
 
       context 'incomplete order' do
@@ -21,6 +26,11 @@ module Spree
 
         it { expect(result).to be_failure }
         it { expect(result.error).to be_present }
+
+        it 'does not publish order.canceled event' do
+          expect(order).not_to receive(:publish_event).with('order.canceled')
+          result
+        end
       end
     end
 

--- a/spree/emails/spec/models/spree/order_spec.rb
+++ b/spree/emails/spec/models/spree/order_spec.rb
@@ -19,42 +19,4 @@ describe Spree::Order, type: :model do
       order.finalize!
     end
   end
-
-  describe '#cancel' do
-    let(:order) { build(:order) }
-    let!(:variant) { create(:variant) }
-    let!(:inventory_units) { create_list(:inventory_unit, 2, variant: variant) }
-    let!(:shipment) { create(:shipment) }
-    let!(:line_items) { create_list(:line_item, 2, order: order, price: 10) }
-
-    before do
-      allow(shipment).to receive_messages inventory_units: inventory_units, order: order
-      allow(order).to receive_messages shipments: [shipment]
-
-      allow(order.line_items).to receive(:find_by).with(hash_including(:variant_id)) { line_items.first }
-
-      allow(order).to receive_messages completed?: true
-      allow(order).to receive_messages allow_cancel?: true
-
-      shipments = [shipment]
-      allow(order).to receive_messages shipments: shipments
-      allow(shipments).to receive_messages states: []
-      allow(shipments).to receive_messages ready: []
-      allow(shipments).to receive_messages pending: []
-      allow(shipments).to receive_messages shipped: []
-      allow(shipments).to receive_message_chain(:sum, :cost).and_return(shipment.cost)
-
-      allow_any_instance_of(Spree::OrderUpdater).to receive(:update_adjustment_total).and_return(10)
-    end
-
-    it 'publishes order.canceled event when canceling', events: true do
-      allow(shipment).to receive(:cancel!)
-      allow(order).to receive :restock_items!
-
-      expect(order).to receive(:publish_event).with('order.canceled')
-      allow(order).to receive(:publish_event).with(anything)
-
-      order.cancel!
-    end
-  end
 end


### PR DESCRIPTION
Let's keep it in service only: https://github.com/spree/spree/blob/main/spree/core/app/services/spree/orders/cancel.rb#L16