### PR TITLE
claude/remove-mailpit-references-xqa8v

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,7 @@ The server app is not checked into the monorepo. It's cloned from [spree-starter
 **Step 1: Start infrastructure**
 
 ```bash
-docker compose up -d     # starts Postgres, Redis, Mailpit
+docker compose up -d     # starts Postgres, Redis, Meilisearch
 ```
 
 Or install PostgreSQL and Redis locally if you prefer.
@@ -197,7 +197,7 @@ TypeScript developers don't need Ruby installed. Docker Compose from the reposit
 docker compose up -d
 ```
 
-This boots PostgreSQL, Redis, Mailpit, and the Spree backend automatically (no `pnpm server:setup` needed). The API is available at `http://localhost:3000`. All outgoing emails are caught by Mailpit and viewable at `http://localhost:8025`.
+This boots PostgreSQL, Redis, Meilisearch, and the Spree backend automatically (no `pnpm server:setup` needed). The API is available at `http://localhost:3000`.
 
 Then install dependencies and start all packages in watch mode:
 

--- a/docs/developer/contributing/developing-spree.mdx
+++ b/docs/developer/contributing/developing-spree.mdx
@@ -45,7 +45,7 @@ The server app is not checked into the monorepo. It's cloned from [spree-starter
 **Step 1: Start infrastructure**
 
 ```bash
-docker compose up -d     # starts Postgres, Redis, Mailpit
+docker compose up -d     # starts Postgres, Redis, Meilisearch
 ```
 
 Or install PostgreSQL and Redis locally if you prefer.
@@ -70,8 +70,6 @@ bin/dev          # starts Rails + Sidekiq + CSS watchers via overmind
 Use `bin/setup --reset` to drop and recreate the database.
 
 The app runs at [http://localhost:3000](http://localhost:3000). Admin Panel is at [http://localhost:3000/admin](http://localhost:3000/admin).
-
-**Emails in local dev:** When using `docker compose up -d`, Mailpit is included automatically. All outgoing emails are caught and viewable at [http://localhost:8025](http://localhost:8025).
 
 ### Running engine tests
 
@@ -169,7 +167,7 @@ TypeScript developers don't need Ruby installed. Docker Compose from the reposit
 docker compose up -d
 ```
 
-This boots PostgreSQL, Redis, Mailpit, and the Spree backend automatically (no `pnpm server:setup` needed). The API is available at `http://localhost:3000`. All outgoing emails are caught by Mailpit and viewable at `http://localhost:8025`.
+This boots PostgreSQL, Redis, Meilisearch, and the Spree backend automatically (no `pnpm server:setup` needed). The API is available at `http://localhost:3000`.
 
 Then install dependencies and start all packages in watch mode:
 

--- a/docs/developer/create-spree-app/quickstart.mdx
+++ b/docs/developer/create-spree-app/quickstart.mdx
@@ -76,7 +76,6 @@ my-store/
 - **Spree** — runs the `ghcr.io/spree/spree:latest` image on the configured port (default `3000`)
 - **PostgreSQL 18** — database with persistent volume
 - **Redis 7** — caching, background jobs, and Action Cable
-- **Mailpit** — local email inbox at [http://localhost:8025](http://localhost:8025)
 - Health checks on all services
 
 ## Customizing the Backend

--- a/packages/create-spree-app/.changeset/bump-cli-version.md
+++ b/packages/create-spree-app/.changeset/bump-cli-version.md
@@ -1,5 +1,0 @@
----
-"create-spree-app": patch
----
-
-Bump @spree/cli dependency to 2.0.0-beta.7 which includes search index initialization during `spree init`.

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-spree-app
 
+## 1.0.1
+
+### Patch Changes
+
+- Remove stale Mailpit references from the generated project README. Mailpit is no longer part of the docker-compose services.
+
 ## 1.0.0
 
 ### Major Release

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/templates/readme.ts
+++ b/packages/create-spree-app/src/templates/readme.ts
@@ -24,7 +24,6 @@ Wait for the services to be healthy, then open:
   - Email: \`${DEFAULT_ADMIN_EMAIL}\`
   - Password: \`${DEFAULT_ADMIN_PASSWORD}\`
 - **Store API:** http://localhost:${port}/api/v3/store
-- **Mailpit (email inbox):** http://localhost:8025
 `
 
   if (hasStorefront) {


### PR DESCRIPTION
Mailpit was removed from the docker-compose.yml services but references
remained in contributor docs, the quickstart guide, and the generated
README template. Clean these up so the docs match the actual stack
(Postgres, Redis, Meilisearch).