### PR TITLE
Fix Carmen deprecation warning for Rails 8.2 compatibility

### DIFF
--- a/spree/core/config/initializers/carmen.rb
+++ b/spree/core/config/initializers/carmen.rb
@@ -1,0 +1,23 @@
+# Patches Carmen::Querying#normalise_name to avoid the deprecated
+# ActiveSupport::Multibyte::Chars API (mb_chars), which will be removed in
+# Rails 8.2.
+#
+# In Ruby 2.4+, String#downcase is already Unicode-aware, making the mb_chars
+# call redundant. Since Spree requires Ruby >= 3.2, we can drop it safely.
+#
+# This patch can be removed once the upstream gem is fixed.
+#
+# See: https://github.com/carmen-ruby/carmen/issues/304
+require 'carmen'
+
+module Spree
+  module CarmenQueryingPatch
+    private
+
+    def normalise_name(name)
+      name.downcase.unicode_normalize(:nfkc)
+    end
+  end
+end
+
+Carmen::Querying.prepend(Spree::CarmenQueryingPatch)


### PR DESCRIPTION
## Summary
This PR adds a patch to the Carmen gem to remove usage of the deprecated `ActiveSupport::Multibyte::Chars` API (`mb_chars`), which will be removed in Rails 8.2.

## Key Changes
- Added `spree/core/config/initializers/carmen.rb` that patches `Carmen::Querying#normalise_name`
- Replaced the deprecated `mb_chars` call with native Ruby 2.4+ `String#downcase`, which is already Unicode-aware
- Applied the patch via `prepend` to override the upstream Carmen implementation

## Implementation Details
- Since Spree requires Ruby >= 3.2, the `mb_chars` call is redundant and can be safely removed
- The patched method maintains the same functionality: downcasing the name and normalizing it to NFKC form
- This is a temporary patch that can be removed once the upstream Carmen gem is fixed (see: https://github.com/carmen-ruby/carmen/issues/304)

https://claude.ai/code/session_01S6BkK55WdzLYkHuzmfp966