### PR TITLE
Fix FulfillmentSerializer crash when line item is deleted

### DIFF
--- a/spree/api/app/serializers/spree/api/v3/fulfillment_serializer.rb
+++ b/spree/api/app/serializers/spree/api/v3/fulfillment_serializer.rb
@@ -36,7 +36,9 @@ module Spree
         # Which items (and how many) are in this fulfillment.
         # A line item can be split across fulfillments with different quantities.
         attribute :items do |shipment|
-          shipment.manifest.map do |item|
+          shipment.manifest.filter_map do |item|
+            next unless item.line_item
+
             {
               item_id: item.line_item.prefixed_id,
               variant_id: item.variant.prefixed_id,

--- a/spree/api/spec/serializers/spree/api/v3/fulfillment_serializer_spec.rb
+++ b/spree/api/spec/serializers/spree/api/v3/fulfillment_serializer_spec.rb
@@ -90,12 +90,16 @@ RSpec.describe Spree::Api::V3::FulfillmentSerializer do
 
   context 'with free shipping promotion' do
     let(:free_shipping_promotion) { create(:free_shipping_promotion, code: 'freeship', kind: :coupon_code) }
+    let(:bare_shipment) { create(:shipment) }
+    let(:bare_order) { bare_shipment.order }
+
+    subject { described_class.new(bare_shipment, params: params).to_h }
 
     before do
-      order.coupon_code = free_shipping_promotion.code
-      Spree::PromotionHandler::Coupon.new(order).apply
-      order.updater.update
-      shipment.reload
+      bare_order.coupon_code = free_shipping_promotion.code
+      Spree::PromotionHandler::Coupon.new(bare_order).apply
+      bare_order.updater.update
+      bare_shipment.reload
     end
 
     it 'returns discount_total reflecting the promotion' do

--- a/spree/api/spec/serializers/spree/api/v3/fulfillment_serializer_spec.rb
+++ b/spree/api/spec/serializers/spree/api/v3/fulfillment_serializer_spec.rb
@@ -2,11 +2,21 @@ require 'spec_helper'
 
 RSpec.describe Spree::Api::V3::FulfillmentSerializer do
   let(:store) { @default_store }
-  let(:base_params) { { store: store, currency: store.default_currency } }
+  let(:params) do
+    {
+      store: store,
+      locale: 'en',
+      currency: store.default_currency,
+      user: nil,
+      includes: [],
+      expand: []
+    }
+  end
 
-  let(:shipment) { create(:shipment) }
+  let(:order) { create(:order_ready_to_ship, store: store) }
+  let(:shipment) { order.shipments.first }
 
-  subject { described_class.new(shipment, params: base_params).to_h }
+  subject { described_class.new(shipment, params: params).to_h }
 
   describe 'serialized attributes' do
     it 'includes cost and total fields' do
@@ -40,11 +50,46 @@ RSpec.describe Spree::Api::V3::FulfillmentSerializer do
         'fulfillment_type' => 'shipping'
       )
     end
+
+    it 'returns status mapped from state' do
+      expect(subject['status']).to eq(shipment.state)
+    end
+  end
+
+  describe '#items' do
+    it 'serializes manifest items with prefixed IDs' do
+      items = subject['items']
+      expect(items).to be_an(Array)
+      expect(items.length).to be >= 1
+
+      item = items.first
+      item_id = item[:item_id] || item['item_id']
+      variant_id = item[:variant_id] || item['variant_id']
+      qty = item[:quantity] || item['quantity']
+
+      expect(item_id).to be_present
+      expect(variant_id).to be_present
+      expect(qty).to be_a(Integer)
+    end
+
+    context 'when a line item has been deleted' do
+      before do
+        line_item = shipment.line_items.first
+        line_item.delete
+        shipment.reload
+      end
+
+      it 'skips manifest entries with nil line_item without raising' do
+        expect {
+          result = described_class.new(shipment, params: params).to_h
+          expect(result['items']).to be_an(Array)
+        }.not_to raise_error
+      end
+    end
   end
 
   context 'with free shipping promotion' do
     let(:free_shipping_promotion) { create(:free_shipping_promotion, code: 'freeship', kind: :coupon_code) }
-    let(:order) { shipment.order }
 
     before do
       order.coupon_code = free_shipping_promotion.code


### PR DESCRIPTION
After deleting a line item, the order's after_commit event serializes the shipment whose manifest still references the deleted line item (stale in-memory cache). Guard with filter_map
+ nil check to skip deleted items.

Add FulfillmentSerializer spec covering:
- Normal manifest serialization with prefixed IDs
- Deleted line item scenario (regression test)
- Expected attribute fields + status mapping