### PR TITLE
Fix admin product lookup failing when user locale differs from store default

### DIFF
--- a/spree/admin/app/controllers/spree/admin/products_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/products_controller.rb
@@ -124,7 +124,9 @@ module Spree
       protected
 
       def find_resource
-        current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
+        find_with_fallback_default_locale do
+          current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
+        end
       end
 
       def load_data

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -481,6 +481,20 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
       expect(response).to render_template(:edit)
     end
 
+    context 'when admin locale differs from default store locale' do
+      before do
+        store.update!(default_locale: 'en', supported_locales: 'en,da')
+        allow(controller).to receive(:add_breadcrumb_for_product)
+      end
+
+      it 'falls back to default locale when product slug is not translated' do
+        slug = Mobility.with_locale('en') { product.slug }
+        allow(controller).to receive(:current_locale).and_return('da')
+        get :edit, params: { id: slug }
+        expect(assigns(:product)).to eq(product)
+      end
+    end
+
     context 'with variants' do
       let!(:variant) { create(:variant, product: product) }
 


### PR DESCRIPTION
When an admin user's selected_locale was set to a non-default locale,
navigating to any product edit page would fail with a RecordNotFound
error and redirect with an error flash.

The store API's find_resource already handled this via
find_with_fallback_default_locale — if the product slug isn't found in
the current locale, it retries in the store's default locale. The admin
products controller was missing this fallback.

Fix: wrap find_resource in find_with_fallback_default_locale, matching
the same pattern used in the store API.

Fixes #13320