### PR TITLE
Fixed: Add type column to spree_payment_setup_sessions for STI

### DIFF
--- a/spree/core/app/models/spree/gateway/bogus.rb
+++ b/spree/core/app/models/spree/gateway/bogus.rb
@@ -120,9 +120,14 @@ module Spree
       true
     end
 
+    def payment_setup_session_class
+      PaymentSetupSessions::Bogus
+    end
+
     def create_payment_setup_session(customer:, external_data: {})
-      payment_setup_sessions.create(
+      payment_setup_session_class.create(
         customer: customer,
+        payment_method: self,
         status: 'pending',
         external_id: "bogus_seti_#{SecureRandom.hex(12)}",
         external_client_secret: "bogus_seti_secret_#{SecureRandom.hex(8)}",

--- a/spree/core/app/models/spree/payment_setup_sessions/bogus.rb
+++ b/spree/core/app/models/spree/payment_setup_sessions/bogus.rb
@@ -1,0 +1,4 @@
+module Spree
+  class PaymentSetupSessions::Bogus < PaymentSetupSession
+  end
+end

--- a/spree/core/db/migrate/20260504103113_add_type_to_spree_payment_setup_sessions.rb
+++ b/spree/core/db/migrate/20260504103113_add_type_to_spree_payment_setup_sessions.rb
@@ -1,0 +1,6 @@
+class AddTypeToSpreePaymentSetupSessions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_payment_setup_sessions, :type, :string
+    add_index :spree_payment_setup_sessions, :type
+  end
+end


### PR DESCRIPTION
gateway extensions can't subclass Spree::PaymentSetupSession properly because the table lacks a type column. The companion spree_payment_sessions table has it; this restores parity