### PR TITLE
fix changing shipping rate when gift card is applied

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/store/carts/fulfillments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts/fulfillments_controller.rb
@@ -46,11 +46,11 @@ module Spree
 
             # Temporary — Spree 6 removes the checkout state machine.
             def try_advance
-              return if @cart.complete? || @cart.canceled?
+              return if @cart.confirm? || @cart.complete? || @cart.canceled?
 
               loop do
+                break if @cart.payment?
                 break unless @cart.next
-                break if @cart.confirm? || @cart.complete?
               end
             rescue StandardError => e
               Rails.error.report(e, context: { order_id: @cart.id, state: @cart.state }, source: 'spree.checkout')

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/fulfillments_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/fulfillments_controller_spec.rb
@@ -79,6 +79,30 @@ RSpec.describe Spree::Api::V3::Store::Carts::FulfillmentsController, type: :cont
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'does not advance from payment to complete' do
+        create(:store_credit_payment_method)
+        credit = create(:store_credit, user: order.user, store: store, amount: order.total)
+        order.payments.create!(
+          source: credit,
+          payment_method: Spree::PaymentMethod::StoreCredit.first,
+          amount: (order.total / 2).to_d,
+          state: 'checkout',
+          response_code: credit.generate_authorization_code
+        )
+        rate = fulfillment.shipping_rates.first
+
+        patch :update, params: {
+          cart_id: order.prefixed_id,
+          id: fulfillment.to_param,
+          selected_delivery_rate_id: rate.to_param
+        }
+
+        expect(response).to have_http_status(:ok)
+        order.reload
+        expect(order.state).to eq('payment')
+        expect(order.completed_at).to be_nil
+      end
     end
 
     context 'error handling' do


### PR DESCRIPTION
### Problem
When: gift card is applied
On: changing shipping method
Error: Spree tries to complete the order, which results in a failure.

### Solution
As comment states for `try_advance` method:

> Auto-advance (e.g. delivery → payment) after rate selection.
> Temporary — Spree 6 removes the checkout state machine.

From now on we proceed up to payment state, not further.

https://github.com/user-attachments/assets/63858b15-7c36-4bde-a337-2adb61c8e495



