### PR TITLE
Allow CI on prev releases stable branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,18 @@ name: Tests
 
 on:
   push:
+<<<<<<< Updated upstream
     branches: [main]
     paths:
       - 'spree/**'
       - '.github/workflows/tests.yml'
+=======
+    branches: [main, '*-stable']
+    paths-ignore:
+      - 'docs/**'
+      - 'packages/**'
+      - '**/*.md'
+>>>>>>> Stashed changes
   pull_request:
     paths:
       - 'spree/**'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because `.github/workflows/tests.yml` contains unresolved merge-conflict markers, which will invalidate the workflow YAML and can break CI for pushes/PRs until fixed.
> 
> **Overview**
> Adjusts the `Tests` workflow `on.push` triggers to include `*-stable` branches and switch from a narrow `paths` filter to `paths-ignore` (ignoring `docs/**`, `packages/**`, and `*.md`).
> 
> **Important:** the workflow file currently includes unresolved git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), making the YAML invalid and likely preventing the workflow from running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693ee4da58b4dc6277b4b204d6495f3161ab4038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->