### PR TITLE
Fixed: backfill existing orders to new status field

### DIFF
--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -1074,6 +1074,8 @@ module Spree
     end
 
     def after_cancel
+      self.status = 'canceled'
+
       shipments.each(&:cancel!)
 
       # payments fully covered by gift card won't be refunded
@@ -1091,6 +1093,8 @@ module Spree
     end
 
     def after_resume
+      self.status = 'placed'
+
       shipments.each(&:resume!)
       consider_risk
       send_order_resumed_webhook

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -1074,7 +1074,7 @@ module Spree
     end
 
     def after_cancel
-      self.status = 'canceled'
+      update_column(:status, 'canceled')
 
       shipments.each(&:cancel!)
 
@@ -1093,7 +1093,7 @@ module Spree
     end
 
     def after_resume
-      self.status = 'placed'
+      update_column(:status, 'placed')
 
       shipments.each(&:resume!)
       consider_risk

--- a/spree/core/app/services/spree/orders/cancel.rb
+++ b/spree/core/app/services/spree/orders/cancel.rb
@@ -38,7 +38,7 @@ module Spree
             created_at: canceled_at
           )
 
-          changes = { canceled_at: canceled_at, status: 'canceled' }
+          changes = { canceled_at: canceled_at }
           changes[:canceler_id] = canceler.id if canceler.present?
           order.update_columns(changes)
           order.cancel!

--- a/spree/core/db/migrate/20260511000001_backfill_status_on_spree_orders.rb
+++ b/spree/core/db/migrate/20260511000001_backfill_status_on_spree_orders.rb
@@ -1,0 +1,23 @@
+class BackfillStatusOnSpreeOrders < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL.squish
+      UPDATE spree_orders SET status = 'placed'
+       WHERE status IS NULL AND state IN ('complete', 'resumed', 'returned')
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE spree_orders SET status = 'canceled'
+       WHERE status IS NULL AND state = 'canceled'
+    SQL
+
+    execute "UPDATE spree_orders SET status = 'draft' WHERE status IS NULL"
+
+    change_column_default :spree_orders, :status, 'draft'
+    change_column_null    :spree_orders, :status, false
+  end
+
+  def down
+    change_column_null    :spree_orders, :status, true
+    change_column_default :spree_orders, :status, nil
+  end
+end

--- a/spree/core/db/migrate/20260511000001_backfill_status_on_spree_orders.rb
+++ b/spree/core/db/migrate/20260511000001_backfill_status_on_spree_orders.rb
@@ -1,23 +1,57 @@
 class BackfillStatusOnSpreeOrders < ActiveRecord::Migration[7.2]
+  BATCH_SIZE = 10_000
+
+  STATE_TO_STATUS = {
+    'placed'   => %w[complete resumed returned awaiting_return],
+    'canceled' => %w[canceled partially_canceled]
+  }.freeze
+
   def up
-    execute <<~SQL.squish
-      UPDATE spree_orders SET status = 'placed'
-       WHERE status IS NULL AND state IN ('complete', 'resumed', 'returned')
-    SQL
+    STATE_TO_STATUS.each do |target_status, states|
+      backfill_in_batches(target_status, states)
+    end
 
-    execute <<~SQL.squish
-      UPDATE spree_orders SET status = 'canceled'
-       WHERE status IS NULL AND state = 'canceled'
-    SQL
-
-    execute "UPDATE spree_orders SET status = 'draft' WHERE status IS NULL"
+    # Anything still NULL (carts, in-progress checkouts) becomes draft.
+    backfill_in_batches('draft', nil)
 
     change_column_default :spree_orders, :status, 'draft'
     change_column_null    :spree_orders, :status, false
   end
 
   def down
-    change_column_null    :spree_orders, :status, true
-    change_column_default :spree_orders, :status, nil
+    raise ActiveRecord::IrreversibleMigration,
+          'Backfilled status values cannot be safely restored: writes made after deploy ' \
+          'are indistinguishable from the backfill. Roll back manually if needed.'
+  end
+
+  private
+
+  def backfill_in_batches(target_status, source_states)
+    quoted_status = connection.quote(target_status)
+    state_filter =
+      if source_states
+        quoted = Array(source_states).map { |s| connection.quote(s) }.join(',')
+        "AND state IN (#{quoted})"
+      else
+        ''
+      end
+
+    loop do
+      # The nested SELECT wrap (`SELECT id FROM (SELECT id ... LIMIT N) AS t`) is
+      # required for MySQL, which refuses an UPDATE that selects from the same
+      # table in the WHERE clause without an intermediate derived table.
+      affected = connection.update(<<~SQL.squish)
+        UPDATE spree_orders SET status = #{quoted_status}
+         WHERE id IN (
+           SELECT id FROM (
+             SELECT id FROM spree_orders
+              WHERE status IS NULL #{state_filter}
+              LIMIT #{BATCH_SIZE}
+           ) AS spree_orders_batch
+         )
+      SQL
+
+      break if affected < BATCH_SIZE
+    end
   end
 end

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -274,6 +274,7 @@ describe Spree::Order, type: :model do
         order.cancel
         order.reload
 
+        expect(order.status).to eq('canceled')
         expect(order.shipments).to all(have_attributes(state: 'canceled'))
         expect(order.payments.store_credits).to all(have_attributes(state: 'void'))
       end
@@ -287,6 +288,7 @@ describe Spree::Order, type: :model do
         order.cancel
         order.reload
 
+        expect(order.status).to eq('canceled')
         expect(order.shipments).to all(have_attributes(state: 'canceled'))
         expect(order.payments).to all(have_attributes(state: 'void'))
         expect(order.payments.store_credits).to all(have_attributes(state: 'void'))
@@ -303,6 +305,11 @@ describe Spree::Order, type: :model do
       expect(order).to receive(:publish_event).with('order.resumed').at_least(:once)
       allow(order).to receive(:publish_event).with(anything)
       order.resume!
+    end
+
+    it 'restores status to placed' do
+      order.resume!
+      expect(order.reload.status).to eq('placed')
     end
   end
 


### PR DESCRIPTION
Which will replace state machine in 6.0 + making sure we're always syncing state <> status