### PR TITLE
Fix address id setters nuyllifying existing address on failed ownership check

### DIFF
--- a/spree/core/app/models/spree/order/address_book.rb
+++ b/spree/core/app/models/spree/order/address_book.rb
@@ -16,14 +16,16 @@ module Spree
       def bill_address_id=(id)
         return if bill_address_id == id
 
-        address = Spree::Address.find_by(id: id)
-        # rubocop:disable Style/ConditionalAssignment
-        if address && user_id.present? && address.user_id == user_id
-          self['bill_address_id'] = address.id
-        else
+        if id.nil?
           self['bill_address_id'] = nil
+          reset_bill_address
+          return
         end
-        # rubocop:enable Style/ConditionalAssignment
+
+        address = Spree::Address.find_by(id: id)
+        return unless address && user_id.present? && address.user_id == user_id
+
+        self['bill_address_id'] = address.id
         reset_bill_address
       end
 
@@ -35,14 +37,16 @@ module Spree
       def ship_address_id=(id)
         return if ship_address_id == id
 
-        address = Spree::Address.find_by(id: id)
-        # rubocop:disable Style/ConditionalAssignment
-        if address && user_id.present? && address.user_id == user_id
-          self['ship_address_id'] = address.id
-        else
+        if id.nil?
           self['ship_address_id'] = nil
+          reset_ship_address
+          return
         end
-        # rubocop:enable Style/ConditionalAssignment
+
+        address = Spree::Address.find_by(id: id)
+        return unless address && user_id.present? && address.user_id == user_id
+
+        self['ship_address_id'] = address.id
         reset_ship_address
       end
 

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -2003,8 +2003,8 @@ describe Spree::Order, type: :model do
     context 'when assigned address does not belong to user' do
       let(:address) { create(:address, user: create(:user)) }
 
-      it 'sets order bill address to nil' do
-        expect { subject }.to change { order.bill_address_id }.to(nil)
+      it 'does not change the existing bill address' do
+        expect { subject }.not_to(change { order.bill_address_id })
       end
     end
 
@@ -2021,8 +2021,8 @@ describe Spree::Order, type: :model do
       end
 
       context 'when assigning a different existing address' do
-        it 'sets order bill address to nil' do
-          expect { subject }.to change { order.bill_address_id }.to(nil)
+        it 'does not change the existing bill address' do
+          expect { subject }.not_to(change { order.bill_address_id })
         end
       end
     end
@@ -2108,8 +2108,8 @@ describe Spree::Order, type: :model do
     context 'when assigned address does not belong to user' do
       let(:address) { create(:address, user: create(:user)) }
 
-      it 'sets order ship address to nil' do
-        expect { subject }.to change { order.ship_address_id }.to(nil)
+      it 'does not change the existing ship address' do
+        expect { subject }.not_to(change { order.ship_address_id })
       end
     end
 
@@ -2126,8 +2126,8 @@ describe Spree::Order, type: :model do
       end
 
       context 'when assigning a different existing address' do
-        it 'sets order ship address to nil' do
-          expect { subject }.to change { order.ship_address_id }.to(nil)
+        it 'does not change the existing ship address' do
+          expect { subject }.not_to(change { order.ship_address_id })
         end
       end
     end


### PR DESCRIPTION
The bill_address_id= and ship_address_id= setters validated that the
incoming address belongs to the order's user before assigning it — a
correct security measure. However, when that check failed, they set the
address_id to nil instead of simply ignoring the invalid assignment.

This caused completed orders to silently lose their billing and shipping
addresses in scenarios such as:
- A guest address (user_id: nil) being re-assigned after the order was
  associated with a user account
- An address belonging to a different user being passed (e.g. from admin)
- An address that no longer exists being referenced

Fix: return early without changing the current value when the ownership
check fails. Explicit nil assignment (to clear an address) still works.
Both setters are fixed identically.

Fixes #13293