### PR TITLE
fix deprecation warning on destroying CC

### DIFF
--- a/spree/core/app/services/spree/credit_cards/destroy.rb
+++ b/spree/core/app/services/spree/credit_cards/destroy.rb
@@ -11,7 +11,7 @@ module Spree
           "#{self.class.name} is deprecated and will be removed in Spree 6.0. " \
           'Use card.destroy directly instead. Payment cleanup is now handled ' \
           'automatically by the before_destroy callback in PaymentSourceConcern.',
-          caller
+          caller_locations(2)
         )
 
         if card.destroy


### PR DESCRIPTION
Error: https://vendo-connect.sentry.io/issues/7489556191/?project=4509685278179328&query=is%3Aunresolved&referrer=issue-stream

```
spree-starter(dev)* Spree::Deprecation.warn(
spree-starter(dev)*           "#{self.class.name} is deprecated and will be removed in Spree 6.0. " \
spree-starter(dev)*           'Use card.destroy directly instead. Payment cleanup is now handled ' \
spree-starter(dev)*           'automatically by the before_destroy callback in PaymentSourceConcern.',
spree-starter(dev)*   caller
spree-starter(dev)>         )
(spree-starter):7:in `<main>': undefined method `absolute_path' for an instance of String (NoMethodError)

            path = frame.absolute_path || frame.path
                        ^^^^^^^^^^^^^^
spree-starter(dev)* Spree::Deprecation.warn(
spree-starter(dev)*           "#{self.class.name} is deprecated and will be removed in Spree 6.0. " \
spree-starter(dev)*           'Use card.destroy directly instead. Payment cleanup is now handled ' \
spree-starter(dev)*           'automatically by the before_destroy callback in PaymentSourceConcern.',
spree-starter(dev)*   caller_locations(2)
spree-starter(dev)>         )
DEPRECATION WARNING: Object is deprecated and will be removed in Spree 6.0. Use card.destroy directly instead. Payment cleanup is now handled automatically by the before_destroy callback in PaymentSourceConcern. (called from <main> at bin/rails:4)
=> "DEPRECATION WARNING: Object is deprecated and will be removed in Spree 6.0. Use card.destroy directly instead. Payment cleanup is now handled automatically by the before_destroy callback in PaymentSourceConcern. (called from <main> at bin/rails:4)"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to deprecation logging that doesn’t affect credit card deletion behavior.
> 
> **Overview**
> Updates `Spree::CreditCards::Destroy` to pass `caller_locations(2)` into `Spree::Deprecation.warn` instead of `caller`, avoiding runtime errors and improving the reported callsite in the deprecation message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef6a720f2949f660b915434050ac4012b4db3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->