### PR TITLE
Prevent deletion of default and last market in store

### DIFF
--- a/spree/admin/spec/controllers/spree/admin/markets_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/markets_controller_spec.rb
@@ -141,21 +141,5 @@ RSpec.describe Spree::Admin::MarketsController, type: :controller do
       delete :destroy, params: { id: market.to_param }
       expect(response).to have_http_status(:redirect)
     end
-
-    context 'when the market is the default market' do
-      it 'does not soft delete the market' do
-        delete :destroy, params: { id: default_market.to_param }
-        expect(default_market.reload.deleted_at).to be_nil
-      end
-    end
-
-    context 'when the market is the only one in the store' do
-      let!(:default_market) { nil }
-
-      it 'does not soft delete the market' do
-        delete :destroy, params: { id: market.to_param }
-        expect(market.reload.deleted_at).to be_nil
-      end
-    end
   end
 end

--- a/spree/admin/spec/controllers/spree/admin/markets_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/markets_controller_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe Spree::Admin::MarketsController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
+    let!(:default_market) { create(:market, :default, store: store) }
     let!(:market) { create(:market, store: store, countries: [country]) }
 
     it 'soft deletes the market' do
@@ -139,6 +140,22 @@ RSpec.describe Spree::Admin::MarketsController, type: :controller do
     it 'redirects to index' do
       delete :destroy, params: { id: market.to_param }
       expect(response).to have_http_status(:redirect)
+    end
+
+    context 'when the market is the default market' do
+      it 'does not soft delete the market' do
+        delete :destroy, params: { id: default_market.to_param }
+        expect(default_market.reload.deleted_at).to be_nil
+      end
+    end
+
+    context 'when the market is the only one in the store' do
+      let!(:default_market) { nil }
+
+      it 'does not soft delete the market' do
+        delete :destroy, params: { id: market.to_param }
+        expect(market.reload.deleted_at).to be_nil
+      end
     end
   end
 end

--- a/spree/core/app/models/spree/market.rb
+++ b/spree/core/app/models/spree/market.rb
@@ -28,7 +28,7 @@ module Spree
     # Callbacks
     #
     before_save :ensure_single_default
-    before_destroy :ensure_not_default
+    before_destroy :ensure_can_be_destroyed
 
     #
     # Scopes
@@ -89,11 +89,18 @@ module Spree
       self.class.where(store_id: store_id, default: true).where.not(id: id).update_all(default: false)
     end
 
-    def ensure_not_default
-      return unless default?
+    def ensure_can_be_destroyed
+      if default?
+        errors.add(:base, :cannot_destroy_default_market)
+        throw(:abort)
+      elsif last_market_in_store?
+        errors.add(:base, :cannot_destroy_last_market)
+        throw(:abort)
+      end
+    end
 
-      errors.add(:base, :cannot_destroy_default_market)
-      throw(:abort)
+    def last_market_in_store?
+      !self.class.where(store_id: store_id).where.not(id: id).exists?
     end
   end
 end

--- a/spree/core/app/models/spree/market.rb
+++ b/spree/core/app/models/spree/market.rb
@@ -28,6 +28,7 @@ module Spree
     # Callbacks
     #
     before_save :ensure_single_default
+    before_destroy :ensure_not_default
 
     #
     # Scopes
@@ -86,6 +87,13 @@ module Spree
       return unless default? && default_changed?
 
       self.class.where(store_id: store_id, default: true).where.not(id: id).update_all(default: false)
+    end
+
+    def ensure_not_default
+      return unless default?
+
+      errors.add(:base, :cannot_destroy_default_market)
+      throw(:abort)
     end
   end
 end

--- a/spree/core/app/models/spree/market.rb
+++ b/spree/core/app/models/spree/market.rb
@@ -28,7 +28,7 @@ module Spree
     # Callbacks
     #
     before_save :ensure_single_default
-    before_destroy :ensure_can_be_destroyed
+    before_destroy :ensure_can_be_deleted
 
     #
     # Scopes
@@ -81,7 +81,20 @@ module Spree
       @supported_locales_list ||= (supported_locales.to_s.split(',').map(&:strip) << default_locale).compact.uniq.sort
     end
 
+    # Returns true when the market is safe to delete. A market cannot be deleted
+    # if it is the default market or the only market in the store, since
+    # Spree::Current.currency would have no fallback.
+    #
+    # @return [Boolean]
+    def can_be_deleted?
+      !default? && !last_in_store?
+    end
+
     private
+
+    def last_in_store?
+      !self.class.where(store_id: store_id).where.not(id: id).exists?
+    end
 
     def ensure_single_default
       return unless default? && default_changed?
@@ -89,18 +102,15 @@ module Spree
       self.class.where(store_id: store_id, default: true).where.not(id: id).update_all(default: false)
     end
 
-    def ensure_can_be_destroyed
+    def ensure_can_be_deleted
+      return if can_be_deleted?
+
       if default?
         errors.add(:base, :cannot_destroy_default_market)
-        throw(:abort)
-      elsif last_market_in_store?
+      else
         errors.add(:base, :cannot_destroy_last_market)
-        throw(:abort)
       end
-    end
-
-    def last_market_in_store?
-      !self.class.where(store_id: store_id).where.not(id: id).exists?
+      throw(:abort)
     end
   end
 end

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -299,6 +299,10 @@ en:
           attributes:
             currency:
               must_match_order_currency: Must match order currency
+        spree/market:
+          attributes:
+            base:
+              cannot_destroy_default_market: Cannot delete the default market.
         spree/market_country:
           attributes:
             country:

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -303,6 +303,7 @@ en:
           attributes:
             base:
               cannot_destroy_default_market: Cannot delete the default market.
+              cannot_destroy_last_market: Cannot delete the only market.
         spree/market_country:
           attributes:
             country:

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Spree::Market, type: :model do
     end
 
     it 'destroys market_countries on destroy' do
+      create(:market, :default, store: store)
       market = create(:market, store: store)
       expect { market.destroy }.to change(Spree::MarketCountry, :count).by(-1)
     end

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe Spree::Market, type: :model do
     end
   end
 
+  describe 'destroy' do
+    it 'does not allow destroying the default market' do
+      market = create(:market, :default, store: store)
+      expect { market.destroy }.not_to change(Spree::Market.with_deleted, :count).from(1)
+      expect(market.reload.deleted_at).to be_nil
+      expect(market.errors[:base]).to include(I18n.t('activerecord.errors.models.spree/market.attributes.base.cannot_destroy_default_market'))
+    end
+
+    it 'allows destroying a non-default market' do
+      create(:market, :default, store: store)
+      market = create(:market, store: store)
+      expect { market.destroy }.to change { market.reload.deleted_at }.from(nil).to(be_present)
+    end
+  end
+
   describe '#ensure_single_default' do
     it 'clears other default markets when setting default' do
       first = create(:market, :default, store: store)

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -96,6 +96,25 @@ RSpec.describe Spree::Market, type: :model do
     end
   end
 
+  describe '#can_be_deleted?' do
+    it 'returns false for the default market' do
+      create(:market, store: store)
+      market = create(:market, :default, store: store)
+      expect(market.can_be_deleted?).to be false
+    end
+
+    it 'returns false for the only market in a store' do
+      market = create(:market, store: store)
+      expect(market.can_be_deleted?).to be false
+    end
+
+    it 'returns true for a non-default market when other markets remain' do
+      create(:market, :default, store: store)
+      market = create(:market, store: store)
+      expect(market.can_be_deleted?).to be true
+    end
+  end
+
   describe 'destroy' do
     it 'does not allow destroying the default market' do
       create(:market, store: store)

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -98,16 +98,32 @@ RSpec.describe Spree::Market, type: :model do
 
   describe 'destroy' do
     it 'does not allow destroying the default market' do
+      create(:market, store: store)
       market = create(:market, :default, store: store)
-      expect { market.destroy }.not_to change(Spree::Market.with_deleted, :count).from(1)
+      expect(market.destroy).to be false
       expect(market.reload.deleted_at).to be_nil
       expect(market.errors[:base]).to include(I18n.t('activerecord.errors.models.spree/market.attributes.base.cannot_destroy_default_market'))
     end
 
-    it 'allows destroying a non-default market' do
+    it 'does not allow destroying the only market in a store' do
+      market = create(:market, store: store)
+      expect(market.destroy).to be false
+      expect(market.reload.deleted_at).to be_nil
+      expect(market.errors[:base]).to include(I18n.t('activerecord.errors.models.spree/market.attributes.base.cannot_destroy_last_market'))
+    end
+
+    it 'allows destroying a non-default market when other markets remain' do
       create(:market, :default, store: store)
       market = create(:market, store: store)
       expect { market.destroy }.to change { market.reload.deleted_at }.from(nil).to(be_present)
+    end
+
+    it 'does not affect markets in other stores when checking for last market' do
+      other_store = create(:store)
+      create(:market, store: other_store)
+      market = create(:market, store: store)
+      expect(market.destroy).to be false
+      expect(market.errors[:base]).to include(I18n.t('activerecord.errors.models.spree/market.attributes.base.cannot_destroy_last_market'))
     end
   end
 


### PR DESCRIPTION
## Summary
This PR adds validation and protection against deleting markets that are critical to store operations. Specifically, it prevents deletion of the default market and the last remaining market in a store, since these are required for currency fallback functionality.

## Key Changes
- Added `can_be_deleted?` method to the Market model that returns false if the market is the default market or the only market in its store
- Implemented `ensure_can_be_deleted` before_destroy callback that prevents deletion and adds appropriate error messages
- Added `last_in_store?` private helper method to check if a market is the only one remaining in its store
- Added localized error messages for both deletion scenarios:
  - "Cannot delete the default market."
  - "Cannot delete the only market."

## Implementation Details
- The validation correctly scopes the "last market" check to the specific store, ensuring markets in other stores don't affect the deletion logic
- The destroy callback uses `throw(:abort)` to prevent the deletion and preserve the record's state
- Error messages are added to the `:base` attribute and use i18n for localization
- Comprehensive test coverage includes edge cases like multi-store scenarios

https://claude.ai/code/session_01Ji3UHaxLC2cM4TsxKw2yre