### PR TITLE
Fixed `api_type` method for non-Spree namespaced gateways

### DIFF
--- a/spree/api/spec/controllers/spree/api/v3/admin/payment_methods_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/payment_methods_controller_spec.rb
@@ -88,4 +88,50 @@ RSpec.describe Spree::Api::V3::Admin::PaymentMethodsController, type: :controlle
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe 'GET #types' do
+    it 'returns the available payment provider subclasses' do
+      get :types, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data']).to be_an(Array)
+      types = json_response['data'].map { |entry| entry['type'] }
+      expect(types).to include('bogus', 'store_credit', 'custom_payment_source_method')
+    end
+
+    it 'filters out providers already installed in the current store' do
+      get :types, as: :json
+
+      types = json_response['data'].map { |entry| entry['type'] }
+      # The seeded `check_payment_method` is scoped to `store`, so `check`
+      # must not be offered again — that's how the admin avoids
+      # double-installing a provider.
+      expect(types).not_to include('check')
+    end
+
+    context 'with provider gems that ship a top-level Gateway class' do
+      # Reproduces the duplicate-key bug from the admin SPA: two providers
+      # whose demodulized leaf is `"Gateway"` must still get unique `type`
+      # values so the React `<SelectItem key>` is unique and the registry
+      # lookup resolves to the right subclass.
+      before do
+        stub_const('SpreeStripe', Module.new)
+        stub_const('SpreeStripe::Gateway', Class.new(Spree::Gateway))
+        stub_const('SpreeAdyen', Module.new)
+        stub_const('SpreeAdyen::Gateway', Class.new(Spree::Gateway))
+
+        allow(Spree::PaymentMethod).to receive(:providers).and_return(
+          [SpreeStripe::Gateway, SpreeAdyen::Gateway, Spree::PaymentMethod::Check]
+        )
+      end
+
+      it 'exposes a unique `type` for every provider' do
+        get :types, as: :json
+
+        types = json_response['data'].map { |entry| entry['type'] }
+        expect(types).to contain_exactly('stripe', 'adyen')
+        expect(types).to eq(types.uniq)
+      end
+    end
+  end
 end

--- a/spree/core/app/models/spree/gateway.rb
+++ b/spree/core/app/models/spree/gateway.rb
@@ -6,6 +6,31 @@ module Spree
 
     validates :type, presence: true, inclusion: { in: :valid_providers_list }
 
+    # Payment provider gems conventionally ship a top-level `Gateway`
+    # class — `SpreeStripe::Gateway`, `SpreeAdyen::Gateway`,
+    # `SpreePaypalCheckout::Gateway`. The default demodulized
+    # `api_type` collapses every provider to `"gateway"`, which
+    # collides in the registry and produces duplicate keys in admin
+    # UIs. For gateway subclasses, use the outer module instead (with
+    # a leading `Spree` namespace stripped), matching the labelling
+    # convention in `PreferenceSchema#subclass_label`:
+    #
+    #   SpreeStripe::Gateway          → "stripe"
+    #   SpreeAdyen::Gateway           → "adyen"
+    #   SpreePaypalCheckout::Gateway  → "paypal_checkout"
+    #   MyShop::Gateway               → "my_shop"
+    #
+    # Subclasses nested under a Gateway module (e.g.
+    # `Spree::Gateway::Bogus`) demodulize to their own leaf and
+    # bypass this fallback.
+    def self.api_type
+      leaf = super
+      return leaf unless leaf == 'gateway'
+
+      outer = to_s.deconstantize.delete_prefix('Spree::').delete_prefix('Spree').presence
+      outer ? outer.underscore : leaf
+    end
+
     def payment_source_class
       CreditCard
     end

--- a/spree/core/spec/models/spree/gateway_spec.rb
+++ b/spree/core/spec/models/spree/gateway_spec.rb
@@ -93,6 +93,53 @@ describe Spree::Gateway, type: :model do
     })
   end
 
+  describe '.api_type' do
+    # Provider gems each ship a top-level `Gateway` class, so the default
+    # `Spree::Base.api_type` (demodulize + underscore) collapses every
+    # provider to `"gateway"`. The override must fall back to the outer
+    # module to keep shorthands unique on the wire.
+    before do
+      stub_const('SpreeStripe', Module.new)
+      stub_const('SpreeStripe::Gateway', Class.new(Spree::Gateway))
+      stub_const('SpreeAdyen', Module.new)
+      stub_const('SpreeAdyen::Gateway', Class.new(Spree::Gateway))
+      stub_const('SpreePaypalCheckout', Module.new)
+      stub_const('SpreePaypalCheckout::Gateway', Class.new(Spree::Gateway))
+      stub_const('AcmePayments', Module.new)
+      stub_const('AcmePayments::Gateway', Class.new(Spree::Gateway))
+    end
+
+    it 'uses the outer module name for Spree-prefixed gateway gems' do
+      expect(SpreeStripe::Gateway.api_type).to eq('stripe')
+      expect(SpreeAdyen::Gateway.api_type).to eq('adyen')
+      expect(SpreePaypalCheckout::Gateway.api_type).to eq('paypal_checkout')
+    end
+
+    it 'underscores a non-Spree outer module name' do
+      expect(AcmePayments::Gateway.api_type).to eq('acme_payments')
+    end
+
+    it 'falls back to "gateway" for the bare Spree::Gateway parent' do
+      expect(Spree::Gateway.api_type).to eq('gateway')
+    end
+
+    it 'leaves subclasses nested under a Gateway module untouched' do
+      # `Spree::Gateway::Bogus.demodulize` → `"Bogus"`, so the
+      # `super == "gateway"` short-circuit doesn't fire.
+      expect(Spree::Gateway::Bogus.api_type).to eq('bogus')
+      expect(Spree::Gateway::CustomPaymentSourceMethod.api_type).to eq('custom_payment_source_method')
+    end
+
+    it 'produces unique values for every registered payment provider' do
+      allow(Spree::PaymentMethod).to receive(:providers).and_return(
+        Spree::PaymentMethod.providers + [SpreeStripe::Gateway, SpreeAdyen::Gateway, SpreePaypalCheckout::Gateway]
+      )
+      types = Spree::PaymentMethod.providers.map(&:api_type)
+
+      expect(types).to eq(types.uniq), "Duplicate api_type values: #{types.tally.select { |_, n| n > 1 }.keys.inspect}"
+    end
+  end
+
   describe '#gateway_dashboard_payment_url' do
     let(:payment_method) { create(:credit_card_payment_method) }
     let(:payment) { create(:payment, payment_method: payment_method, transaction_id: '123') }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the wire-format `type`/`api_type` for gateway payment providers, which can affect admin UI selection and any clients relying on previous type strings. Scope is limited to gateway subclasses and is covered by new model/controller specs.
> 
> **Overview**
> Fixes `Spree::Gateway.api_type` to avoid collisions when provider gems expose a top-level `...::Gateway` class, deriving the API `type` from the outer module name (e.g. `SpreeStripe::Gateway` → `stripe`) instead of always returning `gateway`.
> 
> Adds specs covering the new `api_type` behavior (including non-`Spree` namespaces and nested gateway subclasses) and extends the admin `GET /payment_methods/types` controller spec to ensure returned provider `type` values are unique and exclude providers already installed for the current store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b4e6b23469a571308ac242aa3418b59fdcd18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->