### PR TITLE
Fix data migration part of the `20260515000001_add_store_id_to_spree_newsletter_subscribers` migration.

### DIFF
--- a/spree/core/db/migrate/20260515000001_add_store_id_to_spree_newsletter_subscribers.rb
+++ b/spree/core/db/migrate/20260515000001_add_store_id_to_spree_newsletter_subscribers.rb
@@ -2,14 +2,15 @@ class AddStoreIdToSpreeNewsletterSubscribers < ActiveRecord::Migration[7.2]
   def up
     add_reference :spree_newsletter_subscribers, :store
 
-    if defined?(SpreeMultiTenant)
+    if defined?(SpreeMultiTenant) && table_exists?(:spree_tenants)
       Spree::Tenant.find_each do |tenant|
         SpreeMultiTenant.with_tenant(tenant) do
           Spree::NewsletterSubscriber.where(store_id: nil).update_all(store_id: Spree::Store.default.id)
         end
       end
     else
-      Spree::NewsletterSubscriber.update_all(store_id: Spree::Store.default.id)
+      default_store = Spree::Store.default
+      Spree::NewsletterSubscriber.update_all(store_id: default_store.id) if default_store
     end
 
     change_column_null :spree_newsletter_subscribers, :store_id, false


### PR DESCRIPTION
The data migration won't run on a fresh installation, on CI, etc. We need to check if we have tenants and the default store present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a database migration’s data backfill logic; mistakes could cause migration failures or incorrect `store_id` assignment across tenants, but the change is narrowly scoped with additional guards.
> 
> **Overview**
> Fixes the `20260515000001_add_store_id_to_spree_newsletter_subscribers` migration’s data backfill to run safely on fresh installs/CI.
> 
> The backfill now only runs the multi-tenant path when `SpreeMultiTenant` is present **and** the `spree_tenants` table exists, and the single-tenant path now guards against a missing `Spree::Store.default` before updating `store_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4a71f709aaaf45d341d2cae71e34fde35699b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->