### PR TITLE
Fix metafield parent lookup to survive Zeitwerk code reloads

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/custom_fields_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/custom_fields_controller.rb
@@ -78,20 +78,14 @@ module Spree
 
           ParentLookup = Struct.new(:klass, :value, :segment)
 
-          # Map keyed by route segment to class *name* (string), not the class
-          # object. Storing names keeps the map reload-safe in development:
-          # `Spree.metafields.enabled_resources` holds class references captured
-          # at boot, so after Rails reloads, those references go stale. Names
-          # always re-resolve to the freshly-loaded constant via `constantize`.
-          #
-          # `Spree.user_class.model_name.element` is `'user'` (or `'legacy_user'`),
-          # but the route segment is `customer_id` — alias so both resolve.
+          # Stores class names (not class objects) so the map survives dev-mode
+          # code reloads — `enabled_resources` is captured at boot and its
+          # class references go stale. Aliases `'customer'` because the route
+          # uses `customer_id` while user_class.model_name.element is `'user'`.
           def parent_route_map
             @parent_route_map ||= Spree.metafields.enabled_resources.each_with_object({}) do |klass, m|
               m[klass.model_name.element.to_s] = klass.name
-            end.tap do |map|
-              map['customer'] = Spree.user_class.name
-            end
+            end.merge('customer' => Spree.user_class.name)
           end
 
           # Returns the first segment whose `<segment>_id` is present in params,

--- a/spree/api/app/controllers/spree/api/v3/admin/custom_fields_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/custom_fields_controller.rb
@@ -78,13 +78,19 @@ module Spree
 
           ParentLookup = Struct.new(:klass, :value, :segment)
 
-          # `Spree.user_class.model_name.element` is `'user'`, but the route
-          # segment is `customer_id` — alias here so both resolve to user_class.
+          # Map keyed by route segment to class *name* (string), not the class
+          # object. Storing names keeps the map reload-safe in development:
+          # `Spree.metafields.enabled_resources` holds class references captured
+          # at boot, so after Rails reloads, those references go stale. Names
+          # always re-resolve to the freshly-loaded constant via `constantize`.
+          #
+          # `Spree.user_class.model_name.element` is `'user'` (or `'legacy_user'`),
+          # but the route segment is `customer_id` — alias so both resolve.
           def parent_route_map
             @parent_route_map ||= Spree.metafields.enabled_resources.each_with_object({}) do |klass, m|
-              m[klass.model_name.element.to_s] = klass
+              m[klass.model_name.element.to_s] = klass.name
             end.tap do |map|
-              map['customer'] = Spree.user_class if Spree.metafields.enabled_resources.include?(Spree.user_class)
+              map['customer'] = Spree.user_class.name
             end
           end
 
@@ -97,8 +103,8 @@ module Spree
             match = parent_route_map.find { |segment, _| params[:"#{segment}_id"].present? }
             @parent_lookup =
               if match
-                segment, klass = match
-                ParentLookup.new(klass, params[:"#{segment}_id"], segment)
+                segment, klass_name = match
+                ParentLookup.new(klass_name.constantize, params[:"#{segment}_id"], segment)
               end
           end
         end

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -48,4 +48,31 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      definition_trait: :for_variant,
                      param_key: :variant_id
   end
+
+  # Simulates the dev-mode class-reload condition where
+  # `enabled_resources.include?(Spree.user_class)` returns false because the
+  # cached class reference goes stale after Zeitwerk reloads. The customer
+  # route must still resolve in that case.
+  describe 'when enabled_resources does not contain Spree.user_class' do
+    let!(:parent) { create(:user) }
+    let!(:definition) { create(:metafield_definition, :for_user) }
+    let!(:custom_field) do
+      create(:metafield, resource: parent, metafield_definition: definition,
+                         type: definition.metafield_type, value: 'value-for-parent')
+    end
+
+    before do
+      @original_resources = Rails.application.config.spree.metafields.enabled_resources
+      Rails.application.config.spree.metafields.enabled_resources = @original_resources - [Spree.user_class]
+    end
+
+    after { Rails.application.config.spree.metafields.enabled_resources = @original_resources }
+
+    it 'returns the customer\'s custom fields' do
+      get :index, params: { customer_id: parent.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data'].map { |cf| cf['value'] }).to include('value-for-parent')
+    end
+  end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -49,11 +49,13 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      param_key: :variant_id
   end
 
-  # Regression: in development, `enabled_resources` is captured at boot and
-  # holds stale class references after a code reload, so a class-identity
-  # comparison against the freshly-resolved `Spree.user_class` returned false
-  # and the `customer_id` route segment was dropped from the parent map.
-  describe 'with stale class reference (simulates dev-mode reload)' do
+  # Regression: previously the controller skipped the `customer` alias unless
+  # `enabled_resources.include?(Spree.user_class)` returned true — a check that
+  # broke after dev-mode class reloads because `enabled_resources` held stale
+  # class objects. The route is the source of truth, so the alias is now
+  # unconditional. This test exercises that by removing user_class from the
+  # configured resources.
+  describe 'with user_class missing from enabled_resources' do
     let!(:parent) { create(:user) }
     let!(:definition) { create(:metafield_definition, :for_user) }
     let!(:custom_field) do
@@ -61,18 +63,12 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                          type: definition.metafield_type, value: 'value-for-parent')
     end
 
-    around do |example|
-      original = Rails.application.config.spree.metafields.enabled_resources
-      stale_user = Class.new(Spree.user_class)
-      stale_user.define_singleton_method(:name) { Spree.user_class.name }
-      stale_user.define_singleton_method(:to_s) { Spree.user_class.name }
-      stale_user.define_singleton_method(:model_name) { Spree.user_class.model_name }
-      Rails.application.config.spree.metafields.enabled_resources =
-        original.map { |k| k == Spree.user_class ? stale_user : k }
-      example.run
-    ensure
-      Rails.application.config.spree.metafields.enabled_resources = original
+    before do
+      @original_resources = Rails.application.config.spree.metafields.enabled_resources
+      Rails.application.config.spree.metafields.enabled_resources = @original_resources - [Spree.user_class]
     end
+
+    after { Rails.application.config.spree.metafields.enabled_resources = @original_resources }
 
     it 'still resolves customer parent from route' do
       get :index, params: { customer_id: parent.prefixed_id }, as: :json

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -49,8 +49,26 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      param_key: :variant_id
   end
 
-  it 'aliases customer route segment to Spree.user_class regardless of enabled_resources' do
-    allow(Spree.metafields).to receive(:enabled_resources).and_return([])
-    expect(controller.send(:parent_route_map)['customer']).to eq(Spree.user_class.name)
+  describe 'customer parent with user_class missing from enabled_resources' do
+    let!(:parent) { create(:user) }
+    let!(:definition) { create(:metafield_definition, :for_user) }
+    let!(:custom_field) do
+      create(:metafield, resource: parent, metafield_definition: definition,
+                         type: definition.metafield_type, value: 'value-for-parent')
+    end
+
+    before do
+      @original_resources = Rails.application.config.spree.metafields.enabled_resources
+      Rails.application.config.spree.metafields.enabled_resources = @original_resources - [Spree.user_class]
+    end
+
+    after { Rails.application.config.spree.metafields.enabled_resources = @original_resources }
+
+    it 'returns the customer\'s custom fields' do
+      get :index, params: { customer_id: parent.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data'].map { |cf| cf['value'] }).to include('value-for-parent')
+    end
   end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -48,4 +48,37 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      definition_trait: :for_variant,
                      param_key: :variant_id
   end
+
+  # Regression: in development, `enabled_resources` is captured at boot and
+  # holds stale class references after a code reload, so a class-identity
+  # comparison against the freshly-resolved `Spree.user_class` returned false
+  # and the `customer_id` route segment was dropped from the parent map.
+  describe 'with stale class reference (simulates dev-mode reload)' do
+    let!(:parent) { create(:user) }
+    let!(:definition) { create(:metafield_definition, :for_user) }
+    let!(:custom_field) do
+      create(:metafield, resource: parent, metafield_definition: definition,
+                         type: definition.metafield_type, value: 'value-for-parent')
+    end
+
+    around do |example|
+      original = Rails.application.config.spree.metafields.enabled_resources
+      stale_user = Class.new(Spree.user_class)
+      stale_user.define_singleton_method(:name) { Spree.user_class.name }
+      stale_user.define_singleton_method(:to_s) { Spree.user_class.name }
+      stale_user.define_singleton_method(:model_name) { Spree.user_class.model_name }
+      Rails.application.config.spree.metafields.enabled_resources =
+        original.map { |k| k == Spree.user_class ? stale_user : k }
+      example.run
+    ensure
+      Rails.application.config.spree.metafields.enabled_resources = original
+    end
+
+    it 'still resolves customer parent from route' do
+      get :index, params: { customer_id: parent.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data'].map { |cf| cf['value'] }).to include('value-for-parent')
+    end
+  end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -48,33 +48,4 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      definition_trait: :for_variant,
                      param_key: :variant_id
   end
-
-  # Regression: previously the controller skipped the `customer` alias unless
-  # `enabled_resources.include?(Spree.user_class)` returned true — a check that
-  # broke after dev-mode class reloads because `enabled_resources` held stale
-  # class objects. The route is the source of truth, so the alias is now
-  # unconditional. This test exercises that by removing user_class from the
-  # configured resources.
-  describe 'with user_class missing from enabled_resources' do
-    let!(:parent) { create(:user) }
-    let!(:definition) { create(:metafield_definition, :for_user) }
-    let!(:custom_field) do
-      create(:metafield, resource: parent, metafield_definition: definition,
-                         type: definition.metafield_type, value: 'value-for-parent')
-    end
-
-    before do
-      @original_resources = Rails.application.config.spree.metafields.enabled_resources
-      Rails.application.config.spree.metafields.enabled_resources = @original_resources - [Spree.user_class]
-    end
-
-    after { Rails.application.config.spree.metafields.enabled_resources = @original_resources }
-
-    it 'still resolves customer parent from route' do
-      get :index, params: { customer_id: parent.prefixed_id }, as: :json
-
-      expect(response).to have_http_status(:ok)
-      expect(json_response['data'].map { |cf| cf['value'] }).to include('value-for-parent')
-    end
-  end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -48,27 +48,4 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      definition_trait: :for_variant,
                      param_key: :variant_id
   end
-
-  describe 'customer parent with user_class missing from enabled_resources' do
-    let!(:parent) { create(:user) }
-    let!(:definition) { create(:metafield_definition, :for_user) }
-    let!(:custom_field) do
-      create(:metafield, resource: parent, metafield_definition: definition,
-                         type: definition.metafield_type, value: 'value-for-parent')
-    end
-
-    before do
-      @original_resources = Rails.application.config.spree.metafields.enabled_resources
-      Rails.application.config.spree.metafields.enabled_resources = @original_resources - [Spree.user_class]
-    end
-
-    after { Rails.application.config.spree.metafields.enabled_resources = @original_resources }
-
-    it 'returns the customer\'s custom fields' do
-      get :index, params: { customer_id: parent.prefixed_id }, as: :json
-
-      expect(response).to have_http_status(:ok)
-      expect(json_response['data'].map { |cf| cf['value'] }).to include('value-for-parent')
-    end
-  end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/custom_fields_polymorphic_parent_spec.rb
@@ -48,4 +48,9 @@ RSpec.describe Spree::Api::V3::Admin::CustomFieldsController, type: :controller 
                      definition_trait: :for_variant,
                      param_key: :variant_id
   end
+
+  it 'aliases customer route segment to Spree.user_class regardless of enabled_resources' do
+    allow(Spree.metafields).to receive(:enabled_resources).and_return([])
+    expect(controller.send(:parent_route_map)['customer']).to eq(Spree.user_class.name)
+  end
 end


### PR DESCRIPTION
## Summary
This PR fixes an issue where custom field lookups would fail in development mode when Zeitwerk reloads code, causing stale class references in the `enabled_resources` cache.

## Key Changes
- **Store class names instead of class objects** in `parent_route_map` to ensure the map survives code reloads that invalidate cached class references
- **Resolve class names to actual classes at lookup time** using `constantize` rather than storing direct class references
- **Simplify the customer alias logic** by always including the 'customer' route alias (previously it was conditionally added only if `Spree.user_class` was in `enabled_resources`)
- **Add test coverage** for the dev-mode reload scenario where `enabled_resources` no longer contains the stale `Spree.user_class` reference but the customer route should still resolve correctly

## Implementation Details
The core issue was that `enabled_resources` is captured at boot time with class object references. When Zeitwerk reloads code in development, these cached class references become stale, causing `enabled_resources.include?(Spree.user_class)` to return false even though the user class is still enabled.

By storing class names (strings) instead of class objects, the map persists across reloads. The actual class resolution happens at request time via `constantize`, ensuring we always get the current class definition. The 'customer' alias is now unconditionally merged since we're no longer checking against potentially-stale class references.

https://claude.ai/code/session_012JQJqQWxyXJdRV3sxpzw8F