### PR TITLE
Polish active integration status placement

### DIFF
--- a/spree/admin/app/views/spree/admin/integrations/_integration.html.erb
+++ b/spree/admin/app/views/spree/admin/integrations/_integration.html.erb
@@ -15,14 +15,14 @@
       <p><%= integration_description %></p>
     </div>
 
-    <div class="card-footer flex <% if integration.present? %>items-center justify-between gap-3<% else %>flex-col<% end %>">
+    <div class="card-footer flex <% if integration.present? %>items-center gap-3<% else %>flex-col<% end %>">
       <% if integration.present? %>
         <%= link_to spree.edit_admin_integration_path(integration), class: 'btn btn-sm btn-light' do %>
           <%= icon 'settings' %>
           <%= Spree.t(:settings) %>
         <% end if can?(:update, integration) %>
 
-        <span class="inline-flex items-center text-xs font-medium text-green-700">
+        <span class="ml-auto inline-flex items-center text-xs font-medium text-green-700">
           <span class="w-1.5 h-1.5 rounded-full bg-green-500 mr-1"></span>
           <%= Spree.t(:active) %>
         </span>

--- a/spree/admin/app/views/spree/admin/integrations/_integration.html.erb
+++ b/spree/admin/app/views/spree/admin/integrations/_integration.html.erb
@@ -5,29 +5,27 @@
 
 <div id="integration-<%= integration_class.integration_key %>" class="col mb-6 flex items-stretch">
   <div class="card w-full">
-    <div class="card-header border-b flex flex-col gap-4 items-center justify-between h-auto pr-4 <% if integration.present? %>bg-green-50<% end %>">
+    <div class="card-header border-b flex items-center justify-center h-auto pr-4 <% if integration.present? %>bg-green-50<% end %>">
       <div class="flex items-center py-1">
         <%= image_tag integration_class.icon_path, alt: integration_name, height: 36 if integration_class.icon_path.present? %>
       </div>
-
-      <% if integration.present? %>
-        <span class="badge badge-success small">
-          <%= icon('check', class: 'mr-1') %>
-          <%= Spree.t(:active) %>
-        </span>
-      <% end %>
     </div>
 
     <div class="card-body">
       <p><%= integration_description %></p>
     </div>
 
-    <div class="card-footer flex <% if integration.present? %>items-baseline justify-between<% else %>flex-col<% end %>">
+    <div class="card-footer flex <% if integration.present? %>items-center justify-between gap-3<% else %>flex-col<% end %>">
       <% if integration.present? %>
         <%= link_to spree.edit_admin_integration_path(integration), class: 'btn btn-sm btn-light' do %>
           <%= icon 'settings' %>
           <%= Spree.t(:settings) %>
         <% end if can?(:update, integration) %>
+
+        <span class="inline-flex items-center text-xs font-medium text-green-700">
+          <span class="w-1.5 h-1.5 rounded-full bg-green-500 mr-1"></span>
+          <%= Spree.t(:active) %>
+        </span>
       <% else %>
         <%= link_to_with_icon 'plus', "#{Spree.t('actions.connect')} #{integration_class.integration_name}", spree.new_admin_integration_path(integration: { type: integration_class.name }), class: 'btn btn-primary truncate w-full' if can?(:create, Spree::Integration) %>
       <% end %>


### PR DESCRIPTION
Move the active status indicator out of the integration card header and into the footer next to the settings action. This keeps integration logos from being vertically stretched when an integration is active, while preserving a lightweight status signal that works consistently across integration cards.

Before:
<img width="620" height="714" alt="image" src="https://github.com/user-attachments/assets/57453588-92f5-43ae-b841-3deae472714e" />
Now:
<img width="1212" height="666" alt="image" src="https://github.com/user-attachments/assets/eb3772fa-0473-412c-8f0d-92cfeedece53" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Centered integration card header and improved responsive layout for clearer visual organization.
  * Replaced header badge check with a green inline status pill and dot in the footer to better indicate active integrations.
  * Footer now adapts layout when an integration exists versus when absent, improving spacing and alignment.
  * Settings link remains shown only when the user has update permission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->