### PR TITLE
Use correct even names in docs, specs, examples, comments.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ Subscribers go in `app/subscribers/spree/`:
 ```ruby
 module Spree
   class OrderCompletedSubscriber < Spree::Subscriber
-    subscribes_to 'order.complete'
+    subscribes_to 'order.completed'
 
     def handle(event)
       order = Spree::Order.find_by_prefix_id(event.payload['id'])

--- a/docs/developer/core-concepts/events.mdx
+++ b/docs/developer/core-concepts/events.mdx
@@ -62,7 +62,7 @@ Create a subscriber class in `app/subscribers/` that inherits from `Spree::Subsc
 ```ruby app/subscribers/my_app/order_completed_subscriber.rb
 module MyApp
   class OrderCompletedSubscriber < Spree::Subscriber
-    subscribes_to 'order.complete'
+    subscribes_to 'order.completed'
 
     def handle(event)
       order_id = event.payload['id']
@@ -83,17 +83,17 @@ The `Spree::Subscriber` class provides a clean DSL for declaring subscriptions:
 ```ruby
 class MySubscriber < Spree::Subscriber
   # Subscribe to a single event
-  subscribes_to 'order.complete'
+  subscribes_to 'order.completed'
 
   # Subscribe to multiple events
-  subscribes_to 'order.complete', 'order.cancel', 'order.resume'
+  subscribes_to 'order.completed', 'order.canceled', 'order.resumed'
 
   # Subscribe to all events matching a pattern
   subscribes_to 'order.*'  # All order events
   subscribes_to '*.*'      # All events (use sparingly!)
 
   # Run synchronously instead of via background job
-  subscribes_to 'order.complete', async: false
+  subscribes_to 'order.completed', async: false
 end
 ```
 
@@ -104,11 +104,11 @@ When subscribing to multiple events, use the `on` DSL to route events to specifi
 ```ruby app/subscribers/my_app/order_audit_subscriber.rb
 module MyApp
   class OrderAuditSubscriber < Spree::Subscriber
-    subscribes_to 'order.complete', 'order.cancel', 'order.resume'
+    subscribes_to 'order.completed', 'order.canceled', 'order.resumed'
 
-    on 'order.complete', :log_order_completed
-    on 'order.cancel', :log_order_canceled
-    on 'order.resume', :log_order_resumed
+    on 'order.completed', :log_order_completed
+    on 'order.canceled', :log_order_canceled
+    on 'order.resumed', :log_order_resumed
 
     private
 
@@ -145,7 +145,7 @@ When your subscriber receives an event, you get a `Spree::Event` object with:
 ```ruby
 def handle(event)
   event.id         # => "550e8400-e29b-41d4-a716-446655440000" (UUID)
-  event.name       # => "order.complete"
+  event.name       # => "order.completed"
   event.store_id   # => 1 (ID of the store where the event originated)
   event.payload    # => { "id" => 1, "number" => "R123456", ... }
   event.metadata   # => { "spree_version" => "5.1.0" }
@@ -154,7 +154,7 @@ def handle(event)
   # Helper methods
   event.store        # => Spree::Store instance (lazy loaded)
   event.resource_type # => "order" (extracted from name)
-  event.action        # => "complete" (extracted from name)
+  event.action        # => "completed" (extracted from name)
 end
 ```
 
@@ -426,7 +426,7 @@ For critical operations that must complete before the request finishes, use sync
 
 ```ruby
 class CriticalOrderHandler < Spree::Subscriber
-  subscribes_to 'order.complete', async: false
+  subscribes_to 'order.completed', async: false
 
   def handle(event)
     # This runs immediately, blocking the request
@@ -465,7 +465,7 @@ RSpec.describe MyApp::OrderCompletedSubscriber do
   let(:order) { create(:completed_order_with_totals) }
   let(:event) do
     Spree::Event.new(
-      name: 'order.complete',
+      name: 'order.completed',
       payload: order.event_payload
     )
   end
@@ -484,9 +484,9 @@ end
 Use the `emit_webhook_event` matcher (if available) or stub the events:
 
 ```ruby
-it 'publishes order.complete event' do
+it 'publishes order.completed event' do
   expect(Spree::Events).to receive(:publish).with(
-    'order.complete',
+    'order.completed',
     hash_including('id' => order.id)
   )
 

--- a/docs/developer/core-concepts/events.mdx
+++ b/docs/developer/core-concepts/events.mdx
@@ -521,7 +521,7 @@ Here's a complete example of a subscriber that sends alerts when inventory is lo
 ```ruby app/subscribers/my_app/inventory_alert_subscriber.rb
 module MyApp
   class InventoryAlertSubscriber < Spree::Subscriber
-    subscribes_to 'stock_item.update'
+    subscribes_to 'stock_item.updated'
 
     LOW_STOCK_THRESHOLD = 10
 

--- a/docs/developer/upgrades/5.3-to-5.4.mdx
+++ b/docs/developer/upgrades/5.3-to-5.4.mdx
@@ -81,9 +81,9 @@ If you previously added Subscribers for Events, eg. `order.completed` with code 
 ```ruby
 module MyApp
   class OrderAuditSubscriber < Spree::Subscriber
-    subscribes_to 'order.complete'
+    subscribes_to 'order.completed'
 
-    on 'order.complete', :log_order_completed
+    on 'order.completed', :log_order_completed
 
     private
 

--- a/spree/core/app/jobs/spree/events/subscriber_job.rb
+++ b/spree/core/app/jobs/spree/events/subscriber_job.rb
@@ -10,7 +10,7 @@ module Spree
     # @example Direct usage (typically called by the adapter)
     #   Spree::Events::SubscriberJob.perform_later(
     #     'MySubscriber',
-    #     { name: 'order.complete', payload: {...}, ... }
+    #     { name: 'order.completed', payload: {...}, ... }
     #   )
     #
     class SubscriberJob < Spree::BaseJob

--- a/spree/core/app/models/concerns/spree/publishable.rb
+++ b/spree/core/app/models/concerns/spree/publishable.rb
@@ -122,7 +122,7 @@ module Spree
 
     # Publish an event with this model's data
     #
-    # @param event_name [String] The event name (e.g., 'order.complete')
+    # @param event_name [String] The event name (e.g., 'order.completed')
     # @param payload [Hash, nil] Custom payload (defaults to event_payload)
     # @param metadata [Hash] Additional metadata
     # @return [Spree::Event] The published event

--- a/spree/core/app/models/spree/event.rb
+++ b/spree/core/app/models/spree/event.rb
@@ -6,20 +6,20 @@ module Spree
   # Events are immutable objects that carry information about something
   # that happened in the system. They contain:
   # - An id (UUID)
-  # - A name (e.g., 'order.complete', 'product.create')
+  # - A name (e.g., 'order.completed', 'product.created')
   # - A store_id (the store where the event originated)
   # - A payload (serialized data about the event)
   # - Metadata (contextual information like spree_version)
   #
   # @example Creating an event
   #   event = Spree::Event.new(
-  #     name: 'order.complete',
+  #     name: 'order.completed',
   #     payload: order.serializable_hash
   #   )
   #
   # @example Accessing event data
   #   event.id         # => "550e8400-e29b-41d4-a716-446655440000"
-  #   event.name       # => 'order.complete'
+  #   event.name       # => 'order.completed'
   #   event.store_id   # => 1
   #   event.payload    # => { 'id' => 1, 'number' => 'R123456' }
   #   event.created_at # => 2024-01-15 10:30:00 UTC
@@ -61,19 +61,19 @@ module Spree
     end
 
     # Returns the resource type from the event name
-    # @return [String] The resource type (e.g., 'order' from 'order.complete')
+    # @return [String] The resource type (e.g., 'order' from 'order.completed')
     def resource_type
       @resource_type ||= name.to_s.split('.').first
     end
 
     # Returns the action from the event name
-    # @return [String] The action (e.g., 'complete' from 'order.complete')
+    # @return [String] The action (e.g., 'completed' from 'order.completed')
     def action
       @action ||= name.to_s.split('.').drop(1).join('.')
     end
 
     # Checks if the event matches a pattern
-    # Supports wildcards: 'order.*' matches 'order.complete', 'order.cancel'
+    # Supports wildcards: 'order.*' matches 'order.completed', 'order.canceled'
     # @param pattern [String] The pattern to match against
     # @return [Boolean]
     def matches?(pattern)

--- a/spree/core/app/models/spree/subscriber.rb
+++ b/spree/core/app/models/spree/subscriber.rb
@@ -41,11 +41,11 @@ module Spree
   #
   # @example Subscriber with method routing
   #   class PaymentSubscriber < Spree::Subscriber
-  #     subscribes_to 'payment.completed', 'payment.voided', 'payment.refunded'
+  #     subscribes_to 'payment.completed', 'payment.voided', 'refund.created'
   #
   #     on 'payment.completed', :handle_complete
   #     on 'payment.voided', :handle_void
-  #     on 'payment.refunded', :handle_refund
+  #     on 'refund.created', :handle_refund
   #
   #     private
   #

--- a/spree/core/app/models/spree/subscriber.rb
+++ b/spree/core/app/models/spree/subscriber.rb
@@ -41,11 +41,11 @@ module Spree
   #
   # @example Subscriber with method routing
   #   class PaymentSubscriber < Spree::Subscriber
-  #     subscribes_to 'payment.complete', 'payment.void', 'payment.refund'
+  #     subscribes_to 'payment.completed', 'payment.voided', 'payment.refunded'
   #
-  #     on 'payment.complete', :handle_complete
-  #     on 'payment.void', :handle_void
-  #     on 'payment.refund', :handle_refund
+  #     on 'payment.completed', :handle_complete
+  #     on 'payment.voided', :handle_void
+  #     on 'payment.refunded', :handle_refund
   #
   #     private
   #
@@ -102,8 +102,8 @@ module Spree
       # @return [void]
       #
       # @example
-      #   on 'payment.complete', :handle_complete
-      #   on 'payment.void', :handle_void
+      #   on 'payment.completed', :handle_complete
+      #   on 'payment.voided', :handle_void
       #
       def on(pattern, method_name)
         @event_handlers ||= {}

--- a/spree/core/app/models/spree/subscriber.rb
+++ b/spree/core/app/models/spree/subscriber.rb
@@ -9,7 +9,7 @@ module Spree
   #
   # @example Basic subscriber
   #   class OrderCompletedNotifier < Spree::Subscriber
-  #     subscribes_to 'order.complete'
+  #     subscribes_to 'order.completed'
   #
   #     def call(event)
   #       order_id = event.payload['id']
@@ -19,7 +19,7 @@ module Spree
   #
   # @example Multi-event subscriber
   #   class OrderAuditLogger < Spree::Subscriber
-  #     subscribes_to 'order.complete', 'order.cancel', 'order.resume'
+  #     subscribes_to 'order.completed', 'order.canceled', 'order.resumed'
   #
   #     def call(event)
   #       AuditLog.create!(
@@ -64,7 +64,7 @@ module Spree
   #
   # @example Synchronous subscriber (runs immediately, not via ActiveJob)
   #   class CriticalOrderHandler < Spree::Subscriber
-  #     subscribes_to 'order.complete', async: false
+  #     subscribes_to 'order.completed', async: false
   #
   #     def call(event)
   #       # This runs synchronously
@@ -81,10 +81,10 @@ module Spree
       # @return [void]
       #
       # @example
-      #   subscribes_to 'order.complete'
-      #   subscribes_to 'order.complete', 'order.cancel'
+      #   subscribes_to 'order.completed'
+      #   subscribes_to 'order.completed', 'order.canceled'
       #   subscribes_to 'order.*'
-      #   subscribes_to 'order.complete', async: false
+      #   subscribes_to 'order.completed', async: false
       #
       def subscribes_to(*patterns, **options)
         @subscription_patterns ||= []

--- a/spree/core/app/subscribers/spree/event_log_subscriber.rb
+++ b/spree/core/app/subscribers/spree/event_log_subscriber.rb
@@ -9,7 +9,7 @@ module Spree
   # Rails.application.config.filter_parameters.
   #
   # @example Output
-  #   [Spree Event] order.complete | payload: {"id"=>1} | 0.5ms
+  #   [Spree Event] order.completed | payload: {"id"=>1} | 0.5ms
   #
   class EventLogSubscriber
     NAMESPACE = 'spree'

--- a/spree/core/lib/spree/events.rb
+++ b/spree/core/lib/spree/events.rb
@@ -36,7 +36,7 @@ module Spree
 
       # Publish an event to all matching subscribers
       #
-      # @param name [String] The event name (e.g., 'order.complete')
+      # @param name [String] The event name (e.g., 'order.completed')
       # @param payload [Hash] The event payload (should be serializable)
       # @param metadata [Hash] Additional metadata for the event
       # @return [Spree::Event] The published event

--- a/spree/core/lib/spree/events/adapters/active_support_notifications.rb
+++ b/spree/core/lib/spree/events/adapters/active_support_notifications.rb
@@ -12,7 +12,7 @@ module Spree
       #
       # @example Publishing an event
       #   adapter = ActiveSupportNotifications.new(registry)
-      #   adapter.publish('order.complete', { id: 1 })
+      #   adapter.publish('order.completed', { id: 1 })
       #
       class ActiveSupportNotifications < Base
         NAMESPACE = 'spree'

--- a/spree/core/lib/spree/events/adapters/base.rb
+++ b/spree/core/lib/spree/events/adapters/base.rb
@@ -43,13 +43,13 @@ module Spree
 
         # Publish an event to all matching subscribers.
         #
-        # @param event_name [String] the event name (e.g., 'order.complete')
+        # @param event_name [String] the event name (e.g., 'order.completed')
         # @param payload [Hash] the event payload (should be serializable)
         # @param metadata [Hash] additional metadata for the event
         # @return [Spree::Event] the published event
         #
         # @example
-        #   adapter.publish('order.complete', order.serializable_hash, { user_id: 1 })
+        #   adapter.publish('order.completed', order.serializable_hash, { user_id: 1 })
         #
         def publish(event_name, payload, metadata = {})
           raise NotImplementedError, "#{self.class}#publish must be implemented"
@@ -67,7 +67,7 @@ module Spree
         # @option options [Boolean] :async (true) whether to run async via ActiveJob
         #
         # @example
-        #   adapter.subscribe('order.complete', MySubscriber)
+        #   adapter.subscribe('order.completed', MySubscriber)
         #   adapter.subscribe('order.*', AuditLogger, async: false)
         #
         def subscribe(pattern, subscriber, options = {})

--- a/spree/core/lib/spree/events/registry.rb
+++ b/spree/core/lib/spree/events/registry.rb
@@ -15,7 +15,7 @@ module Spree
     # @example
     #   registry = Spree::Events::Registry.new
     #   registry.register('order.*', MySubscriber, async: true)
-    #   registry.subscriptions_for('order.complete') # => [Subscription]
+    #   registry.subscriptions_for('order.completed') # => [Subscription]
     #
     class Registry
       # Immutable subscription data using Ruby 3.2+ Data class

--- a/spree/core/spec/lib/spree/events/registry_spec.rb
+++ b/spree/core/spec/lib/spree/events/registry_spec.rb
@@ -9,47 +9,47 @@ RSpec.describe Spree::Events::Registry do
 
   describe '#register' do
     it 'registers a subscriber for a pattern' do
-      registry.register('order.complete', subscriber_class)
+      registry.register('order.completed', subscriber_class)
 
       expect(registry.size).to eq(1)
-      expect(registry.registered?('order.complete')).to be true
+      expect(registry.registered?('order.completed')).to be true
     end
 
     it 'allows multiple subscribers for the same pattern' do
-      registry.register('order.complete', subscriber_class)
-      registry.register('order.complete', another_subscriber)
+      registry.register('order.completed', subscriber_class)
+      registry.register('order.completed', another_subscriber)
 
       expect(registry.size).to eq(2)
     end
 
     it 'stores subscription options' do
-      registry.register('order.complete', subscriber_class, async: false)
+      registry.register('order.completed', subscriber_class, async: false)
 
-      subscription = registry.subscriptions_for('order.complete').first
+      subscription = registry.subscriptions_for('order.completed').first
       expect(subscription.options[:async]).to be false
     end
 
     it 'returns the subscription' do
-      subscription = registry.register('order.complete', subscriber_class)
+      subscription = registry.register('order.completed', subscriber_class)
 
       expect(subscription).to be_a(Spree::Events::Registry::Subscription)
-      expect(subscription.pattern).to eq('order.complete')
+      expect(subscription.pattern).to eq('order.completed')
       expect(subscription.subscriber).to eq(subscriber_class)
     end
   end
 
   describe '#unregister' do
     before do
-      registry.register('order.complete', subscriber_class)
-      registry.register('order.complete', another_subscriber)
+      registry.register('order.completed', subscriber_class)
+      registry.register('order.completed', another_subscriber)
     end
 
     it 'removes a specific subscriber' do
-      result = registry.unregister('order.complete', subscriber_class)
+      result = registry.unregister('order.completed', subscriber_class)
 
       expect(result).to be true
       expect(registry.size).to eq(1)
-      expect(registry.subscriptions_for('order.complete').map(&:subscriber)).not_to include(subscriber_class)
+      expect(registry.subscriptions_for('order.completed').map(&:subscriber)).not_to include(subscriber_class)
     end
 
     it 'returns false when subscriber not found' do
@@ -59,20 +59,20 @@ RSpec.describe Spree::Events::Registry do
     end
 
     it 'keeps other subscribers intact' do
-      registry.unregister('order.complete', subscriber_class)
+      registry.unregister('order.completed', subscriber_class)
 
-      expect(registry.subscriptions_for('order.complete').map(&:subscriber)).to include(another_subscriber)
+      expect(registry.subscriptions_for('order.completed').map(&:subscriber)).to include(another_subscriber)
     end
   end
 
   describe '#subscriptions_for' do
     before do
-      registry.register('order.complete', subscriber_class)
+      registry.register('order.completed', subscriber_class)
       registry.register('order.*', another_subscriber)
     end
 
     it 'returns subscriptions for exact match' do
-      subscriptions = registry.subscriptions_for('order.complete')
+      subscriptions = registry.subscriptions_for('order.completed')
 
       expect(subscriptions.size).to eq(2)
     end
@@ -94,7 +94,7 @@ RSpec.describe Spree::Events::Registry do
       before { registry.register('*', Class.new) }
 
       it 'matches all events' do
-        expect(registry.subscriptions_for('order.complete').size).to eq(3)
+        expect(registry.subscriptions_for('order.completed').size).to eq(3)
         expect(registry.subscriptions_for('product.create').size).to eq(1)
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe Spree::Events::Registry do
 
   describe '#all_subscriptions' do
     it 'returns all registered subscriptions' do
-      registry.register('order.complete', subscriber_class)
+      registry.register('order.completed', subscriber_class)
       registry.register('order.*', another_subscriber)
 
       subscriptions = registry.all_subscriptions
@@ -111,7 +111,7 @@ RSpec.describe Spree::Events::Registry do
     end
 
     it 'returns a copy of the subscriptions' do
-      registry.register('order.complete', subscriber_class)
+      registry.register('order.completed', subscriber_class)
 
       subscriptions = registry.all_subscriptions
       subscriptions.clear
@@ -122,17 +122,17 @@ RSpec.describe Spree::Events::Registry do
 
   describe '#patterns' do
     it 'returns unique patterns' do
-      registry.register('order.complete', subscriber_class)
-      registry.register('order.complete', another_subscriber)
+      registry.register('order.completed', subscriber_class)
+      registry.register('order.completed', another_subscriber)
       registry.register('order.*', subscriber_class)
 
-      expect(registry.patterns).to contain_exactly('order.complete', 'order.*')
+      expect(registry.patterns).to contain_exactly('order.completed', 'order.*')
     end
   end
 
   describe '#clear!' do
     it 'removes all subscriptions' do
-      registry.register('order.complete', subscriber_class)
+      registry.register('order.completed', subscriber_class)
       registry.register('order.*', another_subscriber)
 
       registry.clear!
@@ -143,13 +143,13 @@ RSpec.describe Spree::Events::Registry do
 
   describe '#registered?' do
     it 'returns true for registered patterns' do
-      registry.register('order.complete', subscriber_class)
+      registry.register('order.completed', subscriber_class)
 
-      expect(registry.registered?('order.complete')).to be true
+      expect(registry.registered?('order.completed')).to be true
     end
 
     it 'returns false for unregistered patterns' do
-      expect(registry.registered?('order.complete')).to be false
+      expect(registry.registered?('order.completed')).to be false
     end
   end
 

--- a/spree/core/spec/lib/spree/events/registry_spec.rb
+++ b/spree/core/spec/lib/spree/events/registry_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Spree::Events::Registry do
     end
 
     it 'returns false when subscriber not found' do
-      result = registry.unregister('order.cancel', subscriber_class)
+      result = registry.unregister('order.canceled', subscriber_class)
 
       expect(result).to be false
     end
@@ -78,7 +78,7 @@ RSpec.describe Spree::Events::Registry do
     end
 
     it 'returns subscriptions matching wildcard patterns' do
-      subscriptions = registry.subscriptions_for('order.cancel')
+      subscriptions = registry.subscriptions_for('order.canceled')
 
       expect(subscriptions.size).to eq(1)
       expect(subscriptions.first.subscriber).to eq(another_subscriber)

--- a/spree/core/spec/models/spree/event_spec.rb
+++ b/spree/core/spec/models/spree/event_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Spree::Event do
   describe '#action' do
     it 'extracts the action from the event name' do
       event = described_class.new(name: 'order.completed', payload: {})
-      expect(event.action).to eq('complete')
+      expect(event.action).to eq('completed')
     end
 
     it 'handles multi-part actions' do
@@ -154,7 +154,7 @@ RSpec.describe Spree::Event do
 
     it 'matches exact event names' do
       expect(event.matches?('order.completed')).to be true
-      expect(event.matches?('order.cancel')).to be false
+      expect(event.matches?('order.canceled')).to be false
     end
 
     it 'matches wildcard patterns' do
@@ -170,12 +170,12 @@ RSpec.describe Spree::Event do
   describe '.matches?' do
     it 'matches exact names' do
       expect(described_class.matches?('order.completed', 'order.completed')).to be true
-      expect(described_class.matches?('order.completed', 'order.cancel')).to be false
+      expect(described_class.matches?('order.completed', 'order.canceled')).to be false
     end
 
     it 'matches wildcard patterns' do
       expect(described_class.matches?('order.completed', 'order.*')).to be true
-      expect(described_class.matches?('order.cancel', 'order.*')).to be true
+      expect(described_class.matches?('order.canceled', 'order.*')).to be true
       expect(described_class.matches?('product.create', 'order.*')).to be false
     end
 

--- a/spree/core/spec/models/spree/event_spec.rb
+++ b/spree/core/spec/models/spree/event_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe Spree::Event do
   describe '#initialize' do
     it 'creates an event with name and payload' do
       event = described_class.new(
-        name: 'order.complete',
+        name: 'order.completed',
         payload: { id: 1, number: 'R123' }
       )
 
-      expect(event.name).to eq('order.complete')
+      expect(event.name).to eq('order.completed')
       expect(event.payload).to eq({ 'id' => 1, 'number' => 'R123' })
     end
 
     it 'freezes the payload and metadata' do
       event = described_class.new(
-        name: 'order.complete',
+        name: 'order.completed',
         payload: { id: 1 }
       )
 
@@ -104,20 +104,20 @@ RSpec.describe Spree::Event do
 
   describe '#store' do
     it 'returns the store for the store_id' do
-      event = described_class.new(name: 'order.complete', store_id: store.id)
+      event = described_class.new(name: 'order.completed', store_id: store.id)
 
       expect(event.store).to eq(store)
     end
 
     it 'returns nil when store_id is blank' do
       allow(Spree::Current).to receive(:store).and_return(nil)
-      event = described_class.new(name: 'order.complete', store_id: nil)
+      event = described_class.new(name: 'order.completed', store_id: nil)
 
       expect(event.store).to be_nil
     end
 
     it 'memoizes the store lookup' do
-      event = described_class.new(name: 'order.complete', store_id: store.id)
+      event = described_class.new(name: 'order.completed', store_id: store.id)
 
       expect(Spree::Store).to receive(:find_by).once.and_return(store)
 
@@ -127,7 +127,7 @@ RSpec.describe Spree::Event do
 
   describe '#resource_type' do
     it 'extracts the resource type from the event name' do
-      event = described_class.new(name: 'order.complete', payload: {})
+      event = described_class.new(name: 'order.completed', payload: {})
       expect(event.resource_type).to eq('order')
     end
 
@@ -139,7 +139,7 @@ RSpec.describe Spree::Event do
 
   describe '#action' do
     it 'extracts the action from the event name' do
-      event = described_class.new(name: 'order.complete', payload: {})
+      event = described_class.new(name: 'order.completed', payload: {})
       expect(event.action).to eq('complete')
     end
 
@@ -150,10 +150,10 @@ RSpec.describe Spree::Event do
   end
 
   describe '#matches?' do
-    let(:event) { described_class.new(name: 'order.complete', payload: {}) }
+    let(:event) { described_class.new(name: 'order.completed', payload: {}) }
 
     it 'matches exact event names' do
-      expect(event.matches?('order.complete')).to be true
+      expect(event.matches?('order.completed')).to be true
       expect(event.matches?('order.cancel')).to be false
     end
 
@@ -169,18 +169,18 @@ RSpec.describe Spree::Event do
 
   describe '.matches?' do
     it 'matches exact names' do
-      expect(described_class.matches?('order.complete', 'order.complete')).to be true
-      expect(described_class.matches?('order.complete', 'order.cancel')).to be false
+      expect(described_class.matches?('order.completed', 'order.completed')).to be true
+      expect(described_class.matches?('order.completed', 'order.cancel')).to be false
     end
 
     it 'matches wildcard patterns' do
-      expect(described_class.matches?('order.complete', 'order.*')).to be true
+      expect(described_class.matches?('order.completed', 'order.*')).to be true
       expect(described_class.matches?('order.cancel', 'order.*')).to be true
       expect(described_class.matches?('product.create', 'order.*')).to be false
     end
 
     it 'matches global wildcard' do
-      expect(described_class.matches?('order.complete', '*')).to be true
+      expect(described_class.matches?('order.completed', '*')).to be true
       expect(described_class.matches?('anything.here', '*')).to be true
     end
 
@@ -193,14 +193,14 @@ RSpec.describe Spree::Event do
   describe '#attributes' do
     it 'returns a hash representation with string keys' do
       event = described_class.new(
-        name: 'order.complete',
+        name: 'order.completed',
         payload: { id: 1 },
         metadata: { user_id: 5 }
       )
 
       hash = event.attributes
 
-      expect(hash['name']).to eq('order.complete')
+      expect(hash['name']).to eq('order.completed')
       expect(hash['store_id']).to eq(store.id)
       expect(hash['payload']).to eq({ 'id' => 1 })
       expect(hash['metadata']['user_id']).to eq(5)
@@ -210,8 +210,8 @@ RSpec.describe Spree::Event do
 
   describe '#inspect' do
     it 'returns a readable string representation' do
-      event = described_class.new(name: 'order.complete', payload: {})
-      expect(event.inspect).to match(/Spree::Event id="[0-9a-f-]{36}" name="order.complete" store_id=#{store.id} created_at=/)
+      event = described_class.new(name: 'order.completed', payload: {})
+      expect(event.inspect).to match(/Spree::Event id="[0-9a-f-]{36}" name="order.completed" store_id=#{store.id} created_at=/)
     end
   end
 end

--- a/spree/core/spec/models/spree/subscriber_spec.rb
+++ b/spree/core/spec/models/spree/subscriber_spec.rb
@@ -14,23 +14,23 @@ RSpec.describe Spree::Subscriber, events: true do
   describe '.subscribes_to' do
     it 'registers subscription patterns' do
       subscriber_class = Class.new(described_class) do
-        subscribes_to 'order.complete'
+        subscribes_to 'order.completed'
       end
 
-      expect(subscriber_class.subscription_patterns).to eq(['order.complete'])
+      expect(subscriber_class.subscription_patterns).to eq(['order.completed'])
     end
 
     it 'accepts multiple patterns' do
       subscriber_class = Class.new(described_class) do
-        subscribes_to 'order.complete', 'order.cancel'
+        subscribes_to 'order.completed', 'order.cancel'
       end
 
-      expect(subscriber_class.subscription_patterns).to contain_exactly('order.complete', 'order.cancel')
+      expect(subscriber_class.subscription_patterns).to contain_exactly('order.completed', 'order.cancel')
     end
 
     it 'stores subscription options' do
       subscriber_class = Class.new(described_class) do
-        subscribes_to 'order.complete', async: false
+        subscribes_to 'order.completed', async: false
       end
 
       expect(subscriber_class.subscription_options).to eq({ async: false })
@@ -38,11 +38,11 @@ RSpec.describe Spree::Subscriber, events: true do
 
     it 'accumulates patterns from multiple calls' do
       subscriber_class = Class.new(described_class) do
-        subscribes_to 'order.complete'
+        subscribes_to 'order.completed'
         subscribes_to 'order.cancel'
       end
 
-      expect(subscriber_class.subscription_patterns).to contain_exactly('order.complete', 'order.cancel')
+      expect(subscriber_class.subscription_patterns).to contain_exactly('order.completed', 'order.cancel')
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Spree::Subscriber, events: true do
           end
         end
 
-        event = Spree::Event.new(name: 'order.complete', payload: {})
+        event = Spree::Event.new(name: 'order.completed', payload: {})
         subscriber_class.new.call(event)
 
         expect(handled_events).to eq([event])

--- a/spree/core/spec/models/spree/subscriber_spec.rb
+++ b/spree/core/spec/models/spree/subscriber_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Spree::Subscriber, events: true do
 
     it 'accepts multiple patterns' do
       subscriber_class = Class.new(described_class) do
-        subscribes_to 'order.completed', 'order.cancel'
+        subscribes_to 'order.completed', 'order.canceled'
       end
 
-      expect(subscriber_class.subscription_patterns).to contain_exactly('order.completed', 'order.cancel')
+      expect(subscriber_class.subscription_patterns).to contain_exactly('order.completed', 'order.canceled')
     end
 
     it 'stores subscription options' do
@@ -39,10 +39,10 @@ RSpec.describe Spree::Subscriber, events: true do
     it 'accumulates patterns from multiple calls' do
       subscriber_class = Class.new(described_class) do
         subscribes_to 'order.completed'
-        subscribes_to 'order.cancel'
+        subscribes_to 'order.canceled'
       end
 
-      expect(subscriber_class.subscription_patterns).to contain_exactly('order.completed', 'order.cancel')
+      expect(subscriber_class.subscription_patterns).to contain_exactly('order.completed', 'order.canceled')
     end
   end
 

--- a/spree/core/spec/models/spree/subscriber_spec.rb
+++ b/spree/core/spec/models/spree/subscriber_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Spree::Subscriber, events: true do
   describe '.on' do
     it 'maps events to methods' do
       subscriber_class = Class.new(described_class) do
-        subscribes_to 'payment.complete', 'payment.void'
-        on 'payment.complete', :handle_complete
-        on 'payment.void', :handle_void
+        subscribes_to 'payment.completed', 'payment.voided'
+        on 'payment.completed', :handle_complete
+        on 'payment.voided', :handle_void
       end
 
       expect(subscriber_class.event_handlers).to eq({
-        'payment.complete' => :handle_complete,
-        'payment.void' => :handle_void
+        'payment.completed' => :handle_complete,
+        'payment.voided' => :handle_void
       })
     end
   end
@@ -84,9 +84,9 @@ RSpec.describe Spree::Subscriber, events: true do
         called_handlers = []
 
         subscriber_class = Class.new(described_class) do
-          subscribes_to 'payment.complete', 'payment.void'
-          on 'payment.complete', :handle_complete
-          on 'payment.void', :handle_void
+          subscribes_to 'payment.completed', 'payment.voided'
+          on 'payment.completed', :handle_complete
+          on 'payment.voided', :handle_void
 
           define_method(:handle_complete) do |event|
             called_handlers << [:complete, event]
@@ -97,8 +97,8 @@ RSpec.describe Spree::Subscriber, events: true do
           end
         end
 
-        complete_event = Spree::Event.new(name: 'payment.complete', payload: {})
-        void_event = Spree::Event.new(name: 'payment.void', payload: {})
+        complete_event = Spree::Event.new(name: 'payment.completed', payload: {})
+        void_event = Spree::Event.new(name: 'payment.voided', payload: {})
 
         subscriber_class.new.call(complete_event)
         subscriber_class.new.call(void_event)
@@ -114,7 +114,7 @@ RSpec.describe Spree::Subscriber, events: true do
 
         subscriber_class = Class.new(described_class) do
           subscribes_to 'payment.*'
-          on 'payment.complete', :handle_complete
+          on 'payment.completed', :handle_complete
 
           define_method(:handle_complete) do |_event|
             # Should not be called for refund events
@@ -125,7 +125,7 @@ RSpec.describe Spree::Subscriber, events: true do
           end
         end
 
-        event = Spree::Event.new(name: 'payment.refund', payload: {})
+        event = Spree::Event.new(name: 'payment.refunded', payload: {})
         subscriber_class.new.call(event)
 
         expect(handled_events).to eq([event])

--- a/spree/core/spec/subscribers/spree/event_log_subscriber_spec.rb
+++ b/spree/core/spec/subscribers/spree/event_log_subscriber_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe Spree::EventLogSubscriber do
       described_class.attach_to_notifications
       described_class.attach_to_notifications
 
-      event = Spree::Event.new(name: 'order.complete', payload: { 'id' => 1 }, metadata: {})
+      event = Spree::Event.new(name: 'order.completed', payload: { 'id' => 1 }, metadata: {})
 
       log_calls = 0
       allow(Rails.logger).to receive(:info) { log_calls += 1 }
 
-      ActiveSupport::Notifications.instrument('order.complete.spree', event: event) {}
+      ActiveSupport::Notifications.instrument('order.completed.spree', event: event) {}
 
       expect(log_calls).to eq(1)
     end
@@ -74,14 +74,14 @@ RSpec.describe Spree::EventLogSubscriber do
 
     it 'logs events to Rails logger' do
       event = Spree::Event.new(
-        name: 'order.complete',
+        name: 'order.completed',
         payload: { 'id' => 1, 'number' => 'R123' },
         metadata: {}
       )
 
       expect(Rails.logger).to receive(:info).with(/\[Spree Event\].*order\.complete/)
 
-      ActiveSupport::Notifications.instrument('order.complete.spree', event: event) {}
+      ActiveSupport::Notifications.instrument('order.completed.spree', event: event) {}
     end
 
     describe 'filtering sensitive parameters' do
@@ -135,7 +135,7 @@ RSpec.describe Spree::EventLogSubscriber do
 
       it 'does not filter non-sensitive data' do
         event = Spree::Event.new(
-          name: 'order.complete',
+          name: 'order.completed',
           payload: { 'id' => 42, 'total' => '99.99', 'state' => 'complete' },
           metadata: {}
         )
@@ -146,7 +146,7 @@ RSpec.describe Spree::EventLogSubscriber do
           expect(message).to include('complete')
         end
 
-        ActiveSupport::Notifications.instrument('order.complete.spree', event: event) {}
+        ActiveSupport::Notifications.instrument('order.completed.spree', event: event) {}
       end
     end
   end

--- a/spree/core/spec/subscribers/spree/event_log_subscriber_spec.rb
+++ b/spree/core/spec/subscribers/spree/event_log_subscriber_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Spree::EventLogSubscriber do
         metadata: {}
       )
 
-      expect(Rails.logger).to receive(:info).with(/\[Spree Event\].*order\.complete/)
+      expect(Rails.logger).to receive(:info).with(/\[Spree Event\].*order\.completed/)
 
       ActiveSupport::Notifications.instrument('order.completed.spree', event: event) {}
     end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docs/comments and spec fixtures, updating example event names without altering runtime behavior.
> 
> **Overview**
> Updates event naming across documentation, comments, and specs to consistently use the past-tense convention (e.g., `order.completed`, `order.canceled`, `payment.completed`, `stock_item.updated`) instead of legacy present-tense forms.
> 
> This also adjusts tests and logging examples/instrumentation strings to match the corrected event names, keeping the event system behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180c0ce62f824510a3122132658551f9bf976ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->