### PR TITLE
CI: only run backend tests when spree/ changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,15 +3,13 @@ name: Tests
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'packages/**'
-      - '**/*.md'
+    paths:
+      - 'spree/**'
+      - '.github/workflows/tests.yml'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'packages/**'
-      - '**/*.md'
+    paths:
+      - 'spree/**'
+      - '.github/workflows/tests.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Switch `tests.yml` from `paths-ignore` to a `paths` allowlist so the backend matrix only runs when `spree/**` or the workflow itself changes.
- Skips backend test runs for docs-only edits, TypeScript package changes, root config tweaks, and any new top-level folder added later — the previous deny-list approach would silently re-trigger the full suite on any path it didn't explicitly know about.

## Test plan
- [ ] Verify this PR (which only touches `.github/workflows/tests.yml`) does run the Tests workflow — the workflow file is in the allowlist, so it should still trigger here.
- [ ] After merge, confirm a docs-only or `packages/**`-only PR no longer queues the backend matrix.

## Notes
If any backend test job is configured as a **required status check** in branch protection, PRs that don't touch `spree/**` will block waiting for jobs that never run. This is the same behavior as today's `paths-ignore` config, so this PR doesn't make it worse — but worth flagging if we want to add a sentinel "tests-required" gate job in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)