### PR TITLE
Standardize row actions in Admin SPA tables

### DIFF
--- a/packages/admin/e2e/customer-groups.spec.ts
+++ b/packages/admin/e2e/customer-groups.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
-import { gotoIndex, login, rowButton } from './helpers'
+import { gotoIndex, login, openRowMenu, rowButton } from './helpers'
 
 const CUSTOMER_GROUPS_PATH = (storeId: string) => `/${storeId}/customers/groups`
 const CTA = /add customer group/i
@@ -78,10 +78,9 @@ test.describe('customer groups', () => {
     await createCustomerGroup(page, { name })
     await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
 
-    await rowButton(page, name).click()
-    await expect(page.getByRole('heading', { name })).toBeVisible({ timeout: 15_000 })
-
-    await page.getByRole('button', { name: /^delete$/i }).click()
+    // Delete now lives on the per-row kebab menu, not inside the edit sheet.
+    await openRowMenu(page, name)
+    await page.getByRole('menuitem', { name: /^delete$/i }).click()
     await expect(page.getByRole('heading', { name: /delete customer group\?/i })).toBeVisible()
     await page
       .getByRole('dialog')

--- a/packages/admin/e2e/customers.spec.ts
+++ b/packages/admin/e2e/customers.spec.ts
@@ -152,9 +152,10 @@ test.describe('customers', () => {
     // Regression guard for the TanStack Query cross-resource invalidation bug.
     await page.goto(`/${creds.store_id}/customers/groups`)
     const groupRow = page.locator('tr').filter({ hasText: FIXTURE_PROMO_CUSTOMER_GROUP })
-    // The count is the last <td> in the row. Poll until it reads ≥ 2.
+    // The customers_count is column index 1 (0=name, 1=count, trailing kebab
+    // doesn't count toward the data columns we care about). Poll until ≥ 2.
     await expect
-      .poll(async () => Number((await groupRow.locator('td').last().innerText()).trim()), {
+      .poll(async () => Number((await groupRow.locator('td').nth(1).innerText()).trim()), {
         timeout: 15_000,
       })
       .toBeGreaterThanOrEqual(2)

--- a/packages/admin/e2e/gift-cards.spec.ts
+++ b/packages/admin/e2e/gift-cards.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
-import { gotoIndex, login, rowButton } from './helpers'
+import { gotoIndex, login, openRowMenu, rowButton } from './helpers'
 
 const GIFT_CARDS_PATH = (storeId: string) => `/${storeId}/promotions/gift-cards`
 const CTA = /new gift card/i
@@ -91,10 +91,9 @@ test.describe('gift cards', () => {
     await createGiftCard(page, { amount: '10.00', code })
     await expect(rowButton(page, code)).toBeVisible({ timeout: 15_000 })
 
-    await rowButton(page, code).click()
-    await expect(page.getByRole('heading', { name: code })).toBeVisible({ timeout: 15_000 })
-
-    await page.getByRole('button', { name: /^delete$/i }).click()
+    // Delete now lives on the row-action kebab.
+    await openRowMenu(page, code)
+    await page.getByRole('menuitem', { name: /^delete$/i }).click()
     await expect(page.getByRole('heading', { name: /delete gift card\?/i })).toBeVisible()
     await page
       .getByRole('dialog')

--- a/packages/admin/e2e/helpers.ts
+++ b/packages/admin/e2e/helpers.ts
@@ -77,6 +77,19 @@ export async function gotoIndex(page: Page, path: string, ctaButtonName: RegExp)
 }
 
 /**
+ * Open the row-action kebab menu for the row whose cell text contains
+ * `rowText`. Mirrors the universal `admin.row_actions.menu_label` aria-label
+ * ("Open actions") across every resource table.
+ */
+export async function openRowMenu(page: Page, rowText: string) {
+  await page
+    .locator('tr')
+    .filter({ hasText: rowText })
+    .getByRole('button', { name: /open actions/i })
+    .click()
+}
+
+/**
  * Locator for the `<ResourceNameCell>` button on a resource index table.
  * The cell's accessible name is `"<name> <secondary?>"` and a sibling icon
  * `<Button aria-label="Edit <name>">` may exist, so we anchor with `^` plus

--- a/packages/admin/e2e/option-types.spec.ts
+++ b/packages/admin/e2e/option-types.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
-import { gotoIndex, login, rowButton } from './helpers'
+import { gotoIndex, login, openRowMenu, rowButton } from './helpers'
 
 const OPTIONS_PATH = (storeId: string) => `/${storeId}/products/options`
 const CTA = /add option type/i
@@ -103,10 +103,9 @@ test.describe('option types', () => {
     await createOptionType(page, { internalName, label })
     await expect(rowButton(page, internalName)).toBeVisible({ timeout: 15_000 })
 
-    await rowButton(page, internalName).click()
-    await expect(page.getByRole('heading', { name: internalName })).toBeVisible({ timeout: 15_000 })
-
-    await page.getByRole('button', { name: /^delete$/i }).click()
+    // Delete now lives on the row-action kebab.
+    await openRowMenu(page, internalName)
+    await page.getByRole('menuitem', { name: /^delete$/i }).click()
     await expect(page.getByRole('heading', { name: /delete option type\?/i })).toBeVisible()
     await page
       .getByRole('dialog')

--- a/packages/admin/e2e/payment-methods.spec.ts
+++ b/packages/admin/e2e/payment-methods.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
-import { gotoIndex, login, rowButton } from './helpers'
+import { gotoIndex, login, openRowMenu, rowButton } from './helpers'
 
 const PAYMENT_METHODS_PATH = (storeId: string) => `/${storeId}/settings/payment-methods`
 const CTA = /add payment method/i
@@ -94,10 +94,9 @@ test.describe('payment methods', () => {
     await page.getByRole('button', { name: /create payment method/i }).click()
     await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
 
-    await rowButton(page, name).click()
-    await expect(page.getByRole('heading', { name })).toBeVisible({ timeout: 15_000 })
-
-    await page.getByRole('button', { name: /^delete$/i }).click()
+    // Delete now lives on the row-action kebab.
+    await openRowMenu(page, name)
+    await page.getByRole('menuitem', { name: /^delete$/i }).click()
     await expect(page.getByRole('heading', { name: /delete payment method\?/i })).toBeVisible()
     await page
       .getByRole('dialog')

--- a/packages/admin/e2e/stock-locations.spec.ts
+++ b/packages/admin/e2e/stock-locations.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
-import { gotoIndex, login, rowButton } from './helpers'
+import { gotoIndex, login, openRowMenu, rowButton } from './helpers'
 
 const STOCK_LOCATIONS_PATH = (storeId: string) => `/${storeId}/settings/stock-locations`
 const CTA = /add stock location/i
@@ -56,10 +56,9 @@ test.describe('stock locations', () => {
     await createStockLocation(page, name)
     await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
 
-    await rowButton(page, name).click()
-    await expect(page.getByRole('heading', { name })).toBeVisible({ timeout: 15_000 })
-
-    await page.getByRole('button', { name: /^delete$/i }).click()
+    // Delete now lives on the row-action kebab.
+    await openRowMenu(page, name)
+    await page.getByRole('menuitem', { name: /^delete$/i }).click()
     await expect(page.getByRole('heading', { name: /delete stock location\?/i })).toBeVisible()
     await page
       .getByRole('dialog')

--- a/packages/admin/e2e/tax-categories.spec.ts
+++ b/packages/admin/e2e/tax-categories.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
-import { gotoIndex, login, rowButton } from './helpers'
+import { gotoIndex, login, openRowMenu, rowButton } from './helpers'
 
 const TAX_CATEGORIES_PATH = (storeId: string) => `/${storeId}/settings/tax-categories`
 const CTA = /add tax category/i
@@ -67,10 +67,9 @@ test.describe('tax categories', () => {
     await createTaxCategory(page, { name })
     await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
 
-    await rowButton(page, name).click()
-    await expect(page.getByRole('heading', { name })).toBeVisible({ timeout: 15_000 })
-
-    await page.getByRole('button', { name: /^delete$/i }).click()
+    // Delete now lives on the row-action kebab.
+    await openRowMenu(page, name)
+    await page.getByRole('menuitem', { name: /^delete$/i }).click()
     await expect(page.getByRole('heading', { name: /delete tax category\?/i })).toBeVisible()
     await page
       .getByRole('dialog')

--- a/packages/admin/src/components/spree/bulk-action-bar.tsx
+++ b/packages/admin/src/components/spree/bulk-action-bar.tsx
@@ -2,6 +2,7 @@ import type { QueryKey } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { Button } from '@/components/ui/button'
@@ -86,6 +87,7 @@ function interpolate(template: string, n: number) {
 }
 
 export function BulkActionBar({ selectedIds, actions, onClear, onDone }: BulkActionBarProps) {
+  const { t } = useTranslation()
   const confirm = useConfirm()
   const queryClient = useQueryClient()
   const { permissions } = usePermissions()
@@ -122,10 +124,16 @@ export function BulkActionBar({ selectedIds, actions, onClear, onDone }: BulkAct
       for (const key of action.invalidate ?? []) {
         queryClient.invalidateQueries({ queryKey: key })
       }
-      toast.success(interpolate(action.successMessage ?? 'Updated {n} records', count))
+      toast.success(
+        interpolate(
+          action.successMessage ?? t('admin.components.bulk_action_bar.default_success'),
+          count,
+        ),
+      )
       onDone()
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Bulk operation failed'
+      const message =
+        err instanceof Error ? err.message : t('admin.components.bulk_action_bar.default_error')
       toast.error(action.errorMessage ?? message)
     } finally {
       setRunning(false)
@@ -155,7 +163,9 @@ export function BulkActionBar({ selectedIds, actions, onClear, onDone }: BulkAct
       {/* Sticky bar above the table body. Stays at the bottom of the viewport
           when the table is long, so the action set is always reachable. */}
       <div className="sticky bottom-4 z-20 mx-4 my-3 flex items-center gap-2 rounded-lg border bg-popover px-3 py-2 shadow-md">
-        <span className="text-sm font-medium">{count} selected</span>
+        <span className="text-sm font-medium">
+          {t('admin.components.bulk_action_bar.selected', { count })}
+        </span>
         <Button
           type="button"
           variant="ghost"
@@ -163,7 +173,7 @@ export function BulkActionBar({ selectedIds, actions, onClear, onDone }: BulkAct
           onClick={onClear}
           className="text-muted-foreground"
         >
-          Clear
+          {t('admin.actions.clear')}
         </Button>
         <div className="ml-auto flex flex-wrap items-center gap-1">
           {visibleActions.map((action) => (

--- a/packages/admin/src/components/spree/command-palette/command-palette.tsx
+++ b/packages/admin/src/components/spree/command-palette/command-palette.tsx
@@ -58,12 +58,12 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
   const q = input.trim().toLowerCase()
   const matches = (label: string) => !q || label.toLowerCase().includes(q)
   const gotoItems = [
-    { label: 'Dashboard', icon: HomeIcon, to: '/$storeId' as const },
-    { label: 'Products', icon: PackageIcon, to: '/$storeId/products' as const },
-    { label: 'Orders', icon: ShoppingCartIcon, to: '/$storeId/orders' as const },
-    { label: 'Customers', icon: UsersIcon, to: '/$storeId/customers' as const },
-  ].filter((c) => matches(`Go to ${c.label}`))
-  const showLogout = matches('Log out')
+    { label: t('admin.nav.home'), icon: HomeIcon, to: '/$storeId' as const },
+    { label: t('admin.nav.products'), icon: PackageIcon, to: '/$storeId/products' as const },
+    { label: t('admin.nav.orders'), icon: ShoppingCartIcon, to: '/$storeId/orders' as const },
+    { label: t('admin.nav.customers'), icon: UsersIcon, to: '/$storeId/customers' as const },
+  ].filter((c) => matches(t('admin.components.command_palette.goto_label', { label: c.label })))
+  const showLogout = matches(t('admin.auth.logout'))
   const hasResults = products.length > 0 || orders.length > 0 || customers.length > 0
 
   return (
@@ -74,10 +74,8 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
       }}
     >
       <DialogHeader className="sr-only">
-        <DialogTitle>Search and commands</DialogTitle>
-        <DialogDescription>
-          Search across products, orders, and customers, or run a command.
-        </DialogDescription>
+        <DialogTitle>{t('admin.components.command_palette.title')}</DialogTitle>
+        <DialogDescription>{t('admin.components.command_palette.description')}</DialogDescription>
       </DialogHeader>
       <DialogContent
         className="top-1/3 translate-y-0 overflow-hidden p-0 sm:max-w-2xl"
@@ -104,7 +102,7 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
             />
 
             {products.length > 0 && (
-              <CommandGroup heading="Products">
+              <CommandGroup heading={t('admin.nav.products')}>
                 {products.map((p) => (
                   <CommandItem
                     key={p.id}
@@ -126,7 +124,7 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
             )}
 
             {orders.length > 0 && (
-              <CommandGroup heading="Orders">
+              <CommandGroup heading={t('admin.nav.orders')}>
                 {orders.map((o) => (
                   <CommandItem
                     key={o.id}
@@ -151,7 +149,7 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
             )}
 
             {customers.length > 0 && (
-              <CommandGroup heading="Customers">
+              <CommandGroup heading={t('admin.nav.customers')}>
                 {customers.map((c) => (
                   <CommandItem
                     key={c.id}
@@ -177,7 +175,7 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
             {hasResults && (gotoItems.length > 0 || showLogout) && <CommandSeparator />}
 
             {gotoItems.length > 0 && (
-              <CommandGroup heading="Go to">
+              <CommandGroup heading={t('admin.components.command_palette.goto')}>
                 {gotoItems.map(({ label, icon: Icon, to }) => (
                   <CommandItem
                     key={to}
@@ -197,7 +195,7 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
             {gotoItems.length > 0 && showLogout && <CommandSeparator />}
 
             {showLogout && (
-              <CommandGroup heading="Account">
+              <CommandGroup heading={t('admin.nav.account')}>
                 <CommandItem
                   value="action-logout"
                   onSelect={() => {
@@ -206,7 +204,7 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
                   }}
                 >
                   <LogOutIcon />
-                  Log out
+                  {t('admin.auth.logout')}
                 </CommandItem>
               </CommandGroup>
             )}
@@ -232,19 +230,22 @@ function SearchStatus({
   hasResults: boolean
   query: string
 }): ReactNode {
+  const { t } = useTranslation()
   if (isEnabled && isLoading) {
     return (
       <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
         <Loader2Icon className="size-4 animate-spin" />
-        Searching…
+        {t('admin.common.searching')}
       </div>
     )
   }
   if (isEnabled && !hasResults) {
-    return <CommandEmpty>No results for "{query}".</CommandEmpty>
+    return (
+      <CommandEmpty>{t('admin.components.command_palette.no_results', { query })}</CommandEmpty>
+    )
   }
   if (!isEnabled && !query) {
-    return <CommandEmpty>Type to search, or pick a command below.</CommandEmpty>
+    return <CommandEmpty>{t('admin.components.command_palette.empty_hint')}</CommandEmpty>
   }
   return null
 }

--- a/packages/admin/src/components/spree/resource-table.tsx
+++ b/packages/admin/src/components/spree/resource-table.tsx
@@ -154,8 +154,9 @@ interface ResourceTableProps<T> {
   bulkActions?: BulkAction<any>[]
   /**
    * Per-row action menu. When set, a trailing cell renders whatever the
-   * function returns (typically a `<DropdownMenu>` with Edit/Clone/Delete).
-   * Skipped under reorder mode because the trailing cell is already busy.
+   * function returns (typically a `<RowActions>` kebab). Works alongside
+   * `reorder` — the drag handle sits on the leading edge, the actions
+   * menu on the trailing edge.
    */
   rowActions?: (row: T) => ReactNode
 }
@@ -189,7 +190,7 @@ export function ResourceTable<T extends Record<string, any>>({
   const queryClient = useQueryClient()
 
   const selectionEnabled = !!bulkActions?.length && !reorder
-  const rowActionsEnabled = !!rowActions && !reorder
+  const rowActionsEnabled = !!rowActions
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
 
   const {
@@ -422,13 +423,20 @@ export function ResourceTable<T extends Record<string, any>>({
                         {col.label}
                       </TableHead>
                     ))}
+                    {rowActionsEnabled && (
+                      <TableHead className="w-12">
+                        <span className="sr-only">{t('admin.row_actions.menu_label')}</span>
+                      </TableHead>
+                    )}
                   </tr>
                 </TableHeader>
                 <TableBody>
                   {isLoading ? (
-                    <TableEmpty colSpan={visibleColumns.length + 1}>Loading...</TableEmpty>
+                    <TableEmpty colSpan={visibleColumns.length + 1 + (rowActionsEnabled ? 1 : 0)}>
+                      Loading...
+                    </TableEmpty>
                   ) : rows.length === 0 ? (
-                    <TableEmpty colSpan={visibleColumns.length + 1}>
+                    <TableEmpty colSpan={visibleColumns.length + 1 + (rowActionsEnabled ? 1 : 0)}>
                       <Empty className="border-0 p-0">
                         <EmptyHeader>
                           {table.emptyIcon && (
@@ -445,7 +453,12 @@ export function ResourceTable<T extends Record<string, any>>({
                     </TableEmpty>
                   ) : (
                     rows.map((row) => (
-                      <SortableRow key={(row as any).id} row={row} columns={visibleColumns} />
+                      <SortableRow
+                        key={(row as any).id}
+                        row={row}
+                        columns={visibleColumns}
+                        rowActions={rowActions}
+                      />
                     ))
                   )}
                 </TableBody>
@@ -567,9 +580,11 @@ export function ResourceTable<T extends Record<string, any>>({
 function SortableRow<T extends Record<string, any>>({
   row,
   columns,
+  rowActions,
 }: {
   row: T
   columns: ColumnDef[]
+  rowActions?: (row: T) => ReactNode
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: row.id,
@@ -597,6 +612,7 @@ function SortableRow<T extends Record<string, any>>({
           {col.render ? col.render(row) : String((row as any)[col.key] ?? '—')}
         </TableCell>
       ))}
+      {rowActions && <TableCell className="w-12 text-right">{rowActions(row)}</TableCell>}
     </tr>
   )
 }

--- a/packages/admin/src/components/spree/row-actions.tsx
+++ b/packages/admin/src/components/spree/row-actions.tsx
@@ -1,0 +1,84 @@
+import { CopyIcon, EllipsisVerticalIcon, PencilIcon, Trash2Icon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+export interface RowAction {
+  /** Stable key for React reconciliation. Doubles as the i18n action slug
+   *  (`'edit' | 'clone' | 'delete' | …`) when `label` is omitted: the helper
+   *  looks up `admin.row_actions.<key>` for built-ins, so callers don't have
+   *  to repeat the translation key. */
+  key: string
+  /** Override the auto-resolved label for custom (non-built-in) actions. */
+  label?: string
+  /** Override the default icon — required for actions other than the
+   *  three built-ins (edit/clone/delete). */
+  icon?: ReactNode
+  /** Skips rendering when false. Use for CanCanCan gates. */
+  visible?: boolean
+  /** Greys out the item without removing it (in-flight mutations). */
+  disabled?: boolean
+  /** Styles the item red — use for destructive actions. */
+  destructive?: boolean
+  onSelect: () => void
+}
+
+interface RowActionsProps {
+  /** Items in render order. Items with `visible: false` are filtered out. */
+  actions: RowAction[]
+}
+
+const BUILTIN_ICONS: Record<string, ReactNode> = {
+  edit: <PencilIcon className="size-4" />,
+  clone: <CopyIcon className="size-4" />,
+  delete: <Trash2Icon className="size-4" />,
+}
+
+/**
+ * Kebab dropdown shared by every `<ResourceTable rowActions={…}>` consumer
+ * (products, customers, payment methods, …). Keeps the icon, alignment, and
+ * a11y label consistent across the SPA.
+ *
+ * Built-in keys (`edit`, `clone`, `delete`) auto-resolve their label via
+ * `admin.row_actions.<key>` and pick up the matching icon, so the typical
+ * call site is:
+ *
+ *     <RowActions actions={[
+ *       { key: 'edit', onSelect: openEdit },
+ *       { key: 'delete', destructive: true, onSelect: openConfirm },
+ *     ]} />
+ */
+export function RowActions({ actions }: RowActionsProps) {
+  const { t } = useTranslation()
+  const visible = actions.filter((a) => a.visible !== false)
+  if (visible.length === 0) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon-xs" aria-label={t('admin.row_actions.menu_label')}>
+          <EllipsisVerticalIcon className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {visible.map((action) => (
+          <DropdownMenuItem
+            key={action.key}
+            onClick={action.onSelect}
+            disabled={action.disabled}
+            className={action.destructive ? 'text-destructive focus:text-destructive' : undefined}
+          >
+            {action.icon ?? BUILTIN_ICONS[action.key]}
+            {action.label ?? t(`admin.row_actions.${action.key}`)}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/admin/src/components/spree/table-toolbar.tsx
+++ b/packages/admin/src/components/spree/table-toolbar.tsx
@@ -126,11 +126,6 @@ function getOperators(type: string) {
 
 const noValueOperators = ['present', 'blank']
 
-const booleanItems = [
-  { value: 'true', label: 'Yes' },
-  { value: 'false', label: 'No' },
-] as const
-
 // ============================================================================
 // TableToolbar
 // ============================================================================
@@ -565,6 +560,13 @@ function FilterPanel({
 }) {
   const { t } = useTranslation()
   const [draft, setDraft] = useState<FilterRule[]>(initialFilters)
+  const booleanItems = useMemo(
+    () => [
+      { value: 'true', label: t('admin.common.yes') },
+      { value: 'false', label: t('admin.common.no') },
+    ],
+    [t],
+  )
   // Stable `{ value, label }` array for the field-picker `<Select items>`.
   // Building it inline per render produces a new reference each time, which
   // Base UI's Select treats as an `items` change and re-emits state — causing
@@ -724,8 +726,8 @@ function FilterPanel({
                       />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="true">Yes</SelectItem>
-                      <SelectItem value="false">No</SelectItem>
+                      <SelectItem value="true">{t('admin.common.yes')}</SelectItem>
+                      <SelectItem value="false">{t('admin.common.no')}</SelectItem>
                     </SelectContent>
                   </Select>
                 ) : col?.filterType === 'date' ? (

--- a/packages/admin/src/components/spree/top-bar.tsx
+++ b/packages/admin/src/components/spree/top-bar.tsx
@@ -56,6 +56,7 @@ export function TopBar() {
 // ---------------------------------------------------------------------------
 
 function SearchTrigger() {
+  const { t } = useTranslation()
   const { setOpen } = useCommandPalette()
 
   return (
@@ -65,7 +66,7 @@ function SearchTrigger() {
       className="flex w-full max-w-md items-center gap-2 rounded-lg border border-border bg-muted/40 px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted"
     >
       <SearchIcon className="size-4" />
-      <span className="flex-1 text-left">Search products, orders, customers…</span>
+      <span className="flex-1 text-left">{t('admin.components.command_palette.placeholder')}</span>
       <kbd className="hidden rounded border bg-background px-1.5 py-0.5 font-mono text-xs sm:inline-flex">
         {IS_MAC ? '⌘K' : 'Ctrl+K'}
       </kbd>

--- a/packages/admin/src/locales/en.json
+++ b/packages/admin/src/locales/en.json
@@ -72,6 +72,7 @@
     },
     "common": {
       "loading": "Loading…",
+      "searching": "Searching…",
       "no_results": "No results",
       "optional": "Optional",
       "required": "Required",
@@ -187,6 +188,7 @@
     "branding": { "app_name": "Spree Admin", "powered_by": "Powered by Spree Commerce" },
     "nav": {
       "home": "Home",
+      "account": "Account",
       "orders": "Orders",
       "draft_orders": "Draft Orders",
       "products": "Products",
@@ -462,7 +464,20 @@
         "empty": "No countries found"
       },
       "state_combobox": { "search_placeholder": "Search states…", "empty": "No states found" },
-      "command_palette": { "placeholder": "Search products, orders, customers…" },
+      "command_palette": {
+        "placeholder": "Search products, orders, customers…",
+        "title": "Search and commands",
+        "description": "Search across products, orders, and customers, or run a command.",
+        "no_results": "No results for \"{{query}}\".",
+        "empty_hint": "Type to search, or pick a command below.",
+        "goto": "Go to",
+        "goto_label": "Go to {{label}}"
+      },
+      "bulk_action_bar": {
+        "selected": "{{count}} selected",
+        "default_success": "Updated {n} records",
+        "default_error": "Bulk operation failed"
+      },
       "preferences_form": {
         "comma_separated_hint": "Separate values with commas.",
         "tiers": {
@@ -510,6 +525,11 @@
         "prefix_required": "Prefix is required for multi-code batches",
         "number_of_codes_required": "Pick how many codes to generate",
         "expiry_after_start": "Expiry must be after the start date"
+      },
+      "delete_confirm": {
+        "title": "Delete promotion?",
+        "message": "{{name}} will be removed permanently. Promotions referenced by completed orders cannot be deleted.",
+        "default_name": "This promotion"
       },
       "rules": {
         "country": {

--- a/packages/admin/src/locales/en.json
+++ b/packages/admin/src/locales/en.json
@@ -904,6 +904,7 @@
         "no_roles": "No roles available."
       },
       "edit": { "roles_label": "Roles for this store" },
+      "edit_description": "Update profile details and assigned roles for this staff member.",
       "actions_aria": "Actions"
     },
     "api_keys": {
@@ -937,7 +938,6 @@
       },
       "dropdown": {
         "revoke": "Revoke key",
-        "delete": "Delete key",
         "copy_token_aria": "Copy token"
       },
       "badge": { "revoked": "Revoked", "never_used": "Never" },
@@ -983,6 +983,9 @@
           "remove_title": "Remove tags",
           "remove_description": "Pick tags to remove from these customers."
         }
+      },
+      "row_actions": {
+        "delete_confirm": "Delete {{email}}? Customers with completed orders cannot be removed."
       },
       "detail": {
         "delete_label": "Delete customer",

--- a/packages/admin/src/routes/_authenticated/$storeId/customers/groups.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/customers/groups.tsx
@@ -10,6 +10,7 @@ import { adminClient } from '@/client'
 import { Can } from '@/components/spree/can'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Button } from '@/components/ui/button'
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
@@ -31,6 +32,7 @@ import {
 } from '@/hooks/use-customer-groups'
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import {
   CUSTOMER_GROUP_DEFAULTS,
   type CustomerGroupFormValues,
@@ -53,6 +55,9 @@ function CustomerGroupsPage() {
   const { t } = useTranslation()
   const search = Route.useSearch() as z.infer<typeof customerGroupsSearchSchema>
   const navigate = useNavigate()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteCustomerGroup()
+  const { permissions } = usePermissions()
 
   const editId = search.edit
   const isCreating = !!search.new
@@ -73,6 +78,19 @@ function CustomerGroupsPage() {
 
   useRowClickBridge('data-customer-group-id', openEdit)
 
+  async function handleDelete(group: CustomerGroup) {
+    const ok = await confirm({
+      title: t('admin.customers.groups.delete_confirm.title'),
+      message: t('admin.customers.groups.delete_confirm.message', {
+        name: group.name ?? t('admin.customers.groups.default_name'),
+      }),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(group.id)
+  }
+
   return (
     <>
       <ResourceTable<CustomerGroup>
@@ -80,6 +98,20 @@ function CustomerGroupsPage() {
         queryKey="customer-groups"
         queryFn={(params) => adminClient.customerGroups.list(params)}
         searchParams={search}
+        rowActions={(group) => (
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => openEdit(group.id) },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.CustomerGroup),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(group),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.CustomerGroup}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -177,8 +209,6 @@ function EditCustomerGroupSheet({
   const { storeId } = Route.useParams()
   const { data: group, isLoading } = useCustomerGroup(id)
   const updateMutation = useUpdateCustomerGroup(id)
-  const deleteMutation = useDeleteCustomerGroup()
-  const confirm = useConfirm()
 
   const form = useForm<CustomerGroupFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -203,20 +233,6 @@ function EditCustomerGroupSheet({
     } catch (err) {
       if (!mapSpreeErrorsToForm(err, form.setError)) throw err
     }
-  }
-
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.customers.groups.delete_confirm.title'),
-      message: t('admin.customers.groups.delete_confirm.message', {
-        name: group?.name ?? t('admin.customers.groups.default_name'),
-      }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    await deleteMutation.mutateAsync(id)
-    onOpenChange(false)
   }
 
   // Filter the /customers index by this group's id. Ransack join filter on the
@@ -246,18 +262,6 @@ function EditCustomerGroupSheet({
               />
             </div>
             <SheetFooter>
-              <Can I="destroy" a={Subject.CustomerGroup}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={form.formState.isSubmitting || deleteMutation.isPending}
-                  className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                  {t('admin.actions.delete')}
-                </Button>
-              </Can>
               <Button
                 type="button"
                 variant="outline"

--- a/packages/admin/src/routes/_authenticated/$storeId/customers/groups.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/customers/groups.tsx
@@ -88,7 +88,10 @@ function CustomerGroupsPage() {
       confirmLabel: t('admin.actions.delete'),
     })
     if (!ok) return
-    await deleteMutation.mutateAsync(group.id)
+    // `useDeleteCustomerGroup` toasts on success/error via `onError`; the
+    // `.catch` only swallows the rethrow so the row-action callback doesn't
+    // surface an unhandled rejection.
+    await deleteMutation.mutateAsync(group.id).catch(() => undefined)
   }
 
   return (

--- a/packages/admin/src/routes/_authenticated/$storeId/customers/index.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/customers/index.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import type { Customer } from '@spree/admin-sdk'
 import { useMutation } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { PlusIcon, TagsIcon, UserMinusIcon, UserPlusIcon } from 'lucide-react'
@@ -9,9 +10,11 @@ import { z } from 'zod/v4'
 import { adminClient } from '@/client'
 import type { BulkAction, BulkActionFormProps } from '@/components/spree/bulk-action-bar'
 import { BulkDialog } from '@/components/spree/bulk-dialog'
+import { useConfirm } from '@/components/spree/confirm-dialog'
 import { ExportButton } from '@/components/spree/export-button'
 import { ResourceMultiAutocomplete } from '@/components/spree/resource-multi-autocomplete'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { TagCombobox } from '@/components/spree/tag-combobox'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -32,9 +35,11 @@ import {
   useBulkAddCustomerTags,
   useBulkRemoveCustomersFromGroups,
   useBulkRemoveCustomerTags,
+  useDeleteCustomer,
 } from '@/hooks/use-customers'
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import {
   NEW_CUSTOMER_DEFAULTS,
   type NewCustomerFormValues,
@@ -62,6 +67,7 @@ const GROUP_INVALIDATIONS = [['customer-groups']]
 
 function CustomersPage() {
   const { t } = useTranslation()
+  const { storeId } = Route.useParams()
   const search = Route.useSearch() as z.infer<typeof customersSearchSchema>
   const navigate = useNavigate()
   const bulkAddToGroups = useBulkAddCustomersToGroups()
@@ -174,13 +180,14 @@ function CustomersPage() {
 
   return (
     <>
-      <ResourceTable
+      <ResourceTable<Customer>
         tableKey="customers"
         queryKey="customers"
         queryFn={(params) => adminClient.customers.list(params)}
         searchParams={search}
         defaultParams={{ expand: ['customer_groups'] }}
         bulkActions={bulkActions}
+        rowActions={(customer) => <CustomerRowActions customer={customer} storeId={storeId} />}
         actions={(ctx) => (
           <>
             <ExportButton type="Spree::Exports::Customers" {...ctx} />
@@ -193,6 +200,52 @@ function CustomersPage() {
       />
       {isCreating && <NewCustomerSheet open onOpenChange={(o) => !o && closeSheet()} />}
     </>
+  )
+}
+
+/**
+ * Per-row Edit + Delete kebab. Lives in its own component so `useDeleteCustomer`
+ * can be parameterised by customer id (the hook keys its invalidations off the
+ * id and needs a stable identity per row).
+ */
+function CustomerRowActions({ customer, storeId }: { customer: Customer; storeId: string }) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteCustomer(customer.id)
+  const { permissions } = usePermissions()
+
+  async function handleDelete() {
+    const ok = await confirm({
+      title: t('admin.customers.detail.delete_label'),
+      message: t('admin.customers.row_actions.delete_confirm', { email: customer.email ?? '' }),
+      variant: 'destructive',
+      confirmLabel: t('admin.customers.detail.delete_label'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync().catch(() => undefined)
+  }
+
+  return (
+    <RowActions
+      actions={[
+        {
+          key: 'edit',
+          onSelect: () =>
+            navigate({
+              to: '/$storeId/customers/$customerId',
+              params: { storeId, customerId: customer.id },
+            }),
+        },
+        {
+          key: 'delete',
+          destructive: true,
+          visible: permissions.can('destroy', Subject.Customer),
+          disabled: deleteMutation.isPending,
+          onSelect: handleDelete,
+        },
+      ]}
+    />
   )
 }
 

--- a/packages/admin/src/routes/_authenticated/$storeId/products/index.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/products/index.tsx
@@ -41,6 +41,7 @@ import {
   useCloneProduct,
 } from '@/hooks/use-products'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import '@/tables/products'
 
 export const Route = createFileRoute('/_authenticated/$storeId/products/')({
@@ -223,6 +224,7 @@ function ProductRowActions({ product, storeId }: { product: Product; storeId: st
   const confirm = useConfirm()
   const cloneMutation = useCloneProduct()
   const deleteMutation = useDeleteProduct()
+  const { permissions } = usePermissions()
 
   async function handleClone() {
     const cloned = await cloneMutation.mutateAsync(product.id).catch(() => null)
@@ -261,10 +263,16 @@ function ProductRowActions({ product, storeId }: { product: Product; storeId: st
               params: { storeId, productId: product.id },
             }),
         },
-        { key: 'clone', disabled: cloneMutation.isPending, onSelect: handleClone },
+        {
+          key: 'clone',
+          visible: permissions.can('create', Subject.Product),
+          disabled: cloneMutation.isPending,
+          onSelect: handleClone,
+        },
         {
           key: 'delete',
           destructive: true,
+          visible: permissions.can('destroy', Subject.Product),
           disabled: deleteMutation.isPending,
           onSelect: handleDelete,
         },

--- a/packages/admin/src/routes/_authenticated/$storeId/products/index.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/products/index.tsx
@@ -1,11 +1,8 @@
 import type { Product } from '@spree/admin-sdk'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import {
-  CopyIcon,
-  EllipsisVerticalIcon,
   FolderMinusIcon,
   FolderPlusIcon,
-  PencilIcon,
   PlusIcon,
   TagIcon,
   TagsIcon,
@@ -21,14 +18,9 @@ import { useConfirm } from '@/components/spree/confirm-dialog'
 import { ExportButton } from '@/components/spree/export-button'
 import { ResourceMultiAutocomplete } from '@/components/spree/resource-multi-autocomplete'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { TagCombobox } from '@/components/spree/tag-combobox'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { Field, FieldLabel } from '@/components/ui/field'
 import {
   Select,
@@ -259,38 +251,25 @@ function ProductRowActions({ product, storeId }: { product: Product; storeId: st
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon-xs" aria-label={t('admin.row_actions.menu_label')}>
-          <EllipsisVerticalIcon className="size-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() =>
+    <RowActions
+      actions={[
+        {
+          key: 'edit',
+          onSelect: () =>
             navigate({
               to: '/$storeId/products/$productId',
               params: { storeId, productId: product.id },
-            })
-          }
-        >
-          <PencilIcon className="size-4" />
-          {t('admin.row_actions.edit')}
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleClone} disabled={cloneMutation.isPending}>
-          <CopyIcon className="size-4" />
-          {t('admin.row_actions.clone')}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="text-destructive focus:text-destructive"
-          onClick={handleDelete}
-          disabled={deleteMutation.isPending}
-        >
-          <Trash2Icon className="size-4" />
-          {t('admin.row_actions.delete')}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+            }),
+        },
+        { key: 'clone', disabled: cloneMutation.isPending, onSelect: handleClone },
+        {
+          key: 'delete',
+          destructive: true,
+          disabled: deleteMutation.isPending,
+          onSelect: handleDelete,
+        },
+      ]}
+    />
   )
 }
 

--- a/packages/admin/src/routes/_authenticated/$storeId/products/options.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/products/options.tsx
@@ -36,6 +36,7 @@ import { ColorPicker } from '@/components/spree/color-picker'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { DragHandle } from '@/components/spree/drag-handle'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Button } from '@/components/ui/button'
 import {
@@ -77,6 +78,7 @@ import {
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
 import { cn } from '@/lib/utils'
+import { usePermissions } from '@/providers/permission-provider'
 import {
   OPTION_TYPE_DEFAULTS,
   OPTION_TYPE_KINDS,
@@ -103,6 +105,9 @@ function OptionTypesPage() {
   const search = Route.useSearch() as z.infer<typeof optionTypesSearchSchema>
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteOptionType()
+  const { permissions } = usePermissions()
 
   const editId = search.edit
   const isCreating = !!search.new
@@ -123,6 +128,17 @@ function OptionTypesPage() {
 
   useRowClickBridge('data-option-type-id', openEdit)
 
+  async function handleDelete(optionType: OptionType) {
+    const ok = await confirm({
+      title: t('admin.products.options.delete_confirm.title'),
+      message: t('admin.products.options.delete_confirm.message'),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(optionType.id).catch(() => undefined)
+  }
+
   return (
     <>
       <ResourceTable<OptionType>
@@ -130,6 +146,20 @@ function OptionTypesPage() {
         queryKey="option-types"
         queryFn={(params) => adminClient.optionTypes.list({ ...params, expand: ['option_values'] })}
         searchParams={search}
+        rowActions={(optionType) => (
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => openEdit(optionType.id) },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.OptionType),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(optionType),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.OptionType}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -245,8 +275,6 @@ function EditOptionTypeSheet({
   const { t } = useTranslation()
   const { data: optionType, isLoading } = useOptionType(id)
   const updateMutation = useUpdateOptionType(id)
-  const deleteMutation = useDeleteOptionType()
-  const confirm = useConfirm()
 
   const form = useForm<OptionTypeFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -281,18 +309,6 @@ function EditOptionTypeSheet({
     }
   }
 
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.products.options.delete_confirm.title'),
-      message: t('admin.products.options.delete_confirm.message'),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    await deleteMutation.mutateAsync(id)
-    onOpenChange(false)
-  }
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="sm:max-w-2xl">
@@ -316,18 +332,6 @@ function EditOptionTypeSheet({
               <OptionValuesFieldArray form={form} />
             </div>
             <SheetFooter>
-              <Can I="destroy" a={Subject.OptionType}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={form.formState.isSubmitting || deleteMutation.isPending}
-                  className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                  {t('admin.actions.delete')}
-                </Button>
-              </Can>
               <Button
                 type="button"
                 variant="outline"

--- a/packages/admin/src/routes/_authenticated/$storeId/products/transfers.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/products/transfers.tsx
@@ -1,7 +1,7 @@
 import type { StockTransfer, Variant } from '@spree/admin-sdk'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { ArrowLeftRightIcon, PlusIcon, TrashIcon } from 'lucide-react'
+import { ArrowLeftRightIcon, EyeIcon, PlusIcon, TrashIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { z } from 'zod/v4'
@@ -10,6 +10,7 @@ import { Can } from '@/components/spree/can'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { RelativeTime } from '@/components/spree/relative-time'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -39,6 +40,7 @@ import {
 } from '@/hooks/use-stock-transfers'
 import { formatPrice } from '@/lib/formatters'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import '@/tables/stock-transfers'
 
 const stockTransfersSearchSchema = resourceSearchSchema.extend({
@@ -57,6 +59,9 @@ function StockTransfersPage() {
   const { t } = useTranslation()
   const search = Route.useSearch() as z.infer<typeof stockTransfersSearchSchema>
   const navigate = useNavigate()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteStockTransfer()
+  const { permissions } = usePermissions()
 
   const viewId = search.view
   const isCreating = !!search.new
@@ -77,6 +82,17 @@ function StockTransfersPage() {
 
   useRowClickBridge('data-stock-transfer-id', openView)
 
+  async function handleDelete(transfer: StockTransfer) {
+    const ok = await confirm({
+      title: t('admin.products.transfers.delete_confirm.title'),
+      message: t('admin.products.transfers.delete_confirm.message'),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(transfer.id).catch(() => undefined)
+  }
+
   return (
     <>
       <ResourceTable<StockTransfer>
@@ -84,6 +100,25 @@ function StockTransfersPage() {
         queryKey="stock-transfers"
         queryFn={(params) => adminClient.stockTransfers.list(params)}
         searchParams={search}
+        rowActions={(transfer) => (
+          <RowActions
+            actions={[
+              {
+                key: 'view',
+                label: t('admin.actions.view_details'),
+                icon: <EyeIcon className="size-4" />,
+                onSelect: () => openView(transfer.id),
+              },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.StockTransfer),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(transfer),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.StockTransfer}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -373,8 +408,6 @@ function ViewStockTransferSheet({
 }) {
   const { t } = useTranslation()
   const { data: transfer, isLoading } = useStockTransfer(id)
-  const deleteMutation = useDeleteStockTransfer()
-  const confirm = useConfirm()
   const { data: stockLocations } = useStockLocations({ limit: 100 })
 
   const locationsById = useMemo(() => {
@@ -384,18 +417,6 @@ function ViewStockTransferSheet({
     }
     return map
   }, [stockLocations])
-
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.products.transfers.delete_confirm.title'),
-      message: t('admin.products.transfers.delete_confirm.message'),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    await deleteMutation.mutateAsync(id)
-    onOpenChange(false)
-  }
 
   const sourceName = transfer?.source_location_id
     ? (locationsById.get(transfer.source_location_id) ?? transfer.source_location_id)
@@ -482,18 +503,6 @@ function ViewStockTransferSheet({
         )}
 
         <SheetFooter>
-          <Can I="destroy" a={Subject.StockTransfer}>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={onDelete}
-              disabled={deleteMutation.isPending}
-              className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-            >
-              {t('admin.actions.delete')}
-            </Button>
-          </Can>
           <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>
             {t('admin.actions.close')}
           </Button>

--- a/packages/admin/src/routes/_authenticated/$storeId/promotions/$promotionId.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/promotions/$promotionId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { PromotionForm } from '@/components/spree/promotion-editors/promotion-form'
 import {
@@ -14,6 +15,7 @@ export const Route = createFileRoute('/_authenticated/$storeId/promotions/$promo
 })
 
 function EditPromotionPage() {
+  const { t } = useTranslation()
   const { storeId, promotionId } = Route.useParams()
   const navigate = useNavigate()
   const { data: promotion } = usePromotion(promotionId)
@@ -27,10 +29,12 @@ function EditPromotionPage() {
 
   async function onDelete() {
     const ok = await confirm({
-      title: 'Delete promotion?',
-      message: `${promotion?.name ?? 'This promotion'} will be removed permanently. Promotions referenced by completed orders cannot be deleted.`,
+      title: t('admin.promotions.delete_confirm.title'),
+      message: t('admin.promotions.delete_confirm.message', {
+        name: promotion?.name ?? t('admin.promotions.delete_confirm.default_name'),
+      }),
       variant: 'destructive',
-      confirmLabel: 'Delete',
+      confirmLabel: t('admin.actions.delete'),
     })
     if (!ok) return
     await deleteMutation.mutateAsync(promotionId)

--- a/packages/admin/src/routes/_authenticated/$storeId/promotions/gift-cards.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/promotions/gift-cards.tsx
@@ -11,6 +11,7 @@ import { useConfirm } from '@/components/spree/confirm-dialog'
 import { CurrencySelect } from '@/components/spree/currency-select'
 import { ResourceCombobox } from '@/components/spree/resource-combobox'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { StoreDatePicker } from '@/components/spree/store-date-picker'
 import { Button } from '@/components/ui/button'
@@ -35,6 +36,7 @@ import {
 } from '@/hooks/use-gift-cards'
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import { useStore } from '@/providers/store-provider'
 import {
   BATCH_LIMIT,
@@ -68,6 +70,9 @@ function GiftCardsPage() {
   const { t } = useTranslation()
   const search = Route.useSearch() as z.infer<typeof giftCardsSearchSchema>
   const navigate = useNavigate()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteGiftCard()
+  const { permissions } = usePermissions()
 
   const editId = search.edit
   const isCreating = !!search.new
@@ -88,6 +93,17 @@ function GiftCardsPage() {
 
   useRowClickBridge('data-gift-card-id', openEdit)
 
+  async function handleDelete(giftCard: GiftCard) {
+    const ok = await confirm({
+      title: t('admin.pages.promotions.gift_cards.delete_confirm.title'),
+      message: t('admin.pages.promotions.gift_cards.delete_confirm.message'),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(giftCard.id).catch(() => undefined)
+  }
+
   return (
     <>
       <ResourceTable<GiftCard>
@@ -96,6 +112,20 @@ function GiftCardsPage() {
         queryFn={listGiftCards}
         searchParams={search}
         defaultParams={{ expand: LIST_EXPAND }}
+        rowActions={(giftCard) => (
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => openEdit(giftCard.id) },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.GiftCard),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(giftCard),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.GiftCard}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -228,8 +258,6 @@ function EditGiftCardSheet({
   const { t } = useTranslation()
   const { data: giftCard, isLoading } = useGiftCard(id, ['customer', 'created_by', 'orders'])
   const updateMutation = useUpdateGiftCard(id)
-  const deleteMutation = useDeleteGiftCard()
-  const confirm = useConfirm()
 
   const form = useForm<GiftCardEditFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -271,18 +299,6 @@ function EditGiftCardSheet({
     }
   }
 
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.pages.promotions.gift_cards.delete_confirm.title'),
-      message: t('admin.pages.promotions.gift_cards.delete_confirm.message'),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    await deleteMutation.mutateAsync(id)
-    onOpenChange(false)
-  }
-
   // Server-side `editable?` is `active?` — redeemed/canceled cards are
   // read-only. Don't even show the form for those; let staff see the audit
   // info only.
@@ -317,18 +333,6 @@ function EditGiftCardSheet({
               <GiftCardUsageSummary giftCard={giftCard} />
             </div>
             <SheetFooter>
-              <Can I="destroy" a={Subject.GiftCard}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={form.formState.isSubmitting || deleteMutation.isPending}
-                  className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                  {t('admin.actions.delete')}
-                </Button>
-              </Can>
               <Button
                 type="button"
                 variant="outline"

--- a/packages/admin/src/routes/_authenticated/$storeId/promotions/index.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/promotions/index.tsx
@@ -1,6 +1,7 @@
 import type { Promotion } from '@spree/admin-sdk'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { PlusIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { adminClient } from '@/client'
 import { Can } from '@/components/spree/can'
 import { useConfirm } from '@/components/spree/confirm-dialog'
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/_authenticated/$storeId/promotions/')({
 })
 
 function PromotionsPage() {
+  const { t } = useTranslation()
   const search = Route.useSearch()
   const navigate = useNavigate()
   const { storeId } = Route.useParams()
@@ -38,12 +40,12 @@ function PromotionsPage() {
 
   async function handleDelete(promotion: Promotion) {
     const ok = await confirm({
-      title: 'Delete promotion?',
-      // Matches the inline copy used by the detail-page delete handler so the
-      // row-actions kebab + detail-page delete share the same UX.
-      message: `${promotion.name ?? 'This promotion'} will be removed permanently. Promotions referenced by completed orders cannot be deleted.`,
+      title: t('admin.promotions.delete_confirm.title'),
+      message: t('admin.promotions.delete_confirm.message', {
+        name: promotion.name ?? t('admin.promotions.delete_confirm.default_name'),
+      }),
       variant: 'destructive',
-      confirmLabel: 'Delete',
+      confirmLabel: t('admin.actions.delete'),
     })
     if (!ok) return
     await deleteMutation.mutateAsync(promotion.id).catch(() => undefined)
@@ -73,7 +75,7 @@ function PromotionsPage() {
         <Can I="create" a={Subject.Promotion}>
           <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
             <PlusIcon className="size-4" />
-            New promotion
+            {t('admin.pages.promotions.new_title')}
           </Button>
         </Can>
       }

--- a/packages/admin/src/routes/_authenticated/$storeId/promotions/index.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/promotions/index.tsx
@@ -3,10 +3,14 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { PlusIcon } from 'lucide-react'
 import { adminClient } from '@/client'
 import { Can } from '@/components/spree/can'
+import { useConfirm } from '@/components/spree/confirm-dialog'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Button } from '@/components/ui/button'
+import { useDeletePromotion } from '@/hooks/use-promotions'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import '@/tables/promotions'
 
 export const Route = createFileRoute('/_authenticated/$storeId/promotions/')({
@@ -18,6 +22,9 @@ function PromotionsPage() {
   const search = Route.useSearch()
   const navigate = useNavigate()
   const { storeId } = Route.useParams()
+  const confirm = useConfirm()
+  const deleteMutation = useDeletePromotion()
+  const { permissions } = usePermissions()
 
   function openEdit(id: string) {
     navigate({ to: '/$storeId/promotions/$promotionId', params: { storeId, promotionId: id } })
@@ -29,12 +36,39 @@ function PromotionsPage() {
 
   useRowClickBridge('data-promotion-id', openEdit)
 
+  async function handleDelete(promotion: Promotion) {
+    const ok = await confirm({
+      title: 'Delete promotion?',
+      // Matches the inline copy used by the detail-page delete handler so the
+      // row-actions kebab + detail-page delete share the same UX.
+      message: `${promotion.name ?? 'This promotion'} will be removed permanently. Promotions referenced by completed orders cannot be deleted.`,
+      variant: 'destructive',
+      confirmLabel: 'Delete',
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(promotion.id).catch(() => undefined)
+  }
+
   return (
     <ResourceTable<Promotion>
       tableKey="promotions"
       queryKey="promotions"
       queryFn={(params) => adminClient.promotions.list(params)}
       searchParams={search}
+      rowActions={(promotion) => (
+        <RowActions
+          actions={[
+            { key: 'edit', onSelect: () => openEdit(promotion.id) },
+            {
+              key: 'delete',
+              destructive: true,
+              visible: permissions.can('destroy', Subject.Promotion),
+              disabled: deleteMutation.isPending,
+              onSelect: () => handleDelete(promotion),
+            },
+          ]}
+        />
+      )}
       actions={
         <Can I="create" a={Subject.Promotion}>
           <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/api-keys.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/api-keys.tsx
@@ -328,9 +328,15 @@ function ApiKeyRow({ apiKey, showScopes }: { apiKey: ApiKey; showScopes: boolean
               label: t('admin.api_keys.dropdown.revoke'),
               icon: <BanIcon className="size-4" />,
               visible: !isRevoked,
+              disabled: revokeMutation.isPending,
               onSelect: handleRevoke,
             },
-            { key: 'delete', destructive: true, onSelect: handleDelete },
+            {
+              key: 'delete',
+              destructive: true,
+              disabled: deleteMutation.isPending,
+              onSelect: handleDelete,
+            },
           ]}
         />
       </TableCell>

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/api-keys.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/api-keys.tsx
@@ -3,10 +3,10 @@ import { type ApiKey, type ApiKeyCreateParams, SpreeError } from '@spree/admin-s
 import { createFileRoute } from '@tanstack/react-router'
 import {
   AlertTriangleIcon,
+  BanIcon,
   CheckIcon,
   CopyIcon,
   KeyRoundIcon,
-  MoreHorizontalIcon,
   PlusIcon,
 } from 'lucide-react'
 import { useState } from 'react'
@@ -17,6 +17,7 @@ import { z } from 'zod/v4'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { PageHeader } from '@/components/spree/page-header'
 import { RelativeTime } from '@/components/spree/relative-time'
+import { RowActions } from '@/components/spree/row-actions'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -38,13 +39,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import {
   Field,
@@ -327,26 +321,18 @@ function ApiKeyRow({ apiKey, showScopes }: { apiKey: ApiKey; showScopes: boolean
         )}
       </TableCell>
       <TableCell className="text-right">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="icon-sm" variant="ghost" aria-label={t('admin.staff.actions_aria')}>
-              <MoreHorizontalIcon className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {!isRevoked && (
-              <>
-                <DropdownMenuItem onClick={handleRevoke}>
-                  {t('admin.api_keys.dropdown.revoke')}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
-            <DropdownMenuItem variant="destructive" onClick={handleDelete}>
-              {t('admin.api_keys.dropdown.delete')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <RowActions
+          actions={[
+            {
+              key: 'revoke',
+              label: t('admin.api_keys.dropdown.revoke'),
+              icon: <BanIcon className="size-4" />,
+              visible: !isRevoked,
+              onSelect: handleRevoke,
+            },
+            { key: 'delete', destructive: true, onSelect: handleDelete },
+          ]}
+        />
       </TableCell>
     </TableRow>
   )

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/payment-methods.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/payment-methods.tsx
@@ -92,7 +92,10 @@ function PaymentMethodsPage() {
       confirmLabel: t('admin.actions.delete'),
     })
     if (!ok) return
-    await deleteMutation.mutateAsync(method.id)
+    // `useDeletePaymentMethod` toasts on success/error via `onError`; the
+    // `.catch` only swallows the rethrow so the row-action callback doesn't
+    // surface an unhandled rejection.
+    await deleteMutation.mutateAsync(method.id).catch(() => undefined)
   }
 
   return (

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/payment-methods.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/payment-methods.tsx
@@ -14,6 +14,7 @@ import { PaymentMethodForm } from '@/components/spree/payment-method-editors/pay
 import type { PaymentMethodFormValues } from '@/components/spree/payment-method-editors/types'
 import { defaultPreferences } from '@/components/spree/preferences-form'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Button } from '@/components/ui/button'
 import {
@@ -33,6 +34,7 @@ import {
 } from '@/hooks/use-payment-methods'
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import { useStore } from '@/providers/store-provider'
 import {
   PAYMENT_METHOD_BASE_DEFAULTS,
@@ -59,6 +61,9 @@ function PaymentMethodsPage() {
   const search = Route.useSearch() as z.infer<typeof paymentMethodsSearchSchema>
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const confirm = useConfirm()
+  const deleteMutation = useDeletePaymentMethod()
+  const { permissions } = usePermissions()
 
   const editId = search.edit
   const isCreating = !!search.new
@@ -79,6 +84,17 @@ function PaymentMethodsPage() {
 
   useRowClickBridge('data-payment-method-id', openEdit)
 
+  async function handleDelete(method: PaymentMethod) {
+    const ok = await confirm({
+      title: t('admin.payment_methods.delete_confirm.title'),
+      message: t('admin.payment_methods.delete_confirm.message', { name: method.name ?? '' }),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(method.id)
+  }
+
   return (
     <>
       <ResourceTable<PaymentMethod>
@@ -86,6 +102,20 @@ function PaymentMethodsPage() {
         queryKey="payment-methods"
         queryFn={(params) => adminClient.paymentMethods.list(params)}
         searchParams={search}
+        rowActions={(method) => (
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => openEdit(method.id) },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.PaymentMethod),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(method),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.PaymentMethod}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -225,8 +255,6 @@ function EditPaymentMethodSheet({
   const { t } = useTranslation()
   const { data: paymentMethod, isLoading } = usePaymentMethod(id)
   const updateMutation = useUpdatePaymentMethod(id)
-  const deleteMutation = useDeletePaymentMethod()
-  const confirm = useConfirm()
 
   const form = useForm<PaymentMethodFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -275,20 +303,6 @@ function EditPaymentMethodSheet({
     }
   }
 
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.payment_methods.delete_confirm.title'),
-      message: t('admin.payment_methods.delete_confirm.message', {
-        name: paymentMethod?.name ?? '',
-      }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    await deleteMutation.mutateAsync(id)
-    onOpenChange(false)
-  }
-
   // STI shorthand for slot lookup, e.g. `bogus`, `stripe`. The API
   // returns it on the `type` attribute (see PaymentMethodSerializer).
   const providerType = paymentMethod?.type ?? ''
@@ -333,18 +347,6 @@ function EditPaymentMethodSheet({
               />
             </div>
             <SheetFooter>
-              <Can I="destroy" a={Subject.PaymentMethod}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={form.formState.isSubmitting || deleteMutation.isPending}
-                  className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                  {t('admin.actions.delete')}
-                </Button>
-              </Can>
               <Button
                 type="button"
                 variant="outline"

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/staff.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/staff.tsx
@@ -229,6 +229,7 @@ function StaffRow({ member }: { member: AdminUser }) {
                 label: t('admin.pages.staff.actions.remove'),
                 icon: <UserMinusIcon className="size-4" />,
                 destructive: true,
+                disabled: removeMutation.isPending,
                 onSelect: handleRemove,
               },
             ]}
@@ -359,6 +360,7 @@ function InvitationRow({ invitation }: { invitation: Invitation }) {
               key: 'resend',
               label: t('admin.pages.staff.actions.resend'),
               icon: <MailIcon className="size-4" />,
+              disabled: resendMutation.isPending,
               onSelect: handleResend,
             },
             {
@@ -372,6 +374,7 @@ function InvitationRow({ invitation }: { invitation: Invitation }) {
               label: t('admin.pages.staff.actions.revoke'),
               icon: <BanIcon className="size-4" />,
               destructive: true,
+              disabled: deleteMutation.isPending,
               onSelect: handleDelete,
             },
           ]}

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/staff.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/staff.tsx
@@ -2,12 +2,12 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { type AdminUser, type Invitation, type Role, SpreeError } from '@spree/admin-sdk'
 import { createFileRoute } from '@tanstack/react-router'
 import {
+  BanIcon,
   ClockIcon,
   LinkIcon,
   MailIcon,
-  MoreHorizontalIcon,
   PlusIcon,
-  ShieldIcon,
+  UserMinusIcon,
   UsersRoundIcon,
 } from 'lucide-react'
 import { useState } from 'react'
@@ -18,6 +18,7 @@ import { z } from 'zod/v4'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { PageHeader } from '@/components/spree/page-header'
 import { RelativeTime } from '@/components/spree/relative-time'
+import { RowActions } from '@/components/spree/row-actions'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -40,13 +41,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { Field, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
@@ -57,6 +51,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard'
 import {
@@ -219,27 +221,22 @@ function StaffRow({ member }: { member: AdminUser }) {
           )}
         </TableCell>
         <TableCell className="text-right">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button size="icon-sm" variant="ghost" aria-label={t('admin.staff.actions_aria')}>
-                <MoreHorizontalIcon className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => setEditOpen(true)}>
-                <ShieldIcon className="size-4" />
-                {t('admin.actions.edit')}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem variant="destructive" onClick={handleRemove}>
-                {t('admin.pages.staff.actions.remove')}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => setEditOpen(true) },
+              {
+                key: 'remove',
+                label: t('admin.pages.staff.actions.remove'),
+                icon: <UserMinusIcon className="size-4" />,
+                destructive: true,
+                onSelect: handleRemove,
+              },
+            ]}
+          />
         </TableCell>
       </TableRow>
 
-      <EditStaffDialog open={editOpen} onOpenChange={setEditOpen} member={member} />
+      <EditStaffSheet open={editOpen} onOpenChange={setEditOpen} member={member} />
     </>
   )
 }
@@ -356,27 +353,29 @@ function InvitationRow({ invitation }: { invitation: Invitation }) {
         )}
       </TableCell>
       <TableCell className="text-right">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button size="icon-sm" variant="ghost" aria-label={t('admin.staff.actions_aria')}>
-              <MoreHorizontalIcon className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={handleResend}>
-              <MailIcon className="size-4" />
-              {t('admin.pages.staff.actions.resend')}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleCopyLink}>
-              <LinkIcon className="size-4" />
-              {t('admin.staff.actions.copy_invitation_link')}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onClick={handleDelete}>
-              {t('admin.pages.staff.actions.revoke')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <RowActions
+          actions={[
+            {
+              key: 'resend',
+              label: t('admin.pages.staff.actions.resend'),
+              icon: <MailIcon className="size-4" />,
+              onSelect: handleResend,
+            },
+            {
+              key: 'copy-link',
+              label: t('admin.staff.actions.copy_invitation_link'),
+              icon: <LinkIcon className="size-4" />,
+              onSelect: handleCopyLink,
+            },
+            {
+              key: 'revoke',
+              label: t('admin.pages.staff.actions.revoke'),
+              icon: <BanIcon className="size-4" />,
+              destructive: true,
+              onSelect: handleDelete,
+            },
+          ]}
+        />
       </TableCell>
     </TableRow>
   )
@@ -532,7 +531,7 @@ const editSchema = z.object({
 
 type EditFormValues = z.infer<typeof editSchema>
 
-function EditStaffDialog({
+function EditStaffSheet({
   open,
   onOpenChange,
   member,
@@ -574,7 +573,7 @@ function EditStaffDialog({
   }
 
   return (
-    <Dialog
+    <Sheet
       open={open}
       onOpenChange={(next) => {
         if (!next) {
@@ -587,13 +586,13 @@ function EditStaffDialog({
         onOpenChange(next)
       }}
     >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('admin.pages.staff.edit_sheet.title')}</DialogTitle>
-          <DialogDescription>{member.email}</DialogDescription>
-        </DialogHeader>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
-          <DialogBody className="flex flex-col gap-4">
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>{member.full_name || member.email}</SheetTitle>
+          <SheetDescription>{t('admin.staff.edit_description')}</SheetDescription>
+        </SheetHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
             {form.formState.errors.root?.message && (
               <p className="text-sm text-destructive" role="alert">
                 {form.formState.errors.root.message}
@@ -638,8 +637,8 @@ function EditStaffDialog({
               />
               <FieldError errors={[form.formState.errors.role_ids]} />
             </Field>
-          </DialogBody>
-          <DialogFooter>
+          </div>
+          <SheetFooter>
             <Button
               type="button"
               variant="outline"
@@ -649,13 +648,17 @@ function EditStaffDialog({
             >
               {t('admin.actions.cancel')}
             </Button>
-            <Button type="submit" size="sm" disabled={form.formState.isSubmitting}>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={form.formState.isSubmitting || !form.formState.isDirty}
+            >
               {form.formState.isSubmitting ? t('admin.actions.saving') : t('admin.actions.save')}
             </Button>
-          </DialogFooter>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   )
 }
 

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/stock-locations.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/stock-locations.tsx
@@ -17,6 +17,7 @@ import { useConfirm } from '@/components/spree/confirm-dialog'
 import { CountryCombobox } from '@/components/spree/country-combobox'
 import { StateCombobox, useCountryStates } from '@/components/spree/country-state-fields'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -48,6 +49,7 @@ import {
 } from '@/hooks/use-stock-locations'
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import {
   formValuesToParams,
   PICKUP_STOCK_POLICIES,
@@ -79,6 +81,9 @@ function StockLocationsPage() {
   // gets us past the parent-union narrowing.
   const search = Route.useSearch() as z.infer<typeof stockSearchSchema>
   const navigate = useNavigate()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteStockLocation()
+  const { permissions } = usePermissions()
 
   const editId = search.edit
   const isCreating = !!search.new
@@ -102,6 +107,17 @@ function StockLocationsPage() {
 
   useRowClickBridge('data-stock-location-id', openEdit)
 
+  async function handleDelete(location: StockLocation) {
+    const ok = await confirm({
+      title: t('admin.stock_locations.delete_confirm.title'),
+      message: t('admin.stock_locations.delete_confirm.message', { name: location.name ?? '' }),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(location.id).catch(() => undefined)
+  }
+
   return (
     <>
       <ResourceTable<StockLocation>
@@ -109,6 +125,20 @@ function StockLocationsPage() {
         queryKey="stock-locations"
         queryFn={(params) => adminClient.stockLocations.list(params)}
         searchParams={search}
+        rowActions={(location) => (
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => openEdit(location.id) },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.StockLocation),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(location),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.StockLocation}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -213,8 +243,6 @@ function EditStockLocationSheet({
   const { t } = useTranslation()
   const { data: stockLocation, isLoading } = useStockLocation(id)
   const updateMutation = useUpdateStockLocation(id)
-  const deleteMutation = useDeleteStockLocation()
-  const confirm = useConfirm()
 
   const form = useForm<StockLocationFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -241,25 +269,6 @@ function EditStockLocationSheet({
     }
   }
 
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.stock_locations.delete_confirm.title'),
-      message: t('admin.stock_locations.delete_confirm.message', {
-        name: stockLocation?.name ?? '',
-      }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    try {
-      await deleteMutation.mutateAsync(id)
-      onOpenChange(false)
-    } catch {
-      // `useResourceMutation` already surfaces a toast for non-422 errors.
-      // Keep the sheet open so the user can retry or cancel.
-    }
-  }
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent>
@@ -278,18 +287,6 @@ function EditStockLocationSheet({
               <StockItemsPanel stockLocationId={id} />
             </div>
             <SheetFooter>
-              <Can I="destroy" a={Subject.StockLocation}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={form.formState.isSubmitting || deleteMutation.isPending}
-                  className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                  {t('admin.actions.delete')}
-                </Button>
-              </Can>
               <Button
                 type="button"
                 variant="outline"

--- a/packages/admin/src/routes/_authenticated/$storeId/settings/tax-categories.tsx
+++ b/packages/admin/src/routes/_authenticated/$storeId/settings/tax-categories.tsx
@@ -10,6 +10,7 @@ import { adminClient } from '@/client'
 import { Can } from '@/components/spree/can'
 import { useConfirm } from '@/components/spree/confirm-dialog'
 import { ResourceTable, resourceSearchSchema } from '@/components/spree/resource-table'
+import { RowActions } from '@/components/spree/row-actions'
 import { useRowClickBridge } from '@/components/spree/row-click-bridge'
 import { Button } from '@/components/ui/button'
 import { Field, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field'
@@ -32,6 +33,7 @@ import {
 } from '@/hooks/use-tax-categories'
 import { mapSpreeErrorsToForm } from '@/lib/form-errors'
 import { Subject } from '@/lib/permissions'
+import { usePermissions } from '@/providers/permission-provider'
 import {
   TAX_CATEGORY_DEFAULTS,
   type TaxCategoryFormValues,
@@ -54,6 +56,9 @@ function TaxCategoriesPage() {
   const { t } = useTranslation()
   const search = Route.useSearch() as z.infer<typeof taxCategoriesSearchSchema>
   const navigate = useNavigate()
+  const confirm = useConfirm()
+  const deleteMutation = useDeleteTaxCategory()
+  const { permissions } = usePermissions()
 
   const editId = search.edit
   const isCreating = !!search.new
@@ -74,6 +79,19 @@ function TaxCategoriesPage() {
 
   useRowClickBridge('data-tax-category-id', openEdit)
 
+  async function handleDelete(taxCategory: TaxCategory) {
+    const ok = await confirm({
+      title: t('admin.tax_categories.delete_confirm.title'),
+      message: t('admin.tax_categories.delete_confirm.message', {
+        name: taxCategory.name ?? '',
+      }),
+      variant: 'destructive',
+      confirmLabel: t('admin.actions.delete'),
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync(taxCategory.id).catch(() => undefined)
+  }
+
   return (
     <>
       <ResourceTable<TaxCategory>
@@ -81,6 +99,20 @@ function TaxCategoriesPage() {
         queryKey="tax-categories"
         queryFn={(params) => adminClient.taxCategories.list(params)}
         searchParams={search}
+        rowActions={(taxCategory) => (
+          <RowActions
+            actions={[
+              { key: 'edit', onSelect: () => openEdit(taxCategory.id) },
+              {
+                key: 'delete',
+                destructive: true,
+                visible: permissions.can('destroy', Subject.TaxCategory),
+                disabled: deleteMutation.isPending,
+                onSelect: () => handleDelete(taxCategory),
+              },
+            ]}
+          />
+        )}
         actions={
           <Can I="create" a={Subject.TaxCategory}>
             <Button size="sm" className="h-[2.125rem]" onClick={openCreate}>
@@ -173,8 +205,6 @@ function EditTaxCategorySheet({
   const { t } = useTranslation()
   const { data: taxCategory, isLoading } = useTaxCategory(id)
   const updateMutation = useUpdateTaxCategory(id)
-  const deleteMutation = useDeleteTaxCategory()
-  const confirm = useConfirm()
 
   const form = useForm<TaxCategoryFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -203,25 +233,6 @@ function EditTaxCategorySheet({
     }
   }
 
-  async function onDelete() {
-    const ok = await confirm({
-      title: t('admin.tax_categories.delete_confirm.title'),
-      message: t('admin.tax_categories.delete_confirm.message', {
-        name: taxCategory?.name ?? '',
-      }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
-    try {
-      await deleteMutation.mutateAsync(id)
-      onOpenChange(false)
-    } catch {
-      // `useResourceMutation` already toasts non-422 errors; keep the sheet
-      // open so the user can retry.
-    }
-  }
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent>
@@ -239,18 +250,6 @@ function EditTaxCategorySheet({
               <TaxCategoryFormFields form={form} />
             </div>
             <SheetFooter>
-              <Can I="destroy" a={Subject.TaxCategory}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDelete}
-                  disabled={form.formState.isSubmitting || deleteMutation.isPending}
-                  className="mr-auto text-destructive hover:bg-destructive/10 hover:text-destructive"
-                >
-                  {t('admin.actions.delete')}
-                </Button>
-              </Can>
               <Button
                 type="button"
                 variant="outline"

--- a/packages/admin/src/tables/option-types.tsx
+++ b/packages/admin/src/tables/option-types.tsx
@@ -1,9 +1,8 @@
 import type { OptionType } from '@spree/admin-sdk'
-import { ListChecksIcon, PencilIcon } from 'lucide-react'
+import { ListChecksIcon } from 'lucide-react'
 import { RelativeTime } from '@/components/spree/relative-time'
 import { ResourceNameCell } from '@/components/spree/resource-name-cell'
 import { ActiveBadge, Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { defineTable } from '@/lib/table-registry'
 
 const KIND_LABELS: Record<string, string> = {
@@ -69,25 +68,6 @@ defineTable<OptionType>('option-types', {
       label: 'Updated',
       sortable: true,
       render: (ot) => <RelativeTime iso={ot.updated_at} />,
-    },
-    {
-      key: 'actions',
-      label: '',
-      default: true,
-      className: 'w-12 text-right',
-      // Same `data-stock-location-id` hook as the Name column — the route's
-      // RowClickBridge picks this up and opens the edit Sheet.
-      render: (ot) => (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          data-option-type-id={ot.id}
-          aria-label={`Edit ${ot.name}`}
-        >
-          <PencilIcon data-option-type-id={ot.id} className="size-4" />
-        </Button>
-      ),
     },
   ],
 })

--- a/packages/admin/src/tables/stock-locations.tsx
+++ b/packages/admin/src/tables/stock-locations.tsx
@@ -1,8 +1,7 @@
 import type { StockLocation } from '@spree/admin-sdk'
-import { PencilIcon, WarehouseIcon } from 'lucide-react'
+import { WarehouseIcon } from 'lucide-react'
 import { ResourceNameCell } from '@/components/spree/resource-name-cell'
 import { ActiveBadge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { defineTable } from '@/lib/table-registry'
 
 defineTable<StockLocation>('stock-locations', {
@@ -82,25 +81,6 @@ defineTable<StockLocation>('stock-locations', {
       filterable: true,
       filterType: 'boolean',
       render: (sl) => <ActiveBadge active={sl.default} activeLabel="Default" dashWhenInactive />,
-    },
-    {
-      key: 'actions',
-      label: '',
-      default: true,
-      className: 'w-12 text-right',
-      // Same `data-stock-location-id` hook as the Name column — the route's
-      // RowClickBridge picks this up and opens the edit Sheet.
-      render: (sl) => (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          data-stock-location-id={sl.id}
-          aria-label={`Edit ${sl.name}`}
-        >
-          <PencilIcon data-stock-location-id={sl.id} className="size-4" />
-        </Button>
-      ),
     },
   ],
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many admin destroy flows and permission gates; mistakes could hide actions or delete without proper confirm, but changes are UI-only with E2E coverage for the new delete path.
> 
> **Overview**
> Introduces a shared **`RowActions`** kebab on resource index tables and wires it through **`ResourceTable`**’s `rowActions` prop, including when **drag-and-drop reorder** is enabled (handle on the left, menu on the right).
> 
> **Destructive work moves out of edit sheets:** delete (and similar) is triggered from the row menu with confirm dialogs and **CanCanCan**-gated visibility, across customers, products, promotions, gift cards, customer groups, option types, stock transfers, payment methods, stock locations, tax categories, API keys, and staff/invitations. Inline pencil/action columns in some table definitions are removed in favor of the trailing menu.
> 
> **E2E** adds **`openRowMenu`** and updates delete flows to use **Open actions** → **Delete**; customer-groups bulk test reads **`customers_count`** from column index 1 now that a trailing actions cell exists.
> 
> **i18n:** command palette, bulk action bar, filter Yes/No, promotion delete copy, and related **`en.json`** keys; staff **edit** moves from dialog to **sheet**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7865b60f2e92c088ef98bde4cefbbc2d61d1994b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Standardized row action menus (edit, delete, etc.) across resource tables with permission-based visibility and consistent styling.
  * Enabled row actions during drag-and-drop reordering mode.

* **Bug Fixes**
  * Fixed customer count polling in bulk assignment test to use correct column index.

* **Documentation & Localization**
  * Added internationalization support for UI labels, dialogs, and status messages throughout the admin interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->