### PR TITLE
Fix payment unique index migration to deduplicate first

### DIFF
--- a/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
+++ b/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
@@ -1,17 +1,32 @@
 class AddUniqueIndexToSpreePaymentsResponseCode < ActiveRecord::Migration[7.2]
   def up
     # Remove duplicate payments per (order, payment_method, response_code),
-    # keeping the one with the highest id (most recent).
+    # preferring to keep completed payments over incomplete ones.
+    # Among same-state duplicates, keeps the most recent (highest id).
     # Uses derived table for MySQL compatibility.
     execute <<~SQL
       DELETE FROM spree_payments
       WHERE response_code IS NOT NULL
         AND id NOT IN (
-          SELECT max_id FROM (
-            SELECT MAX(id) AS max_id
-            FROM spree_payments
-            WHERE response_code IS NOT NULL
-            GROUP BY order_id, payment_method_id, response_code
+          SELECT keeper_id FROM (
+            SELECT (
+              SELECT id FROM spree_payments p2
+              WHERE p2.order_id = p1.order_id
+                AND p2.payment_method_id = p1.payment_method_id
+                AND p2.response_code = p1.response_code
+              ORDER BY
+                CASE p2.state
+                  WHEN 'completed' THEN 0
+                  WHEN 'pending'   THEN 1
+                  WHEN 'processing' THEN 2
+                  ELSE 3
+                END,
+                p2.id DESC
+              LIMIT 1
+            ) AS keeper_id
+            FROM spree_payments p1
+            WHERE p1.response_code IS NOT NULL
+            GROUP BY p1.order_id, p1.payment_method_id, p1.response_code
           ) AS keeper_ids
         )
     SQL

--- a/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
+++ b/spree/core/db/migrate/20260424000001_add_unique_index_to_spree_payments_response_code.rb
@@ -1,5 +1,21 @@
 class AddUniqueIndexToSpreePaymentsResponseCode < ActiveRecord::Migration[7.2]
-  def change
+  def up
+    # Remove duplicate payments per (order, payment_method, response_code),
+    # keeping the one with the highest id (most recent).
+    # Uses derived table for MySQL compatibility.
+    execute <<~SQL
+      DELETE FROM spree_payments
+      WHERE response_code IS NOT NULL
+        AND id NOT IN (
+          SELECT max_id FROM (
+            SELECT MAX(id) AS max_id
+            FROM spree_payments
+            WHERE response_code IS NOT NULL
+            GROUP BY order_id, payment_method_id, response_code
+          ) AS keeper_ids
+        )
+    SQL
+
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
       # MySQL doesn't support partial indexes, but treats NULL as distinct
       # in unique indexes so multiple payments with NULL response_code are allowed
@@ -12,5 +28,9 @@ class AddUniqueIndexToSpreePaymentsResponseCode < ActiveRecord::Migration[7.2]
                 where: 'response_code IS NOT NULL',
                 name: 'idx_payments_order_method_response_code'
     end
+  end
+
+  def down
+    remove_index :spree_payments, name: 'idx_payments_order_method_response_code'
   end
 end


### PR DESCRIPTION
## Summary
- Fixes `PG::UniqueViolation` when running the `add_unique_index_to_spree_payments_response_code` migration on databases with existing duplicate payment records
- Deletes duplicate payments (keeping the most recent) before creating the unique index
- Uses derived table pattern for MySQL compatibility

Followup to #13938

## Test plan
- [ ] Run migration on a database with duplicate `response_code` payments — should succeed
- [ ] Run `bundle exec rspec spec/models/spree/payment_spec.rb` — all pass
- [ ] Verify index exists after migration: `\d spree_payments` shows `idx_payments_order_method_response_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)