### PR TITLE
Fix CreateLineItems revert removing user-added line items

### DIFF
--- a/spree/core/app/models/spree/promotion/actions/create_line_items.rb
+++ b/spree/core/app/models/spree/promotion/actions/create_line_items.rb
@@ -67,6 +67,7 @@ module Spree
           promotion_action_line_items.each do |item|
             line_item = order.find_line_item_by_variant(item.variant)
             next unless line_item.present?
+            next unless order.promotions.include?(promotion)
 
             Spree.cart_remove_item_service.call(order: order,
                                                 variant: item.variant,

--- a/spree/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/spree/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -133,4 +133,47 @@ describe Spree::Promotion::Actions::CreateLineItems, type: :model do
       end
     end
   end
+
+  describe '#revert' do
+    before do
+      action.promotion_action_line_items.create!(
+        variant: mug,
+        quantity: 1
+      )
+    end
+
+    context 'when promotion was never activated on the order' do
+      before do
+        allow(promotion).to receive(:eligible?).and_return(false)
+      end
+
+      it 'does not remove a user-added line item' do
+        Spree::Cart::AddItem.call(order: order, variant: mug, quantity: 1)
+        expect(order.line_items.count).to eq(1)
+
+        action.revert(order: order)
+
+        order.line_items.reload
+        expect(order.line_items.count).to eq(1)
+        expect(order.line_items.first.variant).to eq(mug)
+      end
+    end
+
+    context 'when promotion was previously activated on the order' do
+      before do
+        order.promotions << promotion
+        allow(promotion).to receive(:eligible?).and_return(false)
+      end
+
+      it 'removes the promotion-added line item' do
+        Spree::Cart::AddItem.call(order: order, variant: mug, quantity: 1)
+        expect(order.line_items.count).to eq(1)
+
+        action.revert(order: order)
+
+        order.line_items.reload
+        expect(order.line_items.count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Fix CreateLineItems#revert blindly removing line items matching the promotion's variant, even when the promotion never added them
- Add guard to only revert when the promotion was previously activated on the order
- Prevents ActiveRecord::RecordNotFound crash in Recalculate when user-added items are wrongly removed

Fixes #10899