### PR TITLE
[CSV Import] fix assigning product to store

### DIFF
--- a/spree/core/app/models/spree/import.rb
+++ b/spree/core/app/models/spree/import.rb
@@ -62,6 +62,7 @@ module Spree
       event :complete do
         transition from: :processing, to: :completed
       end
+      after_transition to: :completed, do: :touch_store
       after_transition to: :completed, do: :publish_import_completed_event
       # NOTE: send_import_completed_email and update_loader_in_import_view
       # are now handled by Spree::Admin::ImportSubscriber listening to 'import.completed' event
@@ -179,6 +180,10 @@ module Spree
     # @return [String]
     def display_name
       "#{Spree.t(type.demodulize.pluralize.downcase)} #{number}"
+    end
+
+    def touch_store
+      store.touch
     end
 
     def publish_import_completed_event

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -67,7 +67,12 @@ module Spree
             end
 
             product = assign_attributes_to_product(product)
-            product.save!
+
+            Spree::Store.no_touching do
+              product.save!
+              assign_store_to_product(product)
+            end
+
             if has_product_attributes?
               handle_metafields(product)
               handle_categories(product)
@@ -94,7 +99,6 @@ module Spree
             product.sku = attributes['sku'] if attributes['sku'].present? && options.empty?
           end
 
-          product.stores << store if product.stores.exclude?(store)
           product.name = attributes['name'] if attributes['name'].present?
           product.description = attributes['description'] if attributes['description'].present?
           product.meta_title = attributes['meta_title'] if attributes['meta_title'].present?
@@ -111,6 +115,10 @@ module Spree
           end
 
           product
+        end
+
+        def assign_store_to_product(product)
+          product.stores << store if product.stores.exclude?(store)
         end
 
         def prepare_shipping_category

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -66,11 +66,10 @@ module Spree
               product = existing_product if existing_product.present?
             end
 
-            product = assign_attributes_to_product(product)
-
+            # Store is touched when the import completes
             Spree::Store.no_touching do
+              product = assign_attributes_to_product(product)
               product.save!
-              assign_store_to_product(product)
             end
 
             if has_product_attributes?
@@ -99,6 +98,7 @@ module Spree
             product.sku = attributes['sku'] if attributes['sku'].present? && options.empty?
           end
 
+          product.stores << store if product.stores.exclude?(store)
           product.name = attributes['name'] if attributes['name'].present?
           product.description = attributes['description'] if attributes['description'].present?
           product.meta_title = attributes['meta_title'] if attributes['meta_title'].present?
@@ -115,10 +115,6 @@ module Spree
           end
 
           product
-        end
-
-        def assign_store_to_product(product)
-          product.stores << store if product.stores.exclude?(store)
         end
 
         def prepare_shipping_category

--- a/spree/core/spec/models/spree/import_spec.rb
+++ b/spree/core/spec/models/spree/import_spec.rb
@@ -95,6 +95,10 @@ RSpec.describe Spree::Import, :job, type: :model do
         expect { import.complete! }.to change(import, :status).from('processing').to('completed')
       end
 
+      it 'touches the store' do
+        expect { import.complete! }.to change { store.reload.updated_at }
+      end
+
       it 'publishes import.completed event' do
         expect(import).to receive(:publish_import_completed_event)
         import.complete!

--- a/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       expect(variant.stock_items.first.stock_location).to eq store.default_stock_location
     end
 
+    it 'does not touch the store when associating the product' do
+      expect { subject.process! }.not_to change { store.reload.updated_at }
+    end
+
     context 'when updating an existing master variant' do
       let!(:existing_product) { create(:product, slug: 'denim-shirt', name: 'Old Name', stores: [store]) }
 


### PR DESCRIPTION
Error:
`PG::QueryCanceled: ERROR: canceling statement due to statement timeout CONTEXT: while rechecking updated tuple (15,7) in relation "spree_stores"`

Explanation:
Every row runs: `product.stores << store if product.stores.exclude?(store)` and `StoreProduct` has `touch: true on :store` so each insert updates `spree_stores.updated_at` on the same store row

Solution:
Do not touch store `udated_at` during import, do it once import completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `Spree::Store` gets `updated_at` updates during imports, which could affect cache invalidation or any logic relying on store touch timing. The change is localized but impacts import completion behavior and product association side effects.
> 
> **Overview**
> Prevents CSV product imports from repeatedly `touch`ing the same `Spree::Store` row while associating products, avoiding lock/timeout issues.
> 
> Product creation/update in `RowProcessors::ProductVariant` is now wrapped in `Spree::Store.no_touching`, and the store is instead touched once when an import transitions to `completed` via a new `Import#touch_store` callback. Specs were updated to assert the store is untouched during row processing and touched on import completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54aea32dd9e92806f7b7f003eb5a6edf6de8f174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->