### PR TITLE
extract CSV stock location to make it editable in spree extensions

### DIFF
--- a/spree/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -167,7 +167,7 @@
           <div class="variants-table__body" data-variants-form-target="variantsContainer" data-test-id="product-variants-table">
           </div>
           <div class="variants-table__footer text-sm rounded-b-2xl">
-            <%= Spree.t('admin.variants_form.total_inventory_html', stock_location: current_store.default_stock_location.name, count: raw("<span data-variants-form-target='stockItemsCount'>#{@product.total_on_hand}</span>") )%>
+            <%= Spree.t('admin.variants_form.total_inventory_html', stock_location: default_stock_location_for_product(@product).name, count: raw("<span data-variants-form-target='stockItemsCount'>#{@product.total_on_hand}</span>") )%>
           </div>
         </div>
       </div>

--- a/spree/core/app/models/spree/variant.rb
+++ b/spree/core/app/models/spree/variant.rb
@@ -471,14 +471,14 @@ module Spree
     # @param stock_location [Spree::StockLocation] the stock location to set the stock for
     # @return [void]
     def set_stock(count_on_hand, backorderable = nil, stock_location = nil)
-      stock_item = stock_items.find_or_initialize_by(stock_location: stock_location || default_stock_location)
+      stock_item = stock_items.find_or_initialize_by(stock_location: set_stock_location(stock_location))
       stock_item.count_on_hand = count_on_hand
       stock_item.backorderable = backorderable if backorderable.present?
       stock_item.save!
     end
 
-    def default_stock_location
-      Spree::Store.current.default_stock_location
+    def set_stock_location(stock_location = nil)
+      stock_location || Spree::Store.current.default_stock_location
     end
 
     def price_modifier_amount_in(currency, options = {})

--- a/spree/core/app/models/spree/variant.rb
+++ b/spree/core/app/models/spree/variant.rb
@@ -471,11 +471,14 @@ module Spree
     # @param stock_location [Spree::StockLocation] the stock location to set the stock for
     # @return [void]
     def set_stock(count_on_hand, backorderable = nil, stock_location = nil)
-      stock_location ||= Spree::Store.current.default_stock_location
-      stock_item = stock_items.find_or_initialize_by(stock_location: stock_location)
+      stock_item = stock_items.find_or_initialize_by(stock_location: stock_location || default_stock_location)
       stock_item.count_on_hand = count_on_hand
       stock_item.backorderable = backorderable if backorderable.present?
       stock_item.save!
+    end
+
+    def default_stock_location
+      Spree::Store.current.default_stock_location
     end
 
     def price_modifier_amount_in(currency, options = {})

--- a/spree/core/app/models/spree/variant.rb
+++ b/spree/core/app/models/spree/variant.rb
@@ -470,15 +470,15 @@ module Spree
     # @param backorderable [Boolean] the backorderable flag
     # @param stock_location [Spree::StockLocation] the stock location to set the stock for
     # @return [void]
-    def set_stock(count_on_hand, backorderable = nil, stock_location = nil)
-      stock_item = stock_items.find_or_initialize_by(stock_location: set_stock_location(stock_location))
+    def set_stock(count_on_hand, backorderable = nil)
+      stock_item = stock_items.find_or_initialize_by(stock_location: default_stock_location)
       stock_item.count_on_hand = count_on_hand
       stock_item.backorderable = backorderable if backorderable.present?
       stock_item.save!
     end
 
-    def set_stock_location(stock_location = nil)
-      stock_location || Spree::Store.current.default_stock_location
+    def default_stock_location
+      Spree::Store.current.default_stock_location
     end
 
     def price_modifier_amount_in(currency, options = {})

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -47,7 +47,7 @@ module Spree
           end
 
           if attributes['inventory_count'].present?
-            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b, store.default_stock_location)
+            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b)
           end
 
           handle_images(variant)

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -47,7 +47,7 @@ module Spree
           end
 
           if attributes['inventory_count'].present?
-            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b, store.default_stock_location)
+            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b, stock_location)
           end
 
           handle_images(variant)
@@ -262,6 +262,10 @@ module Spree
           else
             'draft'
           end
+        end
+
+        def stock_location
+          store.default_stock_location
         end
       end
     end

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -47,7 +47,7 @@ module Spree
           end
 
           if attributes['inventory_count'].present?
-            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b)
+            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b, store.default_stock_location)
           end
 
           handle_images(variant)

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -47,7 +47,7 @@ module Spree
           end
 
           if attributes['inventory_count'].present?
-            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b, stock_location)
+            variant.set_stock(attributes['inventory_count'].to_i, attributes['inventory_backorderable']&.to_b)
           end
 
           handle_images(variant)
@@ -262,10 +262,6 @@ module Spree
           else
             'draft'
           end
-        end
-
-        def stock_location
-          store.default_stock_location
         end
       end
     end

--- a/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       expect(variant.weight.to_f).to eq 0.0
       expect(variant.stock_items.first.count_on_hand).to eq 100
       expect(variant.stock_items.first.backorderable).to eq true
+      expect(variant.stock_items.first.stock_location).to eq store.default_stock_location
     end
 
     context 'when updating an existing master variant' do


### PR DESCRIPTION
Needed to gracefully set default vendor stock location: https://github.com/vendo-dev/spree_multi_vendor/pull/98