### PR TITLE
Change invalid/expired invitation handling to render 404 page

### DIFF
--- a/spree/admin/app/controllers/spree/admin/invitations_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/invitations_controller.rb
@@ -63,8 +63,7 @@ module Spree
           redirect_to spree.new_admin_admin_user_path(token: @invitation.token), status: :see_other
         end
       rescue ActiveRecord::RecordNotFound
-        redirect_to spree.root_path, alert: Spree.t('invalid_or_expired_invitation')
-        nil
+        render :expired, status: :not_found
       end
 
       # PUT /admin/invitations/:id/accept

--- a/spree/admin/app/views/spree/admin/invitations/expired.html.erb
+++ b/spree/admin/app/views/spree/admin/invitations/expired.html.erb
@@ -1,0 +1,4 @@
+<div class="text-center">
+  <h1 class="text-2xl font-semibold mb-2"><%= Spree.t('invitation_expired.heading') %></h1>
+  <p class="text-gray-500"><%= Spree.t('invitation_expired.body') %></p>
+</div>

--- a/spree/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/invitations_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
 
   before do
     allow(controller).to receive(:spree_admin_login_path).and_return('/admin/login')
-    allow(spree).to receive(:root_path).and_return('/')
   end
 
   describe 'GET #index' do
@@ -160,12 +159,9 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
 
         before { get :show, params: { id: invitation.to_param, token: token } }
 
-        it 'redirects to root path' do
-          expect(response).to redirect_to(spree.root_path)
-        end
-
-        it 'sets an alert flash message' do
-          expect(flash[:alert]).to eq(Spree.t('invalid_or_expired_invitation'))
+        it 'renders the expired template with 404 status' do
+          expect(response).to render_template(:expired)
+          expect(response).to have_http_status(:not_found)
         end
       end
     end
@@ -183,21 +179,18 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
       context 'with invalid token' do
         let(:token) { 'invalid' }
 
-        it 'redirects to root path' do
-          expect(response).to redirect_to(spree.root_path)
-        end
-
-        it 'sets an alert flash message' do
-          expect(flash[:alert]).to eq(Spree.t('invalid_or_expired_invitation'))
+        it 'renders the expired template with 404 status' do
+          expect(response).to render_template(:expired)
+          expect(response).to have_http_status(:not_found)
         end
       end
 
       context 'with expired token' do
         let(:invitation) { create(:invitation, inviter: admin_user, resource: store, expires_at: 1.day.ago) }
 
-        it 'redirects to root path' do
-          expect(response).to redirect_to(spree.root_path)
-          expect(flash[:alert]).to eq(Spree.t('invalid_or_expired_invitation'))
+        it 'renders the expired template with 404 status' do
+          expect(response).to render_template(:expired)
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -216,9 +209,9 @@ RSpec.describe Spree::Admin::InvitationsController, type: :controller do
         context 'with already accepted invitation' do
           let(:invitation) { create(:invitation, inviter: admin_user, resource: store, status: 'accepted', invitee: invitee, email: invitee.email) }
 
-          it 'redirects to root path' do
-            expect(response).to redirect_to(spree.root_path)
-            expect(flash[:alert]).to eq(Spree.t('invalid_or_expired_invitation'))
+          it 'renders the expired template with 404 status' do
+            expect(response).to render_template(:expired)
+            expect(response).to have_http_status(:not_found)
           end
         end
       end

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1316,6 +1316,9 @@ en:
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
     inventory_state: Inventory State
     invitation_accepted: Invitation accepted!
+    invitation_expired:
+      body: This invitation link is no longer valid. Please ask the person who invited you to send a new one.
+      heading: Invitation invalid or expired
     invitation_mailer:
       greeting: Hi %{user_name},
       invitation_accepted:


### PR DESCRIPTION
## Summary
Updated the invitation controller to render a dedicated 404 error page instead of redirecting to the root path when an invitation is invalid or expired.

## Key Changes
- Modified `InvitationsController#show` to render an `:expired` template with 404 status instead of redirecting to root path with a flash alert
- Created new `expired.html.erb` template with centered error messaging
- Updated all related controller specs to expect the new 404 response behavior
- Added new i18n translations for the expired invitation page (`invitation_expired.heading` and `invitation_expired.body`)
- Removed unnecessary mock for `spree.root_path` in controller specs

## Implementation Details
- The expired invitation view uses Tailwind CSS classes for styling (text-center, text-2xl, font-semibold, etc.)
- Error messages are now displayed on a dedicated page rather than as flash notifications
- The HTTP status code is now explicitly set to `:not_found` (404) for invalid/expired invitations, improving REST compliance
- All test cases covering invalid tokens, expired tokens, and already-accepted invitations have been updated to verify the new behavior

https://claude.ai/code/session_017uVhzHFUNjWNawfygcXevr