### PR TITLE
Move CreditCard/PaymentSource post destroy cleanup to models/concern

### DIFF
--- a/spree/core/app/models/concerns/spree/payment_source_concern.rb
+++ b/spree/core/app/models/concerns/spree/payment_source_concern.rb
@@ -2,6 +2,10 @@ module Spree
   module PaymentSourceConcern
     extend ActiveSupport::Concern
 
+    included do
+      before_destroy :cleanup_payments_on_incomplete_orders
+    end
+
     # Available actions for the payment source.
     # @return [Array<String>]
     def actions
@@ -34,6 +38,20 @@ module Spree
     # @return [Boolean]
     def has_payment_profile?
       gateway_customer_profile_id.present? || gateway_payment_profile_id.present?
+    end
+
+    private
+
+    # Cleans up payments on incomplete orders before the source is destroyed.
+    # Invalidates checkout-state payments and voids non-checkout payments.
+    def cleanup_payments_on_incomplete_orders
+      incomplete_payments = Spree::Payment.valid
+                                          .where(source: self)
+                                          .joins(:order)
+                                          .merge(Spree::Order.incomplete)
+
+      incomplete_payments.checkout.each(&:invalidate!)
+      incomplete_payments.where.not(state: :checkout).each(&:void!)
     end
   end
 end

--- a/spree/core/app/models/concerns/spree/payment_source_concern.rb
+++ b/spree/core/app/models/concerns/spree/payment_source_concern.rb
@@ -44,9 +44,12 @@ module Spree
 
     # Cleans up payments on incomplete orders before the source is destroyed.
     # Invalidates checkout-state payments and voids non-checkout payments.
+    # Skips payments whose payment_method was already nullified (e.g. when
+    # the payment method itself is being destroyed).
     def cleanup_payments_on_incomplete_orders
       incomplete_payments = Spree::Payment.valid
                                           .where(source: self)
+                                          .where.not(payment_method_id: nil)
                                           .joins(:order)
                                           .merge(Spree::Order.incomplete)
 

--- a/spree/core/app/services/spree/credit_cards/destroy.rb
+++ b/spree/core/app/services/spree/credit_cards/destroy.rb
@@ -1,40 +1,24 @@
 module Spree
   module CreditCards
+    # @deprecated Use card.destroy directly instead. Payment cleanup is now
+    #   handled by the before_destroy callback in Spree::PaymentSourceConcern.
+    #   This service will be removed in Spree 6.0.
     class Destroy
       prepend Spree::ServiceModule::Base
 
       def call(card:)
-        ApplicationRecord.transaction do
-          run :invalidate_payments
-          run :void_payments
-          run :destroy
-        end
-      end
+        Spree::Deprecation.warn(
+          "#{self.class.name} is deprecated and will be removed in Spree 6.0. " \
+          'Use card.destroy directly instead. Payment cleanup is now handled ' \
+          'automatically by the before_destroy callback in PaymentSourceConcern.',
+          caller
+        )
 
-      protected
-
-      def invalidate_payments(card:)
-        payment_scope(card).checkout.each(&:invalidate!)
-
-        success(card: card)
-      end
-
-      def void_payments(card:)
-        payment_scope(card).where.not(state: :checkout).each(&:void!)
-
-        success(card: card)
-      end
-
-      def destroy(card:)
         if card.destroy
           success(card: card)
         else
-          failure(card.errors.full_messages.to_sentance)
+          failure(card.errors.full_messages.to_sentence)
         end
-      end
-
-      def payment_scope(card)
-        card.payments.valid.joins(:order).merge(Spree::Order.incomplete)
       end
     end
   end

--- a/spree/core/spec/models/spree/credit_card_spec.rb
+++ b/spree/core/spec/models/spree/credit_card_spec.rb
@@ -428,4 +428,48 @@ describe Spree::CreditCard, type: :model do
       it { expect(credit_card.wallet_type).to eq('apple_pay') }
     end
   end
+
+  describe '#destroy (PaymentSourceConcern callback)' do
+    let!(:incomplete_order) { create(:order_with_line_items) }
+    let!(:card) { create(:credit_card, user_id: incomplete_order.user_id) }
+
+    context 'with checkout-state payments on incomplete orders' do
+      let!(:checkout_payment) { create(:payment, source: card, order: incomplete_order) }
+
+      it 'invalidates the payment' do
+        card.destroy
+
+        expect(checkout_payment.reload.state).to eq('invalid')
+      end
+    end
+
+    context 'with non-checkout payments on incomplete orders' do
+      let!(:completed_payment) { create(:payment, source: card, order: incomplete_order, state: 'completed') }
+      let!(:pending_payment) { create(:payment, source: card, order: incomplete_order, state: 'pending') }
+
+      it 'voids the payments' do
+        card.destroy
+
+        expect(completed_payment.reload.state).to eq('void')
+        expect(pending_payment.reload.state).to eq('void')
+      end
+    end
+
+    context 'with payments on completed orders' do
+      let!(:completed_order) { create(:completed_order_with_pending_payment, user_id: incomplete_order.user_id) }
+      let!(:completed_order_payment) { create(:payment, source: card, order: completed_order, state: 'completed', amount: completed_order.total) }
+
+      it 'does not modify payments on completed orders' do
+        card.destroy
+
+        expect(completed_order_payment.reload.state).to eq('completed')
+      end
+    end
+
+    it 'soft deletes the credit card' do
+      card.destroy
+
+      expect(card.reload.deleted_at).not_to be_nil
+    end
+  end
 end

--- a/spree/core/spec/services/spree/credit_cards/destroy_spec.rb
+++ b/spree/core/spec/services/spree/credit_cards/destroy_spec.rb
@@ -3,61 +3,38 @@ require 'spec_helper'
 describe Spree::CreditCards::Destroy, type: :service do
   subject { described_class.call(card: credit_card) }
 
-  let!(:order)  { create(:order_with_line_items) }
-  let!(:credit_card)  { create(:credit_card, user_id: order.user_id) }
+  let!(:order) { create(:order_with_line_items) }
+  let!(:credit_card) { create(:credit_card, user_id: order.user_id) }
+
+  before do
+    allow(Spree::Deprecation).to receive(:warn)
+  end
 
   describe '#call' do
-    let!(:payment)          { create(:payment, source: credit_card, order: order) }
-    let!(:complete_payment) { create(:payment, source: credit_card, order: order, state: 'completed') }
+    it 'emits a deprecation warning' do
+      subject
 
-    it 'destroy credit_card and update payment state' do
-      res = subject
-
-      expect(res.success).to eq true
-      expect(payment.reload.state).to eq 'invalid'
-      expect(complete_payment.reload.state).to eq 'void'
-      expect(credit_card.deleted_at).not_to be_nil
+      expect(Spree::Deprecation).to have_received(:warn).with(/deprecated and will be removed in Spree 6.0/, anything)
     end
-  end
 
-  describe '#invalidate_payments' do
-    let!(:completed_order)        { create(:completed_order_with_pending_payment, user_id: order.user_id) }
-    let!(:payment)                { create(:payment, source: credit_card, order: order, amount: order.total) }
-    let!(:complete_order_payment) { create(:payment, source: credit_card, order: completed_order, state: 'completed', amount: completed_order.total) }
-
-    it 'destroy credit_card and invalidate valid checkout payments' do
-      res = subject
-
-      expect(res.success).to eq true
-      expect(payment.reload.state).to eq 'invalid'
-      expect(complete_order_payment.reload.state).to eq 'completed'
-      expect(credit_card.deleted_at).not_to be_nil
-    end
-  end
-
-  describe '#void_payments' do
-    let!(:completed_payment)  { create(:payment, source: credit_card, order: order, state: 'completed') }
-    let!(:processing_payment) { create(:payment, source: credit_card, order: order, state: 'processing') }
-    let!(:pending_payment)    { create(:payment, source: credit_card, order: order, state: 'pending') }
-
-    it 'destroy credit_card and void valid payments' do
-      res = subject
-
-      expect(res.success).to eq true
-      expect(credit_card.deleted_at).not_to be_nil
-      expect(completed_payment.reload.state).to eq 'void'
-      expect(processing_payment.reload.state).to eq 'void'
-      expect(pending_payment.reload.state).to eq 'void'
-    end
-  end
-
-  describe '#destroy' do
-    it 'remove credit_card' do
-      expect(credit_card.deleted_at).to be_nil
-
+    it 'still destroys the credit card' do
       subject
 
       expect(credit_card.reload.deleted_at).not_to be_nil
+    end
+
+    context 'with payments on incomplete orders' do
+      let!(:payment) { create(:payment, source: credit_card, order: order) }
+      let!(:complete_payment) { create(:payment, source: credit_card, order: order, state: 'completed') }
+
+      it 'cleans up payments via the before_destroy callback' do
+        res = subject
+
+        expect(res.success).to eq true
+        expect(payment.reload.state).to eq 'invalid'
+        expect(complete_payment.reload.state).to eq 'void'
+        expect(credit_card.deleted_at).not_to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Previously this lived only in a legacy api v2 service