### PR TITLE
Sanitize CSV export output to avoid CSV formula injection attacks

### DIFF
--- a/spree/core/app/models/spree/export.rb
+++ b/spree/core/app/models/spree/export.rb
@@ -86,10 +86,10 @@ module Spree
           batch.each do |record|
             if multi_line_csv?
               record.to_csv(store).each do |line|
-                csv << line
+                csv << Spree::CSV::FormulaSanitizer.row(line)
               end
             else
-              csv << record.to_csv(store)
+              csv << Spree::CSV::FormulaSanitizer.row(record.to_csv(store))
             end
           end
         end

--- a/spree/core/app/models/spree/exports/product_translations.rb
+++ b/spree/core/app/models/spree/exports/product_translations.rb
@@ -30,7 +30,7 @@ module Spree
           records_to_export.includes(scope_includes).find_in_batches do |batch|
             batch.each do |product|
               product.to_translation_csv(store, locales).each do |line|
-                csv << line
+                csv << Spree::CSV::FormulaSanitizer.row(line)
               end
             end
           end

--- a/spree/core/app/presenters/spree/csv/formula_sanitizer.rb
+++ b/spree/core/app/presenters/spree/csv/formula_sanitizer.rb
@@ -1,0 +1,28 @@
+module Spree
+  module CSV
+    # Neutralizes CSV formula injection (CWE-1236 / OWASP "CSV Injection")
+    # by prefixing cells that would otherwise be evaluated as a formula
+    # when the exported file is opened in Excel, Google Sheets, LibreOffice,
+    # or Numbers.
+    #
+    # The leading apostrophe is the OWASP-recommended marker — spreadsheets
+    # render the cell as plain text without displaying the apostrophe.
+    module FormulaSanitizer
+      TRIGGERS = ["=", "+", "-", "@", "\t", "\r"].freeze
+
+      module_function
+
+      def cell(value)
+        return value unless value.is_a?(String)
+        return value if value.empty?
+        return value unless TRIGGERS.include?(value[0])
+
+        "'#{value}"
+      end
+
+      def row(values)
+        values.map { |v| cell(v) }
+      end
+    end
+  end
+end

--- a/spree/core/app/presenters/spree/csv/formula_sanitizer.rb
+++ b/spree/core/app/presenters/spree/csv/formula_sanitizer.rb
@@ -8,7 +8,7 @@ module Spree
     # The leading apostrophe is the OWASP-recommended marker — spreadsheets
     # render the cell as plain text without displaying the apostrophe.
     module FormulaSanitizer
-      TRIGGERS = ["=", "+", "-", "@", "\t", "\r"].freeze
+      TRIGGERS = ["=", "+", "-", "@", "\t", "\r", "\n"].freeze
 
       module_function
 

--- a/spree/core/spec/models/spree/export_spec.rb
+++ b/spree/core/spec/models/spree/export_spec.rb
@@ -114,6 +114,29 @@ RSpec.describe Spree::Export, :job, type: :model do
     end
   end
 
+  describe 'CSV formula injection' do
+    let(:export) { build(:customer_export, store: store, user: user, format: 'csv') }
+
+    let!(:malicious_customer) do
+      create(:user,
+             first_name: '=HYPERLINK("https://evil.example","Click")',
+             last_name: '+1-555-EVIL',
+             email: 'mallory@example.com')
+    end
+
+    it 'prefixes cells starting with formula triggers when the export runs' do
+      export.save!
+      export.generate
+
+      rows = ::CSV.parse(export.attachment.download)
+      malicious_row = rows.find { |r| r[2] == 'mallory@example.com' }
+
+      expect(malicious_row).not_to be_nil
+      expect(malicious_row[0]).to eq('\'=HYPERLINK("https://evil.example","Click")')
+      expect(malicious_row[1]).to eq("'+1-555-EVIL")
+    end
+  end
+
   describe '#normalize_search_params' do
     let(:export) { build(:export) }
 

--- a/spree/core/spec/presenters/spree/csv/formula_sanitizer_spec.rb
+++ b/spree/core/spec/presenters/spree/csv/formula_sanitizer_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Spree::CSV::FormulaSanitizer do
       expect(described_class.cell("\r=2+2")).to eq("'\r=2+2")
     end
 
+    it 'prefixes strings beginning with a line feed' do
+      expect(described_class.cell("\n=2+2")).to eq("'\n=2+2")
+    end
+
     it 'leaves plain strings untouched' do
       expect(described_class.cell('Alice')).to eq('Alice')
       expect(described_class.cell('alice@example.com')).to eq('alice@example.com')

--- a/spree/core/spec/presenters/spree/csv/formula_sanitizer_spec.rb
+++ b/spree/core/spec/presenters/spree/csv/formula_sanitizer_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe Spree::CSV::FormulaSanitizer do
+  describe '.cell' do
+    %w[= + - @].each do |trigger|
+      it "prefixes strings beginning with #{trigger.inspect}" do
+        expect(described_class.cell("#{trigger}cmd|'/C calc'!A1")).to eq("'#{trigger}cmd|'/C calc'!A1")
+      end
+    end
+
+    it 'prefixes strings beginning with a tab' do
+      expect(described_class.cell("\t=2+2")).to eq("'\t=2+2")
+    end
+
+    it 'prefixes strings beginning with a carriage return' do
+      expect(described_class.cell("\r=2+2")).to eq("'\r=2+2")
+    end
+
+    it 'leaves plain strings untouched' do
+      expect(described_class.cell('Alice')).to eq('Alice')
+      expect(described_class.cell('alice@example.com')).to eq('alice@example.com')
+      expect(described_class.cell('123 Main St')).to eq('123 Main St')
+    end
+
+    it 'leaves empty strings untouched' do
+      expect(described_class.cell('')).to eq('')
+    end
+
+    it 'leaves non-string values untouched' do
+      expect(described_class.cell(nil)).to be_nil
+      expect(described_class.cell(42)).to eq(42)
+      expect(described_class.cell(3.14)).to eq(3.14)
+      expect(described_class.cell(true)).to be(true)
+      expect(described_class.cell(Date.new(2026, 1, 1))).to eq(Date.new(2026, 1, 1))
+    end
+  end
+
+  describe '.row' do
+    it 'sanitizes every cell in the row' do
+      row = ['Alice', '=HYPERLINK("https://evil")', 42, nil, '+1-555-0100']
+      expect(described_class.row(row)).to eq(['Alice', '\'=HYPERLINK("https://evil")', 42, nil, "'+1-555-0100"])
+    end
+
+    it 'returns a new array without mutating the original' do
+      row = ['=evil']
+      result = described_class.row(row)
+      expect(row).to eq(['=evil'])
+      expect(result).to eq(["'=evil"])
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the contents of every generated CSV export by rewriting certain leading characters, which could affect downstream consumers expecting exact values. Logic is straightforward and covered by new unit tests, but touches a core export path.
> 
> **Overview**
> **Security hardening for CSV exports:** all CSV export generation now runs each output row through `Spree::CSV::FormulaSanitizer` to neutralize spreadsheet formula injection by prefixing cells starting with `=`, `+`, `-`, `@`, or leading whitespace/newlines.
> 
> Adds the new `Spree::CSV::FormulaSanitizer` helper plus specs, and extends `Export` specs to assert malicious customer data is sanitized in the produced CSV (including multi-line exports like `ProductTranslations`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4252546aa9492a7da66498530f02522f9f59386b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->