### PR TITLE
Include gift card in order email

### DIFF
--- a/spree/emails/app/views/spree/shared/_purchased_items_table.html.erb
+++ b/spree/emails/app/views/spree/shared/_purchased_items_table.html.erb
@@ -56,6 +56,21 @@
       </td>
     </tr>
   <% end %>
+  <% if order.gift_card_total.positive? %>
+    <tr>
+      <td></td>
+      <td>
+        <p class="f-fallback purchase_total purchase_total--label">
+          <%= Spree.t(:gift_card) %>:
+        </p>
+      </td>
+      <td class="purchase_total-col">
+        <p class="f-fallback purchase_total">
+          -<%= order.display_gift_card_total.to_html %>
+        </p>
+      </td>
+    </tr>
+  <% end %>
   <% order.adjustments.eligible.each do |adjustment| %>
     <% next if (adjustment.source_type == 'Spree::TaxRate') || (adjustment.amount == 0) %>
     <%= render 'spree/shared/purchased_items_table/adjustment', adjustment: adjustment, order: order %>

--- a/spree/emails/app/views/spree/shared/_purchased_items_table.text.erb
+++ b/spree/emails/app/views/spree/shared/_purchased_items_table.text.erb
@@ -19,6 +19,10 @@
   <%= Spree.t(:tax) %>: <%= order.display_additional_tax_total.to_html %>
 <% end %>
 
+<% if order.gift_card_total.positive? %>
+  <%= Spree.t(:gift_card) %>: -<%= order.display_gift_card_total.to_html %>
+<% end %>
+
 <% order.adjustments.eligible.each do |adjustment| %>
   <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
   <%= adjustment.label %> <%= adjustment.display_amount %>


### PR DESCRIPTION
In emails, we display order total MINUS store credits: https://github.com/spree/spree/blob/main/spree/emails/app/views/spree/shared/purchased_items_table/_total.html.erb#L10, so when gift card is applied, the values do not sum up in the email. Thus we should include gift card as promotion, because from user perspective is acts like a promotion

Before:
<img width="350" alt="Screenshot 2026-05-11 at 09 52 55" src="https://github.com/user-attachments/assets/ad697ffe-44c0-46b6-9443-55e0741a1a79" />

After:


<img width="350" alt="Screenshot 2026-05-11 at 10 00 00" src="https://github.com/user-attachments/assets/2fcad0cc-6251-4fb9-aeaa-d9f12b9e3ddc" />
