### PR TITLE
Fix admin datetime fields to respect store timezone

### DIFF
--- a/spree/admin/app/controllers/spree/admin/base_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/base_controller.rb
@@ -88,6 +88,24 @@ module Spree
         @current_timezone ||= current_store.preferred_timezone
       end
 
+      # datetime-local inputs submit values without timezone information. Interpret
+      # them in the store's timezone so they match what the admin sees in the form.
+      def parse_datetime_in_store_timezone(attrs, *fields)
+        zone = ActiveSupport::TimeZone[current_timezone] || Time.zone
+
+        fields.each do |field|
+          value = attrs[field]
+          next if value.blank?
+
+          parsed_value = begin
+            zone.parse(value.to_s)
+          rescue ArgumentError
+            nil
+          end
+          attrs[field] = parsed_value if parsed_value.present?
+        end
+      end
+
       def current_currency
         @current_currency ||= if params[:currency].present? && supported_currency?(params[:currency])
                                 params[:currency]

--- a/spree/admin/app/controllers/spree/admin/products_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/products_controller.rb
@@ -304,11 +304,15 @@ module Spree
       end
 
       def permitted_resource_params
-        @permitted_resource_params ||= if cannot?(:activate, @product) && @new_status&.to_sym == :active
-                                         params.require(:product).permit(permitted_product_attributes).except(:status, :make_active_at)
-                                       else
-                                         params.require(:product).permit(permitted_product_attributes)
-                                       end
+        @permitted_resource_params ||= begin
+          attrs = if cannot?(:activate, @product) && @new_status&.to_sym == :active
+                    params.require(:product).permit(permitted_product_attributes).except(:status, :make_active_at)
+                  else
+                    params.require(:product).permit(permitted_product_attributes)
+                  end
+          parse_datetime_in_store_timezone(attrs, :available_on, :discontinue_on, :make_active_at)
+          attrs
+        end
       end
     end
   end

--- a/spree/admin/app/controllers/spree/admin/promotions_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/promotions_controller.rb
@@ -48,7 +48,26 @@ module Spree
       end
 
       def permitted_resource_params
-        params.require(:promotion).permit(permitted_promotion_attributes)
+        attrs = params.require(:promotion).permit(permitted_promotion_attributes)
+        parse_datetime_in_store_timezone(attrs, :starts_at, :expires_at)
+        attrs
+      end
+
+      # datetime-local inputs submit values without timezone information. Interpret
+      # them in the store's timezone so they match what the admin sees in the form.
+      def parse_datetime_in_store_timezone(attrs, *fields)
+        zone = ActiveSupport::TimeZone[current_timezone] || Time.zone
+
+        fields.each do |field|
+          value = attrs[field]
+          next if value.blank?
+
+          attrs[field] = begin
+            zone.parse(value.to_s)
+          rescue ArgumentError
+            value
+          end
+        end
       end
     end
   end

--- a/spree/admin/app/controllers/spree/admin/promotions_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/promotions_controller.rb
@@ -52,23 +52,6 @@ module Spree
         parse_datetime_in_store_timezone(attrs, :starts_at, :expires_at)
         attrs
       end
-
-      # datetime-local inputs submit values without timezone information. Interpret
-      # them in the store's timezone so they match what the admin sees in the form.
-      def parse_datetime_in_store_timezone(attrs, *fields)
-        zone = ActiveSupport::TimeZone[current_timezone] || Time.zone
-
-        fields.each do |field|
-          value = attrs[field]
-          next if value.blank?
-
-          attrs[field] = begin
-            zone.parse(value.to_s)
-          rescue ArgumentError
-            value
-          end
-        end
-      end
     end
   end
 end

--- a/spree/admin/app/views/spree/admin/products/form/_status.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_status.html.erb
@@ -1,3 +1,13 @@
+<%# datetime-local inputs have no timezone; render values in the store's timezone so admins see and submit values in the store's local time. %>
+<%
+  store_timezone       = ActiveSupport::TimeZone[current_store.preferred_timezone] || Time.zone
+  to_store_local       = ->(value) { value&.in_time_zone(store_timezone)&.strftime('%Y-%m-%dT%H:%M') }
+  make_active_at_local = to_store_local.call(@product.make_active_at)
+  available_on_local   = to_store_local.call(@product.available_on)
+  discontinue_on_local = to_store_local.call(@product.discontinue_on)
+  tz_help              = Spree.t('admin.datetime_field_timezone_help', zone: store_timezone.name)
+%>
+
 <div class="card mb-6">
   <div class="card-body">
     <div class="grid grid-cols-12 gap-6 mb-6">
@@ -14,21 +24,27 @@
       <div class="col-span-6 <%= 'hidden' if @product.active? %>" data-product-form-target="makeActiveAt">
         <% if can?(:activate, @product) %>
           <%= f.spree_datetime_field :make_active_at,
+                                     value: make_active_at_local,
+                                     help: tz_help,
                                      help_bubble: Spree.t('admin.products.status_form.make_active_at'),
-                                     max: @product.discontinue_on %>
+                                     max: discontinue_on_local %>
         <% end %>
       </div>
     </div>
     <div class="grid grid-cols-12 gap-6">
       <div data-product-form-target="availableOn" class="col-span-6">
         <%= f.spree_datetime_field :available_on,
+                                   value: available_on_local,
+                                   help: tz_help,
                                    help_bubble: Spree.t('admin.products.status_form.available_on'),
-                                   max: @product.discontinue_on %>
+                                   max: discontinue_on_local %>
       </div>
       <div data-product-form-target="discontinueOn" class="col-span-6">
         <%= f.spree_datetime_field :discontinue_on,
+                                   value: discontinue_on_local,
+                                   help: tz_help,
                                    help_bubble: Spree.t('admin.products.status_form.discontinue_on'),
-                                   min: @product.make_active_at %>
+                                   min: make_active_at_local %>
       </div>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
@@ -3,12 +3,12 @@
 <% end %>
 
 <%# datetime-local inputs have no timezone; render values in the store's timezone so admins see and submit values in the store's local time. %>
-<% store_timezone = current_store.preferred_timezone %>
 <%
+  store_timezone   = ActiveSupport::TimeZone[current_store.preferred_timezone] || Time.zone
   to_store_local   = ->(value) { value&.in_time_zone(store_timezone)&.strftime('%Y-%m-%dT%H:%M') }
   starts_at_local  = to_store_local.call(@promotion.starts_at)
   expires_at_local = to_store_local.call(@promotion.expires_at)
-  tz_help          = "Time zone: #{store_timezone}"
+  tz_help          = Spree.t('admin.datetime_field_timezone_help', zone: store_timezone.name)
 %>
 
 <%= f.spree_datetime_field :starts_at, value: starts_at_local, help: tz_help %>

--- a/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
@@ -2,6 +2,17 @@
   <%= f.spree_number_field :usage_limit, min: 0, step: 1, help: 'Leave this field blank for unlimited usage.' %>
 <% end %>
 
-<%= f.spree_datetime_field :starts_at %>
+<%# datetime-local inputs have no timezone; render values in the store's timezone so admins see and submit values in the store's local time. %>
+<% store_timezone = current_store.preferred_timezone %>
+<%
+  to_store_local   = ->(value) { value&.in_time_zone(store_timezone)&.strftime('%Y-%m-%dT%H:%M') }
+  starts_at_local  = to_store_local.call(@promotion.starts_at)
+  expires_at_local = to_store_local.call(@promotion.expires_at)
+  tz_help          = "Time zone: #{store_timezone}"
+%>
 
-<%= f.spree_datetime_field :expires_at, help: 'Leave this field blank for no expiration.' %>
+<%= f.spree_datetime_field :starts_at, value: starts_at_local, help: tz_help %>
+
+<%= f.spree_datetime_field :expires_at,
+      value: expires_at_local,
+      help: "Leave this field blank for no expiration. #{tz_help}" %>

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
         top_products: Top products
         view_report: View report
         whats_happening_on_html: Here's what's happening on <strong>%{store_name}</strong> today.
+      datetime_field_timezone_help: 'Time zone: %{zone}'
       digital_shipment_fulfillment_note: This shipment will be marked as fulfilled once the user downloads the digital product
       display_on_options:
         back_end: Only on admin panel

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -1144,6 +1144,31 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
       expect(product.make_active_at).to eq(Time.current.beginning_of_day)
     end
 
+    describe 'datetime fields submitted from a datetime-local input' do
+      before { store.update!(preferred_timezone: 'Asia/Tokyo') }
+
+      let(:product_params) do
+        {
+          status: 'draft',
+          make_active_at: '2026-04-10T09:00',
+          available_on: '2026-04-11T10:30',
+          discontinue_on: '2026-04-20T18:45'
+        }
+      end
+
+      it 'parses the values in the store timezone and stores them as UTC' do
+        send_request
+
+        product.reload
+        tokyo = ActiveSupport::TimeZone['Asia/Tokyo']
+        expect(product.make_active_at).to eq(tokyo.parse('2026-04-10T09:00'))
+        expect(product.available_on).to eq(tokyo.parse('2026-04-11T10:30'))
+        expect(product.discontinue_on).to eq(tokyo.parse('2026-04-20T18:45'))
+        # Tokyo is UTC+9, so 09:00 local is 00:00 UTC.
+        expect(product.make_active_at.utc.strftime('%Y-%m-%dT%H:%M')).to eq('2026-04-10T00:00')
+      end
+    end
+
     describe 'removing last Label and Tag when param not sent' do
       before do
         product.update(tag_list: ['Tag 1'], label_list: ['Label 1'])

--- a/spree/admin/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -137,6 +137,33 @@ RSpec.describe Spree::Admin::PromotionsController, type: :controller do
       patch :update, params: { id: promotion.to_param, promotion: promotion_params }
       expect(response).to redirect_to(spree.admin_promotion_path(promotion))
     end
+
+    context 'with starts_at and expires_at submitted from a datetime-local input' do
+      before { store.update!(preferred_timezone: 'Asia/Tokyo') }
+
+      let(:promotion_params) do
+        {
+          starts_at: '2026-04-10T09:00',
+          expires_at: '2026-04-20T18:30'
+        }
+      end
+
+      it 'parses the values in the store timezone and stores them as UTC' do
+        patch :update, params: { id: promotion.to_param, promotion: promotion_params }
+
+        promotion.reload
+        expect(promotion.starts_at).to eq(ActiveSupport::TimeZone['Asia/Tokyo'].parse('2026-04-10T09:00'))
+        expect(promotion.expires_at).to eq(ActiveSupport::TimeZone['Asia/Tokyo'].parse('2026-04-20T18:30'))
+        # Tokyo is UTC+9, so 09:00 local is 00:00 UTC.
+        expect(promotion.starts_at.utc.strftime('%Y-%m-%dT%H:%M')).to eq('2026-04-10T00:00')
+        expect(promotion.expires_at.utc.strftime('%Y-%m-%dT%H:%M')).to eq('2026-04-20T09:30')
+      end
+
+      it 'leaves blank expires_at as nil' do
+        patch :update, params: { id: promotion.to_param, promotion: promotion_params.merge(expires_at: '') }
+        expect(promotion.reload.expires_at).to be_nil
+      end
+    end
   end
 
   describe 'POST #clone' do


### PR DESCRIPTION
Fixes #13393

## Problem

The `datetime-local` input fields in the admin panel do not include timezone information. The browser displays and accepts input in the user's local timezone, but the server stores the value as-is without timezone conversion. This causes promotions to start/expire and products to become available/discontinue at incorrect times when the store's timezone differs from UTC.

## Solution

Use the existing `current_store.preferred_timezone` to interpret the submitted datetime values, consistent with how order date filters and other datetime inputs are already handled in the admin panel (see `OrdersFiltersHelper`, `ResourceController`, `AnalyticsConcern`).

- **On save**: Parse datetime fields in the store's timezone before persisting
- **On display**: Convert stored UTC values to the store's timezone for form fields, with timezone name shown in help text
- **Shared helper**: `parse_datetime_in_store_timezone` extracted to `BaseController` for reuse across controllers
- **I18n**: Timezone help text uses `Spree.t` key

### Why store timezone instead of browser timezone?

The issue suggests capturing the user's browser timezone via a hidden field. However, Spree already has a per-store timezone preference (`Spree::Store#preferred_timezone`) used throughout the admin (dashboard analytics, order filters, reports, CSV exports). Using the store timezone ensures all admins see consistent scheduling regardless of which device or location they use.

### Affected fields
- **Promotions**: `starts_at`, `expires_at`
- **Products**: `available_on`, `discontinue_on`, `make_active_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
