### PR TITLE
[CSV Import] fix assigning tags to product

### DIFF
--- a/spree/core/app/jobs/spree/imports/assign_tags_job.rb
+++ b/spree/core/app/jobs/spree/imports/assign_tags_job.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Imports
+    class AssignTagsJob < Spree::BaseJob
+      queue_as Spree.queues.imports
+      retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+      def perform(product_id, tags)
+        product = Spree::Product.find(product_id)
+        product.tag_list = tags
+        product.save!
+      end
+    end
+  end
+end

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -72,10 +72,12 @@ module Spree
               product.save!
             end
 
+            handle_tags(product) if attributes['tags'].present?
             if has_product_attributes?
               handle_metafields(product)
               handle_categories(product)
             end
+
             product
           else
             # For non-master variants, only look up the product
@@ -105,7 +107,6 @@ module Spree
           product.meta_description = attributes['meta_description'] if attributes['meta_description'].present?
           product.meta_keywords = attributes['meta_keywords'] if attributes['meta_keywords'].present?
           product.status = to_spree_status(attributes['status']) if attributes['status'].present?
-          product.tag_list = attributes['tags'] if attributes['tags'].present?
 
           if options.empty?
             if attributes['shipping_category'].present?
@@ -234,6 +235,10 @@ module Spree
           end
 
           product.update(metafields_attributes: nested_attrs) unless nested_attrs.empty?
+        end
+
+        def handle_tags(product)
+          Spree::Imports::AssignTagsJob.perform_later(product.id, attributes['tags'])
         end
 
         def handle_categories(product)

--- a/spree/core/spec/jobs/spree/imports/assign_tags_job_spec.rb
+++ b/spree/core/spec/jobs/spree/imports/assign_tags_job_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Imports::AssignTagsJob, type: :job do
+  let(:store) { @default_store }
+  let!(:product) { create(:product) }
+
+  describe '#perform' do
+    it 'assigns tags to the product' do
+      described_class.perform_now(product.id, 'ECO, Gold')
+
+      expect(product.reload.tag_list).to contain_exactly('ECO', 'Gold')
+    end
+
+    it 'replaces existing tags' do
+      product.tag_list = 'Old Tag'
+      product.save!
+
+      described_class.perform_now(product.id, 'New Tag')
+
+      expect(product.reload.tag_list).to contain_exactly('New Tag')
+    end
+
+    it 'is idempotent' do
+      described_class.perform_now(product.id, 'ECO, Gold')
+      described_class.perform_now(product.id, 'ECO, Gold')
+
+      expect(product.reload.tag_list).to contain_exactly('ECO', 'Gold')
+    end
+
+    context 'when there were no matching tags' do
+      it 'creates the tags' do
+        expect {
+          described_class.perform_now(product.id, 'ECO, Gold')
+        }.to change { ActsAsTaggableOn::Tag.count }.by(2)
+      end
+    end
+
+    context 'when there were matching tags' do
+      before do
+        ActsAsTaggableOn::Tag.create(name: 'ECO')
+        ActsAsTaggableOn::Tag.create(name: 'Gold')
+      end
+
+      it 'does not create new tags' do
+        expect {
+          described_class.perform_now(product.id, 'ECO, Gold')
+        }.not_to change { ActsAsTaggableOn::Tag.count }
+      end
+    end
+  end
+end

--- a/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       expect(product.status).to eq 'draft'
       expect(product.description).to eq row_data['description']
       expect(product.stores).to include(store)
-      expect(product.tag_list).to contain_exactly('ECO', 'Gold')
       expect(product.master).to eq variant
       expect(variant.sku).to be_blank
       expect(variant.price_in('USD').amount.to_f).to eq 62.99
@@ -54,6 +53,10 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       expect(variant.stock_items.first.count_on_hand).to eq 100
       expect(variant.stock_items.first.backorderable).to eq true
       expect(variant.stock_items.first.stock_location).to eq store.default_stock_location
+    end
+
+    it 'enqueues AssignTagsJob' do
+      expect { subject.process! }.to have_enqueued_job(Spree::Imports::AssignTagsJob).with(anything, 'ECO, Gold')
     end
 
     it 'does not touch the store when associating the product' do
@@ -81,6 +84,14 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
         expect(stock_item.count_on_hand).to eq 100
         expect(stock_item.backorderable).to eq true
         expect(existing_product.reload.name).to eq 'Denim Shirt'
+      end
+    end
+
+    context 'when tags are not present' do
+      it 'does not enqueue AssignTagsJob' do
+        row_data['tags'] = nil
+
+        expect { subject.process! }.not_to have_enqueued_job(Spree::Imports::AssignTagsJob)
       end
     end
   end


### PR DESCRIPTION
Error:
`PG::TRDeadlockDetected: ERROR: deadlock detected DETAIL: Process 669048 waits for ShareLock on transaction 3731307; blocked by process 669049. Process 669049 waits for ShareLock on transaction 3731308; blocked by process 669048. HINT: See server log for query details. CONTEXT: while rechecking updated tuple (1,90) in relation "spree_tags"`

Explanation:
Occurs when two workers assign the same tag (e.g., "sale") to different products simultaneously.

Solution:
Same pattern as for categories: moves the process out of the main product processing thread to async jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves tag assignment to an async job, changing import timing and relying on background processing; failures or queue backlog could delay tags being applied, but scope is limited to CSV import tagging.
> 
> **Overview**
> Fixes CSV import tag assignment deadlocks by moving `product.tag_list` updates out of the main `ProductVariant` row processor and into a new background job, `Spree::Imports::AssignTagsJob` (with retries on the imports queue).
> 
> Updates the product import specs to assert tag assignment is now *enqueued* (and not run inline), and adds a dedicated job spec covering tag replacement/idempotency and tag creation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b20c14d2b694e13b77839a1dd33e7261b8ae71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->