### PR TITLE
Remove deprecated taxonomy initialization methods from Store

### DIFF
--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -420,55 +420,6 @@ module Spree
       channels.create!(name: 'Online Store', code: Spree::Channel::DEFAULT_CODE)
     end
 
-    def ensure_default_taxonomies_are_created
-      Spree::Deprecation.warn('Store#ensure_default_taxonomies_are_created is deprecated and will be removed in Spree 5.5. Please remove it from your codebase')
-
-      Spree::Events.disable do
-        [
-          translate_with_store_locale_fallback('spree.taxonomy_categories_name'),
-          translate_with_store_locale_fallback('spree.taxonomy_brands_name'),
-          translate_with_store_locale_fallback('spree.taxonomy_collections_name')
-        ].each do |taxonomy_name|
-          # Manual exists?/create to work around Mobility bug with find_or_create_by
-          next if taxonomies.with_matching_name(taxonomy_name).exists?
-
-          taxonomies.create(name: taxonomy_name)
-        end
-      end
-    end
-
-    def ensure_default_automatic_taxons
-      Spree::Deprecation.warn('Store#ensure_default_automatic_taxons is deprecated and will be removed in Spree 5.5. Please remove it from your codebase')
-
-      Spree::Events.disable do
-        # Use Mobility-safe lookup for taxonomy
-        collections_taxonomy = taxonomies.with_matching_name(translate_with_store_locale_fallback('spree.taxonomy_collections_name')).first
-        return unless collections_taxonomy.present?
-
-        automatic_taxons_config = [
-          { name: translate_with_store_locale_fallback('spree.automatic_taxon_names.on_sale'),
-            rule_type: 'Spree::TaxonRules::Sale', rule_value: 'true' },
-          { name: translate_with_store_locale_fallback('spree.automatic_taxon_names.new_arrivals'), rule_type: 'Spree::TaxonRules::AvailableOn', rule_value: 30 }
-        ]
-
-        automatic_taxons_config.map do |config|
-          # Manual exists?/create to work around Mobility bug with first_or_create
-          taxon_scope = collections_taxonomy.taxons.automatic.with_matching_name(config[:name])
-
-          if taxon_scope.exists?
-            taxon_scope.first
-          else
-            collections_taxonomy.taxons.create!(
-              name: config[:name],
-              automatic: true,
-              parent: collections_taxonomy.root,
-              taxon_rules: [TaxonRule.new(type: config[:rule_type], value: config[:rule_value])]
-            )
-          end
-        end
-      end
-    end
-
     # Translates a key using the store's default locale with fallback to :en
     def translate_with_store_locale_fallback(key)
       locale = default_locale.presence&.to_sym || :en


### PR DESCRIPTION
## Summary
This PR removes two deprecated methods from the `Spree::Store` model that were scheduled for removal in Spree 5.5.

## Key Changes
- Removed `ensure_default_taxonomies_are_created` method that was deprecated and warned users to remove it from their codebase
- Removed `ensure_default_automatic_taxons` method that was deprecated and warned users to remove it from their codebase

Both methods were marked as deprecated with warnings indicating they would be removed in Spree 5.5. This change completes that deprecation cycle by removing the methods entirely.

## Implementation Details
The removed methods were responsible for:
- Creating default taxonomies (Categories, Brands, Collections) during store initialization
- Creating automatic taxons (On Sale, New Arrivals) with associated rules

These initialization tasks should now be handled through alternative mechanisms or removed from the initialization flow entirely, as indicated by the deprecation warnings that were in place.

https://claude.ai/code/session_01MwAb4HPwaJ5r1Z8tn3Htwi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this removes already-deprecated `Spree::Store` helper methods and doesn’t change active code paths unless external apps still call them.
> 
> **Overview**
> Removes the deprecated `Spree::Store#ensure_default_taxonomies_are_created` and `#ensure_default_automatic_taxons` methods, which previously created default taxonomies and automatic taxons (with rules) during store setup.
> 
> After this change, `Store` no longer provides built-in taxonomy/taxon initialization via these helpers, so any external code still invoking them will need to be updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7527eb714e4a2c3e13afed5682f94dd1b90fac4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->