### PR TITLE
Harden PNPM setup to mitigate supply chain attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@biomejs/biome": "^2.4.14",
     "turbo": "^2.9.9"
   },
-  "packageManager": "pnpm@10.6.0",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=20"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,26 @@
 packages:
   - "packages/*"
+
+# Supply-chain hardening — see https://pnpm.io/supply-chain-security
+#
+# minimumReleaseAge: delay installing newly-published versions of any
+# dependency by 7 days (10080 minutes). Catches malicious releases that
+# get yanked from the registry within hours of publish.
+#
+# blockExoticSubdeps: refuse transitive dependencies pulled from git
+# URLs, raw tarballs, or other non-registry sources. Direct deps can
+# still opt into exotic sources; subdeps cannot smuggle one in. Default
+# becomes true in pnpm 11.
+#
+# trustPolicy: fail the install if a package's trust level has dropped
+# (e.g. previously signed releases now arriving without provenance).
+# Defends against publisher takeover via leaked credentials.
+#
+# dangerouslyAllowAllBuilds: explicitly pinned to false (already the
+# default). install scripts only run for packages approved via
+# `pnpm approve-builds` — silently flipping this on would auto-run
+# every dependency's postinstall.
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+dangerouslyAllowAllBuilds: false


### PR DESCRIPTION
1. Don't install packages newer than 7 days
2. block packages from github/and other shady sources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pnpm install behavior (release-age gate, blocking exotic transitive sources, trust downgrade failures), which can break dependency resolution in CI/dev if the workspace relies on newer or non-registry subdependencies.
> 
> **Overview**
> Adds pnpm supply-chain hardening settings in `pnpm-workspace.yaml`, including a 7-day `minimumReleaseAge`, `blockExoticSubdeps`, `trustPolicy: no-downgrade`, and explicitly disabling unapproved install scripts.
> 
> Updates the repo’s pinned pnpm version in `package.json` to `pnpm@10.33.4` to align with the new workspace policy expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e9865a18fb350c4ea3ab2d27084ebaa4be52ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->