### PR TITLE
Fix PostgreSQL volume mount path in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
## Summary
Updated the PostgreSQL volume mount path in docker-compose.yml to use the correct directory for data persistence.

## Changes
- Changed PostgreSQL volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
  - This aligns with the standard PostgreSQL data directory structure where the `data` subdirectory is created automatically by PostgreSQL during initialization
  - Prevents potential issues with nested data directories that could occur with the previous path

## Details
The volume mount path has been corrected to follow PostgreSQL's expected directory layout. PostgreSQL will automatically create and manage the `data` subdirectory within `/var/lib/postgresql`, so mounting directly to `/var/lib/postgresql` is the proper approach for containerized deployments.

https://claude.ai/code/session_011pHi8zPHy4G1FbcNbwv341