### PR TITLE
Fixed flaky permission tests

### DIFF
--- a/spree/core/lib/spree/core/permission_configuration.rb
+++ b/spree/core/lib/spree/core/permission_configuration.rb
@@ -105,6 +105,21 @@ module Spree
       @role_permissions = {}
     end
 
+    # Returns a deep copy of this configuration. Useful for snapshotting
+    # state before a test mutates it; restore with {#replace}.
+    def dup
+      copy = super
+      copy.instance_variable_set(:@role_permissions, @role_permissions.deep_dup)
+      copy
+    end
+
+    # Replaces this configuration's state with a deep copy of `other`'s.
+    # Pair with {#dup} to snapshot/restore around code that mutates the
+    # global Spree.permissions config.
+    def replace(other)
+      @role_permissions = other.instance_variable_get(:@role_permissions).deep_dup
+    end
+
     private
 
     def normalize_role_name(role_name)

--- a/spree/core/spec/models/spree/ability_spec.rb
+++ b/spree/core/spec/models/spree/ability_spec.rb
@@ -8,12 +8,6 @@ describe Spree::Ability, type: :model do
   let(:ability) { Spree::Ability.new(user) }
   let(:token) { nil }
 
-  before do
-    # Ensure permission sets are configured (may have been reset by other specs)
-    Spree.permissions.assign(:default, [Spree::PermissionSets::DefaultCustomer])
-    Spree.permissions.assign(:admin, [Spree::PermissionSets::SuperUser])
-  end
-
   context 'for general resource' do
     let(:resource) { Object.new }
 

--- a/spree/core/spec/models/spree/permission_sets/ability_integration_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/ability_integration_spec.rb
@@ -4,14 +4,15 @@ require 'cancan/matchers'
 RSpec.describe 'Permission Sets Integration with Ability', type: :model do
   let(:store) { @default_store }
 
-  before do
-    # Reset permissions before each test
+  # These specs configure Spree.permissions from scratch to assert exact role
+  # resolution, but the config is global — leaving it empty would strip admins
+  # of `accessible_by(:manage)` in every spec that runs after this file.
+  around do |example|
+    saved = Spree.permissions.dup
     Spree.permissions.reset!
-  end
-
-  after do
-    # Reset permissions after each test
-    Spree.permissions.reset!
+    example.run
+  ensure
+    Spree.permissions.replace(saved)
   end
 
   describe 'role-based permissions' do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only and small helper APIs on permission configuration; no production authorization behavior changes.
> 
> **Overview**
> Stabilizes specs that mutate the global **`Spree.permissions`** map by adding **`dup`** / **`replace`** on **`PermissionConfiguration`** so tests can snapshot and restore role→permission-set assignments instead of leaking an empty config to later examples.
> 
> **`ability_integration_spec`** now uses an **`around`** hook: save a copy, **`reset!`**, run the example, then **`replace(saved)`** so admin **`accessible_by(:manage)`** and other defaults stay intact for the rest of the suite. **`ability_spec`** drops a redundant **`before`** that re-assigned default/admin permission sets on every example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064a03421394bae68902f6df982b8810ae3ae025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission configurations now support deep copying and restoration of state, enabling better isolation and reproducibility of permission settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->