### PR TITLE
Fix to get the top performing products on the top end of the table

### DIFF
--- a/spree/core/app/models/spree/reports/products_performance.rb
+++ b/spree/core/app/models/spree/reports/products_performance.rb
@@ -28,16 +28,25 @@ module Spree
         product_scope = store.products
         product_scope = product_scope.where(vendor_id: vendor.id) if defined?(vendor) && vendor.present?
 
+        product_table = Spree::Product.table_name
+
         product_scope.includes(:taxons, :tax_category, variants: :prices, master: :prices).
-                              joins("LEFT JOIN (#{line_items_sql}) AS line_items ON #{Spree::Product.table_name}.id = line_items.product_id").
+                              joins("LEFT JOIN (#{line_items_sql}) AS line_items ON #{product_table}.id = line_items.product_id").
                               select("
-                                spree_products.*,
+                                #{product_table}.*,
                                 COALESCE(SUM(line_items.pre_tax_amount), 0.0) AS pre_tax_amount,
                                 COALESCE(SUM(line_items.quantity), 0) AS quantity,
                                 COALESCE(SUM(line_items.promo_total), 0.0) AS promo_total,
                                 COALESCE(SUM(line_items.tax_total), 0.0) AS tax_total,
                                 COALESCE(SUM(line_items.total), 0.0) AS total
-                              ").group('spree_products.id')
+                              ").group("#{product_table}.id").
+                              order(
+                                Arel.sql(
+                                  'COALESCE(SUM(line_items.quantity), 0) DESC, ' \
+                                  'COALESCE(SUM(line_items.total), 0.0) DESC, ' \
+                                  "#{product_table}.id ASC"
+                                )
+                              )
       end
     end
   end

--- a/spree/core/spec/models/spree/reports/products_performance_spec.rb
+++ b/spree/core/spec/models/spree/reports/products_performance_spec.rb
@@ -81,5 +81,24 @@ RSpec.describe Spree::Reports::ProductsPerformance do
         expect(report.line_items_scope).to be_empty
       end
     end
+
+    context 'ordering by units sold' do
+      let(:product_low) { create(:product, stores: [store]) }
+      let(:product_high) { create(:product, stores: [store]) }
+      let(:variant_low) { create(:variant, product: product_low) }
+      let(:variant_high) { create(:variant, product: product_high) }
+      let(:order_in_range) { create(:completed_order_with_totals, store: store, currency: report.currency) }
+
+      before do
+        order_in_range.update!(completed_at: report.date_from + 1.day)
+        create(:line_item, order: order_in_range, variant: variant_low, quantity: 1)
+        create(:line_item, order: order_in_range, variant: variant_high, quantity: 5)
+      end
+
+      it 'lists higher quantity products first' do
+        ordered_ids = report.line_items_scope.pluck(:id)
+        expect(ordered_ids.index(product_high.id)).to be < ordered_ids.index(product_low.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
The Products performance report builds one row per catalog product with sales rolled up from line items in the date range. The underlying line_items_scope never applied an ORDER BY, so the table order was undefined. Best-selling products were not guaranteed at the top when opening the report.

Approach:
The scope already had COALESCE(SUM(line_items.quantity), 0) as aggregated “units sold” for the window. The fix was to define a clear default sort on that relation so the UI lists highest movers first, with sensible tie-breakers so ordering stays stable.

Changes made:
spree/core/app/models/spree/reports/products_performance.rb — After group(...), added order via Arel.sql:
Units sold descending (SUM(line_items.quantity)).
Then line total descending (SUM(line_items.total)) when quantities tie.
Then spree_products.id ascending for a deterministic order.
I then made a minor cleanup where the product_table is variable used for table_name in select / group so the query stays consistent.

spree/core/spec/models/spree/reports/products_performance_spec.rb — New example “ordering by units sold” that creates two products on the same completed order (quantities 5 vs 1) and asserts the higher-quantity product appears earlier in line_items_scope.pluck(:id).

