### PR TITLE
Add json_api_type backwards-compatible alias to Spree::Base

### DIFF
--- a/spree/core/app/models/spree/base.rb
+++ b/spree/core/app/models/spree/base.rb
@@ -80,6 +80,12 @@ class Spree::Base < ApplicationRecord
     to_s.demodulize.underscore
   end
 
+  # Backwards-compatible alias for `.api_type`. Delegates so subclass
+  # overrides of `api_type` are honored.
+  def self.json_api_type
+    api_type
+  end
+
   def self.to_tom_select_json
     pluck(:name, :id).map do |name, id|
       {

--- a/spree/core/spec/models/spree/base_spec.rb
+++ b/spree/core/spec/models/spree/base_spec.rb
@@ -51,6 +51,24 @@ describe Spree::Base do
     it { expect(Spree::Address.api_type).to eq('address') }
   end
 
+  describe '.json_api_type' do
+    # Backwards-compatible alias retained for extensions that still call
+    # the old name; must delegate so subclass overrides (e.g.
+    # `Spree::Gateway.api_type`) propagate.
+    it { expect(Spree::InventoryUnit.json_api_type).to eq('inventory_unit') }
+    it { expect(Spree::Address.json_api_type).to eq('address') }
+
+    it 'honors subclass overrides of .api_type' do
+      klass = Class.new(Spree::Base) do
+        def self.api_type
+          'overridden'
+        end
+      end
+
+      expect(klass.json_api_type).to eq('overridden')
+    end
+  end
+
   describe '.json_api_columns' do
     it 'skips sensitive data' do
       expect(Spree::LegacyUser.json_api_columns).not_to include('password')


### PR DESCRIPTION
## Summary

Adds a `json_api_type` class method to `Spree::Base` as a backwards-compatible alias for the existing `api_type` method. This allows extensions that still call the old method name to continue working while ensuring subclass overrides are properly honored through delegation. Fixes regression in unreleased 5.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a backwards-compatible delegating alias and accompanying specs, without changing existing `api_type` behavior or data flows.
> 
> **Overview**
> Adds `Spree::Base.json_api_type` as a backwards-compatible alias that delegates to `api_type`, ensuring any subclass overrides of `api_type` are respected.
> 
> Extends `base_spec` to cover the alias on existing models and to assert delegation behavior via a subclass override test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd546e9ad3ae393c6340148cae41c8197379c4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->