### PR TITLE
Allow payment session lookup by external_id

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/store/carts/payment_sessions_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts/payment_sessions_controller.rb
@@ -77,7 +77,8 @@ module Spree
             private
 
             def set_payment_session
-              @payment_session = @cart.payment_sessions.find_by_prefix_id!(params[:id])
+              @payment_session = @cart.payment_sessions.find_by_prefix_id(params[:id]) ||
+                                 @cart.payment_sessions.find_by!(external_id: params[:id])
             end
 
             def serialize_resource(resource)

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/payment_sessions_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/payment_sessions_controller_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe Spree::Api::V3::Store::Carts::PaymentSessionsController, type: :c
       expect(json_response['external_data']).to eq({ 'client_secret' => 'secret_123' })
     end
 
+    it 'finds payment session by external_id' do
+      get :show, params: { cart_id: order.prefixed_id, id: payment_session.external_id }
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['id']).to eq(payment_session.prefixed_id)
+    end
+
     context 'error handling' do
       it 'returns not found for non-existent payment session' do
         get :show, params: { cart_id: order.prefixed_id, id: 'ps_invalid' }
@@ -96,6 +103,18 @@ RSpec.describe Spree::Api::V3::Store::Carts::PaymentSessionsController, type: :c
                                payment_method: payment_method)
 
         get :show, params: { cart_id: order.prefixed_id, id: other_session.to_param }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns not found for external_id from another order' do
+        other_user = create(:user)
+        other_order = create(:order_with_line_items, user: other_user, store: store, state: 'payment')
+        other_session = create(:bogus_payment_session,
+                               order: other_order,
+                               payment_method: payment_method)
+
+        get :show, params: { cart_id: order.prefixed_id, id: other_session.external_id }
 
         expect(response).to have_http_status(:not_found)
       end
@@ -118,6 +137,14 @@ RSpec.describe Spree::Api::V3::Store::Carts::PaymentSessionsController, type: :c
 
       expect(response).to have_http_status(:ok)
       expect(json_response['status']).to eq('completed')
+    end
+
+    it 'completes the payment session by external_id' do
+      patch :complete, params: { cart_id: order.prefixed_id, id: payment_session.external_id, session_result: 'success' }
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['status']).to eq('completed')
+      expect(json_response['id']).to eq(payment_session.prefixed_id)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Payment sessions controller now falls back to `external_id` lookup when a `prefix_id` match is not found
- This enables storefront redirect flows where the payment provider (e.g. Adyen, PayPal) appends its own session ID to the return URL rather than Spree's prefixed ID
- Lookup remains scoped to the cart so sessions from other orders cannot be accessed

## Test plan
- [x] `GET #show` finds payment session by external_id
- [x] `GET #show` returns 404 for external_id from another order (scoping)
- [x] `PATCH #complete` completes payment session by external_id
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)