### PR TITLE
Fix integration edit header update button

### DIFF
--- a/spree/admin/app/views/spree/admin/integrations/edit.html.erb
+++ b/spree/admin/app/views/spree/admin/integrations/edit.html.erb
@@ -5,7 +5,7 @@
 
 <%= render partial: 'spree/admin/shared/error_messages', locals: { target: @integration } %>
 
-<%= form_for @integration, as: :integration, url: spree.admin_integration_path(@integration) do |form| %>
+<%= form_for @integration, as: :integration, url: spree.admin_integration_path(@integration), html: { id: "edit_integration_#{@integration.id}" } do |form| %>
   <div class="grid grid-cols-12 gap-6">
     <div class="col-span-12 lg:col-span-6 lg:col-start-4">
       <%= render "spree/admin/integrations/forms/#{@integration.key}", form: form %>


### PR DESCRIPTION
Set the integration edit form id to match the form target used by the shared admin header update button. Integration forms are rendered with `as: :integration`, while concrete integrations use STI subclasses, so relying on the generated form id can leave the header button pointing at a non-existent form.

This makes the header Update action submit the same form as the in-page Update button across integration detail pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor form markup improvements to the integration edit page for better form identification and structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->