### PR TITLE
Remove deprecated methods scheduled for Spree 5.5

### DIFF
--- a/spree/core/app/models/spree/option_type.rb
+++ b/spree/core/app/models/spree/option_type.rb
@@ -73,12 +73,6 @@ module Spree
     after_update :touch_all_products, if: -> { saved_changes.key?(:presentation) }
     after_destroy :touch_all_products
 
-    # legacy, name itself is now parameterized before saving
-    def filter_param
-      Spree::Deprecation.warn('Spree::OptionType#filter_param is deprecated and will be removed in Spree 5.5. Please use Spree::OptionType#name instead.')
-      name.parameterize
-    end
-
     def self.color
       colors.first
     end

--- a/spree/core/app/models/spree/product.rb
+++ b/spree/core/app/models/spree/product.rb
@@ -548,19 +548,6 @@ module Spree
       super || variants_including_master.with_deleted.find_by(is_master: true)
     end
 
-    # Returns the brand for the product
-    # If a brand association is defined (e.g., belongs_to :brand), it will be used
-    # Otherwise, falls back to brand_taxon for compatibility
-    # @return [Spree::Brand, Spree::Taxon]
-    def brand
-      if self.class.reflect_on_association(:brand)
-        super
-      else
-        Spree::Deprecation.warn('Spree::Product#brand is deprecated and will be removed in Spree 5.5. Please use Spree::Product#brand_taxon instead.')
-        brand_taxon
-      end
-    end
-
     # Returns the brand taxon for the product
     # @return [Spree::Taxon]
     def brand_taxon
@@ -580,7 +567,7 @@ module Spree
     # Returns the brand name for the product
     # @return [String]
     def brand_name
-      brand&.name
+      brand_taxon&.name
     end
 
     def main_taxon
@@ -752,12 +739,6 @@ module Spree
         variant.set_price(default_currency, master_price) if master_price.present?
       end
       save
-    end
-
-    def default_variant_cache_key
-      Spree::Deprecation.warn('Spree::Product#default_variant_cache_key is deprecated and will be removed in Spree 5.5. Please remove any occurrences of it.')
-
-      "spree/default-variant/#{cache_key_with_version}/#{Spree::Config[:track_inventory_levels]}"
     end
 
     def ensure_master

--- a/spree/core/app/models/spree/store_credit.rb
+++ b/spree/core/app/models/spree/store_credit.rb
@@ -189,14 +189,6 @@ module Spree
       "#{id}-SC-#{Time.now.utc.strftime('%Y%m%d%H%M%S%6N')}"
     end
 
-    class << self
-      def default_created_by
-        Spree::Deprecation.warn('StoreCredit#default_created_by is deprecated and will be removed in Spree 5.5. Please use store.users.first instead.')
-
-        Spree::Store.current.users.first
-      end
-    end
-
     private
 
     def create_credit_record(amount, action_attributes = {})

--- a/spree/core/app/models/spree/taxon.rb
+++ b/spree/core/app/models/spree/taxon.rb
@@ -340,11 +340,6 @@ module Spree
       end
     end
 
-    def active_products
-      Spree::Deprecation.warn('active_products is deprecated and will be removed in Spree 5.5. Please use taxon.products.active instead.')
-      products.active
-    end
-
     def regenerate_pretty_name_and_permalink
       Mobility.with_locale(nil) do
         update_columns(pretty_name: generate_pretty_name, permalink: generate_slug, updated_at: Time.current)

--- a/spree/core/spec/models/spree/option_type_spec.rb
+++ b/spree/core/spec/models/spree/option_type_spec.rb
@@ -172,18 +172,6 @@ describe Spree::OptionType, type: :model do
     end
   end
 
-  describe '#filter_param' do
-    let!(:option_type) { create(:option_type, name: 'color', presentation: 'Color') }
-    let!(:other_option_type) { create(:option_type, name: 'secondary color', presentation: 'Secondary Color') }
-    let!(:some_option_type) { create(:option_type, name: 'option type', presentation: 'Some Option Type') }
-
-    it 'returns filtered name param' do
-      expect(option_type.filter_param).to eq('color')
-      expect(other_option_type.filter_param).to eq('secondary-color')
-      expect(some_option_type.filter_param).to eq('option-type')
-    end
-  end
-
   describe '#self.color' do
     let!(:option_type) { create(:option_type, name: 'color', presentation: 'Color') }
 

--- a/spree/core/spec/models/spree/product_spec.rb
+++ b/spree/core/spec/models/spree/product_spec.rb
@@ -643,42 +643,12 @@ describe Spree::Product, type: :model do
     end
   end
 
-  describe '#brand' do
+  describe '#brand_name' do
     let(:taxonomy) { store.taxonomies.find_by(name: Spree.t(:taxonomy_brands_name)) || create(:taxonomy, name: Spree.t(:taxonomy_brands_name), store: store) }
     let(:product) { create(:product, taxons: [taxonomy.taxons.first], stores: [store]) }
 
-    context 'when brand association is not defined' do
-      it 'falls back to brand_taxon' do
-        expect(product.brand).to eql(taxonomy.taxons.first)
-      end
-
-      it 'returns brand name via brand_name method' do
-        expect(product.brand_name).to eql(taxonomy.taxons.first.name)
-      end
-    end
-
-    context 'when brand association is defined' do
-      let(:brand_class) { Class.new(Spree::Base) { self.table_name = 'spree_taxons' } }
-      let(:brand) { brand_class.first }
-
-      before do
-        stub_const('Spree::Brand', brand_class)
-        allow(Spree::Product).to receive(:reflect_on_association).with(:brand).and_return(double(name: :brand))
-        allow(product).to receive(:super).and_return(brand)
-        # Mock the super call by defining the association behavior
-        product.define_singleton_method(:read_attribute) do |attr|
-          attr == :brand_id ? brand.id : super(attr)
-        end
-        product.define_singleton_method(:association) do |name|
-          name == :brand ? double(reader: brand) : super(name)
-        end
-      end
-
-      it 'uses the brand association' do
-        allow(product).to receive(:brand).and_call_original
-        # Since we can't easily mock super, we verify the reflection check
-        expect(Spree::Product.reflect_on_association(:brand)).to be_truthy
-      end
+    it 'returns the brand taxon name' do
+      expect(product.brand_name).to eql(taxonomy.taxons.first.name)
     end
   end
 


### PR DESCRIPTION
## Summary
This PR removes several deprecated methods that were scheduled for removal in Spree 5.5. These methods have been marked with deprecation warnings and alternative approaches have been documented.

## Key Changes

- **Product#brand method**: Removed the `brand` method that provided fallback logic to `brand_taxon`. The `brand_name` method now directly calls `brand_taxon&.name` instead of `brand&.name`.

- **Product#default_variant_cache_key method**: Removed the deprecated cache key generation method that was only issuing a deprecation warning.

- **OptionType#filter_param method**: Removed the deprecated method that parameterized the option type name. The `name` attribute is now parameterized before saving, making this method unnecessary.

- **StoreCredit.default_created_by class method**: Removed the deprecated class method. Users should use `store.users.first` directly instead.

- **Taxon#active_products method**: Removed the deprecated method. Users should use `taxon.products.active` instead.

- **Test updates**: Simplified the `#brand_name` spec to remove complex mocking of the brand association fallback logic, as the `brand` method is no longer available.

## Implementation Details

The changes maintain backward compatibility at the API level by ensuring that the remaining public methods (`brand_name`, `brand_taxon`) continue to work as expected. The removal of the `brand` method simplifies the codebase by eliminating conditional logic that checked for brand association existence.

https://claude.ai/code/session_01MwAb4HPwaJ5r1Z8tn3Htwi