### PR TITLE
Fix I18n.default_locale leak in Spree::Admin::BaseController spec

### DIFF
--- a/spree/admin/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/base_controller_spec.rb
@@ -19,6 +19,15 @@ describe Spree::Admin::BaseController, type: :controller do
 
     let(:store) { Spree::Store.default }
 
+    around do |example|
+      original_default_locale = I18n.default_locale
+      original_locale = I18n.locale
+      example.run
+    ensure
+      I18n.default_locale = original_default_locale
+      I18n.locale = original_locale
+    end
+
     before do
       allow(controller).to receive(:current_store).and_return(store)
     end


### PR DESCRIPTION
## Problem

The `#default_locale` tests in `base_controller_spec.rb` call `get :index`, which triggers the `set_locale` before_action. This sets `I18n.default_locale` globally (via `Spree::Core::ControllerHelpers::Locale#set_locale`), but no cleanup restores it after the test finishes.

When the `:de` locale test runs before other specs in the same process, `I18n.default_locale` is left as `:de`, causing `Spree.t(...)` calls to look up German translations that don't exist — resulting in `translation missing` failures.

**Affected specs:** `products_helper_spec.rb` `#available_status` (4 tests) — and potentially any other spec that relies on `I18n.default_locale` being `:en`.

## Reproduction

```
bundle exec rspec spec/controllers/spree/admin/base_controller_spec.rb \
  spec/helpers/spree/admin/products_helper_spec.rb --seed 800
# => 4 failures (translation missing: de.spree.admin.products.{active,draft,archived,deleted})
```

The failure is order-dependent: it only occurs when the `:de` locale test in `base_controller_spec` runs before the helper spec.

## Root cause

Introduced in 92b673cac3 ("Introduce admin locale preference"), which added the `#default_locale` tests without locale cleanup.

## Fix

Add an `around` hook to the `#default_locale` describe block that saves and restores both `I18n.default_locale` and `I18n.locale`:

```ruby
around do |example|
  original_default_locale = I18n.default_locale
  original_locale = I18n.locale
  example.run
ensure
  I18n.default_locale = original_default_locale
  I18n.locale = original_locale
end
```

## Test plan

- [x] Before fix: `rspec --seed 800` reproduces 4 failures
- [x] After fix: `rspec --seed 800` passes (0 failures)
- [x] Verified all 10 seeds (100–1000, step 100): 0 failures across all runs