### PR TITLE
Fix json preview to now respect admin namespace dependecies

### DIFF
--- a/spree/admin/app/helpers/spree/admin/json_preview_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/json_preview_helper.rb
@@ -69,6 +69,11 @@ module Spree
           return Spree.api.public_send(method_name)
         end
 
+        if namespace == 'Spree::Api::V3::Admin'
+          method_name = "admin_#{class_name.underscore}_serializer"
+          return Spree.api.public_send(method_name) if Spree.api.respond_to?(method_name)
+        end
+
         # Fall back to direct constant lookup
         serializer_class_name = "#{namespace}::#{class_name}Serializer"
         serializer_class_name.safe_constantize

--- a/spree/admin/spec/helpers/spree/admin/json_preview_helper_spec.rb
+++ b/spree/admin/spec/helpers/spree/admin/json_preview_helper_spec.rb
@@ -26,6 +26,40 @@ RSpec.describe Spree::Admin::JsonPreviewHelper, type: :helper do
     end
   end
 
+  describe '#admin_serializer_for (dependency lookup)' do
+    let(:product) { create(:product) }
+
+    context 'when Spree.api responds to admin_<class>_serializer' do
+      it 'returns the class resolved from the dependency' do
+        custom_serializer = Class.new
+        allow(Spree.api).to receive(:respond_to?).and_call_original
+        allow(Spree.api).to receive(:respond_to?).with('admin_product_serializer').and_return(true)
+        allow(Spree.api).to receive(:admin_product_serializer).and_return(custom_serializer)
+
+        expect(helper.send(:admin_serializer_for, product)).to eq(custom_serializer)
+      end
+    end
+
+    context 'when Spree.api does not respond to admin_<class>_serializer' do
+      it 'falls back to direct constant lookup' do
+        allow(Spree.api).to receive(:respond_to?).and_call_original
+        allow(Spree.api).to receive(:respond_to?).with('admin_product_serializer').and_return(false)
+
+        result = helper.send(:admin_serializer_for, product)
+        expect(result).to eq('Spree::Api::V3::Admin::ProductSerializer'.safe_constantize)
+      end
+    end
+
+    context 'store namespace' do
+      it 'uses the unprefixed dependency method, not admin_ prefix' do
+        allow(Spree.api).to receive(:respond_to?).and_call_original
+        # store path must never call admin_ prefixed method
+        expect(Spree.api).not_to receive(:admin_product_serializer)
+        helper.send(:store_serializer_for, product)
+      end
+    end
+  end
+
   describe '#serialize_to_json' do
     context 'with store api_type' do
       it 'serializes Product to JSON' do


### PR DESCRIPTION
Fixing regression with move to v3 API to lookup Spree.api namespaced seralizers before falling back to the defaults. 

Needed to prefix admin_* when dealing with the V3::Admin namespace

Added stronger testing to help prevent future regressions