### PR TITLE
Fix orphaned inventory units when destroying line items on completed …

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ef8eb703-c83f-45d6-a5c9-a789223295d8","pid":5491,"procStart":"Thu May  7 16:34:45 2026","acquiredAt":1778177650040}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ef8eb703-c83f-45d6-a5c9-a789223295d8","pid":5491,"procStart":"Thu May  7 16:34:45 2026","acquiredAt":1778177650040}

--- a/spree/core/app/models/spree/line_item.rb
+++ b/spree/core/app/models/spree/line_item.rb
@@ -293,7 +293,7 @@ module Spree
     end
 
     def verify_order_inventory_before_destroy
-      Spree::OrderInventory.new(order, self).verify(target_shipment)
+      Spree::OrderInventory.new(order, self).verify(target_shipment, removing: true)
     end
 
     def update_adjustments

--- a/spree/core/app/models/spree/order_inventory.rb
+++ b/spree/core/app/models/spree/order_inventory.rb
@@ -28,7 +28,11 @@ module Spree
         # Adding here would create units that the LineItem `dependent: :destroy`
         # cascade can't see (set_up_inventory writes through shipment.inventory_units,
         # leaving line_item.inventory_units stale), producing an orphaned unit.
-        remove(units_count, shipment) if units_count.positive?
+        #
+        # Bypass `remove` because it routes through `set_quantity_to_remove` which
+        # assumes a quantity-change scenario; here we want to drain everything tied
+        # to this line item regardless of `line_item.quantity`.
+        remove_all_units(units_count, shipment) if units_count.positive?
       elsif units_count < line_item.quantity
         quantity = line_item.quantity - units_count
 
@@ -44,6 +48,18 @@ module Spree
     def remove(units_count, target_shipment = nil)
       quantity = set_quantity_to_remove(units_count)
 
+      if target_shipment.present?
+        remove_from_shipment(target_shipment, quantity)
+      else
+        order.shipments.each do |shipment|
+          break if quantity.zero?
+
+          quantity -= remove_from_shipment(shipment, quantity)
+        end
+      end
+    end
+
+    def remove_all_units(quantity, target_shipment = nil)
       if target_shipment.present?
         remove_from_shipment(target_shipment, quantity)
       else

--- a/spree/core/app/models/spree/order_inventory.rb
+++ b/spree/core/app/models/spree/order_inventory.rb
@@ -17,13 +17,19 @@ module Spree
     # In case shipment is passed the stock location should only unstock or
     # restock items if the order is completed. That is so because stock items
     # are always unstocked when the order is completed through +shipment.finalize+
-    def verify(shipment = nil, is_updated: false)
+    def verify(shipment = nil, is_updated: false, removing: false)
       return unless order.completed? || shipment.present?
 
       units_count = inventory_units.reload.sum(&:quantity)
       line_item_changed = is_updated ? !line_item.saved_changes? : !line_item.changed?
 
-      if units_count < line_item.quantity
+      if removing
+        # When the line item is being destroyed, only remove existing inventory.
+        # Adding here would create units that the LineItem `dependent: :destroy`
+        # cascade can't see (set_up_inventory writes through shipment.inventory_units,
+        # leaving line_item.inventory_units stale), producing an orphaned unit.
+        remove(units_count, shipment) if units_count.positive?
+      elsif units_count < line_item.quantity
         quantity = line_item.quantity - units_count
 
         shipment ||= determine_target_shipment

--- a/spree/core/app/models/spree/shipment.rb
+++ b/spree/core/app/models/spree/shipment.rb
@@ -272,16 +272,22 @@ module Spree
     def manifest
       # Grouping by the ID means that we don't have to call out to the association accessor
       # This makes the grouping by faster because it results in less SQL cache hits.
-      inventory_units.group_by(&:variant_id).map do |_variant_id, units|
-        units.group_by(&:line_item_id).map do |_line_item_id, units|
+      inventory_units.group_by(&:variant_id).flat_map do |_variant_id, units|
+        units.group_by(&:line_item_id).filter_map do |_line_item_id, units|
+          line_item = units.first.line_item
+          # Defensively skip orphaned inventory units (line item destroyed
+          # without cascading) so a single bad row doesn't crash callers that
+          # rely on line_item being present (item_cost, item_weight, the admin
+          # shipment manifest view, etc.).
+          next if line_item.nil?
+
           states = {}
           units.group_by(&:state).each { |state, iu| states[state] = iu.sum(&:quantity) }
 
-          line_item = units.first.line_item
           variant = units.first.variant
           ManifestItem.new(line_item, variant, units.sum(&:quantity), states)
         end
-      end.flatten
+      end
     end
 
     def process_order_payments

--- a/spree/core/spec/models/spree/line_item_spec.rb
+++ b/spree/core/spec/models/spree/line_item_spec.rb
@@ -103,6 +103,50 @@ describe Spree::LineItem, type: :model do
     it 'deletes inventory units' do
       expect { line_item.destroy }.to change { line_item.inventory_units.count }.from(1).to(0)
     end
+
+    # Regression test for: destroying a line item on a completed order whose
+    # inventory units had already been cleared was leaving an orphan inventory
+    # unit on the shipment with `line_item_id` pointing to the just-destroyed
+    # line item. Cause: `before_destroy :verify_order_inventory_before_destroy`
+    # ran `OrderInventory#verify` which saw `units_count (0) < line_item.quantity (1)`
+    # and called `add_to_shipment` -> `set_up_inventory`, creating a new IU via
+    # `shipment.inventory_units.create(...)`. The line_item's `inventory_units`
+    # association was already loaded (and empty), so AR's `dependent: :destroy`
+    # cascade had nothing to iterate and the new IU survived. The fix passes
+    # `removing: true` so verify only ever removes when called from before_destroy.
+    context 'on a completed order whose inventory units were already cleared' do
+      let(:order) { create(:completed_order_with_totals) }
+      let(:line_item) { order.line_items.first }
+      let(:shipment) { order.shipments.first }
+      let(:other_line_item) do
+        create(:line_item, order: order, variant: create(:variant), quantity: 1).tap do |li|
+          shipment.set_up_inventory('on_hand', li.variant, order, li, 1)
+        end
+      end
+
+      before do
+        other_line_item
+        # Simulate the production state: the line item we are about to destroy
+        # has zero inventory units left on its shipments (e.g. removed by a
+        # prior partial action), but other line items on the same shipment do.
+        shipment.inventory_units.where(line_item_id: line_item.id).delete_all
+        shipment.inventory_units.reload
+      end
+
+      it 'does not leave an orphaned inventory unit on the shipment' do
+        line_item_id = line_item.id
+        line_item.destroy
+
+        # The destroyed line item's id must not be referenced by any inventory
+        # unit on the shipment afterwards.
+        orphaned = shipment.inventory_units.where(line_item_id: line_item_id)
+        expect(orphaned).to be_empty
+      end
+
+      it 'does not create a new inventory unit during destroy' do
+        expect { line_item.destroy }.not_to change { shipment.inventory_units.count }
+      end
+    end
   end
 
   context '#save' do

--- a/spree/core/spec/models/spree/order_inventory_spec.rb
+++ b/spree/core/spec/models/spree/order_inventory_spec.rb
@@ -239,4 +239,22 @@ describe Spree::OrderInventory, type: :model do
       end
     end
   end
+
+  context '#verify with removing: true' do
+    let(:shipment) { order.shipments.first }
+
+    context 'when the line item has no inventory units yet' do
+      before { shipment.inventory_units.where(line_item_id: line_item.id).delete_all }
+
+      it 'does not create new inventory units (which would be orphaned by the destroy cascade)' do
+        expect { subject.verify(nil, removing: true) }.not_to change { shipment.inventory_units.count }
+      end
+    end
+
+    context 'when the line item has existing inventory units' do
+      it 'removes the existing inventory units' do
+        expect { subject.verify(nil, removing: true) }.to change { shipment.inventory_units_for_item(line_item).sum(:quantity) }.to(0)
+      end
+    end
+  end
 end

--- a/spree/core/spec/models/spree/shipment_spec.rb
+++ b/spree/core/spec/models/spree/shipment_spec.rb
@@ -382,15 +382,17 @@ describe Spree::Shipment, type: :model do
 
       before do
         # Simulate an orphaned inventory unit (e.g. line item deleted directly
-        # in the DB or via an out-of-band script). Bypass validations so we end
-        # up with line_item_id: nil on a persisted row.
-        shipment.inventory_units.create!(
+        # in the DB or via an out-of-band script). Bypass validations so the
+        # spec stays valid even if InventoryUnit gains a presence validation
+        # on line_item later.
+        orphan = shipment.inventory_units.build(
           state: 'on_hand',
           variant: other_variant,
           order: order,
           line_item: nil,
           quantity: 1
         )
+        orphan.save(validate: false)
       end
 
       it 'skips the orphaned inventory unit instead of raising' do

--- a/spree/core/spec/models/spree/shipment_spec.rb
+++ b/spree/core/spec/models/spree/shipment_spec.rb
@@ -376,6 +376,32 @@ describe Spree::Shipment, type: :model do
         expect(shipment.manifest.first.variant).to eq variant
       end
     end
+
+    context 'when an inventory unit has no associated line item' do
+      let(:other_variant) { create(:variant) }
+
+      before do
+        # Simulate an orphaned inventory unit (e.g. line item deleted directly
+        # in the DB or via an out-of-band script). Bypass validations so we end
+        # up with line_item_id: nil on a persisted row.
+        shipment.inventory_units.create!(
+          state: 'on_hand',
+          variant: other_variant,
+          order: order,
+          line_item: nil,
+          quantity: 1
+        )
+      end
+
+      it 'skips the orphaned inventory unit instead of raising' do
+        expect { shipment.manifest }.not_to raise_error
+
+        manifest = shipment.manifest
+        expect(manifest.length).to eq(1)
+        expect(manifest.first.variant).to eq(variant)
+        expect(manifest.first.line_item).to eq(line_item)
+      end
+    end
   end
 
   describe '#can_get_rates?' do


### PR DESCRIPTION
…orders

LineItem#verify_order_inventory_before_destroy could create a new
  InventoryUnit instead of just removing existing ones. When a line item's
  inventory units had already been cleared on a completed order (e.g. by a
  prior partial action), the before_destroy callback ran OrderInventory#verify
  which saw `units_count (0) < line_item.quantity` and called add_to_shipment,
  inserting a new IU via shipment.inventory_units.create. AR's
  `dependent: :destroy` cascade on LineItem.inventory_units then iterated a
  stale (empty) association cache, missed the new IU, and the line item
  destroy completed leaving the IU orphaned with line_item_id pointing to a
  row that no longer existed. Subsequent admin order page renders crashed in
  the shipment manifest partial on `item.line_item.single_money`.

  OrderInventory#verify now accepts `removing: true`, used by the destroy
  callback so verify only ever removes during a destroy. The removal path
  uses a new `remove_all_units` helper that drains the full units_count
  directly, bypassing `set_quantity_to_remove` (which assumes a
  quantity-change scenario, not a full drain). Shipment#manifest also
  defensively skips inventory units with no line_item, so any pre-existing
  orphans (or future ones from other paths) don't break the admin UI.