### PR TITLE
Fix Postgres 18 volume mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
Postgres 18+ changed the expected volume mount point from
`/var/lib/postgresql/data` to `/var/lib/postgresql`. The old path
caused the container to exit immediately on startup with:

  Error: there appears to be PostgreSQL data in /var/lib/postgresql/data

Updated the volume mount in docker-compose.yml to match the new
expected path.