### PR TITLE
Fix Cart::Update#filter_order_items TypeError on Array line_items_attributes

### DIFF
--- a/spree/core/app/services/spree/cart/update.rb
+++ b/spree/core/app/services/spree/cart/update.rb
@@ -23,14 +23,29 @@ module Spree
       private
 
       def filter_order_items(order, params)
-        return params if params[:line_items_attributes].nil? || params[:line_items_attributes][:id]
+        line_items_attrs = params[:line_items_attributes]
+        return params if line_items_attrs.nil?
 
         line_item_ids = order.line_item_ids.map(&:to_s)
 
-        params[:line_items_attributes].each_pair do |id, value|
-          params[:line_items_attributes].delete(id) unless line_item_ids.include?(value[:id].to_s) || value[:variant_id].present?
-        end
-        params
+        filtered =
+          if line_items_attrs.is_a?(Array)
+            line_items_attrs.select { |value| keep_line_item?(value, line_item_ids) }
+          else
+            # Preserve the id-only shortcut: a single unwrapped entry
+            # like `{id: X, quantity: 0}` skips filtering entirely.
+            return params if line_items_attrs[:id]
+
+            line_items_attrs.each_with_object({}) do |(key, value), acc|
+              acc[key] = value if keep_line_item?(value, line_item_ids)
+            end
+          end
+
+        params.merge(line_items_attributes: filtered)
+      end
+
+      def keep_line_item?(value, line_item_ids)
+        line_item_ids.include?(value[:id].to_s) || value[:variant_id].present?
       end
     end
   end

--- a/spree/core/app/services/spree/cart/update.rb
+++ b/spree/core/app/services/spree/cart/update.rb
@@ -27,21 +27,39 @@ module Spree
         return params if line_items_attrs.nil?
 
         line_item_ids = order.line_item_ids.map(&:to_s)
+        normalized = normalize_line_items_attributes(line_items_attrs)
 
         filtered =
-          if line_items_attrs.is_a?(Array)
-            line_items_attrs.select { |value| keep_line_item?(value, line_item_ids) }
+          if normalized.is_a?(Array)
+            normalized.select { |value| keep_line_item?(value, line_item_ids) }
           else
             # Preserve the id-only shortcut: a single unwrapped entry
             # like `{id: X, quantity: 0}` skips filtering entirely.
-            return params if line_items_attrs[:id]
+            return params if normalized[:id]
 
-            line_items_attrs.each_with_object({}) do |(key, value), acc|
+            normalized.each_with_object({}) do |(key, value), acc|
               acc[key] = value if keep_line_item?(value, line_item_ids)
             end
           end
 
         params.merge(line_items_attributes: filtered)
+      end
+
+      # Plain Hashes from JSON or manually-built callers may use string keys,
+      # which would silently bypass the symbol-keyed lookups below. Normalize
+      # to indifferent access at the entry so both key styles behave the same.
+      def normalize_line_items_attributes(attrs)
+        if attrs.is_a?(Array)
+          attrs.map { |value| indifferent(value) }
+        else
+          indifferent(attrs)
+        end
+      end
+
+      def indifferent(value)
+        return value unless value.is_a?(Hash)
+
+        value.with_indifferent_access
       end
 
       def keep_line_item?(value, line_item_ids)

--- a/spree/core/spec/models/spree/order_contents_spec.rb
+++ b/spree/core/spec/models/spree/order_contents_spec.rb
@@ -320,6 +320,18 @@ describe Spree::OrderContents, type: :model do
       expect(subject.order).to receive(:ensure_updated_shipments)
       subject.update_cart params
     end
+
+    # Regression test for #9718
+    context 'with Array form line_items_attributes' do
+      let(:array_params) do
+        { line_items_attributes: [{ id: shirt.id, quantity: 7 }] }
+      end
+
+      it 'does not raise TypeError and updates the line item' do
+        expect { subject.update_cart(array_params) }.not_to raise_error
+        expect(shirt.reload.quantity).to eq 7
+      end
+    end
   end
 
   context 'completed order' do

--- a/spree/core/spec/services/spree/cart/update_spec.rb
+++ b/spree/core/spec/services/spree/cart/update_spec.rb
@@ -89,6 +89,47 @@ module Spree
       end
     end
 
+    context 'with string-keyed Hash shortcut (single line item)' do
+      let(:params) do
+        { line_items_attributes: { 'id' => line_item.id, 'quantity' => 8 } }
+      end
+
+      it 'takes the id-only shortcut and updates the line item' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 8
+      end
+    end
+
+    context 'with string-keyed Hash form (filter path)' do
+      let(:params) do
+        {
+          line_items_attributes: {
+            '0' => { 'id' => line_item.id, 'quantity' => 9 },
+            '1' => { 'id' => '666', 'quantity' => 0 }
+          }
+        }
+      end
+
+      it 'filters out the nonexistent id and updates the valid one' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 9
+      end
+    end
+
+    context 'with string-keyed Array form' do
+      let(:params) do
+        { line_items_attributes: [{ 'id' => line_item.id, 'quantity' => 10 }] }
+      end
+
+      it 'does not silently drop string-keyed entries and updates the line item' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 10
+      end
+    end
+
     context 'with ActionController::Parameters wrapping Array' do
       let(:params) do
         ActionController::Parameters.new(

--- a/spree/core/spec/services/spree/cart/update_spec.rb
+++ b/spree/core/spec/services/spree/cart/update_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+module Spree
+  describe Cart::Update do
+    subject { described_class }
+
+    let(:order) { create(:order) }
+    let(:variant) { create(:variant) }
+    let!(:line_item) { Spree::Cart::AddItem.call(order: order, variant: variant, quantity: 1).value }
+
+    let(:execute) { subject.call(order: order, params: params) }
+
+    context 'with Hash form line_items_attributes (legacy)' do
+      let(:params) do
+        { line_items_attributes: { '0' => { id: line_item.id, quantity: 3 } } }
+      end
+
+      it 'updates line item quantity' do
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 3
+      end
+    end
+
+    context 'with Hash form containing a nonexistent id' do
+      let(:params) do
+        {
+          line_items_attributes: {
+            '0' => { id: line_item.id, quantity: 0 },
+            '1' => { id: '666', quantity: 0 }
+          }
+        }
+      end
+
+      it 'filters out the nonexistent id and does not raise' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+      end
+    end
+
+    context 'with id-only Hash shortcut (single line item)' do
+      let(:params) do
+        { line_items_attributes: { id: line_item.id, quantity: 2 } }
+      end
+
+      it 'passes through and updates the line item' do
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 2
+      end
+    end
+
+    context 'with Array form line_items_attributes (Issue #9718)' do
+      let(:params) do
+        { line_items_attributes: [{ id: line_item.id, quantity: 4 }] }
+      end
+
+      it 'does not raise TypeError and updates the line item' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 4
+      end
+    end
+
+    context 'with Array form containing a nonexistent id' do
+      let(:params) do
+        {
+          line_items_attributes: [
+            { id: line_item.id, quantity: 5 },
+            { id: '666', quantity: 2 }
+          ]
+        }
+      end
+
+      it 'filters out the nonexistent id and updates the valid one' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 5
+      end
+    end
+
+    context 'with Array form containing a new variant_id' do
+      let(:new_variant) { create(:variant) }
+      let(:params) do
+        { line_items_attributes: [{ variant_id: new_variant.id, quantity: 2 }] }
+      end
+
+      it 'keeps entries with variant_id even when id is absent' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+      end
+    end
+
+    context 'with ActionController::Parameters wrapping Array' do
+      let(:params) do
+        ActionController::Parameters.new(
+          line_items_attributes: [{ id: line_item.id, quantity: 6 }]
+        ).permit(line_items_attributes: [:id, :quantity, :variant_id])
+      end
+
+      it 'does not raise and updates the line item' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+        expect(line_item.reload.quantity).to eq 6
+      end
+    end
+
+    context 'with nil line_items_attributes' do
+      let(:params) { { email: 'test@example.com' } }
+
+      it 'does not raise and returns success' do
+        expect { execute }.not_to raise_error
+        expect(execute).to be_success
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #9718

## Background

Issue #9718 was reported on 2019-12-26 against the v2 storefront API: sending `{order: {line_items: [{variant_id: 1, quantity: 5}]}}` crashed `Spree::Cart::Update#filter_order_items` with `TypeError: no implicit conversion of Symbol into Integer`. The bug has sat unfixed for six years.

The original reproduction path no longer exists. The v2 storefront API controllers that passed these params into `Cart::Update` have been removed in the move to v3, and the current `Spree::Api::V3::Store::CartsController` routes through `Spree::Carts::Update` (plural), a completely different service that consumes `params[:items]` as an Array and delegates to `Carts::UpsertItems`. `line_items_attributes` is not part of the v3 surface at all.

## Root cause

`Spree::Cart::Update#filter_order_items` assumed `line_items_attributes` was always a Hash of the `accepts_nested_attributes_for` form (`{"0" => {id: X, quantity: 3}}`):

```ruby
# core/app/services/spree/cart/update.rb (before)
return params if params[:line_items_attributes].nil? || params[:line_items_attributes][:id]
# ...
params[:line_items_attributes].each_pair do |id, value|
  params[:line_items_attributes].delete(id) unless ...
end
```

When `line_items_attributes` is an `Array`, `Array#[](:id)` raises `TypeError` immediately, and `each_pair` is not defined on `Array` either. `ActionController::Parameters` wrapping a permitted array exhibits the same failure mode.

## Why this still matters

`Spree::Cart::Update` remains registered as `Spree.cart_update_service` in `Spree::Dependencies` and backs `Spree::OrderContents#update_cart`. Both are documented extension points: third-party gems and host apps can (and do) call `Spree::OrderContents.new(order).update_cart(params)` directly, or swap `Spree.cart_update_service` via the DI container. Any such caller passing Array-shaped `line_items_attributes` hits this `TypeError`.

Note that no first-party Spree controller reaches this service in the current codebase — the v3 API routes through `Spree::Carts::Update` (plural) instead — so this fix targets the extension surface rather than a user-facing endpoint.

## Fix

`filter_order_items` now accepts all three input shapes:

- `Array` — filtered with `select`
- `Hash` — filtered with `each_with_object({})`
- `ActionController::Parameters` — same path as `Hash`

Filtering is non-destructive: the original implementation mutated `params` via `delete`; the new implementation returns `params.merge(line_items_attributes: filtered)`. The id-only shortcut (`{line_items_attributes: {id: X, quantity: 0}}` without an index wrapper) is preserved. The shared keep/drop predicate is extracted into a small `keep_line_item?` helper so the Array and Hash branches stay in sync.

## Testing

A new service spec `core/spec/services/spree/cart/update_spec.rb` was added (TDD: Red before the fix, Green after) covering eight cases:

- Hash legacy form
- Hash with a nonexistent id (filter path)
- Hash id-only shortcut (early return path)
- Array form (direct reproduction of #9718)
- Array with a nonexistent id (filter path)
- Array with `variant_id` but no `id` (new-item path)
- `ActionController::Parameters` wrapping an Array
- `nil` `line_items_attributes`

Added an integration regression test via `OrderContents#update_cart` that directly reproduces the Issue #9718 reporter's scenario (Array-shaped `line_items_attributes`) against the actual extension entry point.

Full run of `core/spec/services/spree/cart/update_spec.rb` + `core/spec/models/spree/order_contents_spec.rb`: **43 examples, 0 failures, 2 pending** (pre-existing `xcontext` skips, unrelated).

## Not touched

`Spree::Carts::Update` (plural, v3 API) is intentionally left unchanged. It is a separate service with a different parameter contract (`params[:items]` Array → `Carts::UpsertItems`) and does not use `line_items_attributes`. The bug is specific to the legacy singular `Spree::Cart::Update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)