### PR TITLE
State Based Zone -> update states on country change

### DIFF
--- a/spree/admin/app/controllers/spree/admin/states_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/states_controller.rb
@@ -1,12 +1,12 @@
 module Spree
   module Admin
-    class StatesController < Spree::Admin::BaseController
-      def select_options
-        states = Spree::State.accessible_by(current_ability)
-        states = states.where(country_id: params[:country_id]) if params[:country_id].present?
-        states = states.order(:name)
+    class StatesController < ResourceController
+      belongs_to 'spree/country', find_by: :id
 
-        render json: states.pluck(:id, :name).map { |id, name| { id: id, name: name } }
+      def select_options
+        states = @country.states.accessible_by(current_ability).order(:name)
+
+        render json: states.to_tom_select_json
       end
     end
   end

--- a/spree/admin/app/controllers/spree/admin/states_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/states_controller.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Admin
+    class StatesController < Spree::Admin::BaseController
+      def select_options
+        states = Spree::State.accessible_by(current_ability)
+        states = states.where(country_id: params[:country_id]) if params[:country_id].present?
+        states = states.order(:name)
+
+        render json: states.pluck(:id, :name).map { |id, name| { id: id, name: name } }
+      end
+    end
+  end
+end

--- a/spree/admin/app/controllers/spree/admin/zones_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/zones_controller.rb
@@ -23,7 +23,6 @@ module Spree
           current_store.default_country
         end
         @countries = Country.order(:name)
-        @states = @selected_country&.states&.order(:name) || Spree::State.none
         @zones = Zone.order(:name)
       end
 

--- a/spree/admin/app/javascript/spree/admin/application.js
+++ b/spree/admin/app/javascript/spree/admin/application.js
@@ -92,6 +92,7 @@ import TooltipController from 'spree/admin/controllers/tooltip_controller'
 import TurboSubmitButtonController from 'spree/admin/controllers/turbo_submit_button_controller'
 import UnitSystemController from 'spree/admin/controllers/unit_system_controller'
 import VariantsFormController from 'spree/admin/controllers/variants_form_controller'
+import ZoneStateSelectController from 'spree/admin/controllers/zone_state_select_controller'
 import BulkEditorController from 'spree/admin/controllers/bulk_editor_controller'
 import AddressAutocompleteController from 'spree/core/controllers/address_autocomplete_controller'
 import AddressFormController from 'spree/core/controllers/address_form_controller'
@@ -166,6 +167,7 @@ application.register('turbo-submit-button', TurboSubmitButtonController)
 application.register('textarea-autogrow', TextareaAutogrow)
 application.register('unit-system', UnitSystemController)
 application.register('variants-form', VariantsFormController)
+application.register('zone-state-select', ZoneStateSelectController)
 application.register('bulk-editor', BulkEditorController)
 
 LocalTime.start()

--- a/spree/admin/app/javascript/spree/admin/controllers/zone_state_select_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/zone_state_select_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
 
     if (!countryId) return
 
-    const url = `${this.urlValue}?country_id=${countryId}`
+    const url = this.urlValue.replace(':country_id', countryId)
     const response = await get(url, { contentType: 'application/json' })
 
     if (response.ok) {

--- a/spree/admin/app/javascript/spree/admin/controllers/zone_state_select_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/zone_state_select_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+import { get } from '@rails/request.js'
+
+export default class extends Controller {
+  static values = {
+    url: String
+  }
+
+  static targets = ["statesSelect"]
+
+  async countryChanged(event) {
+    const countryId = event.target.value
+    const statesInput = this.statesSelectTarget.querySelector('select')
+    if (!statesInput || !statesInput.tomselect) return
+
+    const tomSelect = statesInput.tomselect
+    tomSelect.clear()
+    tomSelect.clearOptions()
+
+    if (!countryId) return
+
+    const url = `${this.urlValue}?country_id=${countryId}`
+    const response = await get(url, { contentType: 'application/json' })
+
+    if (response.ok) {
+      const states = await response.json
+      states.forEach(state => tomSelect.addOption(state))
+      tomSelect.refreshOptions(false)
+    }
+  }
+}

--- a/spree/admin/app/views/spree/admin/zones/_state_members.html.erb
+++ b/spree/admin/app/views/spree/admin/zones/_state_members.html.erb
@@ -1,4 +1,4 @@
-<div id="state_members">
+<div id="state_members" data-controller="zone-state-select" data-zone-state-select-url-value="<%= spree.admin_states_select_options_path %>">
   <div class="card mb-6">
     <div class="card-header">
       <h5 class="card-title">
@@ -9,12 +9,22 @@
     <div class="card-body">
       <div class="form-group">
         <%= label_tag :states_country_id, Spree.t(:country) %>
-        <%= tom_select_tag :states_country_id, class: 'w-full', options: Spree::Country.joins(:states).to_tom_select_json, active_option: @selected_country&.id, select_data: {action: "auto-submit#submit"} %>
+        <%= tom_select_tag :states_country_id,
+          class: 'w-full',
+          options: Spree::Country.joins(:states).distinct.to_tom_select_json,
+          active_option: @selected_country&.id,
+          select_data: {action: "change->zone-state-select#countryChanged"}
+        %>
       </div>
 
-      <div class="form-group">
+      <div class="form-group" data-zone-state-select-target="statesSelect">
         <%= zone_form.label :state_ids, Spree.t(:states) %>
-        <%= tom_select_tag 'zone[state_ids]', multiple: true, class: 'w-full', options: @states.to_tom_select_json, active_option: @zone.state_ids %>
+        <%= tom_select_tag 'zone[state_ids]',
+          multiple: true,
+          class: 'w-full',
+          options: @states.to_tom_select_json,
+          active_option: @zone.state_ids
+        %>
       </div>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/zones/_state_members.html.erb
+++ b/spree/admin/app/views/spree/admin/zones/_state_members.html.erb
@@ -1,4 +1,4 @@
-<div id="state_members" data-controller="zone-state-select" data-zone-state-select-url-value="<%= spree.admin_states_select_options_path %>">
+<div id="state_members" data-controller="zone-state-select" data-zone-state-select-url-value="<%= spree.select_options_admin_country_states_path(':country_id') %>">
   <div class="card mb-6">
     <div class="card-header">
       <h5 class="card-title">
@@ -22,7 +22,7 @@
         <%= tom_select_tag 'zone[state_ids]',
           multiple: true,
           class: 'w-full',
-          options: @states.to_tom_select_json,
+          url: @selected_country ? spree.select_options_admin_country_states_path(@selected_country) : nil,
           active_option: @zone.state_ids
         %>
       </div>

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -462,7 +462,7 @@ Rails.application.config.after_initialize do
                                      position: 30,
                                      ransack_attribute: 'addresses_country_name',
                                      operators: %i[eq],
-                                     search_url: ->(view_context) { view_context.spree.admin_countries_select_options_path(format: :json) },
+                                     search_url: ->(view_context) { view_context.spree.select_options_admin_countries_path(format: :json) },
                                      partial: 'spree/admin/tables/columns/user_location'
 
   # Number of orders

--- a/spree/admin/config/routes.rb
+++ b/spree/admin/config/routes.rb
@@ -62,10 +62,18 @@ Spree::Core::Engine.add_routes do
     end
     get '/taxons/select_options' => 'taxons#select_options', as: :taxons_select_options, defaults: { format: :json }
     get '/tags/select_options' => 'tags#select_options', as: :tags_select_options, defaults: { format: :json }
-    get '/countries/select_options' => 'countries#select_options', as: :countries_select_options, defaults: { format: :json }
     get '/users/select_options' => 'users#select_options', as: :users_select_options, defaults: { format: :json }
-    get '/states/select_options' => 'states#select_options', as: :states_select_options, defaults: { format: :json }
     get '/stock_locations/select_options' => 'stock_locations#select_options', as: :stock_locations_select_options, defaults: { format: :json }
+    resources :countries, only: [] do
+      collection do
+        get :select_options, defaults: { format: :json }
+      end
+      resources :states, only: [] do
+        collection do
+          get :select_options, defaults: { format: :json }
+        end
+      end
+    end
 
     # media library
     resources :assets, only: [:create, :edit, :update, :destroy] do

--- a/spree/admin/config/routes.rb
+++ b/spree/admin/config/routes.rb
@@ -64,6 +64,7 @@ Spree::Core::Engine.add_routes do
     get '/tags/select_options' => 'tags#select_options', as: :tags_select_options, defaults: { format: :json }
     get '/countries/select_options' => 'countries#select_options', as: :countries_select_options, defaults: { format: :json }
     get '/users/select_options' => 'users#select_options', as: :users_select_options, defaults: { format: :json }
+    get '/states/select_options' => 'states#select_options', as: :states_select_options, defaults: { format: :json }
     get '/stock_locations/select_options' => 'stock_locations#select_options', as: :stock_locations_select_options, defaults: { format: :json }
 
     # media library

--- a/spree/admin/spec/controllers/spree/admin/states_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/states_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::StatesController, type: :controller do
+  stub_authorization!
+
+  render_views
+
+  describe 'GET #select_options' do
+    subject { get :select_options, params: { country_id: country_id }, format: :json }
+
+    let(:country_id) { country_a.id }
+    let(:json) { JSON.parse(response.body) }
+    let(:names) { json.map { |s| s['name'] } }
+
+    let!(:country_a) { create(:country) }
+    let!(:country_b) { create(:country) }
+    let!(:empty_country) { create(:country) }
+    let!(:state_a1) { create(:state, name: 'Alabama', country: country_a) }
+    let!(:state_a2) { create(:state, name: 'California', country: country_a) }
+    let!(:state_b1) { create(:state, name: 'Ontario', country: country_b) }
+
+    it 'returns states for a given country' do
+      subject
+
+      expect(names).to contain_exactly('Alabama', 'California')
+    end
+
+    it 'returns states ordered by name' do
+      subject
+
+      expect(names).to eq(names.sort)
+    end
+
+    context 'when country has no states' do
+      let(:country_id) { empty_country.id }
+
+      it 'returns empty array' do
+        subject
+
+        expect(json).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches admin routing plus Stimulus/TomSelect behavior for zone state selection; regressions could break zone editing or select-option endpoints but scope is limited to admin UI JSON helpers.
> 
> **Overview**
> Improves **state-based zone editing** by dynamically reloading the available states when the selected country changes, instead of relying on a full form auto-submit.
> 
> Adds a nested admin JSON endpoint `countries/:country_id/states/select_options` via a new `Spree::Admin::StatesController#select_options`, and wires a new Stimulus controller (`zone-state-select`) to fetch and repopulate the TomSelect state multiselect on country change.
> 
> Cleans up related plumbing: removes eager-loading `@states` from `ZonesController#load_data`, makes the country list `distinct`, and updates the users table location filter to use the new `select_options_admin_countries_path` route helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6623b13e56b4d657a1e45e3a01734d2bef4a7f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->