### PR TITLE
Fix applying gift cards in a multi-store scenario

### DIFF
--- a/spree/core/app/services/spree/gift_cards/apply.rb
+++ b/spree/core/app/services/spree/gift_cards/apply.rb
@@ -68,7 +68,11 @@ module Spree
         )
         payment_method.name ||= Spree.t(:store_credit_name)
         payment_method.active = true
-        payment_method.save! if payment_method.new_record?
+
+        if payment_method.new_record?
+          payment_method.stores << store unless payment_method.stores.include?(store)
+          payment_method.save!
+        end
 
         payment_method
       end

--- a/spree/core/spec/services/spree/gift_cards/apply_spec.rb
+++ b/spree/core/spec/services/spree/gift_cards/apply_spec.rb
@@ -119,7 +119,9 @@ RSpec.describe Spree::GiftCards::Apply do
     it 'does not generate store credits exceeding the gift card value' do
       threads = orders.map do |order|
         Thread.new do
-          described_class.call(gift_card: gift_card, order: order)
+          ActiveRecord::Base.connection_pool.with_connection do
+            described_class.call(gift_card: gift_card, order: order)
+          end
         end
       end
       threads.each(&:join)

--- a/spree/core/spec/services/spree/gift_cards/apply_spec.rb
+++ b/spree/core/spec/services/spree/gift_cards/apply_spec.rb
@@ -144,4 +144,47 @@ RSpec.describe Spree::GiftCards::Apply do
       expect(order.reload.gift_card).to be_nil
     end
   end
+
+  context 'when the order belongs to a non-default store' do
+    let(:other_store) { create(:store, default: false) }
+    let(:order) { create(:order, store: other_store, user: order_user) }
+    let(:gift_card) { create(:gift_card, amount: 50, store: other_store, user: gift_card_user) }
+
+    it 'applies the gift card to the order' do
+      expect { subject }.to change(Spree::StoreCredit, :count).by(1)
+      expect(subject).to be_success
+
+      expect(order.reload.gift_card).to eq(gift_card)
+      expect(order.gift_card_total).to eq(30)
+
+      expect(gift_card.reload.amount_remaining).to eq(20)
+
+      expect(store_credit_payment).to be_present
+      expect(store_credit_payment).to be_checkout
+      expect(store_credit_payment.source).to eq(gift_card.store_credits.last)
+      expect(store_credit_payment.amount).to eq(30)
+
+      expect(store_credit.amount).to eq(30)
+      expect(store_credit.store).to eq(other_store)
+      expect(store_credit.originator).to eq(gift_card)
+    end
+
+    it 'links the auto-created StoreCredit payment method only to the order store' do
+      expect(subject).to be_success
+
+      payment_method = order.payments.store_credits.last.payment_method
+      expect(payment_method.stores).to contain_exactly(other_store)
+      expect(payment_method.available_for_store?(other_store)).to be true
+    end
+
+    context 'when a StoreCredit payment method already exists for the order store' do
+      let!(:existing_payment_method) { create(:store_credit_payment_method, stores: [other_store]) }
+
+      it 'reuses the existing payment method without creating a duplicate' do
+        expect { subject }.not_to change(Spree::PaymentMethod::StoreCredit, :count)
+        expect(subject).to be_success
+        expect(order.payments.store_credits.last.payment_method).to eq(existing_payment_method)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes an issue with applying a gift card in a multi-store scenario on a non-default store.

When a gift card is applied for the first time on a non-default store, we first ensure that the store credit payment method exists. There was a bug with it that would incorrectly assign the default store to the newly created payment method. 

This is the default behaviour to ensure that the payment method is linked to a store: https://github.com/spree/spree-multi-store/blob/main/app/models/concerns/spree/multi_store_resource.rb#L21

Now, we'll assign the store explicitly.