### PR TITLE
Fix FindByVariant ignoring comparator result

### DIFF
--- a/spree/core/app/finders/spree/line_items/find_by_variant.rb
+++ b/spree/core/app/finders/spree/line_items/find_by_variant.rb
@@ -5,7 +5,8 @@ module Spree
         line_item = order.line_items.loaded? ? order.line_items.detect { |li| li.variant_id == variant.id } : order.line_items.find_by(variant_id: variant.id)
 
         if line_item
-          Spree.cart_compare_line_items_service.call(order: order, line_item: line_item, options: options).value
+          result = Spree.cart_compare_line_items_service.call(order: order, line_item: line_item, options: options).value
+          return nil unless result
         end
 
         line_item

--- a/spree/core/spec/finders/spree/line_items/find_by_variant_spec.rb
+++ b/spree/core/spec/finders/spree/line_items/find_by_variant_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe Spree::LineItems::FindByVariant do
+  subject { described_class.new }
+
+  let(:order) { create(:order) }
+  let(:variant) { create(:variant) }
+
+  context 'when no matching line item exists' do
+    it 'returns nil' do
+      result = subject.execute(order: order, variant: variant)
+      expect(result).to be_nil
+    end
+  end
+
+  context 'when a matching line item exists' do
+    let!(:line_item) { create(:line_item, order: order, variant: variant) }
+
+    context 'when comparator returns true' do
+      it 'returns the line item' do
+        result = subject.execute(order: order, variant: variant)
+        expect(result).to eq(line_item)
+      end
+    end
+
+    context 'when comparator returns false' do
+      before do
+        comparator = double('comparator')
+        allow(comparator).to receive(:call).and_return(double(value: false))
+        allow(Spree).to receive(:cart_compare_line_items_service).and_return(comparator)
+      end
+
+      it 'returns nil' do
+        result = subject.execute(order: order, variant: variant)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with loaded line items association' do
+      before { order.line_items.load }
+
+      it 'returns the line item when comparator returns true' do
+        result = subject.execute(order: order, variant: variant)
+        expect(result).to eq(line_item)
+      end
+
+      context 'when comparator returns false' do
+        before do
+          comparator = double('comparator')
+          allow(comparator).to receive(:call).and_return(double(value: false))
+          allow(Spree).to receive(:cart_compare_line_items_service).and_return(comparator)
+        end
+
+        it 'returns nil' do
+          result = subject.execute(order: order, variant: variant)
+          expect(result).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fix regression introduced in v4.9.0 where FindByVariant calls the comparison service but discards its return value
- The finder now returns nil when the comparator returns false, allowing custom comparison logic to work correctly
- Add test coverage for FindByVariant (none existed previously)

Fixes #12970