### PR TITLE
Relax active_storage_validations version constraint

### DIFF
--- a/spree/core/spree_core.gemspec
+++ b/spree/core/spree_core.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'tracking_number'
   s.add_dependency 'validates_zipcode'
   s.add_dependency 'image_processing', '~> 1.2'
-  s.add_dependency 'active_storage_validations', '1.3.0'
+  s.add_dependency 'active_storage_validations', '>= 1.3', '< 4'
   s.add_dependency 'mobility', '~> 1.3', '>= 1.3.2'
   s.add_dependency 'mobility-ransack', '~> 1.2'
   s.add_dependency 'mobility-actiontext', '~> 1.1'


### PR DESCRIPTION
## Summary
Updated the `active_storage_validations` gem dependency to allow a wider range of compatible versions.

## Changes
- Changed `active_storage_validations` dependency from a pinned version `1.3.0` to a flexible version constraint `>= 1.3, < 4`
  - This allows patch and minor version updates within the 1.x and 2.x/3.x series
  - Maintains compatibility with version 1.3.0 and newer while preventing breaking changes from major version 4.0+

## Benefits
- Enables users to upgrade to newer compatible versions of `active_storage_validations` without being locked to an outdated patch version
- Reduces dependency conflicts when integrating Spree with other gems that may require newer versions of this library
- Maintains stability by preventing automatic upgrades to incompatible major versions

https://claude.ai/code/session_01Jfk1z32iNsB7RhgDXJpcPu