### PR TITLE
Add Store API support for Newsletter Subscribers

### DIFF
--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -82,11 +82,11 @@ paths:
               example:
                 data:
                 - id: admin_UkLWZg9DAJ
-                  email: jen@murazikschumm.name
-                  first_name: Taisha
-                  last_name: Upton
-                  created_at: '2026-05-17T22:57:21.251Z'
-                  updated_at: '2026-05-17T22:57:21.251Z'
+                  email: kelle_blanda@muller.name
+                  first_name: Harlan
+                  last_name: Lesch
+                  created_at: '2026-05-21T18:10:41.219Z'
+                  updated_at: '2026-05-21T18:10:41.219Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -144,11 +144,11 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: geraldine@hills.co.uk
-                first_name: Bennie
-                last_name: Jerde
-                created_at: '2026-05-17T22:57:21.592Z'
-                updated_at: '2026-05-17T22:57:21.592Z'
+                email: ai@ullrich.us
+                first_name: Chasity
+                last_name: Beer
+                created_at: '2026-05-21T18:10:41.591Z'
+                updated_at: '2026-05-21T18:10:41.591Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -201,11 +201,11 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: leon@kessler.us
+                email: florinda@cruickshankfriesen.name
                 first_name: Renamed
-                last_name: Casper
-                created_at: '2026-05-17T22:57:21.878Z'
-                updated_at: '2026-05-17T22:57:21.895Z'
+                last_name: Bednar
+                created_at: '2026-05-21T18:10:41.870Z'
+                updated_at: '2026-05-21T18:10:41.886Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -314,32 +314,32 @@ paths:
                   key_type: publishable
                   token_prefix:
                   scopes: []
-                  created_at: '2026-05-17T22:57:22.193Z'
-                  updated_at: '2026-05-17T22:57:22.193Z'
+                  created_at: '2026-05-21T18:10:42.192Z'
+                  updated_at: '2026-05-21T18:10:42.192Z'
                   revoked_at:
                   last_used_at:
-                  plaintext_token: pk_U35V1CMjxUn8ZqkAukTSrh6d
+                  plaintext_token: pk_gPWGMj9NrPRwrj3ETjUDhZ6H
                   created_by_email:
                 - id: key_gbHJdmfrXB
                   name: Backend integration
                   key_type: secret
-                  token_prefix: sk_RgQsPziGM
+                  token_prefix: sk_TmyLov6pZ
                   scopes:
                   - write_all
-                  created_at: '2026-05-17T22:57:22.194Z'
-                  updated_at: '2026-05-17T22:57:22.194Z'
+                  created_at: '2026-05-21T18:10:42.194Z'
+                  updated_at: '2026-05-21T18:10:42.194Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
                   created_by_email:
                 - id: key_EfhxLZ9ck8
-                  name: hic
+                  name: cum
                   key_type: secret
-                  token_prefix: sk_K32iSYt2g
+                  token_prefix: sk_iXrDjuB2e
                   scopes:
                   - write_all
-                  created_at: '2026-05-17T22:57:22.194Z'
-                  updated_at: '2026-05-17T22:57:22.194Z'
+                  created_at: '2026-05-21T18:10:42.196Z'
+                  updated_at: '2026-05-21T18:10:42.196Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
@@ -402,15 +402,15 @@ paths:
                 id: key_VqXmZF31wY
                 name: CI key
                 key_type: secret
-                token_prefix: sk_AgmxxXG58
+                token_prefix: sk_1cPCpa2fh
                 scopes:
                 - read_orders
-                created_at: '2026-05-17T22:57:22.758Z'
-                updated_at: '2026-05-17T22:57:22.758Z'
+                created_at: '2026-05-21T18:10:42.788Z'
+                updated_at: '2026-05-21T18:10:42.788Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: sk_AgmxxXG58HsQVeszL9SN8yNm
-                created_by_email: clinton@schulistconn.com
+                plaintext_token: sk_1cPCpa2fhNURLms46geRmdKn
+                created_by_email: serita@wisoky.us
         '422':
           description: validation error
           content:
@@ -496,11 +496,11 @@ paths:
                 key_type: publishable
                 token_prefix:
                 scopes: []
-                created_at: '2026-05-17T22:57:23.047Z'
-                updated_at: '2026-05-17T22:57:23.047Z'
+                created_at: '2026-05-21T18:10:43.090Z'
+                updated_at: '2026-05-21T18:10:43.090Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: pk_ZsR9RTxoWgMQbCRWVbza9nAi
+                plaintext_token: pk_LUy7zvNorgvrfpjfH3wnNoZQ
                 created_by_email:
     delete:
       summary: Delete an API key
@@ -590,12 +590,12 @@ paths:
                 id: key_gbHJdmfrXB
                 name: Backend integration
                 key_type: secret
-                token_prefix: sk_9ntyVz4oF
+                token_prefix: sk_ksF9pnh8h
                 scopes:
                 - write_all
-                created_at: '2026-05-17T22:57:23.620Z'
-                updated_at: '2026-05-17T22:57:23.925Z'
-                revoked_at: '2026-05-17T22:57:23.923Z'
+                created_at: '2026-05-21T18:10:43.654Z'
+                updated_at: '2026-05-21T18:10:43.929Z'
+                revoked_at: '2026-05-21T18:10:43.928Z'
                 last_used_at:
                 plaintext_token:
                 created_by_email:
@@ -650,15 +650,15 @@ paths:
                 - id: coupon_UkLWZg9DAJ
                   code: AAA111
                   state: unused
-                  created_at: '2026-05-17T22:57:23.946Z'
-                  updated_at: '2026-05-17T22:57:23.946Z'
+                  created_at: '2026-05-21T18:10:43.945Z'
+                  updated_at: '2026-05-21T18:10:43.945Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 - id: coupon_gbHJdmfrXB
                   code: BBB222
                   state: unused
-                  created_at: '2026-05-17T22:57:23.947Z'
-                  updated_at: '2026-05-17T22:57:23.947Z'
+                  created_at: '2026-05-21T18:10:43.946Z'
+                  updated_at: '2026-05-21T18:10:43.946Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 meta:
@@ -736,8 +736,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Product
                   storefront_visible: true
-                  created_at: '2026-05-17T22:57:24.250Z'
-                  updated_at: '2026-05-17T22:57:24.250Z'
+                  created_at: '2026-05-21T18:10:44.235Z'
+                  updated_at: '2026-05-21T18:10:44.235Z'
                 - id: cfdef_gbHJdmfrXB
                   namespace: custom
                   key: order_notes
@@ -745,8 +745,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Order
                   storefront_visible: true
-                  created_at: '2026-05-17T22:57:24.251Z'
-                  updated_at: '2026-05-17T22:57:24.251Z'
+                  created_at: '2026-05-21T18:10:44.235Z'
+                  updated_at: '2026-05-21T18:10:44.235Z'
                 meta:
                   page: 1
                   limit: 25
@@ -809,8 +809,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-17T22:57:24.816Z'
-                updated_at: '2026-05-17T22:57:24.816Z'
+                created_at: '2026-05-21T18:10:44.787Z'
+                updated_at: '2026-05-21T18:10:44.787Z'
       requestBody:
         content:
           application/json:
@@ -893,8 +893,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-17T22:57:24.818Z'
-                updated_at: '2026-05-17T22:57:24.818Z'
+                created_at: '2026-05-21T18:10:44.789Z'
+                updated_at: '2026-05-21T18:10:44.789Z'
     patch:
       summary: Update a custom field definition
       tags:
@@ -933,8 +933,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: false
-                created_at: '2026-05-17T22:57:25.103Z'
-                updated_at: '2026-05-17T22:57:25.399Z'
+                created_at: '2026-05-21T18:10:45.065Z'
+                updated_at: '2026-05-21T18:10:45.349Z'
       requestBody:
         content:
           application/json:
@@ -1058,14 +1058,14 @@ paths:
                   name: VIPs
                   description: Top spenders
                   customers_count: 0
-                  created_at: '2026-05-17T22:57:25.696Z'
-                  updated_at: '2026-05-17T22:57:25.696Z'
+                  created_at: '2026-05-21T18:10:45.641Z'
+                  updated_at: '2026-05-21T18:10:45.641Z'
                 - id: cg_gbHJdmfrXB
                   name: Wholesale
                   description:
                   customers_count: 0
-                  created_at: '2026-05-17T22:57:25.697Z'
-                  updated_at: '2026-05-17T22:57:25.697Z'
+                  created_at: '2026-05-21T18:10:45.641Z'
+                  updated_at: '2026-05-21T18:10:45.641Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1150,8 +1150,8 @@ paths:
                 name: Wholesale 2
                 description: B2B accounts
                 customers_count: 1
-                created_at: '2026-05-17T22:57:26.563Z'
-                updated_at: '2026-05-17T22:57:26.563Z'
+                created_at: '2026-05-21T18:10:46.497Z'
+                updated_at: '2026-05-21T18:10:46.497Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1257,24 +1257,24 @@ paths:
                 name: VIPs
                 description: Top spenders
                 customers_count: 1
-                created_at: '2026-05-17T22:57:27.194Z'
-                updated_at: '2026-05-17T22:57:27.194Z'
+                created_at: '2026-05-21T18:10:47.060Z'
+                updated_at: '2026-05-21T18:10:47.060Z'
                 customers:
                 - id: cus_UkLWZg9DAJ
-                  email: lakeisha_weimann@swaniawskitillman.info
-                  first_name: Drucilla
-                  last_name: Mraz
+                  email: ava@okon.name
+                  first_name: Susanna
+                  last_name: Turner
                   phone:
                   accepts_email_marketing: false
-                  full_name: Drucilla Mraz
+                  full_name: Susanna Turner
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
-                  login: lakeisha_weimann@swaniawskitillman.info
+                  login: ava@okon.name
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-17T22:57:27.460Z'
-                  updated_at: '2026-05-17T22:57:27.460Z'
+                  created_at: '2026-05-21T18:10:47.320Z'
+                  updated_at: '2026-05-21T18:10:47.320Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -1352,8 +1352,8 @@ paths:
                 name: VIP customers (Q1)
                 description: Top spenders
                 customers_count: 0
-                created_at: '2026-05-17T22:57:28.061Z'
-                updated_at: '2026-05-17T22:57:28.346Z'
+                created_at: '2026-05-21T18:10:47.911Z'
+                updated_at: '2026-05-21T18:10:48.190Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1506,8 +1506,8 @@ paths:
                   state_name: New York
                   label:
                   metadata: {}
-                  created_at: '2026-05-17T22:57:29.199Z'
-                  updated_at: '2026-05-17T22:57:29.199Z'
+                  created_at: '2026-05-21T18:10:49.027Z'
+                  updated_at: '2026-05-21T18:10:49.027Z'
                   customer_id: cus_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -1595,8 +1595,8 @@ paths:
                 state_name: New York
                 label: Office
                 metadata: {}
-                created_at: '2026-05-17T22:57:30.589Z'
-                updated_at: '2026-05-17T22:57:30.589Z'
+                created_at: '2026-05-21T18:10:50.367Z'
+                updated_at: '2026-05-21T18:10:50.367Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -1707,8 +1707,8 @@ paths:
                 state_name: New York
                 label:
                 metadata: {}
-                created_at: '2026-05-17T22:57:30.858Z'
-                updated_at: '2026-05-17T22:57:31.401Z'
+                created_at: '2026-05-21T18:10:50.635Z'
+                updated_at: '2026-05-21T18:10:51.171Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -1841,8 +1841,8 @@ paths:
                   customer_id: cus_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   metadata: {}
-                  created_at: '2026-05-17T22:57:32.516Z'
-                  updated_at: '2026-05-17T22:57:32.516Z'
+                  created_at: '2026-05-21T18:10:52.250Z'
+                  updated_at: '2026-05-21T18:10:52.250Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1929,8 +1929,8 @@ paths:
                 customer_id: cus_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 metadata: {}
-                created_at: '2026-05-17T22:57:33.067Z'
-                updated_at: '2026-05-17T22:57:33.067Z'
+                created_at: '2026-05-21T18:10:52.796Z'
+                updated_at: '2026-05-21T18:10:52.796Z'
     delete:
       summary: Delete a customer credit card
       tags:
@@ -2049,8 +2049,8 @@ paths:
                   currency: USD
                   memo:
                   metadata: {}
-                  created_at: '2026-05-17T22:57:34.424Z'
-                  updated_at: '2026-05-17T22:57:34.424Z'
+                  created_at: '2026-05-21T18:10:54.199Z'
+                  updated_at: '2026-05-21T18:10:54.199Z'
                   customer_id: cus_UkLWZg9DAJ
                   created_by_id: admin_UkLWZg9DAJ
                   category_id: sccat_UkLWZg9DAJ
@@ -2125,8 +2125,8 @@ paths:
                 currency: USD
                 memo: Goodwill
                 metadata: {}
-                created_at: '2026-05-17T22:57:35.514Z'
-                updated_at: '2026-05-17T22:57:35.514Z'
+                created_at: '2026-05-21T18:10:55.292Z'
+                updated_at: '2026-05-21T18:10:55.292Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_gbHJdmfrXB
                 category_id: sccat_UkLWZg9DAJ
@@ -2217,8 +2217,8 @@ paths:
                 currency: USD
                 memo: Updated
                 metadata: {}
-                created_at: '2026-05-17T22:57:36.047Z'
-                updated_at: '2026-05-17T22:57:36.325Z'
+                created_at: '2026-05-21T18:10:55.821Z'
+                updated_at: '2026-05-21T18:10:56.098Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_UkLWZg9DAJ
                 category_id: sccat_UkLWZg9DAJ
@@ -2372,8 +2372,8 @@ paths:
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-17T22:57:37.396Z'
-                  updated_at: '2026-05-17T22:57:37.396Z'
+                  created_at: '2026-05-21T18:10:57.233Z'
+                  updated_at: '2026-05-21T18:10:57.233Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -2456,8 +2456,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-17T22:57:38.226Z'
-                updated_at: '2026-05-17T22:57:38.226Z'
+                created_at: '2026-05-21T18:10:58.068Z'
+                updated_at: '2026-05-21T18:10:58.068Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2573,8 +2573,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-17T22:57:38.506Z'
-                updated_at: '2026-05-17T22:57:38.506Z'
+                created_at: '2026-05-21T18:10:58.336Z'
+                updated_at: '2026-05-21T18:10:58.336Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2648,8 +2648,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-17T22:57:39.051Z'
-                updated_at: '2026-05-17T22:57:39.332Z'
+                created_at: '2026-05-21T18:10:58.876Z'
+                updated_at: '2026-05-21T18:10:59.154Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2728,6 +2728,161 @@ paths:
       responses:
         '204':
           description: customer deleted
+  "/api/v3/admin/customers/bulk_add_to_groups":
+    post:
+      summary: Bulk-add customers to groups
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Attaches each customer in `ids` to every group in `customer_group_ids`.
+        Idempotent — customers already in a group are skipped server-side.
+        Groups from sibling stores are silently ignored. Returns counts of
+        customers and groups that were processed (post store-scoping).
+
+
+        **Required scope:** `write_customers` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const result = await client.customers.bulkAddToGroups({
+            ids: ['cus_UkLWZg9DAJ', 'cus_QrLWXg9CAJ'],
+            customer_group_ids: ['cg_UkLWZg9DAJ'],
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: customers added to groups
+          content:
+            application/json:
+              example:
+                customer_count: 1
+                customer_group_count: 1
+              schema:
+                type: object
+                properties:
+                  customer_count:
+                    type: integer
+                  customer_group_count:
+                    type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - ids
+              - customer_group_ids
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - cus_UkLWZg9DAJ
+                  - cus_QrLWXg9CAJ
+                customer_group_ids:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - cg_UkLWZg9DAJ
+  "/api/v3/admin/customers/bulk_remove_from_groups":
+    post:
+      summary: Bulk-remove customers from groups
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Detaches each customer in `ids` from every group in `customer_group_ids`.
+        No-op for non-members. Groups from sibling stores are silently ignored.
+
+
+        **Required scope:** `write_customers` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const result = await client.customers.bulkRemoveFromGroups({
+            ids: ['cus_UkLWZg9DAJ'],
+            customer_group_ids: ['cg_UkLWZg9DAJ'],
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: customers removed from groups
+          content:
+            application/json:
+              example:
+                customer_count: 1
+                customer_group_count: 1
+              schema:
+                type: object
+                properties:
+                  customer_count:
+                    type: integer
+                  customer_group_count:
+                    type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - ids
+              - customer_group_ids
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - cus_UkLWZg9DAJ
+                customer_group_ids:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - cg_UkLWZg9DAJ
   "/api/v3/admin/exports":
     get:
       summary: List exports
@@ -2771,11 +2926,11 @@ paths:
               example:
                 data:
                 - id: exp_UkLWZg9DAJ
-                  number: EF181505182
+                  number: EF106832425
                   type: Spree::Exports::Products
                   format: csv
-                  created_at: '2026-05-17T22:57:40.165Z'
-                  updated_at: '2026-05-17T22:57:40.165Z'
+                  created_at: '2026-05-21T18:11:01.605Z'
+                  updated_at: '2026-05-21T18:11:01.605Z'
                   user_id: admin_UkLWZg9DAJ
                   done: false
                   filename:
@@ -2842,11 +2997,11 @@ paths:
             application/json:
               example:
                 id: exp_gbHJdmfrXB
-                number: EF196782958
+                number: EF378981566
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-17T22:57:40.457Z'
-                updated_at: '2026-05-17T22:57:40.457Z'
+                created_at: '2026-05-21T18:11:01.903Z'
+                updated_at: '2026-05-21T18:11:01.903Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -2933,11 +3088,11 @@ paths:
             application/json:
               example:
                 id: exp_UkLWZg9DAJ
-                number: EF446204860
+                number: EF499734650
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-17T22:57:40.725Z'
-                updated_at: '2026-05-17T22:57:40.725Z'
+                created_at: '2026-05-21T18:11:02.171Z'
+                updated_at: '2026-05-21T18:11:02.171Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3088,15 +3243,15 @@ paths:
               example:
                 data:
                 - id: inv_UkLWZg9DAJ
-                  email: elizbeth_thompson@king.info
+                  email: gudrun.erdman@pfefferharvey.biz
                   status: pending
-                  created_at: '2026-05-17T22:57:41.583Z'
-                  updated_at: '2026-05-17T22:57:41.583Z'
-                  expires_at: '2026-05-31T22:57:41.581Z'
+                  created_at: '2026-05-21T18:11:03.022Z'
+                  updated_at: '2026-05-21T18:11:03.022Z'
+                  expires_at: '2026-06-04T18:11:03.020Z'
                   role_id: role_UkLWZg9DAJ
                   role_name: admin
-                  inviter_email: carmela@schaden.ca
-                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=Sm1UZP3PfJPPUdSmcVoXpAX2"
+                  inviter_email: gertrud_paucek@corwin.com
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=oneuuQSVMG5G4bcVNYPZUQE9"
                 meta:
                   page: 1
                   limit: 25
@@ -3153,13 +3308,13 @@ paths:
                 id: inv_gbHJdmfrXB
                 email: new-staff@example.com
                 status: pending
-                created_at: '2026-05-17T22:57:41.880Z'
-                updated_at: '2026-05-17T22:57:41.880Z'
-                expires_at: '2026-05-31T22:57:41.878Z'
+                created_at: '2026-05-21T18:11:03.317Z'
+                updated_at: '2026-05-21T18:11:03.317Z'
+                expires_at: '2026-06-04T18:11:03.315Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: myong@rau.name
-                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=TemhXQKMdCgFXmyPhhDS37sy"
+                inviter_email: lashawnda_johns@nolan.us
+                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=1Bj17uQWhsg5tYdTVk5amqTA"
       requestBody:
         content:
           application/json:
@@ -3262,15 +3417,15 @@ paths:
             application/json:
               example:
                 id: inv_UkLWZg9DAJ
-                email: lesley_bernhard@mcculloughkihn.co.uk
+                email: darleen.harris@streich.biz
                 status: pending
-                created_at: '2026-05-17T22:57:42.445Z'
-                updated_at: '2026-05-17T22:57:42.445Z'
-                expires_at: '2026-05-31T22:57:42.442Z'
+                created_at: '2026-05-21T18:11:03.882Z'
+                updated_at: '2026-05-21T18:11:03.882Z'
+                expires_at: '2026-06-04T18:11:03.880Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: johnsie@hermanncummerata.com
-                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=e8J3mdcca4TSodmoxqdbCoFi"
+                inviter_email: maranda.white@smithmertz.ca
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=S6EjxjJWQ3XQhCVm1EhozQQR"
   "/api/v3/admin/me":
     get:
       summary: Get current admin user and permissions
@@ -3316,11 +3471,11 @@ paths:
               example:
                 user:
                   id: admin_UkLWZg9DAJ
-                  email: sparkle.mcclure@paucek.ca
-                  first_name: Delma
-                  last_name: Lind
-                  created_at: '2026-05-17T22:57:42.721Z'
-                  updated_at: '2026-05-17T22:57:42.721Z'
+                  email: gilbert@faheyfahey.co.uk
+                  first_name: Twyla
+                  last_name: Watsica
+                  created_at: '2026-05-21T18:11:04.160Z'
+                  updated_at: '2026-05-21T18:11:04.160Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -3470,8 +3625,8 @@ paths:
                   kind: dropdown
                   metadata: {}
                   filterable: true
-                  created_at: '2026-05-17T22:57:42.762Z'
-                  updated_at: '2026-05-17T22:57:42.762Z'
+                  created_at: '2026-05-21T18:11:04.205Z'
+                  updated_at: '2026-05-21T18:11:04.205Z'
                 meta:
                   page: 1
                   limit: 25
@@ -3562,8 +3717,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-17T22:57:43.336Z'
-                updated_at: '2026-05-17T22:57:43.336Z'
+                created_at: '2026-05-21T18:11:04.784Z'
+                updated_at: '2026-05-21T18:11:04.784Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -3684,8 +3839,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-17T22:57:43.621Z'
-                updated_at: '2026-05-17T22:57:43.621Z'
+                created_at: '2026-05-21T18:11:05.069Z'
+                updated_at: '2026-05-21T18:11:05.069Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '404':
@@ -3757,8 +3912,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-17T22:57:44.197Z'
-                updated_at: '2026-05-17T22:57:44.475Z'
+                created_at: '2026-05-21T18:11:05.633Z'
+                updated_at: '2026-05-21T18:11:05.926Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -3917,7 +4072,7 @@ paths:
               example:
                 data:
                 - id: ful_UkLWZg9DAJ
-                  number: H93726194260
+                  number: H55703158790
                   tracking: U10000
                   tracking_url:
                   cost: '10.0'
@@ -3942,8 +4097,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-17T22:57:45.414Z'
-                  updated_at: '2026-05-17T22:57:45.527Z'
+                  created_at: '2026-05-21T18:11:06.921Z'
+                  updated_at: '2026-05-21T18:11:07.008Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_UkLWZg9DAJ
                 meta:
@@ -4026,7 +4181,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H67359691291
+                number: H33304075909
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -4051,8 +4206,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-17T22:57:46.167Z'
-                updated_at: '2026-05-17T22:57:46.285Z'
+                created_at: '2026-05-21T18:11:07.631Z'
+                updated_at: '2026-05-21T18:11:07.686Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
     patch:
@@ -4111,7 +4266,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H82376403615
+                number: H57005977773
                 tracking: 1Z999AA10123456784
                 tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
                 cost: '10.0'
@@ -4136,8 +4291,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-17T22:57:46.881Z'
-                updated_at: '2026-05-17T22:57:47.225Z'
+                created_at: '2026-05-21T18:11:08.270Z'
+                updated_at: '2026-05-21T18:11:08.607Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
       requestBody:
@@ -4206,7 +4361,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H42791123467
+                number: H64771060776
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -4223,7 +4378,7 @@ paths:
                 display_tax_total: "$0.00"
                 status: shipped
                 fulfillment_type: shipping
-                fulfilled_at: '2026-05-17T22:57:47Z'
+                fulfilled_at: '2026-05-21T18:11:09Z'
                 items:
                 - item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
@@ -4231,8 +4386,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-17T22:57:47.543Z'
-                updated_at: '2026-05-17T22:57:47.892Z'
+                created_at: '2026-05-21T18:11:08.923Z'
+                updated_at: '2026-05-21T18:11:09.289Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
@@ -4290,7 +4445,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H68028933136
+                number: H29612628564
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -4315,8 +4470,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-17T22:57:48.220Z'
-                updated_at: '2026-05-17T22:57:48.568Z'
+                created_at: '2026-05-21T18:11:09.604Z'
+                updated_at: '2026-05-21T18:11:09.958Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
@@ -4374,7 +4529,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H18035538721
+                number: H32055728452
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -4399,8 +4554,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-17T22:57:48.894Z'
-                updated_at: '2026-05-17T22:57:49.260Z'
+                created_at: '2026-05-21T18:11:10.300Z'
+                updated_at: '2026-05-21T18:11:10.670Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
@@ -4461,7 +4616,7 @@ paths:
               example:
                 data:
                 - id: ful_gbHJdmfrXB
-                  number: H42674651588
+                  number: H90633868146
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -4486,8 +4641,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-17T22:57:49.949Z'
-                  updated_at: '2026-05-17T22:57:49.997Z'
+                  created_at: '2026-05-21T18:11:11.340Z'
+                  updated_at: '2026-05-21T18:11:11.385Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_gbHJdmfrXB
       requestBody:
@@ -4559,7 +4714,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 0262137AC51DF7BF
+                code: 4FE246FA26B40985
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -4573,8 +4728,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-17T22:57:50.337Z'
-                updated_at: '2026-05-17T22:57:50.632Z'
+                created_at: '2026-05-21T18:11:11.716Z'
+                updated_at: '2026-05-21T18:11:12.007Z'
       requestBody:
         content:
           application/json:
@@ -4705,8 +4860,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 2
                   currency: USD
-                  name: Product 103053
-                  slug: product-103053
+                  name: Product 10487
+                  slug: product-10487
                   options_text: 'Size: S'
                   price: '10.0'
                   display_price: "$10.00"
@@ -4738,12 +4893,12 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-17T22:57:51.306Z'
-                    updated_at: '2026-05-17T22:57:51.306Z'
+                    created_at: '2026-05-21T18:11:12.695Z'
+                    updated_at: '2026-05-21T18:11:12.695Z'
                   digital_links: []
                   metadata: {}
-                  created_at: '2026-05-17T22:57:51.591Z'
-                  updated_at: '2026-05-17T22:57:51.591Z'
+                  created_at: '2026-05-21T18:11:12.991Z'
+                  updated_at: '2026-05-21T18:11:12.991Z'
                   cost_price: '17.0'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
@@ -4810,8 +4965,8 @@ paths:
                 variant_id: variant_VqXmZF31wY
                 quantity: 3
                 currency: USD
-                name: Product 128467
-                slug: product-128467
+                name: Product 126547
+                slug: product-126547
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -4843,12 +4998,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-17T22:57:52.529Z'
-                  updated_at: '2026-05-17T22:57:52.529Z'
+                  created_at: '2026-05-21T18:11:14.028Z'
+                  updated_at: '2026-05-21T18:11:14.028Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-17T22:57:52.559Z'
-                updated_at: '2026-05-17T22:57:52.559Z'
+                created_at: '2026-05-21T18:11:14.053Z'
+                updated_at: '2026-05-21T18:11:14.053Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -4937,8 +5092,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 2
                 currency: USD
-                name: Product 135720
-                slug: product-135720
+                name: Product 133638
+                slug: product-133638
                 options_text: 'Size: S'
                 price: '10.0'
                 display_price: "$10.00"
@@ -4970,12 +5125,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-17T22:57:52.633Z'
-                  updated_at: '2026-05-17T22:57:52.633Z'
+                  created_at: '2026-05-21T18:11:14.139Z'
+                  updated_at: '2026-05-21T18:11:14.139Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-17T22:57:52.918Z'
-                updated_at: '2026-05-17T22:57:52.918Z'
+                created_at: '2026-05-21T18:11:14.433Z'
+                updated_at: '2026-05-21T18:11:14.433Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
     patch:
@@ -5037,8 +5192,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 5
                 currency: USD
-                name: Product 14367
-                slug: product-14367
+                name: Product 141563
+                slug: product-141563
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -5070,12 +5225,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-17T22:57:53.243Z'
-                  updated_at: '2026-05-17T22:57:53.243Z'
+                  created_at: '2026-05-21T18:11:14.759Z'
+                  updated_at: '2026-05-21T18:11:14.759Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-17T22:57:53.531Z'
-                updated_at: '2026-05-17T22:57:53.828Z'
+                created_at: '2026-05-21T18:11:15.044Z'
+                updated_at: '2026-05-21T18:11:15.352Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -5201,8 +5356,8 @@ paths:
                 data:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-0cb507c6b6fd
-                  number: PSQU5GQO
+                  response_code: BGS-68effea76f43
+                  number: PA0E91P2
                   amount: '110.0'
                   display_amount: "$110.00"
                   status: completed
@@ -5220,14 +5375,14 @@ paths:
                     customer_id:
                     payment_method_id: pm_gbHJdmfrXB
                     metadata: {}
-                    created_at: '2026-05-17T22:57:54.817Z'
-                    updated_at: '2026-05-17T22:57:54.821Z'
+                    created_at: '2026-05-21T18:11:16.469Z'
+                    updated_at: '2026-05-21T18:11:16.471Z'
                   metadata: {}
                   avs_response:
                   cvv_response_code:
                   cvv_response_message:
-                  created_at: '2026-05-17T22:57:54.820Z'
-                  updated_at: '2026-05-17T22:57:54.820Z'
+                  created_at: '2026-05-21T18:11:16.470Z'
+                  updated_at: '2026-05-21T18:11:16.470Z'
                   captured_amount: '0.0'
                   order_id: or_UkLWZg9DAJ
                 meta:
@@ -5294,7 +5449,7 @@ paths:
                 id: py_gbHJdmfrXB
                 payment_method_id: pm_EfhxLZ9ck8
                 response_code:
-                number: PD00W24T
+                number: P7NSTYZI
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -5305,8 +5460,8 @@ paths:
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-17T22:57:56.148Z'
-                updated_at: '2026-05-17T22:57:56.148Z'
+                created_at: '2026-05-21T18:11:17.771Z'
+                updated_at: '2026-05-21T18:11:17.771Z'
                 captured_amount: '0.0'
                 order_id: or_gbHJdmfrXB
       requestBody:
@@ -5396,8 +5551,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-111160a6f3ed
-                number: PEQOW0S0
+                response_code: BGS-cacbdea24d28
+                number: PK9QXUFZ
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -5415,14 +5570,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-17T22:57:56.525Z'
-                  updated_at: '2026-05-17T22:57:56.527Z'
+                  created_at: '2026-05-21T18:11:18.181Z'
+                  updated_at: '2026-05-21T18:11:18.184Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-17T22:57:56.526Z'
-                updated_at: '2026-05-17T22:57:56.526Z'
+                created_at: '2026-05-21T18:11:18.182Z'
+                updated_at: '2026-05-21T18:11:18.182Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
@@ -5481,8 +5636,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-f5c608409d35
-                number: P2IQ5WXV
+                response_code: BGS-efbbca6d3e6b
+                number: PAP44T33
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -5500,14 +5655,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-17T22:57:57.172Z'
-                  updated_at: '2026-05-17T22:57:57.175Z'
+                  created_at: '2026-05-21T18:11:18.837Z'
+                  updated_at: '2026-05-21T18:11:18.839Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-17T22:57:57.174Z'
-                updated_at: '2026-05-17T22:57:57.517Z'
+                created_at: '2026-05-21T18:11:18.838Z'
+                updated_at: '2026-05-21T18:11:19.158Z'
                 captured_amount: '110.0'
                 order_id: or_UkLWZg9DAJ
         '422':
@@ -5576,8 +5731,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: void-BGS-a7822422048d
-                number: PHHVVBKB
+                response_code: void-BGS-df4aa5520eb3
+                number: PP2A7W5U
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: void
@@ -5595,14 +5750,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-17T22:57:58.605Z'
-                  updated_at: '2026-05-17T22:57:58.608Z'
+                  created_at: '2026-05-21T18:11:20.228Z'
+                  updated_at: '2026-05-21T18:11:20.230Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-17T22:57:58.607Z'
-                updated_at: '2026-05-17T22:57:58.909Z'
+                created_at: '2026-05-21T18:11:20.229Z'
+                updated_at: '2026-05-21T18:11:20.539Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/refunds":
@@ -5730,14 +5885,14 @@ paths:
             application/json:
               example:
                 id: re_UkLWZg9DAJ
-                transaction_id: BGS-1e98d2337e15
+                transaction_id: BGS-162d0a7eaeca
                 amount: '5.0'
                 payment_id: py_UkLWZg9DAJ
                 refund_reason_id: rr_UkLWZg9DAJ
                 reimbursement_id:
                 metadata: {}
-                created_at: '2026-05-17T22:58:00.262Z'
-                updated_at: '2026-05-17T22:58:00.262Z'
+                created_at: '2026-05-21T18:11:21.881Z'
+                updated_at: '2026-05-21T18:11:21.881Z'
       requestBody:
         content:
           application/json:
@@ -5809,8 +5964,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R421111487
-                email: pamila_mohr@champlin.name
+                number: R127319008
+                email: mariko@christiansen.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -5853,8 +6008,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-17T22:58:00.562Z'
-                updated_at: '2026-05-17T22:58:00.616Z'
+                created_at: '2026-05-21T18:11:22.177Z'
+                updated_at: '2026-05-21T18:11:22.244Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -6025,8 +6180,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R960433554
-                  email: hue@hanesatterfield.com
+                  number: R820326830
+                  email: sol@ebert.ca
                   customer_note:
                   currency: USD
                   locale: en
@@ -6069,8 +6224,8 @@ paths:
                   metadata: {}
                   canceled_at:
                   approved_at:
-                  created_at: '2026-05-17T22:58:02.356Z'
-                  updated_at: '2026-05-17T22:58:02.356Z'
+                  created_at: '2026-05-21T18:11:23.988Z'
+                  updated_at: '2026-05-21T18:11:23.988Z'
                   preferred_stock_location_id:
                   tags: []
                   internal_note:
@@ -6213,7 +6368,7 @@ paths:
                 id: or_gbHJdmfrXB
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R338726767
+                number: R134720113
                 email: pinned@example.com
                 customer_note:
                 currency: USD
@@ -6257,8 +6412,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-17T22:58:04.037Z'
-                updated_at: '2026-05-17T22:58:04.041Z'
+                created_at: '2026-05-21T18:11:25.674Z'
+                updated_at: '2026-05-21T18:11:25.677Z'
                 preferred_stock_location_id: sloc_UkLWZg9DAJ
                 tags: []
                 internal_note:
@@ -6442,8 +6597,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R077708501
-                email: brenda.collier@wintheiserhessel.com
+                number: R107305096
+                email: lawanda.goodwin@schulist.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -6486,8 +6641,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-17T22:58:04.316Z'
-                updated_at: '2026-05-17T22:58:04.316Z'
+                created_at: '2026-05-21T18:11:25.951Z'
+                updated_at: '2026-05-21T18:11:25.951Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -6558,7 +6713,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R719018821
+                number: R663137812
                 email: updated@example.com
                 customer_note:
                 currency: USD
@@ -6602,8 +6757,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-17T22:58:05.432Z'
-                updated_at: '2026-05-17T22:58:05.724Z'
+                created_at: '2026-05-21T18:11:27.065Z'
+                updated_at: '2026-05-21T18:11:27.352Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -6784,8 +6939,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R016462732
-                email: dexter@lednerbarton.us
+                number: R388861139
+                email: paul.balistreri@quitzon.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -6812,7 +6967,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status: ready
                 payment_status: paid
-                completed_at: '2026-05-17T22:58:06.625Z'
+                completed_at: '2026-05-21T18:11:28.250Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -6828,8 +6983,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-17T22:58:06.570Z'
-                updated_at: '2026-05-17T22:58:06.651Z'
+                created_at: '2026-05-21T18:11:28.197Z'
+                updated_at: '2026-05-21T18:11:28.276Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -6910,8 +7065,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R062143227
-                email: narcisa@oberbrunner.co.uk
+                number: R089309105
+                email: arleen.prohaska@shanahangrady.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -6938,7 +7093,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-17T22:58:07.890Z'
+                completed_at: '2026-05-21T18:11:29.520Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -6952,10 +7107,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-17T22:58:08.177Z'
+                canceled_at: '2026-05-21T18:11:29.814Z'
                 approved_at:
-                created_at: '2026-05-17T22:58:07.834Z'
-                updated_at: '2026-05-17T22:58:08.218Z'
+                created_at: '2026-05-21T18:11:29.466Z'
+                updated_at: '2026-05-21T18:11:29.851Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7014,8 +7169,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R328362970
-                email: myrtie@mooreadams.co.uk
+                number: R821320090
+                email: tia_bahringer@koch.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -7042,7 +7197,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-17T22:58:08.595Z'
+                completed_at: '2026-05-21T18:11:30.205Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -7057,9 +7212,9 @@ paths:
                 display_payment_total: "$0.00"
                 metadata: {}
                 canceled_at:
-                approved_at: '2026-05-17T22:58:08.896Z'
-                created_at: '2026-05-17T22:58:08.517Z'
-                updated_at: '2026-05-17T22:58:08.595Z'
+                approved_at: '2026-05-21T18:11:30.500Z'
+                created_at: '2026-05-21T18:11:30.151Z'
+                updated_at: '2026-05-21T18:11:30.205Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7118,8 +7273,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R862448919
-                email: steven@kihnschmidt.com
+                number: R851503398
+                email: nidia.ruecker@parker.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -7146,7 +7301,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-17T22:58:09.237Z'
+                completed_at: '2026-05-21T18:11:30.837Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -7160,10 +7315,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-17T22:58:09.515Z'
+                canceled_at: '2026-05-21T18:11:31.121Z'
                 approved_at:
-                created_at: '2026-05-17T22:58:09.182Z'
-                updated_at: '2026-05-17T22:58:09.601Z'
+                created_at: '2026-05-21T18:11:30.783Z'
+                updated_at: '2026-05-21T18:11:31.205Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7222,8 +7377,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R636920706
-                email: tanja@pfannerstillfritsch.name
+                number: R035776695
+                email: nanette@terrypredovic.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -7250,7 +7405,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-17T22:58:09.934Z'
+                completed_at: '2026-05-21T18:11:31.546Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -7266,8 +7421,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-17T22:58:09.880Z'
-                updated_at: '2026-05-17T22:58:09.934Z'
+                created_at: '2026-05-21T18:11:31.489Z'
+                updated_at: '2026-05-21T18:11:31.546Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7342,8 +7497,8 @@ paths:
                   auto_capture:
                   storefront_visible: true
                   position: 1
-                  created_at: '2026-05-17T22:58:10.232Z'
-                  updated_at: '2026-05-17T22:58:10.233Z'
+                  created_at: '2026-05-21T18:11:31.844Z'
+                  updated_at: '2026-05-21T18:11:31.845Z'
                   preferences: {}
                   preference_schema: []
                 meta:
@@ -7483,8 +7638,8 @@ paths:
                 auto_capture:
                 storefront_visible: true
                 position: 1
-                created_at: '2026-05-17T22:58:10.803Z'
-                updated_at: '2026-05-17T22:58:10.805Z'
+                created_at: '2026-05-21T18:11:32.415Z'
+                updated_at: '2026-05-21T18:11:32.417Z'
                 preferences: {}
                 preference_schema: []
   "/api/v3/admin/products/{product_id}/custom_fields":
@@ -7554,8 +7709,8 @@ paths:
                   field_type: short_text
                   key: custom.title
                   value: wool
-                  created_at: '2026-05-17T22:58:11.118Z'
-                  updated_at: '2026-05-17T22:58:11.118Z'
+                  created_at: '2026-05-21T18:11:32.732Z'
+                  updated_at: '2026-05-21T18:11:32.732Z'
                   storefront_visible: true
                   custom_field_definition_id: cfdef_UkLWZg9DAJ
                 meta:
@@ -7622,8 +7777,8 @@ paths:
                 field_type: long_text
                 key: custom.description
                 value: A longer description
-                created_at: '2026-05-17T22:58:11.733Z'
-                updated_at: '2026-05-17T22:58:11.733Z'
+                created_at: '2026-05-21T18:11:33.356Z'
+                updated_at: '2026-05-21T18:11:33.356Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_gbHJdmfrXB
         '422':
@@ -7707,8 +7862,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: wool
-                created_at: '2026-05-17T22:58:12.085Z'
-                updated_at: '2026-05-17T22:58:12.085Z'
+                created_at: '2026-05-21T18:11:33.706Z'
+                updated_at: '2026-05-21T18:11:33.706Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
     patch:
@@ -7755,8 +7910,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: cotton
-                created_at: '2026-05-17T22:58:12.401Z'
-                updated_at: '2026-05-17T22:58:12.680Z'
+                created_at: '2026-05-21T18:11:34.022Z'
+                updated_at: '2026-05-21T18:11:34.306Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
       requestBody:
@@ -7894,33 +8049,33 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 398974
-                  slug: product-398974
+                  name: Product 393216
+                  slug: product-393216
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-17T22:58:13.003Z'
+                  available_on: '2025-05-21T18:11:34.653Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Officiis magnam distinctio voluptatibus dolores provident.
-                    Quae neque corrupti natus id voluptatem occaecati. Eos commodi
-                    deserunt quas voluptatibus occaecati ut minus impedit. Molestias
-                    tempora quaerat fuga animi occaecati autem voluptatem. Ad error
-                    reiciendis odit architecto asperiores quaerat laborum a. Quisquam
-                    voluptas cupiditate saepe corporis. Rerum quibusdam odio recusandae
-                    minima. Rerum reprehenderit magnam qui exercitationem. Debitis
-                    ex optio rem facere officia maiores. Assumenda amet deserunt omnis
-                    reiciendis repellendus. Facere cupiditate tempore vel itaque minus.
-                    Possimus quisquam error atque recusandae vel. Pariatur repudiandae
-                    nam consequuntur fuga voluptates blanditiis dolores beatae. Temporibus
-                    vitae nam odio velit voluptatibus.
+                  description: Vero nulla quasi dignissimos maxime sequi ipsam voluptas
+                    eaque. Distinctio quibusdam sint accusantium consectetur. Suscipit
+                    nobis aliquid laudantium nihil. Asperiores modi laudantium culpa
+                    blanditiis sapiente ab architecto ut. Provident ipsa doloribus
+                    illo accusamus fugiat ullam magni voluptates. Aut laboriosam repellendus
+                    iusto omnis alias. Ipsam eius totam minima rerum molestiae. Aspernatur
+                    sequi voluptatum quia cum architecto sunt eveniet esse. Quibusdam
+                    consequatur totam in non neque. Nam quaerat molestias fugit neque
+                    nemo vitae veritatis saepe. Voluptatibus minima aspernatur pariatur
+                    doloribus repudiandae eaque. Doloremque quisquam eveniet repellendus
+                    aut eos quam blanditiis occaecati. Sequi iste asperiores distinctio
+                    harum. Voluptatibus optio asperiores voluptas labore non laboriosam.
                   description_html: |-
-                    Officiis magnam distinctio voluptatibus dolores provident. Quae neque corrupti natus id voluptatem occaecati. Eos commodi deserunt quas voluptatibus occaecati ut minus impedit. Molestias tempora quaerat fuga animi occaecati autem voluptatem.
-                    Ad error reiciendis odit architecto asperiores quaerat laborum a. Quisquam voluptas cupiditate saepe corporis. Rerum quibusdam odio recusandae minima. Rerum reprehenderit magnam qui exercitationem. Debitis ex optio rem facere officia maiores.
-                    Assumenda amet deserunt omnis reiciendis repellendus. Facere cupiditate tempore vel itaque minus. Possimus quisquam error atque recusandae vel. Pariatur repudiandae nam consequuntur fuga voluptates blanditiis dolores beatae. Temporibus vitae nam odio velit voluptatibus.
+                    Vero nulla quasi dignissimos maxime sequi ipsam voluptas eaque. Distinctio quibusdam sint accusantium consectetur. Suscipit nobis aliquid laudantium nihil. Asperiores modi laudantium culpa blanditiis sapiente ab architecto ut.
+                    Provident ipsa doloribus illo accusamus fugiat ullam magni voluptates. Aut laboriosam repellendus iusto omnis alias. Ipsam eius totam minima rerum molestiae. Aspernatur sequi voluptatum quia cum architecto sunt eveniet esse. Quibusdam consequatur totam in non neque.
+                    Nam quaerat molestias fugit neque nemo vitae veritatis saepe. Voluptatibus minima aspernatur pariatur doloribus repudiandae eaque. Doloremque quisquam eveniet repellendus aut eos quam blanditiis occaecati. Sequi iste asperiores distinctio harum. Voluptatibus optio asperiores voluptas labore non laboriosam.
                   default_variant_id: variant_UkLWZg9DAJ
                   thumbnail_url:
                   tags: []
@@ -7935,16 +8090,16 @@ paths:
                     display_compare_at_amount:
                     price_list_id:
                     variant_id: variant_UkLWZg9DAJ
-                    created_at: '2026-05-17T22:58:13.027Z'
-                    updated_at: '2026-05-17T22:58:13.027Z'
+                    created_at: '2026-05-21T18:11:34.688Z'
+                    updated_at: '2026-05-21T18:11:34.688Z'
                   original_price:
                   status: active
-                  make_active_at: '2025-05-17T22:58:13.003Z'
+                  make_active_at: '2025-05-21T18:11:34.654Z'
                   discontinue_on:
                   metadata: {}
                   deleted_at:
-                  created_at: '2026-05-17T22:58:13.014Z'
-                  updated_at: '2026-05-17T22:58:13.028Z'
+                  created_at: '2026-05-21T18:11:34.668Z'
+                  updated_at: '2026-05-21T18:11:34.690Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -8078,8 +8233,8 @@ paths:
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-17T22:58:13.688Z'
-                updated_at: '2026-05-17T22:58:13.691Z'
+                created_at: '2026-05-21T18:11:35.401Z'
+                updated_at: '2026-05-21T18:11:35.404Z'
                 tax_category_id:
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -8259,25 +8414,32 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 438556
-                slug: product-438556
+                name: Product 439727
+                slug: product-439727
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-17T22:58:14.064Z'
+                available_on: '2025-05-21T18:11:35.746Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Voluptatem magni libero quam officia earum esse inventore
-                  assumenda. Dolores impedit aliquam eum voluptatem. Ducimus ullam
-                  consequuntur nam perspiciatis deleniti aut. Vero necessitatibus
-                  magnam et fugiat perspiciatis. Sunt eos repellendus odit incidunt.
-                description_html: Voluptatem magni libero quam officia earum esse
-                  inventore assumenda. Dolores impedit aliquam eum voluptatem. Ducimus
-                  ullam consequuntur nam perspiciatis deleniti aut. Vero necessitatibus
-                  magnam et fugiat perspiciatis. Sunt eos repellendus odit incidunt.
+                description: Eaque quos laborum maxime rem. Tenetur consequatur iste
+                  inventore quae. Nobis libero fuga animi dolorum ea eveniet deserunt.
+                  Repellendus autem placeat tempore nesciunt unde in suscipit eligendi.
+                  Occaecati minus exercitationem vel dignissimos. Veritatis blanditiis
+                  adipisci perspiciatis vero autem sapiente fugiat quos. Laboriosam
+                  provident omnis unde qui nam quasi corrupti quibusdam. Hic minus
+                  aliquam voluptates tempore culpa facere. Sed earum aperiam natus
+                  repellat blanditiis asperiores nobis animi. Illo veritatis autem
+                  quibusdam laudantium blanditiis alias. Dolorem quae laboriosam qui
+                  voluptate occaecati ab. Maiores deserunt fugit maxime temporibus
+                  cupiditate tempore distinctio minus.
+                description_html: |-
+                  Eaque quos laborum maxime rem. Tenetur consequatur iste inventore quae. Nobis libero fuga animi dolorum ea eveniet deserunt. Repellendus autem placeat tempore nesciunt unde in suscipit eligendi.
+                  Occaecati minus exercitationem vel dignissimos. Veritatis blanditiis adipisci perspiciatis vero autem sapiente fugiat quos. Laboriosam provident omnis unde qui nam quasi corrupti quibusdam. Hic minus aliquam voluptates tempore culpa facere.
+                  Sed earum aperiam natus repellat blanditiis asperiores nobis animi. Illo veritatis autem quibusdam laudantium blanditiis alias. Dolorem quae laboriosam qui voluptate occaecati ab. Maiores deserunt fugit maxime temporibus cupiditate tempore distinctio minus.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -8292,16 +8454,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-17T22:58:14.092Z'
-                  updated_at: '2026-05-17T22:58:14.092Z'
+                  created_at: '2026-05-21T18:11:35.771Z'
+                  updated_at: '2026-05-21T18:11:35.771Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-17T22:58:14.064Z'
+                make_active_at: '2025-05-21T18:11:35.746Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-17T22:58:14.078Z'
-                updated_at: '2026-05-17T22:58:14.093Z'
+                created_at: '2026-05-21T18:11:35.758Z'
+                updated_at: '2026-05-21T18:11:35.772Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -8368,29 +8530,27 @@ paths:
               example:
                 id: prod_UkLWZg9DAJ
                 name: Updated Name
-                slug: product-452799
+                slug: product-451000
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-17T22:58:14.706Z'
+                available_on: '2025-05-21T18:11:36.403Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Facilis error earum consequuntur in. Ut sint dolor exercitationem
-                  cupiditate tenetur cum. Eos earum accusantium repellendus fugiat
-                  eum non. Explicabo molestiae eligendi eaque aperiam. Quaerat enim
-                  unde impedit expedita iure omnis vel. Ut dicta autem omnis quas
-                  ipsam unde. Delectus quo ad nihil dignissimos. Dicta tenetur eius
-                  provident veritatis ut error quia ullam. Labore neque atque ipsam
-                  qui voluptatum eligendi. Id laborum magni est deserunt natus consequuntur.
-                  Quibusdam ab modi officia tempore facilis omnis. Et nemo consequatur
-                  dolorum labore.
+                description: Sequi in quas magni odio excepturi. Libero nostrum eius
+                  ipsa eos molestias officiis aut officia. Dignissimos ex distinctio
+                  velit ut molestiae ipsa animi. Minus architecto tempora error totam
+                  autem rerum soluta laboriosam. Assumenda alias temporibus dolorem
+                  laboriosam necessitatibus culpa eaque natus. Officia voluptate dolore
+                  occaecati molestias tenetur neque quia. Magni sit nisi sapiente
+                  ipsa ea similique. Repudiandae facilis veritatis sunt vitae consectetur
+                  tempora possimus fugiat.
                 description_html: |-
-                  Facilis error earum consequuntur in. Ut sint dolor exercitationem cupiditate tenetur cum. Eos earum accusantium repellendus fugiat eum non. Explicabo molestiae eligendi eaque aperiam.
-                  Quaerat enim unde impedit expedita iure omnis vel. Ut dicta autem omnis quas ipsam unde. Delectus quo ad nihil dignissimos. Dicta tenetur eius provident veritatis ut error quia ullam. Labore neque atque ipsam qui voluptatum eligendi.
-                  Id laborum magni est deserunt natus consequuntur. Quibusdam ab modi officia tempore facilis omnis. Et nemo consequatur dolorum labore.
+                  Sequi in quas magni odio excepturi. Libero nostrum eius ipsa eos molestias officiis aut officia. Dignissimos ex distinctio velit ut molestiae ipsa animi. Minus architecto tempora error totam autem rerum soluta laboriosam.
+                  Assumenda alias temporibus dolorem laboriosam necessitatibus culpa eaque natus. Officia voluptate dolore occaecati molestias tenetur neque quia. Magni sit nisi sapiente ipsa ea similique. Repudiandae facilis veritatis sunt vitae consectetur tempora possimus fugiat.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -8405,16 +8565,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-17T22:58:14.732Z'
-                  updated_at: '2026-05-17T22:58:14.732Z'
+                  created_at: '2026-05-21T18:11:36.428Z'
+                  updated_at: '2026-05-21T18:11:36.428Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-17T22:58:14.706Z'
+                make_active_at: '2025-05-21T18:11:36.403Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-17T22:58:14.720Z'
-                updated_at: '2026-05-17T22:58:15.016Z'
+                created_at: '2026-05-21T18:11:36.416Z'
+                updated_at: '2026-05-21T18:11:36.715Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -8617,8 +8777,8 @@ paths:
               example:
                 data:
                 - id: pact_UkLWZg9DAJ
-                  created_at: '2026-05-17T22:58:15.703Z'
-                  updated_at: '2026-05-17T22:58:15.703Z'
+                  created_at: '2026-05-21T18:11:37.379Z'
+                  updated_at: '2026-05-21T18:11:37.379Z'
                   type: free_shipping
                   promotion_id: promo_UkLWZg9DAJ
                   preferences: {}
@@ -8679,8 +8839,8 @@ paths:
             application/json:
               example:
                 id: pact_UkLWZg9DAJ
-                created_at: '2026-05-17T22:58:16.273Z'
-                updated_at: '2026-05-17T22:58:16.273Z'
+                created_at: '2026-05-21T18:11:37.945Z'
+                updated_at: '2026-05-21T18:11:37.945Z'
                 type: free_shipping
                 promotion_id: promo_UkLWZg9DAJ
                 preferences: {}
@@ -8790,8 +8950,8 @@ paths:
               example:
                 data:
                 - id: prorule_UkLWZg9DAJ
-                  created_at: '2026-05-17T22:58:16.871Z'
-                  updated_at: '2026-05-17T22:58:16.871Z'
+                  created_at: '2026-05-21T18:11:38.523Z'
+                  updated_at: '2026-05-21T18:11:38.523Z'
                   type: currency
                   promotion_id: promo_UkLWZg9DAJ
                   preferences:
@@ -8858,8 +9018,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-17T22:58:17.455Z'
-                updated_at: '2026-05-17T22:58:17.455Z'
+                created_at: '2026-05-21T18:11:39.091Z'
+                updated_at: '2026-05-21T18:11:39.091Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -8932,8 +9092,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-17T22:58:17.744Z'
-                updated_at: '2026-05-17T22:58:18.021Z'
+                created_at: '2026-05-21T18:11:39.384Z'
+                updated_at: '2026-05-21T18:11:39.664Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -9023,7 +9183,7 @@ paths:
                   name: Summer Sale
                   description:
                   code: summer
-                  starts_at: '2026-05-17T22:58:18.315Z'
+                  starts_at: '2026-05-21T18:11:39.958Z'
                   expires_at:
                   usage_limit:
                   match_policy: all
@@ -9034,8 +9194,8 @@ paths:
                   code_prefix:
                   promotion_category_id:
                   metadata: {}
-                  created_at: '2026-05-17T22:58:18.316Z'
-                  updated_at: '2026-05-17T22:58:18.317Z'
+                  created_at: '2026-05-21T18:11:39.959Z'
+                  updated_at: '2026-05-21T18:11:39.960Z'
                   store_ids:
                   - store_UkLWZg9DAJ
                   action_ids: []
@@ -9141,7 +9301,7 @@ paths:
                 name: Black Friday
                 description:
                 code: blackfriday-os
-                starts_at: '2026-05-17T22:58:19.244Z'
+                starts_at: '2026-05-21T18:11:40.878Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -9152,8 +9312,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-17T22:58:19.245Z'
-                updated_at: '2026-05-17T22:58:19.266Z'
+                created_at: '2026-05-21T18:11:40.879Z'
+                updated_at: '2026-05-21T18:11:40.900Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids:
@@ -9306,7 +9466,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-17T22:58:19.562Z'
+                starts_at: '2026-05-21T18:11:41.191Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -9317,8 +9477,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-17T22:58:19.563Z'
-                updated_at: '2026-05-17T22:58:19.564Z'
+                created_at: '2026-05-21T18:11:41.191Z'
+                updated_at: '2026-05-21T18:11:41.192Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -9414,7 +9574,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-17T22:58:20.443Z'
+                starts_at: '2026-05-21T18:11:42.115Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -9425,8 +9585,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-17T22:58:20.443Z'
-                updated_at: '2026-05-17T22:58:20.736Z'
+                created_at: '2026-05-21T18:11:42.115Z'
+                updated_at: '2026-05-21T18:11:42.394Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -9778,8 +9938,8 @@ paths:
                 data:
                 - id: role_UkLWZg9DAJ
                   name: admin
-                  created_at: '2026-05-17T22:58:21.622Z'
-                  updated_at: '2026-05-17T22:58:21.622Z'
+                  created_at: '2026-05-21T18:11:43.260Z'
+                  updated_at: '2026-05-21T18:11:43.260Z'
                 meta:
                   page: 1
                   limit: 25
@@ -9914,8 +10074,8 @@ paths:
                   pickup_stock_policy: local
                   pickup_ready_in_minutes:
                   pickup_instructions:
-                  created_at: '2026-05-17T22:58:21.908Z'
-                  updated_at: '2026-05-17T22:58:21.908Z'
+                  created_at: '2026-05-21T18:11:43.547Z'
+                  updated_at: '2026-05-21T18:11:43.547Z'
                 meta:
                   page: 1
                   limit: 25
@@ -10026,8 +10186,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 30
                 pickup_instructions:
-                created_at: '2026-05-17T22:58:22.489Z'
-                updated_at: '2026-05-17T22:58:22.489Z'
+                created_at: '2026-05-21T18:11:44.126Z'
+                updated_at: '2026-05-21T18:11:44.126Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -10201,8 +10361,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes:
                 pickup_instructions:
-                created_at: '2026-05-17T22:58:22.779Z'
-                updated_at: '2026-05-17T22:58:22.779Z'
+                created_at: '2026-05-21T18:11:44.416Z'
+                updated_at: '2026-05-21T18:11:44.416Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '404':
@@ -10287,8 +10447,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 45
                 pickup_instructions:
-                created_at: '2026-05-17T22:58:23.346Z'
-                updated_at: '2026-05-17T22:58:23.623Z'
+                created_at: '2026-05-21T18:11:44.981Z'
+                updated_at: '2026-05-21T18:11:45.255Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -10491,8 +10651,8 @@ paths:
                 data:
                 - id: sccat_UkLWZg9DAJ
                   name: Goodwill
-                  created_at: '2026-05-17T22:58:24.197Z'
-                  updated_at: '2026-05-17T22:58:24.197Z'
+                  created_at: '2026-05-21T18:11:45.829Z'
+                  updated_at: '2026-05-21T18:11:45.829Z'
                   non_expiring: false
                 meta:
                   page: 1
@@ -10583,8 +10743,8 @@ paths:
               example:
                 id: sccat_UkLWZg9DAJ
                 name: Goodwill
-                created_at: '2026-05-17T22:58:24.493Z'
-                updated_at: '2026-05-17T22:58:24.493Z'
+                created_at: '2026-05-21T18:11:46.128Z'
+                updated_at: '2026-05-21T18:11:46.128Z'
                 non_expiring: false
               schema:
                 "$ref": "#/components/schemas/StoreCreditCategory"
@@ -10649,8 +10809,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-17T22:57:20.918Z'
-                updated_at: '2026-05-17T22:58:25.097Z'
+                created_at: '2026-05-21T18:10:40.892Z'
+                updated_at: '2026-05-21T18:11:46.714Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -10721,8 +10881,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-17T22:57:20.918Z'
-                updated_at: '2026-05-17T22:58:25.709Z'
+                created_at: '2026-05-21T18:10:40.892Z'
+                updated_at: '2026-05-21T18:11:47.343Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -10942,13 +11102,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-17T22:58:27.121Z'
-                  updated_at: '2026-05-17T22:58:27.134Z'
+                  created_at: '2026-05-21T18:11:48.762Z'
+                  updated_at: '2026-05-21T18:11:48.775Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 509759
+                  product_name: Product 50221
                 - id: variant_gbHJdmfrXB
                   product_id: prod_UkLWZg9DAJ
                   sku: SKU-57
@@ -10959,10 +11119,10 @@ paths:
                   purchasable: true
                   in_stock: false
                   backorderable: true
-                  weight: 80.73
-                  height: 2.44
-                  width: 113.51
-                  depth: 190.29
+                  weight: 135.61
+                  height: 190.22
+                  width: 43.51
+                  depth: 109.66
                   price:
                     id: price_gbHJdmfrXB
                     amount: '19.99'
@@ -10985,8 +11145,8 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-17T22:58:27.144Z'
-                    updated_at: '2026-05-17T22:58:27.144Z'
+                    created_at: '2026-05-21T18:11:48.786Z'
+                    updated_at: '2026-05-21T18:11:48.786Z'
                   metadata: {}
                   position: 2
                   cost_price: '17.0'
@@ -10995,13 +11155,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-17T22:58:27.141Z'
-                  updated_at: '2026-05-17T22:58:27.155Z'
+                  created_at: '2026-05-21T18:11:48.783Z'
+                  updated_at: '2026-05-21T18:11:48.798Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 509759
+                  product_name: Product 50221
                 meta:
                   page: 1
                   limit: 25
@@ -11112,8 +11272,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-17T22:58:27.805Z'
-                  updated_at: '2026-05-17T22:58:27.805Z'
+                  created_at: '2026-05-21T18:11:49.443Z'
+                  updated_at: '2026-05-21T18:11:49.443Z'
                 metadata: {}
                 position: 3
                 cost_price:
@@ -11122,13 +11282,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-17T22:58:27.808Z'
-                updated_at: '2026-05-17T22:58:27.810Z'
+                created_at: '2026-05-21T18:11:49.446Z'
+                updated_at: '2026-05-21T18:11:49.447Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 512942
+                product_name: Product 512416
         '422':
           description: validation error
           content:
@@ -11315,10 +11475,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 110.63
-                height: 3.38
-                width: 79.16
-                depth: 28.31
+                weight: 21.18
+                height: 160.0
+                width: 127.7
+                depth: 17.83
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -11341,8 +11501,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-17T22:58:28.233Z'
-                  updated_at: '2026-05-17T22:58:28.233Z'
+                  created_at: '2026-05-21T18:11:49.893Z'
+                  updated_at: '2026-05-21T18:11:49.893Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -11351,13 +11511,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-17T22:58:28.231Z'
-                updated_at: '2026-05-17T22:58:28.246Z'
+                created_at: '2026-05-21T18:11:49.887Z'
+                updated_at: '2026-05-21T18:11:49.910Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 535621
+                product_name: Product 537070
         '404':
           description: variant not found
           content:
@@ -11436,10 +11596,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 24.88
-                height: 167.5
-                width: 121.98
-                depth: 156.64
+                weight: 103.11
+                height: 18.21
+                width: 34.43
+                depth: 192.11
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -11462,8 +11622,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-17T22:58:28.920Z'
-                  updated_at: '2026-05-17T22:58:28.920Z'
+                  created_at: '2026-05-21T18:11:50.606Z'
+                  updated_at: '2026-05-21T18:11:50.606Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -11472,13 +11632,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-17T22:58:28.917Z'
-                updated_at: '2026-05-17T22:58:29.223Z'
+                created_at: '2026-05-21T18:11:50.603Z'
+                updated_at: '2026-05-21T18:11:50.909Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 552946
+                product_name: Product 555738
       requestBody:
         content:
           application/json:
@@ -12581,6 +12741,10 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/StoreCredit"
+        customer_groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/CustomerGroup"
       required:
       - id
       - email

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -590,16 +590,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjQxNmNkZmZkLTFjNjMtNDVlZS1hZmZmLWZhMDIyNjg4ZTRmYiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1NjU4fQ.di9q1SWMr4u6iu85LphhF1wm14rfo7TSMV_mL-w2x_c
-                refresh_token: BzLiMBEy42daj8QzPgfdN7VR
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImFjMTYxZjIyLTY2ODUtNDM0My1hZjhlLWFmNmZiY2Q4NzA3ZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzE2fQ.BuOWlcghPrLfW7-ka3a2yD1Giq5DAG-5amAPCOsJOvY
+                refresh_token: PZZGJT4udwGkyKEPgs4WRtus
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Muriel
-                  last_name: Rolfson
+                  first_name: Henriette
+                  last_name: Stamm
                   phone:
                   accepts_email_marketing: false
-                  full_name: Muriel Rolfson
+                  full_name: Henriette Stamm
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -672,16 +672,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImY1ZTI0OWZjLTU2OWItNGMxOS05NmY0LTczMGQ0MTkyNDllYSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1NjU5fQ.Mj5GatT53qoIVQWM5C6SGLMjC_8W-tbfBAYiwuqxssw
-                refresh_token: ATUxJ8cznsCRdeM94bt6MpFb
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijg2NTFkMTJlLTRiMTItNDZhNi1hYjgzLTY4MjI1YWNhN2FhYyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzE3fQ.mz2V3U-_6wrTzoLytYOOGc7mgH7eG71jQ_oA4mIHGtY
+                refresh_token: sRppucnbaakQTvpFCoJArcde
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Yoshiko
-                  last_name: Gerlach
+                  first_name: Richard
+                  last_name: Larson
                   phone:
                   accepts_email_marketing: false
-                  full_name: Yoshiko Gerlach
+                  full_name: Richard Larson
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -845,9 +845,9 @@ paths:
                 data:
                 - id: cart_gbHJdmfrXB
                   market_id:
-                  number: R664489317
-                  token: DNbsRBmEum7pEjvQP1kQfL82Sa9dpamPvNH
-                  email: ching.mcdermott@muller.ca
+                  number: R560405209
+                  token: iqxaKurjyPCbwiuDRJwhMTLpUQs2SCohKfM
+                  email: carly@nicolas.com
                   customer_note:
                   currency: USD
                   locale: en
@@ -889,8 +889,8 @@ paths:
                     variant_id: variant_gbHJdmfrXB
                     quantity: 1
                     currency: USD
-                    name: Product 583769
-                    slug: product-583769
+                    name: Product 584574
+                    slug: product-584574
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -915,7 +915,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_gbHJdmfrXB
-                    number: H67163565781
+                    number: H60885401848
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -944,7 +944,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Ilona Raynor
+                      name: Milissa Kutch
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1014,9 +1014,9 @@ paths:
                   market:
                 - id: cart_UkLWZg9DAJ
                   market_id:
-                  number: R608295263
-                  token: hPKQmwQsRPWzchLyF6W66k6tmz7FDgywVra
-                  email: ching.mcdermott@muller.ca
+                  number: R504946559
+                  token: hC1f3UJxu4NErrgku3ZwU2LT4szVo2mJGUv
+                  email: carly@nicolas.com
                   customer_note:
                   currency: USD
                   locale: en
@@ -1058,8 +1058,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 571600
-                    slug: product-571600
+                    name: Product 576038
+                    slug: product-576038
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1084,7 +1084,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H06444123777
+                    number: H14566689291
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -1113,7 +1113,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Ilona Raynor
+                      name: Milissa Kutch
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1256,8 +1256,8 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R614354862
-                token: GFVVFvrWYoqA1u1YH7pVUxznA9FVYYYN16i
+                number: R582709141
+                token: sbMgF8VrnBNczXfdVscfNEDYvzNFowJwh2s
                 email:
                 customer_note:
                 currency: USD
@@ -1412,9 +1412,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R391007411
-                token: TJQaoQquys2FEa6bQAQG6UNsTbugSQWxvu9
-                email: tama.mayert@padberg.info
+                number: R911594733
+                token: A3bGmry4ZwaVKavBsi7VH9dHvdws3WTttaD
+                email: carmine_littel@kshlerin.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -1441,7 +1441,7 @@ paths:
                 display_delivery_total: "$0.00"
                 warnings:
                 - code: line_item_removed
-                  message: Product 623222 was removed because it was sold out
+                  message: Product 62216 was removed because it was sold out
                   line_item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                 store_credit_total: '0.0'
@@ -1583,9 +1583,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R819048584
-                token: 2fF1kfwXemRtwo39BV6ZNNQHG29ThFThfx7
-                email: mohammed@mueller.info
+                number: R537545049
+                token: YAfcmRTUDf8ak8FPefKTgpqKXuur3RZrz5S
+                email: viola.dickens@mitchellcollier.com
                 customer_note: Leave at door
                 currency: USD
                 locale: en
@@ -1629,8 +1629,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 639240
-                  slug: product-639240
+                  name: Product 637993
+                  slug: product-637993
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -1655,7 +1655,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H40312398138
+                  number: H35255737216
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -1684,7 +1684,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Adella Kris
+                    name: Chung O'Keefe
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1921,9 +1921,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R632083010
-                token: Hud7FDknGoibTteuPcBENinKizai8DriaWj
-                email: chasity.bergnaum@ritchiekulas.com
+                number: R231347948
+                token: RnHB5VgA21xi2SsJFvCKad7qbWLdo47QGnV
+                email: reinaldo@hesselschimmel.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -1965,8 +1965,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 659069
-                  slug: product-659069
+                  name: Product 653132
+                  slug: product-653132
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1991,7 +1991,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H50751149271
+                  number: H45239248483
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -2020,7 +2020,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Aurelia McGlynn
+                    name: Dexter Boyer
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2155,8 +2155,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R775225129
-                email: nora@bayer.info
+                number: R264397359
+                email: enda@becker.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -2183,7 +2183,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: backorder
                 payment_status: paid
-                completed_at: '2026-05-21T14:01:05.267Z'
+                completed_at: '2026-05-21T18:12:04.119Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -2193,8 +2193,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 677597
-                  slug: product-677597
+                  name: Product 679791
+                  slug: product-679791
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -2219,7 +2219,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H07213205217
+                  number: H72789993064
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -2248,7 +2248,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Phylis Kozey
+                    name: Gabriela Kemmer
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2277,8 +2277,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-d9218ca0c082
-                  number: P6TGTMWL
+                  response_code: BGS-6d4860421892
+                  number: PDDA4ACI
                   amount: '29.99'
                   display_amount: "$29.99"
                   status: completed
@@ -3134,16 +3134,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk2ZTc1YzViLTY4NjMtNDkzMy1iYWFhLTZmNDZhNzFiY2VhZSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1NjcxfQ.TGikt0JLnGCtiRl8AWD75GYMbSA_VFk8R8tkkcVmo4M
-                refresh_token: rUy5d5FkkFKRKVTjSNLMmGXC
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImRhYjViODFiLWZkODQtNDU1NC1iZjJkLWFlYWUzZWJjYWEyZiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzMwfQ.A7ZqLfCc-PN69iuQHuMdSM6U_leCsrC5gV5ABpuwtbc
+                refresh_token: S8rzSN7cnzSAwzjbRFiTKHL8
                 user:
                   id: cus_UkLWZg9DAJ
                   email: customer@example.com
-                  first_name: Iris
-                  last_name: Hirthe
+                  first_name: Denita
+                  last_name: Rau
                   phone:
                   accepts_email_marketing: false
-                  full_name: Iris Hirthe
+                  full_name: Denita Rau
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -3316,8 +3316,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R453573119
-                  email: vesta@okuneva.com
+                  number: R600105954
+                  email: adria@okuneva.biz
                   customer_note:
                   currency: USD
                   locale: en
@@ -3344,7 +3344,7 @@ paths:
                   display_delivery_total: "$100.00"
                   fulfillment_status:
                   payment_status:
-                  completed_at: '2026-05-21T14:01:12.513Z'
+                  completed_at: '2026-05-21T18:12:11.464Z'
                   store_credit_total: '0.0'
                   display_store_credit_total: "$0.00"
                   covered_by_store_credit: false
@@ -3354,8 +3354,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 763572
-                    slug: product-763572
+                    name: Product 767917
+                    slug: product-767917
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -3380,7 +3380,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H92480409501
+                    number: H90711662288
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -3409,7 +3409,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Aleen Powlowski
+                      name: Annie Marks
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -3572,8 +3572,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R788321337
-                email: marylin.baumbach@osinski.ca
+                number: R060306455
+                email: josefine.friesen@armstrong.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -3600,7 +3600,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-21T14:01:13.194Z'
+                completed_at: '2026-05-21T18:12:12.168Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -3610,8 +3610,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 78558
-                  slug: product-78558
+                  name: Product 787709
+                  slug: product-787709
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3636,7 +3636,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H85969598405
+                  number: H26048702619
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -3665,7 +3665,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Ruthe Davis
+                    name: Nyla Rau
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3785,8 +3785,8 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijg4ZWUyNGZiLTI2YjgtNDQxZi1hM2IwLTQ0ZDE1NWMxZDljNyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1Njc0fQ.H0u-Q3oSCKP2k0LaX7rQVF_U8c1IUvaRnwvBrzw8kGk
-                refresh_token: Zm5W1wfivD9a8J1WsaKiBAyc
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImVkNGE2MDhlLTdmNmUtNDc5NS1iNDc0LWU0MGQ2NGY1NjM0NCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzMzfQ.zdjx-98AkEn-FCaKaIeYCOa0VzQacbTGsoD8RtSVrIc
+                refresh_token: JmzdDVvP1CZnWvpsNvAwkEos
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
@@ -3900,12 +3900,12 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: amie@oga.ca
-                first_name: Jacinta
-                last_name: Lang
+                email: drew@skiles.ca
+                first_name: Zackary
+                last_name: Lind
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                full_name: Jacinta Lang
+                full_name: Zackary Lind
                 available_store_credit_total: '0'
                 display_available_store_credit_total: "$0.00"
                 addresses:
@@ -4039,7 +4039,7 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: raelene@marquardt.name
+                email: mimi_marquardt@gibson.co.uk
                 first_name: Updated
                 last_name: Name
                 phone: 555-555-0199
@@ -4279,9 +4279,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R877670295
-                token: jgYbDf4iuvRHVAFiJSJPC67pctiy9JX6pm3
-                email: amal@beerkulas.ca
+                number: R983640452
+                token: FUsN4w2fk57RAyQxK2uwVh1EFUSeoApoNWz
+                email: jamey@weberwalter.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -4330,8 +4330,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 866689
-                  slug: product-866689
+                  name: Product 868984
+                  slug: product-868984
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4356,7 +4356,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H97941431341
+                  number: H01257048332
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4385,7 +4385,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Delora Kerluke
+                    name: Idell Corkery
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4539,9 +4539,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R645855426
-                token: xKbwRLgMS3z13qkQ8U9pN6NYL6ofcQ9GHZ7
-                email: latina.homenick@kuhn.us
+                number: R506477402
+                token: ZbbF51wzUqPGTMG3ngYRzSSDbLK3Ee9wdcW
+                email: norris@wintheiser.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -4583,8 +4583,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 885251
-                  slug: product-885251
+                  name: Product 883927
+                  slug: product-883927
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4609,7 +4609,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H21042794370
+                  number: H66163861804
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4638,7 +4638,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Meri O'Hara
+                    name: Faye Kertzmann
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4781,9 +4781,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R735538070
-                token: pJmy9PSsevBtccAFgssJj5xxWh7Zx2avpvg
-                email: rocky_murray@kemmerwillms.us
+                number: R787693305
+                token: naZG9yps6zPNYyBArZBgKKY6nnqYpGC5rTw
+                email: isabelle.gutmann@batzdaugherty.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -4827,8 +4827,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 90269
-                  slug: product-90269
+                  name: Product 905832
+                  slug: product-905832
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4853,7 +4853,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H61990909745
+                  number: H48213234073
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4882,7 +4882,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Gianna Prosacco
+                    name: Kerri Hahn
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5039,9 +5039,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R786565483
-                token: rPCVCzH2MAhdyzFpsLwftnwAWtyVzCAuH5j
-                email: scot_thiel@jacobs.biz
+                number: R501407956
+                token: mBMtKueSANaxHuT7o3H1zs5CWXfBtLZR76a
+                email: aldo.hickle@bode.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -5080,8 +5080,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 924064
-                  slug: product-924064
+                  name: Product 923228
+                  slug: product-923228
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5106,7 +5106,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H72899618600
+                  number: H63891944560
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5135,7 +5135,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Hoa Abshire
+                    name: Julieann Kuhn
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5164,8 +5164,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260521140122745447
-                  number: PKDTTE1C
+                  response_code: 1-SC-20260521181222228580
+                  number: PLBPL882
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: checkout
@@ -5344,9 +5344,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R305341957
-                token: cYad5ZEwRxucQSrUZeYvDNJJeNzFMkpais6
-                email: leonard@gerhold.name
+                number: R971301843
+                token: TAXrAS6nE34CGB4J4SM9jYAC7D1LAfEdvuB
+                email: beatris@monahanconsidine.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -5388,8 +5388,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 967644
-                  slug: product-967644
+                  name: Product 966445
+                  slug: product-966445
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5414,7 +5414,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H87527277081
+                  number: H50426852278
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5443,7 +5443,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Marget Carter
+                    name: Hilda Gorczany
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5472,8 +5472,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260521140125170061
-                  number: P247ASB1
+                  response_code: 1-SC-20260521181224917306
+                  number: P50IZG86
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: invalid
@@ -5597,7 +5597,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: 5F5907332CD24C13
+                  code: DFE1B771D0A9F320
                   status: active
                   currency: USD
                   amount: '10.0'
@@ -5693,7 +5693,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: E7D8EEDBD8B38629
+                code: B3971A4B112F7143
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -5784,9 +5784,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R898038455
-                token: kwoDUG5ytVevnyteMSLq11LFUoUeQvgvj3C
-                email: lavone_pfeffer@metzokeefe.co.uk
+                number: R881799706
+                token: RVbjRddtDRtcExjXQRpMB8Bim5LNSShGBH6
+                email: remona@effertzbauch.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -5834,8 +5834,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 998774
-                  slug: product-998774
+                  name: Product 996441
+                  slug: product-996441
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5862,8 +5862,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 1007565
-                  slug: product-1007565
+                  name: Product 1009810
+                  slug: product-1009810
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -6006,9 +6006,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R361093646
-                token: ANzLKaHuynyv78jwmNXN17TGQvYaPbpDZpf
-                email: artie@luettgen.info
+                number: R794423726
+                token: 1sJMUmLYsh3UaeGjL4VQKgK3DMj8h2YAx2z
+                email: pablo_corwin@hillsstark.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -6053,8 +6053,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1032574
-                  slug: product-1032574
+                  name: Product 1039114
+                  slug: product-1039114
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6177,9 +6177,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R782177832
-                token: 3qTD9CqYFu8if2zPw9fjYJT6bcLLBXgqdkB
-                email: twana.adams@hagenes.biz
+                number: R184817343
+                token: vPBcAwTjPCjFLRYvznh9D9dkaWZt8aapnyH
+                email: michael.lang@hackett.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -6723,17 +6723,24 @@ paths:
 
         - If the email is already verified for this store, the existing subscription is returned unchanged.
         - If the request is unauthenticated (guest), the subscription is created in an unverified state
-          and a `newsletter_subscriber.subscription_requested` event is published containing the
-          `verification_token` and the validated `redirect_url`. Storefronts subscribe to this event
-          via a webhook to send the confirmation email; the link should point at
-          `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
+          and two events are published: `newsletter_subscriber.subscription_requested` (carrying the
+          `verification_token` and the validated `redirect_url`, intended for headless storefronts that
+          want to send the confirmation email themselves via a webhook handler) and the legacy
+          `newsletter_subscriber.subscribed` lifecycle event (which the bundled `spree_emails` package
+          listens to and uses to send a default confirmation email). The confirmation link should point
+          at `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
           when the user clicks it.
         - If the request is authenticated via JWT and the customer's email matches the subscribed email,
-          the subscription is auto-verified — no event is fired.
+          the subscription is auto-verified and no events are fired — the JWT already proves email
+          ownership, so no confirmation email is needed.
 
-        The optional `redirect_url` is where the verification token should land on the storefront. It is
-        validated against the store's [Allowed Origins](/developer/core-concepts/allowed-origins) and
-        silently dropped from the webhook payload if it does not match (secure-by-default).
+        The optional `redirect_url` is where the verification token should land on the storefront. The
+        server does not return a validation error when the URL is outside the store's
+        [Allowed Origins](/developer/core-concepts/allowed-origins); instead, the URL is silently
+        omitted from the webhook payload (secure-by-default). When no allow-list is configured on the
+        store, the URL is also omitted. Callers therefore receive the same 201 regardless, and the
+        webhook handler should fall back to the store's storefront URL when `redirect_url` is missing
+        from the payload.
 
         Newsletter consent is preserved across registration: if a guest subscribes and later registers
         with the same email, the existing subscriber record is reused.
@@ -6775,11 +6782,11 @@ paths:
             application/json:
               example:
                 id: sub_UkLWZg9DAJ
-                email: jenise@kutch.biz
-                created_at: '2026-05-21T14:01:32.605Z'
-                updated_at: '2026-05-21T14:01:32.605Z'
+                email: eufemia@stoltenbergwalter.ca
+                created_at: '2026-05-21T18:12:32.551Z'
+                updated_at: '2026-05-21T18:12:32.553Z'
                 verified: true
-                verified_at: '2026-05-21T14:01:32Z'
+                verified_at: '2026-05-21T18:12:32Z'
                 customer_id: cus_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -6811,7 +6818,9 @@ paths:
                   format: uri
                   example: https://your-store.com/newsletter/confirm
                   description: Storefront URL the verification token should be appended
-                    to. Must be in the store's allowed origins.
+                    to. Silently omitted from the webhook payload when the store has
+                    allowed origins configured and this URL does not match one of
+                    them, or when no allowed origins are configured at all.
               required:
               - email
   "/api/v3/store/newsletter_subscribers/verify":
@@ -6856,10 +6865,10 @@ paths:
               example:
                 id: sub_UkLWZg9DAJ
                 email: pending@example.com
-                created_at: '2026-05-21T14:01:32.629Z'
-                updated_at: '2026-05-21T14:01:32.640Z'
+                created_at: '2026-05-21T18:12:32.578Z'
+                updated_at: '2026-05-21T18:12:32.591Z'
                 verified: true
-                verified_at: '2026-05-21T14:01:32Z'
+                verified_at: '2026-05-21T18:12:32Z'
                 customer_id:
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -6957,7 +6966,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R219546930
+                number: R444420762
                 email: guest@example.com
                 customer_note:
                 currency: USD
@@ -6985,7 +6994,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-21T14:01:33.348Z'
+                completed_at: '2026-05-21T18:12:33.331Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -6995,8 +7004,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1078893
-                  slug: product-1078893
+                  name: Product 1079404
+                  slug: product-1079404
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7021,7 +7030,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H66784286474
+                  number: H37244671113
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -7050,7 +7059,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Naida Boyer
+                    name: Bud Bartoletti
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7195,9 +7204,9 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_a17b47e0398d13f0b001d373
+                external_id: bogus_799f9d0cdd2a024b44a972f2
                 external_data:
-                  client_secret: bogus_secret_5dec9b38272306eb
+                  client_secret: bogus_secret_e705380ff182660e
                 customer_external_id:
                 expires_at:
                 amount: '110.0'
@@ -7295,7 +7304,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_9d936b37603e2d2e9f882ba5
+                external_id: bogus_aecf7276c91c09ca9e9ec79a
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7357,7 +7366,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_62a32b13abfdf70ffe97ebfe
+                external_id: bogus_4d892ef9777434a81f39f60d
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7459,7 +7468,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_690fbde1d19bee42865caa8f
+                external_id: bogus_a8a35246fb9e9da3d0a251b8
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7544,8 +7553,8 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_c30c9b5f22811f96e01ae78e
-                external_client_secret: bogus_seti_secret_4c73525f5d30ff33
+                external_id: bogus_seti_c85316f2ab8114ec81687ed4
+                external_client_secret: bogus_seti_secret_a15e9cd71178a98c
                 external_data: {}
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
@@ -7644,8 +7653,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_d7fa0cbdbc9e070360f09d67
-                external_client_secret: seti_secret_890b28449262f42d588f7226
+                external_id: seti_test_674107c9a4a65317bbdc129d
+                external_client_secret: seti_secret_66eb1d151fa172598a741e14
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7721,8 +7730,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_0deba6c34d39f196388036e2
-                external_client_secret: seti_secret_c8e8baf1be390bcebea53f33
+                external_id: seti_test_047d39fe078d8f5dfb59fc7a
+                external_client_secret: seti_secret_8320035d2ef40c47c4e63f5b
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7816,7 +7825,7 @@ paths:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 response_code:
-                number: P8EAYC6L
+                number: PDW8QZGM
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7912,7 +7921,7 @@ paths:
                   body_html: ''
                 - id: pol_OIJLhNcSbf
                   name: Privacy Policy
-                  slug: privacy-policy-e33e52be-144d-4d70-99a2-978929d3c22a
+                  slug: privacy-policy-64c6fe11-a85d-4ac3-bcf3-2d7e2f51e471
                   body: We respect your privacy.
                   body_html: |
                     <div class="trix-content">
@@ -8156,13 +8165,13 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1173606
-                  slug: product-1173606
+                  name: Product 117952
+                  slug: product-117952
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-05-21T14:01:43.412Z'
+                  available_on: '2025-05-21T18:12:43.946Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -8184,29 +8193,34 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 1189963
-                  slug: product-1189963
+                  name: Product 1184416
+                  slug: product-1184416
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-21T14:01:43.466Z'
+                  available_on: '2025-05-21T18:12:44.008Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Nobis autem cum dolorum nesciunt harum sequi voluptates.
-                    Sunt qui hic libero exercitationem ratione iusto. Vero odit quia
-                    assumenda minus similique corrupti a. Iste aliquam temporibus
-                    et aliquid beatae. Placeat odit voluptates molestias quam accusantium
-                    natus sed. Ut vero cumque delectus consectetur rem. Quae nam repudiandae
-                    corporis voluptate. Debitis rerum a recusandae sit dolorum earum
-                    fugiat ea. Praesentium alias veritatis molestias neque incidunt
-                    laudantium doloribus. Quo non eum placeat dolorem.
+                  description: Impedit quam aliquid ducimus magni. Quas nulla placeat
+                    totam suscipit doloribus quos inventore earum. Veniam officiis
+                    ad ipsum sed optio error perferendis. Doloremque molestias magnam
+                    harum consequatur at accusamus tempore sunt. Deleniti voluptatum
+                    laborum vero nisi. Sunt delectus soluta amet hic consequuntur
+                    occaecati. Molestias illum minima velit ullam. Modi animi temporibus
+                    adipisci veritatis voluptatum libero unde. Sunt mollitia tenetur
+                    fugit enim. Accusantium minima id culpa laudantium molestias.
+                    Rerum saepe necessitatibus repellat tempora quis. Unde saepe laborum
+                    iure non quisquam nesciunt sed. Voluptas debitis placeat asperiores
+                    dolorem quia facilis rem. Atque quae enim at quis accusamus sequi
+                    vel.
                   description_html: |-
-                    Nobis autem cum dolorum nesciunt harum sequi voluptates. Sunt qui hic libero exercitationem ratione iusto. Vero odit quia assumenda minus similique corrupti a.
-                    Iste aliquam temporibus et aliquid beatae. Placeat odit voluptates molestias quam accusantium natus sed. Ut vero cumque delectus consectetur rem. Quae nam repudiandae corporis voluptate.
-                    Debitis rerum a recusandae sit dolorum earum fugiat ea. Praesentium alias veritatis molestias neque incidunt laudantium doloribus. Quo non eum placeat dolorem.
+                    Impedit quam aliquid ducimus magni. Quas nulla placeat totam suscipit doloribus quos inventore earum. Veniam officiis ad ipsum sed optio error perferendis.
+                    Doloremque molestias magnam harum consequatur at accusamus tempore sunt. Deleniti voluptatum laborum vero nisi. Sunt delectus soluta amet hic consequuntur occaecati.
+                    Molestias illum minima velit ullam. Modi animi temporibus adipisci veritatis voluptatum libero unde. Sunt mollitia tenetur fugit enim. Accusantium minima id culpa laudantium molestias.
+                    Rerum saepe necessitatibus repellat tempora quis. Unde saepe laborum iure non quisquam nesciunt sed. Voluptas debitis placeat asperiores dolorem quia facilis rem. Atque quae enim at quis accusamus sequi vel.
                   default_variant_id: variant_EfhxLZ9ck8
                   thumbnail_url:
                   tags: []
@@ -8308,13 +8322,13 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 1451391
-                slug: product-1451391
+                name: Product 1453321
+                slug: product-1453321
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-05-21T14:01:44.847Z'
+                available_on: '2025-05-21T18:12:45.816Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -8341,7 +8355,7 @@ paths:
                   amount_in_cents: 999
                   currency: USD
                   display_amount: "$9.99"
-                  recorded_at: '2026-05-06T14:01:44Z'
+                  recorded_at: '2026-05-06T18:12:45Z'
               schema:
                 "$ref": "#/components/schemas/Product"
         '404':
@@ -8716,9 +8730,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R744140023
-                token: pTFm3XRZudeeoLXmviqWz6uNkVtaBp4uLrV
-                email: kathlene@beer.info
+                number: R563436707
+                token: MEKMkDqDZiwtriHVLkLzxZ7hGj4nxCtmBig
+                email: renate_tromp@adams.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -8757,8 +8771,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1658176
-                  slug: product-1658176
+                  name: Product 1657
+                  slug: product-1657
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -8783,7 +8797,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H59588366435
+                  number: H22654230230
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -8812,7 +8826,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Veta Mitchell
+                    name: Marissa Sipes
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -8841,8 +8855,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260521140150066371
-                  number: PEHXTQG6
+                  response_code: 1-SC-20260521181251050531
+                  number: PFR3QR4H
                   amount: '10.0'
                   display_amount: "$10.00"
                   status: checkout
@@ -8985,9 +8999,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R244936382
-                token: Ycdv7VgR4x426YxWUz7eoyGEFZ1sRY4SpaC
-                email: eloisa.gerhold@gleason.biz
+                number: R554787846
+                token: vfB6PnFw9cPg6LbJqQKBA7jHh5zQGzRLtnz
+                email: elvis@hyatt.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -9029,8 +9043,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1673068
-                  slug: product-1673068
+                  name: Product 1673494
+                  slug: product-1673494
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -9055,7 +9069,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H49623074593
+                  number: H45381203670
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -9084,7 +9098,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Grady Pacocha
+                    name: Ozella Hirthe
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -9214,7 +9228,7 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: QL7gtUL5AUfgexgDh9iQFWaA
+                  token: czkimqa2wGQpziZPiHu4TETD
                   is_default: false
                   is_private: true
                 meta:
@@ -9290,7 +9304,7 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: zmk9bk8qkYJRXzjhxhYRV1Gg
+                token: HkhGZqtmkmgvuTiENz7zMHwA
                 is_default: false
                 is_private: true
               schema:
@@ -9386,7 +9400,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: FjFxxfkdRu9GRLaAmWerHsP1
+                token: URczbyJbeCgRS1a82JhitHvQ
                 is_default: false
                 is_private: true
               schema:
@@ -9448,7 +9462,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: zTCwhxBSEZYoDbdjgF57VnYE
+                token: RbsVopS8AJBteR6s51rRT9tN
                 is_default: false
                 is_private: true
               schema:

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -590,16 +590,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjllNWE1NWJlLTJkYzktNDE4MC1iNzVhLTJkMDZiZTA5OWU3MyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc4NzE0Nzk0fQ.WFswarYhOtFQrLBlhP-Eb7SA6CAGdJCjTLsUfw9u-Cg
-                refresh_token: 51fTpJHejSdmreCpH6oBm82L
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjQxNmNkZmZkLTFjNjMtNDVlZS1hZmZmLWZhMDIyNjg4ZTRmYiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1NjU4fQ.di9q1SWMr4u6iu85LphhF1wm14rfo7TSMV_mL-w2x_c
+                refresh_token: BzLiMBEy42daj8QzPgfdN7VR
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Carrie
-                  last_name: Metz
+                  first_name: Muriel
+                  last_name: Rolfson
                   phone:
                   accepts_email_marketing: false
-                  full_name: Carrie Metz
+                  full_name: Muriel Rolfson
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -672,16 +672,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk5MTM5YTQxLTk1ODQtNDNmYy05Y2M5LWExNWFiNzQ0Y2Q4ZiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc4NzE0Nzk1fQ.Ms3kK7ALwfl8AEFgqOTtQuY4OXYdpyHN6ifI-4MWStg
-                refresh_token: mLMEGNP4zaY5Za3k5N4puKhF
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImY1ZTI0OWZjLTU2OWItNGMxOS05NmY0LTczMGQ0MTkyNDllYSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1NjU5fQ.Mj5GatT53qoIVQWM5C6SGLMjC_8W-tbfBAYiwuqxssw
+                refresh_token: ATUxJ8cznsCRdeM94bt6MpFb
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Abram
-                  last_name: Trantow
+                  first_name: Yoshiko
+                  last_name: Gerlach
                   phone:
                   accepts_email_marketing: false
-                  full_name: Abram Trantow
+                  full_name: Yoshiko Gerlach
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -845,9 +845,9 @@ paths:
                 data:
                 - id: cart_gbHJdmfrXB
                   market_id:
-                  number: R139181277
-                  token: HcVHbgtZJ4WxxcynuTKt6p79iQNAxukuSNX
-                  email: alejandra@leuschke.com
+                  number: R664489317
+                  token: DNbsRBmEum7pEjvQP1kQfL82Sa9dpamPvNH
+                  email: ching.mcdermott@muller.ca
                   customer_note:
                   currency: USD
                   locale: en
@@ -889,8 +889,8 @@ paths:
                     variant_id: variant_gbHJdmfrXB
                     quantity: 1
                     currency: USD
-                    name: Product 583630
-                    slug: product-583630
+                    name: Product 583769
+                    slug: product-583769
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -915,7 +915,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_gbHJdmfrXB
-                    number: H38066716360
+                    number: H67163565781
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -944,7 +944,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Winfred Dietrich
+                      name: Ilona Raynor
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1014,9 +1014,9 @@ paths:
                   market:
                 - id: cart_UkLWZg9DAJ
                   market_id:
-                  number: R653240222
-                  token: Lta26Lyfq4EtwsMwD1kt4az1XZLr14fQKqn
-                  email: alejandra@leuschke.com
+                  number: R608295263
+                  token: hPKQmwQsRPWzchLyF6W66k6tmz7FDgywVra
+                  email: ching.mcdermott@muller.ca
                   customer_note:
                   currency: USD
                   locale: en
@@ -1058,8 +1058,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 574608
-                    slug: product-574608
+                    name: Product 571600
+                    slug: product-571600
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1084,7 +1084,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H27683996067
+                    number: H06444123777
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -1113,7 +1113,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Winfred Dietrich
+                      name: Ilona Raynor
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1256,8 +1256,8 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R175749722
-                token: rrsVnbxwLVc2KkMntz2RqPaKhfxtDk4AaQx
+                number: R614354862
+                token: GFVVFvrWYoqA1u1YH7pVUxznA9FVYYYN16i
                 email:
                 customer_note:
                 currency: USD
@@ -1412,9 +1412,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R662034436
-                token: utvMuyjqh2mMd74g3NcvfyCvJVMPqYSZ9At
-                email: takisha.gusikowski@harber.us
+                number: R391007411
+                token: TJQaoQquys2FEa6bQAQG6UNsTbugSQWxvu9
+                email: tama.mayert@padberg.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -1441,7 +1441,7 @@ paths:
                 display_delivery_total: "$0.00"
                 warnings:
                 - code: line_item_removed
-                  message: Product 628846 was removed because it was sold out
+                  message: Product 623222 was removed because it was sold out
                   line_item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                 store_credit_total: '0.0'
@@ -1583,9 +1583,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R973162333
-                token: QPDkdD3JJT4D25jB8dadWYfyrSxvWpPXnp1
-                email: nova.schiller@will.biz
+                number: R819048584
+                token: 2fF1kfwXemRtwo39BV6ZNNQHG29ThFThfx7
+                email: mohammed@mueller.info
                 customer_note: Leave at door
                 currency: USD
                 locale: en
@@ -1629,8 +1629,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 631959
-                  slug: product-631959
+                  name: Product 639240
+                  slug: product-639240
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -1655,7 +1655,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H29882311098
+                  number: H40312398138
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -1684,7 +1684,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Casimira Emmerich
+                    name: Adella Kris
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1921,9 +1921,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R252978915
-                token: 4Lii2eNk6MZSo8FLKpBmUXXTHLTNdTLfAC8
-                email: celesta.conroy@carroll.info
+                number: R632083010
+                token: Hud7FDknGoibTteuPcBENinKizai8DriaWj
+                email: chasity.bergnaum@ritchiekulas.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -1965,8 +1965,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 659809
-                  slug: product-659809
+                  name: Product 659069
+                  slug: product-659069
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1991,7 +1991,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H28360472279
+                  number: H50751149271
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -2020,7 +2020,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Meryl Kohler
+                    name: Aurelia McGlynn
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2155,8 +2155,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R923625339
-                email: kellye@will.biz
+                number: R775225129
+                email: nora@bayer.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -2183,7 +2183,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: backorder
                 payment_status: paid
-                completed_at: '2026-05-13T22:26:41.547Z'
+                completed_at: '2026-05-21T14:01:05.267Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -2193,8 +2193,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 676533
-                  slug: product-676533
+                  name: Product 677597
+                  slug: product-677597
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -2219,7 +2219,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H91422323884
+                  number: H07213205217
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -2248,7 +2248,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Catharine Cronin
+                    name: Phylis Kozey
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2277,8 +2277,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-9ccf88928ac4
-                  number: PRCUU49P
+                  response_code: BGS-d9218ca0c082
+                  number: P6TGTMWL
                   amount: '29.99'
                   display_amount: "$29.99"
                   status: completed
@@ -3134,16 +3134,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImNkNzQ5N2QzLTM5YjctNGYzMi04OGNiLWQzNWI1ODM2MWQxZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc4NzE0ODA4fQ.tOwJzz71w-YuOe_DK0dHrNS4f1ZccZxLVRe5kSATM3M
-                refresh_token: 5G4xXN5Vx6ThMLPdqLHAoyAp
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk2ZTc1YzViLTY4NjMtNDkzMy1iYWFhLTZmNDZhNzFiY2VhZSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1NjcxfQ.TGikt0JLnGCtiRl8AWD75GYMbSA_VFk8R8tkkcVmo4M
+                refresh_token: rUy5d5FkkFKRKVTjSNLMmGXC
                 user:
                   id: cus_UkLWZg9DAJ
                   email: customer@example.com
-                  first_name: Jamal
-                  last_name: Berge
+                  first_name: Iris
+                  last_name: Hirthe
                   phone:
                   accepts_email_marketing: false
-                  full_name: Jamal Berge
+                  full_name: Iris Hirthe
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -3316,8 +3316,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R531767804
-                  email: kourtney_glover@harber.biz
+                  number: R453573119
+                  email: vesta@okuneva.com
                   customer_note:
                   currency: USD
                   locale: en
@@ -3344,7 +3344,7 @@ paths:
                   display_delivery_total: "$100.00"
                   fulfillment_status:
                   payment_status:
-                  completed_at: '2026-05-13T22:26:49.047Z'
+                  completed_at: '2026-05-21T14:01:12.513Z'
                   store_credit_total: '0.0'
                   display_store_credit_total: "$0.00"
                   covered_by_store_credit: false
@@ -3354,8 +3354,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 764134
-                    slug: product-764134
+                    name: Product 763572
+                    slug: product-763572
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -3380,7 +3380,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H30074853996
+                    number: H92480409501
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -3409,7 +3409,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Sebrina Hermann
+                      name: Aleen Powlowski
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -3572,8 +3572,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R928393368
-                email: salina@olson.ca
+                number: R788321337
+                email: marylin.baumbach@osinski.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -3600,7 +3600,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-13T22:26:49.756Z'
+                completed_at: '2026-05-21T14:01:13.194Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -3610,8 +3610,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 783776
-                  slug: product-783776
+                  name: Product 78558
+                  slug: product-78558
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3636,7 +3636,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H92068676734
+                  number: H85969598405
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -3665,7 +3665,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Shiela Romaguera
+                    name: Ruthe Davis
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3785,8 +3785,8 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImVlMjZiNjE5LTg3MjktNDhkNi05NmEzLThlZmJhYmNhNzRkNCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc4NzE0ODEwfQ.mrOcLTuL5ZJ1Wg8_6Fgl8zKtVCcMFqrmceormTlOOUM
-                refresh_token: pMnXxoXdrUE1b8DanCp2HaFs
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijg4ZWUyNGZiLTI2YjgtNDQxZi1hM2IwLTQ0ZDE1NWMxZDljNyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5Mzc1Njc0fQ.H0u-Q3oSCKP2k0LaX7rQVF_U8c1IUvaRnwvBrzw8kGk
+                refresh_token: Zm5W1wfivD9a8J1WsaKiBAyc
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
@@ -3900,12 +3900,12 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: alberta@haaglebsack.biz
-                first_name: Rebekah
-                last_name: Dickinson
+                email: amie@oga.ca
+                first_name: Jacinta
+                last_name: Lang
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                full_name: Rebekah Dickinson
+                full_name: Jacinta Lang
                 available_store_credit_total: '0'
                 display_available_store_credit_total: "$0.00"
                 addresses:
@@ -4039,7 +4039,7 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: huey.morissette@johns.us
+                email: raelene@marquardt.name
                 first_name: Updated
                 last_name: Name
                 phone: 555-555-0199
@@ -4279,9 +4279,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R944275414
-                token: msg6sEmFpE3ouDVpMU1EdLZ3yeuJieR5aTS
-                email: jasmine@ortiz.co.uk
+                number: R877670295
+                token: jgYbDf4iuvRHVAFiJSJPC67pctiy9JX6pm3
+                email: amal@beerkulas.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -4330,8 +4330,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 864988
-                  slug: product-864988
+                  name: Product 866689
+                  slug: product-866689
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4356,7 +4356,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H39326999271
+                  number: H97941431341
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4385,7 +4385,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Darin Nolan
+                    name: Delora Kerluke
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4539,9 +4539,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R847897368
-                token: o5ZBcbm28ynKSmisZKNn4S6uSzQQ29V4LzP
-                email: sherell_sauer@danielrussel.name
+                number: R645855426
+                token: xKbwRLgMS3z13qkQ8U9pN6NYL6ofcQ9GHZ7
+                email: latina.homenick@kuhn.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -4583,8 +4583,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 884521
-                  slug: product-884521
+                  name: Product 885251
+                  slug: product-885251
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4609,7 +4609,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H45597673137
+                  number: H21042794370
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4638,7 +4638,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Angelita Hirthe
+                    name: Meri O'Hara
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4781,9 +4781,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R776312936
-                token: PZxhxWxQUUeUfBPNAWtA84T3wj4VSjgDAuX
-                email: darlene@hegmann.com
+                number: R735538070
+                token: pJmy9PSsevBtccAFgssJj5xxWh7Zx2avpvg
+                email: rocky_murray@kemmerwillms.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -4827,8 +4827,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 902074
-                  slug: product-902074
+                  name: Product 90269
+                  slug: product-90269
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4853,7 +4853,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H84960578003
+                  number: H61990909745
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4882,7 +4882,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Marcella Gleason
+                    name: Gianna Prosacco
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5039,9 +5039,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R477575561
-                token: XmsrQSMW1GjTQXoR84zjmPkRKDBu9wPohGR
-                email: jordon_reynolds@monahanlind.biz
+                number: R786565483
+                token: rPCVCzH2MAhdyzFpsLwftnwAWtyVzCAuH5j
+                email: scot_thiel@jacobs.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -5080,8 +5080,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 928799
-                  slug: product-928799
+                  name: Product 924064
+                  slug: product-924064
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5106,7 +5106,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H17569959219
+                  number: H72899618600
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5135,7 +5135,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Cherilyn Rohan
+                    name: Hoa Abshire
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5164,8 +5164,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260513222659480328
-                  number: PJICQI95
+                  response_code: 1-SC-20260521140122745447
+                  number: PKDTTE1C
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: checkout
@@ -5344,9 +5344,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R763170613
-                token: jazQ6BN13e6FaHWeFZZtsY3SWiJbYmT32Vs
-                email: epifania@schadensteuber.ca
+                number: R305341957
+                token: cYad5ZEwRxucQSrUZeYvDNJJeNzFMkpais6
+                email: leonard@gerhold.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -5388,8 +5388,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 969841
-                  slug: product-969841
+                  name: Product 967644
+                  slug: product-967644
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5414,7 +5414,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H66513225741
+                  number: H87527277081
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5443,7 +5443,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Alona Lebsack
+                    name: Marget Carter
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5472,8 +5472,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260513222702020297
-                  number: PRSNCO99
+                  response_code: 1-SC-20260521140125170061
+                  number: P247ASB1
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: invalid
@@ -5597,7 +5597,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: 35825F9FC9C04D3E
+                  code: 5F5907332CD24C13
                   status: active
                   currency: USD
                   amount: '10.0'
@@ -5693,7 +5693,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 3B095595FD9C8DF0
+                code: E7D8EEDBD8B38629
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -5784,9 +5784,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R218798477
-                token: FDVh29CghDceRzZhTTRHQcH6RzwtaYu7ZoM
-                email: toccara_bode@greenholtsenger.info
+                number: R898038455
+                token: kwoDUG5ytVevnyteMSLq11LFUoUeQvgvj3C
+                email: lavone_pfeffer@metzokeefe.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -5834,8 +5834,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 994255
-                  slug: product-994255
+                  name: Product 998774
+                  slug: product-998774
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5862,8 +5862,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 1004709
-                  slug: product-1004709
+                  name: Product 1007565
+                  slug: product-1007565
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -6006,9 +6006,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R208536174
-                token: sPa7oQxwwRHBBMxMdgeELoGPVNup8VFHhKf
-                email: ping.rice@huelslittel.us
+                number: R361093646
+                token: ANzLKaHuynyv78jwmNXN17TGQvYaPbpDZpf
+                email: artie@luettgen.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -6053,8 +6053,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1035511
-                  slug: product-1035511
+                  name: Product 1032574
+                  slug: product-1032574
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6177,9 +6177,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R450595189
-                token: egYzsmtmVmA8p8CnZuYJY5xCqPqCXyjvcP2
-                email: amberly@bernhard.biz
+                number: R782177832
+                token: 3qTD9CqYFu8if2zPw9fjYJT6bcLLBXgqdkB
+                email: twana.adams@hagenes.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -6709,6 +6709,182 @@ paths:
                   message: Country not found
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/newsletter_subscribers":
+    post:
+      summary: Subscribe to the newsletter
+      tags:
+      - Newsletter Subscribers
+      security:
+      - api_key: []
+      description: |
+        Subscribes an email address to the newsletter for the current store.
+
+        Behavior:
+
+        - If the email is already verified for this store, the existing subscription is returned unchanged.
+        - If the request is unauthenticated (guest), the subscription is created in an unverified state
+          and a `newsletter_subscriber.subscription_requested` event is published containing the
+          `verification_token` and the validated `redirect_url`. Storefronts subscribe to this event
+          via a webhook to send the confirmation email; the link should point at
+          `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
+          when the user clicks it.
+        - If the request is authenticated via JWT and the customer's email matches the subscribed email,
+          the subscription is auto-verified — no event is fired.
+
+        The optional `redirect_url` is where the verification token should land on the storefront. It is
+        validated against the store's [Allowed Origins](/developer/core-concepts/allowed-origins) and
+        silently dropped from the webhook payload if it does not match (secure-by-default).
+
+        Newsletter consent is preserved across registration: if a guest subscribes and later registers
+        with the same email, the existing subscriber record is reused.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const subscriber = await client.newsletterSubscribers.create({
+            email: 'subscriber@example.com',
+            // Where the verification token should land. Must be in the store's
+            // allowed origins. The storefront's webhook handler will send the
+            // confirmation email with a link to `<redirect_url>?token=<token>`.
+            redirect_url: 'https://your-store.com/newsletter/confirm',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: false
+        description: Optional Bearer JWT — when present, links the subscription to
+          that customer
+        schema:
+          type: string
+      responses:
+        '201':
+          description: auto-verified when JWT matches subscribed email
+          content:
+            application/json:
+              example:
+                id: sub_UkLWZg9DAJ
+                email: jenise@kutch.biz
+                created_at: '2026-05-21T14:01:32.605Z'
+                updated_at: '2026-05-21T14:01:32.605Z'
+                verified: true
+                verified_at: '2026-05-21T14:01:32Z'
+                customer_id: cus_UkLWZg9DAJ
+              schema:
+                "$ref": "#/components/schemas/NewsletterSubscriber"
+        '422':
+          description: invalid email format
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Email is invalid
+                  details:
+                    email:
+                    - is invalid
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: subscriber@example.com
+                redirect_url:
+                  type: string
+                  format: uri
+                  example: https://your-store.com/newsletter/confirm
+                  description: Storefront URL the verification token should be appended
+                    to. Must be in the store's allowed origins.
+              required:
+              - email
+  "/api/v3/store/newsletter_subscribers/verify":
+    post:
+      summary: Verify a newsletter subscription
+      tags:
+      - Newsletter Subscribers
+      security:
+      - api_key: []
+      description: |
+        Confirms a pending newsletter subscription using the verification token sent by email.
+
+        After successful verification:
+        - The subscriber record is marked verified.
+        - If the subscription is associated with a customer, that customer's `accepts_email_marketing`
+          flag is set to `true`.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const subscriber = await client.newsletterSubscribers.verify({
+            token: 'abc123def456',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: subscription verified
+          content:
+            application/json:
+              example:
+                id: sub_UkLWZg9DAJ
+                email: pending@example.com
+                created_at: '2026-05-21T14:01:32.629Z'
+                updated_at: '2026-05-21T14:01:32.640Z'
+                verified: true
+                verified_at: '2026-05-21T14:01:32Z'
+                customer_id:
+              schema:
+                "$ref": "#/components/schemas/NewsletterSubscriber"
+        '422':
+          description: missing token
+          content:
+            application/json:
+              example:
+                error:
+                  code: parameter_missing
+                  message: token is required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  example: abc123def456
+                  description: Verification token from the confirmation email
+              required:
+              - token
   "/api/v3/store/orders/{id}":
     get:
       summary: Get an order
@@ -6781,7 +6957,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R197640310
+                number: R219546930
                 email: guest@example.com
                 customer_note:
                 currency: USD
@@ -6809,7 +6985,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-13T22:27:10.111Z'
+                completed_at: '2026-05-21T14:01:33.348Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -6819,8 +6995,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1079923
-                  slug: product-1079923
+                  name: Product 1078893
+                  slug: product-1078893
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6845,7 +7021,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H69918660946
+                  number: H66784286474
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -6874,7 +7050,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Lasandra Parker
+                    name: Naida Boyer
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -6906,7 +7082,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 258 Lovely Street
+                  address1: 260 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -6925,7 +7101,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 259 Lovely Street
+                  address1: 261 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -7019,9 +7195,9 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_9a4fd867e33eda3a85f7af87
+                external_id: bogus_a17b47e0398d13f0b001d373
                 external_data:
-                  client_secret: bogus_secret_15971e84c2d8ac80
+                  client_secret: bogus_secret_5dec9b38272306eb
                 customer_external_id:
                 expires_at:
                 amount: '110.0'
@@ -7119,7 +7295,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_3683ac1ff6e691f3adbfb2ec
+                external_id: bogus_9d936b37603e2d2e9f882ba5
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7181,7 +7357,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_9107f7f0c69399f6d227c22c
+                external_id: bogus_62a32b13abfdf70ffe97ebfe
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7283,7 +7459,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_16f2990e33899eaa9093a63f
+                external_id: bogus_690fbde1d19bee42865caa8f
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7368,8 +7544,8 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_b86e791bebf1f51c2f249647
-                external_client_secret: bogus_seti_secret_21e471b276d8a28b
+                external_id: bogus_seti_c30c9b5f22811f96e01ae78e
+                external_client_secret: bogus_seti_secret_4c73525f5d30ff33
                 external_data: {}
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
@@ -7468,8 +7644,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_bd7e3c37db41dadfdd3ded55
-                external_client_secret: seti_secret_668be0e627f0b82a32113dd8
+                external_id: seti_test_d7fa0cbdbc9e070360f09d67
+                external_client_secret: seti_secret_890b28449262f42d588f7226
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7545,8 +7721,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_88c1489315b6c12dd3f35176
-                external_client_secret: seti_secret_a4e461ece2ef965cf95ab200
+                external_id: seti_test_0deba6c34d39f196388036e2
+                external_client_secret: seti_secret_c8e8baf1be390bcebea53f33
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7640,7 +7816,7 @@ paths:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 response_code:
-                number: PREKGE98
+                number: P8EAYC6L
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7736,7 +7912,7 @@ paths:
                   body_html: ''
                 - id: pol_OIJLhNcSbf
                   name: Privacy Policy
-                  slug: privacy-policy-05ad8a43-341b-4283-b2b3-42a1597d4c3f
+                  slug: privacy-policy-e33e52be-144d-4d70-99a2-978929d3c22a
                   body: We respect your privacy.
                   body_html: |
                     <div class="trix-content">
@@ -7980,13 +8156,13 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1171648
-                  slug: product-1171648
+                  name: Product 1173606
+                  slug: product-1173606
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-05-13T22:27:20.479Z'
+                  available_on: '2025-05-21T14:01:43.412Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -8008,28 +8184,29 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 1189078
-                  slug: product-1189078
+                  name: Product 1189963
+                  slug: product-1189963
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-13T22:27:20.542Z'
+                  available_on: '2025-05-21T14:01:43.466Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Nisi nostrum blanditiis sit reiciendis id dolorum.
-                    Rerum consequatur laudantium fugiat corrupti eum atque perspiciatis
-                    repellendus. Repellendus eum laborum praesentium totam consequuntur.
-                    Dignissimos facere aut eaque suscipit. Sit itaque officiis recusandae
-                    tempore libero sapiente laboriosam. Quod quisquam natus deleniti
-                    provident et error velit. Veritatis facere temporibus qui maiores
-                    quaerat iure aliquid. Iusto repudiandae tenetur assumenda officia
-                    occaecati.
+                  description: Nobis autem cum dolorum nesciunt harum sequi voluptates.
+                    Sunt qui hic libero exercitationem ratione iusto. Vero odit quia
+                    assumenda minus similique corrupti a. Iste aliquam temporibus
+                    et aliquid beatae. Placeat odit voluptates molestias quam accusantium
+                    natus sed. Ut vero cumque delectus consectetur rem. Quae nam repudiandae
+                    corporis voluptate. Debitis rerum a recusandae sit dolorum earum
+                    fugiat ea. Praesentium alias veritatis molestias neque incidunt
+                    laudantium doloribus. Quo non eum placeat dolorem.
                   description_html: |-
-                    Nisi nostrum blanditiis sit reiciendis id dolorum. Rerum consequatur laudantium fugiat corrupti eum atque perspiciatis repellendus. Repellendus eum laborum praesentium totam consequuntur.
-                    Dignissimos facere aut eaque suscipit. Sit itaque officiis recusandae tempore libero sapiente laboriosam. Quod quisquam natus deleniti provident et error velit. Veritatis facere temporibus qui maiores quaerat iure aliquid. Iusto repudiandae tenetur assumenda officia occaecati.
+                    Nobis autem cum dolorum nesciunt harum sequi voluptates. Sunt qui hic libero exercitationem ratione iusto. Vero odit quia assumenda minus similique corrupti a.
+                    Iste aliquam temporibus et aliquid beatae. Placeat odit voluptates molestias quam accusantium natus sed. Ut vero cumque delectus consectetur rem. Quae nam repudiandae corporis voluptate.
+                    Debitis rerum a recusandae sit dolorum earum fugiat ea. Praesentium alias veritatis molestias neque incidunt laudantium doloribus. Quo non eum placeat dolorem.
                   default_variant_id: variant_EfhxLZ9ck8
                   thumbnail_url:
                   tags: []
@@ -8131,13 +8308,13 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 1453907
-                slug: product-1453907
+                name: Product 1451391
+                slug: product-1451391
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-05-13T22:27:22.136Z'
+                available_on: '2025-05-21T14:01:44.847Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -8164,7 +8341,7 @@ paths:
                   amount_in_cents: 999
                   currency: USD
                   display_amount: "$9.99"
-                  recorded_at: '2026-04-28T22:27:22Z'
+                  recorded_at: '2026-05-06T14:01:44Z'
               schema:
                 "$ref": "#/components/schemas/Product"
         '404':
@@ -8539,9 +8716,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R001729941
-                token: W5ynafzKqDZLvj1bsDGYkxVU9XfM54fj2TU
-                email: christal.gorczany@zboncak.biz
+                number: R744140023
+                token: pTFm3XRZudeeoLXmviqWz6uNkVtaBp4uLrV
+                email: kathlene@beer.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -8580,8 +8757,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1655543
-                  slug: product-1655543
+                  name: Product 1658176
+                  slug: product-1658176
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -8606,7 +8783,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H55534597898
+                  number: H59588366435
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -8635,7 +8812,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Natalie Lind
+                    name: Veta Mitchell
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -8664,8 +8841,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260513222727628021
-                  number: PZL9IN69
+                  response_code: 1-SC-20260521140150066371
+                  number: PEHXTQG6
                   amount: '10.0'
                   display_amount: "$10.00"
                   status: checkout
@@ -8692,7 +8869,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 322 Lovely Street
+                  address1: 324 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -8711,7 +8888,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 323 Lovely Street
+                  address1: 325 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -8808,9 +8985,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R023022648
-                token: k1F6SZ5iqCV1Vu88Ywos6XpvwkPwy1ARPt6
-                email: kyung.conroy@schummconn.co.uk
+                number: R244936382
+                token: Ycdv7VgR4x426YxWUz7eoyGEFZ1sRY4SpaC
+                email: eloisa.gerhold@gleason.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -8852,8 +9029,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1672629
-                  slug: product-1672629
+                  name: Product 1673068
+                  slug: product-1673068
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -8878,7 +9055,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H15373018353
+                  number: H49623074593
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -8907,7 +9084,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Linsey Grant
+                    name: Grady Pacocha
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -8939,7 +9116,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 330 Lovely Street
+                  address1: 332 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -8958,7 +9135,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 331 Lovely Street
+                  address1: 333 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -9037,7 +9214,7 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: pNUefpiorWppH4tuM9RHiv38
+                  token: QL7gtUL5AUfgexgDh9iQFWaA
                   is_default: false
                   is_private: true
                 meta:
@@ -9113,7 +9290,7 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: bQSKNBBhCXtHWSoDUJahXA69
+                token: zmk9bk8qkYJRXzjhxhYRV1Gg
                 is_default: false
                 is_private: true
               schema:
@@ -9209,7 +9386,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: cst3bHUPsMnW4TqL1P89krGH
+                token: FjFxxfkdRu9GRLaAmWerHsP1
                 is_default: false
                 is_private: true
               schema:
@@ -9271,7 +9448,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: NUaszyr9oB7MvNSvd2Ri7qHf
+                token: zTCwhxBSEZYoDbdjgF57VnYE
                 is_default: false
                 is_private: true
               schema:
@@ -9500,6 +9677,8 @@ tags:
   description: Markets, countries, currencies, and locales
 - name: Wishlists
   description: Customer wishlists
+- name: Newsletter Subscribers
+  description: Guest and customer newsletter subscriptions (double opt-in)
 - name: Policies
   description: Store policies (return policy, privacy policy, terms of service)
 - name: Digitals
@@ -9526,6 +9705,9 @@ x-tagGroups:
 - name: Wishlists
   tags:
   - Wishlists
+- name: Newsletter Subscribers
+  tags:
+  - Newsletter Subscribers
 - name: Policies
   tags:
   - Policies

--- a/docs/developer/core-concepts/customers.mdx
+++ b/docs/developer/core-concepts/customers.mdx
@@ -3,6 +3,8 @@ title: Customers
 description: Customer accounts — registration, authentication, profiles, and guest checkout
 ---
 
+import { Since } from '/snippets/since.mdx';
+
 ## Overview
 
 Customers interact with your store through the Store API. They can register, log in, manage their profile, and view order history.
@@ -177,6 +179,64 @@ curl -X PATCH 'https://api.mystore.com/api/v3/store/customer/password_resets/RES
 </CodeGroup>
 
 On success, the user is automatically logged in and a JWT token is returned. The reset token expires after 15 minutes (configurable via `Spree::Config.customer_password_reset_expires_in`) and is single-use (changing the password invalidates it).
+
+## Newsletter Subscriptions
+
+<Since version="5.5" />
+
+Headless storefronts often need to collect newsletter signups before account creation (footer forms, popup overlays). The Store API exposes a double opt-in subscription flow that mirrors the password reset webhook pattern.
+
+### Step 1: Subscribe
+
+<CodeGroup>
+
+```typescript SDK
+await client.newsletterSubscribers.create({
+  email: 'guest@example.com',
+  redirect_url: 'https://myshop.com/newsletter/confirm',
+})
+// Returns the NewsletterSubscriber (verified: false for guests)
+```
+
+```bash cURL
+curl -X POST 'https://api.mystore.com/api/v3/store/newsletter_subscribers' \
+  -H 'X-Spree-Api-Key: pk_xxx' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "email": "guest@example.com",
+    "redirect_url": "https://myshop.com/newsletter/confirm"
+  }'
+```
+
+</CodeGroup>
+
+The optional `redirect_url` points at the storefront page that will receive the verification token. It is validated against the store's [Allowed Origins](/developer/core-concepts/allowed-origins) — URLs that do not match are silently dropped from the webhook payload (secure-by-default).
+
+This fires a `newsletter_subscriber.subscription_requested` event whose payload includes `email`, `verification_token`, and the validated `redirect_url`. Subscribe to this event from your storefront's webhook handler to send the confirmation email — the link in the email should point to `<redirect_url>?token=<verification_token>`. The bundled `spree_emails` package also listens to this event and sends a default confirmation email if you're not running a headless storefront.
+
+If the request is authenticated via a customer JWT and the JWT's email matches the subscribed email, the subscription is **auto-verified** and no event is fired (the user has already proven email ownership).
+
+### Step 2: Verify
+
+<CodeGroup>
+
+```typescript SDK
+await client.newsletterSubscribers.verify({
+  token: 'token-from-email',
+})
+// Returns the verified NewsletterSubscriber
+```
+
+```bash cURL
+curl -X POST 'https://api.mystore.com/api/v3/store/newsletter_subscribers/verify' \
+  -H 'X-Spree-Api-Key: pk_xxx' \
+  -H 'Content-Type: application/json' \
+  -d '{ "token": "token-from-email" }'
+```
+
+</CodeGroup>
+
+On success, the subscriber is marked verified. If the subscription is linked to a customer record, that customer's `accepts_email_marketing` flag is also set to `true`. Consent is preserved across registration: if a guest subscribes and later registers with the same email, the existing subscriber is reused — registration won't accidentally reset their opt-in state.
 
 ## Customer Profile
 

--- a/docs/developer/deployment/emails.mdx
+++ b/docs/developer/deployment/emails.mdx
@@ -24,7 +24,7 @@ Spree Backend → Webhook POST → Storefront → render email → send via Rese
 
 1. **Create a webhook endpoint** in Spree Admin → Settings → Developers → Webhooks:
    - **URL:** `https://your-storefront.com/api/webhooks/spree`
-   - **Events:** `order.completed`, `order.canceled`, `order.shipped`, `customer.password_reset_requested`
+   - **Events:** `order.completed`, `order.canceled`, `order.shipped`, `customer.password_reset_requested`, `newsletter_subscriber.subscription_requested`
 
 2. **Configure the storefront** with the webhook secret and email provider:
 
@@ -45,6 +45,7 @@ EMAIL_FROM=Your Store <orders@your-domain.com>
 | `order.canceled` | Cancellation notice |
 | `order.shipped` | Shipping notification with tracking link |
 | `customer.password_reset_requested` | Password reset link |
+| `newsletter_subscriber.subscription_requested` | Newsletter double opt-in confirmation link |
 
 ### Custom Frameworks
 

--- a/docs/developer/storefront/nextjs/customization.mdx
+++ b/docs/developer/storefront/nextjs/customization.mdx
@@ -150,6 +150,7 @@ Email templates are React components in `src/lib/emails/`:
 | `order-canceled.tsx` | `order.canceled` | Cancellation notice with items |
 | `shipment-shipped.tsx` | `order.shipped` | Tracking number and link |
 | `password-reset.tsx` | `customer.password_reset_requested` | Reset button and fallback link |
+| `newsletter-confirmation.tsx` | `newsletter_subscriber.subscription_requested` | Double opt-in confirmation link |
 
 Customize templates by editing these files directly. They use `@react-email/components` for email-safe layout primitives.
 
@@ -175,6 +176,7 @@ export const POST = createWebhookHandler({
     'order.canceled': handleOrderCanceled,
     'order.shipped': handleOrderShipped,
     'customer.password_reset_requested': handlePasswordReset,
+    'newsletter_subscriber.subscription_requested': handleNewsletterConfirmation,
   },
 })
 ```

--- a/packages/sdk/.changeset/store-newsletter-subscribers.md
+++ b/packages/sdk/.changeset/store-newsletter-subscribers.md
@@ -1,0 +1,7 @@
+---
+'@spree/sdk': minor
+---
+
+Add `client.newsletterSubscribers.create()` and `client.newsletterSubscribers.verify()` for the new Store API newsletter subscription endpoints.
+
+Lets headless storefronts subscribe guests to the newsletter before account creation and confirm the double opt-in via the verification token from the confirmation email. Pass `redirect_url` on `create()` and the storefront receives a `newsletter_subscriber.subscription_requested` webhook with the token + validated redirect URL so it can send the confirmation email itself — same pattern as `customer.password_reset_requested`. When called with a JWT and the customer's own email, the subscription is auto-verified.

--- a/packages/sdk/.changeset/store-newsletter-subscribers.md
+++ b/packages/sdk/.changeset/store-newsletter-subscribers.md
@@ -5,3 +5,5 @@
 Add `client.newsletterSubscribers.create()` and `client.newsletterSubscribers.verify()` for the new Store API newsletter subscription endpoints.
 
 Lets headless storefronts subscribe guests to the newsletter before account creation and confirm the double opt-in via the verification token from the confirmation email. Pass `redirect_url` on `create()` and the storefront receives a `newsletter_subscriber.subscription_requested` webhook with the token + validated redirect URL so it can send the confirmation email itself — same pattern as `customer.password_reset_requested`. When called with a JWT and the customer's own email, the subscription is auto-verified.
+
+Consent is now preserved across registration: when `client.customers.create()` is called with an email that already has a newsletter subscription on the current store, that subscriber is linked to the new user. If the subscription was verified, `accepts_email_marketing` is set to `true` on the returned customer even when the registration body sent `false` — so guests who opted in before signing up don't lose their consent.

--- a/packages/sdk/examples/newsletter-subscribers/create.ts
+++ b/packages/sdk/examples/newsletter-subscribers/create.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@spree/sdk'
+
+const client = createClient({
+  baseUrl: 'https://your-store.com',
+  publishableKey: '<api-key>',
+})
+
+// region:example
+const subscriber = await client.newsletterSubscribers.create({
+  email: 'subscriber@example.com',
+  // Where the verification token should land. Must be in the store's
+  // allowed origins. The storefront's webhook handler will send the
+  // confirmation email with a link to `<redirect_url>?token=<token>`.
+  redirect_url: 'https://your-store.com/newsletter/confirm',
+})
+// endregion:example
+
+export { subscriber }

--- a/packages/sdk/examples/newsletter-subscribers/create.ts
+++ b/packages/sdk/examples/newsletter-subscribers/create.ts
@@ -8,9 +8,6 @@ const client = createClient({
 // region:example
 const subscriber = await client.newsletterSubscribers.create({
   email: 'subscriber@example.com',
-  // Where the verification token should land. Must be in the store's
-  // allowed origins. The storefront's webhook handler will send the
-  // confirmation email with a link to `<redirect_url>?token=<token>`.
   redirect_url: 'https://your-store.com/newsletter/confirm',
 })
 // endregion:example

--- a/packages/sdk/examples/newsletter-subscribers/verify.ts
+++ b/packages/sdk/examples/newsletter-subscribers/verify.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@spree/sdk'
+
+const client = createClient({
+  baseUrl: 'https://your-store.com',
+  publishableKey: '<api-key>',
+})
+
+// region:example
+const subscriber = await client.newsletterSubscribers.verify({
+  token: 'abc123def456',
+})
+// endregion:example
+
+export { subscriber }

--- a/packages/sdk/src/store-client.ts
+++ b/packages/sdk/src/store-client.ts
@@ -28,6 +28,7 @@ import type {
   Locale,
   LoginCredentials,
   Market,
+  NewsletterSubscriber,
   Order,
   OrderListParams,
   Payment,
@@ -599,6 +600,50 @@ export class StoreClient {
      */
     create: (params: RegisterParams): Promise<AuthTokens> =>
       this.request<AuthTokens>('POST', '/customers', { body: params }),
+  }
+
+  // ============================================
+  // Newsletter Subscribers
+  // ============================================
+
+  readonly newsletterSubscribers = {
+    /**
+     * Subscribe an email address to the newsletter for the current store.
+     *
+     * Behavior:
+     * - If the email already has a verified subscription, the existing record is returned unchanged.
+     * - Guest subscriptions are created in an unverified state and a
+     *   `newsletter_subscriber.subscription_requested` webhook event is fired with the
+     *   verification token + validated `redirect_url`; the storefront sends the
+     *   confirmation email and the link points at `redirect_url?token=...`.
+     * - When the call is authenticated via JWT and the customer's email matches the subscribed
+     *   email, the subscription is auto-verified — no confirmation email is sent.
+     *
+     * `redirect_url` must match one of the store's allowed origins (see Allowed Origins
+     * in the admin). If it does not, it is silently dropped from the webhook payload to
+     * prevent open-redirect / token-exfiltration attacks.
+     *
+     * Pass `options.token` (JWT) to link the subscription to an authenticated customer.
+     */
+    create: (
+      params: { email: string; redirect_url?: string },
+      options?: RequestOptions,
+    ): Promise<NewsletterSubscriber> =>
+      this.request<NewsletterSubscriber>('POST', '/newsletter_subscribers', {
+        ...options,
+        body: params,
+      }),
+
+    /**
+     * Confirm a pending newsletter subscription using the verification token from the
+     * confirmation email. On success the subscriber is marked verified and, when linked
+     * to a customer, that customer's `accepts_email_marketing` flag is set to `true`.
+     */
+    verify: (params: { token: string }, options?: RequestOptions): Promise<NewsletterSubscriber> =>
+      this.request<NewsletterSubscriber>('POST', '/newsletter_subscribers/verify', {
+        ...options,
+        body: params,
+      }),
   }
 
   readonly customer = {

--- a/packages/sdk/src/store-client.ts
+++ b/packages/sdk/src/store-client.ts
@@ -609,21 +609,10 @@ export class StoreClient {
   readonly newsletterSubscribers = {
     /**
      * Subscribe an email address to the newsletter for the current store.
-     *
-     * Behavior:
-     * - If the email already has a verified subscription, the existing record is returned unchanged.
-     * - Guest subscriptions are created in an unverified state and a
-     *   `newsletter_subscriber.subscription_requested` webhook event is fired with the
-     *   verification token + validated `redirect_url`; the storefront sends the
-     *   confirmation email and the link points at `redirect_url?token=...`.
-     * - When the call is authenticated via JWT and the customer's email matches the subscribed
-     *   email, the subscription is auto-verified — no confirmation email is sent.
-     *
-     * `redirect_url` must match one of the store's allowed origins (see Allowed Origins
-     * in the admin). If it does not, it is silently dropped from the webhook payload to
-     * prevent open-redirect / token-exfiltration attacks.
-     *
-     * Pass `options.token` (JWT) to link the subscription to an authenticated customer.
+     * Guests get an unverified record; pass a JWT via `options.token` to link
+     * to a customer (auto-verifies when the JWT email matches `params.email`).
+     * `redirect_url` is dropped from the webhook payload when it's not in the
+     * store's allowed origins.
      */
     create: (
       params: { email: string; redirect_url?: string },
@@ -635,9 +624,7 @@ export class StoreClient {
       }),
 
     /**
-     * Confirm a pending newsletter subscription using the verification token from the
-     * confirmation email. On success the subscriber is marked verified and, when linked
-     * to a customer, that customer's `accepts_email_marketing` flag is set to `true`.
+     * Confirm a pending subscription using the token from the confirmation email.
      */
     verify: (params: { token: string }, options?: RequestOptions): Promise<NewsletterSubscriber> =>
       this.request<NewsletterSubscriber>('POST', '/newsletter_subscribers/verify', {

--- a/packages/sdk/tests/mocks/handlers.ts
+++ b/packages/sdk/tests/mocks/handlers.ts
@@ -113,6 +113,15 @@ export const fixtures = {
     quantity: 1,
     variant_id: 'var_1',
   },
+  newsletterSubscriber: {
+    id: 'sub_1',
+    email: 'subscriber@example.com',
+    verified: false,
+    verified_at: null as string | null,
+    customer_id: null as string | null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
 }
 
 const paginationMeta = { page: 1, limit: 25, count: 1, pages: 1 }
@@ -612,5 +621,18 @@ export const handlers = [
   http.delete(
     `${API_PREFIX}/wishlists/:wishlistId/items/:id`,
     () => new HttpResponse(null, { status: 204 }),
+  ),
+
+  // Newsletter Subscribers
+  http.post(`${API_PREFIX}/newsletter_subscribers`, () =>
+    HttpResponse.json(fixtures.newsletterSubscriber, { status: 201 }),
+  ),
+
+  http.post(`${API_PREFIX}/newsletter_subscribers/verify`, () =>
+    HttpResponse.json({
+      ...fixtures.newsletterSubscriber,
+      verified: true,
+      verified_at: '2026-01-02T00:00:00Z',
+    }),
   ),
 ]

--- a/packages/sdk/tests/newsletter-subscribers.test.ts
+++ b/packages/sdk/tests/newsletter-subscribers.test.ts
@@ -1,0 +1,113 @@
+import { HttpResponse, http } from 'msw'
+import { beforeAll, describe, expect, it } from 'vitest'
+import type { Client } from '../src'
+import { createTestClient, TEST_BASE_URL } from './helpers'
+import { fixtures } from './mocks/handlers'
+import { server } from './mocks/server'
+
+const API_PREFIX = `${TEST_BASE_URL}/api/v3/store`
+
+describe('newsletterSubscribers', () => {
+  let client: Client
+  beforeAll(() => {
+    client = createTestClient()
+  })
+
+  describe('create', () => {
+    it('subscribes a guest email', async () => {
+      const result = await client.newsletterSubscribers.create({
+        email: 'subscriber@example.com',
+      })
+
+      expect(result.id).toBe('sub_1')
+      expect(result.email).toBe('subscriber@example.com')
+      expect(result.verified).toBe(false)
+      expect(result.customer_id).toBeNull()
+    })
+
+    it('sends the email in the request body', async () => {
+      let capturedBody: Record<string, unknown> = {}
+      server.use(
+        http.post(`${API_PREFIX}/newsletter_subscribers`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(fixtures.newsletterSubscriber, { status: 201 })
+        }),
+      )
+
+      await client.newsletterSubscribers.create({ email: 'guest@example.com' })
+
+      expect(capturedBody.email).toBe('guest@example.com')
+    })
+
+    it('forwards redirect_url for webhook-driven confirmation emails', async () => {
+      let capturedBody: Record<string, unknown> = {}
+      server.use(
+        http.post(`${API_PREFIX}/newsletter_subscribers`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(fixtures.newsletterSubscriber, { status: 201 })
+        }),
+      )
+
+      await client.newsletterSubscribers.create({
+        email: 'guest@example.com',
+        redirect_url: 'https://storefront.example.com/newsletter/confirm',
+      })
+
+      expect(capturedBody.redirect_url).toBe('https://storefront.example.com/newsletter/confirm')
+    })
+
+    it('forwards a JWT when provided', async () => {
+      let capturedAuth: string | null = null
+      server.use(
+        http.post(`${API_PREFIX}/newsletter_subscribers`, ({ request }) => {
+          capturedAuth = request.headers.get('Authorization')
+          return HttpResponse.json(
+            {
+              ...fixtures.newsletterSubscriber,
+              verified: true,
+              verified_at: '2026-01-02T00:00:00Z',
+              customer_id: 'user_1',
+            },
+            { status: 201 },
+          )
+        }),
+      )
+
+      const result = await client.newsletterSubscribers.create(
+        { email: 'test@example.com' },
+        { token: 'user-jwt' },
+      )
+
+      expect(capturedAuth).toBe('Bearer user-jwt')
+      expect(result.verified).toBe(true)
+      expect(result.customer_id).toBe('user_1')
+    })
+  })
+
+  describe('verify', () => {
+    it('verifies a subscription using the token', async () => {
+      const result = await client.newsletterSubscribers.verify({ token: 'abc123' })
+
+      expect(result.verified).toBe(true)
+      expect(result.verified_at).toBe('2026-01-02T00:00:00Z')
+    })
+
+    it('sends the token in the request body', async () => {
+      let capturedBody: Record<string, unknown> = {}
+      server.use(
+        http.post(`${API_PREFIX}/newsletter_subscribers/verify`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({
+            ...fixtures.newsletterSubscriber,
+            verified: true,
+            verified_at: '2026-01-02T00:00:00Z',
+          })
+        }),
+      )
+
+      await client.newsletterSubscribers.verify({ token: 'verify-token-xyz' })
+
+      expect(capturedBody.token).toBe('verify-token-xyz')
+    })
+  })
+})

--- a/spree/admin/app/helpers/spree/admin/webhook_endpoints_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/webhook_endpoints_helper.rb
@@ -93,6 +93,7 @@ module Spree
       def custom_webhook_events
         %w[
           customer.password_reset_requested
+          newsletter_subscriber.subscription_requested
           order.completed
           order.paid
           order.canceled

--- a/spree/api/app/controllers/spree/api/v3/store/customers_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/customers_controller.rb
@@ -13,6 +13,7 @@ module Spree
             user = Spree.user_class.new(permitted_params.except(:current_password))
 
             if user.save
+              link_matching_newsletter_subscriber!(user)
               refresh_token = Spree::RefreshToken.create_for(user, request_env: {
                 ip_address: request.remote_ip,
                 user_agent: request.user_agent&.truncate(255)
@@ -93,6 +94,11 @@ module Spree
 
           def user_serializer
             Spree.api.customer_serializer
+          end
+
+          def link_matching_newsletter_subscriber!(user)
+            subscriber = Spree::NewsletterSubscriber.find_by(email: user.email, store: current_store)
+            Spree::Newsletter::LinkUser.new(subscriber: subscriber, user: user).call
           end
         end
       end

--- a/spree/api/app/controllers/spree/api/v3/store/newsletter_subscribers_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/newsletter_subscribers_controller.rb
@@ -1,0 +1,96 @@
+module Spree
+  module Api
+    module V3
+      module Store
+        class NewsletterSubscribersController < Store::BaseController
+          rate_limit to: Spree::Api::Config[:rate_limit_register],
+                     within: Spree::Api::Config[:rate_limit_window].seconds,
+                     store: Rails.cache,
+                     only: [:create, :verify],
+                     with: RATE_LIMIT_RESPONSE
+
+          # Authentication is optional — the parent's `before_action :authenticate_user`
+          # leaves `current_user` nil when no JWT is present, which is the guest path.
+          # When a JWT *is* present, we use it to link the subscription to the customer
+          # (and auto-verify if the email matches).
+
+          # POST /api/v3/store/newsletter_subscribers
+          # Subscribes a guest or authenticated customer to the newsletter for the current store.
+          # If the email already has a verified subscription, returns the existing record.
+          # If a JWT is provided, the subscription is linked to that customer; if the customer's
+          # email matches the subscribed email, the subscription is auto-verified.
+          #
+          # The optional `redirect_url` is the storefront page that should receive the
+          # verification token (e.g. `https://your-store.com/newsletter/confirm`). When
+          # provided, it is validated against the store's allowed origins and forwarded
+          # in the `newsletter_subscriber.subscription_requested` event so the storefront
+          # webhook handler can build the confirmation email link as
+          # `redirect_url?token=<verification_token>`.
+          def create
+            subscriber = Spree::NewsletterSubscriber.subscribe(
+              email: params[:email],
+              user: current_user,
+              store: current_store,
+              redirect_url: validated_redirect_url
+            )
+
+            if subscriber.errors.any?
+              render_errors(subscriber.errors)
+            else
+              render json: serialize_resource(subscriber), status: :created
+            end
+          end
+
+          # POST /api/v3/store/newsletter_subscribers/verify
+          # Confirms a newsletter subscription using the verification token sent by email.
+          # Accepts: { "token": "..." }
+          def verify
+            token = params[:token]
+
+            if token.blank?
+              return render_error(
+                code: ERROR_CODES[:parameter_missing],
+                message: 'token is required',
+                status: :unprocessable_content
+              )
+            end
+
+            subscriber = Spree::NewsletterSubscriber.for_store(current_store).unverified.find_by(verification_token: token)
+
+            unless subscriber
+              return render_error(
+                code: ERROR_CODES[:invalid_token],
+                message: Spree.t(:newsletter_verification_token_invalid, scope: :api),
+                status: :unprocessable_content
+              )
+            end
+
+            Spree::Newsletter::Verify.new(subscriber: subscriber).call
+
+            render json: serialize_resource(subscriber)
+          end
+
+          protected
+
+          def serializer_class
+            Spree::Api::V3::NewsletterSubscriberSerializer
+          end
+
+          private
+
+          # Validates the requested redirect_url against the current store's allowed
+          # origins. Returns nil (the link will be dropped from the event) when the URL
+          # is not in the allow-list — same secure-by-default behavior as password resets.
+          def validated_redirect_url
+            redirect_url = params[:redirect_url]
+            return nil if redirect_url.blank?
+            return nil unless current_store.allowed_origins.exists?
+            return nil unless current_store.allowed_origin?(redirect_url)
+
+            redirect_url
+          end
+        end
+      end
+    end
+  end
+end

--- a/spree/api/app/controllers/spree/api/v3/store/newsletter_subscribers_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/newsletter_subscribers_controller.rb
@@ -9,23 +9,7 @@ module Spree
                      only: [:create, :verify],
                      with: RATE_LIMIT_RESPONSE
 
-          # Authentication is optional — the parent's `before_action :authenticate_user`
-          # leaves `current_user` nil when no JWT is present, which is the guest path.
-          # When a JWT *is* present, we use it to link the subscription to the customer
-          # (and auto-verify if the email matches).
-
           # POST /api/v3/store/newsletter_subscribers
-          # Subscribes a guest or authenticated customer to the newsletter for the current store.
-          # If the email already has a verified subscription, returns the existing record.
-          # If a JWT is provided, the subscription is linked to that customer; if the customer's
-          # email matches the subscribed email, the subscription is auto-verified.
-          #
-          # The optional `redirect_url` is the storefront page that should receive the
-          # verification token (e.g. `https://your-store.com/newsletter/confirm`). When
-          # provided, it is validated against the store's allowed origins and forwarded
-          # in the `newsletter_subscriber.subscription_requested` event so the storefront
-          # webhook handler can build the confirmation email link as
-          # `redirect_url?token=<verification_token>`.
           def create
             subscriber = Spree::NewsletterSubscriber.subscribe(
               email: params[:email],
@@ -42,8 +26,6 @@ module Spree
           end
 
           # POST /api/v3/store/newsletter_subscribers/verify
-          # Confirms a newsletter subscription using the verification token sent by email.
-          # Accepts: { "token": "..." }
           def verify
             token = params[:token]
 
@@ -78,13 +60,12 @@ module Spree
 
           private
 
-          # Validates the requested redirect_url against the current store's allowed
-          # origins. Returns nil (the link will be dropped from the event) when the URL
-          # is not in the allow-list — same secure-by-default behavior as password resets.
+          # Drop redirect_url when it isn't in the store's allow-list — secure-by-default,
+          # mirrors password_resets. Returning nil omits it from the webhook payload rather
+          # than rejecting the request, so callers can't probe the allow-list via 4xx errors.
           def validated_redirect_url
             redirect_url = params[:redirect_url]
             return nil if redirect_url.blank?
-            return nil unless current_store.allowed_origins.exists?
             return nil unless current_store.allowed_origin?(redirect_url)
 
             redirect_url

--- a/spree/api/config/locales/en.yml
+++ b/spree/api/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
       invalid_taxonomy_id: Invalid taxonomy id.
       must_specify_api_key: You must specify an API key.
       negative_quantity: quantity is negative
+      newsletter_verification_token_invalid: Newsletter verification token is invalid or has expired.
       order:
         could_not_transition: The order could not be transitioned. Please fix the errors and try again.
         insufficient_quantity: An item in your cart has become unavailable.

--- a/spree/api/config/routes.rb
+++ b/spree/api/config/routes.rb
@@ -60,6 +60,13 @@ Spree::Core::Engine.add_routes do
         # Customers
         resources :customers, only: [:create]
 
+        # Newsletter Subscriptions (guest-accessible: subscribe + verify by token)
+        resources :newsletter_subscribers, only: [:create] do
+          collection do
+            post :verify
+          end
+        end
+
         # Current customer profile and nested resources (/customers/me/...)
         namespace :customer, path: 'customers/me' do
           get '/', action: :show, controller: '/spree/api/v3/store/customers'

--- a/spree/api/spec/controllers/spree/api/v3/store/customers_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/customers_controller_spec.rb
@@ -72,6 +72,45 @@ RSpec.describe Spree::Api::V3::Store::CustomersController, type: :controller do
       expect(new_user.metadata).to eq({ 'source' => 'storefront' })
     end
 
+    context 'with a matching newsletter subscriber on the current store' do
+      it 'links an existing unverified subscriber to the new user without auto-opting them in' do
+        subscriber = create(
+          :newsletter_subscriber,
+          :unverified,
+          email: valid_params[:email],
+          user: nil,
+          store: store
+        )
+
+        post :create, params: valid_params
+
+        expect(response).to have_http_status(:created)
+        new_user = Spree.user_class.find_by(email: valid_params[:email])
+        expect(subscriber.reload.user).to eq(new_user)
+        expect(new_user.accepts_email_marketing).to eq(false)
+      end
+
+      it 'links an existing verified subscriber and carries the opt-in onto the new user' do
+        subscriber = create(
+          :newsletter_subscriber,
+          :verified,
+          email: valid_params[:email],
+          user: nil,
+          store: store
+        )
+
+        # Earlier guest consent should win even when the registration body sends
+        # accepts_email_marketing=false.
+        post :create, params: valid_params.merge(accepts_email_marketing: false)
+
+        expect(response).to have_http_status(:created)
+        new_user = Spree.user_class.find_by(email: valid_params[:email])
+        expect(subscriber.reload.user).to eq(new_user)
+        expect(new_user.accepts_email_marketing).to eq(true)
+        expect(json_response['user']['accepts_email_marketing']).to eq(true)
+      end
+    end
+
     context 'validation errors' do
       it 'returns validation error for blank email' do
         post :create, params: { email: '', password: 'password123', password_confirmation: 'password123' }

--- a/spree/api/spec/integration/spree/api/v3/store/newsletter_subscribers_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/newsletter_subscribers_spec.rb
@@ -18,17 +18,24 @@ RSpec.describe 'Newsletter Subscribers API', type: :request, swagger_doc: 'api-r
 
         - If the email is already verified for this store, the existing subscription is returned unchanged.
         - If the request is unauthenticated (guest), the subscription is created in an unverified state
-          and a `newsletter_subscriber.subscription_requested` event is published containing the
-          `verification_token` and the validated `redirect_url`. Storefronts subscribe to this event
-          via a webhook to send the confirmation email; the link should point at
-          `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
+          and two events are published: `newsletter_subscriber.subscription_requested` (carrying the
+          `verification_token` and the validated `redirect_url`, intended for headless storefronts that
+          want to send the confirmation email themselves via a webhook handler) and the legacy
+          `newsletter_subscriber.subscribed` lifecycle event (which the bundled `spree_emails` package
+          listens to and uses to send a default confirmation email). The confirmation link should point
+          at `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
           when the user clicks it.
         - If the request is authenticated via JWT and the customer's email matches the subscribed email,
-          the subscription is auto-verified — no event is fired.
+          the subscription is auto-verified and no events are fired — the JWT already proves email
+          ownership, so no confirmation email is needed.
 
-        The optional `redirect_url` is where the verification token should land on the storefront. It is
-        validated against the store's [Allowed Origins](/developer/core-concepts/allowed-origins) and
-        silently dropped from the webhook payload if it does not match (secure-by-default).
+        The optional `redirect_url` is where the verification token should land on the storefront. The
+        server does not return a validation error when the URL is outside the store's
+        [Allowed Origins](/developer/core-concepts/allowed-origins); instead, the URL is silently
+        omitted from the webhook payload (secure-by-default). When no allow-list is configured on the
+        store, the URL is also omitted. Callers therefore receive the same 201 regardless, and the
+        webhook handler should fall back to the store's storefront URL when `redirect_url` is missing
+        from the payload.
 
         Newsletter consent is preserved across registration: if a guest subscribes and later registers
         with the same email, the existing subscriber record is reused.
@@ -47,7 +54,7 @@ RSpec.describe 'Newsletter Subscribers API', type: :request, swagger_doc: 'api-r
             type: :string,
             format: 'uri',
             example: 'https://your-store.com/newsletter/confirm',
-            description: 'Storefront URL the verification token should be appended to. Must be in the store\'s allowed origins.'
+            description: 'Storefront URL the verification token should be appended to. Silently omitted from the webhook payload when the store has allowed origins configured and this URL does not match one of them, or when no allowed origins are configured at all.'
           }
         },
         required: %w[email]

--- a/spree/api/spec/integration/spree/api/v3/store/newsletter_subscribers_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/newsletter_subscribers_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Newsletter Subscribers API', type: :request, swagger_doc: 'api-reference/store.yaml' do
+  include_context 'API v3 Store'
+
+  path '/api/v3/store/newsletter_subscribers' do
+    post 'Subscribe to the newsletter' do
+      tags 'Newsletter Subscribers'
+      consumes 'application/json'
+      produces 'application/json'
+      security [api_key: []]
+      description <<~DESC
+        Subscribes an email address to the newsletter for the current store.
+
+        Behavior:
+
+        - If the email is already verified for this store, the existing subscription is returned unchanged.
+        - If the request is unauthenticated (guest), the subscription is created in an unverified state
+          and a `newsletter_subscriber.subscription_requested` event is published containing the
+          `verification_token` and the validated `redirect_url`. Storefronts subscribe to this event
+          via a webhook to send the confirmation email; the link should point at
+          `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
+          when the user clicks it.
+        - If the request is authenticated via JWT and the customer's email matches the subscribed email,
+          the subscription is auto-verified — no event is fired.
+
+        The optional `redirect_url` is where the verification token should land on the storefront. It is
+        validated against the store's [Allowed Origins](/developer/core-concepts/allowed-origins) and
+        silently dropped from the webhook payload if it does not match (secure-by-default).
+
+        Newsletter consent is preserved across registration: if a guest subscribes and later registers
+        with the same email, the existing subscriber record is reused.
+      DESC
+
+      sdk_example 'newsletter-subscribers/create'
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+      parameter name: 'Authorization', in: :header, type: :string, required: false,
+                description: 'Optional Bearer JWT — when present, links the subscription to that customer'
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string, format: 'email', example: 'subscriber@example.com' },
+          redirect_url: {
+            type: :string,
+            format: 'uri',
+            example: 'https://your-store.com/newsletter/confirm',
+            description: 'Storefront URL the verification token should be appended to. Must be in the store\'s allowed origins.'
+          }
+        },
+        required: %w[email]
+      }
+
+      response '201', 'subscription created (or existing returned)' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { '' }
+        let(:body) { { email: 'subscriber@example.com' } }
+
+        schema '$ref' => '#/components/schemas/NewsletterSubscriber'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['email']).to eq('subscriber@example.com')
+          expect(data['verified']).to eq(false)
+          expect(data['id']).to be_present
+          expect(data['customer_id']).to be_nil
+        end
+      end
+
+      response '201', 'subscription created with a validated redirect_url' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { '' }
+        let(:body) do
+          {
+            email: 'subscriber@example.com',
+            redirect_url: 'https://storefront.example.com/newsletter/confirm'
+          }
+        end
+
+        before do
+          store.allowed_origins.create!(origin: 'https://storefront.example.com')
+        end
+
+        schema '$ref' => '#/components/schemas/NewsletterSubscriber'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['email']).to eq('subscriber@example.com')
+          expect(data['verified']).to eq(false)
+        end
+      end
+
+      response '201', 'subscription created but redirect_url is dropped (not in allowed origins)' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { '' }
+        let(:body) do
+          {
+            email: 'subscriber@example.com',
+            redirect_url: 'https://evil.example.com/phish'
+          }
+        end
+
+        before do
+          store.allowed_origins.create!(origin: 'https://storefront.example.com')
+        end
+
+        schema '$ref' => '#/components/schemas/NewsletterSubscriber'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          # Subscription itself succeeds; the redirect_url is silently dropped from
+          # the webhook event payload to prevent open-redirect / token-exfiltration.
+          expect(data['email']).to eq('subscriber@example.com')
+          expect(data['verified']).to eq(false)
+        end
+      end
+
+      response '201', 'auto-verified when JWT matches subscribed email' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { "Bearer #{jwt_token}" }
+        let(:body) { { email: user.email } }
+
+        schema '$ref' => '#/components/schemas/NewsletterSubscriber'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['email']).to eq(user.email)
+          expect(data['verified']).to eq(true)
+          expect(data['customer_id']).to eq(user.prefixed_id)
+        end
+      end
+
+      response '422', 'invalid email format' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { '' }
+        let(:body) { { email: 'not-an-email' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['error']['code']).to eq('validation_error')
+        end
+      end
+    end
+  end
+
+  path '/api/v3/store/newsletter_subscribers/verify' do
+    post 'Verify a newsletter subscription' do
+      tags 'Newsletter Subscribers'
+      consumes 'application/json'
+      produces 'application/json'
+      security [api_key: []]
+      description <<~DESC
+        Confirms a pending newsletter subscription using the verification token sent by email.
+
+        After successful verification:
+        - The subscriber record is marked verified.
+        - If the subscription is associated with a customer, that customer's `accepts_email_marketing`
+          flag is set to `true`.
+      DESC
+
+      sdk_example 'newsletter-subscribers/verify'
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          token: {
+            type: :string,
+            example: 'abc123def456',
+            description: 'Verification token from the confirmation email'
+          }
+        },
+        required: %w[token]
+      }
+
+      response '200', 'subscription verified' do
+        let(:'x-spree-api-key') { api_key.token }
+        let!(:subscriber) { create(:newsletter_subscriber, :unverified, email: 'pending@example.com', store: store) }
+        let(:body) { { token: subscriber.verification_token } }
+
+        schema '$ref' => '#/components/schemas/NewsletterSubscriber'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['email']).to eq('pending@example.com')
+          expect(data['verified']).to eq(true)
+          expect(data['verified_at']).to be_present
+        end
+      end
+
+      response '422', 'invalid or expired token' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:body) { { token: 'not-a-real-token' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['error']['code']).to eq('invalid_token')
+        end
+      end
+
+      response '422', 'missing token' do
+        let(:'x-spree-api-key') { api_key.token }
+        let(:body) { {} }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['error']['code']).to eq('parameter_missing')
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/swagger_helper.rb
+++ b/spree/api/spec/swagger_helper.rb
@@ -75,6 +75,7 @@ RSpec.configure do |config|
         { name: 'Customers', description: 'Customer account, addresses, saved payment methods, and order history' },
         { name: 'Markets', description: 'Markets, countries, currencies, and locales' },
         { name: 'Wishlists', description: 'Customer wishlists' },
+        { name: 'Newsletter Subscribers', description: 'Guest and customer newsletter subscriptions (double opt-in)' },
         { name: 'Policies', description: 'Store policies (return policy, privacy policy, terms of service)' },
         { name: 'Digitals', description: 'Digital product downloads' }
       ],
@@ -86,6 +87,7 @@ RSpec.configure do |config|
         { name: 'Customers', tags: ['Customers'] },
         { name: 'Markets', tags: ['Markets'] },
         { name: 'Wishlists', tags: ['Wishlists'] },
+        { name: 'Newsletter Subscribers', tags: ['Newsletter Subscribers'] },
         { name: 'Policies', tags: ['Policies'] },
         { name: 'Digitals', tags: ['Digitals'] }
       ],

--- a/spree/core/app/models/spree/newsletter_subscriber.rb
+++ b/spree/core/app/models/spree/newsletter_subscriber.rb
@@ -55,10 +55,15 @@ module Spree
       Spree::CSV::NewsletterSubscriberPresenter.new(self).call
     end
 
-    def self.subscribe(email:, user: nil, store: nil)
+    def self.subscribe(email:, user: nil, store: nil, redirect_url: nil)
       store ||= Spree::Current.store
 
-      Spree::Newsletter::Subscribe.new(email: email, current_user: user, current_store: store).call
+      Spree::Newsletter::Subscribe.new(
+        email: email,
+        current_user: user,
+        current_store: store,
+        redirect_url: redirect_url
+      ).call
     end
 
     def self.verify(token:)

--- a/spree/core/app/services/spree/newsletter/link_user.rb
+++ b/spree/core/app/services/spree/newsletter/link_user.rb
@@ -1,0 +1,53 @@
+module Spree
+  module Newsletter
+    # Reconciles a Spree::NewsletterSubscriber with the customer who owns the email.
+    # Backfills the user link and propagates verified opt-in onto the user record so
+    # consent given before account creation isn't silently lost on registration.
+    #
+    # Best-effort: validation failures are logged but never re-raised. Callers are
+    # already past the point where rolling back makes sense (the user record exists,
+    # the subscription exists). This is reconciliation, not a precondition.
+    class LinkUser
+      def initialize(subscriber:, user:)
+        @subscriber = subscriber
+        @user = user
+      end
+
+      def call
+        return if subscriber.blank? || user.blank?
+        return if subscriber.user_id == user.id && !needs_marketing_propagation?
+
+        link_subscriber_to_user
+        propagate_marketing_consent if needs_marketing_propagation?
+
+        subscriber
+      end
+
+      private
+
+      attr_reader :subscriber, :user
+
+      def link_subscriber_to_user
+        return if subscriber.user_id == user.id
+
+        return if subscriber.update(user: user)
+
+        Rails.logger.warn(
+          "NewsletterSubscriber #{subscriber.id} link to user #{user.id} failed: #{subscriber.errors.full_messages.to_sentence}"
+        )
+      end
+
+      def needs_marketing_propagation?
+        subscriber.verified? && !user.accepts_email_marketing?
+      end
+
+      def propagate_marketing_consent
+        return if user.update(accepts_email_marketing: true)
+
+        Rails.logger.warn(
+          "User #{user.id} accepts_email_marketing update failed: #{user.errors.full_messages.to_sentence}"
+        )
+      end
+    end
+  end
+end

--- a/spree/core/app/services/spree/newsletter/subscribe.rb
+++ b/spree/core/app/services/spree/newsletter/subscribe.rb
@@ -1,10 +1,11 @@
 module Spree
   module Newsletter
     class Subscribe
-      def initialize(email:, current_user: nil, current_store: nil)
+      def initialize(email:, current_user: nil, current_store: nil, redirect_url: nil)
         @email = email
         @current_user = current_user
         @current_store = current_store || Spree::Store.current
+        @redirect_url = redirect_url
       end
 
       def call
@@ -20,14 +21,38 @@ module Spree
           end
         end
 
-        # publish event to trigger email delivery via subscriber
-        subscriber.publish_event('newsletter_subscriber.subscribed') unless subscriber.verified?
+        publish_subscription_events unless subscriber.verified?
         subscriber
       end
 
       private
 
-      attr_reader :email, :current_user, :current_store
+      attr_reader :email, :current_user, :current_store, :redirect_url
+
+      def publish_subscription_events
+        subscriber.publish_event(
+          'newsletter_subscriber.subscription_requested',
+          subscription_requested_payload
+        )
+
+        # Legacy lifecycle event — kept for the bundled Spree::NewsletterMailer
+        # subscriber. Headless storefronts should listen to
+        # `newsletter_subscriber.subscription_requested` instead since it carries
+        # the verification_token and validated redirect_url.
+        subscriber.publish_event('newsletter_subscriber.subscribed')
+      end
+
+      def subscription_requested_payload
+        payload = {
+          id: subscriber.prefixed_id,
+          email: subscriber.email,
+          verification_token: subscriber.verification_token,
+          store_id: subscriber.store&.prefixed_id,
+          customer_id: subscriber.user&.prefixed_id
+        }
+        payload[:redirect_url] = redirect_url if redirect_url.present?
+        payload
+      end
 
       def upsert_subscriber
         @upsert_subscriber ||= Spree::NewsletterSubscriber.find_or_create_by(email: email, store: current_store) do |new_record|

--- a/spree/core/app/services/spree/newsletter/subscribe.rb
+++ b/spree/core/app/services/spree/newsletter/subscribe.rb
@@ -9,19 +9,24 @@ module Spree
       end
 
       def call
-        return existed_subscription if existed_subscription.present?
+        if existed_subscription.present?
+          Spree::Newsletter::LinkUser.new(subscriber: existed_subscription, user: known_user).call
+          return existed_subscription
+        end
 
         ActiveRecord::Base.transaction do
           upsert_subscriber
           return subscriber if subscriber.errors.any?
 
+          Spree::Newsletter::LinkUser.new(subscriber: subscriber, user: known_user).call
+
           if subscriber.email == current_user&.email
-            # no need to verified since user email is already verified
+            # User's email is already verified by login — skip the double opt-in.
             Spree::Newsletter::Verify.new(subscriber: subscriber).call
           end
         end
 
-        publish_subscription_events unless subscriber.verified?
+        subscriber.publish_event('newsletter_subscriber.subscription_requested', subscription_requested_payload) unless subscriber.verified?
         subscriber
       end
 
@@ -29,25 +34,12 @@ module Spree
 
       attr_reader :email, :current_user, :current_store, :redirect_url
 
-      def publish_subscription_events
-        subscriber.publish_event(
-          'newsletter_subscriber.subscription_requested',
-          subscription_requested_payload
-        )
-
-        # Legacy lifecycle event — kept for the bundled Spree::NewsletterMailer
-        # subscriber. Headless storefronts should listen to
-        # `newsletter_subscriber.subscription_requested` instead since it carries
-        # the verification_token and validated redirect_url.
-        subscriber.publish_event('newsletter_subscriber.subscribed')
-      end
-
       def subscription_requested_payload
         payload = {
           id: subscriber.prefixed_id,
           email: subscriber.email,
           verification_token: subscriber.verification_token,
-          store_id: subscriber.store&.prefixed_id,
+          store_id: current_store.prefixed_id,
           customer_id: subscriber.user&.prefixed_id
         }
         payload[:redirect_url] = redirect_url if redirect_url.present?
@@ -56,13 +48,17 @@ module Spree
 
       def upsert_subscriber
         @upsert_subscriber ||= Spree::NewsletterSubscriber.find_or_create_by(email: email, store: current_store) do |new_record|
-          new_record.user = Spree.user_class.find_by(email: new_record.email) || current_user
+          new_record.user = known_user
         end
       end
       alias_method :subscriber, :upsert_subscriber
 
       def existed_subscription
         @existed_subscription ||= Spree::NewsletterSubscriber.verified.find_by(email: email, store: current_store)
+      end
+
+      def known_user
+        @known_user ||= current_user || Spree.user_class.find_by(email: email)
       end
     end
   end

--- a/spree/core/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/spree/core/spec/models/spree/newsletter_subscriber_spec.rb
@@ -73,7 +73,7 @@ describe Spree::NewsletterSubscriber, type: :model, newsletter: true do
       let(:store) { create(:store) }
 
       before do
-        allow(Spree::Newsletter::Subscribe).to receive(:new).with(email: email, current_user: user, current_store: store).and_return(subscribe_service)
+        allow(Spree::Newsletter::Subscribe).to receive(:new).with(email: email, current_user: user, current_store: store, redirect_url: nil).and_return(subscribe_service)
       end
 
       it 'calls subscribe service' do
@@ -90,7 +90,7 @@ describe Spree::NewsletterSubscriber, type: :model, newsletter: true do
 
       before do
         allow(Spree::Current).to receive(:store).and_return(current_store)
-        allow(Spree::Newsletter::Subscribe).to receive(:new).with(email: email, current_user: nil, current_store: current_store).and_return(subscribe_service)
+        allow(Spree::Newsletter::Subscribe).to receive(:new).with(email: email, current_user: nil, current_store: current_store, redirect_url: nil).and_return(subscribe_service)
       end
 
       it 'calls subscribe service' do

--- a/spree/core/spec/services/spree/newsletter/subscribe_spec.rb
+++ b/spree/core/spec/services/spree/newsletter/subscribe_spec.rb
@@ -32,7 +32,6 @@ module Spree
 
       it 'does not publish any subscription events' do
         expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
-        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscribed')
 
         service
       end
@@ -79,13 +78,6 @@ module Spree
         expect(published[:payload]).not_to have_key(:redirect_url)
       end
 
-      it 'also publishes the legacy subscribed lifecycle event' do
-        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
-        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscribed')
-
-        service
-      end
-
       it 'returns an instance of NewsletterSubscriber' do
         expect(service).to be_a(NewsletterSubscriber)
       end
@@ -123,9 +115,17 @@ module Spree
 
       it 'does not publish any subscription events' do
         expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
-        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscribed')
 
         service
+      end
+
+      context 'when a logged in user matches the subscription email' do
+        let(:user) { create(:user, email: email, accepts_email_marketing: false) }
+
+        it 'links the existing subscriber to the user and preserves consent' do
+          expect(service.user).to eq(user)
+          expect(user.reload.accepts_email_marketing).to eq(true)
+        end
       end
     end
 
@@ -142,9 +142,18 @@ module Spree
 
       it 'publishes the subscription_requested event so the email is re-dispatched' do
         expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything).once
-        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscribed').once
 
         service
+      end
+
+      context 'when a logged in user matches the subscription email' do
+        let(:user) { create(:user, email: email, accepts_email_marketing: false) }
+
+        it 'links and verifies the existing subscriber' do
+          expect(service.user).to eq(user)
+          expect(service.reload).to be_verified
+          expect(user.reload.accepts_email_marketing).to eq(true)
+        end
       end
     end
 

--- a/spree/core/spec/services/spree/newsletter/subscribe_spec.rb
+++ b/spree/core/spec/services/spree/newsletter/subscribe_spec.rb
@@ -8,13 +8,15 @@ module Spree
       {
         email: email,
         current_user: user,
-        current_store: store
+        current_store: store,
+        redirect_url: redirect_url
       }
     end
 
     let(:email) { 'foo@example.com' }
     let(:user) { nil }
     let(:store) { nil }
+    let(:redirect_url) { nil }
     let(:default_store) { @default_store || create(:store) }
 
     before do
@@ -28,7 +30,8 @@ module Spree
         expect(service.errors).to be_present
       end
 
-      it 'does not send a confirmation email' do
+      it 'does not publish any subscription events' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
         expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscribed')
 
         service
@@ -47,8 +50,8 @@ module Spree
         expect(service).to be_a(NewsletterSubscriber)
       end
 
-      it 'does not send a confirmation email' do
-        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscribed')
+      it 'does not publish subscription_requested (auto-verified)' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
 
         service
       end
@@ -62,8 +65,23 @@ module Spree
       let(:user) { create(:user) }
       let(:email) { 'test@example.com' }
 
-      it 'sends a confirmation email' do
-        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscribed').once
+      it 'publishes subscription_requested with the verification token' do
+        published = nil
+        allow_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event) do |sub, name, payload = nil|
+          published = { name: name, payload: payload } if name == 'newsletter_subscriber.subscription_requested'
+        end
+
+        service
+
+        expect(published).to be_present
+        expect(published[:payload][:email]).to eq('test@example.com')
+        expect(published[:payload][:verification_token]).to be_present
+        expect(published[:payload]).not_to have_key(:redirect_url)
+      end
+
+      it 'also publishes the legacy subscribed lifecycle event' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
+        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscribed')
 
         service
       end
@@ -74,6 +92,21 @@ module Spree
 
       it 'creates a new unverified subscriber' do
         expect { service }.to change { Spree::NewsletterSubscriber.unverified.count }.by(1)
+      end
+    end
+
+    context 'when a redirect_url is provided' do
+      let(:redirect_url) { 'https://storefront.example.com/newsletter/confirm' }
+
+      it 'forwards redirect_url in the subscription_requested payload' do
+        published = nil
+        allow_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event) do |sub, name, payload = nil|
+          published = payload if name == 'newsletter_subscriber.subscription_requested'
+        end
+
+        service
+
+        expect(published[:redirect_url]).to eq(redirect_url)
       end
     end
 
@@ -88,7 +121,8 @@ module Spree
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
       end
 
-      it 'does not send a confirmation email' do
+      it 'does not publish any subscription events' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything)
         expect_any_instance_of(Spree::NewsletterSubscriber).not_to receive(:publish_event).with('newsletter_subscriber.subscribed')
 
         service
@@ -106,7 +140,8 @@ module Spree
         expect { service }.not_to change(Spree::NewsletterSubscriber, :count)
       end
 
-      it 'sends a confirmation email' do
+      it 'publishes the subscription_requested event so the email is re-dispatched' do
+        expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscription_requested', anything).once
         expect_any_instance_of(Spree::NewsletterSubscriber).to receive(:publish_event).with('newsletter_subscriber.subscribed').once
 
         service

--- a/spree/emails/app/mailers/spree/newsletter_mailer.rb
+++ b/spree/emails/app/mailers/spree/newsletter_mailer.rb
@@ -1,10 +1,22 @@
 module Spree
   class NewsletterMailer < BaseMailer
-    def email_confirmation(subscriber)
+    # @param subscriber [Spree::NewsletterSubscriber]
+    # @param redirect_url [String, nil] Storefront page that handles the verification token.
+    #   When provided, the link is built as `<redirect_url>?token=<verification_token>`.
+    #   Falls back to `<store.storefront_url>/?token=<verification_token>` for legacy setups.
+    def email_confirmation(subscriber, redirect_url: nil)
       @subscriber = subscriber
       store = subscriber.store || Spree::Current.store || Spree::Store.default
-      @confirm_email_url = spree.verify_newsletter_subscribers_url(token: @subscriber.verification_token, host: store.storefront_url)
+      base_url = redirect_url.presence || store.storefront_url
+      @confirm_email_url = append_token(base_url, @subscriber.verification_token)
       mail(to: @subscriber.email, from: from_address, subject: Spree.t('newsletter_mailer.email_confirmation.subject'))
+    end
+
+    private
+
+    def append_token(url, token)
+      separator = url.include?('?') ? '&' : '?'
+      "#{url}#{separator}token=#{CGI.escape(token.to_s)}"
     end
   end
 end

--- a/spree/emails/app/mailers/spree/newsletter_mailer.rb
+++ b/spree/emails/app/mailers/spree/newsletter_mailer.rb
@@ -1,9 +1,5 @@
 module Spree
   class NewsletterMailer < BaseMailer
-    # @param subscriber [Spree::NewsletterSubscriber]
-    # @param redirect_url [String, nil] Storefront page that handles the verification token.
-    #   When provided, the link is built as `<redirect_url>?token=<verification_token>`.
-    #   Falls back to `<store.storefront_url>/?token=<verification_token>` for legacy setups.
     def email_confirmation(subscriber, redirect_url: nil)
       @subscriber = subscriber
       store = subscriber.store || Spree::Current.store || Spree::Store.default
@@ -14,7 +10,15 @@ module Spree
 
     private
 
+    # URI-based merge preserves existing query params and fragments so the token
+    # doesn't get swallowed by a `#section` or clobber an existing `?source=`.
     def append_token(url, token)
+      uri = URI.parse(url.to_s)
+      params = URI.decode_www_form(uri.query || '')
+      params << ['token', token.to_s]
+      uri.query = URI.encode_www_form(params)
+      uri.to_s
+    rescue URI::InvalidURIError
       separator = url.include?('?') ? '&' : '?'
       "#{url}#{separator}token=#{CGI.escape(token.to_s)}"
     end

--- a/spree/emails/app/subscribers/spree/newsletter_subscriber_email_subscriber.rb
+++ b/spree/emails/app/subscribers/spree/newsletter_subscriber_email_subscriber.rb
@@ -2,7 +2,11 @@
 
 module Spree
   class NewsletterSubscriberEmailSubscriber < Spree::Subscriber
-    subscribes_to 'newsletter_subscriber.subscribed'
+    # Listens to the `subscription_requested` event because that's where the
+    # validated storefront `redirect_url` is carried. The mailer needs that URL
+    # (or falls back to `store.storefront_url`) to build a verification link
+    # that actually points to the storefront's confirmation page.
+    subscribes_to 'newsletter_subscriber.subscription_requested'
 
     def handle(event)
       subscriber = find_subscriber(event)
@@ -12,7 +16,7 @@ module Spree
       store = subscriber.store || Spree::Current.store || Spree::Store.default
       return unless store.prefers_send_consumer_transactional_emails?
 
-      NewsletterMailer.email_confirmation(subscriber).deliver_later
+      NewsletterMailer.email_confirmation(subscriber, redirect_url: event.payload['redirect_url']).deliver_later
     end
 
     private

--- a/spree/emails/app/subscribers/spree/newsletter_subscriber_email_subscriber.rb
+++ b/spree/emails/app/subscribers/spree/newsletter_subscriber_email_subscriber.rb
@@ -2,10 +2,6 @@
 
 module Spree
   class NewsletterSubscriberEmailSubscriber < Spree::Subscriber
-    # Listens to the `subscription_requested` event because that's where the
-    # validated storefront `redirect_url` is carried. The mailer needs that URL
-    # (or falls back to `store.storefront_url`) to build a verification link
-    # that actually points to the storefront's confirmation page.
     subscribes_to 'newsletter_subscriber.subscription_requested'
 
     def handle(event)

--- a/spree/emails/spec/mailers/spree/newsletter_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/newsletter_mailer_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Spree::NewsletterMailer, type: :mailer do
+  let(:store) { @default_store }
+  let(:subscriber) { create(:newsletter_subscriber, :unverified, email: 'guest@example.com', store: store) }
+
+  describe '#email_confirmation' do
+    context 'when a redirect_url is provided' do
+      it 'builds the confirmation link from the redirect URL with the verification token appended' do
+        message = described_class.email_confirmation(subscriber, redirect_url: 'https://storefront.example.com/newsletter/confirm')
+
+        expect(message.body.encoded).to include("https://storefront.example.com/newsletter/confirm?token=#{subscriber.verification_token}")
+      end
+
+      it 'merges the token into an existing query string instead of appending a new one' do
+        message = described_class.email_confirmation(subscriber, redirect_url: 'https://storefront.example.com/newsletter/confirm?source=footer')
+
+        expect(message.body.encoded).to include("https://storefront.example.com/newsletter/confirm?source=footer&amp;token=#{subscriber.verification_token}")
+      end
+    end
+
+    context 'when no redirect_url is provided' do
+      it 'falls back to the store storefront URL' do
+        message = described_class.email_confirmation(subscriber)
+
+        expect(message.body.encoded).to include(store.storefront_url.to_s)
+        expect(message.body.encoded).to include("token=#{subscriber.verification_token}")
+      end
+    end
+
+    it 'sends the email to the subscriber' do
+      message = described_class.email_confirmation(subscriber)
+
+      expect(message.to).to eq([subscriber.email])
+    end
+  end
+end

--- a/spree/emails/spec/mailers/spree/newsletter_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/newsletter_mailer_spec.rb
@@ -17,6 +17,18 @@ describe Spree::NewsletterMailer, type: :mailer do
 
         expect(message.body.encoded).to include("https://storefront.example.com/newsletter/confirm?source=footer&amp;token=#{subscriber.verification_token}")
       end
+
+      it 'preserves a URL fragment when appending the token' do
+        message = described_class.email_confirmation(
+          subscriber,
+          redirect_url: 'https://storefront.example.com/account#newsletter'
+        )
+
+        # The token belongs in the query string, not after the fragment.
+        expect(message.body.encoded).to include(
+          "https://storefront.example.com/account?token=#{subscriber.verification_token}#newsletter"
+        )
+      end
     end
 
     context 'when no redirect_url is provided' do

--- a/spree/emails/spec/subscribers/spree/newsletter_subscriber_email_subscriber_spec.rb
+++ b/spree/emails/spec/subscribers/spree/newsletter_subscriber_email_subscriber_spec.rb
@@ -7,19 +7,29 @@ RSpec.describe Spree::NewsletterSubscriberEmailSubscriber do
   let(:newsletter_subscriber) { create(:newsletter_subscriber, store: store) }
   let(:subscriber) { described_class.new }
 
-  def mock_event(newsletter_subscriber)
-    double('Event', payload: { 'id' => newsletter_subscriber.prefixed_id })
+  def mock_event(newsletter_subscriber, redirect_url: nil)
+    payload = { 'id' => newsletter_subscriber.prefixed_id }
+    payload['redirect_url'] = redirect_url if redirect_url
+    double('Event', payload: payload)
   end
 
   before do
     store.update!(preferences: store.preferences.merge(send_consumer_transactional_emails: true))
   end
 
-  describe 'newsletter_subscriber.subscribed event' do
-    it 'sends email confirmation' do
-      expect(Spree::NewsletterMailer).to receive(:email_confirmation).with(newsletter_subscriber).and_return(double(deliver_later: true))
+  describe 'newsletter_subscriber.subscription_requested event' do
+    it 'sends email confirmation without a redirect URL when none is provided' do
+      expect(Spree::NewsletterMailer).to receive(:email_confirmation).with(newsletter_subscriber, redirect_url: nil).and_return(double(deliver_later: true))
 
       subscriber.handle(mock_event(newsletter_subscriber))
+    end
+
+    it 'forwards the redirect URL from the event payload' do
+      expect(Spree::NewsletterMailer).to receive(:email_confirmation).
+        with(newsletter_subscriber, redirect_url: 'https://storefront.example.com/newsletter/confirm').
+        and_return(double(deliver_later: true))
+
+      subscriber.handle(mock_event(newsletter_subscriber, redirect_url: 'https://storefront.example.com/newsletter/confirm'))
     end
 
     context 'when subscriber is already verified' do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Admin API endpoints and updates the `Customer` schema, which may impact generated clients/typings and consumers expecting the previous OpenAPI contract. Remaining changes are example payload churn with low behavioral risk.
> 
> **Overview**
> **Admin API OpenAPI spec updates (`docs/api-reference/admin.yaml`)**: documents two new endpoints, `POST /api/v3/admin/customers/bulk_add_to_groups` and `POST /api/v3/admin/customers/bulk_remove_from_groups`, including request/response shapes, required scope (`write_customers`), and SDK code samples.
> 
> Updates the `Customer` schema to include a `customer_groups` array of `CustomerGroup` references. Also refreshes numerous example values/timestamps/tokens across existing endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278eab9a1a3cd6ba15cca2ce04fcadda6bf04500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->