### PR TITLE
Fix API key scope handling and form checkbox styling

### DIFF
--- a/spree/admin/app/views/spree/admin/api_keys/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/api_keys/_form.html.erb
@@ -34,7 +34,7 @@
   </div>
   <div class="card-body">
     <% Spree::ApiKey::SCOPES.each do |scope| %>
-      <div class="custom-control custom-checkbox mb-1">
+      <div class="custom-control form-checkbox mb-1">
         <%= f.check_box :scopes, { multiple: true, class: 'custom-control-input', id: "api_key_scopes_#{scope}" }, scope, nil %>
         <%= f.label "scopes_#{scope}", scope, class: 'custom-control-label font-mono text-sm' %>
       </div>

--- a/spree/admin/spec/features/spree/admin/api_keys_spec.rb
+++ b/spree/admin/spec/features/spree/admin/api_keys_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.feature 'API Keys', :js do
+  stub_authorization!
+
+  let!(:admin_user) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(admin_user)
+  end
+
+  describe 'creating a secret API key' do
+    before { visit spree.new_admin_api_key_path }
+
+    it 'allows checking scope checkboxes and saves them' do
+      fill_in 'api_key_name', with: 'My Integration'
+      select 'Secret', from: 'api_key_key_type'
+
+      check 'api_key_scopes_read_orders'
+      check 'api_key_scopes_write_products'
+
+      expect(page).to have_checked_field('api_key_scopes_read_orders', visible: :all)
+      expect(page).to have_checked_field('api_key_scopes_write_products', visible: :all)
+
+      within('#page-header') { click_button 'Create' }
+
+      expect(page).not_to have_content('Scopes contains unknown scopes')
+      expect(page).to have_content('Store this key securely')
+
+      api_key = Spree::ApiKey.last
+      expect(api_key.name).to eq('My Integration')
+      expect(api_key.key_type).to eq('secret')
+      expect(api_key.scopes).to contain_exactly('read_orders', 'write_products')
+    end
+
+    it 'renders scope checkboxes inside a form-checkbox container so they show checked state' do
+      expect(page).to have_css('.custom-control.form-checkbox input#api_key_scopes_read_orders', visible: :all)
+      expect(page).not_to have_css('.custom-control.custom-checkbox input#api_key_scopes_read_orders', visible: :all)
+    end
+  end
+end

--- a/spree/admin/spec/features/spree/admin/api_keys_spec.rb
+++ b/spree/admin/spec/features/spree/admin/api_keys_spec.rb
@@ -14,30 +14,28 @@ RSpec.feature 'API Keys', :js do
   describe 'creating a secret API key' do
     before { visit spree.new_admin_api_key_path }
 
-    it 'allows checking scope checkboxes and saves them' do
+    it 'allows checking scope checkboxes and saves them without an "unknown scopes" error' do
+      # Scope checkboxes use the .form-checkbox style with the actual <input>
+      # visually hidden; clicks must be routed through the associated <label>.
+      expect(page).to have_css('.custom-control.form-checkbox input#api_key_scopes_read_orders', visible: :all)
+
       fill_in 'api_key_name', with: 'My Integration'
       select 'Secret', from: 'api_key_key_type'
 
-      check 'api_key_scopes_read_orders'
-      check 'api_key_scopes_write_products'
+      check 'read_orders', allow_label_click: true
+      check 'write_products', allow_label_click: true
 
       expect(page).to have_checked_field('api_key_scopes_read_orders', visible: :all)
       expect(page).to have_checked_field('api_key_scopes_write_products', visible: :all)
 
-      within('#page-header') { click_button 'Create' }
+      click_button 'Create'
 
       expect(page).not_to have_content('Scopes contains unknown scopes')
-      expect(page).to have_content('Store this key securely')
 
       api_key = Spree::ApiKey.last
       expect(api_key.name).to eq('My Integration')
       expect(api_key.key_type).to eq('secret')
       expect(api_key.scopes).to contain_exactly('read_orders', 'write_products')
-    end
-
-    it 'renders scope checkboxes inside a form-checkbox container so they show checked state' do
-      expect(page).to have_css('.custom-control.form-checkbox input#api_key_scopes_read_orders', visible: :all)
-      expect(page).not_to have_css('.custom-control.custom-checkbox input#api_key_scopes_read_orders', visible: :all)
     end
   end
 end

--- a/spree/core/app/models/spree/api_key.rb
+++ b/spree/core/app/models/spree/api_key.rb
@@ -29,6 +29,10 @@ module Spree
     # The DB driver handles array <-> JSON conversion; no `serialize` needed.
     attribute :scopes, default: []
 
+    def scopes=(value)
+      super(Array(value).map(&:to_s).reject(&:blank?))
+    end
+
     # Returns the raw token value. For publishable keys this is the persisted
     # +token+ column. For secret keys it is only available in memory immediately
     # after creation (not persisted).

--- a/spree/core/spec/models/spree/api_key_spec.rb
+++ b/spree/core/spec/models/spree/api_key_spec.rb
@@ -280,6 +280,12 @@ RSpec.describe Spree::ApiKey, type: :model do
         key = build(:api_key, :publishable, store: store, scopes: [])
         expect(key).to be_valid
       end
+
+      it 'filters out blank values from the scopes array (sentinel from form hidden field)' do
+        key = build(:api_key, :secret, store: store, scopes: ['', 'read_orders'])
+        expect(key.scopes).to eq(['read_orders'])
+        expect(key).to be_valid
+      end
     end
 
     describe '#has_scope?' do


### PR DESCRIPTION
## Summary
This PR fixes issues with API key scope management and improves the form styling for scope checkboxes in the admin interface.

## Key Changes
- **Scope filtering**: Added a custom setter for the `scopes` attribute in `ApiKey` model that filters out blank values from the array. This handles sentinel values from form hidden fields that are used to ensure the parameter is always present.
- **Form styling**: Changed the scope checkbox container class from `custom-checkbox` to `form-checkbox` to properly display the checked state in the admin form.
- **Test coverage**: Added comprehensive feature tests for API key creation, including:
  - Verification that scope checkboxes can be selected and are properly saved
  - Validation that scope checkboxes are rendered with the correct CSS classes for proper styling

## Implementation Details
- The `scopes=` setter uses `Array(value).map(&:to_s).reject(&:blank?)` to ensure all values are strings and blank entries are removed
- The form checkbox class change aligns with the expected styling convention used elsewhere in the admin interface
- Tests verify both the functional behavior (scopes are saved correctly) and the visual rendering (correct CSS classes are applied)

https://claude.ai/code/session_01WmEjQH2FZyRjYoTvgh1u5N