### PR TITLE
Fix admin product lookup with multi-locale

### DIFF
--- a/spree/admin/app/controllers/spree/admin/products_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/products_controller.rb
@@ -124,7 +124,9 @@ module Spree
       protected
 
       def find_resource
-        current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
+        find_with_fallback_default_locale do
+          current_store.products.accessible_by(current_ability, :manage).friendly.find(params[:id])
+        end
       end
 
       def load_data

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -509,6 +509,21 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
           "but found: #{inputs_with_ids.map { |el| el['id'] }.join(', ')}"
       end
     end
+
+    context 'when admin user locale differs from store default locale' do
+      let!(:product) { create(:product, stores: [store], status: 'active') }
+
+      before do
+        store.update!(default_locale: 'en')
+        allow(controller).to receive(:current_locale).and_return('da')
+        allow(I18n).to receive(:locale).and_return(:'da')
+      end
+
+      it 'falls back to default locale and renders the edit template' do
+        get :edit, params: { id: product.to_param }
+        expect(response).to render_template(:edit)
+      end
+    end
   end
 
   describe 'PUT #update' do


### PR DESCRIPTION
## Summary
- Fix admin product pages returning 303 when admin user locale differs from store default
- Wrap find_resource with find_with_fallback_default_locale, the same pattern already used by the storefront
- Add test for locale fallback in admin product controller

Fixes #13320