### PR TITLE
Potential fix for code scanning alert no. 111: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spelling_lint.yml
+++ b/.github/workflows/spelling_lint.yml
@@ -3,6 +3,9 @@ name: Lint Code Spelling
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check spelling all files with codespell


### PR DESCRIPTION
Potential fix for [https://github.com/spree/spree/security/code-scanning/111](https://github.com/spree/spree/security/code-scanning/111)

Add an explicit top-level `permissions` block to `.github/workflows/spelling_lint.yml` so all jobs inherit least-privilege access.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

Best single fix without changing behavior:
- Insert at workflow root (after `on:` is a clear location) a block:
  ```yml
  permissions:
    contents: read
  ```
This preserves existing functionality (`actions/checkout` and lint commands continue to work) while satisfying CodeQL and enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow permissions to least-privilege, without changing any build or lint commands.
> 
> **Overview**
> Adds a top-level `permissions` block to `.github/workflows/spelling_lint.yml`, setting `contents: read` so the spelling-lint jobs run with explicit least-privilege repository access (addressing code scanning alerts) while keeping workflow behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e8fc786d1f8a7af0b27ab0488dda06404907a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->