### PR TITLE
Fixed Payment Sessions API concurrency issues

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/store/carts/payment_sessions_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts/payment_sessions_controller.rb
@@ -5,24 +5,27 @@ module Spree
         module Carts
           class PaymentSessionsController < Store::BaseController
             include Spree::Api::V3::CartResolvable
+            include Spree::Api::V3::OrderLock
 
             before_action :find_cart!
             before_action :set_payment_session, only: [:show, :update, :complete]
 
             # POST /api/v3/store/carts/:cart_id/payment_sessions
             def create
-              payment_method = current_store.payment_methods.find_by_prefix_id!(permitted_params[:payment_method_id])
+              with_order_lock do
+                payment_method = current_store.payment_methods.find_by_prefix_id!(permitted_params[:payment_method_id])
 
-              @payment_session = payment_method.create_payment_session(
-                order: @cart,
-                amount: permitted_params[:amount],
-                external_data: permitted_params[:external_data] || {}
-              )
+                @payment_session = payment_method.create_payment_session(
+                  order: @cart,
+                  amount: permitted_params[:amount],
+                  external_data: permitted_params[:external_data] || {}
+                )
 
-              if @payment_session.persisted?
-                render json: serialize_resource(@payment_session), status: :created
-              else
-                render_errors(@payment_session.errors)
+                if @payment_session.persisted?
+                  render json: serialize_resource(@payment_session), status: :created
+                else
+                  render_errors(@payment_session.errors)
+                end
               end
             end
 
@@ -33,30 +36,41 @@ module Spree
 
             # PATCH /api/v3/store/carts/:cart_id/payment_sessions/:id
             def update
-              @payment_session.payment_method.update_payment_session(
-                payment_session: @payment_session,
-                amount: permitted_params[:amount],
-                external_data: permitted_params[:external_data] || {}
-              )
+              with_order_lock do
+                @payment_session.payment_method.update_payment_session(
+                  payment_session: @payment_session,
+                  amount: permitted_params[:amount],
+                  external_data: permitted_params[:external_data] || {}
+                )
 
-              if @payment_session.errors.empty?
-                render json: serialize_resource(@payment_session.reload)
-              else
-                render_errors(@payment_session.errors)
+                if @payment_session.errors.empty?
+                  render json: serialize_resource(@payment_session.reload)
+                else
+                  render_errors(@payment_session.errors)
+                end
               end
             end
 
             # PATCH /api/v3/store/carts/:cart_id/payment_sessions/:id/complete
             def complete
-              @payment_session.payment_method.complete_payment_session(
-                payment_session: @payment_session,
-                params: complete_params
-              )
+              with_order_lock do
+                @payment_session.reload
 
-              if @payment_session.errors.empty?
-                render json: serialize_resource(@payment_session.reload)
-              else
-                render_errors(@payment_session.errors)
+                if @payment_session.completed?
+                  render json: serialize_resource(@payment_session)
+                  return
+                end
+
+                @payment_session.payment_method.complete_payment_session(
+                  payment_session: @payment_session,
+                  params: complete_params
+                )
+
+                if @payment_session.errors.empty?
+                  render json: serialize_resource(@payment_session.reload)
+                else
+                  render_errors(@payment_session.errors)
+                end
               end
             end
 

--- a/spree/api/app/controllers/spree/api/v3/store/carts/payment_sessions_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts/payment_sessions_controller.rb
@@ -37,6 +37,8 @@ module Spree
             # PATCH /api/v3/store/carts/:cart_id/payment_sessions/:id
             def update
               with_order_lock do
+                @payment_session.reload
+
                 @payment_session.payment_method.update_payment_session(
                   payment_session: @payment_session,
                   amount: permitted_params[:amount],

--- a/spree/api/app/controllers/spree/api/v3/webhooks/payments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/webhooks/payments_controller.rb
@@ -31,7 +31,7 @@ module Spree
 
             # Process asynchronously — gateways have timeout limits and will
             # retry on timeouts, so we must return 200 quickly.
-            Spree::Payments::HandleWebhookJob.perform_later(
+            Spree::Payments::HandleWebhookJob.set(wait: 5.seconds).perform_later(
               payment_method_id: payment_method.id,
               action: result[:action].to_s,
               payment_session_id: result[:payment_session].id

--- a/spree/api/app/controllers/spree/api/v3/webhooks/payments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/webhooks/payments_controller.rb
@@ -31,7 +31,7 @@ module Spree
 
             # Process asynchronously — gateways have timeout limits and will
             # retry on timeouts, so we must return 200 quickly.
-            Spree::Payments::HandleWebhookJob.set(wait: 5.seconds).perform_later(
+            Spree::Payments::HandleWebhookJob.set(wait: 30.seconds).perform_later(
               payment_method_id: payment_method.id,
               action: result[:action].to_s,
               payment_session_id: result[:payment_session].id

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/payment_sessions_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/payment_sessions_controller_spec.rb
@@ -146,5 +146,18 @@ RSpec.describe Spree::Api::V3::Store::Carts::PaymentSessionsController, type: :c
       expect(json_response['status']).to eq('completed')
       expect(json_response['id']).to eq(payment_session.prefixed_id)
     end
+
+    context 'when session is already completed' do
+      before do
+        payment_session.update_column(:status, 'completed')
+      end
+
+      it 'returns success without re-processing' do
+        patch :complete, params: { cart_id: order.prefixed_id, id: payment_session.to_param, session_result: 'success' }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['status']).to eq('completed')
+      end
+    end
   end
 end

--- a/spree/api/spec/controllers/spree/api/v3/webhooks/payments_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/webhooks/payments_controller_spec.rb
@@ -95,14 +95,18 @@ RSpec.describe Spree::Api::V3::Webhooks::PaymentsController, type: :controller d
         expect(response).to have_http_status(:ok)
       end
 
-      it 'enqueues HandleWebhookJob' do
-        expect {
-          post :create, params: { payment_method_id: payment_method.prefixed_id }
-        }.to have_enqueued_job(Spree::Payments::HandleWebhookJob).with(
-          payment_method_id: payment_method.id,
-          action: 'captured',
-          payment_session_id: payment_session.id
-        )
+      it 'enqueues HandleWebhookJob with a delay' do
+        Timecop.freeze do
+          expect {
+            post :create, params: { payment_method_id: payment_method.prefixed_id }
+          }.to have_enqueued_job(Spree::Payments::HandleWebhookJob)
+            .at(5.seconds.from_now)
+            .with(
+              payment_method_id: payment_method.id,
+              action: 'captured',
+              payment_session_id: payment_session.id
+            )
+        end
       end
     end
   end

--- a/spree/api/spec/controllers/spree/api/v3/webhooks/payments_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/webhooks/payments_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Spree::Api::V3::Webhooks::PaymentsController, type: :controller d
           expect {
             post :create, params: { payment_method_id: payment_method.prefixed_id }
           }.to have_enqueued_job(Spree::Payments::HandleWebhookJob)
-            .at(5.seconds.from_now)
+            .at(30.seconds.from_now)
             .with(
               payment_method_id: payment_method.id,
               action: 'captured',

--- a/spree/api/spec/serializers/spree/api/v3/payment_serializer_spec.rb
+++ b/spree/api/spec/serializers/spree/api/v3/payment_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Spree::Api::V3::PaymentSerializer do
         'id' => payment.prefixed_id,
         'status' => 'checkout',
         'number' => payment.number,
-        'response_code' => '12345'
+        'response_code' => payment.response_code
       )
       expect(subject['amount']).to be_present
     end

--- a/spree/core/app/models/spree/gateway/bogus.rb
+++ b/spree/core/app/models/spree/gateway/bogus.rb
@@ -32,7 +32,7 @@ module Spree
     def authorize(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id&.starts_with?('BGS-'))
-        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: generate_authorization, avs_result: { code: 'D' })
       else
         Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
       end
@@ -41,18 +41,18 @@ module Spree
     def purchase(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id&.starts_with?('BGS-'))
-        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
+        Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: generate_authorization, avs_result: { code: 'M' })
       else
         Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
       end
     end
 
     def credit(_money, _credit_card, _response_code, _options = {})
-      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: generate_authorization)
     end
 
     def capture(_money, authorization, _gateway_options)
-      if authorization == '12345'
+      if authorization&.start_with?('BGS-')
         Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true)
       else
         Spree::PaymentResponse.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
@@ -60,11 +60,11 @@ module Spree
     end
 
     def void(_response_code, _credit_card, _options = {})
-      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: 'void-12345')
+      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: "void-#{generate_authorization}")
     end
 
     def cancel(_response_code, _payment = nil)
-      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::PaymentResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: generate_authorization)
     end
 
     def test?
@@ -149,6 +149,10 @@ module Spree
     end
 
     private
+
+    def generate_authorization
+      "BGS-#{SecureRandom.hex(6)}"
+    end
 
     def generate_profile_id(success)
       record = true

--- a/spree/core/app/models/spree/payment.rb
+++ b/spree/core/app/models/spree/payment.rb
@@ -42,6 +42,7 @@ module Spree
 
     validates :payment_method, presence: true
     validates :source, presence: true, if: :source_required?
+    validates :response_code, uniqueness: { scope: [:order_id, :payment_method_id] }, allow_nil: true
     validate :payment_method_available_for_order, on: :create
 
     before_validation :validate_source

--- a/spree/core/app/models/spree/payment_session.rb
+++ b/spree/core/app/models/spree/payment_session.rb
@@ -92,6 +92,11 @@ module Spree
         p.amount = amount
         p.skip_source_requirement = true
       end
+    rescue ActiveRecord::RecordNotUnique
+      order.payments.find_by!(
+        payment_method: payment_method,
+        response_code: external_id
+      )
     end
 
     private

--- a/spree/core/app/services/spree/payments/handle_webhook.rb
+++ b/spree/core/app/services/spree/payments/handle_webhook.rb
@@ -30,6 +30,12 @@ module Spree
 
       def handle_success(payment_session, order, metadata)
         order.with_lock do
+          # Idempotency: if the session was already completed (by the API
+          # endpoint or a previous webhook), skip duplicate processing.
+          if payment_session.reload.completed?
+            return success(payment_session)
+          end
+
           # Ensure payment record exists
           payment = payment_session.find_or_create_payment!(metadata)
 

--- a/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
+++ b/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexToSpreePaymentsResponseCode < ActiveRecord::Migration[7.2]
+  def change
+    add_index :spree_payments, [:order_id, :payment_method_id, :response_code],
+              unique: true,
+              where: 'response_code IS NOT NULL',
+              name: 'idx_payments_order_method_response_code'
+  end
+end

--- a/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
+++ b/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
@@ -1,8 +1,16 @@
 class AddUniqueIndexToSpreePaymentsResponseCode < ActiveRecord::Migration[7.2]
   def change
-    add_index :spree_payments, [:order_id, :payment_method_id, :response_code],
-              unique: true,
-              where: 'response_code IS NOT NULL',
-              name: 'idx_payments_order_method_response_code'
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      # MySQL doesn't support partial indexes, but treats NULL as distinct
+      # in unique indexes so multiple payments with NULL response_code are allowed
+      add_index :spree_payments, [:order_id, :payment_method_id, :response_code],
+                unique: true,
+                name: 'idx_payments_order_method_response_code'
+    else
+      add_index :spree_payments, [:order_id, :payment_method_id, :response_code],
+                unique: true,
+                where: 'response_code IS NOT NULL',
+                name: 'idx_payments_order_method_response_code'
+    end
   end
 end

--- a/spree/core/db/sample_data/orders.rb
+++ b/spree/core/db/sample_data/orders.rb
@@ -122,7 +122,7 @@ if method
       source: credit_card.clone,
       payment_method: method
     ).first_or_create!
-    payment.update_columns(state: 'pending', response_code: '12345')
+    payment.update_columns(state: 'pending', response_code: "BGS-#{SecureRandom.hex(6)}")
   end
 end
 

--- a/spree/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/spree/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     order         { create(:order, total: amount) }
     amount        { 45.75 }
     state         { 'checkout' }
-    response_code { '12345' }
+    response_code { "BGS-#{SecureRandom.hex(6)}" }
 
     payment_method { create(:credit_card_payment_method, stores: [order.store]) }
     association(:source, factory: :credit_card)

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -259,7 +259,7 @@ describe Spree::Order, type: :model do
 
       it 'voids transactions for incomplete payments' do
         order.cancel
-        expect(order.reload.payments.pluck(:response_code).uniq).to contain_exactly('void-12345') # Bogus gateway responds with void-12345 response code
+        expect(order.reload.payments.pluck(:response_code)).to all(start_with('void-BGS-'))
       end
     end
   end

--- a/spree/core/spec/models/spree/payment_session_spec.rb
+++ b/spree/core/spec/models/spree/payment_session_spec.rb
@@ -288,5 +288,20 @@ RSpec.describe Spree::PaymentSession, type: :model do
       expect(payment_session.payment).to be_present
       expect(payment_session.find_or_create_payment!.id).to eq(payment_session.payment.id)
     end
+
+    it 'handles RecordNotUnique by returning the existing payment' do
+      existing = create(:payment,
+                        order: order,
+                        payment_method: payment_method,
+                        response_code: payment_session.external_id,
+                        amount: payment_session.amount)
+
+      # Simulate a race condition where find_or_create_by! raises RecordNotUnique
+      allow(order.payments).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
+
+      payment = payment_session.find_or_create_payment!
+
+      expect(payment.id).to eq(existing.id)
+    end
   end
 end

--- a/spree/core/spec/models/spree/payment_spec.rb
+++ b/spree/core/spec/models/spree/payment_spec.rb
@@ -533,7 +533,7 @@ describe Spree::Payment, type: :model do
         before do
           payment.amount = 100
           payment.state = 'pending'
-          payment.response_code = '12345'
+          payment.response_code = "BGS-#{SecureRandom.hex(6)}"
         end
 
         context 'if successful' do
@@ -656,7 +656,7 @@ describe Spree::Payment, type: :model do
           # Change it to something different
           payment.response_code = 'abc'
           payment.void_transaction!
-          expect(payment.response_code).to eq('void-12345')
+          expect(payment.response_code).to start_with('void-BGS-')
         end
       end
 

--- a/spree/core/spec/services/spree/payments/handle_webhook_spec.rb
+++ b/spree/core/spec/services/spree/payments/handle_webhook_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe Spree::Payments::HandleWebhook do
 
         expect(result).to be_success
       end
+
+      it 'does not create a duplicate payment' do
+        expect {
+          subject.call(payment_method: payment_method, action: :captured, payment_session: payment_session)
+        }.not_to change { order.payments.count }
+      end
     end
   end
 end


### PR DESCRIPTION
When a logged-in user completes their first order via Stripe, two concurrent code paths race to create the payment record:

1. API path: Frontend calls PATCH /payment_sessions/:id/complete which calls complete_payment_session (creates Payment, completes session), then POST /carts/:id/complete to finalize
the order.
2. Webhook path: Stripe sends a webhook immediately. HandleWebhookJob runs within milliseconds (Sidekiq), calls find_or_create_payment!, completes payment+session, completes order.

Both paths call find_or_create_payment! concurrently. Since there's no order-level lock on the API path and no unique index on (order_id, payment_method_id, response_code), two
Spree::Payment records are created. Result: duplicate payments on the order, duplicate saved cards in the customer's account.