### PR TITLE
Fix error when creating promo coupon code with blank expiration date

### DIFF
--- a/spree/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/spree/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -106,7 +106,7 @@ module Spree
     def inject_yaml_permitted_classes
       inside dummy_path do
         inject_into_file 'config/application.rb', %Q[
-    config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone]
+    config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, Time]
         ], after: /config\.load_defaults.*$/, verbose: true
       end
     end

--- a/spree/core/lib/spree/core/engine.rb
+++ b/spree/core/lib/spree/core/engine.rb
@@ -47,7 +47,7 @@ module Spree
         app.config.spree = Environment.new(SpreeCalculators.new, SpreeValidators.new, Spree::Core::Configuration.new, Spree::Core::Dependencies.new)
 
         app.config.active_record.yaml_column_permitted_classes ||= []
-        app.config.active_record.yaml_column_permitted_classes.concat([Symbol, BigDecimal, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone])
+        app.config.active_record.yaml_column_permitted_classes.concat([Symbol, BigDecimal, ActiveSupport::HashWithIndifferentAccess, ActiveSupport::TimeWithZone, ActiveSupport::TimeZone, Time])
         Spree::Config = app.config.spree.preferences
         Spree::RuntimeConfig = app.config.spree.preferences # for compatibility
         Spree::Dependencies = app.config.spree.dependencies


### PR DESCRIPTION
The `Psych::DisallowedClass (Tried to dump unspecified class: Time)` & `Psych::DisallowedClass (Tried to dump unspecified class: ActiveSupport::TimeZone)` errors occur when the `audited` gem tries to YAML-serialize the promotion's changes after create, when expiration date is blank.

