### PR TITLE
[CSV Import] Add guards against conrurrent processing of option types/values

### DIFF
--- a/spree/core/app/jobs/spree/imports/assign_tags_job.rb
+++ b/spree/core/app/jobs/spree/imports/assign_tags_job.rb
@@ -1,16 +1,6 @@
 module Spree
   module Imports
-    class AssignTagsJob < Spree::BaseJob
-      queue_as Spree.queues.imports
-
-      # Narrowed to transient infrastructure errors. RecordNotFound (deleted product)
-      # and RecordInvalid (validation failure) won't recover from retry — they belong
-      # in error reporting, not the retry queue.
-      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
-               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
-               wait: :polynomially_longer, attempts: 5
-      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
-
+    class AssignTagsJob < Spree::Imports::BaseJob
       def perform(product_id, tags)
         product = Spree::Product.find(product_id)
         product.tag_list = tags

--- a/spree/core/app/jobs/spree/imports/assign_tags_job.rb
+++ b/spree/core/app/jobs/spree/imports/assign_tags_job.rb
@@ -2,7 +2,14 @@ module Spree
   module Imports
     class AssignTagsJob < Spree::BaseJob
       queue_as Spree.queues.imports
-      retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+      # Narrowed to transient infrastructure errors. RecordNotFound (deleted product)
+      # and RecordInvalid (validation failure) won't recover from retry — they belong
+      # in error reporting, not the retry queue.
+      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
+               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
+               wait: :polynomially_longer, attempts: 5
+      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
 
       def perform(product_id, tags)
         product = Spree::Product.find(product_id)

--- a/spree/core/app/jobs/spree/imports/base_job.rb
+++ b/spree/core/app/jobs/spree/imports/base_job.rb
@@ -1,0 +1,31 @@
+module Spree
+  module Imports
+    # Shared base for every job in the imports pipeline.
+    #
+    # Retry policy is intentionally narrow: only transient infrastructure errors
+    # (DB deadlocks, lock-wait timeouts, dropped connections) are replayed. Broad
+    # `retry_on StandardError` would replay jobs whose post-work side effects
+    # (counter increments, state transitions, lifecycle events) had already
+    # partially fired, breaking idempotency. Per-row business errors are caught
+    # inside `Spree::ImportRow#process!` and converted to `row.fail!`, so they
+    # never bubble up to the job layer.
+    #
+    # Subclasses may extend the retry list (e.g. `CreateCategoriesJob` adds
+    # `RecordNotUnique` to recover from concurrent-import taxon creation races).
+    #
+    # We intentionally do NOT `discard_on ActiveRecord::RecordNotFound`: Sidekiq is
+    # known to start a job before the enqueuing transaction has committed, so an
+    # early `find` can raise `RecordNotFound` for a record that will exist a moment
+    # later. Letting the job retry covers that window.
+    class BaseJob < Spree::BaseJob
+      queue_as Spree.queues.imports
+
+      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
+               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
+               ActiveRecord::RecordNotFound,
+               wait: :polynomially_longer, attempts: 5
+
+      discard_on ActiveJob::DeserializationError
+    end
+  end
+end

--- a/spree/core/app/jobs/spree/imports/create_categories_job.rb
+++ b/spree/core/app/jobs/spree/imports/create_categories_job.rb
@@ -1,16 +1,10 @@
 module Spree
   module Imports
-    class CreateCategoriesJob < Spree::BaseJob
-      queue_as Spree.queues.imports
-
-      # Narrowed to transient infrastructure errors plus RecordNotUnique — concurrent
-      # imports can race on `with_matching_name(...).first || create!(...)` for the
-      # same taxonomy/taxon name and hit the unique index; a retry then finds the row.
-      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
-               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
-               ActiveRecord::RecordNotUnique,
-               wait: :polynomially_longer, attempts: 5
-      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
+    class CreateCategoriesJob < Spree::Imports::BaseJob
+      # Concurrent imports can race on `with_matching_name(...).first || create!(...)`
+      # for the same taxonomy/taxon name and hit the unique index; a retry then finds
+      # the peer's committed row.
+      retry_on ActiveRecord::RecordNotUnique, wait: :polynomially_longer, attempts: 5
 
       def perform(product_id, store_id, taxon_pretty_names)
         product = Spree::Product.find(product_id)

--- a/spree/core/app/jobs/spree/imports/create_categories_job.rb
+++ b/spree/core/app/jobs/spree/imports/create_categories_job.rb
@@ -2,7 +2,15 @@ module Spree
   module Imports
     class CreateCategoriesJob < Spree::BaseJob
       queue_as Spree.queues.imports
-      retry_on StandardError, wait: :polynomially_longer, attempts: 5
+
+      # Narrowed to transient infrastructure errors plus RecordNotUnique — concurrent
+      # imports can race on `with_matching_name(...).first || create!(...)` for the
+      # same taxonomy/taxon name and hit the unique index; a retry then finds the row.
+      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
+               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
+               ActiveRecord::RecordNotUnique,
+               wait: :polynomially_longer, attempts: 5
+      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
 
       def perform(product_id, store_id, taxon_pretty_names)
         product = Spree::Product.find(product_id)

--- a/spree/core/app/jobs/spree/imports/create_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/create_rows_job.rb
@@ -1,8 +1,6 @@
 module Spree
   module Imports
-    class CreateRowsJob < Spree::BaseJob
-      queue_as Spree.queues.imports
-
+    class CreateRowsJob < Spree::Imports::BaseJob
       discard_on ::CSV::MalformedCSVError, EncodingError do |job, error|
         import = Spree::Import.find(job.arguments.first)
         import.update_columns(processing_errors: error.message, status: :failed, updated_at: Time.current)

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -10,7 +10,7 @@ module Spree
       retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
                ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
                wait: :polynomially_longer, attempts: 5
-      discard_on ActiveJob::DeserializationError
+      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
 
       def perform(import_id, row_ids)
         import = Spree::Import.find(import_id)

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -3,6 +3,9 @@ module Spree
     class ProcessGroupJob < Spree::BaseJob
       queue_as Spree.queues.imports
 
+      retry_on StandardError, wait: :polynomially_longer, attempts: 5
+      discard_on ActiveJob::DeserializationError
+
       def perform(import_id, row_ids)
         import = Spree::Import.find(import_id)
         Spree::Current.store = import.store
@@ -10,7 +13,8 @@ module Spree
         mappings = import.mappings.mapped.to_a
         schema_fields = import.schema_fields
         large = import.large_import?
-        rows = import.rows.where(id: row_ids).order(:row_number)
+        # Skip rows already completed on a prior attempt so retries don't double-process them.
+        rows = import.rows.where(id: row_ids).pending_and_failed.order(:row_number)
 
         if large
           Spree::Events.disable do

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -1,17 +1,6 @@
 module Spree
   module Imports
-    class ProcessGroupJob < Spree::BaseJob
-      queue_as Spree.queues.imports
-
-      # Narrow retry to transient infrastructure errors so we don't replay jobs whose
-      # check_import_completion side effects (counter bump, complete!, events) have
-      # already partially fired. Per-row exceptions are caught inside ImportRow#process!
-      # and converted to row.fail!, so they never bubble up here.
-      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
-               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
-               wait: :polynomially_longer, attempts: 5
-      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
-
+    class ProcessGroupJob < Spree::Imports::BaseJob
       def perform(import_id, row_ids)
         import = Spree::Import.find(import_id)
         Spree::Current.store = import.store

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -28,14 +28,15 @@ module Spree
 
       # Completion is row-state-derived so retry-induced over-increments of the counter
       # stay harmless. The counter pre-check just shortcuts the row scan for workers
-      # that obviously can't be the last group to finish.
+      # that obviously can't be the last group to finish. `in_flight` excludes orphaned
+      # `processing` rows past the stall window so a dead worker can't block completion.
       def check_import_completion(import, large)
         Spree::Import.where(id: import.id).update_all(
           'completed_groups_count = COALESCE(completed_groups_count, 0) + 1'
         )
         import.reload
 
-        if import.completed_groups_count >= import.processing_groups_count && import.rows.unprocessed.none?
+        if import.completed_groups_count >= import.processing_groups_count && import.rows.in_flight.none?
           import.complete! if import.status == 'processing'
         elsif large && (import.completed_groups_count % 10).zero?
           import.publish_event('import.progress')

--- a/spree/core/app/jobs/spree/imports/process_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_rows_job.rb
@@ -3,6 +3,9 @@ module Spree
     class ProcessRowsJob < Spree::BaseJob
       queue_as Spree.queues.imports
 
+      retry_on StandardError, wait: :polynomially_longer, attempts: 5
+      discard_on ActiveJob::DeserializationError
+
       BATCH_SIZE = 100
 
       def perform(import_id)

--- a/spree/core/app/jobs/spree/imports/process_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_rows_job.rb
@@ -1,18 +1,6 @@
 module Spree
   module Imports
-    class ProcessRowsJob < Spree::BaseJob
-      queue_as Spree.queues.imports
-
-      # Narrow retry to transient infrastructure errors. Dispatch is idempotent — we
-      # always recompute from `pending_and_failed` rows — but a retry triggered by a
-      # mid-dispatch failure could re-enqueue group jobs that were already queued for
-      # rows still in `pending` state. ProcessGroupJob is guarded against double-work
-      # via the same pending_and_failed scope on its row pull.
-      retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
-               ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
-               wait: :polynomially_longer, attempts: 5
-      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
-
+    class ProcessRowsJob < Spree::Imports::BaseJob
       BATCH_SIZE = 100
 
       def perform(import_id)

--- a/spree/core/app/jobs/spree/imports/process_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_rows_job.rb
@@ -11,7 +11,7 @@ module Spree
       retry_on ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout,
                ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed,
                wait: :polynomially_longer, attempts: 5
-      discard_on ActiveJob::DeserializationError
+      discard_on ActiveRecord::RecordNotFound, ActiveJob::DeserializationError
 
       BATCH_SIZE = 100
 

--- a/spree/core/app/models/spree/import_row.rb
+++ b/spree/core/app/models/spree/import_row.rb
@@ -41,6 +41,11 @@ module Spree
       # are now handled by Spree::Admin::ImportRowSubscriber
     end
 
+    # How long a row may sit in `processing` before we consider its owning worker dead
+    # (OOM, SIGKILL, deploy without graceful drain — none of these trigger a Sidekiq
+    # retry). After this window, stalled rows no longer block the import from completing.
+    STALLED_PROCESSING_AFTER = 1.hour
+
     #
     # Scopes
     #
@@ -48,7 +53,13 @@ module Spree
     scope :completed, -> { where(status: :completed) }
     scope :failed, -> { where(status: :failed) }
     scope :processed, -> { where(status: %i[completed failed]) }
-    scope :unprocessed, -> { where.not(status: %i[completed failed]) }
+    # Rows still legitimately blocking import completion: `pending` (not started) or
+    # `processing` with a recent updated_at (worker still alive). Orphaned `processing`
+    # rows past the stall window are excluded so a dead worker can't permanently block
+    # completion — operators can clean those up separately.
+    scope :in_flight, -> {
+      where(status: :pending).or(where(status: :processing).where(updated_at: STALLED_PROCESSING_AFTER.ago..))
+    }
 
     def data_json
       @data_json ||= JSON.parse(data)

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -163,34 +163,38 @@ module Spree
           end
         end
 
+        # Concurrent CSV imports can race when creating shared OptionTypes/OptionValues.
+        # Recover the losing worker by re-fetching the peer's row whether the conflict
+        # surfaces via the DB unique index (RecordNotUnique) or the AR uniqueness
+        # validator (RecordInvalid with a :taken error on the relevant attribute).
         def find_or_create_option_type!(presentation)
           Spree::OptionType.search_by_name(presentation).first || Spree::OptionType.create!(presentation: presentation)
-        rescue ActiveRecord::RecordNotUnique
-          Spree::OptionType.search_by_name(presentation).first!
-        rescue ActiveRecord::RecordInvalid => e
-          raise unless e.record.errors.where(:name, :taken).any?
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+          raise unless uniqueness_conflict?(e, :name)
 
           Spree::OptionType.search_by_name(presentation).first!
         end
 
         def find_or_create_option_value!(option_type, presentation)
           option_type.option_values.search_by_name(presentation).first || option_type.option_values.create!(presentation: presentation)
-        rescue ActiveRecord::RecordNotUnique
-          option_type.option_values.search_by_name(presentation).first!
-        rescue ActiveRecord::RecordInvalid => e
-          raise unless e.record.errors.where(:name, :taken).any?
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+          raise unless uniqueness_conflict?(e, :name)
 
           option_type.option_values.search_by_name(presentation).first!
         end
 
         def find_or_create_product_option_type!(option_type)
           Spree::ProductOptionType.find_or_create_by!(product: product, option_type: option_type)
-        rescue ActiveRecord::RecordNotUnique
-          Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
-        rescue ActiveRecord::RecordInvalid => e
-          raise unless e.record.errors.where(:product_id, :taken).any?
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+          raise unless uniqueness_conflict?(e, :product_id)
 
           Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
+        end
+
+        # RecordNotUnique is always a uniqueness conflict; RecordInvalid only when the
+        # given attribute has a :taken error (other validation failures must propagate).
+        def uniqueness_conflict?(error, attribute)
+          error.is_a?(ActiveRecord::RecordNotUnique) || error.record.errors.where(attribute, :taken).any?
         end
 
         def handle_images(variant)

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -131,52 +131,66 @@ module Spree
         def prepare_option_value_variants
           return [] if options.empty?
 
-          options.map do |option|
-            option_type = find_or_create_option_type(option[:option_name])
-            option_value = find_or_create_option_value(option_type, option[:option_value])
+          ActiveRecord::Base.no_touching do
+            options.map do |option|
+              option_type = find_or_create_option_type!(option[:option_name])
+              option_value = find_or_create_option_value!(option_type, option[:option_value])
 
-            # ensure product option types include new option type
-            find_or_create_product_option_type(option_type)
+              # ensure product option types include new option type
+              find_or_create_product_option_type!(option_type)
 
-            Spree::OptionValueVariant.new(option_value: option_value)
+              Spree::OptionValueVariant.new(option_value: option_value)
+            end
           end
         end
 
-        # Concurrent CSV imports can race when creating shared OptionTypes/OptionValues
-        # (e.g. two workers both inserting "Color"). Recover from both losers of the race:
-        # the DB unique index (RecordNotUnique) when validators ran against pre-commit state,
-        # and the AR uniqueness validator (RecordInvalid on :name) when the peer commit landed
-        # first. Re-fetch by the parameterized name, which is the DB-enforced uniqueness key.
-        def find_or_create_option_type(presentation)
-          Spree::OptionType.search_by_name(presentation).first ||
-            Spree::OptionType.create!(presentation: presentation)
-        rescue ActiveRecord::RecordNotUnique
-          Spree::OptionType.find_by!(name: presentation.to_s.parameterize)
-        rescue ActiveRecord::RecordInvalid => e
-          raise unless name_uniqueness_conflict?(e.record)
+        def options
+          @options ||= begin
+            options = []
 
-          Spree::OptionType.find_by!(name: presentation.to_s.parameterize)
+            OPTION_TYPES_COUNT.times.map do |index|
+              next if attributes["option#{index + 1}_name"].blank?
+              next if attributes["option#{index + 1}_value"].blank?
+
+              options << {
+                index: index + 1,
+                option_name: attributes["option#{index + 1}_name"],
+                option_value: attributes["option#{index + 1}_value"]
+              }
+            end
+
+            options
+          end
         end
 
-        def find_or_create_option_value(option_type, presentation)
-          option_type.option_values.search_by_name(presentation).first ||
-            option_type.option_values.create!(presentation: presentation)
+        def find_or_create_option_type!(presentation)
+          Spree::OptionType.search_by_name(presentation).first || Spree::OptionType.create!(presentation: presentation)
         rescue ActiveRecord::RecordNotUnique
-          option_type.option_values.find_by!(name: presentation.to_s.parameterize)
+          Spree::OptionType.search_by_name(presentation).first!
         rescue ActiveRecord::RecordInvalid => e
-          raise unless name_uniqueness_conflict?(e.record)
+          raise unless e.record.errors.where(:name, :taken).any?
 
-          option_type.option_values.find_by!(name: presentation.to_s.parameterize)
+          Spree::OptionType.search_by_name(presentation).first!
         end
 
-        def find_or_create_product_option_type(option_type)
+        def find_or_create_option_value!(option_type, presentation)
+          option_type.option_values.search_by_name(presentation).first || option_type.option_values.create!(presentation: presentation)
+        rescue ActiveRecord::RecordNotUnique
+          option_type.option_values.search_by_name(presentation).first!
+        rescue ActiveRecord::RecordInvalid => e
+          raise unless e.record.errors.where(:name, :taken).any?
+
+          option_type.option_values.search_by_name(presentation).first!
+        end
+
+        def find_or_create_product_option_type!(option_type)
           Spree::ProductOptionType.find_or_create_by!(product: product, option_type: option_type)
         rescue ActiveRecord::RecordNotUnique
           Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
-        end
+        rescue ActiveRecord::RecordInvalid => e
+          raise unless e.record.errors.where(:product_id, :taken).any?
 
-        def name_uniqueness_conflict?(record)
-          record.errors.where(:name, :taken).any?
+          Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
         end
 
         def handle_images(variant)
@@ -202,25 +216,6 @@ module Spree
               nil,
               link_variant_id
             )
-          end
-        end
-
-        def options
-          @options ||= begin
-            options = []
-
-            OPTION_TYPES_COUNT.times.map do |index|
-              next if attributes["option#{index + 1}_name"].blank?
-              next if attributes["option#{index + 1}_value"].blank?
-
-              options << {
-                index: index + 1,
-                option_name: attributes["option#{index + 1}_name"],
-                option_value: attributes["option#{index + 1}_value"]
-              }
-            end
-
-            options
           end
         end
 

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -132,14 +132,51 @@ module Spree
           return [] if options.empty?
 
           options.map do |option|
-            option_type = Spree::OptionType.search_by_name(option[:option_name]).first || Spree::OptionType.create!(presentation: option[:option_name])
-            option_value = option_type.option_values.search_by_name(option[:option_value]).first || option_type.option_values.create!(presentation: option[:option_value])
+            option_type = find_or_create_option_type(option[:option_name])
+            option_value = find_or_create_option_value(option_type, option[:option_value])
 
             # ensure product option types include new option type
-            Spree::ProductOptionType.find_or_create_by!(product: product, option_type: option_type)
+            find_or_create_product_option_type(option_type)
 
             Spree::OptionValueVariant.new(option_value: option_value)
           end
+        end
+
+        # Concurrent CSV imports can race when creating shared OptionTypes/OptionValues
+        # (e.g. two workers both inserting "Color"). Recover from both losers of the race:
+        # the DB unique index (RecordNotUnique) when validators ran against pre-commit state,
+        # and the AR uniqueness validator (RecordInvalid on :name) when the peer commit landed
+        # first. Re-fetch by the parameterized name, which is the DB-enforced uniqueness key.
+        def find_or_create_option_type(presentation)
+          Spree::OptionType.search_by_name(presentation).first ||
+            Spree::OptionType.create!(presentation: presentation)
+        rescue ActiveRecord::RecordNotUnique
+          Spree::OptionType.find_by!(name: presentation.to_s.parameterize)
+        rescue ActiveRecord::RecordInvalid => e
+          raise unless name_uniqueness_conflict?(e.record)
+
+          Spree::OptionType.find_by!(name: presentation.to_s.parameterize)
+        end
+
+        def find_or_create_option_value(option_type, presentation)
+          option_type.option_values.search_by_name(presentation).first ||
+            option_type.option_values.create!(presentation: presentation)
+        rescue ActiveRecord::RecordNotUnique
+          option_type.option_values.find_by!(name: presentation.to_s.parameterize)
+        rescue ActiveRecord::RecordInvalid => e
+          raise unless name_uniqueness_conflict?(e.record)
+
+          option_type.option_values.find_by!(name: presentation.to_s.parameterize)
+        end
+
+        def find_or_create_product_option_type(option_type)
+          Spree::ProductOptionType.find_or_create_by!(product: product, option_type: option_type)
+        rescue ActiveRecord::RecordNotUnique
+          Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
+        end
+
+        def name_uniqueness_conflict?(record)
+          record.errors.where(:name, :taken).any?
         end
 
         def handle_images(variant)

--- a/spree/core/spec/jobs/spree/imports/process_group_job_spec.rb
+++ b/spree/core/spec/jobs/spree/imports/process_group_job_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe Spree::Imports::ProcessGroupJob, type: :job do
     end
   end
 
+  context 'when a row in the passed batch is already completed (job retry)' do
+    # Simulates a Sidekiq retry of the group job where some rows finished on the
+    # prior attempt — those must not be reprocessed and duplicate side effects.
+    let!(:completed_row) do
+      create(:import_row, import: import, row_number: 2, status: :completed,
+             data: { 'slug' => 'already-done', 'sku' => 'DONE', 'name' => 'Already Done', 'price' => '1.00' }.to_json)
+    end
+
+    it 'reprocesses pending/failed rows and skips the completed row' do
+      expect {
+        described_class.perform_now(import.id, [row.id, completed_row.id])
+      }.to change(Spree::Product, :count).by(1) # only the pending row creates a product; completed row is skipped
+
+      expect(row.reload.status).to eq('completed')
+      expect(completed_row.reload.status).to eq('completed')
+    end
+  end
+
   context 'with product + variant rows in a group' do
     let!(:variant_row) do
       create(:import_row, import: import, row_number: 2, status: :pending,

--- a/spree/core/spec/jobs/spree/imports/process_group_job_spec.rb
+++ b/spree/core/spec/jobs/spree/imports/process_group_job_spec.rb
@@ -105,6 +105,46 @@ RSpec.describe Spree::Imports::ProcessGroupJob, type: :job do
     end
   end
 
+  context 'when a sibling row is orphaned in processing (worker killed)' do
+    # A row whose worker died (OOM, SIGKILL, deploy without graceful drain) stays
+    # in `processing` indefinitely. Once it's been there longer than the stall window,
+    # it must not block the import from completing — otherwise a dead worker
+    # permanently jams every import that lost a row.
+    let!(:orphaned_row) do
+      create(:import_row, import: import, row_number: 2, status: :processing,
+             data: { 'slug' => 'orphan', 'sku' => 'ORPHAN', 'name' => 'Orphan', 'price' => '1.00' }.to_json)
+    end
+
+    before do
+      orphaned_row.update_columns(updated_at: (Spree::ImportRow::STALLED_PROCESSING_AFTER + 5.minutes).ago)
+      import.update_columns(processing_groups_count: 2, completed_groups_count: 1)
+    end
+
+    it 'completes the import despite the stalled row' do
+      described_class.perform_now(import.id, [row.id])
+
+      expect(import.reload.status).to eq('completed')
+      expect(orphaned_row.reload.status).to eq('processing') # left alone for operator review
+    end
+  end
+
+  context 'when a sibling row is still actively processing' do
+    let!(:active_row) do
+      create(:import_row, import: import, row_number: 2, status: :processing,
+             data: { 'slug' => 'active', 'sku' => 'ACTIVE', 'name' => 'Active', 'price' => '1.00' }.to_json)
+    end
+
+    before do
+      import.update_columns(processing_groups_count: 2, completed_groups_count: 1)
+    end
+
+    it 'does not complete the import while a live worker is still on a row' do
+      described_class.perform_now(import.id, [row.id])
+
+      expect(import.reload.status).to eq('processing')
+    end
+  end
+
   context 'with product + variant rows in a group' do
     let!(:variant_row) do
       create(:import_row, import: import, row_number: 2, status: :pending,

--- a/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -142,14 +142,14 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
 
     context 'when a concurrent worker has already created the option type/value' do
       # Simulates two Sidekiq workers racing on the same option name during a CSV import.
-      # Force search_by_name to miss so create! runs and the peer record asserts itself
-      # via either the AR uniqueness validator or the DB unique index.
+      # Force search_by_name to miss on the initial lookup so create! runs, then return
+      # real results on retry so the rescue path can find the peer's record.
+      # Option values don't need stubbing — they don't exist yet, so search_by_name
+      # naturally misses and create! succeeds.
       before do
-        allow(Spree::OptionType).to receive(:search_by_name).and_return(Spree::OptionType.none)
-        allow_any_instance_of(Spree::OptionType).to receive(:option_values).and_wrap_original do |original|
-          original.call.tap do |relation|
-            allow(relation).to receive(:search_by_name).and_return(Spree::OptionValue.none)
-          end
+        seen_option_types = Set.new
+        allow(Spree::OptionType).to receive(:search_by_name).and_wrap_original do |original, query|
+          seen_option_types.add?(query) ? Spree::OptionType.none : original.call(query)
         end
       end
 
@@ -163,19 +163,13 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       context 'when the create! reaches the DB and the unique index rejects it' do
         # Mirrors the production race: validator passed (peer not committed yet) but
         # the INSERT collides at the DB once the peer commits. Pre-create the peer rows
-        # and force create! to raise RecordNotUnique directly so we exercise the
-        # DB-level rescue path.
+        # so find_by!/search_by_name can locate them on retry.
+        # Option values are pre-created, so search_by_name naturally finds them.
         let!(:color_blue) { create(:option_value, name: 'Blue', presentation: 'Blue', option_type: Spree::OptionType.find_by(name: 'color')) }
         let!(:size_xs) { create(:option_value, name: 'XS', presentation: 'XS', option_type: Spree::OptionType.find_by(name: 'size')) }
 
         before do
           allow(Spree::OptionType).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
-          allow_any_instance_of(Spree::OptionType).to receive(:option_values).and_wrap_original do |original|
-            original.call.tap do |relation|
-              allow(relation).to receive(:search_by_name).and_return(Spree::OptionValue.none)
-              allow(relation).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
-            end
-          end
         end
 
         it 'recovers and reuses existing records' do
@@ -185,6 +179,22 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
           expect(Spree::OptionType.where(name: 'size').count).to eq 1
           expect(Spree::OptionValue.where(name: 'blue').count).to eq 1
           expect(Spree::OptionValue.where(name: 'xs').count).to eq 1
+        end
+      end
+
+      context 'when a concurrent worker causes a ProductOptionType uniqueness conflict' do
+        before do
+          # Stub find_or_create_by! to raise RecordInvalid with a product_id taken error,
+          # simulating a peer worker that committed the same product-option_type association.
+          record = Spree::ProductOptionType.new(product: product)
+          record.errors.add(:product_id, :taken)
+          allow(Spree::ProductOptionType).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordInvalid.new(record))
+          allow(Spree::ProductOptionType).to receive(:find_by!).and_call_original
+        end
+
+        it 'recovers and reuses the existing product option type' do
+          expect { subject.process! }.not_to raise_error
+          expect(variant.option_values.map(&:presentation).sort).to contain_exactly('Blue', 'XS')
         end
       end
     end

--- a/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -140,6 +140,55 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       expect(size_option_type.option_values.find_by(presentation: 'XS')).to be_present
     end
 
+    context 'when a concurrent worker has already created the option type/value' do
+      # Simulates two Sidekiq workers racing on the same option name during a CSV import.
+      # Force search_by_name to miss so create! runs and the peer record asserts itself
+      # via either the AR uniqueness validator or the DB unique index.
+      before do
+        allow(Spree::OptionType).to receive(:search_by_name).and_return(Spree::OptionType.none)
+        allow_any_instance_of(Spree::OptionType).to receive(:option_values).and_wrap_original do |original|
+          original.call.tap do |relation|
+            allow(relation).to receive(:search_by_name).and_return(Spree::OptionValue.none)
+          end
+        end
+      end
+
+      it 'recovers from the AR uniqueness validator and reuses existing records' do
+        expect { subject.process! }.not_to raise_error
+        expect(variant.option_values.map(&:presentation).sort).to contain_exactly('Blue', 'XS')
+        expect(Spree::OptionType.where(name: 'color').count).to eq 1
+        expect(Spree::OptionType.where(name: 'size').count).to eq 1
+      end
+
+      context 'when the create! reaches the DB and the unique index rejects it' do
+        # Mirrors the production race: validator passed (peer not committed yet) but
+        # the INSERT collides at the DB once the peer commits. Pre-create the peer rows
+        # and force create! to raise RecordNotUnique directly so we exercise the
+        # DB-level rescue path.
+        let!(:color_blue) { create(:option_value, name: 'Blue', presentation: 'Blue', option_type: Spree::OptionType.find_by(name: 'color')) }
+        let!(:size_xs) { create(:option_value, name: 'XS', presentation: 'XS', option_type: Spree::OptionType.find_by(name: 'size')) }
+
+        before do
+          allow(Spree::OptionType).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+          allow_any_instance_of(Spree::OptionType).to receive(:option_values).and_wrap_original do |original|
+            original.call.tap do |relation|
+              allow(relation).to receive(:search_by_name).and_return(Spree::OptionValue.none)
+              allow(relation).to receive(:create!).and_raise(ActiveRecord::RecordNotUnique)
+            end
+          end
+        end
+
+        it 'recovers and reuses existing records' do
+          expect { subject.process! }.not_to raise_error
+          expect(variant.option_values.map(&:presentation).sort).to contain_exactly('Blue', 'XS')
+          expect(Spree::OptionType.where(name: 'color').count).to eq 1
+          expect(Spree::OptionType.where(name: 'size').count).to eq 1
+          expect(Spree::OptionValue.where(name: 'blue').count).to eq 1
+          expect(Spree::OptionValue.where(name: 'xs').count).to eq 1
+        end
+      end
+    end
+
     context 'when importing a variant row for existing variant' do
       let(:color_option_type) { Spree::OptionType.find_by(name: 'color') || create(:option_type, name: 'color', presentation: 'Color') }
       let(:size_option_type) { Spree::OptionType.find_by(name: 'size') || create(:option_type, name: 'size', presentation: 'Size') }


### PR DESCRIPTION
To combat/minimize NotUnique errors


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CSV import processing pipeline (Sidekiq/ActiveJob retries, row completion logic, and option type/value creation), where subtle changes can lead to duplicate side effects or stuck/incorrect import completion. Added guards and tests reduce risk, but behavior changes under retry/concurrency should be validated in production-like load.
> 
> **Overview**
> Improves CSV import reliability by introducing `Spree::Imports::BaseJob` with a narrowed retry policy for transient DB/connection errors, and migrating import jobs to inherit from it (with `CreateCategoriesJob` explicitly retrying `RecordNotUnique`).
> 
> Prevents duplicate work and premature/blocked completion by having `ProcessGroupJob` only process `pending`/`failed` rows on retry and only finalize imports when no `in_flight` rows remain; `ImportRow` adds an `in_flight` scope plus a stall window to ignore long-stuck `processing` rows.
> 
> Makes variant option creation more concurrency-safe by wrapping option type/value and product-option-type creation in find-or-create helpers that recover from uniqueness conflicts (`RecordNotUnique` / `RecordInvalid :taken`), and adds specs covering retries, stalled rows, and concurrent option creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f303679a038477ac6f434cad34ffc7c3354d3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reprocesses only pending/failed rows to avoid duplicate work and prevents premature import finalization by tightening completion gating.

* **Improvements**
  * New shared imports job base with safer queue/retry/discard behavior for transient failures.
  * Adds an "in-flight" filter to ignore stalled processing rows.

* **Refactor**
  * Concurrency-safe handling when creating variant option types/values to recover from race conflicts.

* **Tests**
  * Expanded specs for completion, retries, progress publishing, and race-condition recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->