### PR TITLE
Paginate option values in admin option type form

### DIFF
--- a/spree/admin/app/controllers/spree/admin/option_types_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/option_types_controller.rb
@@ -8,11 +8,10 @@ module Spree
 
       before_action :add_breadcrumbs
 
-      OPTION_VALUES_PER_PAGE = 50
-
       private
 
       def setup_option_values
+        per_page = Spree::Admin::RuntimeConfig.admin_option_values_per_page
         @option_values_page = [params[:option_values_page].to_i, 1].max
         @option_values_total = @option_type.option_values.count
 
@@ -22,9 +21,9 @@ module Spree
           @option_values_pages = 1
         else
           @option_values = @option_type.option_values.order(:position)
-                             .offset((@option_values_page - 1) * OPTION_VALUES_PER_PAGE)
-                             .limit(OPTION_VALUES_PER_PAGE)
-          @option_values_pages = (@option_values_total.to_f / OPTION_VALUES_PER_PAGE).ceil
+                             .offset((@option_values_page - 1) * per_page)
+                             .limit(per_page)
+          @option_values_pages = (@option_values_total.to_f / per_page).ceil
         end
       end
 

--- a/spree/admin/app/controllers/spree/admin/option_types_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/option_types_controller.rb
@@ -1,17 +1,31 @@
 module Spree
   module Admin
     class OptionTypesController < ResourceController
-      before_action :setup_new_option_value, only: :edit
+      before_action :setup_option_values, only: [:edit, :new]
 
       include ProductsBreadcrumbConcern
       add_breadcrumb Spree.t(:options), :admin_option_types_path
 
       before_action :add_breadcrumbs
 
+      OPTION_VALUES_PER_PAGE = 50
+
       private
 
-      def setup_new_option_value
-        @option_type.option_values.build if @option_type.option_values.empty?
+      def setup_option_values
+        @option_values_page = [params[:option_values_page].to_i, 1].max
+        @option_values_total = @option_type.option_values.count
+
+        if @option_values_total == 0
+          @option_type.option_values.build
+          @option_values = @option_type.option_values
+          @option_values_pages = 1
+        else
+          @option_values = @option_type.option_values.order(:position)
+                             .offset((@option_values_page - 1) * OPTION_VALUES_PER_PAGE)
+                             .limit(OPTION_VALUES_PER_PAGE)
+          @option_values_pages = (@option_values_total.to_f / OPTION_VALUES_PER_PAGE).ceil
+        end
       end
 
       def add_breadcrumbs

--- a/spree/admin/app/views/spree/admin/option_types/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/option_types/_form.html.erb
@@ -76,7 +76,8 @@
       <% if @option_values_pages > 1 %>
         <div class="flex items-center justify-between p-3 border-t">
           <span class="text-sm text-gray-500">
-            Showing <%= (@option_values_page - 1) * Spree::Admin::OptionTypesController::OPTION_VALUES_PER_PAGE + 1 %>-<%= [@option_values_page * Spree::Admin::OptionTypesController::OPTION_VALUES_PER_PAGE, @option_values_total].min %> of <%= @option_values_total %>
+            <% per_page = Spree::Admin::RuntimeConfig.admin_option_values_per_page %>
+            Showing <%= (@option_values_page - 1) * per_page + 1 %>-<%= [@option_values_page * per_page, @option_values_total].min %> of <%= @option_values_total %>
           </span>
           <div class="flex gap-1.5">
             <% if @option_values_page > 1 %>

--- a/spree/admin/app/views/spree/admin/option_types/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/option_types/_form.html.erb
@@ -36,6 +36,11 @@
   <div class="card mb-6">
     <div class="card-header flex justify-between items-center">
       <h5 class="card-title"><%= Spree.t(:option_values) %></h5>
+      <% if @option_values_total > 0 %>
+        <span class="text-sm text-gray-500">
+          <%= @option_values_total %> <%= 'value'.pluralize(@option_values_total) %>
+        </span>
+      <% end %>
     </div>
     <div class="card-body p-0">
       <div class="table-responsive">
@@ -50,8 +55,7 @@
             </tr>
           </thead>
           <tbody id="option_values" data-controller="sortable" data-sortable-handle-value=".move-handle" data-sortable-resource-name-value="option_value" data-sortable-response-kind-value="turbo-stream">
-            <% @option_type.option_values.build if @option_type.option_values.empty? %>
-            <%= f.fields_for :option_values do |option_value_form| %>
+            <%= f.fields_for :option_values, @option_values do |option_value_form| %>
               <%= render partial: 'option_value_fields', locals: { f: option_value_form, option_type: @option_type } %>
             <% end %>
 
@@ -69,5 +73,35 @@
           </tbody>
         </table>
       </div>
+      <% if @option_values_pages > 1 %>
+        <div class="flex items-center justify-between p-3 border-t">
+          <span class="text-sm text-gray-500">
+            Showing <%= (@option_values_page - 1) * Spree::Admin::OptionTypesController::OPTION_VALUES_PER_PAGE + 1 %>-<%= [@option_values_page * Spree::Admin::OptionTypesController::OPTION_VALUES_PER_PAGE, @option_values_total].min %> of <%= @option_values_total %>
+          </span>
+          <div class="flex gap-1.5">
+            <% if @option_values_page > 1 %>
+              <%= link_to icon('chevron-left', class: 'text-gray-900 mr-0'),
+                  spree.edit_admin_option_type_path(@option_type, option_values_page: @option_values_page - 1),
+                  class: "btn btn-light p-2",
+                  'aria-label': 'Previous page' %>
+            <% else %>
+              <button class="btn btn-light p-2 cursor-not-allowed opacity-50" disabled>
+                <%= icon('chevron-left', class: 'text-gray-900 mr-0') %>
+              </button>
+            <% end %>
+
+            <% if @option_values_page < @option_values_pages %>
+              <%= link_to icon('chevron-right', class: 'text-gray-900 mr-0'),
+                  spree.edit_admin_option_type_path(@option_type, option_values_page: @option_values_page + 1),
+                  class: "btn btn-light p-2",
+                  'aria-label': 'Next page' %>
+            <% else %>
+              <button class="btn btn-light p-2 cursor-not-allowed opacity-50" disabled>
+                <%= icon('chevron-right', class: 'text-gray-900 mr-0') %>
+              </button>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>

--- a/spree/admin/lib/spree/admin/runtime_configuration.rb
+++ b/spree/admin/lib/spree/admin/runtime_configuration.rb
@@ -11,6 +11,7 @@ module Spree
       preference :admin_records_per_page, :integer, default: DEFAULT_PER_PAGE
       preference :admin_products_per_page, :integer, default: DEFAULT_PER_PAGE
       preference :admin_orders_per_page, :integer, default: DEFAULT_PER_PAGE
+      preference :admin_option_values_per_page, :integer, default: 50
 
       preference :include_application_importmap, :boolean, default: false
       preference :legacy_sidebar_navigation, :boolean, default: false


### PR DESCRIPTION
## Summary
- Option types with thousands of values (e.g. from CSV imports) caused the edit page to hang — 7.5s render time rendering all values as nested form fields at once
- Paginates option values at 50 per page with prev/next navigation
- Shows total count in the card header
- Form submission only updates visible rows; omitted rows are untouched since `accepts_nested_attributes_for` only processes present attributes

## Test plan
- [ ] Edit an option type with few values (<50) — no pagination shown, works as before
- [ ] Edit an option type with many values (>50) — pagination controls appear, shows "Showing 1-50 of N"
- [ ] Navigate between pages — correct values shown per page
- [ ] Add a new option value via "Add one" button — still works
- [ ] Edit and save option values on any page — changes persist
- [ ] Create a new option type — empty form row appears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)