### PR TITLE
improve admin product bulk actions permissions

### DIFF
--- a/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
@@ -31,7 +31,7 @@ module Spree
       end
 
       def authorize_admin
-        params[:kind]&.to_sym == :set_active ? authorize!(:bulk_set_active, Spree::Product) : super
+        params[:kind] == 'set_active' ? authorize!(:bulk_set_active, Spree::Product) : super
       end
     end
   end

--- a/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
@@ -1,6 +1,16 @@
 module Spree
   module Admin
     class BulkOperationsController < Spree::Admin::BaseController
+      BULK_ACTION_PERMISSIONS = {
+        set_active: [:bulk_set_active, Spree::Product],
+        set_draft: [:bulk_set_draft, Spree::Product],
+        set_archived: [:bulk_set_archived, Spree::Product],
+        add_to_taxons: [:manage, Spree::Classification],
+        remove_from_taxons: [:manage, Spree::Classification],
+        add_tags: [:manage_tags, Spree::Product],
+        remove_tags: [:manage_tags, Spree::Product]
+      }.freeze
+
       # GET /admin/bulk_operations/new?kind=:action_key&table_key=:table_key
       # Generic bulk modal action that reads configuration from BulkAction
       def new
@@ -28,6 +38,11 @@ module Spree
 
         table = Spree.admin.tables.get(table_key)
         table.find_bulk_action(key.to_sym)
+      end
+
+      def authorize_admin
+        permission = BULK_ACTION_PERMISSIONS[params[:kind]&.to_sym]
+        permission.present? ? authorize!(*permission) : super
       end
     end
   end

--- a/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
@@ -31,7 +31,7 @@ module Spree
       end
 
       def authorize_admin
-        params[:kind] == 'set_active' ? authorize!(:bulk_set_active, Spree::Product) : super
+        params[:kind] == 'set_active' ? authorize!(:bulk_activate, Spree::Product) : super
       end
     end
   end

--- a/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/bulk_operations_controller.rb
@@ -1,16 +1,6 @@
 module Spree
   module Admin
     class BulkOperationsController < Spree::Admin::BaseController
-      BULK_ACTION_PERMISSIONS = {
-        set_active: [:bulk_set_active, Spree::Product],
-        set_draft: [:bulk_set_draft, Spree::Product],
-        set_archived: [:bulk_set_archived, Spree::Product],
-        add_to_taxons: [:manage, Spree::Classification],
-        remove_from_taxons: [:manage, Spree::Classification],
-        add_tags: [:manage_tags, Spree::Product],
-        remove_tags: [:manage_tags, Spree::Product]
-      }.freeze
-
       # GET /admin/bulk_operations/new?kind=:action_key&table_key=:table_key
       # Generic bulk modal action that reads configuration from BulkAction
       def new
@@ -41,8 +31,7 @@ module Spree
       end
 
       def authorize_admin
-        permission = BULK_ACTION_PERMISSIONS[params[:kind]&.to_sym]
-        permission.present? ? authorize!(*permission) : super
+        params[:kind]&.to_sym == :set_active ? authorize!(:bulk_set_active, Spree::Product) : super
       end
     end
   end

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -135,7 +135,7 @@ Rails.application.config.after_initialize do
                                                     action_path: ->(view_context) { view_context.spree.bulk_status_update_admin_products_path(status: 'active') },
                                                     body: 'admin.bulk_ops.products.body.set_active',
                                                     position: 10,
-                                                    condition: -> { can?(:bulk_set_active, Spree::Product) }
+                                                    condition: -> { can?(:bulk_activate, Spree::Product) }
 
   Spree.admin.tables.products.add_bulk_action :set_draft,
                                                     label: 'admin.bulk_ops.products.title.set_draft',

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -135,21 +135,23 @@ Rails.application.config.after_initialize do
                                                     action_path: ->(view_context) { view_context.spree.bulk_status_update_admin_products_path(status: 'active') },
                                                     body: 'admin.bulk_ops.products.body.set_active',
                                                     position: 10,
-                                                    condition: -> { can?(:activate, Spree::Product) }
+                                                    condition: -> { can?(:bulk_set_active, Spree::Product) }
 
   Spree.admin.tables.products.add_bulk_action :set_draft,
                                                     label: 'admin.bulk_ops.products.title.set_draft',
                                                     icon: 'circle-dotted',
                                                     action_path: ->(view_context) { view_context.spree.bulk_status_update_admin_products_path(status: 'draft') },
                                                     body: 'admin.bulk_ops.products.body.set_draft',
-                                                    position: 20
+                                                    position: 20,
+                                                    condition: -> { can?(:bulk_set_draft, Spree::Product) }
 
   Spree.admin.tables.products.add_bulk_action :set_archived,
                                                     label: 'admin.bulk_ops.products.title.set_archived',
                                                     icon: 'archive',
                                                     action_path: ->(view_context) { view_context.spree.bulk_status_update_admin_products_path(status: 'archived') },
                                                     body: 'admin.bulk_ops.products.body.set_archived',
-                                                    position: 30
+                                                    position: 30,
+                                                    condition: -> { can?(:bulk_set_archived, Spree::Product) }
 
   Spree.admin.tables.products.add_bulk_action :add_to_taxons,
                                                     label: 'admin.bulk_ops.products.title.add_to_taxons',

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -142,16 +142,14 @@ Rails.application.config.after_initialize do
                                                     icon: 'circle-dotted',
                                                     action_path: ->(view_context) { view_context.spree.bulk_status_update_admin_products_path(status: 'draft') },
                                                     body: 'admin.bulk_ops.products.body.set_draft',
-                                                    position: 20,
-                                                    condition: -> { can?(:bulk_set_draft, Spree::Product) }
+                                                    position: 20
 
   Spree.admin.tables.products.add_bulk_action :set_archived,
                                                     label: 'admin.bulk_ops.products.title.set_archived',
                                                     icon: 'archive',
                                                     action_path: ->(view_context) { view_context.spree.bulk_status_update_admin_products_path(status: 'archived') },
                                                     body: 'admin.bulk_ops.products.body.set_archived',
-                                                    position: 30,
-                                                    condition: -> { can?(:bulk_set_archived, Spree::Product) }
+                                                    position: 30
 
   Spree.admin.tables.products.add_bulk_action :add_to_taxons,
                                                     label: 'admin.bulk_ops.products.title.add_to_taxons',


### PR DESCRIPTION
This is to improve managing permissions for roles with limited access i.e vendor.
The solution uses same permissions in two places: products table definition & bulk actions controller. So we are not duplicating logic.
This is needed for one more reason: CanCan has fundamental limitation. I.e we can't have both:                                                                                                                                                                                                    
  - can?(:activate, Spree::Product) → false (class check)                                                                                                   
  - can?(:activate, active_vendor_product) → true (instance check)

That's why I introduced `bulk_set_active`