### PR TITLE
Direct price currency conversions

### DIFF
--- a/spree/admin/app/controllers/spree/admin/currency_conversions_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/currency_conversions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class CurrencyConversionsController < BaseController
+      skip_before_action :authorize_admin
+      before_action :authorize_currency_conversion
+
+      # GET /admin/currency_conversions?amount=99&from=USD&to=EUR,GBP
+      def index
+        conversions = Spree::Admin::FrankfurterCurrencyConversion.convert(
+          amount: params[:amount],
+          from: params[:from],
+          to: params[:to].to_s.split(',')
+        )
+
+        render json: { conversions: conversions.transform_values(&:to_f) }
+      end
+
+      private
+
+      def authorize_currency_conversion
+        authorize! :manage, Spree::Price
+      end
+    end
+  end
+end

--- a/spree/admin/app/javascript/spree/admin/application.js
+++ b/spree/admin/app/javascript/spree/admin/application.js
@@ -53,6 +53,7 @@ import CalendarRangeController from 'spree/admin/controllers/calendar_range_cont
 import Clipboard from 'spree/admin/controllers/clipboard_controller'
 import CodeMirrorController from 'spree/admin/controllers/codemirror_controller'
 import ColorPaletteController from 'spree/admin/controllers/color_palette_controller'
+import CurrencyPricesController from 'spree/admin/controllers/currency_prices_controller'
 import ColumnSelectorController from 'spree/admin/controllers/column_selector_controller'
 import ColorPickerController from 'spree/admin/controllers/color_picker_controller'
 import DropdownController from 'spree/admin/controllers/dropdown_controller'
@@ -118,6 +119,7 @@ application.register('codemirror', CodeMirrorController)
 application.register('color-palette', ColorPaletteController)
 application.register('color-picker', ColorPickerController)
 application.register('column-selector', ColumnSelectorController)
+application.register('currency-prices', CurrencyPricesController)
 application.register('dialog', Dialog)
 application.register('drawer', Dialog)
 application.register('disable-submit-button', DisableSubmitButtonController)

--- a/spree/admin/app/javascript/spree/admin/controllers/currency_prices_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/currency_prices_controller.js
@@ -1,0 +1,126 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * Suggests prices in other store currencies using reference FX rates (ECB via Frankfurter).
+ * Filled values remain editable. Only runs when data-currency-prices-url-value is set.
+ */
+export default class extends Controller {
+  static values = {
+    url: String,
+    locale: { type: String, default: 'en' }
+  }
+
+  connect() {
+    this._debounce = null
+  }
+
+  scheduleConvert(event) {
+    if (!this.hasUrlValue || !this.urlValue) return
+
+    clearTimeout(this._debounce)
+    this._debounce = setTimeout(() => this.convertFrom(event.target), 400)
+  }
+
+  async convertFrom(sourceInput) {
+    if (!(sourceInput instanceof HTMLInputElement) || sourceInput.disabled || sourceInput.readOnly) return
+    if (!sourceInput.name?.includes('prices_attributes')) return
+
+    const isAmount = sourceInput.name.includes('[amount]') && !sourceInput.name.includes('compare_at')
+    const isCompare = sourceInput.name.includes('compare_at_amount')
+    if (!isAmount && !isCompare) return
+
+    const row = sourceInput.closest('tr')
+    if (!row) return
+
+    const fromCurrency = this.currencyFromRow(row)
+    if (!fromCurrency) return
+
+    const amount = this.parseNumber(sourceInput.value)
+    if (!Number.isFinite(amount) || amount <= 0) return
+
+    const targets = this.otherCurrenciesInTable(row, fromCurrency)
+    if (targets.length === 0) return
+
+    const url = `${this.urlValue}?${new URLSearchParams({
+      amount: String(amount),
+      from: fromCurrency,
+      to: targets.join(',')
+    })}`
+
+    const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
+    const headers = { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
+    if (token) headers['X-CSRF-Token'] = token
+
+    let data
+    try {
+      const res = await fetch(url, { headers, credentials: 'same-origin' })
+      if (!res.ok) return
+      data = await res.json()
+    } catch (_e) {
+      return
+    }
+
+    const conversions = data.conversions || {}
+    for (const [code, value] of Object.entries(conversions)) {
+      const targetInput = this.findPriceInputInTable(sourceInput, row, code, isCompare)
+      if (!targetInput || targetInput === sourceInput) continue
+      targetInput.value = this.formatNumber(Number(value))
+      targetInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+  }
+
+  currencyFromRow(row) {
+    const cell = row.querySelector('td')
+    return cell?.textContent?.trim() || null
+  }
+
+  otherCurrenciesInTable(sourceRow, fromCurrency) {
+    const table = sourceRow.closest('table')
+    if (!table) return []
+
+    const codes = []
+    table.querySelectorAll('tbody tr').forEach((tr) => {
+      const c = this.currencyFromRow(tr)
+      if (c && c !== fromCurrency) codes.push(c)
+    })
+    return [...new Set(codes)]
+  }
+
+  findPriceInputInTable(sourceInput, sourceRow, currencyCode, isCompare) {
+    const table = sourceRow.closest('table')
+    if (!table) return null
+
+    for (const tr of table.querySelectorAll('tbody tr')) {
+      if (this.currencyFromRow(tr) !== currencyCode) continue
+      const cells = tr.querySelectorAll('td')
+      const colIndex = isCompare ? 2 : 1
+      const cell = cells[colIndex]
+      return cell?.querySelector('input[type="text"], input:not([type])') || null
+    }
+    return null
+  }
+
+  parseNumber(value) {
+    if (value === null || value === undefined) return NaN
+    let str = String(value).trim()
+    if (str === '') return NaN
+
+    const lastComma = str.lastIndexOf(',')
+    const lastDot = str.lastIndexOf('.')
+    if (lastComma > lastDot) {
+      str = str.replace(/\./g, '').replace(',', '.')
+    } else if (lastDot === -1 && lastComma !== -1 && /^\d{1,3}$/.test(str.substring(lastComma + 1))) {
+      str = str.replace(',', '.')
+    }
+    return parseFloat(str)
+  }
+
+  formatNumber(number) {
+    if (!Number.isFinite(number)) return ''
+    return number.toLocaleString(this.localeValue, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      useGrouping: false
+    })
+  }
+}

--- a/spree/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -40,11 +40,13 @@ export default class extends CheckboxSelectAll {
     stockLocations: Array,
     optionValuesSelectOptions: Array,
     locale: String,
-    adminPath: String
+    adminPath: String,
+    currencyConversionsUrl: String
   }
 
   connect() {
     super.connect()
+    this._currencyConvertDebounce = null
     this.optionNameOptions = this.newOptionNameInputTarget.options
     this.sortable = new Sortable(this.optionsContainerTarget, {
       group: 'options',
@@ -323,6 +325,7 @@ export default class extends CheckboxSelectAll {
     childrenPricesKeys.forEach((key) => {
       this.updatePriceForVariant(key, parentPrice, currency)
     })
+    this.scheduleCrossCurrencyConvert(event.target)
   }
 
   selectChildVariants(event) {
@@ -369,6 +372,7 @@ export default class extends CheckboxSelectAll {
     const currency = event.target.dataset.currency
     const nestingLevel = variantName.split('/').length
     this.updatePriceForVariant(variantName, event.target.value, currency)
+    this.scheduleCrossCurrencyConvert(event.target)
     if (nestingLevel > 1) {
       const parentName = variantName.split('/')[0]
       this.updateParentPriceRange(parentName, currency)
@@ -1134,6 +1138,79 @@ export default class extends CheckboxSelectAll {
         }
       }
     }
+  }
+
+  scheduleCrossCurrencyConvert(sourceInput) {
+    if (!this.hasCurrencyConversionsUrlValue || !this.currencyConversionsUrlValue) return
+    if (!this.currenciesValue || this.currenciesValue.length < 2) return
+
+    clearTimeout(this._currencyConvertDebounce)
+    this._currencyConvertDebounce = setTimeout(() => this.crossCurrencyConvertFromInput(sourceInput), 400)
+  }
+
+  async crossCurrencyConvertFromInput(sourceInput) {
+    if (!this.hasCurrencyConversionsUrlValue || !this.currencyConversionsUrlValue) return
+
+    const fromCurrency = sourceInput.dataset.currency
+    if (!fromCurrency) return
+
+    const amount = this.parseLocaleNumber(sourceInput.value)
+    if (!Number.isFinite(amount) || amount <= 0) return
+
+    const to = this.currenciesValue.filter((c) => c !== fromCurrency)
+    if (to.length === 0) return
+
+    const url = `${this.currencyConversionsUrlValue}?${new URLSearchParams({
+      amount: String(amount),
+      from: fromCurrency,
+      to: to.join(',')
+    })}`
+
+    const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
+    const headers = { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
+    if (token) headers['X-CSRF-Token'] = token
+
+    let data
+    try {
+      const res = await fetch(url, { headers, credentials: 'same-origin' })
+      if (!res.ok) return
+      data = await res.json()
+    } catch (_e) {
+      return
+    }
+
+    const variantRow = sourceInput.closest('[data-variants-form-target="variant"]')
+    if (!variantRow) return
+    const { variantName } = variantRow.dataset
+
+    const conversions = data.conversions || {}
+    for (const [code, value] of Object.entries(conversions)) {
+      const other = variantRow.querySelector(`input[data-slot="[prices_attributes][${code}][amount]_input"]`)
+      if (!other || other === sourceInput) continue
+      other.value = this.formatNumber(Number(value))
+      this.updatePriceForVariant(variantName, other.value, code)
+    }
+
+    if (variantName && !variantName.includes('/')) {
+      this.propagatePriceConversionsToNestedVariants(variantName, conversions)
+    }
+  }
+
+  propagatePriceConversionsToNestedVariants(parentInternalName, conversions) {
+    if (!this.variantsContainerTarget) return
+
+    const rows = this.variantsContainerTarget.querySelectorAll(`[data-variant-name^="${parentInternalName}/"]`)
+    rows.forEach((childRow) => {
+      const childName = childRow.dataset.variantName
+      if (!childName) return
+
+      for (const [code, value] of Object.entries(conversions)) {
+        const input = childRow.querySelector(`input[data-slot="[prices_attributes][${code}][amount]_input"]`)
+        if (!input) continue
+        input.value = this.formatNumber(Number(value))
+        this.updatePriceForVariant(childName, input.value, code)
+      }
+    })
   }
 
   toggleInventoryForm(value) {

--- a/spree/admin/app/services/spree/admin/frankfurter_currency_conversion.rb
+++ b/spree/admin/app/services/spree/admin/frankfurter_currency_conversion.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+require 'json'
+require 'net/http'
+require 'uri'
+
+module Spree
+  module Admin
+    # Fetches ECB-based FX rates from Frankfurter (https://www.frankfurter.app) and converts amounts.
+    # Used only for admin UI suggestions; merchants should review converted prices before saving.
+    class FrankfurterCurrencyConversion
+      BASE_URL = 'https://api.frankfurter.app'
+
+      class << self
+        # @param amount [String, Numeric] amount in +from+ currency
+        # @param from [String] ISO 4217 currency code
+        # @param to [Array<String>] target ISO codes (excluding +from+)
+        # @return [Hash<String, BigDecimal>] target code => converted amount (2 decimals)
+        def convert(amount:, from:, to:)
+          amt = begin
+            BigDecimal(amount.to_s)
+          rescue ArgumentError
+            nil
+          end
+          return {} if amt.nil? || !amt.positive?
+
+          from_code = from.to_s.upcase
+          targets = normalize_targets(to, from_code)
+          return {} if targets.empty?
+
+          rates = cached_rates(from_code, targets)
+          return {} if rates.blank?
+
+          targets.each_with_object({}) do |code, out|
+            rate = rates[code]
+            next unless rate
+
+            out[code] = (amt * BigDecimal(rate.to_s)).round(2)
+          end
+        end
+
+        private
+
+        def normalize_targets(to, from_code)
+          Array(to).flat_map { |s| s.to_s.split(/[\s,]+/) }.map(&:strip).map(&:upcase).uniq.reject do |c|
+            c.blank? || c == from_code || !::Money::Currency.find(c)
+          end
+        end
+
+        def cached_rates(from_code, targets)
+          cache_key = ['spree', 'admin', 'frankfurter', from_code, targets.sort.join('-'), Time.zone.today.to_s].join('/')
+          Rails.cache.fetch(cache_key, expires_in: 12.hours) do
+            fetch_rates(from_code, targets)
+          end
+        end
+
+        def fetch_rates(from_code, targets)
+          uri = URI("#{BASE_URL}/latest?from=#{CGI.escape(from_code)}&to=#{CGI.escape(targets.join(','))}")
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true
+          http.open_timeout = 3
+          http.read_timeout = 5
+          response = http.request(Net::HTTP::Get.new(uri.request_uri))
+          return {} unless response.is_a?(Net::HTTPSuccess)
+
+          data = JSON.parse(response.body)
+          data['rates'] || {}
+        rescue StandardError => e
+          Rails.logger.warn("[FrankfurterCurrencyConversion] #{e.class}: #{e.message}")
+          {}
+        end
+      end
+    end
+  end
+end

--- a/spree/admin/app/views/spree/admin/products/form/_variants.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_variants.html.erb
@@ -16,6 +16,9 @@
         data-variants-form-current-stock-location-id-value="<%= default_stock_location_for_product(@product).id %>"
         data-variants-form-stock-locations-value="<%= available_stock_locations_for_product(@product).ids.map(&:to_s).to_json %>"
         data-variants-form-admin-path-value="<%= spree.admin_path %>"
+        <% if supported_currencies.length > 1 && can?(:manage, Spree::Price) %>
+          data-variants-form-currency-conversions-url-value="<%= spree.admin_currency_conversions_path %>"
+        <% end %>
         <% if @product_options.present? %> data-variants-form-options-value="<%= @product_options.to_json %>" <% end %>
         <% if @product_available_options.present? %> data-variants-form-available-options-value="<%= @product_available_options.to_json %>" <% end %>
         <% if @product_stock.present? %> data-variants-form-stock-value="<%= @product_stock.to_json %>" <% end %>

--- a/spree/admin/app/views/spree/admin/variants/form/_pricing.html.erb
+++ b/spree/admin/app/views/spree/admin/variants/form/_pricing.html.erb
@@ -1,4 +1,11 @@
-<div class="card mb-6" data-product-form-target="pricesForm">
+<% conversion_url = supported_currencies.length > 1 && can?(:manage, Spree::Price) ? spree.admin_currency_conversions_path : nil %>
+<div class="card mb-6"
+     data-product-form-target="pricesForm"
+     <% if conversion_url %>
+       data-controller="currency-prices"
+       data-currency-prices-url-value="<%= conversion_url %>"
+       data-currency-prices-locale-value="<%= I18n.locale %>"
+     <% end %>>
   <div class="card-header flex items-center justify-between border-b-0">
     <h5 class="card-title">
       <%= Spree.t(:pricing) %>
@@ -9,6 +16,9 @@
     <% end %>
   </div>
   <div class="card-body p-0">
+    <% if conversion_url %>
+      <p class="form-text px-4 pt-3 mb-0"><%= Spree.t('admin.currency_prices.auto_convert_hint') %></p>
+    <% end %>
     <table class="table border-t">
       <thead>
         <tr>
@@ -22,7 +32,7 @@
           </th>
         </tr>
       </thead>
-      <tbody>
+      <tbody <% if conversion_url %>data-action="input->currency-prices#scheduleConvert"<% end %>>
         <% base_prices = f.object.prices.select { |p| p.price_list_id.nil? } %>
         <%= f.fields_for :prices, base_prices do |price_form| %>
           <%= price_form.hidden_field :id if price_form.object.persisted? %>

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -92,6 +92,8 @@ en:
       coupon_codes:
         unused: Unused
         used: Used
+      currency_prices:
+        auto_convert_hint: When you enter an amount in one currency, suggested amounts appear in your other supported currencies using reference exchange rates. You can edit any value before saving.
       created_at: Created At
       dashboard:
         getting_started:

--- a/spree/admin/config/routes.rb
+++ b/spree/admin/config/routes.rb
@@ -27,6 +27,7 @@ Spree::Core::Engine.add_routes do
     # variant search
     post 'variants/search'
     get 'variants/search', defaults: { format: :json }
+    get 'currency_conversions', to: 'currency_conversions#index', as: :currency_conversions, defaults: { format: :json }
     # product translations
     resources :product_translations, only: [:index]
     # stock

--- a/spree/admin/spec/controllers/spree/admin/currency_conversions_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/currency_conversions_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Admin::CurrencyConversionsController, type: :controller do
+  stub_authorization!
+
+  describe '#index' do
+    it 'returns suggested conversions as JSON' do
+      allow(Spree::Admin::FrankfurterCurrencyConversion).to receive(:convert).and_return(
+        { 'EUR' => BigDecimal('92.50'), 'GBP' => BigDecimal('79.99') }
+      )
+
+      get :index, params: { amount: '100', from: 'USD', to: 'EUR,GBP' }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(
+        'conversions' => { 'EUR' => 92.5, 'GBP' => 79.99 }
+      )
+    end
+  end
+end


### PR DESCRIPTION
With multiple store currencies, merchants had to type (or copy) the product/variant price into every currency field by hand, which was slow and error-prone.

Approach:
Starting off by treating the conversions as suggestions only, not authoritative pricing:
Server — A small service calls Frankfurter (ECB-based rates), multiplies the entered amount, rounds to two decimals, and caches results (~12h) to limit external traffic. A JSON-only admin endpoint runs the conversion and checks manage on Spree::Price so only users who can edit prices get suggestions.

Client — Stimulus debounces (~400ms) on price inputs, calls that endpoint with amount, from, and to (other supported currencies), then writes the returned values into the other currency inputs. All fields stay normal inputs so merchants can change any number before save.

Two UIs — Master pricing table (product form card) uses a dedicated currency-prices controller on the table body. Variants matrix uses the existing variants-form controller with a currencyConversionsUrl value and the same fetch/fill logic, plus propagation from parent rows to nested variant rows so when the parent row gets suggested amounts, children rows get the same targets filled and internal pricesValue stays consistent.

Changes:
Backend: FrankfurterCurrencyConversion service, CurrencyConversionsController#index, admin route currency_conversions.
Frontend: currency_prices_controller.js (master table), registration in application.js, variants_form_controller.js (URL value, debounced fetch, fill, parent→children propagation).
Views: Pricing partial wires data-controller / URL / tbody input action when multi-currency + can manage prices; variants form sets data-variants-form-currency-conversions-url-value under the same conditions.
i18n: admin.currency_prices.auto_convert_hint in English locale for the UI hint.
Tests: Controller spec for the JSON endpoint (stubbing the conversion service).