### PR TITLE
Allow tests to run on stable branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, '*-stable']
     paths:
       - 'spree/**'
       - '.github/workflows/tests.yml'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to GitHub Actions triggers; the main impact is increased CI runs on pushes to `*-stable` branches.
> 
> **Overview**
> The `Tests` GitHub Actions workflow is updated to trigger on `push` events for both `main` and any `*-stable` branch (in addition to existing path filters), so CI runs automatically for stable branch updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd057a3e6b4ea4d54c82c8227cc3e202fef72a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->