### PR TITLE
Remove broken remove_transition that skips confirm step

### DIFF
--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -102,7 +102,6 @@ module Spree
       go_to_state :payment, if: ->(order) { order.payment? || order.payment_required? }
       go_to_state :confirm, if: ->(order) { order.confirmation_required? }
       go_to_state :complete
-      remove_transition from: :delivery, to: :confirm, unless: ->(order) { order.confirmation_required? }
     end
 
     self.whitelisted_ransackable_associations = %w[shipments user created_by approver canceler promotions bill_address ship_address line_items store]

--- a/spree/core/spec/models/spree/order/checkout_spec.rb
+++ b/spree/core/spec/models/spree/order/checkout_spec.rb
@@ -18,6 +18,7 @@ describe Spree::Order, type: :model do
       [
         { address: :delivery },
         { delivery: :payment },
+        { delivery: :confirm },
         { payment: :confirm },
         { confirm: :complete },
         { payment: :complete },
@@ -32,9 +33,13 @@ describe Spree::Order, type: :model do
       end
     end
 
-    it 'does not have a transition from delivery to confirm' do
+    # Regression test for #11900 — the delivery → confirm transition must
+    # exist so that orders skipping payment (e.g. $0 orders) still reach the
+    # confirm step when confirmation_required? is true. The transition is
+    # gated at runtime by the :if option on the :confirm go_to_state.
+    it 'has a transition from delivery to confirm' do
       transition = Spree::Order.find_transition(from: :delivery, to: :confirm)
-      expect(transition).to be_nil
+      expect(transition).not_to be_nil
     end
 
     it '.find_transition when contract was broken' do
@@ -316,6 +321,22 @@ describe Spree::Order, type: :model do
         it 'transitions to complete' do
           order.next!
           expect(order.state).to eq('complete')
+        end
+      end
+
+      # Regression test for #11900 — a $0 order (payment not required) that
+      # still requires confirmation must transition delivery → confirm, not
+      # delivery → complete.
+      context 'without payment required but with confirmation required' do
+        before do
+          allow(order).to receive_messages payment_required?: false
+          allow(order).to receive_messages confirmation_required?: true
+        end
+
+        it 'transitions to confirm' do
+          order.next!
+          assert_state_changed(order, 'delivery', 'confirm')
+          expect(order.state).to eq('confirm')
         end
       end
 
@@ -652,11 +673,6 @@ describe Spree::Order, type: :model do
       Spree::Order.checkout_flow(&@old_checkout_flow)
     end
 
-    it 'maintains removed transitions' do
-      transition = Spree::Order.find_transition(from: :delivery, to: :confirm)
-      expect(transition).to be_nil
-    end
-
     context 'before' do
       before do
         Spree::Order.class_eval do
@@ -702,11 +718,6 @@ describe Spree::Order, type: :model do
 
     after do
       Spree::Order.checkout_flow(&@old_checkout_flow)
-    end
-
-    it 'maintains removed transitions' do
-      transition = Spree::Order.find_transition(from: :delivery, to: :confirm)
-      expect(transition).to be_nil
     end
 
     specify do


### PR DESCRIPTION
Fixes #11900

## Problem

`remove_transition` in `order.rb` (line 105) uses an `:unless` option:

```ruby
remove_transition from: :delivery, to: :confirm, unless: ->(order) { order.confirmation_required? }
```

However, `remove_transition` ([checkout.rb L181-184](https://github.com/spree/spree/blob/37e764163358a5d0e2f985b3da2c3229909f5459/spree/core/app/models/spree/order/checkout.rb#L181-L184)) does not implement `:unless` — it unconditionally removes the transition. `find_transition` only matches on `:from` / `:to`, ignoring any other options.

This causes the confirm step to be skipped even when `confirmation_required?` returns true (e.g., for \$0 orders where the payment step is skipped).

### History

Commit fe909259c8 (2020) attempted to fix this by adding `:unless` to the `remove_transition` call, but `:unless` was never implemented in the checkout module. The bug has persisted since then.

## Solution

Remove the `remove_transition` line entirely. The `go_to_state :confirm, if: ->(order) { order.confirmation_required? }` on line 103 already gates the confirm step correctly at runtime — the state_machine gem evaluates the `:if` condition per-order when the `next` event fires.

The `remove_transition` was therefore redundant (when working) and harmful (since `:unless` was ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)