### PR TITLE
Use Spree::Money instance correctly as argument for money column type

### DIFF
--- a/spree/admin/app/helpers/spree/admin/table_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/table_helper.rb
@@ -79,7 +79,13 @@ module Spree
       def render_money_column(value, column)
         return empty_column_placeholder if value.blank?
 
-        value.respond_to?(:display_amount) ? value.display_amount : Spree::Money.new(value, currency: current_currency).to_html
+        if value.respond_to?(:display_amount)
+          value.display_amount
+        elsif value.is_a?(Spree::Money)
+          value.to_html
+        else
+          Spree::Money.new(value, currency: current_currency).to_html
+        end
       end
 
       # Render date column

--- a/spree/admin/spec/helpers/spree/admin/table_helper_spec.rb
+++ b/spree/admin/spec/helpers/spree/admin/table_helper_spec.rb
@@ -353,6 +353,15 @@ RSpec.describe Spree::Admin::TableHelper, type: :helper do
 
       expect(result).to eq('$25.00')
     end
+
+    it 'uses Spree::Money instance as argument' do
+      gbp_money = Spree::Money.new(72.98, currency: 'GBP')
+
+      result = helper.render_money_column(gbp_money, column)
+
+      expect(result).to include('£')
+      expect(result).to include('72.98')
+    end
   end
 
   describe '#render_date_column' do


### PR DESCRIPTION
Use `Spree::Money` instance correctly as argument for money column type