### PR TITLE
Skip running `20260515000001_add_store_id_to_spree_newsletter_subscribers.rb` on spree_multi_tenant

### DIFF
--- a/spree/core/db/migrate/20260515000001_add_store_id_to_spree_newsletter_subscribers.rb
+++ b/spree/core/db/migrate/20260515000001_add_store_id_to_spree_newsletter_subscribers.rb
@@ -2,15 +2,11 @@ class AddStoreIdToSpreeNewsletterSubscribers < ActiveRecord::Migration[7.2]
   def up
     add_reference :spree_newsletter_subscribers, :store
 
-    if defined?(SpreeMultiTenant)
-      Spree::Tenant.find_each do |tenant|
-        SpreeMultiTenant.with_tenant(tenant) do
-          Spree::NewsletterSubscriber.where(store_id: nil).update_all(store_id: Spree::Store.default.id)
-        end
-      end
-    else
-      Spree::NewsletterSubscriber.update_all(store_id: Spree::Store.default.id)
-    end
+    # For spree_multi_tenant we need handle the backfill and indices there
+    return if defined?(SpreeMultiTenant)
+
+    default_store = Spree::Store.default
+    Spree::NewsletterSubscriber.update_all(store_id: default_store.id) if default_store&.persisted?
 
     change_column_null :spree_newsletter_subscribers, :store_id, false
 
@@ -19,8 +15,11 @@ class AddStoreIdToSpreeNewsletterSubscribers < ActiveRecord::Migration[7.2]
   end
 
   def down
-    remove_index :spree_newsletter_subscribers, [:email, :store_id], if_exists: true
-    add_index :spree_newsletter_subscribers, :email, unique: true, if_not_exists: true
+    unless defined?(SpreeMultiTenant)
+      remove_index :spree_newsletter_subscribers, [:email, :store_id], if_exists: true
+      add_index :spree_newsletter_subscribers, :email, unique: true, if_not_exists: true
+    end
+
     remove_reference :spree_newsletter_subscribers, :store
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes a database migration’s behavior based on `SpreeMultiTenant`, which can leave multi-tenant installs with only the new column but without the backfill, NOT NULL constraint, or composite unique index unless handled elsewhere.
> 
> **Overview**
> Updates `20260515000001_add_store_id_to_spree_newsletter_subscribers.rb` to **early-return when `SpreeMultiTenant` is defined**, so multi-tenant apps only add the `store` reference and must handle backfill/indexing separately.
> 
> For non-multi-tenant installs, the migration now **backfills `store_id` only if a persisted default store exists**, then enforces `store_id` NOT NULL and switches the unique index from `email` to `[:email, :store_id]`; the `down` path mirrors this by reverting indexes *only* when not multi-tenant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce246c01989222f5ad361d09b53bb7075cb2f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->