### PR TITLE
Improve and document Authentication strategies for API

### DIFF
--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -82,12 +82,12 @@ paths:
               example:
                 data:
                 - id: admin_UkLWZg9DAJ
-                  email: krista@zboncakokuneva.us
-                  first_name: Erwin
-                  last_name: Braun
-                  full_name: Erwin Braun
-                  created_at: '2026-05-26T12:42:46.794Z'
-                  updated_at: '2026-05-26T12:42:46.794Z'
+                  email: tomeka.moore@strosin.com
+                  first_name: Loria
+                  last_name: Boyer
+                  full_name: Loria Boyer
+                  created_at: '2026-05-26T15:16:41.133Z'
+                  updated_at: '2026-05-26T15:16:41.133Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -145,12 +145,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: jen.mayer@gleason.us
-                first_name: Lakia
-                last_name: Ryan
-                full_name: Lakia Ryan
-                created_at: '2026-05-26T12:42:47.189Z'
-                updated_at: '2026-05-26T12:42:47.189Z'
+                email: michiko@corkerynitzsche.name
+                first_name: Herschel
+                last_name: Jacobson
+                full_name: Herschel Jacobson
+                created_at: '2026-05-26T15:16:41.482Z'
+                updated_at: '2026-05-26T15:16:41.482Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -203,12 +203,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: kathe@vonruedendicki.biz
+                email: treva.welch@cartwright.info
                 first_name: Renamed
-                last_name: O'Hara
-                full_name: Renamed O'Hara
-                created_at: '2026-05-26T12:42:47.469Z'
-                updated_at: '2026-05-26T12:42:47.487Z'
+                last_name: Corkery
+                full_name: Renamed Corkery
+                created_at: '2026-05-26T15:16:41.761Z'
+                updated_at: '2026-05-26T15:16:41.777Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -317,32 +317,32 @@ paths:
                   key_type: publishable
                   token_prefix:
                   scopes: []
-                  created_at: '2026-05-26T12:42:47.777Z'
-                  updated_at: '2026-05-26T12:42:47.777Z'
+                  created_at: '2026-05-26T15:16:42.211Z'
+                  updated_at: '2026-05-26T15:16:42.211Z'
                   revoked_at:
                   last_used_at:
-                  plaintext_token: pk_MXpnpNbeH6Jonc9PHFAAkrRN
+                  plaintext_token: pk_TAXzVgPEbRY5rWt79znVk5Gm
                   created_by_email:
                 - id: key_gbHJdmfrXB
                   name: Backend integration
                   key_type: secret
-                  token_prefix: sk_3wzZtNJd9
+                  token_prefix: sk_LumTbZiVT
                   scopes:
                   - write_all
-                  created_at: '2026-05-26T12:42:47.778Z'
-                  updated_at: '2026-05-26T12:42:47.778Z'
+                  created_at: '2026-05-26T15:16:42.212Z'
+                  updated_at: '2026-05-26T15:16:42.212Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
                   created_by_email:
                 - id: key_EfhxLZ9ck8
-                  name: facilis
+                  name: autem
                   key_type: secret
-                  token_prefix: sk_rst3YWMdZ
+                  token_prefix: sk_kepWFCbSR
                   scopes:
                   - write_all
-                  created_at: '2026-05-26T12:42:47.778Z'
-                  updated_at: '2026-05-26T12:42:47.778Z'
+                  created_at: '2026-05-26T15:16:42.212Z'
+                  updated_at: '2026-05-26T15:16:42.212Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
@@ -405,15 +405,15 @@ paths:
                 id: key_VqXmZF31wY
                 name: CI key
                 key_type: secret
-                token_prefix: sk_sySDky4Kf
+                token_prefix: sk_AmM3N529B
                 scopes:
                 - read_orders
-                created_at: '2026-05-26T12:42:48.347Z'
-                updated_at: '2026-05-26T12:42:48.347Z'
+                created_at: '2026-05-26T15:16:42.924Z'
+                updated_at: '2026-05-26T15:16:42.924Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: sk_sySDky4KfskBpQC6HVsRCEsU
-                created_by_email: bula.kemmer@hayesrath.name
+                plaintext_token: sk_AmM3N529BA7uqSw7k2aCzLVM
+                created_by_email: lilliana_oreilly@ledner.us
         '422':
           description: validation error
           content:
@@ -499,11 +499,11 @@ paths:
                 key_type: publishable
                 token_prefix:
                 scopes: []
-                created_at: '2026-05-26T12:42:48.641Z'
-                updated_at: '2026-05-26T12:42:48.641Z'
+                created_at: '2026-05-26T15:16:43.257Z'
+                updated_at: '2026-05-26T15:16:43.257Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: pk_Wsz6ry2mTHN8U1k4DyGQPgoE
+                plaintext_token: pk_agbcCXvwGQTP2o8s6NUEjgrE
                 created_by_email:
     delete:
       summary: Delete an API key
@@ -593,15 +593,200 @@ paths:
                 id: key_gbHJdmfrXB
                 name: Backend integration
                 key_type: secret
-                token_prefix: sk_HSvSsXbqA
+                token_prefix: sk_YWJDVhxQj
                 scopes:
                 - write_all
-                created_at: '2026-05-26T12:42:49.216Z'
-                updated_at: '2026-05-26T12:42:49.498Z'
-                revoked_at: '2026-05-26T12:42:49.497Z'
+                created_at: '2026-05-26T15:16:43.958Z'
+                updated_at: '2026-05-26T15:16:44.374Z'
+                revoked_at: '2026-05-26T15:16:44.373Z'
                 last_used_at:
                 plaintext_token:
                 created_by_email:
+  "/api/v3/admin/auth/login":
+    post:
+      summary: Login
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+      description: |
+        Authenticates an admin user and returns a short-lived JWT access token.
+        The rotatable refresh token is set in an HttpOnly cookie — it is not
+        included in the response body.
+
+        Dispatches by the `provider` field to a strategy registered in
+        `Spree.admin_authentication_strategies`. When `provider` is omitted it
+        defaults to `email`, which uses the built-in email/password strategy.
+
+        To plug in a third-party identity provider (Okta, Azure AD, Google
+        Workspace SSO, a custom JWT issuer, SAML, etc.), register a
+        `Spree::Authentication::Strategies::BaseStrategy` subclass under a
+        provider key, then send `{ "provider": "<your_key>", ... }` with the
+        fields your strategy requires. The endpoint returns the same Spree-issued
+        JWT regardless of which strategy authenticated the request.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          // The refresh token is set as an HttpOnly cookie; only `token` and `user` come back in the body.
+          const auth = await client.auth.login({
+            email: 'admin@example.com',
+            password: 'password123',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: login successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjQ3M2RmNzE0LTkwYmItNGI1NS05Njk0LWQyMDE0MjJlNjAyOCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODA4OTA0fQ.5ZZ4Yj1v80rlf9a6n5Z0f7_lCw12dx-Fi_zmuYzHfi8
+                user:
+                  id: admin_UkLWZg9DAJ
+                  email: admin@example.com
+                  first_name: Mira
+                  last_name: Reichel
+                  full_name: Mira Reichel
+                  created_at: '2026-05-26T15:16:44.647Z'
+                  updated_at: '2026-05-26T15:16:44.647Z'
+                  roles:
+                  - id: role_UkLWZg9DAJ
+                    name: admin
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '401':
+          description: invalid credentials
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_failed
+                  message: Invalid email or password
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - title: EmailPasswordLogin
+                description: Built-in email/password authentication (default when
+                  `provider` is omitted).
+                type: object
+                properties:
+                  provider:
+                    type: string
+                    enum:
+                    - email
+                    default: email
+                  email:
+                    type: string
+                    format: email
+                    example: admin@example.com
+                  password:
+                    type: string
+                    example: password123
+                required:
+                - email
+                - password
+              - title: ProviderLogin
+                description: |
+                  Provider-dispatched login. The `provider` key selects a registered
+                  strategy class; the remaining fields are forwarded to the strategy's
+                  `authenticate` method. Required fields depend on the registered strategy
+                  — consult its documentation.
+                type: object
+                properties:
+                  provider:
+                    type: string
+                    example: okta
+                    description: Registered provider key (anything other than `email`).
+                required:
+                - provider
+                additionalProperties: true
+  "/api/v3/admin/auth/refresh":
+    post:
+      summary: Refresh token
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+      description: |
+        Exchanges the HttpOnly refresh-token cookie for a new access JWT and a
+        rotated refresh token cookie. No request body or Authorization header
+        is required — the cookie alone authenticates the call.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          // Driven entirely by the HttpOnly refresh-token cookie + CSRF header (set by the SDK).
+          const auth = await client.auth.refresh()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '401':
+          description: missing or invalid refresh-token cookie
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_refresh_token
+                  message: Refresh token cookie missing
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/admin/auth/logout":
+    post:
+      summary: Logout
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+      description: Revokes the refresh-token cookie, effectively logging the admin
+        out.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          await client.auth.logout()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: logout successful
   "/api/v3/admin/promotions/{promotion_id}/coupon_codes":
     parameters:
     - name: promotion_id
@@ -653,15 +838,15 @@ paths:
                 - id: coupon_UkLWZg9DAJ
                   code: AAA111
                   state: unused
-                  created_at: '2026-05-26T12:42:49.518Z'
-                  updated_at: '2026-05-26T12:42:49.518Z'
+                  created_at: '2026-05-26T15:16:46.080Z'
+                  updated_at: '2026-05-26T15:16:46.080Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 - id: coupon_gbHJdmfrXB
                   code: BBB222
                   state: unused
-                  created_at: '2026-05-26T12:42:49.519Z'
-                  updated_at: '2026-05-26T12:42:49.519Z'
+                  created_at: '2026-05-26T15:16:46.081Z'
+                  updated_at: '2026-05-26T15:16:46.081Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 meta:
@@ -739,8 +924,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Product
                   storefront_visible: true
-                  created_at: '2026-05-26T12:42:49.819Z'
-                  updated_at: '2026-05-26T12:42:49.819Z'
+                  created_at: '2026-05-26T15:16:46.373Z'
+                  updated_at: '2026-05-26T15:16:46.373Z'
                 - id: cfdef_gbHJdmfrXB
                   namespace: custom
                   key: order_notes
@@ -748,8 +933,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Order
                   storefront_visible: true
-                  created_at: '2026-05-26T12:42:49.820Z'
-                  updated_at: '2026-05-26T12:42:49.820Z'
+                  created_at: '2026-05-26T15:16:46.373Z'
+                  updated_at: '2026-05-26T15:16:46.373Z'
                 meta:
                   page: 1
                   limit: 25
@@ -812,8 +997,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-26T12:42:50.394Z'
-                updated_at: '2026-05-26T12:42:50.394Z'
+                created_at: '2026-05-26T15:16:46.928Z'
+                updated_at: '2026-05-26T15:16:46.928Z'
       requestBody:
         content:
           application/json:
@@ -896,8 +1081,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-26T12:42:50.397Z'
-                updated_at: '2026-05-26T12:42:50.397Z'
+                created_at: '2026-05-26T15:16:46.931Z'
+                updated_at: '2026-05-26T15:16:46.931Z'
     patch:
       summary: Update a custom field definition
       tags:
@@ -936,8 +1121,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: false
-                created_at: '2026-05-26T12:42:50.682Z'
-                updated_at: '2026-05-26T12:42:50.965Z'
+                created_at: '2026-05-26T15:16:47.207Z'
+                updated_at: '2026-05-26T15:16:47.481Z'
       requestBody:
         content:
           application/json:
@@ -1061,14 +1246,14 @@ paths:
                   name: VIPs
                   description: Top spenders
                   customers_count: 0
-                  created_at: '2026-05-26T12:42:51.261Z'
-                  updated_at: '2026-05-26T12:42:51.261Z'
+                  created_at: '2026-05-26T15:16:47.787Z'
+                  updated_at: '2026-05-26T15:16:47.787Z'
                 - id: cg_gbHJdmfrXB
                   name: Wholesale
                   description:
                   customers_count: 0
-                  created_at: '2026-05-26T12:42:51.262Z'
-                  updated_at: '2026-05-26T12:42:51.262Z'
+                  created_at: '2026-05-26T15:16:47.788Z'
+                  updated_at: '2026-05-26T15:16:47.788Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1153,8 +1338,8 @@ paths:
                 name: Wholesale 2
                 description: B2B accounts
                 customers_count: 1
-                created_at: '2026-05-26T12:42:52.143Z'
-                updated_at: '2026-05-26T12:42:52.143Z'
+                created_at: '2026-05-26T15:16:48.643Z'
+                updated_at: '2026-05-26T15:16:48.643Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1260,24 +1445,24 @@ paths:
                 name: VIPs
                 description: Top spenders
                 customers_count: 1
-                created_at: '2026-05-26T12:42:52.761Z'
-                updated_at: '2026-05-26T12:42:52.761Z'
+                created_at: '2026-05-26T15:16:49.207Z'
+                updated_at: '2026-05-26T15:16:49.207Z'
                 customers:
                 - id: cus_UkLWZg9DAJ
-                  email: chia@shields.info
-                  first_name: Sibyl
-                  last_name: Ruecker
+                  email: adrienne@effertz.name
+                  first_name: Agustin
+                  last_name: Grant
                   phone:
                   accepts_email_marketing: false
-                  full_name: Sibyl Ruecker
+                  full_name: Agustin Grant
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
-                  login: chia@shields.info
+                  login: adrienne@effertz.name
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-26T12:42:53.023Z'
-                  updated_at: '2026-05-26T12:42:53.023Z'
+                  created_at: '2026-05-26T15:16:49.466Z'
+                  updated_at: '2026-05-26T15:16:49.466Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -1355,8 +1540,8 @@ paths:
                 name: VIP customers (Q1)
                 description: Top spenders
                 customers_count: 0
-                created_at: '2026-05-26T12:42:53.700Z'
-                updated_at: '2026-05-26T12:42:53.977Z'
+                created_at: '2026-05-26T15:16:50.034Z'
+                updated_at: '2026-05-26T15:16:50.310Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1509,8 +1694,8 @@ paths:
                   state_name: New York
                   label:
                   metadata: {}
-                  created_at: '2026-05-26T12:42:54.830Z'
-                  updated_at: '2026-05-26T12:42:54.830Z'
+                  created_at: '2026-05-26T15:16:51.172Z'
+                  updated_at: '2026-05-26T15:16:51.172Z'
                   customer_id: cus_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -1598,8 +1783,8 @@ paths:
                 state_name: New York
                 label: Office
                 metadata: {}
-                created_at: '2026-05-26T12:42:56.256Z'
-                updated_at: '2026-05-26T12:42:56.256Z'
+                created_at: '2026-05-26T15:16:52.521Z'
+                updated_at: '2026-05-26T15:16:52.521Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -1710,8 +1895,8 @@ paths:
                 state_name: New York
                 label:
                 metadata: {}
-                created_at: '2026-05-26T12:42:56.525Z'
-                updated_at: '2026-05-26T12:42:57.067Z'
+                created_at: '2026-05-26T15:16:52.787Z'
+                updated_at: '2026-05-26T15:16:53.325Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -1844,8 +2029,8 @@ paths:
                   customer_id: cus_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   metadata: {}
-                  created_at: '2026-05-26T12:42:58.161Z'
-                  updated_at: '2026-05-26T12:42:58.161Z'
+                  created_at: '2026-05-26T15:16:54.419Z'
+                  updated_at: '2026-05-26T15:16:54.419Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1932,8 +2117,8 @@ paths:
                 customer_id: cus_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 metadata: {}
-                created_at: '2026-05-26T12:42:58.710Z'
-                updated_at: '2026-05-26T12:42:58.710Z'
+                created_at: '2026-05-26T15:16:55.044Z'
+                updated_at: '2026-05-26T15:16:55.044Z'
     delete:
       summary: Delete a customer credit card
       tags:
@@ -2052,8 +2237,8 @@ paths:
                   currency: USD
                   memo:
                   metadata: {}
-                  created_at: '2026-05-26T12:43:00.094Z'
-                  updated_at: '2026-05-26T12:43:00.094Z'
+                  created_at: '2026-05-26T15:16:56.558Z'
+                  updated_at: '2026-05-26T15:16:56.558Z'
                   customer_id: cus_UkLWZg9DAJ
                   created_by_id: admin_UkLWZg9DAJ
                   category_id: sccat_UkLWZg9DAJ
@@ -2128,8 +2313,8 @@ paths:
                 currency: USD
                 memo: Goodwill
                 metadata: {}
-                created_at: '2026-05-26T12:43:01.199Z'
-                updated_at: '2026-05-26T12:43:01.199Z'
+                created_at: '2026-05-26T15:16:57.774Z'
+                updated_at: '2026-05-26T15:16:57.774Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_gbHJdmfrXB
                 category_id: sccat_UkLWZg9DAJ
@@ -2220,8 +2405,8 @@ paths:
                 currency: USD
                 memo: Updated
                 metadata: {}
-                created_at: '2026-05-26T12:43:01.740Z'
-                updated_at: '2026-05-26T12:43:02.024Z'
+                created_at: '2026-05-26T15:16:58.338Z'
+                updated_at: '2026-05-26T15:16:58.622Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_UkLWZg9DAJ
                 category_id: sccat_UkLWZg9DAJ
@@ -2375,8 +2560,8 @@ paths:
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-26T12:43:03.106Z'
-                  updated_at: '2026-05-26T12:43:03.106Z'
+                  created_at: '2026-05-26T15:16:59.749Z'
+                  updated_at: '2026-05-26T15:16:59.749Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -2459,8 +2644,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T12:43:03.934Z'
-                updated_at: '2026-05-26T12:43:03.934Z'
+                created_at: '2026-05-26T15:17:00.577Z'
+                updated_at: '2026-05-26T15:17:00.577Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2576,8 +2761,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T12:43:04.206Z'
-                updated_at: '2026-05-26T12:43:04.206Z'
+                created_at: '2026-05-26T15:17:00.845Z'
+                updated_at: '2026-05-26T15:17:00.845Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2651,8 +2836,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T12:43:04.752Z'
-                updated_at: '2026-05-26T12:43:05.035Z'
+                created_at: '2026-05-26T15:17:01.383Z'
+                updated_at: '2026-05-26T15:17:01.662Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -3082,11 +3267,11 @@ paths:
               example:
                 data:
                 - id: exp_UkLWZg9DAJ
-                  number: EF532072077
+                  number: EF713687169
                   type: Spree::Exports::Products
                   format: csv
-                  created_at: '2026-05-26T12:43:09.204Z'
-                  updated_at: '2026-05-26T12:43:09.204Z'
+                  created_at: '2026-05-26T15:17:05.745Z'
+                  updated_at: '2026-05-26T15:17:05.745Z'
                   user_id: admin_UkLWZg9DAJ
                   done: false
                   filename:
@@ -3153,11 +3338,11 @@ paths:
             application/json:
               example:
                 id: exp_gbHJdmfrXB
-                number: EF574479198
+                number: EF835182032
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-26T12:43:09.506Z'
-                updated_at: '2026-05-26T12:43:09.506Z'
+                created_at: '2026-05-26T15:17:06.040Z'
+                updated_at: '2026-05-26T15:17:06.040Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3244,11 +3429,11 @@ paths:
             application/json:
               example:
                 id: exp_UkLWZg9DAJ
-                number: EF872001258
+                number: EF096265475
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-26T12:43:09.778Z'
-                updated_at: '2026-05-26T12:43:09.778Z'
+                created_at: '2026-05-26T15:17:06.313Z'
+                updated_at: '2026-05-26T15:17:06.313Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3431,8 +3616,8 @@ paths:
                   codes_count: 2
                   currency: USD
                   prefix: WELCOME
-                  created_at: '2026-05-26T12:43:10.373Z'
-                  updated_at: '2026-05-26T12:43:10.373Z'
+                  created_at: '2026-05-26T15:17:06.915Z'
+                  updated_at: '2026-05-26T15:17:06.915Z'
                   amount: '50.0'
                   expires_at:
                   created_by_id:
@@ -3513,8 +3698,8 @@ paths:
                 codes_count: 5
                 currency: USD
                 prefix: NEWCAMP
-                created_at: '2026-05-26T12:43:10.938Z'
-                updated_at: '2026-05-26T12:43:10.938Z'
+                created_at: '2026-05-26T15:17:07.486Z'
+                updated_at: '2026-05-26T15:17:07.486Z'
                 amount: '25.0'
                 expires_at: '2030-12-31'
                 created_by_id: admin_UkLWZg9DAJ
@@ -3615,8 +3800,8 @@ paths:
                 codes_count: 2
                 currency: USD
                 prefix: WELCOME
-                created_at: '2026-05-26T12:43:11.226Z'
-                updated_at: '2026-05-26T12:43:11.226Z'
+                created_at: '2026-05-26T15:17:07.792Z'
+                updated_at: '2026-05-26T15:17:07.792Z'
                 amount: '50.0'
                 expires_at:
                 created_by_id:
@@ -3719,7 +3904,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: 9B9ED58051A4985A
+                  code: E2BF7D4745015B17
                   status: active
                   currency: USD
                   amount: '50.0'
@@ -3733,12 +3918,12 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-05-26T12:43:11.794Z'
-                  updated_at: '2026-05-26T12:43:11.794Z'
+                  created_at: '2026-05-26T15:17:08.365Z'
+                  updated_at: '2026-05-26T15:17:08.365Z'
                   customer_id:
                   created_by_id:
                 - id: gc_gbHJdmfrXB
-                  code: DB1278946CB996BA
+                  code: E559172DA4C7878C
                   status: active
                   currency: USD
                   amount: '25.0'
@@ -3752,8 +3937,8 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-05-26T12:43:11.795Z'
-                  updated_at: '2026-05-26T12:43:11.795Z'
+                  created_at: '2026-05-26T15:17:08.366Z'
+                  updated_at: '2026-05-26T15:17:08.366Z'
                   customer_id:
                   created_by_id:
                 meta:
@@ -3838,7 +4023,7 @@ paths:
             application/json:
               example:
                 id: gc_EfhxLZ9ck8
-                code: AD209AAC9CF152FC
+                code: 5694A6AEC885A87D
                 status: active
                 currency: USD
                 amount: '25.0'
@@ -3852,8 +4037,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T12:43:12.382Z'
-                updated_at: '2026-05-26T12:43:12.382Z'
+                created_at: '2026-05-26T15:17:08.962Z'
+                updated_at: '2026-05-26T15:17:08.962Z'
                 customer_id:
                 created_by_id: admin_UkLWZg9DAJ
               schema:
@@ -3959,7 +4144,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: ECF343EE602414CC
+                code: 29D65A40D3A8F3C0
                 status: active
                 currency: USD
                 amount: '50.0'
@@ -3973,8 +4158,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T12:43:12.680Z'
-                updated_at: '2026-05-26T12:43:12.680Z'
+                created_at: '2026-05-26T15:17:09.255Z'
+                updated_at: '2026-05-26T15:17:09.255Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4034,7 +4219,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 21BB618C1AF1DE93
+                code: 0D691EBD2377ECE4
                 status: active
                 currency: USD
                 amount: '75.0'
@@ -4048,8 +4233,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T12:43:13.248Z'
-                updated_at: '2026-05-26T12:43:13.527Z'
+                created_at: '2026-05-26T15:17:09.812Z'
+                updated_at: '2026-05-26T15:17:10.086Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4161,15 +4346,15 @@ paths:
               example:
                 data:
                 - id: inv_UkLWZg9DAJ
-                  email: tennie@stiedemanntorp.name
+                  email: rachel.runolfsdottir@ernser.co.uk
                   status: pending
-                  created_at: '2026-05-26T12:43:14.372Z'
-                  updated_at: '2026-05-26T12:43:14.372Z'
-                  expires_at: '2026-06-09T12:43:14.370Z'
+                  created_at: '2026-05-26T15:17:10.932Z'
+                  updated_at: '2026-05-26T15:17:10.932Z'
+                  expires_at: '2026-06-09T15:17:10.929Z'
                   role_id: role_UkLWZg9DAJ
                   role_name: admin
-                  inviter_email: raye.reichel@barton.co.uk
-                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=Cy22mSZXN67XaQANUimVWAxP"
+                  inviter_email: ulysses.hoppe@welch.info
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=jn7J2U9mPwRPKwU6TPtEfTRW"
                   invitee_exists: false
                   store:
                     id: store_UkLWZg9DAJ
@@ -4230,13 +4415,13 @@ paths:
                 id: inv_gbHJdmfrXB
                 email: new-staff@example.com
                 status: pending
-                created_at: '2026-05-26T12:43:14.672Z'
-                updated_at: '2026-05-26T12:43:14.672Z'
-                expires_at: '2026-06-09T12:43:14.669Z'
+                created_at: '2026-05-26T15:17:11.236Z'
+                updated_at: '2026-05-26T15:17:11.236Z'
+                expires_at: '2026-06-09T15:17:11.233Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: helen@binsshields.us
-                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=BSNMzr8QmbUJBWFQ9KVmhPmZ"
+                inviter_email: roma_gulgowski@hackett.co.uk
+                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=j6Lbgsjm8bTrDo61cc3SRwVD"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -4343,15 +4528,15 @@ paths:
             application/json:
               example:
                 id: inv_UkLWZg9DAJ
-                email: lenna.jenkins@bergnaumgrady.ca
+                email: ivy.wiegand@jaskolski.biz
                 status: pending
-                created_at: '2026-05-26T12:43:15.228Z'
-                updated_at: '2026-05-26T12:43:15.228Z'
-                expires_at: '2026-06-09T12:43:15.226Z'
+                created_at: '2026-05-26T15:17:11.791Z'
+                updated_at: '2026-05-26T15:17:11.791Z'
+                expires_at: '2026-06-09T15:17:11.788Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: shawanda@baumbach.name
-                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=kD18oQX1d1ZVvQji3vskUXSH"
+                inviter_email: alane@koelpin.name
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=4QApEuM7S9unyb3tr4MzbtG8"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -4433,12 +4618,12 @@ paths:
                   default_locale: en
                   tax_inclusive: false
                   default: false
-                  supported_locales:
-                  - en
                   country_isos:
                   - DE
-                  created_at: '2026-05-26T12:43:15.280Z'
-                  updated_at: '2026-05-26T12:43:15.280Z'
+                  supported_locales:
+                  - en
+                  created_at: '2026-05-26T15:17:11.849Z'
+                  updated_at: '2026-05-26T15:17:11.849Z'
                 meta:
                   page: 1
                   limit: 25
@@ -4523,13 +4708,13 @@ paths:
                 default_locale: fr
                 tax_inclusive: true
                 default: false
+                country_isos:
+                - FR
                 supported_locales:
                 - en
                 - fr
-                country_isos:
-                - FR
-                created_at: '2026-05-26T12:43:15.886Z'
-                updated_at: '2026-05-26T12:43:15.886Z'
+                created_at: '2026-05-26T15:17:12.476Z'
+                updated_at: '2026-05-26T15:17:12.476Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -4658,12 +4843,12 @@ paths:
                 default_locale: en
                 tax_inclusive: false
                 default: false
-                supported_locales:
-                - en
                 country_isos:
                 - DE
-                created_at: '2026-05-26T12:43:16.211Z'
-                updated_at: '2026-05-26T12:43:16.211Z'
+                supported_locales:
+                - en
+                created_at: '2026-05-26T15:17:12.814Z'
+                updated_at: '2026-05-26T15:17:12.814Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '404':
@@ -4735,12 +4920,12 @@ paths:
                 default_locale: en
                 tax_inclusive: true
                 default: false
-                supported_locales:
-                - en
                 country_isos:
                 - DE
-                created_at: '2026-05-26T12:43:16.815Z'
-                updated_at: '2026-05-26T12:43:17.100Z'
+                supported_locales:
+                - en
+                created_at: '2026-05-26T15:17:13.455Z'
+                updated_at: '2026-05-26T15:17:13.762Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -4877,12 +5062,12 @@ paths:
               example:
                 user:
                   id: admin_UkLWZg9DAJ
-                  email: brunilda@cartwright.biz
-                  first_name: Milagro
-                  last_name: Marks
-                  full_name: Milagro Marks
-                  created_at: '2026-05-26T12:43:18.270Z'
-                  updated_at: '2026-05-26T12:43:18.270Z'
+                  email: magaret.wiegand@west.co.uk
+                  first_name: Sherman
+                  last_name: Zemlak
+                  full_name: Sherman Zemlak
+                  created_at: '2026-05-26T15:17:14.969Z'
+                  updated_at: '2026-05-26T15:17:14.969Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -5032,8 +5217,8 @@ paths:
                   kind: dropdown
                   metadata: {}
                   filterable: true
-                  created_at: '2026-05-26T12:43:18.311Z'
-                  updated_at: '2026-05-26T12:43:18.311Z'
+                  created_at: '2026-05-26T15:17:15.008Z'
+                  updated_at: '2026-05-26T15:17:15.008Z'
                 meta:
                   page: 1
                   limit: 25
@@ -5124,8 +5309,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T12:43:18.885Z'
-                updated_at: '2026-05-26T12:43:18.885Z'
+                created_at: '2026-05-26T15:17:15.571Z'
+                updated_at: '2026-05-26T15:17:15.571Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -5246,8 +5431,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T12:43:19.174Z'
-                updated_at: '2026-05-26T12:43:19.174Z'
+                created_at: '2026-05-26T15:17:15.853Z'
+                updated_at: '2026-05-26T15:17:15.853Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '404':
@@ -5319,8 +5504,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T12:43:19.734Z'
-                updated_at: '2026-05-26T12:43:20.014Z'
+                created_at: '2026-05-26T15:17:16.412Z'
+                updated_at: '2026-05-26T15:17:16.686Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -5479,7 +5664,7 @@ paths:
               example:
                 data:
                 - id: ful_UkLWZg9DAJ
-                  number: H72381361328
+                  number: H07377188157
                   tracking: U10000
                   tracking_url:
                   cost: '10.0'
@@ -5504,8 +5689,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-26T12:43:20.965Z'
-                  updated_at: '2026-05-26T12:43:21.034Z'
+                  created_at: '2026-05-26T15:17:17.624Z'
+                  updated_at: '2026-05-26T15:17:17.696Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_UkLWZg9DAJ
                 meta:
@@ -5588,7 +5773,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H55504215330
+                number: H36392953413
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5613,8 +5798,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T12:43:21.647Z'
-                updated_at: '2026-05-26T12:43:21.706Z'
+                created_at: '2026-05-26T15:17:18.295Z'
+                updated_at: '2026-05-26T15:17:18.349Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
     patch:
@@ -5673,7 +5858,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H24051808415
+                number: H86091051668
                 tracking: 1Z999AA10123456784
                 tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
                 cost: '10.0'
@@ -5698,8 +5883,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T12:43:22.301Z'
-                updated_at: '2026-05-26T12:43:22.638Z'
+                created_at: '2026-05-26T15:17:18.927Z'
+                updated_at: '2026-05-26T15:17:19.271Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
       requestBody:
@@ -5768,7 +5953,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H24412245737
+                number: H47435003131
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5785,7 +5970,7 @@ paths:
                 display_tax_total: "$0.00"
                 status: shipped
                 fulfillment_type: shipping
-                fulfilled_at: '2026-05-26T12:43:23Z'
+                fulfilled_at: '2026-05-26T15:17:20Z'
                 items:
                 - item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
@@ -5793,8 +5978,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T12:43:22.946Z'
-                updated_at: '2026-05-26T12:43:23.313Z'
+                created_at: '2026-05-26T15:17:19.675Z'
+                updated_at: '2026-05-26T15:17:20.042Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
@@ -5852,7 +6037,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H57549274092
+                number: H61583984317
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5877,8 +6062,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T12:43:23.670Z'
-                updated_at: '2026-05-26T12:43:24.005Z'
+                created_at: '2026-05-26T15:17:20.465Z'
+                updated_at: '2026-05-26T15:17:20.835Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
@@ -5936,7 +6121,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H33252464732
+                number: H01359414754
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5961,8 +6146,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T12:43:24.327Z'
-                updated_at: '2026-05-26T12:43:24.678Z'
+                created_at: '2026-05-26T15:17:21.178Z'
+                updated_at: '2026-05-26T15:17:21.583Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
@@ -6023,7 +6208,7 @@ paths:
               example:
                 data:
                 - id: ful_gbHJdmfrXB
-                  number: H76063483327
+                  number: H12667263367
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -6048,8 +6233,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-26T12:43:25.353Z'
-                  updated_at: '2026-05-26T12:43:25.395Z'
+                  created_at: '2026-05-26T15:17:22.248Z'
+                  updated_at: '2026-05-26T15:17:22.327Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_gbHJdmfrXB
       requestBody:
@@ -6121,7 +6306,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 000AFB3EB6BC1603
+                code: B68F1701E3F59046
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -6135,8 +6320,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T12:43:25.722Z'
-                updated_at: '2026-05-26T12:43:26.027Z'
+                created_at: '2026-05-26T15:17:22.705Z'
+                updated_at: '2026-05-26T15:17:22.998Z'
                 customer_id:
                 created_by_id:
       requestBody:
@@ -6269,8 +6454,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 2
                   currency: USD
-                  name: Product 108818
-                  slug: product-108818
+                  name: Product 107050
+                  slug: product-107050
                   options_text: 'Size: S'
                   price: '10.0'
                   display_price: "$10.00"
@@ -6302,12 +6487,12 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-26T12:43:26.704Z'
-                    updated_at: '2026-05-26T12:43:26.704Z'
+                    created_at: '2026-05-26T15:17:23.725Z'
+                    updated_at: '2026-05-26T15:17:23.725Z'
                   digital_links: []
                   metadata: {}
-                  created_at: '2026-05-26T12:43:26.991Z'
-                  updated_at: '2026-05-26T12:43:26.991Z'
+                  created_at: '2026-05-26T15:17:24.012Z'
+                  updated_at: '2026-05-26T15:17:24.012Z'
                   cost_price: '17.0'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
@@ -6374,8 +6559,8 @@ paths:
                 variant_id: variant_VqXmZF31wY
                 quantity: 3
                 currency: USD
-                name: Product 129518
-                slug: product-129518
+                name: Product 128656
+                slug: product-128656
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -6407,12 +6592,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T12:43:27.918Z'
-                  updated_at: '2026-05-26T12:43:27.918Z'
+                  created_at: '2026-05-26T15:17:24.920Z'
+                  updated_at: '2026-05-26T15:17:24.920Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T12:43:27.951Z'
-                updated_at: '2026-05-26T12:43:27.951Z'
+                created_at: '2026-05-26T15:17:24.953Z'
+                updated_at: '2026-05-26T15:17:24.953Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -6501,8 +6686,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 2
                 currency: USD
-                name: Product 132864
-                slug: product-132864
+                name: Product 135754
+                slug: product-135754
                 options_text: 'Size: S'
                 price: '10.0'
                 display_price: "$10.00"
@@ -6534,12 +6719,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T12:43:28.018Z'
-                  updated_at: '2026-05-26T12:43:28.018Z'
+                  created_at: '2026-05-26T15:17:25.037Z'
+                  updated_at: '2026-05-26T15:17:25.037Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T12:43:28.304Z'
-                updated_at: '2026-05-26T12:43:28.304Z'
+                created_at: '2026-05-26T15:17:25.327Z'
+                updated_at: '2026-05-26T15:17:25.327Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
     patch:
@@ -6601,8 +6786,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 5
                 currency: USD
-                name: Product 147088
-                slug: product-147088
+                name: Product 146203
+                slug: product-146203
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -6634,12 +6819,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T12:43:28.621Z'
-                  updated_at: '2026-05-26T12:43:28.621Z'
+                  created_at: '2026-05-26T15:17:25.650Z'
+                  updated_at: '2026-05-26T15:17:25.650Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T12:43:28.907Z'
-                updated_at: '2026-05-26T12:43:29.205Z'
+                created_at: '2026-05-26T15:17:25.946Z'
+                updated_at: '2026-05-26T15:17:26.250Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -6765,8 +6950,8 @@ paths:
                 data:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-558e57f5d744
-                  number: PNDTT9GC
+                  response_code: BGS-701d22e84a8e
+                  number: PHH9S7QR
                   amount: '110.0'
                   display_amount: "$110.00"
                   status: completed
@@ -6784,14 +6969,14 @@ paths:
                     customer_id:
                     payment_method_id: pm_gbHJdmfrXB
                     metadata: {}
-                    created_at: '2026-05-26T12:43:30.195Z'
-                    updated_at: '2026-05-26T12:43:30.197Z'
+                    created_at: '2026-05-26T15:17:27.258Z'
+                    updated_at: '2026-05-26T15:17:27.262Z'
                   metadata: {}
                   avs_response:
                   cvv_response_code:
                   cvv_response_message:
-                  created_at: '2026-05-26T12:43:30.196Z'
-                  updated_at: '2026-05-26T12:43:30.196Z'
+                  created_at: '2026-05-26T15:17:27.260Z'
+                  updated_at: '2026-05-26T15:17:27.260Z'
                   captured_amount: '0.0'
                   order_id: or_UkLWZg9DAJ
                 meta:
@@ -6858,7 +7043,7 @@ paths:
                 id: py_gbHJdmfrXB
                 payment_method_id: pm_EfhxLZ9ck8
                 response_code:
-                number: PRLXLSE1
+                number: PWTNWM8J
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -6869,8 +7054,8 @@ paths:
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T12:43:31.503Z'
-                updated_at: '2026-05-26T12:43:31.503Z'
+                created_at: '2026-05-26T15:17:28.789Z'
+                updated_at: '2026-05-26T15:17:28.789Z'
                 captured_amount: '0.0'
                 order_id: or_gbHJdmfrXB
       requestBody:
@@ -6960,8 +7145,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-d877df37d6f0
-                number: P2VPLRI1
+                response_code: BGS-352ec785c4a2
+                number: PXH3K71O
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -6979,14 +7164,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T12:43:31.879Z'
-                  updated_at: '2026-05-26T12:43:31.882Z'
+                  created_at: '2026-05-26T15:17:29.170Z'
+                  updated_at: '2026-05-26T15:17:29.173Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T12:43:31.881Z'
-                updated_at: '2026-05-26T12:43:31.881Z'
+                created_at: '2026-05-26T15:17:29.172Z'
+                updated_at: '2026-05-26T15:17:29.172Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
@@ -7045,8 +7230,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-854a246a7c2d
-                number: PIJ45Z2M
+                response_code: BGS-519856d2f7a1
+                number: PPVZCDJ7
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -7064,14 +7249,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T12:43:32.537Z'
-                  updated_at: '2026-05-26T12:43:32.539Z'
+                  created_at: '2026-05-26T15:17:29.840Z'
+                  updated_at: '2026-05-26T15:17:29.842Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T12:43:32.538Z'
-                updated_at: '2026-05-26T12:43:32.866Z'
+                created_at: '2026-05-26T15:17:29.841Z'
+                updated_at: '2026-05-26T15:17:30.182Z'
                 captured_amount: '110.0'
                 order_id: or_UkLWZg9DAJ
         '422':
@@ -7140,8 +7325,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: void-BGS-2ed11968ee67
-                number: PA0YA2SB
+                response_code: void-BGS-f6d5642615af
+                number: PCIC0TAT
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: void
@@ -7159,14 +7344,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T12:43:33.925Z'
-                  updated_at: '2026-05-26T12:43:33.928Z'
+                  created_at: '2026-05-26T15:17:31.381Z'
+                  updated_at: '2026-05-26T15:17:31.384Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T12:43:33.927Z'
-                updated_at: '2026-05-26T12:43:34.225Z'
+                created_at: '2026-05-26T15:17:31.383Z'
+                updated_at: '2026-05-26T15:17:31.685Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/refunds":
@@ -7294,14 +7479,14 @@ paths:
             application/json:
               example:
                 id: re_UkLWZg9DAJ
-                transaction_id: BGS-8f6bb1510833
+                transaction_id: BGS-7e30d908a79f
                 amount: '5.0'
                 payment_id: py_UkLWZg9DAJ
                 refund_reason_id: rr_UkLWZg9DAJ
                 reimbursement_id:
                 metadata: {}
-                created_at: '2026-05-26T12:43:35.559Z'
-                updated_at: '2026-05-26T12:43:35.559Z'
+                created_at: '2026-05-26T15:17:32.992Z'
+                updated_at: '2026-05-26T15:17:32.992Z'
       requestBody:
         content:
           application/json:
@@ -7373,8 +7558,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R911948765
-                email: lelah@powlowski.info
+                number: R806432825
+                email: luci@dicki.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -7417,8 +7602,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T12:43:35.855Z'
-                updated_at: '2026-05-26T12:43:35.906Z'
+                created_at: '2026-05-26T15:17:33.290Z'
+                updated_at: '2026-05-26T15:17:33.336Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7589,8 +7774,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R530084501
-                  email: clemente.feest@robelkris.info
+                  number: R908627775
+                  email: jackson@kuhlman.biz
                   customer_note:
                   currency: USD
                   locale: en
@@ -7633,8 +7818,8 @@ paths:
                   metadata: {}
                   canceled_at:
                   approved_at:
-                  created_at: '2026-05-26T12:43:37.653Z'
-                  updated_at: '2026-05-26T12:43:37.653Z'
+                  created_at: '2026-05-26T15:17:35.052Z'
+                  updated_at: '2026-05-26T15:17:35.052Z'
                   preferred_stock_location_id:
                   tags: []
                   internal_note:
@@ -7777,7 +7962,7 @@ paths:
                 id: or_gbHJdmfrXB
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R383898514
+                number: R374953449
                 email: pinned@example.com
                 customer_note:
                 currency: USD
@@ -7821,8 +8006,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T12:43:39.336Z'
-                updated_at: '2026-05-26T12:43:39.338Z'
+                created_at: '2026-05-26T15:17:36.786Z'
+                updated_at: '2026-05-26T15:17:36.789Z'
                 preferred_stock_location_id: sloc_UkLWZg9DAJ
                 tags: []
                 internal_note:
@@ -8006,8 +8191,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R366457856
-                email: maris@hammes.co.uk
+                number: R846317291
+                email: tona_schinner@toyschaefer.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -8050,8 +8235,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T12:43:39.618Z'
-                updated_at: '2026-05-26T12:43:39.618Z'
+                created_at: '2026-05-26T15:17:37.069Z'
+                updated_at: '2026-05-26T15:17:37.069Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8122,7 +8307,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R554622571
+                number: R111696884
                 email: updated@example.com
                 customer_note:
                 currency: USD
@@ -8166,8 +8351,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T12:43:40.726Z'
-                updated_at: '2026-05-26T12:43:41.017Z'
+                created_at: '2026-05-26T15:17:40.294Z'
+                updated_at: '2026-05-26T15:17:40.592Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8348,8 +8533,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R277721850
-                email: elodia@torphykunde.name
+                number: R728222526
+                email: bradley@medhurstprice.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -8376,7 +8561,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status: ready
                 payment_status: paid
-                completed_at: '2026-05-26T12:43:41.913Z'
+                completed_at: '2026-05-26T15:17:41.536Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8392,8 +8577,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T12:43:41.861Z'
-                updated_at: '2026-05-26T12:43:41.939Z'
+                created_at: '2026-05-26T15:17:41.437Z'
+                updated_at: '2026-05-26T15:17:41.567Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8474,8 +8659,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R820951567
-                email: roseann@hauck.biz
+                number: R242958792
+                email: elliott.heathcote@mills.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -8502,7 +8687,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-26T12:43:43.178Z'
+                completed_at: '2026-05-26T15:17:42.912Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8516,10 +8701,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-26T12:43:43.471Z'
+                canceled_at: '2026-05-26T15:17:43.247Z'
                 approved_at:
-                created_at: '2026-05-26T12:43:43.130Z'
-                updated_at: '2026-05-26T12:43:43.511Z'
+                created_at: '2026-05-26T15:17:42.826Z'
+                updated_at: '2026-05-26T15:17:43.302Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8578,8 +8763,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R358980474
-                email: petronila@bashirian.us
+                number: R670744364
+                email: alida.mante@bernhard.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -8606,7 +8791,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T12:43:43.853Z'
+                completed_at: '2026-05-26T15:17:43.667Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8621,9 +8806,9 @@ paths:
                 display_payment_total: "$0.00"
                 metadata: {}
                 canceled_at:
-                approved_at: '2026-05-26T12:43:44.139Z'
-                created_at: '2026-05-26T12:43:43.804Z'
-                updated_at: '2026-05-26T12:43:43.853Z'
+                approved_at: '2026-05-26T15:17:43.958Z'
+                created_at: '2026-05-26T15:17:43.606Z'
+                updated_at: '2026-05-26T15:17:43.667Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8682,8 +8867,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R199529795
-                email: delilah@hesselhackett.com
+                number: R587376574
+                email: emmy.purdy@abbott.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -8710,7 +8895,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-26T12:43:44.485Z'
+                completed_at: '2026-05-26T15:17:44.298Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8724,10 +8909,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-26T12:43:44.762Z'
+                canceled_at: '2026-05-26T15:17:44.578Z'
                 approved_at:
-                created_at: '2026-05-26T12:43:44.432Z'
-                updated_at: '2026-05-26T12:43:44.844Z'
+                created_at: '2026-05-26T15:17:44.239Z'
+                updated_at: '2026-05-26T15:17:44.709Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8786,8 +8971,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R108673461
-                email: eulah@littelanderson.us
+                number: R631396038
+                email: clair@heathcote.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -8814,7 +8999,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T12:43:45.173Z'
+                completed_at: '2026-05-26T15:17:45.088Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8830,8 +9015,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T12:43:45.123Z'
-                updated_at: '2026-05-26T12:43:45.173Z'
+                created_at: '2026-05-26T15:17:45.003Z'
+                updated_at: '2026-05-26T15:17:45.088Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8906,8 +9091,8 @@ paths:
                   auto_capture:
                   storefront_visible: true
                   position: 1
-                  created_at: '2026-05-26T12:43:45.478Z'
-                  updated_at: '2026-05-26T12:43:45.480Z'
+                  created_at: '2026-05-26T15:17:45.394Z'
+                  updated_at: '2026-05-26T15:17:45.395Z'
                   preferences: {}
                   preference_schema: []
                 meta:
@@ -9047,8 +9232,8 @@ paths:
                 auto_capture:
                 storefront_visible: true
                 position: 1
-                created_at: '2026-05-26T12:43:46.061Z'
-                updated_at: '2026-05-26T12:43:46.062Z'
+                created_at: '2026-05-26T15:17:46.094Z'
+                updated_at: '2026-05-26T15:17:46.095Z'
                 preferences: {}
                 preference_schema: []
   "/api/v3/admin/price_lists":
@@ -9121,8 +9306,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-05-26T12:43:46.345Z'
-                  updated_at: '2026-05-26T12:43:46.345Z'
+                  created_at: '2026-05-26T15:17:46.409Z'
+                  updated_at: '2026-05-26T15:17:46.409Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -9136,8 +9321,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-05-26T12:43:46.346Z'
-                  updated_at: '2026-05-26T12:43:46.346Z'
+                  created_at: '2026-05-26T15:17:46.411Z'
+                  updated_at: '2026-05-26T15:17:46.411Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -9201,8 +9386,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T12:43:47.340Z'
-                updated_at: '2026-05-26T12:43:47.342Z'
+                created_at: '2026-05-26T15:17:47.869Z'
+                updated_at: '2026-05-26T15:17:47.871Z'
                 currently_active: false
                 products_count: 1
                 prices_count: 2
@@ -9350,8 +9535,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T12:43:47.639Z'
-                updated_at: '2026-05-26T12:43:47.639Z'
+                created_at: '2026-05-26T15:17:48.181Z'
+                updated_at: '2026-05-26T15:17:48.181Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9409,8 +9594,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T12:43:49.202Z'
-                updated_at: '2026-05-26T12:43:49.480Z'
+                created_at: '2026-05-26T15:17:49.744Z'
+                updated_at: '2026-05-26T15:17:50.024Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9568,8 +9753,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T12:43:49.788Z'
-                updated_at: '2026-05-26T12:43:50.099Z'
+                created_at: '2026-05-26T15:17:50.319Z'
+                updated_at: '2026-05-26T15:17:50.600Z'
                 currently_active: true
                 products_count: 0
                 prices_count: 0
@@ -9617,8 +9802,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T12:43:50.129Z'
-                updated_at: '2026-05-26T12:43:50.432Z'
+                created_at: '2026-05-26T15:17:50.607Z'
+                updated_at: '2026-05-26T15:17:50.887Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9729,8 +9914,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-05-26T12:43:50.504Z'
-                  updated_at: '2026-05-26T12:43:50.504Z'
+                  created_at: '2026-05-26T15:17:50.937Z'
+                  updated_at: '2026-05-26T15:17:50.937Z'
                 - id: price_EfhxLZ9ck8
                   amount: '5.0'
                   amount_in_cents: 500
@@ -9741,8 +9926,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id: pl_UkLWZg9DAJ
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-05-26T12:43:50.508Z'
-                  updated_at: '2026-05-26T12:43:50.508Z'
+                  created_at: '2026-05-26T15:17:50.941Z'
+                  updated_at: '2026-05-26T15:17:50.941Z'
                 meta:
                   page: 1
                   limit: 25
@@ -9821,8 +10006,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id:
                 variant_id: variant_EfhxLZ9ck8
-                created_at: '2026-05-26T12:43:51.148Z'
-                updated_at: '2026-05-26T12:43:51.148Z'
+                created_at: '2026-05-26T15:17:51.609Z'
+                updated_at: '2026-05-26T15:17:51.609Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -9906,8 +10091,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-05-26T12:43:51.216Z'
-                updated_at: '2026-05-26T12:43:51.216Z'
+                created_at: '2026-05-26T15:17:51.669Z'
+                updated_at: '2026-05-26T15:17:51.669Z'
               schema:
                 "$ref": "#/components/schemas/Price"
         '404':
@@ -9969,8 +10154,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-05-26T12:43:51.895Z'
-                updated_at: '2026-05-26T12:43:52.182Z'
+                created_at: '2026-05-26T15:17:52.332Z'
+                updated_at: '2026-05-26T15:17:52.612Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -10270,8 +10455,8 @@ paths:
                   field_type: short_text
                   key: custom.title
                   value: wool
-                  created_at: '2026-05-26T12:43:53.647Z'
-                  updated_at: '2026-05-26T12:43:53.647Z'
+                  created_at: '2026-05-26T15:17:54.124Z'
+                  updated_at: '2026-05-26T15:17:54.124Z'
                   storefront_visible: true
                   custom_field_definition_id: cfdef_UkLWZg9DAJ
                 meta:
@@ -10338,8 +10523,8 @@ paths:
                 field_type: long_text
                 key: custom.description
                 value: A longer description
-                created_at: '2026-05-26T12:43:54.246Z'
-                updated_at: '2026-05-26T12:43:54.246Z'
+                created_at: '2026-05-26T15:17:54.778Z'
+                updated_at: '2026-05-26T15:17:54.778Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_gbHJdmfrXB
         '422':
@@ -10423,8 +10608,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: wool
-                created_at: '2026-05-26T12:43:54.597Z'
-                updated_at: '2026-05-26T12:43:54.597Z'
+                created_at: '2026-05-26T15:17:55.324Z'
+                updated_at: '2026-05-26T15:17:55.324Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
     patch:
@@ -10471,8 +10656,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: cotton
-                created_at: '2026-05-26T12:43:54.908Z'
-                updated_at: '2026-05-26T12:43:55.194Z'
+                created_at: '2026-05-26T15:17:55.649Z'
+                updated_at: '2026-05-26T15:17:55.934Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
       requestBody:
@@ -10610,28 +10795,34 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 555940
-                  slug: product-555940
+                  name: Product 552304
+                  slug: product-552304
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-26T12:43:55.526Z'
+                  available_on: '2025-05-26T15:17:56.255Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Sed officiis delectus neque eos tempore. Voluptatum
-                    tenetur reprehenderit enim cum itaque ea aut voluptatibus. Iste
-                    sequi explicabo rem placeat modi reprehenderit perspiciatis. Consectetur
-                    eveniet iure numquam vitae repellendus fuga. Illum eaque suscipit
-                    dolor aspernatur aperiam itaque sed. Id quia eius praesentium
-                    accusamus deserunt placeat. Blanditiis culpa necessitatibus eligendi
-                    quos explicabo temporibus iusto neque. Blanditiis ratione enim
-                    dignissimos laudantium fugit.
+                  description: Animi vitae hic eos saepe impedit. Ea optio placeat
+                    unde molestiae itaque. Blanditiis numquam pariatur beatae recusandae
+                    est corporis nobis. Perferendis delectus earum aperiam in consectetur.
+                    Autem molestiae ex deleniti laudantium labore rerum in. Beatae
+                    repellendus consequuntur maxime eveniet quibusdam non inventore
+                    iste. Sit unde nesciunt sapiente ex eius assumenda. Porro impedit
+                    libero repellat ea delectus nam. Labore optio molestias id nemo
+                    quaerat a soluta. Ex hic aperiam doloremque quos amet esse illum
+                    placeat. Distinctio cupiditate placeat quibusdam repellat consequatur
+                    necessitatibus. Sint cupiditate sunt magnam harum incidunt nemo
+                    totam. Corporis recusandae eligendi officia debitis incidunt.
+                    Corporis sequi repudiandae id consectetur minima.
                   description_html: |-
-                    Sed officiis delectus neque eos tempore. Voluptatum tenetur reprehenderit enim cum itaque ea aut voluptatibus. Iste sequi explicabo rem placeat modi reprehenderit perspiciatis. Consectetur eveniet iure numquam vitae repellendus fuga. Illum eaque suscipit dolor aspernatur aperiam itaque sed.
-                    Id quia eius praesentium accusamus deserunt placeat. Blanditiis culpa necessitatibus eligendi quos explicabo temporibus iusto neque. Blanditiis ratione enim dignissimos laudantium fugit.
+                    Animi vitae hic eos saepe impedit. Ea optio placeat unde molestiae itaque. Blanditiis numquam pariatur beatae recusandae est corporis nobis.
+                    Perferendis delectus earum aperiam in consectetur. Autem molestiae ex deleniti laudantium labore rerum in. Beatae repellendus consequuntur maxime eveniet quibusdam non inventore iste. Sit unde nesciunt sapiente ex eius assumenda. Porro impedit libero repellat ea delectus nam.
+                    Labore optio molestias id nemo quaerat a soluta. Ex hic aperiam doloremque quos amet esse illum placeat. Distinctio cupiditate placeat quibusdam repellat consequatur necessitatibus.
+                    Sint cupiditate sunt magnam harum incidunt nemo totam. Corporis recusandae eligendi officia debitis incidunt. Corporis sequi repudiandae id consectetur minima.
                   default_variant_id: variant_UkLWZg9DAJ
                   thumbnail_url:
                   tags: []
@@ -10646,16 +10837,16 @@ paths:
                     display_compare_at_amount:
                     price_list_id:
                     variant_id: variant_UkLWZg9DAJ
-                    created_at: '2026-05-26T12:43:55.554Z'
-                    updated_at: '2026-05-26T12:43:55.554Z'
+                    created_at: '2026-05-26T15:17:56.282Z'
+                    updated_at: '2026-05-26T15:17:56.282Z'
                   original_price:
                   status: active
-                  make_active_at: '2025-05-26T12:43:55.526Z'
+                  make_active_at: '2025-05-26T15:17:56.255Z'
                   discontinue_on:
                   metadata: {}
                   deleted_at:
-                  created_at: '2026-05-26T12:43:55.540Z'
-                  updated_at: '2026-05-26T12:43:55.555Z'
+                  created_at: '2026-05-26T15:17:56.269Z'
+                  updated_at: '2026-05-26T15:17:56.283Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -10789,8 +10980,8 @@ paths:
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T12:43:56.215Z'
-                updated_at: '2026-05-26T12:43:56.218Z'
+                created_at: '2026-05-26T15:17:56.958Z'
+                updated_at: '2026-05-26T15:17:56.961Z'
                 tax_category_id:
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -10970,28 +11161,31 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 599015
-                slug: product-599015
+                name: Product 598440
+                slug: product-598440
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-26T12:43:56.578Z'
+                available_on: '2025-05-26T15:17:57.322Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Laudantium eius ea quasi recusandae vero. Nihil officia
-                  culpa voluptatum iusto. Tempore delectus sint minus aliquam doloribus
-                  quos libero. Iusto dolorum nemo alias porro modi officia fugit rerum.
-                  Aut facilis debitis provident omnis rerum eligendi eum a. Quam quaerat
-                  maiores hic aliquid perspiciatis dolorum commodi dolor. Molestiae
-                  provident porro expedita cupiditate asperiores adipisci dolor. Officiis
-                  beatae ut accusantium laborum enim sunt ex illo. Numquam natus odio
-                  officiis dolore nulla.
+                description: Quo laboriosam delectus consectetur quia omnis illum
+                  nobis. Pariatur neque fugit assumenda ad at repudiandae. Odio quisquam
+                  magnam quae placeat quod. Quia excepturi eligendi impedit velit
+                  aspernatur assumenda iste repellendus. Hic id consequuntur culpa
+                  a. Accusantium corporis tempora eos accusamus a similique voluptate
+                  officia. At a ratione sint unde dicta ut. Nobis recusandae voluptas
+                  praesentium reiciendis rem molestiae iste. Placeat commodi quam
+                  perferendis cum repudiandae maiores nobis repellendus. Veritatis
+                  temporibus voluptatum architecto nisi nihil. Sequi explicabo soluta
+                  laudantium autem ex.
                 description_html: |-
-                  Laudantium eius ea quasi recusandae vero. Nihil officia culpa voluptatum iusto. Tempore delectus sint minus aliquam doloribus quos libero. Iusto dolorum nemo alias porro modi officia fugit rerum.
-                  Aut facilis debitis provident omnis rerum eligendi eum a. Quam quaerat maiores hic aliquid perspiciatis dolorum commodi dolor. Molestiae provident porro expedita cupiditate asperiores adipisci dolor. Officiis beatae ut accusantium laborum enim sunt ex illo. Numquam natus odio officiis dolore nulla.
+                  Quo laboriosam delectus consectetur quia omnis illum nobis. Pariatur neque fugit assumenda ad at repudiandae. Odio quisquam magnam quae placeat quod.
+                  Quia excepturi eligendi impedit velit aspernatur assumenda iste repellendus. Hic id consequuntur culpa a. Accusantium corporis tempora eos accusamus a similique voluptate officia. At a ratione sint unde dicta ut.
+                  Nobis recusandae voluptas praesentium reiciendis rem molestiae iste. Placeat commodi quam perferendis cum repudiandae maiores nobis repellendus. Veritatis temporibus voluptatum architecto nisi nihil. Sequi explicabo soluta laudantium autem ex.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11006,16 +11200,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-26T12:43:56.602Z'
-                  updated_at: '2026-05-26T12:43:56.602Z'
+                  created_at: '2026-05-26T15:17:57.347Z'
+                  updated_at: '2026-05-26T15:17:57.347Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-26T12:43:56.578Z'
+                make_active_at: '2025-05-26T15:17:57.322Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T12:43:56.590Z'
-                updated_at: '2026-05-26T12:43:56.603Z'
+                created_at: '2026-05-26T15:17:57.334Z'
+                updated_at: '2026-05-26T15:17:57.348Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11082,28 +11276,29 @@ paths:
               example:
                 id: prod_UkLWZg9DAJ
                 name: Updated Name
-                slug: product-614078
+                slug: product-613804
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-26T12:43:57.210Z'
+                available_on: '2025-05-26T15:17:58.026Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Expedita officia vero atque saepe voluptatem. Cumque
-                  explicabo totam vitae similique alias. Sed dolore ipsa dolorum quae.
-                  Vero accusamus officia ea expedita. Quisquam modi quos rem ad. Dolorum
-                  qui quam animi explicabo vitae molestias. Iusto labore doloribus
-                  iste fugit nemo unde dignissimos. Distinctio illum ab ipsam omnis
-                  eaque nam. Tempore impedit nulla voluptatem autem sint aliquam.
-                  Voluptates eos quaerat similique quisquam facere unde culpa. Molestias
-                  ea ducimus sapiente architecto inventore sint officiis cumque.
+                description: Repellat illo quasi debitis dolore. Quas voluptatum rerum
+                  odio cupiditate voluptates distinctio rem. Placeat quia a vitae
+                  deleniti. Magnam exercitationem atque tempora eaque ad alias. Vero
+                  debitis temporibus vitae illo voluptatem quos. Laudantium itaque
+                  reiciendis recusandae molestiae quasi in ad laborum. Consectetur
+                  dolores iste amet doloremque ducimus officia nam consequuntur. Modi
+                  hic eligendi molestias suscipit. Voluptate assumenda magnam consequuntur
+                  facere minima cumque. Beatae ut consequatur animi quasi. Beatae
+                  iure quam ipsum hic amet eos recusandae.
                 description_html: |-
-                  Expedita officia vero atque saepe voluptatem. Cumque explicabo totam vitae similique alias. Sed dolore ipsa dolorum quae.
-                  Vero accusamus officia ea expedita. Quisquam modi quos rem ad. Dolorum qui quam animi explicabo vitae molestias.
-                  Iusto labore doloribus iste fugit nemo unde dignissimos. Distinctio illum ab ipsam omnis eaque nam. Tempore impedit nulla voluptatem autem sint aliquam. Voluptates eos quaerat similique quisquam facere unde culpa. Molestias ea ducimus sapiente architecto inventore sint officiis cumque.
+                  Repellat illo quasi debitis dolore. Quas voluptatum rerum odio cupiditate voluptates distinctio rem. Placeat quia a vitae deleniti. Magnam exercitationem atque tempora eaque ad alias.
+                  Vero debitis temporibus vitae illo voluptatem quos. Laudantium itaque reiciendis recusandae molestiae quasi in ad laborum. Consectetur dolores iste amet doloremque ducimus officia nam consequuntur. Modi hic eligendi molestias suscipit.
+                  Voluptate assumenda magnam consequuntur facere minima cumque. Beatae ut consequatur animi quasi. Beatae iure quam ipsum hic amet eos recusandae.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11118,16 +11313,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-26T12:43:57.235Z'
-                  updated_at: '2026-05-26T12:43:57.235Z'
+                  created_at: '2026-05-26T15:17:58.053Z'
+                  updated_at: '2026-05-26T15:17:58.053Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-26T12:43:57.210Z'
+                make_active_at: '2025-05-26T15:17:58.026Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T12:43:57.223Z'
-                updated_at: '2026-05-26T12:43:57.528Z'
+                created_at: '2026-05-26T15:17:58.038Z'
+                updated_at: '2026-05-26T15:17:58.375Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11660,8 +11855,8 @@ paths:
               example:
                 data:
                 - id: pact_UkLWZg9DAJ
-                  created_at: '2026-05-26T12:44:00.929Z'
-                  updated_at: '2026-05-26T12:44:00.929Z'
+                  created_at: '2026-05-26T15:18:02.283Z'
+                  updated_at: '2026-05-26T15:18:02.283Z'
                   type: free_shipping
                   promotion_id: promo_UkLWZg9DAJ
                   preferences: {}
@@ -11722,8 +11917,8 @@ paths:
             application/json:
               example:
                 id: pact_UkLWZg9DAJ
-                created_at: '2026-05-26T12:44:01.503Z'
-                updated_at: '2026-05-26T12:44:01.503Z'
+                created_at: '2026-05-26T15:18:02.843Z'
+                updated_at: '2026-05-26T15:18:02.843Z'
                 type: free_shipping
                 promotion_id: promo_UkLWZg9DAJ
                 preferences: {}
@@ -11833,8 +12028,8 @@ paths:
               example:
                 data:
                 - id: prorule_UkLWZg9DAJ
-                  created_at: '2026-05-26T12:44:02.087Z'
-                  updated_at: '2026-05-26T12:44:02.087Z'
+                  created_at: '2026-05-26T15:18:03.442Z'
+                  updated_at: '2026-05-26T15:18:03.442Z'
                   type: currency
                   promotion_id: promo_UkLWZg9DAJ
                   preferences:
@@ -11901,8 +12096,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-26T12:44:02.661Z'
-                updated_at: '2026-05-26T12:44:02.661Z'
+                created_at: '2026-05-26T15:18:04.069Z'
+                updated_at: '2026-05-26T15:18:04.069Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -11975,8 +12170,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-26T12:44:02.954Z'
-                updated_at: '2026-05-26T12:44:03.236Z'
+                created_at: '2026-05-26T15:18:04.485Z'
+                updated_at: '2026-05-26T15:18:04.822Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -12066,7 +12261,7 @@ paths:
                   name: Summer Sale
                   description:
                   code: summer
-                  starts_at: '2026-05-26T12:44:03.527Z'
+                  starts_at: '2026-05-26T15:18:05.133Z'
                   expires_at:
                   usage_limit:
                   match_policy: all
@@ -12077,8 +12272,8 @@ paths:
                   code_prefix:
                   promotion_category_id:
                   metadata: {}
-                  created_at: '2026-05-26T12:44:03.529Z'
-                  updated_at: '2026-05-26T12:44:03.530Z'
+                  created_at: '2026-05-26T15:18:05.135Z'
+                  updated_at: '2026-05-26T15:18:05.138Z'
                   store_ids:
                   - store_UkLWZg9DAJ
                   action_ids: []
@@ -12184,7 +12379,7 @@ paths:
                 name: Black Friday
                 description:
                 code: blackfriday-os
-                starts_at: '2026-05-26T12:44:04.446Z'
+                starts_at: '2026-05-26T15:18:06.078Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12195,8 +12390,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T12:44:04.447Z'
-                updated_at: '2026-05-26T12:44:04.468Z'
+                created_at: '2026-05-26T15:18:06.079Z'
+                updated_at: '2026-05-26T15:18:06.101Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids:
@@ -12349,7 +12544,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-26T12:44:04.762Z'
+                starts_at: '2026-05-26T15:18:06.395Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12360,8 +12555,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T12:44:04.762Z'
-                updated_at: '2026-05-26T12:44:04.763Z'
+                created_at: '2026-05-26T15:18:06.396Z'
+                updated_at: '2026-05-26T15:18:06.396Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -12457,7 +12652,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-26T12:44:05.647Z'
+                starts_at: '2026-05-26T15:18:07.272Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12468,8 +12663,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T12:44:05.648Z'
-                updated_at: '2026-05-26T12:44:05.933Z'
+                created_at: '2026-05-26T15:18:07.273Z'
+                updated_at: '2026-05-26T15:18:07.551Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -12705,15 +12900,15 @@ paths:
                   label: Country
                   description:
                   preference_schema:
+                  - key: country_id
+                    type: integer
+                    default:
                   - key: country_iso
                     type: string
                     default:
                   - key: country_isos
                     type: array
                     default: []
-                  - key: country_id
-                    type: integer
-                    default:
                 - type: currency
                   label: Currency
                   description:
@@ -12821,8 +13016,8 @@ paths:
                 data:
                 - id: role_UkLWZg9DAJ
                   name: admin
-                  created_at: '2026-05-26T12:44:06.829Z'
-                  updated_at: '2026-05-26T12:44:06.829Z'
+                  created_at: '2026-05-26T15:18:08.431Z'
+                  updated_at: '2026-05-26T15:18:08.431Z'
                 meta:
                   page: 1
                   limit: 25
@@ -12957,8 +13152,8 @@ paths:
                   pickup_stock_policy: local
                   pickup_ready_in_minutes:
                   pickup_instructions:
-                  created_at: '2026-05-26T12:44:07.118Z'
-                  updated_at: '2026-05-26T12:44:07.118Z'
+                  created_at: '2026-05-26T15:18:08.715Z'
+                  updated_at: '2026-05-26T15:18:08.715Z'
                 meta:
                   page: 1
                   limit: 25
@@ -13069,8 +13264,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 30
                 pickup_instructions:
-                created_at: '2026-05-26T12:44:07.700Z'
-                updated_at: '2026-05-26T12:44:07.700Z'
+                created_at: '2026-05-26T15:18:09.297Z'
+                updated_at: '2026-05-26T15:18:09.297Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -13244,8 +13439,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes:
                 pickup_instructions:
-                created_at: '2026-05-26T12:44:07.990Z'
-                updated_at: '2026-05-26T12:44:07.990Z'
+                created_at: '2026-05-26T15:18:09.590Z'
+                updated_at: '2026-05-26T15:18:09.590Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '404':
@@ -13330,8 +13525,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 45
                 pickup_instructions:
-                created_at: '2026-05-26T12:44:08.560Z'
-                updated_at: '2026-05-26T12:44:08.838Z'
+                created_at: '2026-05-26T15:18:10.156Z'
+                updated_at: '2026-05-26T15:18:10.433Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -13534,8 +13729,8 @@ paths:
                 data:
                 - id: sccat_UkLWZg9DAJ
                   name: Goodwill
-                  created_at: '2026-05-26T12:44:09.415Z'
-                  updated_at: '2026-05-26T12:44:09.415Z'
+                  created_at: '2026-05-26T15:18:11.001Z'
+                  updated_at: '2026-05-26T15:18:11.001Z'
                   non_expiring: false
                 meta:
                   page: 1
@@ -13626,8 +13821,8 @@ paths:
               example:
                 id: sccat_UkLWZg9DAJ
                 name: Goodwill
-                created_at: '2026-05-26T12:44:09.714Z'
-                updated_at: '2026-05-26T12:44:09.714Z'
+                created_at: '2026-05-26T15:18:11.299Z'
+                updated_at: '2026-05-26T15:18:11.299Z'
                 non_expiring: false
               schema:
                 "$ref": "#/components/schemas/StoreCreditCategory"
@@ -13692,8 +13887,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-26T12:42:46.469Z'
-                updated_at: '2026-05-26T12:44:10.290Z'
+                created_at: '2026-05-26T15:16:40.807Z'
+                updated_at: '2026-05-26T15:18:11.897Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -13764,8 +13959,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-26T12:42:46.469Z'
-                updated_at: '2026-05-26T12:44:10.911Z'
+                created_at: '2026-05-26T15:16:40.807Z'
+                updated_at: '2026-05-26T15:18:12.617Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -13985,13 +14180,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-26T12:44:12.335Z'
-                  updated_at: '2026-05-26T12:44:12.347Z'
+                  created_at: '2026-05-26T15:18:14.082Z'
+                  updated_at: '2026-05-26T15:18:14.093Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 752256
+                  product_name: Product 756684
                 - id: variant_gbHJdmfrXB
                   product_id: prod_UkLWZg9DAJ
                   sku: SKU-94
@@ -14002,10 +14197,10 @@ paths:
                   purchasable: true
                   in_stock: false
                   backorderable: true
-                  weight: 89.39
-                  height: 90.94
-                  width: 173.91
-                  depth: 44.3
+                  weight: 89.4
+                  height: 187.92
+                  width: 121.46
+                  depth: 5.3
                   price:
                     id: price_gbHJdmfrXB
                     amount: '19.99'
@@ -14028,8 +14223,8 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-26T12:44:12.357Z'
-                    updated_at: '2026-05-26T12:44:12.357Z'
+                    created_at: '2026-05-26T15:18:14.101Z'
+                    updated_at: '2026-05-26T15:18:14.101Z'
                   metadata: {}
                   position: 2
                   cost_price: '17.0'
@@ -14038,13 +14233,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-26T12:44:12.354Z'
-                  updated_at: '2026-05-26T12:44:12.369Z'
+                  created_at: '2026-05-26T15:18:14.099Z'
+                  updated_at: '2026-05-26T15:18:14.110Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 752256
+                  product_name: Product 756684
                 meta:
                   page: 1
                   limit: 25
@@ -14155,8 +14350,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T12:44:13.020Z'
-                  updated_at: '2026-05-26T12:44:13.020Z'
+                  created_at: '2026-05-26T15:18:14.758Z'
+                  updated_at: '2026-05-26T15:18:14.758Z'
                 metadata: {}
                 position: 3
                 cost_price:
@@ -14165,13 +14360,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T12:44:13.023Z'
-                updated_at: '2026-05-26T12:44:13.025Z'
+                created_at: '2026-05-26T15:18:14.764Z'
+                updated_at: '2026-05-26T15:18:14.765Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 761955
+                product_name: Product 768191
         '422':
           description: validation error
           content:
@@ -14358,10 +14553,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 57.3
-                height: 29.54
-                width: 119.92
-                depth: 56.73
+                weight: 10.6
+                height: 132.98
+                width: 8.61
+                depth: 173.2
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -14384,8 +14579,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T12:44:13.424Z'
-                  updated_at: '2026-05-26T12:44:13.424Z'
+                  created_at: '2026-05-26T15:18:15.190Z'
+                  updated_at: '2026-05-26T15:18:15.190Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -14394,13 +14589,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T12:44:13.422Z'
-                updated_at: '2026-05-26T12:44:13.436Z'
+                created_at: '2026-05-26T15:18:15.188Z'
+                updated_at: '2026-05-26T15:18:15.201Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 784310
+                product_name: Product 782677
         '404':
           description: variant not found
           content:
@@ -14479,10 +14674,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 140.27
-                height: 137.84
-                width: 138.66
-                depth: 182.72
+                weight: 43.4
+                height: 140.52
+                width: 28.49
+                depth: 106.25
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -14505,8 +14700,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T12:44:14.135Z'
-                  updated_at: '2026-05-26T12:44:14.135Z'
+                  created_at: '2026-05-26T15:18:15.875Z'
+                  updated_at: '2026-05-26T15:18:15.875Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -14515,13 +14710,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T12:44:14.133Z'
-                updated_at: '2026-05-26T12:44:14.431Z'
+                created_at: '2026-05-26T15:18:15.871Z'
+                updated_at: '2026-05-26T15:18:16.177Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 80441
+                product_name: Product 805520
       requestBody:
         content:
           application/json:
@@ -14790,14 +14985,10 @@ components:
         token:
           type: string
           description: JWT access token
-        refresh_token:
-          type: string
-          description: Refresh token for obtaining new access tokens
         user:
           "$ref": "#/components/schemas/AdminUser"
       required:
       - token
-      - refresh_token
       - user
     PermissionRule:
       type: object
@@ -16247,11 +16438,11 @@ components:
           type: boolean
         default:
           type: boolean
-        supported_locales:
+        country_isos:
           type: array
           items:
             type: string
-        country_isos:
+        supported_locales:
           type: array
           items:
             type: string
@@ -16270,8 +16461,8 @@ components:
       - default_locale
       - tax_inclusive
       - default
-      - supported_locales
       - country_isos
+      - supported_locales
       - created_at
       - updated_at
       x-typelizer: true

--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -82,12 +82,12 @@ paths:
               example:
                 data:
                 - id: admin_UkLWZg9DAJ
-                  email: man@mcclureauer.biz
-                  first_name: Marquetta
-                  last_name: Cormier
-                  full_name: Marquetta Cormier
-                  created_at: '2026-05-26T15:35:57.769Z'
-                  updated_at: '2026-05-26T15:35:57.769Z'
+                  email: kaitlyn_stokes@raumarvin.com
+                  first_name: Modesta
+                  last_name: Walker
+                  full_name: Modesta Walker
+                  created_at: '2026-05-26T16:11:55.501Z'
+                  updated_at: '2026-05-26T16:11:55.501Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -145,12 +145,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: barry@torp.name
-                first_name: Carlee
-                last_name: Jaskolski
-                full_name: Carlee Jaskolski
-                created_at: '2026-05-26T15:35:58.127Z'
-                updated_at: '2026-05-26T15:35:58.127Z'
+                email: lakenya@zieme.biz
+                first_name: Jordan
+                last_name: Herman
+                full_name: Jordan Herman
+                created_at: '2026-05-26T16:11:55.855Z'
+                updated_at: '2026-05-26T16:11:55.855Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -203,12 +203,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: estrella@howe.name
+                email: marketta@ziemannschroeder.co.uk
                 first_name: Renamed
-                last_name: Sanford
-                full_name: Renamed Sanford
-                created_at: '2026-05-26T15:35:58.421Z'
-                updated_at: '2026-05-26T15:35:58.457Z'
+                last_name: Reichel
+                full_name: Renamed Reichel
+                created_at: '2026-05-26T16:11:56.204Z'
+                updated_at: '2026-05-26T16:11:56.238Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -317,32 +317,32 @@ paths:
                   key_type: publishable
                   token_prefix:
                   scopes: []
-                  created_at: '2026-05-26T15:35:58.784Z'
-                  updated_at: '2026-05-26T15:35:58.784Z'
+                  created_at: '2026-05-26T16:11:56.556Z'
+                  updated_at: '2026-05-26T16:11:56.556Z'
                   revoked_at:
                   last_used_at:
-                  plaintext_token: pk_VVx6ipjSCRCPopLW3XJ5eYBN
+                  plaintext_token: pk_sMAe8wVfz8C8UEma1dzHXGuB
                   created_by_email:
                 - id: key_gbHJdmfrXB
                   name: Backend integration
                   key_type: secret
-                  token_prefix: sk_1rUUtKkCq
+                  token_prefix: sk_8GrpM2be2
                   scopes:
                   - write_all
-                  created_at: '2026-05-26T15:35:58.786Z'
-                  updated_at: '2026-05-26T15:35:58.786Z'
+                  created_at: '2026-05-26T16:11:56.558Z'
+                  updated_at: '2026-05-26T16:11:56.558Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
                   created_by_email:
                 - id: key_EfhxLZ9ck8
-                  name: ullam
+                  name: libero
                   key_type: secret
-                  token_prefix: sk_48T8Djhom
+                  token_prefix: sk_53SjiyxYD
                   scopes:
                   - write_all
-                  created_at: '2026-05-26T15:35:58.788Z'
-                  updated_at: '2026-05-26T15:35:58.788Z'
+                  created_at: '2026-05-26T16:11:56.560Z'
+                  updated_at: '2026-05-26T16:11:56.560Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
@@ -405,15 +405,15 @@ paths:
                 id: key_VqXmZF31wY
                 name: CI key
                 key_type: secret
-                token_prefix: sk_SaeebacDd
+                token_prefix: sk_d2znVaYUc
                 scopes:
                 - read_orders
-                created_at: '2026-05-26T15:35:59.373Z'
-                updated_at: '2026-05-26T15:35:59.373Z'
+                created_at: '2026-05-26T16:11:57.239Z'
+                updated_at: '2026-05-26T16:11:57.239Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: sk_SaeebacDdaFX4tCiwwSxHCpM
-                created_by_email: kara@mills.com
+                plaintext_token: sk_d2znVaYUcjv7xLXu7gNm1vGc
+                created_by_email: laurice@schinnerlindgren.us
         '422':
           description: validation error
           content:
@@ -499,11 +499,11 @@ paths:
                 key_type: publishable
                 token_prefix:
                 scopes: []
-                created_at: '2026-05-26T15:35:59.662Z'
-                updated_at: '2026-05-26T15:35:59.662Z'
+                created_at: '2026-05-26T16:11:57.532Z'
+                updated_at: '2026-05-26T16:11:57.532Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: pk_RW1nWfzT6hBcGL9p9HYeWiNu
+                plaintext_token: pk_VMqsBqSQyYziwRjbWKTyNd5h
                 created_by_email:
     delete:
       summary: Delete an API key
@@ -593,12 +593,12 @@ paths:
                 id: key_gbHJdmfrXB
                 name: Backend integration
                 key_type: secret
-                token_prefix: sk_7Tm2n4xHa
+                token_prefix: sk_LMPdjpQhR
                 scopes:
                 - write_all
-                created_at: '2026-05-26T15:36:00.246Z'
-                updated_at: '2026-05-26T15:36:00.527Z'
-                revoked_at: '2026-05-26T15:36:00.526Z'
+                created_at: '2026-05-26T16:11:58.097Z'
+                updated_at: '2026-05-26T16:11:58.376Z'
+                revoked_at: '2026-05-26T16:11:58.374Z'
                 last_used_at:
                 plaintext_token:
                 created_by_email:
@@ -652,15 +652,15 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImVhMjVmNDcyLWVlOTEtNGY2My04M2M0LWZhZGIxYjA5OGI3NSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODEwMDYxfQ.hW0FAtB-jX0RA22qm3hzKhz5P8XdJAISbLCbD7uVkyM
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjFiOTNkNjUzLTU0NmMtNDhlYS1hZDRiLWE1NWU5OTY0YzZkZCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODEyMjE4fQ.FSbBqYArfkNhx4AOUgjEQi8EtOuiO0OJFtWwIfgDJkQ
                 user:
                   id: admin_UkLWZg9DAJ
                   email: admin@example.com
-                  first_name: Wenona
-                  last_name: Murphy
-                  full_name: Wenona Murphy
-                  created_at: '2026-05-26T15:36:00.794Z'
-                  updated_at: '2026-05-26T15:36:00.794Z'
+                  first_name: Ruby
+                  last_name: Frami
+                  full_name: Ruby Frami
+                  created_at: '2026-05-26T16:11:58.643Z'
+                  updated_at: '2026-05-26T16:11:58.643Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -714,7 +714,8 @@ paths:
                     example: okta
                     description: Registered provider key (anything other than `email`).
                     not:
-                      const: email
+                      enum:
+                      - email
                 required:
                 - provider
                 additionalProperties: true
@@ -754,15 +755,15 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImZlOGVmNzY0LTBhY2UtNGI5YS04NTliLWIwYzg3ODgyZmEwOSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODEwMDYxfQ.6h9b0XTFy9snf7q4XTwOnDLv3ISdVdMt2z0D4zbyZZg
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjNhMWI5M2M4LWM2Y2UtNGNhMy04NmNkLTRjZjFlZGZjNjczNSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODEyMjE5fQ.hxO8Fmk8Emo9J8B2jWENXY8VDb0NSV8JnzvOpqR3m44
                 user:
                   id: admin_UkLWZg9DAJ
                   email: admin@example.com
-                  first_name: Refugia
-                  last_name: Jacobi
-                  full_name: Refugia Jacobi
-                  created_at: '2026-05-26T15:36:01.912Z'
-                  updated_at: '2026-05-26T15:36:01.912Z'
+                  first_name: Melissa
+                  last_name: Hills
+                  full_name: Melissa Hills
+                  created_at: '2026-05-26T16:11:59.743Z'
+                  updated_at: '2026-05-26T16:11:59.743Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -859,15 +860,15 @@ paths:
                 - id: coupon_UkLWZg9DAJ
                   code: AAA111
                   state: unused
-                  created_at: '2026-05-26T15:36:02.512Z'
-                  updated_at: '2026-05-26T15:36:02.512Z'
+                  created_at: '2026-05-26T16:12:00.430Z'
+                  updated_at: '2026-05-26T16:12:00.430Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 - id: coupon_gbHJdmfrXB
                   code: BBB222
                   state: unused
-                  created_at: '2026-05-26T15:36:02.514Z'
-                  updated_at: '2026-05-26T15:36:02.514Z'
+                  created_at: '2026-05-26T16:12:00.431Z'
+                  updated_at: '2026-05-26T16:12:00.431Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 meta:
@@ -945,8 +946,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Product
                   storefront_visible: true
-                  created_at: '2026-05-26T15:36:02.810Z'
-                  updated_at: '2026-05-26T15:36:02.810Z'
+                  created_at: '2026-05-26T16:12:00.726Z'
+                  updated_at: '2026-05-26T16:12:00.726Z'
                 - id: cfdef_gbHJdmfrXB
                   namespace: custom
                   key: order_notes
@@ -954,8 +955,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Order
                   storefront_visible: true
-                  created_at: '2026-05-26T15:36:02.811Z'
-                  updated_at: '2026-05-26T15:36:02.811Z'
+                  created_at: '2026-05-26T16:12:00.727Z'
+                  updated_at: '2026-05-26T16:12:00.727Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1018,8 +1019,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-26T15:36:03.382Z'
-                updated_at: '2026-05-26T15:36:03.382Z'
+                created_at: '2026-05-26T16:12:01.285Z'
+                updated_at: '2026-05-26T16:12:01.285Z'
       requestBody:
         content:
           application/json:
@@ -1102,8 +1103,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-26T15:36:03.385Z'
-                updated_at: '2026-05-26T15:36:03.385Z'
+                created_at: '2026-05-26T16:12:01.288Z'
+                updated_at: '2026-05-26T16:12:01.288Z'
     patch:
       summary: Update a custom field definition
       tags:
@@ -1142,8 +1143,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: false
-                created_at: '2026-05-26T15:36:03.667Z'
-                updated_at: '2026-05-26T15:36:03.951Z'
+                created_at: '2026-05-26T16:12:01.575Z'
+                updated_at: '2026-05-26T16:12:01.862Z'
       requestBody:
         content:
           application/json:
@@ -1267,14 +1268,14 @@ paths:
                   name: VIPs
                   description: Top spenders
                   customers_count: 0
-                  created_at: '2026-05-26T15:36:04.246Z'
-                  updated_at: '2026-05-26T15:36:04.246Z'
+                  created_at: '2026-05-26T16:12:02.163Z'
+                  updated_at: '2026-05-26T16:12:02.163Z'
                 - id: cg_gbHJdmfrXB
                   name: Wholesale
                   description:
                   customers_count: 0
-                  created_at: '2026-05-26T15:36:04.247Z'
-                  updated_at: '2026-05-26T15:36:04.247Z'
+                  created_at: '2026-05-26T16:12:02.164Z'
+                  updated_at: '2026-05-26T16:12:02.164Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1359,8 +1360,8 @@ paths:
                 name: Wholesale 2
                 description: B2B accounts
                 customers_count: 1
-                created_at: '2026-05-26T15:36:05.145Z'
-                updated_at: '2026-05-26T15:36:05.145Z'
+                created_at: '2026-05-26T16:12:03.069Z'
+                updated_at: '2026-05-26T16:12:03.069Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1466,24 +1467,24 @@ paths:
                 name: VIPs
                 description: Top spenders
                 customers_count: 1
-                created_at: '2026-05-26T15:36:05.735Z'
-                updated_at: '2026-05-26T15:36:05.735Z'
+                created_at: '2026-05-26T16:12:03.679Z'
+                updated_at: '2026-05-26T16:12:03.679Z'
                 customers:
                 - id: cus_UkLWZg9DAJ
-                  email: vasiliki.okon@prohaska.info
-                  first_name: Lillia
-                  last_name: Windler
+                  email: evie@heller.biz
+                  first_name: Avelina
+                  last_name: Weber
                   phone:
                   accepts_email_marketing: false
-                  full_name: Lillia Windler
+                  full_name: Avelina Weber
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
-                  login: vasiliki.okon@prohaska.info
+                  login: evie@heller.biz
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-26T15:36:05.999Z'
-                  updated_at: '2026-05-26T15:36:05.999Z'
+                  created_at: '2026-05-26T16:12:03.948Z'
+                  updated_at: '2026-05-26T16:12:03.948Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -1561,8 +1562,8 @@ paths:
                 name: VIP customers (Q1)
                 description: Top spenders
                 customers_count: 0
-                created_at: '2026-05-26T15:36:06.588Z'
-                updated_at: '2026-05-26T15:36:06.870Z'
+                created_at: '2026-05-26T16:12:04.532Z'
+                updated_at: '2026-05-26T16:12:04.839Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1715,8 +1716,8 @@ paths:
                   state_name: New York
                   label:
                   metadata: {}
-                  created_at: '2026-05-26T15:36:07.730Z'
-                  updated_at: '2026-05-26T15:36:07.730Z'
+                  created_at: '2026-05-26T16:12:05.803Z'
+                  updated_at: '2026-05-26T16:12:05.803Z'
                   customer_id: cus_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -1804,8 +1805,8 @@ paths:
                 state_name: New York
                 label: Office
                 metadata: {}
-                created_at: '2026-05-26T15:36:09.105Z'
-                updated_at: '2026-05-26T15:36:09.105Z'
+                created_at: '2026-05-26T16:12:07.161Z'
+                updated_at: '2026-05-26T16:12:07.161Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -1916,8 +1917,8 @@ paths:
                 state_name: New York
                 label:
                 metadata: {}
-                created_at: '2026-05-26T15:36:09.391Z'
-                updated_at: '2026-05-26T15:36:09.945Z'
+                created_at: '2026-05-26T16:12:07.438Z'
+                updated_at: '2026-05-26T16:12:08.064Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -2050,8 +2051,8 @@ paths:
                   customer_id: cus_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   metadata: {}
-                  created_at: '2026-05-26T15:36:11.059Z'
-                  updated_at: '2026-05-26T15:36:11.059Z'
+                  created_at: '2026-05-26T16:12:09.473Z'
+                  updated_at: '2026-05-26T16:12:09.473Z'
                 meta:
                   page: 1
                   limit: 25
@@ -2138,8 +2139,8 @@ paths:
                 customer_id: cus_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 metadata: {}
-                created_at: '2026-05-26T15:36:11.642Z'
-                updated_at: '2026-05-26T15:36:11.642Z'
+                created_at: '2026-05-26T16:12:10.055Z'
+                updated_at: '2026-05-26T16:12:10.055Z'
     delete:
       summary: Delete a customer credit card
       tags:
@@ -2258,8 +2259,8 @@ paths:
                   currency: USD
                   memo:
                   metadata: {}
-                  created_at: '2026-05-26T15:36:13.034Z'
-                  updated_at: '2026-05-26T15:36:13.034Z'
+                  created_at: '2026-05-26T16:12:11.460Z'
+                  updated_at: '2026-05-26T16:12:11.460Z'
                   customer_id: cus_UkLWZg9DAJ
                   created_by_id: admin_UkLWZg9DAJ
                   category_id: sccat_UkLWZg9DAJ
@@ -2334,8 +2335,8 @@ paths:
                 currency: USD
                 memo: Goodwill
                 metadata: {}
-                created_at: '2026-05-26T15:36:14.147Z'
-                updated_at: '2026-05-26T15:36:14.147Z'
+                created_at: '2026-05-26T16:12:12.603Z'
+                updated_at: '2026-05-26T16:12:12.603Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_gbHJdmfrXB
                 category_id: sccat_UkLWZg9DAJ
@@ -2426,8 +2427,8 @@ paths:
                 currency: USD
                 memo: Updated
                 metadata: {}
-                created_at: '2026-05-26T15:36:14.690Z'
-                updated_at: '2026-05-26T15:36:14.974Z'
+                created_at: '2026-05-26T16:12:13.232Z'
+                updated_at: '2026-05-26T16:12:13.518Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_UkLWZg9DAJ
                 category_id: sccat_UkLWZg9DAJ
@@ -2581,8 +2582,8 @@ paths:
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-26T15:36:16.065Z'
-                  updated_at: '2026-05-26T15:36:16.065Z'
+                  created_at: '2026-05-26T16:12:14.666Z'
+                  updated_at: '2026-05-26T16:12:14.666Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -2665,8 +2666,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T15:36:16.907Z'
-                updated_at: '2026-05-26T15:36:16.907Z'
+                created_at: '2026-05-26T16:12:15.501Z'
+                updated_at: '2026-05-26T16:12:15.501Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2782,8 +2783,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T15:36:17.180Z'
-                updated_at: '2026-05-26T15:36:17.180Z'
+                created_at: '2026-05-26T16:12:15.770Z'
+                updated_at: '2026-05-26T16:12:15.770Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2857,8 +2858,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T15:36:17.731Z'
-                updated_at: '2026-05-26T15:36:18.013Z'
+                created_at: '2026-05-26T16:12:16.321Z'
+                updated_at: '2026-05-26T16:12:16.603Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -3288,11 +3289,11 @@ paths:
               example:
                 data:
                 - id: exp_UkLWZg9DAJ
-                  number: EF257712950
+                  number: EF917174541
                   type: Spree::Exports::Products
                   format: csv
-                  created_at: '2026-05-26T15:36:22.196Z'
-                  updated_at: '2026-05-26T15:36:22.196Z'
+                  created_at: '2026-05-26T16:12:20.761Z'
+                  updated_at: '2026-05-26T16:12:20.761Z'
                   user_id: admin_UkLWZg9DAJ
                   done: false
                   filename:
@@ -3359,11 +3360,11 @@ paths:
             application/json:
               example:
                 id: exp_gbHJdmfrXB
-                number: EF461421877
+                number: EF717713311
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-26T15:36:22.499Z'
-                updated_at: '2026-05-26T15:36:22.499Z'
+                created_at: '2026-05-26T16:12:21.059Z'
+                updated_at: '2026-05-26T16:12:21.059Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3450,11 +3451,11 @@ paths:
             application/json:
               example:
                 id: exp_UkLWZg9DAJ
-                number: EF186425869
+                number: EF426554878
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-26T15:36:22.771Z'
-                updated_at: '2026-05-26T15:36:22.771Z'
+                created_at: '2026-05-26T16:12:21.330Z'
+                updated_at: '2026-05-26T16:12:21.330Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3637,8 +3638,8 @@ paths:
                   codes_count: 2
                   currency: USD
                   prefix: WELCOME
-                  created_at: '2026-05-26T15:36:23.373Z'
-                  updated_at: '2026-05-26T15:36:23.373Z'
+                  created_at: '2026-05-26T16:12:21.926Z'
+                  updated_at: '2026-05-26T16:12:21.926Z'
                   amount: '50.0'
                   expires_at:
                   created_by_id:
@@ -3719,8 +3720,8 @@ paths:
                 codes_count: 5
                 currency: USD
                 prefix: NEWCAMP
-                created_at: '2026-05-26T15:36:23.942Z'
-                updated_at: '2026-05-26T15:36:23.942Z'
+                created_at: '2026-05-26T16:12:22.496Z'
+                updated_at: '2026-05-26T16:12:22.496Z'
                 amount: '25.0'
                 expires_at: '2030-12-31'
                 created_by_id: admin_UkLWZg9DAJ
@@ -3821,8 +3822,8 @@ paths:
                 codes_count: 2
                 currency: USD
                 prefix: WELCOME
-                created_at: '2026-05-26T15:36:24.235Z'
-                updated_at: '2026-05-26T15:36:24.235Z'
+                created_at: '2026-05-26T16:12:22.788Z'
+                updated_at: '2026-05-26T16:12:22.788Z'
                 amount: '50.0'
                 expires_at:
                 created_by_id:
@@ -3925,7 +3926,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: '0080027813FFDA32'
+                  code: E9E1428FD796712F
                   status: active
                   currency: USD
                   amount: '50.0'
@@ -3939,12 +3940,12 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-05-26T15:36:24.806Z'
-                  updated_at: '2026-05-26T15:36:24.806Z'
+                  created_at: '2026-05-26T16:12:23.364Z'
+                  updated_at: '2026-05-26T16:12:23.364Z'
                   customer_id:
                   created_by_id:
                 - id: gc_gbHJdmfrXB
-                  code: FC42E063EF732A04
+                  code: D2F00134CB4D9913
                   status: active
                   currency: USD
                   amount: '25.0'
@@ -3958,8 +3959,8 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-05-26T15:36:24.807Z'
-                  updated_at: '2026-05-26T15:36:24.807Z'
+                  created_at: '2026-05-26T16:12:23.365Z'
+                  updated_at: '2026-05-26T16:12:23.365Z'
                   customer_id:
                   created_by_id:
                 meta:
@@ -4044,7 +4045,7 @@ paths:
             application/json:
               example:
                 id: gc_EfhxLZ9ck8
-                code: 8A19D86124B5CF08
+                code: 31F056B764C08321
                 status: active
                 currency: USD
                 amount: '25.0'
@@ -4058,8 +4059,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:36:25.402Z'
-                updated_at: '2026-05-26T15:36:25.402Z'
+                created_at: '2026-05-26T16:12:23.972Z'
+                updated_at: '2026-05-26T16:12:23.972Z'
                 customer_id:
                 created_by_id: admin_UkLWZg9DAJ
               schema:
@@ -4165,7 +4166,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 99B349C6D4C6C4FD
+                code: F15BC55E98D6DB74
                 status: active
                 currency: USD
                 amount: '50.0'
@@ -4179,8 +4180,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:36:25.702Z'
-                updated_at: '2026-05-26T15:36:25.702Z'
+                created_at: '2026-05-26T16:12:24.270Z'
+                updated_at: '2026-05-26T16:12:24.270Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4240,7 +4241,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: EC57664CC61B9EB8
+                code: 32CC301C086F291F
                 status: active
                 currency: USD
                 amount: '75.0'
@@ -4254,8 +4255,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:36:26.279Z'
-                updated_at: '2026-05-26T15:36:26.562Z'
+                created_at: '2026-05-26T16:12:24.842Z'
+                updated_at: '2026-05-26T16:12:25.123Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4367,15 +4368,15 @@ paths:
               example:
                 data:
                 - id: inv_UkLWZg9DAJ
-                  email: phyliss@cassin.us
+                  email: hung.turcotte@brekkewehner.name
                   status: pending
-                  created_at: '2026-05-26T15:36:27.411Z'
-                  updated_at: '2026-05-26T15:36:27.411Z'
-                  expires_at: '2026-06-09T15:36:27.408Z'
+                  created_at: '2026-05-26T16:12:25.976Z'
+                  updated_at: '2026-05-26T16:12:25.976Z'
+                  expires_at: '2026-06-09T16:12:25.973Z'
                   role_id: role_UkLWZg9DAJ
                   role_name: admin
-                  inviter_email: bari_christiansen@kulas.co.uk
-                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=Y32XibVjzoPAmDZYg8MvsAQi"
+                  inviter_email: brande@rodriguez.us
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=R2VpavHrbEcsj4MK8cEG7mNx"
                   invitee_exists: false
                   store:
                     id: store_UkLWZg9DAJ
@@ -4436,13 +4437,13 @@ paths:
                 id: inv_gbHJdmfrXB
                 email: new-staff@example.com
                 status: pending
-                created_at: '2026-05-26T15:36:27.718Z'
-                updated_at: '2026-05-26T15:36:27.718Z'
-                expires_at: '2026-06-09T15:36:27.715Z'
+                created_at: '2026-05-26T16:12:26.278Z'
+                updated_at: '2026-05-26T16:12:26.278Z'
+                expires_at: '2026-06-09T16:12:26.275Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: audrea@bartolettiweimann.ca
-                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=t3Q2Z2gkSMayNbxtv46Q8gtA"
+                inviter_email: arturo@carroll.ca
+                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=gcFU19NSNVETM6Jj1uSi69yh"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -4549,15 +4550,15 @@ paths:
             application/json:
               example:
                 id: inv_UkLWZg9DAJ
-                email: carolyne@conn.us
+                email: sarina@creminwiza.us
                 status: pending
-                created_at: '2026-05-26T15:36:28.272Z'
-                updated_at: '2026-05-26T15:36:28.272Z'
-                expires_at: '2026-06-09T15:36:28.270Z'
+                created_at: '2026-05-26T16:12:26.833Z'
+                updated_at: '2026-05-26T16:12:26.833Z'
+                expires_at: '2026-06-09T16:12:26.831Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: rocio@hudson.co.uk
-                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=ANT4cxRkXhJ8Qnw4yJTHPSmj"
+                inviter_email: kimber@swaniawski.us
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=yRB6MxhKyVFRgWXWRXJmRXey"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -4643,8 +4644,8 @@ paths:
                   - DE
                   supported_locales:
                   - en
-                  created_at: '2026-05-26T15:36:28.330Z'
-                  updated_at: '2026-05-26T15:36:28.330Z'
+                  created_at: '2026-05-26T16:12:26.890Z'
+                  updated_at: '2026-05-26T16:12:26.890Z'
                 meta:
                   page: 1
                   limit: 25
@@ -4734,8 +4735,8 @@ paths:
                 supported_locales:
                 - en
                 - fr
-                created_at: '2026-05-26T15:36:28.941Z'
-                updated_at: '2026-05-26T15:36:28.941Z'
+                created_at: '2026-05-26T16:12:27.501Z'
+                updated_at: '2026-05-26T16:12:27.501Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -4868,8 +4869,8 @@ paths:
                 - DE
                 supported_locales:
                 - en
-                created_at: '2026-05-26T15:36:29.267Z'
-                updated_at: '2026-05-26T15:36:29.267Z'
+                created_at: '2026-05-26T16:12:27.829Z'
+                updated_at: '2026-05-26T16:12:27.829Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '404':
@@ -4945,8 +4946,8 @@ paths:
                 - DE
                 supported_locales:
                 - en
-                created_at: '2026-05-26T15:36:29.866Z'
-                updated_at: '2026-05-26T15:36:30.152Z'
+                created_at: '2026-05-26T16:12:28.435Z'
+                updated_at: '2026-05-26T16:12:28.718Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -5083,12 +5084,12 @@ paths:
               example:
                 user:
                   id: admin_UkLWZg9DAJ
-                  email: lavonia@terry.name
-                  first_name: Stephan
-                  last_name: Boyle
-                  full_name: Stephan Boyle
-                  created_at: '2026-05-26T15:36:31.351Z'
-                  updated_at: '2026-05-26T15:36:31.351Z'
+                  email: earline_carroll@osinskistrosin.info
+                  first_name: Cordell
+                  last_name: Schmitt
+                  full_name: Cordell Schmitt
+                  created_at: '2026-05-26T16:12:29.922Z'
+                  updated_at: '2026-05-26T16:12:29.922Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -5238,8 +5239,8 @@ paths:
                   kind: dropdown
                   metadata: {}
                   filterable: true
-                  created_at: '2026-05-26T15:36:31.413Z'
-                  updated_at: '2026-05-26T15:36:31.413Z'
+                  created_at: '2026-05-26T16:12:29.971Z'
+                  updated_at: '2026-05-26T16:12:29.971Z'
                 meta:
                   page: 1
                   limit: 25
@@ -5330,8 +5331,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T15:36:32.038Z'
-                updated_at: '2026-05-26T15:36:32.038Z'
+                created_at: '2026-05-26T16:12:30.584Z'
+                updated_at: '2026-05-26T16:12:30.584Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -5452,8 +5453,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T15:36:32.341Z'
-                updated_at: '2026-05-26T15:36:32.341Z'
+                created_at: '2026-05-26T16:12:30.884Z'
+                updated_at: '2026-05-26T16:12:30.884Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '404':
@@ -5525,8 +5526,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T15:36:32.969Z'
-                updated_at: '2026-05-26T15:36:33.368Z'
+                created_at: '2026-05-26T16:12:31.534Z'
+                updated_at: '2026-05-26T16:12:31.813Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -5685,7 +5686,7 @@ paths:
               example:
                 data:
                 - id: ful_UkLWZg9DAJ
-                  number: H96395040097
+                  number: H21426817644
                   tracking: U10000
                   tracking_url:
                   cost: '10.0'
@@ -5710,8 +5711,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-26T15:36:34.422Z'
-                  updated_at: '2026-05-26T15:36:34.505Z'
+                  created_at: '2026-05-26T16:12:32.807Z'
+                  updated_at: '2026-05-26T16:12:32.886Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_UkLWZg9DAJ
                 meta:
@@ -5794,7 +5795,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H04009472925
+                number: H02734152340
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5819,8 +5820,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:36:35.150Z'
-                updated_at: '2026-05-26T15:36:35.234Z'
+                created_at: '2026-05-26T16:12:33.518Z'
+                updated_at: '2026-05-26T16:12:33.582Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
     patch:
@@ -5879,7 +5880,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H26889269295
+                number: H27987471741
                 tracking: 1Z999AA10123456784
                 tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
                 cost: '10.0'
@@ -5904,8 +5905,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:36:35.852Z'
-                updated_at: '2026-05-26T15:36:36.213Z'
+                created_at: '2026-05-26T16:12:34.190Z'
+                updated_at: '2026-05-26T16:12:34.537Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
       requestBody:
@@ -5974,7 +5975,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H96976373458
+                number: H69306138629
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5991,7 +5992,7 @@ paths:
                 display_tax_total: "$0.00"
                 status: shipped
                 fulfillment_type: shipping
-                fulfilled_at: '2026-05-26T15:36:36Z'
+                fulfilled_at: '2026-05-26T16:12:35Z'
                 items:
                 - item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
@@ -5999,8 +6000,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:36:36.570Z'
-                updated_at: '2026-05-26T15:36:36.957Z'
+                created_at: '2026-05-26T16:12:34.928Z'
+                updated_at: '2026-05-26T16:12:35.370Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
@@ -6058,7 +6059,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H43549723427
+                number: H79577206102
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6083,8 +6084,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:36:37.368Z'
-                updated_at: '2026-05-26T15:36:37.716Z'
+                created_at: '2026-05-26T16:12:35.712Z'
+                updated_at: '2026-05-26T16:12:36.066Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
@@ -6142,7 +6143,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H85189054446
+                number: H59689445550
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6167,8 +6168,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:36:38.073Z'
-                updated_at: '2026-05-26T15:36:38.474Z'
+                created_at: '2026-05-26T16:12:36.394Z'
+                updated_at: '2026-05-26T16:12:36.772Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
@@ -6229,7 +6230,7 @@ paths:
               example:
                 data:
                 - id: ful_gbHJdmfrXB
-                  number: H09797035655
+                  number: H53323829337
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -6254,8 +6255,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-26T15:36:39.184Z'
-                  updated_at: '2026-05-26T15:36:39.236Z'
+                  created_at: '2026-05-26T16:12:37.468Z'
+                  updated_at: '2026-05-26T16:12:37.514Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_gbHJdmfrXB
       requestBody:
@@ -6327,7 +6328,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 7B9E2478235A09B0
+                code: 7C74EE58D26F1DA3
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -6341,8 +6342,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:36:39.582Z'
-                updated_at: '2026-05-26T15:36:39.883Z'
+                created_at: '2026-05-26T16:12:37.861Z'
+                updated_at: '2026-05-26T16:12:38.166Z'
                 customer_id:
                 created_by_id:
       requestBody:
@@ -6475,8 +6476,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 2
                   currency: USD
-                  name: Product 102111
-                  slug: product-102111
+                  name: Product 106736
+                  slug: product-106736
                   options_text: 'Size: S'
                   price: '10.0'
                   display_price: "$10.00"
@@ -6508,12 +6509,12 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-26T15:36:40.604Z'
-                    updated_at: '2026-05-26T15:36:40.604Z'
+                    created_at: '2026-05-26T16:12:38.865Z'
+                    updated_at: '2026-05-26T16:12:38.865Z'
                   digital_links: []
                   metadata: {}
-                  created_at: '2026-05-26T15:36:40.901Z'
-                  updated_at: '2026-05-26T15:36:40.901Z'
+                  created_at: '2026-05-26T16:12:39.158Z'
+                  updated_at: '2026-05-26T16:12:39.158Z'
                   cost_price: '17.0'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
@@ -6580,8 +6581,8 @@ paths:
                 variant_id: variant_VqXmZF31wY
                 quantity: 3
                 currency: USD
-                name: Product 126801
-                slug: product-126801
+                name: Product 126379
+                slug: product-126379
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -6613,12 +6614,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:36:41.848Z'
-                  updated_at: '2026-05-26T15:36:41.848Z'
+                  created_at: '2026-05-26T16:12:40.169Z'
+                  updated_at: '2026-05-26T16:12:40.169Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T15:36:41.881Z'
-                updated_at: '2026-05-26T15:36:41.881Z'
+                created_at: '2026-05-26T16:12:40.233Z'
+                updated_at: '2026-05-26T16:12:40.233Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -6707,8 +6708,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 2
                 currency: USD
-                name: Product 13276
-                slug: product-13276
+                name: Product 132960
+                slug: product-132960
                 options_text: 'Size: S'
                 price: '10.0'
                 display_price: "$10.00"
@@ -6740,12 +6741,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:36:41.976Z'
-                  updated_at: '2026-05-26T15:36:41.976Z'
+                  created_at: '2026-05-26T16:12:40.319Z'
+                  updated_at: '2026-05-26T16:12:40.319Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T15:36:42.275Z'
-                updated_at: '2026-05-26T15:36:42.275Z'
+                created_at: '2026-05-26T16:12:40.672Z'
+                updated_at: '2026-05-26T16:12:40.672Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
     patch:
@@ -6807,8 +6808,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 5
                 currency: USD
-                name: Product 14831
-                slug: product-14831
+                name: Product 142304
+                slug: product-142304
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -6840,12 +6841,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:36:42.609Z'
-                  updated_at: '2026-05-26T15:36:42.609Z'
+                  created_at: '2026-05-26T16:12:41.005Z'
+                  updated_at: '2026-05-26T16:12:41.005Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T15:36:42.900Z'
-                updated_at: '2026-05-26T15:36:43.213Z'
+                created_at: '2026-05-26T16:12:41.293Z'
+                updated_at: '2026-05-26T16:12:41.588Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -6971,8 +6972,8 @@ paths:
                 data:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-3c01b8a4ac51
-                  number: P6SHB6QB
+                  response_code: BGS-fb554349125f
+                  number: P1B8HOBK
                   amount: '110.0'
                   display_amount: "$110.00"
                   status: completed
@@ -6990,14 +6991,14 @@ paths:
                     customer_id:
                     payment_method_id: pm_gbHJdmfrXB
                     metadata: {}
-                    created_at: '2026-05-26T15:36:44.352Z'
-                    updated_at: '2026-05-26T15:36:44.354Z'
+                    created_at: '2026-05-26T16:12:42.609Z'
+                    updated_at: '2026-05-26T16:12:42.611Z'
                   metadata: {}
                   avs_response:
                   cvv_response_code:
                   cvv_response_message:
-                  created_at: '2026-05-26T15:36:44.353Z'
-                  updated_at: '2026-05-26T15:36:44.353Z'
+                  created_at: '2026-05-26T16:12:42.610Z'
+                  updated_at: '2026-05-26T16:12:42.610Z'
                   captured_amount: '0.0'
                   order_id: or_UkLWZg9DAJ
                 meta:
@@ -7064,7 +7065,7 @@ paths:
                 id: py_gbHJdmfrXB
                 payment_method_id: pm_EfhxLZ9ck8
                 response_code:
-                number: PPD94T81
+                number: PYKPEF6D
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7075,8 +7076,8 @@ paths:
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:36:45.696Z'
-                updated_at: '2026-05-26T15:36:45.696Z'
+                created_at: '2026-05-26T16:12:44.021Z'
+                updated_at: '2026-05-26T16:12:44.021Z'
                 captured_amount: '0.0'
                 order_id: or_gbHJdmfrXB
       requestBody:
@@ -7166,8 +7167,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-41700c3aded2
-                number: P1B0M48R
+                response_code: BGS-cb0e28824009
+                number: P5L7QR1T
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -7185,14 +7186,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T15:36:46.076Z'
-                  updated_at: '2026-05-26T15:36:46.079Z'
+                  created_at: '2026-05-26T16:12:44.393Z'
+                  updated_at: '2026-05-26T16:12:44.396Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:36:46.078Z'
-                updated_at: '2026-05-26T15:36:46.078Z'
+                created_at: '2026-05-26T16:12:44.395Z'
+                updated_at: '2026-05-26T16:12:44.395Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
@@ -7251,8 +7252,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-03e0f17be730
-                number: PO27G2VE
+                response_code: BGS-bce1b7b66ee7
+                number: P5QPPK46
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -7270,14 +7271,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T15:36:46.744Z'
-                  updated_at: '2026-05-26T15:36:46.747Z'
+                  created_at: '2026-05-26T16:12:45.123Z'
+                  updated_at: '2026-05-26T16:12:45.126Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:36:46.746Z'
-                updated_at: '2026-05-26T15:36:47.095Z'
+                created_at: '2026-05-26T16:12:45.125Z'
+                updated_at: '2026-05-26T16:12:45.459Z'
                 captured_amount: '110.0'
                 order_id: or_UkLWZg9DAJ
         '422':
@@ -7346,8 +7347,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: void-BGS-fdb719d7dc34
-                number: P2B1XUCU
+                response_code: void-BGS-2cd9f486d559
+                number: PN45KFXM
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: void
@@ -7365,14 +7366,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T15:36:48.217Z'
-                  updated_at: '2026-05-26T15:36:48.220Z'
+                  created_at: '2026-05-26T16:12:46.548Z'
+                  updated_at: '2026-05-26T16:12:46.550Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:36:48.219Z'
-                updated_at: '2026-05-26T15:36:48.532Z'
+                created_at: '2026-05-26T16:12:46.549Z'
+                updated_at: '2026-05-26T16:12:46.857Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/refunds":
@@ -7500,14 +7501,14 @@ paths:
             application/json:
               example:
                 id: re_UkLWZg9DAJ
-                transaction_id: BGS-ff2be9f2e002
+                transaction_id: BGS-47496253cbfc
                 amount: '5.0'
                 payment_id: py_UkLWZg9DAJ
                 refund_reason_id: rr_UkLWZg9DAJ
                 reimbursement_id:
                 metadata: {}
-                created_at: '2026-05-26T15:36:49.925Z'
-                updated_at: '2026-05-26T15:36:49.925Z'
+                created_at: '2026-05-26T16:12:48.332Z'
+                updated_at: '2026-05-26T16:12:48.332Z'
       requestBody:
         content:
           application/json:
@@ -7579,8 +7580,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R874324883
-                email: jannette@schaden.name
+                number: R261232121
+                email: tambra.graham@ziemann.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -7623,8 +7624,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:36:50.273Z'
-                updated_at: '2026-05-26T15:36:50.332Z'
+                created_at: '2026-05-26T16:12:48.631Z'
+                updated_at: '2026-05-26T16:12:48.679Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7795,8 +7796,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R568071828
-                  email: mason@stehr.name
+                  number: R429606837
+                  email: benton_larkin@reynolds.co.uk
                   customer_note:
                   currency: USD
                   locale: en
@@ -7839,8 +7840,8 @@ paths:
                   metadata: {}
                   canceled_at:
                   approved_at:
-                  created_at: '2026-05-26T15:36:52.105Z'
-                  updated_at: '2026-05-26T15:36:52.105Z'
+                  created_at: '2026-05-26T16:12:50.490Z'
+                  updated_at: '2026-05-26T16:12:50.490Z'
                   preferred_stock_location_id:
                   tags: []
                   internal_note:
@@ -7983,7 +7984,7 @@ paths:
                 id: or_gbHJdmfrXB
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R170706649
+                number: R970412419
                 email: pinned@example.com
                 customer_note:
                 currency: USD
@@ -8027,8 +8028,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:36:53.862Z'
-                updated_at: '2026-05-26T15:36:53.865Z'
+                created_at: '2026-05-26T16:12:52.257Z'
+                updated_at: '2026-05-26T16:12:52.260Z'
                 preferred_stock_location_id: sloc_UkLWZg9DAJ
                 tags: []
                 internal_note:
@@ -8212,8 +8213,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R607205941
-                email: sidney@cruickshank.us
+                number: R192431263
+                email: jackie.bergnaum@schmidtbayer.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -8256,8 +8257,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:36:54.149Z'
-                updated_at: '2026-05-26T15:36:54.149Z'
+                created_at: '2026-05-26T16:12:52.542Z'
+                updated_at: '2026-05-26T16:12:52.542Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8328,7 +8329,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R169903146
+                number: R080725845
                 email: updated@example.com
                 customer_note:
                 currency: USD
@@ -8372,8 +8373,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:36:55.285Z'
-                updated_at: '2026-05-26T15:36:55.577Z'
+                created_at: '2026-05-26T16:12:53.885Z'
+                updated_at: '2026-05-26T16:12:54.237Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8554,8 +8555,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R083827354
-                email: liza@paucek.biz
+                number: R195995246
+                email: norris@kuhlman.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -8582,7 +8583,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status: ready
                 payment_status: paid
-                completed_at: '2026-05-26T15:36:56.505Z'
+                completed_at: '2026-05-26T16:12:55.560Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8598,8 +8599,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:36:56.438Z'
-                updated_at: '2026-05-26T15:36:56.538Z'
+                created_at: '2026-05-26T16:12:55.464Z'
+                updated_at: '2026-05-26T16:12:55.607Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8680,8 +8681,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R082989840
-                email: kenyetta.schamberger@murphy.com
+                number: R675496720
+                email: lynwood_durgan@jerde.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -8708,7 +8709,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-26T15:36:57.817Z'
+                completed_at: '2026-05-26T16:12:57.041Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8722,10 +8723,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-26T15:36:58.133Z'
+                canceled_at: '2026-05-26T16:12:57.344Z'
                 approved_at:
-                created_at: '2026-05-26T15:36:57.760Z'
-                updated_at: '2026-05-26T15:36:58.180Z'
+                created_at: '2026-05-26T16:12:56.979Z'
+                updated_at: '2026-05-26T16:12:57.419Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8784,8 +8785,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R273096821
-                email: andre.weissnat@volkman.name
+                number: R677992716
+                email: shandi@bradtkeharber.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -8812,7 +8813,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:36:58.558Z'
+                completed_at: '2026-05-26T16:12:57.795Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8827,9 +8828,9 @@ paths:
                 display_payment_total: "$0.00"
                 metadata: {}
                 canceled_at:
-                approved_at: '2026-05-26T15:36:58.856Z'
-                created_at: '2026-05-26T15:36:58.499Z'
-                updated_at: '2026-05-26T15:36:58.557Z'
+                approved_at: '2026-05-26T16:12:58.093Z'
+                created_at: '2026-05-26T16:12:57.737Z'
+                updated_at: '2026-05-26T16:12:57.795Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8888,8 +8889,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R780361580
-                email: ronni_carroll@haleywalker.com
+                number: R763215454
+                email: giselle@wuckert.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -8916,7 +8917,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-26T15:36:59.210Z'
+                completed_at: '2026-05-26T16:12:58.511Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8930,10 +8931,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-26T15:36:59.492Z'
+                canceled_at: '2026-05-26T16:12:58.808Z'
                 approved_at:
-                created_at: '2026-05-26T15:36:59.148Z'
-                updated_at: '2026-05-26T15:36:59.579Z'
+                created_at: '2026-05-26T16:12:58.441Z'
+                updated_at: '2026-05-26T16:12:58.901Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8992,8 +8993,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R251197778
-                email: orval@becker.co.uk
+                number: R416458573
+                email: dakota@haag.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -9020,7 +9021,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:36:59.935Z'
+                completed_at: '2026-05-26T16:12:59.293Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9036,8 +9037,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:36:59.873Z'
-                updated_at: '2026-05-26T15:36:59.935Z'
+                created_at: '2026-05-26T16:12:59.204Z'
+                updated_at: '2026-05-26T16:12:59.293Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9112,8 +9113,8 @@ paths:
                   auto_capture:
                   storefront_visible: true
                   position: 1
-                  created_at: '2026-05-26T15:37:00.242Z'
-                  updated_at: '2026-05-26T15:37:00.243Z'
+                  created_at: '2026-05-26T16:12:59.601Z'
+                  updated_at: '2026-05-26T16:12:59.602Z'
                   preferences: {}
                   preference_schema: []
                 meta:
@@ -9253,8 +9254,8 @@ paths:
                 auto_capture:
                 storefront_visible: true
                 position: 1
-                created_at: '2026-05-26T15:37:00.825Z'
-                updated_at: '2026-05-26T15:37:00.826Z'
+                created_at: '2026-05-26T16:13:00.235Z'
+                updated_at: '2026-05-26T16:13:00.237Z'
                 preferences: {}
                 preference_schema: []
   "/api/v3/admin/price_lists":
@@ -9327,8 +9328,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-05-26T15:37:01.117Z'
-                  updated_at: '2026-05-26T15:37:01.117Z'
+                  created_at: '2026-05-26T16:13:00.549Z'
+                  updated_at: '2026-05-26T16:13:00.549Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -9342,8 +9343,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-05-26T15:37:01.119Z'
-                  updated_at: '2026-05-26T15:37:01.119Z'
+                  created_at: '2026-05-26T16:13:00.551Z'
+                  updated_at: '2026-05-26T16:13:00.551Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -9407,8 +9408,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:37:02.195Z'
-                updated_at: '2026-05-26T15:37:02.196Z'
+                created_at: '2026-05-26T16:13:01.662Z'
+                updated_at: '2026-05-26T16:13:01.664Z'
                 currently_active: false
                 products_count: 1
                 prices_count: 2
@@ -9556,8 +9557,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:37:02.497Z'
-                updated_at: '2026-05-26T15:37:02.497Z'
+                created_at: '2026-05-26T16:13:02.010Z'
+                updated_at: '2026-05-26T16:13:02.010Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9615,8 +9616,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:37:04.093Z'
-                updated_at: '2026-05-26T15:37:04.376Z'
+                created_at: '2026-05-26T16:13:03.739Z'
+                updated_at: '2026-05-26T16:13:04.021Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9774,8 +9775,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:37:04.669Z'
-                updated_at: '2026-05-26T15:37:04.950Z'
+                created_at: '2026-05-26T16:13:04.320Z'
+                updated_at: '2026-05-26T16:13:04.604Z'
                 currently_active: true
                 products_count: 0
                 prices_count: 0
@@ -9823,8 +9824,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:37:04.957Z'
-                updated_at: '2026-05-26T15:37:05.241Z'
+                created_at: '2026-05-26T16:13:04.612Z'
+                updated_at: '2026-05-26T16:13:04.892Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9935,8 +9936,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-05-26T15:37:05.318Z'
-                  updated_at: '2026-05-26T15:37:05.318Z'
+                  created_at: '2026-05-26T16:13:04.948Z'
+                  updated_at: '2026-05-26T16:13:04.948Z'
                 - id: price_EfhxLZ9ck8
                   amount: '5.0'
                   amount_in_cents: 500
@@ -9947,8 +9948,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id: pl_UkLWZg9DAJ
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-05-26T15:37:05.324Z'
-                  updated_at: '2026-05-26T15:37:05.324Z'
+                  created_at: '2026-05-26T16:13:04.955Z'
+                  updated_at: '2026-05-26T16:13:04.955Z'
                 meta:
                   page: 1
                   limit: 25
@@ -10027,8 +10028,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id:
                 variant_id: variant_EfhxLZ9ck8
-                created_at: '2026-05-26T15:37:05.983Z'
-                updated_at: '2026-05-26T15:37:05.983Z'
+                created_at: '2026-05-26T16:13:05.688Z'
+                updated_at: '2026-05-26T16:13:05.688Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -10112,8 +10113,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-05-26T15:37:06.045Z'
-                updated_at: '2026-05-26T15:37:06.045Z'
+                created_at: '2026-05-26T16:13:05.792Z'
+                updated_at: '2026-05-26T16:13:05.792Z'
               schema:
                 "$ref": "#/components/schemas/Price"
         '404':
@@ -10175,8 +10176,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-05-26T15:37:06.770Z'
-                updated_at: '2026-05-26T15:37:07.054Z'
+                created_at: '2026-05-26T16:13:06.598Z'
+                updated_at: '2026-05-26T16:13:06.880Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -10476,8 +10477,8 @@ paths:
                   field_type: short_text
                   key: custom.title
                   value: wool
-                  created_at: '2026-05-26T15:37:08.538Z'
-                  updated_at: '2026-05-26T15:37:08.538Z'
+                  created_at: '2026-05-26T16:13:08.426Z'
+                  updated_at: '2026-05-26T16:13:08.426Z'
                   storefront_visible: true
                   custom_field_definition_id: cfdef_UkLWZg9DAJ
                 meta:
@@ -10544,8 +10545,8 @@ paths:
                 field_type: long_text
                 key: custom.description
                 value: A longer description
-                created_at: '2026-05-26T15:37:09.156Z'
-                updated_at: '2026-05-26T15:37:09.156Z'
+                created_at: '2026-05-26T16:13:09.086Z'
+                updated_at: '2026-05-26T16:13:09.086Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_gbHJdmfrXB
         '422':
@@ -10629,8 +10630,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: wool
-                created_at: '2026-05-26T15:37:09.519Z'
-                updated_at: '2026-05-26T15:37:09.519Z'
+                created_at: '2026-05-26T16:13:09.478Z'
+                updated_at: '2026-05-26T16:13:09.478Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
     patch:
@@ -10677,8 +10678,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: cotton
-                created_at: '2026-05-26T15:37:09.840Z'
-                updated_at: '2026-05-26T15:37:10.126Z'
+                created_at: '2026-05-26T16:13:09.877Z'
+                updated_at: '2026-05-26T16:13:10.226Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
       requestBody:
@@ -10816,36 +10817,33 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 552852
-                  slug: product-552852
+                  name: Product 551779
+                  slug: product-551779
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-26T15:37:10.469Z'
+                  available_on: '2025-05-26T16:13:10.601Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Laborum doloribus architecto dolorum excepturi quos.
-                    Quasi quam atque natus officiis ratione consectetur id modi. Itaque
-                    laboriosam facilis vero aperiam nisi minima eos. Libero ipsa excepturi
-                    adipisci accusantium. Sequi consequatur occaecati saepe non aliquid
-                    mollitia veritatis amet. Inventore eos totam assumenda occaecati
-                    doloremque. Odio iste nemo voluptatem saepe ad magni labore quod.
-                    Quaerat cupiditate totam fugit natus amet quod quo accusantium.
-                    Veritatis nam nemo alias sunt eveniet enim dignissimos magnam.
-                    Repellat facilis minus eveniet rem. Minus itaque dolores non consequuntur
-                    eum atque officia tempora. Ratione occaecati veritatis optio doloribus
-                    molestiae nam eum atque. Veniam sit modi nemo molestias. Accusamus
-                    officiis voluptates non amet. Repudiandae consequuntur occaecati
-                    minima vero sequi fugiat perspiciatis. Illo doloremque error provident
-                    libero quam.
+                  description: Doloribus sed culpa exercitationem harum explicabo.
+                    Esse minus repudiandae dicta commodi tenetur possimus. Ut illum
+                    officia sequi non aliquam. Laboriosam rem error debitis impedit
+                    dolorum mollitia. Vel eos ducimus nemo sed repellat quae ex. Libero
+                    quae voluptas voluptatibus occaecati quo minima natus esse. Nihil
+                    facilis autem suscipit pariatur. Exercitationem nostrum sint distinctio
+                    minima. Sit eveniet voluptate impedit adipisci eum. In maxime
+                    iure veniam laudantium hic repellendus at sed. Et magni veniam
+                    ea molestiae reprehenderit hic eius ex. Sed at soluta iusto vitae
+                    impedit modi atque. Facere quia iure eligendi deleniti optio.
+                    Dolorem occaecati fuga omnis officiis deleniti.
                   description_html: |-
-                    Laborum doloribus architecto dolorum excepturi quos. Quasi quam atque natus officiis ratione consectetur id modi. Itaque laboriosam facilis vero aperiam nisi minima eos. Libero ipsa excepturi adipisci accusantium. Sequi consequatur occaecati saepe non aliquid mollitia veritatis amet.
-                    Inventore eos totam assumenda occaecati doloremque. Odio iste nemo voluptatem saepe ad magni labore quod. Quaerat cupiditate totam fugit natus amet quod quo accusantium.
-                    Veritatis nam nemo alias sunt eveniet enim dignissimos magnam. Repellat facilis minus eveniet rem. Minus itaque dolores non consequuntur eum atque officia tempora. Ratione occaecati veritatis optio doloribus molestiae nam eum atque.
-                    Veniam sit modi nemo molestias. Accusamus officiis voluptates non amet. Repudiandae consequuntur occaecati minima vero sequi fugiat perspiciatis. Illo doloremque error provident libero quam.
+                    Doloribus sed culpa exercitationem harum explicabo. Esse minus repudiandae dicta commodi tenetur possimus. Ut illum officia sequi non aliquam.
+                    Laboriosam rem error debitis impedit dolorum mollitia. Vel eos ducimus nemo sed repellat quae ex. Libero quae voluptas voluptatibus occaecati quo minima natus esse. Nihil facilis autem suscipit pariatur. Exercitationem nostrum sint distinctio minima.
+                    Sit eveniet voluptate impedit adipisci eum. In maxime iure veniam laudantium hic repellendus at sed. Et magni veniam ea molestiae reprehenderit hic eius ex.
+                    Sed at soluta iusto vitae impedit modi atque. Facere quia iure eligendi deleniti optio. Dolorem occaecati fuga omnis officiis deleniti.
                   default_variant_id: variant_UkLWZg9DAJ
                   thumbnail_url:
                   tags: []
@@ -10860,16 +10858,16 @@ paths:
                     display_compare_at_amount:
                     price_list_id:
                     variant_id: variant_UkLWZg9DAJ
-                    created_at: '2026-05-26T15:37:10.499Z'
-                    updated_at: '2026-05-26T15:37:10.499Z'
+                    created_at: '2026-05-26T16:13:10.629Z'
+                    updated_at: '2026-05-26T16:13:10.629Z'
                   original_price:
                   status: active
-                  make_active_at: '2025-05-26T15:37:10.469Z'
+                  make_active_at: '2025-05-26T16:13:10.601Z'
                   discontinue_on:
                   metadata: {}
                   deleted_at:
-                  created_at: '2026-05-26T15:37:10.485Z'
-                  updated_at: '2026-05-26T15:37:10.500Z'
+                  created_at: '2026-05-26T16:13:10.615Z'
+                  updated_at: '2026-05-26T16:13:10.630Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -11003,8 +11001,8 @@ paths:
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T15:37:11.178Z'
-                updated_at: '2026-05-26T15:37:11.181Z'
+                created_at: '2026-05-26T16:13:11.307Z'
+                updated_at: '2026-05-26T16:13:11.309Z'
                 tax_category_id:
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11184,37 +11182,35 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 594932
-                slug: product-594932
+                name: Product 591287
+                slug: product-591287
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-26T15:37:11.550Z'
+                available_on: '2025-05-26T16:13:11.678Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Eum placeat error ex dignissimos aperiam odit provident
-                  explicabo. Quibusdam cupiditate fugit ipsam vel rerum. Perferendis
-                  itaque cupiditate laborum odio. Molestias voluptatibus praesentium
-                  totam nisi quaerat reiciendis. Voluptatem numquam eaque praesentium
-                  culpa ab iusto labore voluptatibus. Beatae inventore sapiente incidunt
-                  optio eum et laboriosam quis. Occaecati aut excepturi qui delectus
-                  doloremque temporibus iure. Quam error libero quaerat doloribus
-                  vero quasi reiciendis voluptatum. Placeat inventore amet repudiandae
-                  veniam. Eveniet similique autem sapiente minus blanditiis eaque
-                  voluptatem. Aliquid distinctio illum molestiae cumque. Nisi laboriosam
-                  enim perferendis placeat laborum. Illum reiciendis nisi quaerat
-                  accusamus repellendus dolor deleniti. Aspernatur corrupti officia
-                  inventore sed sit. Corporis dolore nemo odit soluta officiis expedita
-                  nulla eum. Ducimus omnis vitae mollitia veniam aperiam esse officia
-                  labore.
+                description: Ab vero perspiciatis repellat rem aspernatur minus. Recusandae
+                  suscipit facilis culpa sunt inventore. Nemo soluta at qui eligendi
+                  eveniet cumque consectetur. Omnis iure labore asperiores illo optio
+                  consequatur. Sint fugit nulla atque inventore illo exercitationem.
+                  Rem magnam iure porro quisquam. Laboriosam magnam vero possimus
+                  incidunt harum. Aut harum doloribus alias nam eligendi numquam ducimus.
+                  Ad sapiente magnam id illo consequuntur quod consectetur. Nesciunt
+                  nemo commodi laborum corrupti architecto voluptatum eveniet. Libero
+                  possimus optio totam cumque quasi iusto inventore. Ea amet quos
+                  explicabo corporis. Unde deserunt rerum minima blanditiis repudiandae
+                  tenetur amet. Atque reprehenderit recusandae cupiditate quis modi
+                  error laboriosam repudiandae. Recusandae modi ipsam suscipit autem
+                  perferendis eum error illum.
                 description_html: |-
-                  Eum placeat error ex dignissimos aperiam odit provident explicabo. Quibusdam cupiditate fugit ipsam vel rerum. Perferendis itaque cupiditate laborum odio.
-                  Molestias voluptatibus praesentium totam nisi quaerat reiciendis. Voluptatem numquam eaque praesentium culpa ab iusto labore voluptatibus. Beatae inventore sapiente incidunt optio eum et laboriosam quis. Occaecati aut excepturi qui delectus doloremque temporibus iure. Quam error libero quaerat doloribus vero quasi reiciendis voluptatum.
-                  Placeat inventore amet repudiandae veniam. Eveniet similique autem sapiente minus blanditiis eaque voluptatem. Aliquid distinctio illum molestiae cumque. Nisi laboriosam enim perferendis placeat laborum.
-                  Illum reiciendis nisi quaerat accusamus repellendus dolor deleniti. Aspernatur corrupti officia inventore sed sit. Corporis dolore nemo odit soluta officiis expedita nulla eum. Ducimus omnis vitae mollitia veniam aperiam esse officia labore.
+                  Ab vero perspiciatis repellat rem aspernatur minus. Recusandae suscipit facilis culpa sunt inventore. Nemo soluta at qui eligendi eveniet cumque consectetur.
+                  Omnis iure labore asperiores illo optio consequatur. Sint fugit nulla atque inventore illo exercitationem. Rem magnam iure porro quisquam. Laboriosam magnam vero possimus incidunt harum. Aut harum doloribus alias nam eligendi numquam ducimus.
+                  Ad sapiente magnam id illo consequuntur quod consectetur. Nesciunt nemo commodi laborum corrupti architecto voluptatum eveniet. Libero possimus optio totam cumque quasi iusto inventore.
+                  Ea amet quos explicabo corporis. Unde deserunt rerum minima blanditiis repudiandae tenetur amet. Atque reprehenderit recusandae cupiditate quis modi error laboriosam repudiandae. Recusandae modi ipsam suscipit autem perferendis eum error illum.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11229,16 +11225,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:37:11.576Z'
-                  updated_at: '2026-05-26T15:37:11.576Z'
+                  created_at: '2026-05-26T16:13:11.709Z'
+                  updated_at: '2026-05-26T16:13:11.709Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-26T15:37:11.550Z'
+                make_active_at: '2025-05-26T16:13:11.678Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T15:37:11.563Z'
-                updated_at: '2026-05-26T15:37:11.578Z'
+                created_at: '2026-05-26T16:13:11.693Z'
+                updated_at: '2026-05-26T16:13:11.710Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11305,29 +11301,22 @@ paths:
               example:
                 id: prod_UkLWZg9DAJ
                 name: Updated Name
-                slug: product-618063
+                slug: product-619152
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-26T15:37:12.200Z'
+                available_on: '2025-05-26T16:13:12.328Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Totam odio vero pariatur fugiat officia. Animi itaque
-                  tempora voluptate culpa magni mollitia. Minus odio dolore facilis
-                  assumenda veritatis. Recusandae eos expedita reprehenderit quidem
-                  rerum. Accusantium eaque enim sint illo necessitatibus adipisci.
-                  Repellat ullam corporis placeat rerum laboriosam quis alias ad.
-                  Omnis rerum nihil alias similique assumenda. Eveniet provident deleniti
-                  aut rem animi maxime distinctio dolores. Iure quas molestias eum
-                  ea eaque magnam dolor alias. Adipisci in reprehenderit eius alias
-                  a placeat quos animi. Fuga saepe labore illum aliquid veniam.
-                description_html: |-
-                  Totam odio vero pariatur fugiat officia. Animi itaque tempora voluptate culpa magni mollitia. Minus odio dolore facilis assumenda veritatis. Recusandae eos expedita reprehenderit quidem rerum. Accusantium eaque enim sint illo necessitatibus adipisci.
-                  Repellat ullam corporis placeat rerum laboriosam quis alias ad. Omnis rerum nihil alias similique assumenda. Eveniet provident deleniti aut rem animi maxime distinctio dolores.
-                  Iure quas molestias eum ea eaque magnam dolor alias. Adipisci in reprehenderit eius alias a placeat quos animi. Fuga saepe labore illum aliquid veniam.
+                description: Veritatis quibusdam quisquam nisi doloremque asperiores.
+                  Corrupti dolorem sequi odit cumque vero totam. Architecto exercitationem
+                  minus nemo blanditiis iure numquam eaque.
+                description_html: Veritatis quibusdam quisquam nisi doloremque asperiores.
+                  Corrupti dolorem sequi odit cumque vero totam. Architecto exercitationem
+                  minus nemo blanditiis iure numquam eaque.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11342,16 +11331,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:37:12.227Z'
-                  updated_at: '2026-05-26T15:37:12.227Z'
+                  created_at: '2026-05-26T16:13:12.353Z'
+                  updated_at: '2026-05-26T16:13:12.353Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-26T15:37:12.200Z'
+                make_active_at: '2025-05-26T16:13:12.328Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T15:37:12.213Z'
-                updated_at: '2026-05-26T15:37:12.519Z'
+                created_at: '2026-05-26T16:13:12.341Z'
+                updated_at: '2026-05-26T16:13:12.644Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11884,8 +11873,8 @@ paths:
               example:
                 data:
                 - id: pact_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:37:16.028Z'
-                  updated_at: '2026-05-26T15:37:16.028Z'
+                  created_at: '2026-05-26T16:13:16.258Z'
+                  updated_at: '2026-05-26T16:13:16.258Z'
                   type: free_shipping
                   promotion_id: promo_UkLWZg9DAJ
                   preferences: {}
@@ -11946,8 +11935,8 @@ paths:
             application/json:
               example:
                 id: pact_UkLWZg9DAJ
-                created_at: '2026-05-26T15:37:16.618Z'
-                updated_at: '2026-05-26T15:37:16.618Z'
+                created_at: '2026-05-26T16:13:16.825Z'
+                updated_at: '2026-05-26T16:13:16.825Z'
                 type: free_shipping
                 promotion_id: promo_UkLWZg9DAJ
                 preferences: {}
@@ -12057,8 +12046,8 @@ paths:
               example:
                 data:
                 - id: prorule_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:37:17.213Z'
-                  updated_at: '2026-05-26T15:37:17.213Z'
+                  created_at: '2026-05-26T16:13:17.409Z'
+                  updated_at: '2026-05-26T16:13:17.409Z'
                   type: currency
                   promotion_id: promo_UkLWZg9DAJ
                   preferences:
@@ -12125,8 +12114,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-26T15:37:17.789Z'
-                updated_at: '2026-05-26T15:37:17.789Z'
+                created_at: '2026-05-26T16:13:17.988Z'
+                updated_at: '2026-05-26T16:13:17.988Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -12199,8 +12188,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-26T15:37:18.084Z'
-                updated_at: '2026-05-26T15:37:18.366Z'
+                created_at: '2026-05-26T16:13:18.276Z'
+                updated_at: '2026-05-26T16:13:18.552Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -12290,7 +12279,7 @@ paths:
                   name: Summer Sale
                   description:
                   code: summer
-                  starts_at: '2026-05-26T15:37:18.659Z'
+                  starts_at: '2026-05-26T16:13:18.839Z'
                   expires_at:
                   usage_limit:
                   match_policy: all
@@ -12301,8 +12290,8 @@ paths:
                   code_prefix:
                   promotion_category_id:
                   metadata: {}
-                  created_at: '2026-05-26T15:37:18.660Z'
-                  updated_at: '2026-05-26T15:37:18.661Z'
+                  created_at: '2026-05-26T16:13:18.840Z'
+                  updated_at: '2026-05-26T16:13:18.841Z'
                   store_ids:
                   - store_UkLWZg9DAJ
                   action_ids: []
@@ -12408,7 +12397,7 @@ paths:
                 name: Black Friday
                 description:
                 code: blackfriday-os
-                starts_at: '2026-05-26T15:37:19.603Z'
+                starts_at: '2026-05-26T16:13:19.743Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12419,8 +12408,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T15:37:19.605Z'
-                updated_at: '2026-05-26T15:37:19.628Z'
+                created_at: '2026-05-26T16:13:19.744Z'
+                updated_at: '2026-05-26T16:13:19.763Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids:
@@ -12573,7 +12562,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-26T15:37:19.922Z'
+                starts_at: '2026-05-26T16:13:20.066Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12584,8 +12573,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T15:37:19.923Z'
-                updated_at: '2026-05-26T15:37:19.924Z'
+                created_at: '2026-05-26T16:13:20.066Z'
+                updated_at: '2026-05-26T16:13:20.067Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -12681,7 +12670,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-26T15:37:20.811Z'
+                starts_at: '2026-05-26T16:13:20.943Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12692,8 +12681,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T15:37:20.811Z'
-                updated_at: '2026-05-26T15:37:21.096Z'
+                created_at: '2026-05-26T16:13:20.944Z'
+                updated_at: '2026-05-26T16:13:21.228Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -13045,8 +13034,8 @@ paths:
                 data:
                 - id: role_UkLWZg9DAJ
                   name: admin
-                  created_at: '2026-05-26T15:37:21.998Z'
-                  updated_at: '2026-05-26T15:37:21.998Z'
+                  created_at: '2026-05-26T16:13:22.193Z'
+                  updated_at: '2026-05-26T16:13:22.193Z'
                 meta:
                   page: 1
                   limit: 25
@@ -13181,8 +13170,8 @@ paths:
                   pickup_stock_policy: local
                   pickup_ready_in_minutes:
                   pickup_instructions:
-                  created_at: '2026-05-26T15:37:22.287Z'
-                  updated_at: '2026-05-26T15:37:22.287Z'
+                  created_at: '2026-05-26T16:13:22.481Z'
+                  updated_at: '2026-05-26T16:13:22.481Z'
                 meta:
                   page: 1
                   limit: 25
@@ -13293,8 +13282,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 30
                 pickup_instructions:
-                created_at: '2026-05-26T15:37:22.874Z'
-                updated_at: '2026-05-26T15:37:22.874Z'
+                created_at: '2026-05-26T16:13:23.062Z'
+                updated_at: '2026-05-26T16:13:23.062Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -13468,8 +13457,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes:
                 pickup_instructions:
-                created_at: '2026-05-26T15:37:23.235Z'
-                updated_at: '2026-05-26T15:37:23.235Z'
+                created_at: '2026-05-26T16:13:23.350Z'
+                updated_at: '2026-05-26T16:13:23.350Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '404':
@@ -13554,8 +13543,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 45
                 pickup_instructions:
-                created_at: '2026-05-26T15:37:23.838Z'
-                updated_at: '2026-05-26T15:37:24.123Z'
+                created_at: '2026-05-26T16:13:23.913Z'
+                updated_at: '2026-05-26T16:13:24.193Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -13758,8 +13747,8 @@ paths:
                 data:
                 - id: sccat_UkLWZg9DAJ
                   name: Goodwill
-                  created_at: '2026-05-26T15:37:24.715Z'
-                  updated_at: '2026-05-26T15:37:24.715Z'
+                  created_at: '2026-05-26T16:13:24.773Z'
+                  updated_at: '2026-05-26T16:13:24.773Z'
                   non_expiring: false
                 meta:
                   page: 1
@@ -13850,8 +13839,8 @@ paths:
               example:
                 id: sccat_UkLWZg9DAJ
                 name: Goodwill
-                created_at: '2026-05-26T15:37:25.013Z'
-                updated_at: '2026-05-26T15:37:25.013Z'
+                created_at: '2026-05-26T16:13:25.067Z'
+                updated_at: '2026-05-26T16:13:25.067Z'
                 non_expiring: false
               schema:
                 "$ref": "#/components/schemas/StoreCreditCategory"
@@ -13916,8 +13905,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-26T15:35:57.400Z'
-                updated_at: '2026-05-26T15:37:25.596Z'
+                created_at: '2026-05-26T16:11:54.992Z'
+                updated_at: '2026-05-26T16:13:25.774Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -13988,8 +13977,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-26T15:35:57.400Z'
-                updated_at: '2026-05-26T15:37:26.209Z'
+                created_at: '2026-05-26T16:11:54.992Z'
+                updated_at: '2026-05-26T16:13:26.386Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -14209,13 +14198,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-26T15:37:27.638Z'
-                  updated_at: '2026-05-26T15:37:27.651Z'
+                  created_at: '2026-05-26T16:13:27.811Z'
+                  updated_at: '2026-05-26T16:13:27.825Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 753738
+                  product_name: Product 753715
                 - id: variant_gbHJdmfrXB
                   product_id: prod_UkLWZg9DAJ
                   sku: SKU-94
@@ -14226,10 +14215,10 @@ paths:
                   purchasable: true
                   in_stock: false
                   backorderable: true
-                  weight: 170.62
-                  height: 69.67
-                  width: 199.89
-                  depth: 87.8
+                  weight: 130.85
+                  height: 166.65
+                  width: 108.23
+                  depth: 119.88
                   price:
                     id: price_gbHJdmfrXB
                     amount: '19.99'
@@ -14252,8 +14241,8 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-26T15:37:27.662Z'
-                    updated_at: '2026-05-26T15:37:27.662Z'
+                    created_at: '2026-05-26T16:13:27.836Z'
+                    updated_at: '2026-05-26T16:13:27.836Z'
                   metadata: {}
                   position: 2
                   cost_price: '17.0'
@@ -14262,13 +14251,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-26T15:37:27.660Z'
-                  updated_at: '2026-05-26T15:37:27.674Z'
+                  created_at: '2026-05-26T16:13:27.833Z'
+                  updated_at: '2026-05-26T16:13:27.847Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 753738
+                  product_name: Product 753715
                 meta:
                   page: 1
                   limit: 25
@@ -14379,8 +14368,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:37:28.347Z'
-                  updated_at: '2026-05-26T15:37:28.347Z'
+                  created_at: '2026-05-26T16:13:28.503Z'
+                  updated_at: '2026-05-26T16:13:28.503Z'
                 metadata: {}
                 position: 3
                 cost_price:
@@ -14389,13 +14378,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T15:37:28.353Z'
-                updated_at: '2026-05-26T15:37:28.355Z'
+                created_at: '2026-05-26T16:13:28.507Z'
+                updated_at: '2026-05-26T16:13:28.508Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 761921
+                product_name: Product 766019
         '422':
           description: validation error
           content:
@@ -14582,10 +14571,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 41.76
-                height: 27.88
-                width: 87.9
-                depth: 55.0
+                weight: 18.3
+                height: 189.2
+                width: 53.43
+                depth: 41.8
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -14608,8 +14597,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:37:28.771Z'
-                  updated_at: '2026-05-26T15:37:28.771Z'
+                  created_at: '2026-05-26T16:13:28.899Z'
+                  updated_at: '2026-05-26T16:13:28.899Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -14618,13 +14607,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T15:37:28.768Z'
-                updated_at: '2026-05-26T15:37:28.784Z'
+                created_at: '2026-05-26T16:13:28.897Z'
+                updated_at: '2026-05-26T16:13:28.912Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 789310
+                product_name: Product 784102
         '404':
           description: variant not found
           content:
@@ -14703,10 +14692,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 82.38
-                height: 119.79
-                width: 29.26
-                depth: 28.7
+                weight: 189.23
+                height: 159.19
+                width: 67.14
+                depth: 185.25
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -14729,8 +14718,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:37:29.472Z'
-                  updated_at: '2026-05-26T15:37:29.472Z'
+                  created_at: '2026-05-26T16:13:29.599Z'
+                  updated_at: '2026-05-26T16:13:29.599Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -14739,13 +14728,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T15:37:29.470Z'
-                updated_at: '2026-05-26T15:37:29.772Z'
+                created_at: '2026-05-26T16:13:29.597Z'
+                updated_at: '2026-05-26T16:13:29.890Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 8053
+                product_name: Product 801029
       requestBody:
         content:
           application/json:

--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -82,12 +82,12 @@ paths:
               example:
                 data:
                 - id: admin_UkLWZg9DAJ
-                  email: tomeka.moore@strosin.com
-                  first_name: Loria
-                  last_name: Boyer
-                  full_name: Loria Boyer
-                  created_at: '2026-05-26T15:16:41.133Z'
-                  updated_at: '2026-05-26T15:16:41.133Z'
+                  email: man@mcclureauer.biz
+                  first_name: Marquetta
+                  last_name: Cormier
+                  full_name: Marquetta Cormier
+                  created_at: '2026-05-26T15:35:57.769Z'
+                  updated_at: '2026-05-26T15:35:57.769Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -145,12 +145,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: michiko@corkerynitzsche.name
-                first_name: Herschel
-                last_name: Jacobson
-                full_name: Herschel Jacobson
-                created_at: '2026-05-26T15:16:41.482Z'
-                updated_at: '2026-05-26T15:16:41.482Z'
+                email: barry@torp.name
+                first_name: Carlee
+                last_name: Jaskolski
+                full_name: Carlee Jaskolski
+                created_at: '2026-05-26T15:35:58.127Z'
+                updated_at: '2026-05-26T15:35:58.127Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -203,12 +203,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: treva.welch@cartwright.info
+                email: estrella@howe.name
                 first_name: Renamed
-                last_name: Corkery
-                full_name: Renamed Corkery
-                created_at: '2026-05-26T15:16:41.761Z'
-                updated_at: '2026-05-26T15:16:41.777Z'
+                last_name: Sanford
+                full_name: Renamed Sanford
+                created_at: '2026-05-26T15:35:58.421Z'
+                updated_at: '2026-05-26T15:35:58.457Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -317,32 +317,32 @@ paths:
                   key_type: publishable
                   token_prefix:
                   scopes: []
-                  created_at: '2026-05-26T15:16:42.211Z'
-                  updated_at: '2026-05-26T15:16:42.211Z'
+                  created_at: '2026-05-26T15:35:58.784Z'
+                  updated_at: '2026-05-26T15:35:58.784Z'
                   revoked_at:
                   last_used_at:
-                  plaintext_token: pk_TAXzVgPEbRY5rWt79znVk5Gm
+                  plaintext_token: pk_VVx6ipjSCRCPopLW3XJ5eYBN
                   created_by_email:
                 - id: key_gbHJdmfrXB
                   name: Backend integration
                   key_type: secret
-                  token_prefix: sk_LumTbZiVT
+                  token_prefix: sk_1rUUtKkCq
                   scopes:
                   - write_all
-                  created_at: '2026-05-26T15:16:42.212Z'
-                  updated_at: '2026-05-26T15:16:42.212Z'
+                  created_at: '2026-05-26T15:35:58.786Z'
+                  updated_at: '2026-05-26T15:35:58.786Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
                   created_by_email:
                 - id: key_EfhxLZ9ck8
-                  name: autem
+                  name: ullam
                   key_type: secret
-                  token_prefix: sk_kepWFCbSR
+                  token_prefix: sk_48T8Djhom
                   scopes:
                   - write_all
-                  created_at: '2026-05-26T15:16:42.212Z'
-                  updated_at: '2026-05-26T15:16:42.212Z'
+                  created_at: '2026-05-26T15:35:58.788Z'
+                  updated_at: '2026-05-26T15:35:58.788Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
@@ -405,15 +405,15 @@ paths:
                 id: key_VqXmZF31wY
                 name: CI key
                 key_type: secret
-                token_prefix: sk_AmM3N529B
+                token_prefix: sk_SaeebacDd
                 scopes:
                 - read_orders
-                created_at: '2026-05-26T15:16:42.924Z'
-                updated_at: '2026-05-26T15:16:42.924Z'
+                created_at: '2026-05-26T15:35:59.373Z'
+                updated_at: '2026-05-26T15:35:59.373Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: sk_AmM3N529BA7uqSw7k2aCzLVM
-                created_by_email: lilliana_oreilly@ledner.us
+                plaintext_token: sk_SaeebacDdaFX4tCiwwSxHCpM
+                created_by_email: kara@mills.com
         '422':
           description: validation error
           content:
@@ -499,11 +499,11 @@ paths:
                 key_type: publishable
                 token_prefix:
                 scopes: []
-                created_at: '2026-05-26T15:16:43.257Z'
-                updated_at: '2026-05-26T15:16:43.257Z'
+                created_at: '2026-05-26T15:35:59.662Z'
+                updated_at: '2026-05-26T15:35:59.662Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: pk_agbcCXvwGQTP2o8s6NUEjgrE
+                plaintext_token: pk_RW1nWfzT6hBcGL9p9HYeWiNu
                 created_by_email:
     delete:
       summary: Delete an API key
@@ -593,12 +593,12 @@ paths:
                 id: key_gbHJdmfrXB
                 name: Backend integration
                 key_type: secret
-                token_prefix: sk_YWJDVhxQj
+                token_prefix: sk_7Tm2n4xHa
                 scopes:
                 - write_all
-                created_at: '2026-05-26T15:16:43.958Z'
-                updated_at: '2026-05-26T15:16:44.374Z'
-                revoked_at: '2026-05-26T15:16:44.373Z'
+                created_at: '2026-05-26T15:36:00.246Z'
+                updated_at: '2026-05-26T15:36:00.527Z'
+                revoked_at: '2026-05-26T15:36:00.526Z'
                 last_used_at:
                 plaintext_token:
                 created_by_email:
@@ -652,15 +652,15 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjQ3M2RmNzE0LTkwYmItNGI1NS05Njk0LWQyMDE0MjJlNjAyOCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODA4OTA0fQ.5ZZ4Yj1v80rlf9a6n5Z0f7_lCw12dx-Fi_zmuYzHfi8
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImVhMjVmNDcyLWVlOTEtNGY2My04M2M0LWZhZGIxYjA5OGI3NSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODEwMDYxfQ.hW0FAtB-jX0RA22qm3hzKhz5P8XdJAISbLCbD7uVkyM
                 user:
                   id: admin_UkLWZg9DAJ
                   email: admin@example.com
-                  first_name: Mira
-                  last_name: Reichel
-                  full_name: Mira Reichel
-                  created_at: '2026-05-26T15:16:44.647Z'
-                  updated_at: '2026-05-26T15:16:44.647Z'
+                  first_name: Wenona
+                  last_name: Murphy
+                  full_name: Wenona Murphy
+                  created_at: '2026-05-26T15:36:00.794Z'
+                  updated_at: '2026-05-26T15:36:00.794Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -713,6 +713,8 @@ paths:
                     type: string
                     example: okta
                     description: Registered provider key (anything other than `email`).
+                    not:
+                      const: email
                 required:
                 - provider
                 additionalProperties: true
@@ -747,6 +749,25 @@ paths:
         schema:
           type: string
       responses:
+        '200':
+          description: refresh successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImZlOGVmNzY0LTBhY2UtNGI5YS04NTliLWIwYzg3ODgyZmEwOSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzc5ODEwMDYxfQ.6h9b0XTFy9snf7q4XTwOnDLv3ISdVdMt2z0D4zbyZZg
+                user:
+                  id: admin_UkLWZg9DAJ
+                  email: admin@example.com
+                  first_name: Refugia
+                  last_name: Jacobi
+                  full_name: Refugia Jacobi
+                  created_at: '2026-05-26T15:36:01.912Z'
+                  updated_at: '2026-05-26T15:36:01.912Z'
+                  roles:
+                  - id: role_UkLWZg9DAJ
+                    name: admin
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
         '401':
           description: missing or invalid refresh-token cookie
           content:
@@ -838,15 +859,15 @@ paths:
                 - id: coupon_UkLWZg9DAJ
                   code: AAA111
                   state: unused
-                  created_at: '2026-05-26T15:16:46.080Z'
-                  updated_at: '2026-05-26T15:16:46.080Z'
+                  created_at: '2026-05-26T15:36:02.512Z'
+                  updated_at: '2026-05-26T15:36:02.512Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 - id: coupon_gbHJdmfrXB
                   code: BBB222
                   state: unused
-                  created_at: '2026-05-26T15:16:46.081Z'
-                  updated_at: '2026-05-26T15:16:46.081Z'
+                  created_at: '2026-05-26T15:36:02.514Z'
+                  updated_at: '2026-05-26T15:36:02.514Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 meta:
@@ -924,8 +945,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Product
                   storefront_visible: true
-                  created_at: '2026-05-26T15:16:46.373Z'
-                  updated_at: '2026-05-26T15:16:46.373Z'
+                  created_at: '2026-05-26T15:36:02.810Z'
+                  updated_at: '2026-05-26T15:36:02.810Z'
                 - id: cfdef_gbHJdmfrXB
                   namespace: custom
                   key: order_notes
@@ -933,8 +954,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Order
                   storefront_visible: true
-                  created_at: '2026-05-26T15:16:46.373Z'
-                  updated_at: '2026-05-26T15:16:46.373Z'
+                  created_at: '2026-05-26T15:36:02.811Z'
+                  updated_at: '2026-05-26T15:36:02.811Z'
                 meta:
                   page: 1
                   limit: 25
@@ -997,8 +1018,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-26T15:16:46.928Z'
-                updated_at: '2026-05-26T15:16:46.928Z'
+                created_at: '2026-05-26T15:36:03.382Z'
+                updated_at: '2026-05-26T15:36:03.382Z'
       requestBody:
         content:
           application/json:
@@ -1081,8 +1102,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-05-26T15:16:46.931Z'
-                updated_at: '2026-05-26T15:16:46.931Z'
+                created_at: '2026-05-26T15:36:03.385Z'
+                updated_at: '2026-05-26T15:36:03.385Z'
     patch:
       summary: Update a custom field definition
       tags:
@@ -1121,8 +1142,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: false
-                created_at: '2026-05-26T15:16:47.207Z'
-                updated_at: '2026-05-26T15:16:47.481Z'
+                created_at: '2026-05-26T15:36:03.667Z'
+                updated_at: '2026-05-26T15:36:03.951Z'
       requestBody:
         content:
           application/json:
@@ -1246,14 +1267,14 @@ paths:
                   name: VIPs
                   description: Top spenders
                   customers_count: 0
-                  created_at: '2026-05-26T15:16:47.787Z'
-                  updated_at: '2026-05-26T15:16:47.787Z'
+                  created_at: '2026-05-26T15:36:04.246Z'
+                  updated_at: '2026-05-26T15:36:04.246Z'
                 - id: cg_gbHJdmfrXB
                   name: Wholesale
                   description:
                   customers_count: 0
-                  created_at: '2026-05-26T15:16:47.788Z'
-                  updated_at: '2026-05-26T15:16:47.788Z'
+                  created_at: '2026-05-26T15:36:04.247Z'
+                  updated_at: '2026-05-26T15:36:04.247Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1338,8 +1359,8 @@ paths:
                 name: Wholesale 2
                 description: B2B accounts
                 customers_count: 1
-                created_at: '2026-05-26T15:16:48.643Z'
-                updated_at: '2026-05-26T15:16:48.643Z'
+                created_at: '2026-05-26T15:36:05.145Z'
+                updated_at: '2026-05-26T15:36:05.145Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1445,24 +1466,24 @@ paths:
                 name: VIPs
                 description: Top spenders
                 customers_count: 1
-                created_at: '2026-05-26T15:16:49.207Z'
-                updated_at: '2026-05-26T15:16:49.207Z'
+                created_at: '2026-05-26T15:36:05.735Z'
+                updated_at: '2026-05-26T15:36:05.735Z'
                 customers:
                 - id: cus_UkLWZg9DAJ
-                  email: adrienne@effertz.name
-                  first_name: Agustin
-                  last_name: Grant
+                  email: vasiliki.okon@prohaska.info
+                  first_name: Lillia
+                  last_name: Windler
                   phone:
                   accepts_email_marketing: false
-                  full_name: Agustin Grant
+                  full_name: Lillia Windler
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
-                  login: adrienne@effertz.name
+                  login: vasiliki.okon@prohaska.info
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-26T15:16:49.466Z'
-                  updated_at: '2026-05-26T15:16:49.466Z'
+                  created_at: '2026-05-26T15:36:05.999Z'
+                  updated_at: '2026-05-26T15:36:05.999Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -1540,8 +1561,8 @@ paths:
                 name: VIP customers (Q1)
                 description: Top spenders
                 customers_count: 0
-                created_at: '2026-05-26T15:16:50.034Z'
-                updated_at: '2026-05-26T15:16:50.310Z'
+                created_at: '2026-05-26T15:36:06.588Z'
+                updated_at: '2026-05-26T15:36:06.870Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -1694,8 +1715,8 @@ paths:
                   state_name: New York
                   label:
                   metadata: {}
-                  created_at: '2026-05-26T15:16:51.172Z'
-                  updated_at: '2026-05-26T15:16:51.172Z'
+                  created_at: '2026-05-26T15:36:07.730Z'
+                  updated_at: '2026-05-26T15:36:07.730Z'
                   customer_id: cus_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -1783,8 +1804,8 @@ paths:
                 state_name: New York
                 label: Office
                 metadata: {}
-                created_at: '2026-05-26T15:16:52.521Z'
-                updated_at: '2026-05-26T15:16:52.521Z'
+                created_at: '2026-05-26T15:36:09.105Z'
+                updated_at: '2026-05-26T15:36:09.105Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -1895,8 +1916,8 @@ paths:
                 state_name: New York
                 label:
                 metadata: {}
-                created_at: '2026-05-26T15:16:52.787Z'
-                updated_at: '2026-05-26T15:16:53.325Z'
+                created_at: '2026-05-26T15:36:09.391Z'
+                updated_at: '2026-05-26T15:36:09.945Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -2029,8 +2050,8 @@ paths:
                   customer_id: cus_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   metadata: {}
-                  created_at: '2026-05-26T15:16:54.419Z'
-                  updated_at: '2026-05-26T15:16:54.419Z'
+                  created_at: '2026-05-26T15:36:11.059Z'
+                  updated_at: '2026-05-26T15:36:11.059Z'
                 meta:
                   page: 1
                   limit: 25
@@ -2117,8 +2138,8 @@ paths:
                 customer_id: cus_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 metadata: {}
-                created_at: '2026-05-26T15:16:55.044Z'
-                updated_at: '2026-05-26T15:16:55.044Z'
+                created_at: '2026-05-26T15:36:11.642Z'
+                updated_at: '2026-05-26T15:36:11.642Z'
     delete:
       summary: Delete a customer credit card
       tags:
@@ -2237,8 +2258,8 @@ paths:
                   currency: USD
                   memo:
                   metadata: {}
-                  created_at: '2026-05-26T15:16:56.558Z'
-                  updated_at: '2026-05-26T15:16:56.558Z'
+                  created_at: '2026-05-26T15:36:13.034Z'
+                  updated_at: '2026-05-26T15:36:13.034Z'
                   customer_id: cus_UkLWZg9DAJ
                   created_by_id: admin_UkLWZg9DAJ
                   category_id: sccat_UkLWZg9DAJ
@@ -2313,8 +2334,8 @@ paths:
                 currency: USD
                 memo: Goodwill
                 metadata: {}
-                created_at: '2026-05-26T15:16:57.774Z'
-                updated_at: '2026-05-26T15:16:57.774Z'
+                created_at: '2026-05-26T15:36:14.147Z'
+                updated_at: '2026-05-26T15:36:14.147Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_gbHJdmfrXB
                 category_id: sccat_UkLWZg9DAJ
@@ -2405,8 +2426,8 @@ paths:
                 currency: USD
                 memo: Updated
                 metadata: {}
-                created_at: '2026-05-26T15:16:58.338Z'
-                updated_at: '2026-05-26T15:16:58.622Z'
+                created_at: '2026-05-26T15:36:14.690Z'
+                updated_at: '2026-05-26T15:36:14.974Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_UkLWZg9DAJ
                 category_id: sccat_UkLWZg9DAJ
@@ -2560,8 +2581,8 @@ paths:
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-05-26T15:16:59.749Z'
-                  updated_at: '2026-05-26T15:16:59.749Z'
+                  created_at: '2026-05-26T15:36:16.065Z'
+                  updated_at: '2026-05-26T15:36:16.065Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -2644,8 +2665,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T15:17:00.577Z'
-                updated_at: '2026-05-26T15:17:00.577Z'
+                created_at: '2026-05-26T15:36:16.907Z'
+                updated_at: '2026-05-26T15:36:16.907Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2761,8 +2782,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T15:17:00.845Z'
-                updated_at: '2026-05-26T15:17:00.845Z'
+                created_at: '2026-05-26T15:36:17.180Z'
+                updated_at: '2026-05-26T15:36:17.180Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -2836,8 +2857,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-05-26T15:17:01.383Z'
-                updated_at: '2026-05-26T15:17:01.662Z'
+                created_at: '2026-05-26T15:36:17.731Z'
+                updated_at: '2026-05-26T15:36:18.013Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -3267,11 +3288,11 @@ paths:
               example:
                 data:
                 - id: exp_UkLWZg9DAJ
-                  number: EF713687169
+                  number: EF257712950
                   type: Spree::Exports::Products
                   format: csv
-                  created_at: '2026-05-26T15:17:05.745Z'
-                  updated_at: '2026-05-26T15:17:05.745Z'
+                  created_at: '2026-05-26T15:36:22.196Z'
+                  updated_at: '2026-05-26T15:36:22.196Z'
                   user_id: admin_UkLWZg9DAJ
                   done: false
                   filename:
@@ -3338,11 +3359,11 @@ paths:
             application/json:
               example:
                 id: exp_gbHJdmfrXB
-                number: EF835182032
+                number: EF461421877
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-26T15:17:06.040Z'
-                updated_at: '2026-05-26T15:17:06.040Z'
+                created_at: '2026-05-26T15:36:22.499Z'
+                updated_at: '2026-05-26T15:36:22.499Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3429,11 +3450,11 @@ paths:
             application/json:
               example:
                 id: exp_UkLWZg9DAJ
-                number: EF096265475
+                number: EF186425869
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-05-26T15:17:06.313Z'
-                updated_at: '2026-05-26T15:17:06.313Z'
+                created_at: '2026-05-26T15:36:22.771Z'
+                updated_at: '2026-05-26T15:36:22.771Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -3616,8 +3637,8 @@ paths:
                   codes_count: 2
                   currency: USD
                   prefix: WELCOME
-                  created_at: '2026-05-26T15:17:06.915Z'
-                  updated_at: '2026-05-26T15:17:06.915Z'
+                  created_at: '2026-05-26T15:36:23.373Z'
+                  updated_at: '2026-05-26T15:36:23.373Z'
                   amount: '50.0'
                   expires_at:
                   created_by_id:
@@ -3698,8 +3719,8 @@ paths:
                 codes_count: 5
                 currency: USD
                 prefix: NEWCAMP
-                created_at: '2026-05-26T15:17:07.486Z'
-                updated_at: '2026-05-26T15:17:07.486Z'
+                created_at: '2026-05-26T15:36:23.942Z'
+                updated_at: '2026-05-26T15:36:23.942Z'
                 amount: '25.0'
                 expires_at: '2030-12-31'
                 created_by_id: admin_UkLWZg9DAJ
@@ -3800,8 +3821,8 @@ paths:
                 codes_count: 2
                 currency: USD
                 prefix: WELCOME
-                created_at: '2026-05-26T15:17:07.792Z'
-                updated_at: '2026-05-26T15:17:07.792Z'
+                created_at: '2026-05-26T15:36:24.235Z'
+                updated_at: '2026-05-26T15:36:24.235Z'
                 amount: '50.0'
                 expires_at:
                 created_by_id:
@@ -3904,7 +3925,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: E2BF7D4745015B17
+                  code: '0080027813FFDA32'
                   status: active
                   currency: USD
                   amount: '50.0'
@@ -3918,12 +3939,12 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-05-26T15:17:08.365Z'
-                  updated_at: '2026-05-26T15:17:08.365Z'
+                  created_at: '2026-05-26T15:36:24.806Z'
+                  updated_at: '2026-05-26T15:36:24.806Z'
                   customer_id:
                   created_by_id:
                 - id: gc_gbHJdmfrXB
-                  code: E559172DA4C7878C
+                  code: FC42E063EF732A04
                   status: active
                   currency: USD
                   amount: '25.0'
@@ -3937,8 +3958,8 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-05-26T15:17:08.366Z'
-                  updated_at: '2026-05-26T15:17:08.366Z'
+                  created_at: '2026-05-26T15:36:24.807Z'
+                  updated_at: '2026-05-26T15:36:24.807Z'
                   customer_id:
                   created_by_id:
                 meta:
@@ -4023,7 +4044,7 @@ paths:
             application/json:
               example:
                 id: gc_EfhxLZ9ck8
-                code: 5694A6AEC885A87D
+                code: 8A19D86124B5CF08
                 status: active
                 currency: USD
                 amount: '25.0'
@@ -4037,8 +4058,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:17:08.962Z'
-                updated_at: '2026-05-26T15:17:08.962Z'
+                created_at: '2026-05-26T15:36:25.402Z'
+                updated_at: '2026-05-26T15:36:25.402Z'
                 customer_id:
                 created_by_id: admin_UkLWZg9DAJ
               schema:
@@ -4144,7 +4165,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 29D65A40D3A8F3C0
+                code: 99B349C6D4C6C4FD
                 status: active
                 currency: USD
                 amount: '50.0'
@@ -4158,8 +4179,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:17:09.255Z'
-                updated_at: '2026-05-26T15:17:09.255Z'
+                created_at: '2026-05-26T15:36:25.702Z'
+                updated_at: '2026-05-26T15:36:25.702Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4219,7 +4240,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 0D691EBD2377ECE4
+                code: EC57664CC61B9EB8
                 status: active
                 currency: USD
                 amount: '75.0'
@@ -4233,8 +4254,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:17:09.812Z'
-                updated_at: '2026-05-26T15:17:10.086Z'
+                created_at: '2026-05-26T15:36:26.279Z'
+                updated_at: '2026-05-26T15:36:26.562Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4346,15 +4367,15 @@ paths:
               example:
                 data:
                 - id: inv_UkLWZg9DAJ
-                  email: rachel.runolfsdottir@ernser.co.uk
+                  email: phyliss@cassin.us
                   status: pending
-                  created_at: '2026-05-26T15:17:10.932Z'
-                  updated_at: '2026-05-26T15:17:10.932Z'
-                  expires_at: '2026-06-09T15:17:10.929Z'
+                  created_at: '2026-05-26T15:36:27.411Z'
+                  updated_at: '2026-05-26T15:36:27.411Z'
+                  expires_at: '2026-06-09T15:36:27.408Z'
                   role_id: role_UkLWZg9DAJ
                   role_name: admin
-                  inviter_email: ulysses.hoppe@welch.info
-                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=jn7J2U9mPwRPKwU6TPtEfTRW"
+                  inviter_email: bari_christiansen@kulas.co.uk
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=Y32XibVjzoPAmDZYg8MvsAQi"
                   invitee_exists: false
                   store:
                     id: store_UkLWZg9DAJ
@@ -4415,13 +4436,13 @@ paths:
                 id: inv_gbHJdmfrXB
                 email: new-staff@example.com
                 status: pending
-                created_at: '2026-05-26T15:17:11.236Z'
-                updated_at: '2026-05-26T15:17:11.236Z'
-                expires_at: '2026-06-09T15:17:11.233Z'
+                created_at: '2026-05-26T15:36:27.718Z'
+                updated_at: '2026-05-26T15:36:27.718Z'
+                expires_at: '2026-06-09T15:36:27.715Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: roma_gulgowski@hackett.co.uk
-                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=j6Lbgsjm8bTrDo61cc3SRwVD"
+                inviter_email: audrea@bartolettiweimann.ca
+                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=t3Q2Z2gkSMayNbxtv46Q8gtA"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -4528,15 +4549,15 @@ paths:
             application/json:
               example:
                 id: inv_UkLWZg9DAJ
-                email: ivy.wiegand@jaskolski.biz
+                email: carolyne@conn.us
                 status: pending
-                created_at: '2026-05-26T15:17:11.791Z'
-                updated_at: '2026-05-26T15:17:11.791Z'
-                expires_at: '2026-06-09T15:17:11.788Z'
+                created_at: '2026-05-26T15:36:28.272Z'
+                updated_at: '2026-05-26T15:36:28.272Z'
+                expires_at: '2026-06-09T15:36:28.270Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: alane@koelpin.name
-                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=4QApEuM7S9unyb3tr4MzbtG8"
+                inviter_email: rocio@hudson.co.uk
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=ANT4cxRkXhJ8Qnw4yJTHPSmj"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -4622,8 +4643,8 @@ paths:
                   - DE
                   supported_locales:
                   - en
-                  created_at: '2026-05-26T15:17:11.849Z'
-                  updated_at: '2026-05-26T15:17:11.849Z'
+                  created_at: '2026-05-26T15:36:28.330Z'
+                  updated_at: '2026-05-26T15:36:28.330Z'
                 meta:
                   page: 1
                   limit: 25
@@ -4713,8 +4734,8 @@ paths:
                 supported_locales:
                 - en
                 - fr
-                created_at: '2026-05-26T15:17:12.476Z'
-                updated_at: '2026-05-26T15:17:12.476Z'
+                created_at: '2026-05-26T15:36:28.941Z'
+                updated_at: '2026-05-26T15:36:28.941Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -4847,8 +4868,8 @@ paths:
                 - DE
                 supported_locales:
                 - en
-                created_at: '2026-05-26T15:17:12.814Z'
-                updated_at: '2026-05-26T15:17:12.814Z'
+                created_at: '2026-05-26T15:36:29.267Z'
+                updated_at: '2026-05-26T15:36:29.267Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '404':
@@ -4924,8 +4945,8 @@ paths:
                 - DE
                 supported_locales:
                 - en
-                created_at: '2026-05-26T15:17:13.455Z'
-                updated_at: '2026-05-26T15:17:13.762Z'
+                created_at: '2026-05-26T15:36:29.866Z'
+                updated_at: '2026-05-26T15:36:30.152Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -5062,12 +5083,12 @@ paths:
               example:
                 user:
                   id: admin_UkLWZg9DAJ
-                  email: magaret.wiegand@west.co.uk
-                  first_name: Sherman
-                  last_name: Zemlak
-                  full_name: Sherman Zemlak
-                  created_at: '2026-05-26T15:17:14.969Z'
-                  updated_at: '2026-05-26T15:17:14.969Z'
+                  email: lavonia@terry.name
+                  first_name: Stephan
+                  last_name: Boyle
+                  full_name: Stephan Boyle
+                  created_at: '2026-05-26T15:36:31.351Z'
+                  updated_at: '2026-05-26T15:36:31.351Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -5217,8 +5238,8 @@ paths:
                   kind: dropdown
                   metadata: {}
                   filterable: true
-                  created_at: '2026-05-26T15:17:15.008Z'
-                  updated_at: '2026-05-26T15:17:15.008Z'
+                  created_at: '2026-05-26T15:36:31.413Z'
+                  updated_at: '2026-05-26T15:36:31.413Z'
                 meta:
                   page: 1
                   limit: 25
@@ -5309,8 +5330,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T15:17:15.571Z'
-                updated_at: '2026-05-26T15:17:15.571Z'
+                created_at: '2026-05-26T15:36:32.038Z'
+                updated_at: '2026-05-26T15:36:32.038Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -5431,8 +5452,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T15:17:15.853Z'
-                updated_at: '2026-05-26T15:17:15.853Z'
+                created_at: '2026-05-26T15:36:32.341Z'
+                updated_at: '2026-05-26T15:36:32.341Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '404':
@@ -5504,8 +5525,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-05-26T15:17:16.412Z'
-                updated_at: '2026-05-26T15:17:16.686Z'
+                created_at: '2026-05-26T15:36:32.969Z'
+                updated_at: '2026-05-26T15:36:33.368Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -5664,7 +5685,7 @@ paths:
               example:
                 data:
                 - id: ful_UkLWZg9DAJ
-                  number: H07377188157
+                  number: H96395040097
                   tracking: U10000
                   tracking_url:
                   cost: '10.0'
@@ -5689,8 +5710,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-26T15:17:17.624Z'
-                  updated_at: '2026-05-26T15:17:17.696Z'
+                  created_at: '2026-05-26T15:36:34.422Z'
+                  updated_at: '2026-05-26T15:36:34.505Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_UkLWZg9DAJ
                 meta:
@@ -5773,7 +5794,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H36392953413
+                number: H04009472925
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5798,8 +5819,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:17:18.295Z'
-                updated_at: '2026-05-26T15:17:18.349Z'
+                created_at: '2026-05-26T15:36:35.150Z'
+                updated_at: '2026-05-26T15:36:35.234Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
     patch:
@@ -5858,7 +5879,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H86091051668
+                number: H26889269295
                 tracking: 1Z999AA10123456784
                 tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
                 cost: '10.0'
@@ -5883,8 +5904,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:17:18.927Z'
-                updated_at: '2026-05-26T15:17:19.271Z'
+                created_at: '2026-05-26T15:36:35.852Z'
+                updated_at: '2026-05-26T15:36:36.213Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
       requestBody:
@@ -5953,7 +5974,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H47435003131
+                number: H96976373458
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -5970,7 +5991,7 @@ paths:
                 display_tax_total: "$0.00"
                 status: shipped
                 fulfillment_type: shipping
-                fulfilled_at: '2026-05-26T15:17:20Z'
+                fulfilled_at: '2026-05-26T15:36:36Z'
                 items:
                 - item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
@@ -5978,8 +5999,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:17:19.675Z'
-                updated_at: '2026-05-26T15:17:20.042Z'
+                created_at: '2026-05-26T15:36:36.570Z'
+                updated_at: '2026-05-26T15:36:36.957Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
@@ -6037,7 +6058,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H61583984317
+                number: H43549723427
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6062,8 +6083,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:17:20.465Z'
-                updated_at: '2026-05-26T15:17:20.835Z'
+                created_at: '2026-05-26T15:36:37.368Z'
+                updated_at: '2026-05-26T15:36:37.716Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
@@ -6121,7 +6142,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H01359414754
+                number: H85189054446
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6146,8 +6167,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-05-26T15:17:21.178Z'
-                updated_at: '2026-05-26T15:17:21.583Z'
+                created_at: '2026-05-26T15:36:38.073Z'
+                updated_at: '2026-05-26T15:36:38.474Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
@@ -6208,7 +6229,7 @@ paths:
               example:
                 data:
                 - id: ful_gbHJdmfrXB
-                  number: H12667263367
+                  number: H09797035655
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -6233,8 +6254,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-05-26T15:17:22.248Z'
-                  updated_at: '2026-05-26T15:17:22.327Z'
+                  created_at: '2026-05-26T15:36:39.184Z'
+                  updated_at: '2026-05-26T15:36:39.236Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_gbHJdmfrXB
       requestBody:
@@ -6306,7 +6327,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: B68F1701E3F59046
+                code: 7B9E2478235A09B0
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -6320,8 +6341,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-05-26T15:17:22.705Z'
-                updated_at: '2026-05-26T15:17:22.998Z'
+                created_at: '2026-05-26T15:36:39.582Z'
+                updated_at: '2026-05-26T15:36:39.883Z'
                 customer_id:
                 created_by_id:
       requestBody:
@@ -6454,8 +6475,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 2
                   currency: USD
-                  name: Product 107050
-                  slug: product-107050
+                  name: Product 102111
+                  slug: product-102111
                   options_text: 'Size: S'
                   price: '10.0'
                   display_price: "$10.00"
@@ -6487,12 +6508,12 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-26T15:17:23.725Z'
-                    updated_at: '2026-05-26T15:17:23.725Z'
+                    created_at: '2026-05-26T15:36:40.604Z'
+                    updated_at: '2026-05-26T15:36:40.604Z'
                   digital_links: []
                   metadata: {}
-                  created_at: '2026-05-26T15:17:24.012Z'
-                  updated_at: '2026-05-26T15:17:24.012Z'
+                  created_at: '2026-05-26T15:36:40.901Z'
+                  updated_at: '2026-05-26T15:36:40.901Z'
                   cost_price: '17.0'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
@@ -6559,8 +6580,8 @@ paths:
                 variant_id: variant_VqXmZF31wY
                 quantity: 3
                 currency: USD
-                name: Product 128656
-                slug: product-128656
+                name: Product 126801
+                slug: product-126801
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -6592,12 +6613,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:17:24.920Z'
-                  updated_at: '2026-05-26T15:17:24.920Z'
+                  created_at: '2026-05-26T15:36:41.848Z'
+                  updated_at: '2026-05-26T15:36:41.848Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T15:17:24.953Z'
-                updated_at: '2026-05-26T15:17:24.953Z'
+                created_at: '2026-05-26T15:36:41.881Z'
+                updated_at: '2026-05-26T15:36:41.881Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -6686,8 +6707,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 2
                 currency: USD
-                name: Product 135754
-                slug: product-135754
+                name: Product 13276
+                slug: product-13276
                 options_text: 'Size: S'
                 price: '10.0'
                 display_price: "$10.00"
@@ -6719,12 +6740,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:17:25.037Z'
-                  updated_at: '2026-05-26T15:17:25.037Z'
+                  created_at: '2026-05-26T15:36:41.976Z'
+                  updated_at: '2026-05-26T15:36:41.976Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T15:17:25.327Z'
-                updated_at: '2026-05-26T15:17:25.327Z'
+                created_at: '2026-05-26T15:36:42.275Z'
+                updated_at: '2026-05-26T15:36:42.275Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
     patch:
@@ -6786,8 +6807,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 5
                 currency: USD
-                name: Product 146203
-                slug: product-146203
+                name: Product 14831
+                slug: product-14831
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -6819,12 +6840,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:17:25.650Z'
-                  updated_at: '2026-05-26T15:17:25.650Z'
+                  created_at: '2026-05-26T15:36:42.609Z'
+                  updated_at: '2026-05-26T15:36:42.609Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-05-26T15:17:25.946Z'
-                updated_at: '2026-05-26T15:17:26.250Z'
+                created_at: '2026-05-26T15:36:42.900Z'
+                updated_at: '2026-05-26T15:36:43.213Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -6950,8 +6971,8 @@ paths:
                 data:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-701d22e84a8e
-                  number: PHH9S7QR
+                  response_code: BGS-3c01b8a4ac51
+                  number: P6SHB6QB
                   amount: '110.0'
                   display_amount: "$110.00"
                   status: completed
@@ -6969,14 +6990,14 @@ paths:
                     customer_id:
                     payment_method_id: pm_gbHJdmfrXB
                     metadata: {}
-                    created_at: '2026-05-26T15:17:27.258Z'
-                    updated_at: '2026-05-26T15:17:27.262Z'
+                    created_at: '2026-05-26T15:36:44.352Z'
+                    updated_at: '2026-05-26T15:36:44.354Z'
                   metadata: {}
                   avs_response:
                   cvv_response_code:
                   cvv_response_message:
-                  created_at: '2026-05-26T15:17:27.260Z'
-                  updated_at: '2026-05-26T15:17:27.260Z'
+                  created_at: '2026-05-26T15:36:44.353Z'
+                  updated_at: '2026-05-26T15:36:44.353Z'
                   captured_amount: '0.0'
                   order_id: or_UkLWZg9DAJ
                 meta:
@@ -7043,7 +7064,7 @@ paths:
                 id: py_gbHJdmfrXB
                 payment_method_id: pm_EfhxLZ9ck8
                 response_code:
-                number: PWTNWM8J
+                number: PPD94T81
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7054,8 +7075,8 @@ paths:
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:17:28.789Z'
-                updated_at: '2026-05-26T15:17:28.789Z'
+                created_at: '2026-05-26T15:36:45.696Z'
+                updated_at: '2026-05-26T15:36:45.696Z'
                 captured_amount: '0.0'
                 order_id: or_gbHJdmfrXB
       requestBody:
@@ -7145,8 +7166,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-352ec785c4a2
-                number: PXH3K71O
+                response_code: BGS-41700c3aded2
+                number: P1B0M48R
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -7164,14 +7185,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T15:17:29.170Z'
-                  updated_at: '2026-05-26T15:17:29.173Z'
+                  created_at: '2026-05-26T15:36:46.076Z'
+                  updated_at: '2026-05-26T15:36:46.079Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:17:29.172Z'
-                updated_at: '2026-05-26T15:17:29.172Z'
+                created_at: '2026-05-26T15:36:46.078Z'
+                updated_at: '2026-05-26T15:36:46.078Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
@@ -7230,8 +7251,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-519856d2f7a1
-                number: PPVZCDJ7
+                response_code: BGS-03e0f17be730
+                number: PO27G2VE
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -7249,14 +7270,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T15:17:29.840Z'
-                  updated_at: '2026-05-26T15:17:29.842Z'
+                  created_at: '2026-05-26T15:36:46.744Z'
+                  updated_at: '2026-05-26T15:36:46.747Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:17:29.841Z'
-                updated_at: '2026-05-26T15:17:30.182Z'
+                created_at: '2026-05-26T15:36:46.746Z'
+                updated_at: '2026-05-26T15:36:47.095Z'
                 captured_amount: '110.0'
                 order_id: or_UkLWZg9DAJ
         '422':
@@ -7325,8 +7346,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: void-BGS-f6d5642615af
-                number: PCIC0TAT
+                response_code: void-BGS-fdb719d7dc34
+                number: P2B1XUCU
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: void
@@ -7344,14 +7365,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-05-26T15:17:31.381Z'
-                  updated_at: '2026-05-26T15:17:31.384Z'
+                  created_at: '2026-05-26T15:36:48.217Z'
+                  updated_at: '2026-05-26T15:36:48.220Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-05-26T15:17:31.383Z'
-                updated_at: '2026-05-26T15:17:31.685Z'
+                created_at: '2026-05-26T15:36:48.219Z'
+                updated_at: '2026-05-26T15:36:48.532Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/refunds":
@@ -7479,14 +7500,14 @@ paths:
             application/json:
               example:
                 id: re_UkLWZg9DAJ
-                transaction_id: BGS-7e30d908a79f
+                transaction_id: BGS-ff2be9f2e002
                 amount: '5.0'
                 payment_id: py_UkLWZg9DAJ
                 refund_reason_id: rr_UkLWZg9DAJ
                 reimbursement_id:
                 metadata: {}
-                created_at: '2026-05-26T15:17:32.992Z'
-                updated_at: '2026-05-26T15:17:32.992Z'
+                created_at: '2026-05-26T15:36:49.925Z'
+                updated_at: '2026-05-26T15:36:49.925Z'
       requestBody:
         content:
           application/json:
@@ -7558,8 +7579,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R806432825
-                email: luci@dicki.name
+                number: R874324883
+                email: jannette@schaden.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -7602,8 +7623,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:17:33.290Z'
-                updated_at: '2026-05-26T15:17:33.336Z'
+                created_at: '2026-05-26T15:36:50.273Z'
+                updated_at: '2026-05-26T15:36:50.332Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -7774,8 +7795,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R908627775
-                  email: jackson@kuhlman.biz
+                  number: R568071828
+                  email: mason@stehr.name
                   customer_note:
                   currency: USD
                   locale: en
@@ -7818,8 +7839,8 @@ paths:
                   metadata: {}
                   canceled_at:
                   approved_at:
-                  created_at: '2026-05-26T15:17:35.052Z'
-                  updated_at: '2026-05-26T15:17:35.052Z'
+                  created_at: '2026-05-26T15:36:52.105Z'
+                  updated_at: '2026-05-26T15:36:52.105Z'
                   preferred_stock_location_id:
                   tags: []
                   internal_note:
@@ -7962,7 +7983,7 @@ paths:
                 id: or_gbHJdmfrXB
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R374953449
+                number: R170706649
                 email: pinned@example.com
                 customer_note:
                 currency: USD
@@ -8006,8 +8027,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:17:36.786Z'
-                updated_at: '2026-05-26T15:17:36.789Z'
+                created_at: '2026-05-26T15:36:53.862Z'
+                updated_at: '2026-05-26T15:36:53.865Z'
                 preferred_stock_location_id: sloc_UkLWZg9DAJ
                 tags: []
                 internal_note:
@@ -8191,8 +8212,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R846317291
-                email: tona_schinner@toyschaefer.ca
+                number: R607205941
+                email: sidney@cruickshank.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -8235,8 +8256,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:17:37.069Z'
-                updated_at: '2026-05-26T15:17:37.069Z'
+                created_at: '2026-05-26T15:36:54.149Z'
+                updated_at: '2026-05-26T15:36:54.149Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8307,7 +8328,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R111696884
+                number: R169903146
                 email: updated@example.com
                 customer_note:
                 currency: USD
@@ -8351,8 +8372,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:17:40.294Z'
-                updated_at: '2026-05-26T15:17:40.592Z'
+                created_at: '2026-05-26T15:36:55.285Z'
+                updated_at: '2026-05-26T15:36:55.577Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8533,8 +8554,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R728222526
-                email: bradley@medhurstprice.ca
+                number: R083827354
+                email: liza@paucek.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -8561,7 +8582,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status: ready
                 payment_status: paid
-                completed_at: '2026-05-26T15:17:41.536Z'
+                completed_at: '2026-05-26T15:36:56.505Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8577,8 +8598,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:17:41.437Z'
-                updated_at: '2026-05-26T15:17:41.567Z'
+                created_at: '2026-05-26T15:36:56.438Z'
+                updated_at: '2026-05-26T15:36:56.538Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8659,8 +8680,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R242958792
-                email: elliott.heathcote@mills.biz
+                number: R082989840
+                email: kenyetta.schamberger@murphy.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -8687,7 +8708,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-26T15:17:42.912Z'
+                completed_at: '2026-05-26T15:36:57.817Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8701,10 +8722,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-26T15:17:43.247Z'
+                canceled_at: '2026-05-26T15:36:58.133Z'
                 approved_at:
-                created_at: '2026-05-26T15:17:42.826Z'
-                updated_at: '2026-05-26T15:17:43.302Z'
+                created_at: '2026-05-26T15:36:57.760Z'
+                updated_at: '2026-05-26T15:36:58.180Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8763,8 +8784,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R670744364
-                email: alida.mante@bernhard.name
+                number: R273096821
+                email: andre.weissnat@volkman.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -8791,7 +8812,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:17:43.667Z'
+                completed_at: '2026-05-26T15:36:58.558Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8806,9 +8827,9 @@ paths:
                 display_payment_total: "$0.00"
                 metadata: {}
                 canceled_at:
-                approved_at: '2026-05-26T15:17:43.958Z'
-                created_at: '2026-05-26T15:17:43.606Z'
-                updated_at: '2026-05-26T15:17:43.667Z'
+                approved_at: '2026-05-26T15:36:58.856Z'
+                created_at: '2026-05-26T15:36:58.499Z'
+                updated_at: '2026-05-26T15:36:58.557Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8867,8 +8888,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R587376574
-                email: emmy.purdy@abbott.co.uk
+                number: R780361580
+                email: ronni_carroll@haleywalker.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -8895,7 +8916,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-05-26T15:17:44.298Z'
+                completed_at: '2026-05-26T15:36:59.210Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -8909,10 +8930,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-05-26T15:17:44.578Z'
+                canceled_at: '2026-05-26T15:36:59.492Z'
                 approved_at:
-                created_at: '2026-05-26T15:17:44.239Z'
-                updated_at: '2026-05-26T15:17:44.709Z'
+                created_at: '2026-05-26T15:36:59.148Z'
+                updated_at: '2026-05-26T15:36:59.579Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8971,8 +8992,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R631396038
-                email: clair@heathcote.co.uk
+                number: R251197778
+                email: orval@becker.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -8999,7 +9020,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:17:45.088Z'
+                completed_at: '2026-05-26T15:36:59.935Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9015,8 +9036,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-05-26T15:17:45.003Z'
-                updated_at: '2026-05-26T15:17:45.088Z'
+                created_at: '2026-05-26T15:36:59.873Z'
+                updated_at: '2026-05-26T15:36:59.935Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9091,8 +9112,8 @@ paths:
                   auto_capture:
                   storefront_visible: true
                   position: 1
-                  created_at: '2026-05-26T15:17:45.394Z'
-                  updated_at: '2026-05-26T15:17:45.395Z'
+                  created_at: '2026-05-26T15:37:00.242Z'
+                  updated_at: '2026-05-26T15:37:00.243Z'
                   preferences: {}
                   preference_schema: []
                 meta:
@@ -9232,8 +9253,8 @@ paths:
                 auto_capture:
                 storefront_visible: true
                 position: 1
-                created_at: '2026-05-26T15:17:46.094Z'
-                updated_at: '2026-05-26T15:17:46.095Z'
+                created_at: '2026-05-26T15:37:00.825Z'
+                updated_at: '2026-05-26T15:37:00.826Z'
                 preferences: {}
                 preference_schema: []
   "/api/v3/admin/price_lists":
@@ -9306,8 +9327,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-05-26T15:17:46.409Z'
-                  updated_at: '2026-05-26T15:17:46.409Z'
+                  created_at: '2026-05-26T15:37:01.117Z'
+                  updated_at: '2026-05-26T15:37:01.117Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -9321,8 +9342,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-05-26T15:17:46.411Z'
-                  updated_at: '2026-05-26T15:17:46.411Z'
+                  created_at: '2026-05-26T15:37:01.119Z'
+                  updated_at: '2026-05-26T15:37:01.119Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -9386,8 +9407,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:17:47.869Z'
-                updated_at: '2026-05-26T15:17:47.871Z'
+                created_at: '2026-05-26T15:37:02.195Z'
+                updated_at: '2026-05-26T15:37:02.196Z'
                 currently_active: false
                 products_count: 1
                 prices_count: 2
@@ -9535,8 +9556,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:17:48.181Z'
-                updated_at: '2026-05-26T15:17:48.181Z'
+                created_at: '2026-05-26T15:37:02.497Z'
+                updated_at: '2026-05-26T15:37:02.497Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9594,8 +9615,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:17:49.744Z'
-                updated_at: '2026-05-26T15:17:50.024Z'
+                created_at: '2026-05-26T15:37:04.093Z'
+                updated_at: '2026-05-26T15:37:04.376Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9753,8 +9774,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:17:50.319Z'
-                updated_at: '2026-05-26T15:17:50.600Z'
+                created_at: '2026-05-26T15:37:04.669Z'
+                updated_at: '2026-05-26T15:37:04.950Z'
                 currently_active: true
                 products_count: 0
                 prices_count: 0
@@ -9802,8 +9823,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-05-26T15:17:50.607Z'
-                updated_at: '2026-05-26T15:17:50.887Z'
+                created_at: '2026-05-26T15:37:04.957Z'
+                updated_at: '2026-05-26T15:37:05.241Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -9914,8 +9935,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-05-26T15:17:50.937Z'
-                  updated_at: '2026-05-26T15:17:50.937Z'
+                  created_at: '2026-05-26T15:37:05.318Z'
+                  updated_at: '2026-05-26T15:37:05.318Z'
                 - id: price_EfhxLZ9ck8
                   amount: '5.0'
                   amount_in_cents: 500
@@ -9926,8 +9947,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id: pl_UkLWZg9DAJ
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-05-26T15:17:50.941Z'
-                  updated_at: '2026-05-26T15:17:50.941Z'
+                  created_at: '2026-05-26T15:37:05.324Z'
+                  updated_at: '2026-05-26T15:37:05.324Z'
                 meta:
                   page: 1
                   limit: 25
@@ -10006,8 +10027,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id:
                 variant_id: variant_EfhxLZ9ck8
-                created_at: '2026-05-26T15:17:51.609Z'
-                updated_at: '2026-05-26T15:17:51.609Z'
+                created_at: '2026-05-26T15:37:05.983Z'
+                updated_at: '2026-05-26T15:37:05.983Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -10091,8 +10112,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-05-26T15:17:51.669Z'
-                updated_at: '2026-05-26T15:17:51.669Z'
+                created_at: '2026-05-26T15:37:06.045Z'
+                updated_at: '2026-05-26T15:37:06.045Z'
               schema:
                 "$ref": "#/components/schemas/Price"
         '404':
@@ -10154,8 +10175,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-05-26T15:17:52.332Z'
-                updated_at: '2026-05-26T15:17:52.612Z'
+                created_at: '2026-05-26T15:37:06.770Z'
+                updated_at: '2026-05-26T15:37:07.054Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -10455,8 +10476,8 @@ paths:
                   field_type: short_text
                   key: custom.title
                   value: wool
-                  created_at: '2026-05-26T15:17:54.124Z'
-                  updated_at: '2026-05-26T15:17:54.124Z'
+                  created_at: '2026-05-26T15:37:08.538Z'
+                  updated_at: '2026-05-26T15:37:08.538Z'
                   storefront_visible: true
                   custom_field_definition_id: cfdef_UkLWZg9DAJ
                 meta:
@@ -10523,8 +10544,8 @@ paths:
                 field_type: long_text
                 key: custom.description
                 value: A longer description
-                created_at: '2026-05-26T15:17:54.778Z'
-                updated_at: '2026-05-26T15:17:54.778Z'
+                created_at: '2026-05-26T15:37:09.156Z'
+                updated_at: '2026-05-26T15:37:09.156Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_gbHJdmfrXB
         '422':
@@ -10608,8 +10629,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: wool
-                created_at: '2026-05-26T15:17:55.324Z'
-                updated_at: '2026-05-26T15:17:55.324Z'
+                created_at: '2026-05-26T15:37:09.519Z'
+                updated_at: '2026-05-26T15:37:09.519Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
     patch:
@@ -10656,8 +10677,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: cotton
-                created_at: '2026-05-26T15:17:55.649Z'
-                updated_at: '2026-05-26T15:17:55.934Z'
+                created_at: '2026-05-26T15:37:09.840Z'
+                updated_at: '2026-05-26T15:37:10.126Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
       requestBody:
@@ -10795,34 +10816,36 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 552304
-                  slug: product-552304
+                  name: Product 552852
+                  slug: product-552852
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-26T15:17:56.255Z'
+                  available_on: '2025-05-26T15:37:10.469Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Animi vitae hic eos saepe impedit. Ea optio placeat
-                    unde molestiae itaque. Blanditiis numquam pariatur beatae recusandae
-                    est corporis nobis. Perferendis delectus earum aperiam in consectetur.
-                    Autem molestiae ex deleniti laudantium labore rerum in. Beatae
-                    repellendus consequuntur maxime eveniet quibusdam non inventore
-                    iste. Sit unde nesciunt sapiente ex eius assumenda. Porro impedit
-                    libero repellat ea delectus nam. Labore optio molestias id nemo
-                    quaerat a soluta. Ex hic aperiam doloremque quos amet esse illum
-                    placeat. Distinctio cupiditate placeat quibusdam repellat consequatur
-                    necessitatibus. Sint cupiditate sunt magnam harum incidunt nemo
-                    totam. Corporis recusandae eligendi officia debitis incidunt.
-                    Corporis sequi repudiandae id consectetur minima.
+                  description: Laborum doloribus architecto dolorum excepturi quos.
+                    Quasi quam atque natus officiis ratione consectetur id modi. Itaque
+                    laboriosam facilis vero aperiam nisi minima eos. Libero ipsa excepturi
+                    adipisci accusantium. Sequi consequatur occaecati saepe non aliquid
+                    mollitia veritatis amet. Inventore eos totam assumenda occaecati
+                    doloremque. Odio iste nemo voluptatem saepe ad magni labore quod.
+                    Quaerat cupiditate totam fugit natus amet quod quo accusantium.
+                    Veritatis nam nemo alias sunt eveniet enim dignissimos magnam.
+                    Repellat facilis minus eveniet rem. Minus itaque dolores non consequuntur
+                    eum atque officia tempora. Ratione occaecati veritatis optio doloribus
+                    molestiae nam eum atque. Veniam sit modi nemo molestias. Accusamus
+                    officiis voluptates non amet. Repudiandae consequuntur occaecati
+                    minima vero sequi fugiat perspiciatis. Illo doloremque error provident
+                    libero quam.
                   description_html: |-
-                    Animi vitae hic eos saepe impedit. Ea optio placeat unde molestiae itaque. Blanditiis numquam pariatur beatae recusandae est corporis nobis.
-                    Perferendis delectus earum aperiam in consectetur. Autem molestiae ex deleniti laudantium labore rerum in. Beatae repellendus consequuntur maxime eveniet quibusdam non inventore iste. Sit unde nesciunt sapiente ex eius assumenda. Porro impedit libero repellat ea delectus nam.
-                    Labore optio molestias id nemo quaerat a soluta. Ex hic aperiam doloremque quos amet esse illum placeat. Distinctio cupiditate placeat quibusdam repellat consequatur necessitatibus.
-                    Sint cupiditate sunt magnam harum incidunt nemo totam. Corporis recusandae eligendi officia debitis incidunt. Corporis sequi repudiandae id consectetur minima.
+                    Laborum doloribus architecto dolorum excepturi quos. Quasi quam atque natus officiis ratione consectetur id modi. Itaque laboriosam facilis vero aperiam nisi minima eos. Libero ipsa excepturi adipisci accusantium. Sequi consequatur occaecati saepe non aliquid mollitia veritatis amet.
+                    Inventore eos totam assumenda occaecati doloremque. Odio iste nemo voluptatem saepe ad magni labore quod. Quaerat cupiditate totam fugit natus amet quod quo accusantium.
+                    Veritatis nam nemo alias sunt eveniet enim dignissimos magnam. Repellat facilis minus eveniet rem. Minus itaque dolores non consequuntur eum atque officia tempora. Ratione occaecati veritatis optio doloribus molestiae nam eum atque.
+                    Veniam sit modi nemo molestias. Accusamus officiis voluptates non amet. Repudiandae consequuntur occaecati minima vero sequi fugiat perspiciatis. Illo doloremque error provident libero quam.
                   default_variant_id: variant_UkLWZg9DAJ
                   thumbnail_url:
                   tags: []
@@ -10837,16 +10860,16 @@ paths:
                     display_compare_at_amount:
                     price_list_id:
                     variant_id: variant_UkLWZg9DAJ
-                    created_at: '2026-05-26T15:17:56.282Z'
-                    updated_at: '2026-05-26T15:17:56.282Z'
+                    created_at: '2026-05-26T15:37:10.499Z'
+                    updated_at: '2026-05-26T15:37:10.499Z'
                   original_price:
                   status: active
-                  make_active_at: '2025-05-26T15:17:56.255Z'
+                  make_active_at: '2025-05-26T15:37:10.469Z'
                   discontinue_on:
                   metadata: {}
                   deleted_at:
-                  created_at: '2026-05-26T15:17:56.269Z'
-                  updated_at: '2026-05-26T15:17:56.283Z'
+                  created_at: '2026-05-26T15:37:10.485Z'
+                  updated_at: '2026-05-26T15:37:10.500Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -10980,8 +11003,8 @@ paths:
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T15:17:56.958Z'
-                updated_at: '2026-05-26T15:17:56.961Z'
+                created_at: '2026-05-26T15:37:11.178Z'
+                updated_at: '2026-05-26T15:37:11.181Z'
                 tax_category_id:
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11161,31 +11184,37 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 598440
-                slug: product-598440
+                name: Product 594932
+                slug: product-594932
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-26T15:17:57.322Z'
+                available_on: '2025-05-26T15:37:11.550Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Quo laboriosam delectus consectetur quia omnis illum
-                  nobis. Pariatur neque fugit assumenda ad at repudiandae. Odio quisquam
-                  magnam quae placeat quod. Quia excepturi eligendi impedit velit
-                  aspernatur assumenda iste repellendus. Hic id consequuntur culpa
-                  a. Accusantium corporis tempora eos accusamus a similique voluptate
-                  officia. At a ratione sint unde dicta ut. Nobis recusandae voluptas
-                  praesentium reiciendis rem molestiae iste. Placeat commodi quam
-                  perferendis cum repudiandae maiores nobis repellendus. Veritatis
-                  temporibus voluptatum architecto nisi nihil. Sequi explicabo soluta
-                  laudantium autem ex.
+                description: Eum placeat error ex dignissimos aperiam odit provident
+                  explicabo. Quibusdam cupiditate fugit ipsam vel rerum. Perferendis
+                  itaque cupiditate laborum odio. Molestias voluptatibus praesentium
+                  totam nisi quaerat reiciendis. Voluptatem numquam eaque praesentium
+                  culpa ab iusto labore voluptatibus. Beatae inventore sapiente incidunt
+                  optio eum et laboriosam quis. Occaecati aut excepturi qui delectus
+                  doloremque temporibus iure. Quam error libero quaerat doloribus
+                  vero quasi reiciendis voluptatum. Placeat inventore amet repudiandae
+                  veniam. Eveniet similique autem sapiente minus blanditiis eaque
+                  voluptatem. Aliquid distinctio illum molestiae cumque. Nisi laboriosam
+                  enim perferendis placeat laborum. Illum reiciendis nisi quaerat
+                  accusamus repellendus dolor deleniti. Aspernatur corrupti officia
+                  inventore sed sit. Corporis dolore nemo odit soluta officiis expedita
+                  nulla eum. Ducimus omnis vitae mollitia veniam aperiam esse officia
+                  labore.
                 description_html: |-
-                  Quo laboriosam delectus consectetur quia omnis illum nobis. Pariatur neque fugit assumenda ad at repudiandae. Odio quisquam magnam quae placeat quod.
-                  Quia excepturi eligendi impedit velit aspernatur assumenda iste repellendus. Hic id consequuntur culpa a. Accusantium corporis tempora eos accusamus a similique voluptate officia. At a ratione sint unde dicta ut.
-                  Nobis recusandae voluptas praesentium reiciendis rem molestiae iste. Placeat commodi quam perferendis cum repudiandae maiores nobis repellendus. Veritatis temporibus voluptatum architecto nisi nihil. Sequi explicabo soluta laudantium autem ex.
+                  Eum placeat error ex dignissimos aperiam odit provident explicabo. Quibusdam cupiditate fugit ipsam vel rerum. Perferendis itaque cupiditate laborum odio.
+                  Molestias voluptatibus praesentium totam nisi quaerat reiciendis. Voluptatem numquam eaque praesentium culpa ab iusto labore voluptatibus. Beatae inventore sapiente incidunt optio eum et laboriosam quis. Occaecati aut excepturi qui delectus doloremque temporibus iure. Quam error libero quaerat doloribus vero quasi reiciendis voluptatum.
+                  Placeat inventore amet repudiandae veniam. Eveniet similique autem sapiente minus blanditiis eaque voluptatem. Aliquid distinctio illum molestiae cumque. Nisi laboriosam enim perferendis placeat laborum.
+                  Illum reiciendis nisi quaerat accusamus repellendus dolor deleniti. Aspernatur corrupti officia inventore sed sit. Corporis dolore nemo odit soluta officiis expedita nulla eum. Ducimus omnis vitae mollitia veniam aperiam esse officia labore.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11200,16 +11229,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:17:57.347Z'
-                  updated_at: '2026-05-26T15:17:57.347Z'
+                  created_at: '2026-05-26T15:37:11.576Z'
+                  updated_at: '2026-05-26T15:37:11.576Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-26T15:17:57.322Z'
+                make_active_at: '2025-05-26T15:37:11.550Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T15:17:57.334Z'
-                updated_at: '2026-05-26T15:17:57.348Z'
+                created_at: '2026-05-26T15:37:11.563Z'
+                updated_at: '2026-05-26T15:37:11.578Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11276,29 +11305,29 @@ paths:
               example:
                 id: prod_UkLWZg9DAJ
                 name: Updated Name
-                slug: product-613804
+                slug: product-618063
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 0
-                available_on: '2025-05-26T15:17:58.026Z'
+                available_on: '2025-05-26T15:37:12.200Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Repellat illo quasi debitis dolore. Quas voluptatum rerum
-                  odio cupiditate voluptates distinctio rem. Placeat quia a vitae
-                  deleniti. Magnam exercitationem atque tempora eaque ad alias. Vero
-                  debitis temporibus vitae illo voluptatem quos. Laudantium itaque
-                  reiciendis recusandae molestiae quasi in ad laborum. Consectetur
-                  dolores iste amet doloremque ducimus officia nam consequuntur. Modi
-                  hic eligendi molestias suscipit. Voluptate assumenda magnam consequuntur
-                  facere minima cumque. Beatae ut consequatur animi quasi. Beatae
-                  iure quam ipsum hic amet eos recusandae.
+                description: Totam odio vero pariatur fugiat officia. Animi itaque
+                  tempora voluptate culpa magni mollitia. Minus odio dolore facilis
+                  assumenda veritatis. Recusandae eos expedita reprehenderit quidem
+                  rerum. Accusantium eaque enim sint illo necessitatibus adipisci.
+                  Repellat ullam corporis placeat rerum laboriosam quis alias ad.
+                  Omnis rerum nihil alias similique assumenda. Eveniet provident deleniti
+                  aut rem animi maxime distinctio dolores. Iure quas molestias eum
+                  ea eaque magnam dolor alias. Adipisci in reprehenderit eius alias
+                  a placeat quos animi. Fuga saepe labore illum aliquid veniam.
                 description_html: |-
-                  Repellat illo quasi debitis dolore. Quas voluptatum rerum odio cupiditate voluptates distinctio rem. Placeat quia a vitae deleniti. Magnam exercitationem atque tempora eaque ad alias.
-                  Vero debitis temporibus vitae illo voluptatem quos. Laudantium itaque reiciendis recusandae molestiae quasi in ad laborum. Consectetur dolores iste amet doloremque ducimus officia nam consequuntur. Modi hic eligendi molestias suscipit.
-                  Voluptate assumenda magnam consequuntur facere minima cumque. Beatae ut consequatur animi quasi. Beatae iure quam ipsum hic amet eos recusandae.
+                  Totam odio vero pariatur fugiat officia. Animi itaque tempora voluptate culpa magni mollitia. Minus odio dolore facilis assumenda veritatis. Recusandae eos expedita reprehenderit quidem rerum. Accusantium eaque enim sint illo necessitatibus adipisci.
+                  Repellat ullam corporis placeat rerum laboriosam quis alias ad. Omnis rerum nihil alias similique assumenda. Eveniet provident deleniti aut rem animi maxime distinctio dolores.
+                  Iure quas molestias eum ea eaque magnam dolor alias. Adipisci in reprehenderit eius alias a placeat quos animi. Fuga saepe labore illum aliquid veniam.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11313,16 +11342,16 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:17:58.053Z'
-                  updated_at: '2026-05-26T15:17:58.053Z'
+                  created_at: '2026-05-26T15:37:12.227Z'
+                  updated_at: '2026-05-26T15:37:12.227Z'
                 original_price:
                 status: active
-                make_active_at: '2025-05-26T15:17:58.026Z'
+                make_active_at: '2025-05-26T15:37:12.200Z'
                 discontinue_on:
                 metadata: {}
                 deleted_at:
-                created_at: '2026-05-26T15:17:58.038Z'
-                updated_at: '2026-05-26T15:17:58.375Z'
+                created_at: '2026-05-26T15:37:12.213Z'
+                updated_at: '2026-05-26T15:37:12.519Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11855,8 +11884,8 @@ paths:
               example:
                 data:
                 - id: pact_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:18:02.283Z'
-                  updated_at: '2026-05-26T15:18:02.283Z'
+                  created_at: '2026-05-26T15:37:16.028Z'
+                  updated_at: '2026-05-26T15:37:16.028Z'
                   type: free_shipping
                   promotion_id: promo_UkLWZg9DAJ
                   preferences: {}
@@ -11917,8 +11946,8 @@ paths:
             application/json:
               example:
                 id: pact_UkLWZg9DAJ
-                created_at: '2026-05-26T15:18:02.843Z'
-                updated_at: '2026-05-26T15:18:02.843Z'
+                created_at: '2026-05-26T15:37:16.618Z'
+                updated_at: '2026-05-26T15:37:16.618Z'
                 type: free_shipping
                 promotion_id: promo_UkLWZg9DAJ
                 preferences: {}
@@ -12028,8 +12057,8 @@ paths:
               example:
                 data:
                 - id: prorule_UkLWZg9DAJ
-                  created_at: '2026-05-26T15:18:03.442Z'
-                  updated_at: '2026-05-26T15:18:03.442Z'
+                  created_at: '2026-05-26T15:37:17.213Z'
+                  updated_at: '2026-05-26T15:37:17.213Z'
                   type: currency
                   promotion_id: promo_UkLWZg9DAJ
                   preferences:
@@ -12096,8 +12125,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-26T15:18:04.069Z'
-                updated_at: '2026-05-26T15:18:04.069Z'
+                created_at: '2026-05-26T15:37:17.789Z'
+                updated_at: '2026-05-26T15:37:17.789Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -12170,8 +12199,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-05-26T15:18:04.485Z'
-                updated_at: '2026-05-26T15:18:04.822Z'
+                created_at: '2026-05-26T15:37:18.084Z'
+                updated_at: '2026-05-26T15:37:18.366Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -12261,7 +12290,7 @@ paths:
                   name: Summer Sale
                   description:
                   code: summer
-                  starts_at: '2026-05-26T15:18:05.133Z'
+                  starts_at: '2026-05-26T15:37:18.659Z'
                   expires_at:
                   usage_limit:
                   match_policy: all
@@ -12272,8 +12301,8 @@ paths:
                   code_prefix:
                   promotion_category_id:
                   metadata: {}
-                  created_at: '2026-05-26T15:18:05.135Z'
-                  updated_at: '2026-05-26T15:18:05.138Z'
+                  created_at: '2026-05-26T15:37:18.660Z'
+                  updated_at: '2026-05-26T15:37:18.661Z'
                   store_ids:
                   - store_UkLWZg9DAJ
                   action_ids: []
@@ -12379,7 +12408,7 @@ paths:
                 name: Black Friday
                 description:
                 code: blackfriday-os
-                starts_at: '2026-05-26T15:18:06.078Z'
+                starts_at: '2026-05-26T15:37:19.603Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12390,8 +12419,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T15:18:06.079Z'
-                updated_at: '2026-05-26T15:18:06.101Z'
+                created_at: '2026-05-26T15:37:19.605Z'
+                updated_at: '2026-05-26T15:37:19.628Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids:
@@ -12544,7 +12573,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-26T15:18:06.395Z'
+                starts_at: '2026-05-26T15:37:19.922Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12555,8 +12584,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T15:18:06.396Z'
-                updated_at: '2026-05-26T15:18:06.396Z'
+                created_at: '2026-05-26T15:37:19.923Z'
+                updated_at: '2026-05-26T15:37:19.924Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -12652,7 +12681,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-05-26T15:18:07.272Z'
+                starts_at: '2026-05-26T15:37:20.811Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -12663,8 +12692,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-05-26T15:18:07.273Z'
-                updated_at: '2026-05-26T15:18:07.551Z'
+                created_at: '2026-05-26T15:37:20.811Z'
+                updated_at: '2026-05-26T15:37:21.096Z'
                 store_ids:
                 - store_UkLWZg9DAJ
                 action_ids: []
@@ -13016,8 +13045,8 @@ paths:
                 data:
                 - id: role_UkLWZg9DAJ
                   name: admin
-                  created_at: '2026-05-26T15:18:08.431Z'
-                  updated_at: '2026-05-26T15:18:08.431Z'
+                  created_at: '2026-05-26T15:37:21.998Z'
+                  updated_at: '2026-05-26T15:37:21.998Z'
                 meta:
                   page: 1
                   limit: 25
@@ -13152,8 +13181,8 @@ paths:
                   pickup_stock_policy: local
                   pickup_ready_in_minutes:
                   pickup_instructions:
-                  created_at: '2026-05-26T15:18:08.715Z'
-                  updated_at: '2026-05-26T15:18:08.715Z'
+                  created_at: '2026-05-26T15:37:22.287Z'
+                  updated_at: '2026-05-26T15:37:22.287Z'
                 meta:
                   page: 1
                   limit: 25
@@ -13264,8 +13293,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 30
                 pickup_instructions:
-                created_at: '2026-05-26T15:18:09.297Z'
-                updated_at: '2026-05-26T15:18:09.297Z'
+                created_at: '2026-05-26T15:37:22.874Z'
+                updated_at: '2026-05-26T15:37:22.874Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -13439,8 +13468,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes:
                 pickup_instructions:
-                created_at: '2026-05-26T15:18:09.590Z'
-                updated_at: '2026-05-26T15:18:09.590Z'
+                created_at: '2026-05-26T15:37:23.235Z'
+                updated_at: '2026-05-26T15:37:23.235Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '404':
@@ -13525,8 +13554,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 45
                 pickup_instructions:
-                created_at: '2026-05-26T15:18:10.156Z'
-                updated_at: '2026-05-26T15:18:10.433Z'
+                created_at: '2026-05-26T15:37:23.838Z'
+                updated_at: '2026-05-26T15:37:24.123Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -13729,8 +13758,8 @@ paths:
                 data:
                 - id: sccat_UkLWZg9DAJ
                   name: Goodwill
-                  created_at: '2026-05-26T15:18:11.001Z'
-                  updated_at: '2026-05-26T15:18:11.001Z'
+                  created_at: '2026-05-26T15:37:24.715Z'
+                  updated_at: '2026-05-26T15:37:24.715Z'
                   non_expiring: false
                 meta:
                   page: 1
@@ -13821,8 +13850,8 @@ paths:
               example:
                 id: sccat_UkLWZg9DAJ
                 name: Goodwill
-                created_at: '2026-05-26T15:18:11.299Z'
-                updated_at: '2026-05-26T15:18:11.299Z'
+                created_at: '2026-05-26T15:37:25.013Z'
+                updated_at: '2026-05-26T15:37:25.013Z'
                 non_expiring: false
               schema:
                 "$ref": "#/components/schemas/StoreCreditCategory"
@@ -13887,8 +13916,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-26T15:16:40.807Z'
-                updated_at: '2026-05-26T15:18:11.897Z'
+                created_at: '2026-05-26T15:35:57.400Z'
+                updated_at: '2026-05-26T15:37:25.596Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -13959,8 +13988,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-05-26T15:16:40.807Z'
-                updated_at: '2026-05-26T15:18:12.617Z'
+                created_at: '2026-05-26T15:35:57.400Z'
+                updated_at: '2026-05-26T15:37:26.209Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -14180,13 +14209,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-26T15:18:14.082Z'
-                  updated_at: '2026-05-26T15:18:14.093Z'
+                  created_at: '2026-05-26T15:37:27.638Z'
+                  updated_at: '2026-05-26T15:37:27.651Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 756684
+                  product_name: Product 753738
                 - id: variant_gbHJdmfrXB
                   product_id: prod_UkLWZg9DAJ
                   sku: SKU-94
@@ -14197,10 +14226,10 @@ paths:
                   purchasable: true
                   in_stock: false
                   backorderable: true
-                  weight: 89.4
-                  height: 187.92
-                  width: 121.46
-                  depth: 5.3
+                  weight: 170.62
+                  height: 69.67
+                  width: 199.89
+                  depth: 87.8
                   price:
                     id: price_gbHJdmfrXB
                     amount: '19.99'
@@ -14223,8 +14252,8 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-05-26T15:18:14.101Z'
-                    updated_at: '2026-05-26T15:18:14.101Z'
+                    created_at: '2026-05-26T15:37:27.662Z'
+                    updated_at: '2026-05-26T15:37:27.662Z'
                   metadata: {}
                   position: 2
                   cost_price: '17.0'
@@ -14233,13 +14262,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-05-26T15:18:14.099Z'
-                  updated_at: '2026-05-26T15:18:14.110Z'
+                  created_at: '2026-05-26T15:37:27.660Z'
+                  updated_at: '2026-05-26T15:37:27.674Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 756684
+                  product_name: Product 753738
                 meta:
                   page: 1
                   limit: 25
@@ -14350,8 +14379,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:18:14.758Z'
-                  updated_at: '2026-05-26T15:18:14.758Z'
+                  created_at: '2026-05-26T15:37:28.347Z'
+                  updated_at: '2026-05-26T15:37:28.347Z'
                 metadata: {}
                 position: 3
                 cost_price:
@@ -14360,13 +14389,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T15:18:14.764Z'
-                updated_at: '2026-05-26T15:18:14.765Z'
+                created_at: '2026-05-26T15:37:28.353Z'
+                updated_at: '2026-05-26T15:37:28.355Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 768191
+                product_name: Product 761921
         '422':
           description: validation error
           content:
@@ -14553,10 +14582,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 10.6
-                height: 132.98
-                width: 8.61
-                depth: 173.2
+                weight: 41.76
+                height: 27.88
+                width: 87.9
+                depth: 55.0
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -14579,8 +14608,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:18:15.190Z'
-                  updated_at: '2026-05-26T15:18:15.190Z'
+                  created_at: '2026-05-26T15:37:28.771Z'
+                  updated_at: '2026-05-26T15:37:28.771Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -14589,13 +14618,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T15:18:15.188Z'
-                updated_at: '2026-05-26T15:18:15.201Z'
+                created_at: '2026-05-26T15:37:28.768Z'
+                updated_at: '2026-05-26T15:37:28.784Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 782677
+                product_name: Product 789310
         '404':
           description: variant not found
           content:
@@ -14674,10 +14703,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 43.4
-                height: 140.52
-                width: 28.49
-                depth: 106.25
+                weight: 82.38
+                height: 119.79
+                width: 29.26
+                depth: 28.7
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -14700,8 +14729,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-05-26T15:18:15.875Z'
-                  updated_at: '2026-05-26T15:18:15.875Z'
+                  created_at: '2026-05-26T15:37:29.472Z'
+                  updated_at: '2026-05-26T15:37:29.472Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -14710,13 +14739,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-05-26T15:18:15.871Z'
-                updated_at: '2026-05-26T15:18:16.177Z'
+                created_at: '2026-05-26T15:37:29.470Z'
+                updated_at: '2026-05-26T15:37:29.772Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 805520
+                product_name: Product 8053
       requestBody:
         content:
           application/json:

--- a/docs/api-reference/store-api/rate-limitting.mdx
+++ b/docs/api-reference/store-api/rate-limitting.mdx
@@ -14,7 +14,6 @@ The Store API enforces rate limits to protect against abuse and ensure fair usag
 | `POST /auth/login` | 5 requests | Per IP | 1 minute |
 | `POST /customers` | 3 requests | Per IP | 1 minute |
 | `POST /auth/refresh` | 10 requests | Per IP | 1 minute |
-| `POST /auth/oauth/callback` | 5 requests | Per IP | 1 minute |
 
 The global rate limit is tracked by your publishable API key (`X-Spree-Api-Key`). If the key is not provided, the limit falls back to the client's IP address.
 

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -601,16 +601,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjIxYTBkZTI2LWVjYmMtNGY5OC04ZDVjLTZmMGI0NTIwYTI0NSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzAyfQ.kdlwXNcgs2jyogbR6hqL-_AWBbYPJ_zh-s46lWFiTsc
-                refresh_token: VNkXPSibSKSNPvu2TbPa5fzc
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk1OTUwNTE2LTg0ZDMtNGIyNy1iZGFiLTZmYTBkYTNiZTE2NCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDU1fQ.UrTQMWKxKb9VeAXhlMwR8EpF6vezYhUDJ36jDCLCzV4
+                refresh_token: Sf1YLV9Vcs4Z7xF3ep2FdzLp
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Stephaine
-                  last_name: Towne
+                  first_name: Myesha
+                  last_name: McKenzie
                   phone:
                   accepts_email_marketing: false
-                  full_name: Stephaine Towne
+                  full_name: Myesha McKenzie
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -665,6 +665,8 @@ paths:
                     type: string
                     example: auth0
                     description: Registered provider key (anything other than `email`).
+                    not:
+                      const: email
                 required:
                 - provider
                 additionalProperties: true
@@ -703,16 +705,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImM2Y2NkYWNhLThkMzktNGVkOS1iNWM0LTJiZWZhMGQ3Y2RmOCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzAzfQ.83Gw0ZK9l767kGVmPFtTYp6QETckMFWaJvnPYiKWdyI
-                refresh_token: zJrHUhRhsgAKZapCNfSiHZ9V
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk2YjQ4NDRlLTVlYTEtNDgwMS05YjZkLTdlYjEwYmU3ZTk5ZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDU2fQ.dNUeqwWFo3WzVMAk7aap2VsFxe2qeUaRed2k86hfwfo
+                refresh_token: 2K3eLgPq6bWMmu4P8z6wTh64
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Janie
-                  last_name: Funk
+                  first_name: Velma
+                  last_name: Johnston
                   phone:
                   accepts_email_marketing: false
-                  full_name: Janie Funk
+                  full_name: Velma Johnston
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -876,9 +878,9 @@ paths:
                 data:
                 - id: cart_gbHJdmfrXB
                   market_id:
-                  number: R122236372
-                  token: U2nim1qtQjuDyj2kTq3HSdHo4Kkj8nLT6wT
-                  email: jaymie_goyette@stiedemann.info
+                  number: R904109241
+                  token: Agyt2vfNgA5z1QdB1aCUHwa6hDFL3JLjxhX
+                  email: timika_simonis@yost.co.uk
                   customer_note:
                   currency: USD
                   locale: en
@@ -920,8 +922,8 @@ paths:
                     variant_id: variant_gbHJdmfrXB
                     quantity: 1
                     currency: USD
-                    name: Product 833501
-                    slug: product-833501
+                    name: Product 833845
+                    slug: product-833845
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -946,7 +948,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_gbHJdmfrXB
-                    number: H60984625405
+                    number: H94704449388
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -975,7 +977,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Young West
+                      name: Fabiola Cormier
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1007,7 +1009,7 @@ paths:
                     first_name: John
                     last_name: Doe
                     full_name: John Doe
-                    address1: 105 Lovely Street
+                    address1: 101 Lovely Street
                     address2: Northwest
                     postal_code: '10118'
                     city: New York
@@ -1026,7 +1028,7 @@ paths:
                     first_name: John
                     last_name: Doe
                     full_name: John Doe
-                    address1: 106 Lovely Street
+                    address1: 102 Lovely Street
                     address2: Northwest
                     postal_code: '10118'
                     city: New York
@@ -1045,9 +1047,9 @@ paths:
                   market:
                 - id: cart_UkLWZg9DAJ
                   market_id:
-                  number: R524109072
-                  token: RDe6KqL3ttuQMTJiiF4QaoMKvdSsNsJQdQR
-                  email: jaymie_goyette@stiedemann.info
+                  number: R036630490
+                  token: qsE8mSUKJNws9NnTgBDPUFQkwcr1HS5643h
+                  email: timika_simonis@yost.co.uk
                   customer_note:
                   currency: USD
                   locale: en
@@ -1089,8 +1091,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 825207
-                    slug: product-825207
+                    name: Product 823692
+                    slug: product-823692
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1115,7 +1117,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H98781380235
+                    number: H40294182590
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -1144,7 +1146,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Young West
+                      name: Fabiola Cormier
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1176,7 +1178,7 @@ paths:
                     first_name: John
                     last_name: Doe
                     full_name: John Doe
-                    address1: 103 Lovely Street
+                    address1: 99 Lovely Street
                     address2: Northwest
                     postal_code: '10118'
                     city: New York
@@ -1195,7 +1197,7 @@ paths:
                     first_name: John
                     last_name: Doe
                     full_name: John Doe
-                    address1: 104 Lovely Street
+                    address1: 100 Lovely Street
                     address2: Northwest
                     postal_code: '10118'
                     city: New York
@@ -1287,8 +1289,8 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R319530089
-                token: vXZwiq43kwPRgMF4j4GENW3ZqQKe13j2g3g
+                number: R826900104
+                token: p9JT8xWtDbqHKZs788eLDt5GkFUsNCrySTJ
                 email:
                 customer_note:
                 currency: USD
@@ -1443,9 +1445,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R759835307
-                token: YFMEQyRfA9f68iKC1edGzbsHQRhSsAsrZEo
-                email: sabrina_heathcote@pfannerstill.us
+                number: R038202138
+                token: 3vhBJdkoneVSJTq7AwmU4tZEENSJE8L1iDY
+                email: jarrett.jacobi@bradtke.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -1472,7 +1474,7 @@ paths:
                 display_delivery_total: "$0.00"
                 warnings:
                 - code: line_item_removed
-                  message: Product 879473 was removed because it was sold out
+                  message: Product 876858 was removed because it was sold out
                   line_item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                 store_credit_total: '0.0'
@@ -1497,7 +1499,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 113 Lovely Street
+                  address1: 109 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -1516,7 +1518,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 114 Lovely Street
+                  address1: 110 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -1614,9 +1616,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R174029970
-                token: PBCAthebZu4iKwNEWrNHk4z2E7ubSWnHqWB
-                email: eugena@hermiston.com
+                number: R162129196
+                token: kacsDq5sAeA4bvHpEyWua3i2vxQm7U21jVv
+                email: edison_hermann@kuphal.info
                 customer_note: Leave at door
                 currency: USD
                 locale: en
@@ -1660,8 +1662,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 885746
-                  slug: product-885746
+                  name: Product 886755
+                  slug: product-886755
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -1686,7 +1688,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H15282670883
+                  number: H75244992135
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -1715,7 +1717,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Amada Schuppe
+                    name: Sunni McClure
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1747,7 +1749,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 117 Lovely Street
+                  address1: 113 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -1766,7 +1768,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 118 Lovely Street
+                  address1: 114 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -1952,9 +1954,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R161299580
-                token: Ndo7cgwrPYT44N6844Lyf2eAUFzevA4Lwnh
-                email: kelvin@beierbergnaum.name
+                number: R231091983
+                token: DERZSb96LDTTB7bfJMY9s43jYAtVzAnhjCd
+                email: horacio@herman.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -1996,8 +1998,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 908099
-                  slug: product-908099
+                  name: Product 902266
+                  slug: product-902266
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -2022,7 +2024,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H17401405738
+                  number: H45937813483
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -2051,7 +2053,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Kristian Durgan
+                    name: Teresa Stamm
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2083,7 +2085,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 123 Lovely Street
+                  address1: 119 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -2102,7 +2104,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 124 Lovely Street
+                  address1: 120 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -2186,8 +2188,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R169779204
-                email: daphne.okuneva@bogan.us
+                number: R959851052
+                email: collin.bradtke@bayer.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -2214,7 +2216,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: backorder
                 payment_status: paid
-                completed_at: '2026-05-26T15:18:29.801Z'
+                completed_at: '2026-05-26T15:37:42.350Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -2224,8 +2226,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 926059
-                  slug: product-926059
+                  name: Product 922020
+                  slug: product-922020
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -2250,7 +2252,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H62448608797
+                  number: H50676292807
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -2279,7 +2281,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Marna Boehm
+                    name: Maudie Nitzsche
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2308,8 +2310,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-877e14020a23
-                  number: P8RI17CO
+                  response_code: BGS-0ffdc30bdcb9
+                  number: PNNYCH80
                   amount: '29.99'
                   display_amount: "$29.99"
                   status: completed
@@ -2336,7 +2338,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 131 Lovely Street
+                  address1: 127 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -2355,7 +2357,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 132 Lovely Street
+                  address1: 128 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -3165,16 +3167,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjEyZDM1YWNjLWY5ODQtNDYyYi05YjEzLTQ4ODZjNzRmN2VhMSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzE1fQ.ynX1AI2VeWCg7xRYVGCdtb06JFbgEFZD7o4z0Tq4yOo
-                refresh_token: pBQXxsimdEvXSBv3HbfCjXEV
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjQ4NGQyYmMzLTg1ODUtNGI1Yy1iOTEwLWRhZTVmNGViNGIzMyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDY4fQ.nHnou945vpPDO4F4Avh7h0CEvoGgH3Zs4NTMbNkvirY
+                refresh_token: G4FPrYJGk1oyeJ38DFAj1K8j
                 user:
                   id: cus_UkLWZg9DAJ
                   email: customer@example.com
-                  first_name: America
-                  last_name: Ruecker
+                  first_name: Cher
+                  last_name: Vandervort
                   phone:
                   accepts_email_marketing: false
-                  full_name: America Ruecker
+                  full_name: Cher Vandervort
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -3347,8 +3349,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R640848252
-                  email: dong.considine@powlowski.name
+                  number: R123781058
+                  email: shirlene.tremblay@bins.ca
                   customer_note:
                   currency: USD
                   locale: en
@@ -3375,7 +3377,7 @@ paths:
                   display_delivery_total: "$100.00"
                   fulfillment_status:
                   payment_status:
-                  completed_at: '2026-05-26T15:18:36.842Z'
+                  completed_at: '2026-05-26T15:37:49.679Z'
                   store_credit_total: '0.0'
                   display_store_credit_total: "$0.00"
                   covered_by_store_credit: false
@@ -3385,8 +3387,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 1014923
-                    slug: product-1014923
+                    name: Product 101651
+                    slug: product-101651
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -3411,7 +3413,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H32758246803
+                    number: H80439451392
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -3440,7 +3442,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Josefa Jakubowski
+                      name: Kathy Kshlerin
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -3472,7 +3474,7 @@ paths:
                     first_name: John
                     last_name: Doe
                     full_name: John Doe
-                    address1: 151 Lovely Street
+                    address1: 147 Lovely Street
                     address2: Northwest
                     postal_code: '10118'
                     city: New York
@@ -3491,7 +3493,7 @@ paths:
                     first_name: John
                     last_name: Doe
                     full_name: John Doe
-                    address1: 152 Lovely Street
+                    address1: 148 Lovely Street
                     address2: Northwest
                     postal_code: '10118'
                     city: New York
@@ -3603,8 +3605,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R918052512
-                email: nakesha.beatty@nolan.ca
+                number: R866691797
+                email: ezra_cassin@nienow.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -3631,7 +3633,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:18:37.521Z'
+                completed_at: '2026-05-26T15:37:50.403Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -3641,8 +3643,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1035339
-                  slug: product-1035339
+                  name: Product 103381
+                  slug: product-103381
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3667,7 +3669,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H89370037960
+                  number: H15902875686
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -3696,7 +3698,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Georgann Boyle
+                    name: Catina Kunde
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3728,7 +3730,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 157 Lovely Street
+                  address1: 153 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -3747,7 +3749,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 158 Lovely Street
+                  address1: 154 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -3816,8 +3818,8 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk1Yjg3NjI0LWE3YjEtNDkzZi05YzU4LTAyNzVmNTFmYjlkZiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzE4fQ.M8RoE9VIS-WgTrwnHG35LLwtqZLft8C7-Oe2mCwxTZY
-                refresh_token: LG1mA3CHWx7uBMQrWc7xKv14
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImMxOWU4OGE1LTM4YTktNGUwZi05MmNhLWU3ZjU1ZjFiNjlhNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDcxfQ.Jr-b1n0HSlEeVxJINXR_BpFVsZ5ag-s92cWpLwpqu9E
+                refresh_token: htQdQqRGe6yAeCMpRLJ6f6Th
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
@@ -3931,12 +3933,12 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: bruno@gusikowski.com
-                first_name: Carmelita
-                last_name: Ortiz
+                email: brittani.prosacco@stoltenberg.name
+                first_name: Isa
+                last_name: Schowalter
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                full_name: Carmelita Ortiz
+                full_name: Isa Schowalter
                 available_store_credit_total: '0'
                 display_available_store_credit_total: "$0.00"
                 addresses:
@@ -3944,7 +3946,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 164 Lovely Street
+                  address1: 160 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -3962,7 +3964,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 163 Lovely Street
+                  address1: 159 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -3981,7 +3983,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 164 Lovely Street
+                  address1: 160 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4000,7 +4002,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 163 Lovely Street
+                  address1: 159 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4070,7 +4072,7 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: zelda.shanahan@millsnienow.co.uk
+                email: josefine.cruickshank@schiller.com
                 first_name: Updated
                 last_name: Name
                 phone: 555-555-0199
@@ -4083,7 +4085,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 166 Lovely Street
+                  address1: 162 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4101,7 +4103,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 165 Lovely Street
+                  address1: 161 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4120,7 +4122,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 166 Lovely Street
+                  address1: 162 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4139,7 +4141,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 165 Lovely Street
+                  address1: 161 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4310,9 +4312,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R469093938
-                token: xikLpS3L51xVhCEPeZFsnQJtk3EuRxKnbB8
-                email: rivka_koelpin@paucekmoen.com
+                number: R137828818
+                token: X9RAZky8SYrZbuwHxM6s3WnGWZrqneqr4Lh
+                email: nila.hegmann@price.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -4361,8 +4363,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1111413
-                  slug: product-1111413
+                  name: Product 1118494
+                  slug: product-1118494
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4387,7 +4389,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H93637457615
+                  number: H07536733782
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4416,7 +4418,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Saul Lynch
+                    name: Gigi Spencer
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4448,7 +4450,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 183 Lovely Street
+                  address1: 179 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4467,7 +4469,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 184 Lovely Street
+                  address1: 180 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4570,9 +4572,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R545084696
-                token: iCyC1iunB3FTmAr5bD3wc6FK2UGP9hrokv8
-                email: tanisha_doyle@gutmannmonahan.com
+                number: R794685504
+                token: Ag3ebaf6kZai83zxwqXJtvRUukMNkiaFh69
+                email: eloise_hauck@emard.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -4614,8 +4616,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1133189
-                  slug: product-1133189
+                  name: Product 1139442
+                  slug: product-1139442
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4640,7 +4642,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H05571311130
+                  number: H98249401469
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4669,7 +4671,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Rosaura Breitenberg
+                    name: Lasandra Hartmann
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4701,7 +4703,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 191 Lovely Street
+                  address1: 187 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4720,7 +4722,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 192 Lovely Street
+                  address1: 188 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4812,9 +4814,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R097838778
-                token: FowNXKT85S6DtwNUunGAQ8pzDw1mCBxuNb5
-                email: kyra.upton@pfannerstillshanahan.co.uk
+                number: R392103802
+                token: CMfey9gE8TNTbWbwcxbUeHAZwb1WXVgiqax
+                email: tressa@spencer.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -4858,8 +4860,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1154817
-                  slug: product-1154817
+                  name: Product 1155243
+                  slug: product-1155243
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4884,7 +4886,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H63032637002
+                  number: H19402011424
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4913,7 +4915,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Millie Ebert
+                    name: Lashay Gibson
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4945,7 +4947,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 199 Lovely Street
+                  address1: 195 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -4964,7 +4966,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 200 Lovely Street
+                  address1: 196 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -5070,9 +5072,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R930046502
-                token: iu4XzoHZHCYJ4uKksYJnHRgy4XmXJ3AfoYo
-                email: luella@okuneva.com
+                number: R753898035
+                token: akymx8RLCMAg8J56WjV3dRGqQvNcQKTSdvc
+                email: winnifred@gleason.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -5111,8 +5113,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1174119
-                  slug: product-1174119
+                  name: Product 117861
+                  slug: product-117861
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5137,7 +5139,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H28447050387
+                  number: H31605697508
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5166,7 +5168,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Rafaela Wiza
+                    name: Ilona Leuschke
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5195,8 +5197,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260526151847106486
-                  number: P0843JCG
+                  response_code: 1-SC-20260526153800327758
+                  number: PVRT65UP
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: checkout
@@ -5223,7 +5225,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 207 Lovely Street
+                  address1: 203 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -5242,7 +5244,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 208 Lovely Street
+                  address1: 204 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -5375,9 +5377,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R977551241
-                token: RpTqDb5DBbtGa1KS9dyqsAu9iiiqxNs2sDB
-                email: mckinley.gutmann@gulgowski.com
+                number: R206030460
+                token: GP7wS7WS4U31U8dgKxAU2zQns61k7BDrkFm
+                email: maple@schowalter.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -5419,8 +5421,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1215095
-                  slug: product-1215095
+                  name: Product 1219747
+                  slug: product-1219747
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5445,7 +5447,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H48022064922
+                  number: H57934696315
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5474,7 +5476,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Laticia Crist
+                    name: Kareem McKenzie
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5503,8 +5505,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260526151849756905
-                  number: PXXO590U
+                  response_code: 1-SC-20260526153802888161
+                  number: PH8B107A
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: invalid
@@ -5531,7 +5533,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 223 Lovely Street
+                  address1: 219 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -5550,7 +5552,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 224 Lovely Street
+                  address1: 220 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -5628,7 +5630,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: DDE21760979E4D26
+                  code: 89D6BB75EF9E64AE
                   status: active
                   currency: USD
                   amount: '10.0'
@@ -5724,7 +5726,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: F83C2B7B5380C478
+                code: EA7BBE7AD1A2C2BD
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -5815,9 +5817,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R092402852
-                token: qwBgb6XQM6zFgJLY2ojzech8vMy491CjCA6
-                email: nicole@abshire.info
+                number: R874771603
+                token: kBTVikFUtj784edEmZpNBefacp2BMvjcFW9
+                email: pamela@wiza.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -5865,8 +5867,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1242224
-                  slug: product-1242224
+                  name: Product 1246172
+                  slug: product-1246172
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5893,8 +5895,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 1254165
-                  slug: product-1254165
+                  name: Product 1257042
+                  slug: product-1257042
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -5924,7 +5926,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 238 Lovely Street
+                  address1: 234 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -6037,9 +6039,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R798905018
-                token: jnn6NUz7UFdi2ntAeMG1UdamJaECf1KWft1
-                email: justin_crooks@turnerhagenes.name
+                number: R210411134
+                token: RmvBx39wicsHrzj6dHaUjUryykCqqQjuNqF
+                email: slyvia.schneider@harvey.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -6084,8 +6086,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1285651
-                  slug: product-1285651
+                  name: Product 1285574
+                  slug: product-1285574
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6115,7 +6117,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 247 Lovely Street
+                  address1: 243 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -6208,9 +6210,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R516488661
-                token: gRdozv9x8DHnMSBEMY5iPiWy6LweyxWwma1
-                email: melani@mcdermott.com
+                number: R269763917
+                token: 7bFMBSMVMzipBFrYknFjYBSdpXp4hqqVXve
+                email: rashad@haleygrimes.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -6261,7 +6263,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 250 Lovely Street
+                  address1: 246 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -6821,11 +6823,11 @@ paths:
             application/json:
               example:
                 id: sub_UkLWZg9DAJ
-                email: trang@wisoky.co.uk
-                created_at: '2026-05-26T15:18:58.261Z'
-                updated_at: '2026-05-26T15:18:58.263Z'
+                email: margarette_considine@kris.biz
+                created_at: '2026-05-26T15:38:10.673Z'
+                updated_at: '2026-05-26T15:38:10.676Z'
                 verified: true
-                verified_at: '2026-05-26T15:18:58Z'
+                verified_at: '2026-05-26T15:38:10Z'
                 customer_id: cus_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -6904,10 +6906,10 @@ paths:
               example:
                 id: sub_UkLWZg9DAJ
                 email: pending@example.com
-                created_at: '2026-05-26T15:18:58.286Z'
-                updated_at: '2026-05-26T15:18:58.301Z'
+                created_at: '2026-05-26T15:38:10.698Z'
+                updated_at: '2026-05-26T15:38:10.707Z'
                 verified: true
-                verified_at: '2026-05-26T15:18:58Z'
+                verified_at: '2026-05-26T15:38:10Z'
                 customer_id:
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -7005,7 +7007,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R343738947
+                number: R917825879
                 email: guest@example.com
                 customer_note:
                 currency: USD
@@ -7033,7 +7035,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:18:59.042Z'
+                completed_at: '2026-05-26T15:38:11.463Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -7043,8 +7045,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1329945
-                  slug: product-1329945
+                  name: Product 1329397
+                  slug: product-1329397
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7069,7 +7071,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H28584229086
+                  number: H32620565377
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -7098,7 +7100,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Daina Hermann
+                    name: Genoveva Harber
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7130,7 +7132,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 260 Lovely Street
+                  address1: 256 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -7149,7 +7151,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 261 Lovely Street
+                  address1: 257 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -7243,9 +7245,9 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_0700e17faa1837c001511f81
+                external_id: bogus_ff3f04085f7251909ff5a444
                 external_data:
-                  client_secret: bogus_secret_9c77bde25df31471
+                  client_secret: bogus_secret_0ca9845259e00e2e
                 customer_external_id:
                 expires_at:
                 amount: '110.0'
@@ -7343,7 +7345,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_320015ac5c056ccc25aa2723
+                external_id: bogus_4d76cceb5949aca1f607f39e
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7405,7 +7407,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_51b94c093e4c1ddd5fd3a920
+                external_id: bogus_8dcacbfb9c7eca45595b0d90
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7507,7 +7509,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_ef770656e1326eade8816880
+                external_id: bogus_c9c27c106afde0b762dcb352
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7592,8 +7594,8 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_90862b635aec3b35fca6374c
-                external_client_secret: bogus_seti_secret_ca7ef34fe7a5ad16
+                external_id: bogus_seti_626428bd5f19304143c8d3e2
+                external_client_secret: bogus_seti_secret_eedfe4c913da1edb
                 external_data: {}
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
@@ -7692,8 +7694,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_b355e93ced50c51e8e54f235
-                external_client_secret: seti_secret_fe9e9907cdb023c6e06ca883
+                external_id: seti_test_eca5d52087f5c77f56af6b94
+                external_client_secret: seti_secret_8120cbc70c9f7dbeaee7e5e5
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7769,8 +7771,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_3c2fe35422bcb8663e9c7656
-                external_client_secret: seti_secret_8f096ee3dc62fd925aeaa4fb
+                external_id: seti_test_896c062cc747863746b494d6
+                external_client_secret: seti_secret_6a5120adbea8fdbf136a2fdc
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7864,7 +7866,7 @@ paths:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 response_code:
-                number: PLT4ONYC
+                number: PE18A1T6
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7960,7 +7962,7 @@ paths:
                   body_html: ''
                 - id: pol_OIJLhNcSbf
                   name: Privacy Policy
-                  slug: privacy-policy-589e0a93-8fbc-4ac7-be33-2a43079cfc7c
+                  slug: privacy-policy-b9cfe5a5-8d47-49b5-b8be-c111e206e077
                   body: We respect your privacy.
                   body_html: |
                     <div class="trix-content">
@@ -8204,13 +8206,13 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1426035
-                  slug: product-1426035
+                  name: Product 1429156
+                  slug: product-1429156
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-05-26T15:19:09.467Z'
+                  available_on: '2025-05-26T15:38:21.861Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -8232,36 +8234,43 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 1436961
-                  slug: product-1436961
+                  name: Product 1431122
+                  slug: product-1431122
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-26T15:19:09.519Z'
+                  available_on: '2025-05-26T15:38:21.927Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Eius deleniti dolorum fugiat vitae et non. Totam a
-                    eligendi sit veniam facere sunt. Eveniet explicabo consequatur
-                    mollitia dicta molestias esse. Natus rem architecto cumque minima.
-                    Dolorum maxime maiores ad repellendus modi dolorem sint delectus.
-                    Recusandae quaerat quas perspiciatis adipisci eligendi. Aut dolore
-                    sint ipsam eligendi natus culpa eum. Deserunt eius animi voluptatem
-                    commodi quasi sint. Corporis repellendus atque autem quasi. Suscipit
-                    eveniet excepturi rerum hic illum perspiciatis nihil. Ad ratione
-                    voluptatibus quas est ducimus odio minima hic. Tempora recusandae
-                    ducimus saepe nobis accusantium nemo. Magni eos in corporis delectus
-                    molestiae quaerat. Aperiam inventore dolor cum provident aspernatur
-                    excepturi beatae tenetur. Maxime quos consectetur omnis pariatur
-                    quam dolor. Quod nemo totam quis modi consectetur nobis adipisci.
-                    Minima dignissimos ad nemo accusantium numquam distinctio modi.
+                  description: Architecto cupiditate voluptates quis fuga. Tenetur
+                    blanditiis asperiores consequuntur ab tempora. Sint id dignissimos
+                    occaecati maiores velit quam modi explicabo. Aut fugiat enim ab
+                    unde alias. Atque corporis repudiandae maiores molestiae laudantium
+                    eveniet suscipit laborum. Sunt necessitatibus assumenda fugit
+                    cumque itaque. Temporibus non totam quisquam perferendis itaque
+                    praesentium. Deserunt fugiat eveniet labore nulla commodi. Eligendi
+                    natus placeat molestias iste soluta molestiae veritatis cupiditate.
+                    Consectetur illo nisi sunt cupiditate recusandae possimus. Voluptates
+                    in doloribus officiis voluptate quibusdam rerum. Adipisci vel
+                    esse nam distinctio voluptatum veritatis impedit sit. Exercitationem
+                    sequi nostrum nemo voluptas blanditiis maxime soluta officia.
+                    Delectus cupiditate corrupti rem assumenda provident ab eveniet.
+                    Eaque veniam nemo unde atque quo. Quidem unde ipsum atque hic
+                    deleniti. Nobis animi possimus cumque doloribus iste eligendi
+                    impedit reiciendis. Inventore officiis nobis sunt fuga repellendus
+                    autem repudiandae. Molestiae magni repellendus illum voluptatum
+                    esse debitis libero. Sunt nulla harum nemo cum occaecati. Praesentium
+                    delectus consequatur voluptates consectetur. Eaque alias molestias
+                    expedita porro eum officiis quas quo.
                   description_html: |-
-                    Eius deleniti dolorum fugiat vitae et non. Totam a eligendi sit veniam facere sunt. Eveniet explicabo consequatur mollitia dicta molestias esse. Natus rem architecto cumque minima. Dolorum maxime maiores ad repellendus modi dolorem sint delectus.
-                    Recusandae quaerat quas perspiciatis adipisci eligendi. Aut dolore sint ipsam eligendi natus culpa eum. Deserunt eius animi voluptatem commodi quasi sint. Corporis repellendus atque autem quasi.
-                    Suscipit eveniet excepturi rerum hic illum perspiciatis nihil. Ad ratione voluptatibus quas est ducimus odio minima hic. Tempora recusandae ducimus saepe nobis accusantium nemo. Magni eos in corporis delectus molestiae quaerat. Aperiam inventore dolor cum provident aspernatur excepturi beatae tenetur.
-                    Maxime quos consectetur omnis pariatur quam dolor. Quod nemo totam quis modi consectetur nobis adipisci. Minima dignissimos ad nemo accusantium numquam distinctio modi.
+                    Architecto cupiditate voluptates quis fuga. Tenetur blanditiis asperiores consequuntur ab tempora. Sint id dignissimos occaecati maiores velit quam modi explicabo. Aut fugiat enim ab unde alias. Atque corporis repudiandae maiores molestiae laudantium eveniet suscipit laborum.
+                    Sunt necessitatibus assumenda fugit cumque itaque. Temporibus non totam quisquam perferendis itaque praesentium. Deserunt fugiat eveniet labore nulla commodi. Eligendi natus placeat molestias iste soluta molestiae veritatis cupiditate. Consectetur illo nisi sunt cupiditate recusandae possimus.
+                    Voluptates in doloribus officiis voluptate quibusdam rerum. Adipisci vel esse nam distinctio voluptatum veritatis impedit sit. Exercitationem sequi nostrum nemo voluptas blanditiis maxime soluta officia. Delectus cupiditate corrupti rem assumenda provident ab eveniet. Eaque veniam nemo unde atque quo.
+                    Quidem unde ipsum atque hic deleniti. Nobis animi possimus cumque doloribus iste eligendi impedit reiciendis. Inventore officiis nobis sunt fuga repellendus autem repudiandae.
+                    Molestiae magni repellendus illum voluptatum esse debitis libero. Sunt nulla harum nemo cum occaecati. Praesentium delectus consequatur voluptates consectetur. Eaque alias molestias expedita porro eum officiis quas quo.
                   default_variant_id: variant_EfhxLZ9ck8
                   thumbnail_url:
                   tags: []
@@ -8363,13 +8372,13 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 1707862
-                slug: product-1707862
+                name: Product 1707032
+                slug: product-1707032
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-05-26T15:19:10.902Z'
+                available_on: '2025-05-26T15:38:23.597Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -8396,7 +8405,7 @@ paths:
                   amount_in_cents: 999
                   currency: USD
                   display_amount: "$9.99"
-                  recorded_at: '2026-05-11T15:19:10Z'
+                  recorded_at: '2026-05-11T15:38:23Z'
               schema:
                 "$ref": "#/components/schemas/Product"
         '404':
@@ -8771,9 +8780,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R161014377
-                token: Kubs8ysPbZpppfQzuui3QgKMzRYnWSmdMRB
-                email: maxwell@hauck.ca
+                number: R431665319
+                token: y9RwVuYgeDcBkccKnX3kjdWKELzyzgTfege
+                email: rafael_paucek@casper.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -8812,8 +8821,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1904547
-                  slug: product-1904547
+                  name: Product 1906245
+                  slug: product-1906245
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -8838,7 +8847,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H37207137670
+                  number: H05530615606
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -8867,7 +8876,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Jeanne Carroll
+                    name: Lanora Hirthe
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -8896,8 +8905,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260526151916068791
-                  number: P41JGOY8
+                  response_code: 1-SC-20260526153828961175
+                  number: P9PHJKI7
                   amount: '10.0'
                   display_amount: "$10.00"
                   status: checkout
@@ -8924,7 +8933,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 324 Lovely Street
+                  address1: 320 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -8943,7 +8952,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 325 Lovely Street
+                  address1: 321 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -9040,9 +9049,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R121095421
-                token: 7k2A6E8uoxqnqHHEYhp7x9hWnVu8yvAnRvp
-                email: mozella@prosacco.biz
+                number: R701106151
+                token: d71VruvCcMbK4zcCD8TvvgmAZpBvQNzmBU7
+                email: huong_kessler@becker.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -9084,8 +9093,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1924302
-                  slug: product-1924302
+                  name: Product 1926273
+                  slug: product-1926273
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -9110,7 +9119,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H09699694367
+                  number: H54912924704
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -9139,7 +9148,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Mirian Hand
+                    name: Alberta Bashirian
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -9171,7 +9180,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 332 Lovely Street
+                  address1: 328 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -9190,7 +9199,7 @@ paths:
                   first_name: John
                   last_name: Doe
                   full_name: John Doe
-                  address1: 333 Lovely Street
+                  address1: 329 Lovely Street
                   address2: Northwest
                   postal_code: '10118'
                   city: New York
@@ -9269,7 +9278,7 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: Nvi8s72a2YB45NeCjK7DGvZ4
+                  token: crmx6PTbvJHbhpwuSBgB9bRF
                   is_default: false
                   is_private: true
                 meta:
@@ -9345,7 +9354,7 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: svZetprRURhh8BPnkeYASHQC
+                token: VQV5AxYmsWCTu8uzR8a5cuqv
                 is_default: false
                 is_private: true
               schema:
@@ -9441,7 +9450,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: GWbrZqTpfyqcUNgbTfqYm9JT
+                token: Sq8rjnm6ZdRFHiJRaEokNwRf
                 is_default: false
                 is_private: true
               schema:
@@ -9503,7 +9512,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: uhSCTcyW2QHcPwhqG7FL61vV
+                token: zXfbwrobotUvjVTpim8k4Anf
                 is_default: false
                 is_private: true
               schema:

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -561,8 +561,19 @@ paths:
       - Authentication
       security:
       - api_key: []
-      description: Authenticates a customer with email/password and returns a JWT
-        token
+      description: |
+        Authenticates a customer and returns a JWT access token + refresh token.
+
+        Dispatches by the `provider` field to a strategy registered in
+        `Spree.store_authentication_strategies`. When `provider` is omitted it
+        defaults to `email`, which uses the built-in email/password strategy.
+
+        To plug in a third-party identity provider (Auth0, Okta, Firebase, a
+        custom JWT issuer, SAML, etc.), register a `Spree::Authentication::Strategies::BaseStrategy`
+        subclass under a provider key, then send `{ "provider": "<your_key>", ... }`
+        with the fields your strategy requires. The endpoint returns the same
+        Spree-issued JWT + refresh token regardless of which strategy authenticated
+        the request.
       x-codeSamples:
       - lang: javascript
         label: Spree SDK
@@ -590,16 +601,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImFjMTYxZjIyLTY2ODUtNDM0My1hZjhlLWFmNmZiY2Q4NzA3ZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzE2fQ.BuOWlcghPrLfW7-ka3a2yD1Giq5DAG-5amAPCOsJOvY
-                refresh_token: PZZGJT4udwGkyKEPgs4WRtus
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjIxYTBkZTI2LWVjYmMtNGY5OC04ZDVjLTZmMGI0NTIwYTI0NSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzAyfQ.kdlwXNcgs2jyogbR6hqL-_AWBbYPJ_zh-s46lWFiTsc
+                refresh_token: VNkXPSibSKSNPvu2TbPa5fzc
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Henriette
-                  last_name: Stamm
+                  first_name: Stephaine
+                  last_name: Towne
                   phone:
                   accepts_email_marketing: false
-                  full_name: Henriette Stamm
+                  full_name: Stephaine Towne
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -621,22 +632,42 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                provider:
-                  type: string
-                  example: email
-                  description: 'Authentication provider (default: email)'
-                email:
-                  type: string
-                  format: email
-                  example: customer@example.com
-                password:
-                  type: string
-                  example: password123
-              required:
-              - email
-              - password
+              oneOf:
+              - title: EmailPasswordLogin
+                description: Built-in email/password authentication (default when
+                  `provider` is omitted).
+                type: object
+                properties:
+                  provider:
+                    type: string
+                    enum:
+                    - email
+                    default: email
+                  email:
+                    type: string
+                    format: email
+                    example: customer@example.com
+                  password:
+                    type: string
+                    example: password123
+                required:
+                - email
+                - password
+              - title: ProviderLogin
+                description: |
+                  Provider-dispatched login. The `provider` key selects a registered
+                  strategy class; the remaining fields are forwarded to the strategy's
+                  `authenticate` method. Required fields depend on the registered strategy
+                  — consult its documentation.
+                type: object
+                properties:
+                  provider:
+                    type: string
+                    example: auth0
+                    description: Registered provider key (anything other than `email`).
+                required:
+                - provider
+                additionalProperties: true
   "/api/v3/store/auth/refresh":
     post:
       summary: Refresh token
@@ -672,16 +703,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijg2NTFkMTJlLTRiMTItNDZhNi1hYjgzLTY4MjI1YWNhN2FhYyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzE3fQ.mz2V3U-_6wrTzoLytYOOGc7mgH7eG71jQ_oA4mIHGtY
-                refresh_token: sRppucnbaakQTvpFCoJArcde
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImM2Y2NkYWNhLThkMzktNGVkOS1iNWM0LTJiZWZhMGQ3Y2RmOCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzAzfQ.83Gw0ZK9l767kGVmPFtTYp6QETckMFWaJvnPYiKWdyI
+                refresh_token: zJrHUhRhsgAKZapCNfSiHZ9V
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Richard
-                  last_name: Larson
+                  first_name: Janie
+                  last_name: Funk
                   phone:
                   accepts_email_marketing: false
-                  full_name: Richard Larson
+                  full_name: Janie Funk
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -845,9 +876,9 @@ paths:
                 data:
                 - id: cart_gbHJdmfrXB
                   market_id:
-                  number: R560405209
-                  token: iqxaKurjyPCbwiuDRJwhMTLpUQs2SCohKfM
-                  email: carly@nicolas.com
+                  number: R122236372
+                  token: U2nim1qtQjuDyj2kTq3HSdHo4Kkj8nLT6wT
+                  email: jaymie_goyette@stiedemann.info
                   customer_note:
                   currency: USD
                   locale: en
@@ -889,8 +920,8 @@ paths:
                     variant_id: variant_gbHJdmfrXB
                     quantity: 1
                     currency: USD
-                    name: Product 584574
-                    slug: product-584574
+                    name: Product 833501
+                    slug: product-833501
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -915,7 +946,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_gbHJdmfrXB
-                    number: H60885401848
+                    number: H60984625405
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -944,7 +975,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Milissa Kutch
+                      name: Young West
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1014,9 +1045,9 @@ paths:
                   market:
                 - id: cart_UkLWZg9DAJ
                   market_id:
-                  number: R504946559
-                  token: hC1f3UJxu4NErrgku3ZwU2LT4szVo2mJGUv
-                  email: carly@nicolas.com
+                  number: R524109072
+                  token: RDe6KqL3ttuQMTJiiF4QaoMKvdSsNsJQdQR
+                  email: jaymie_goyette@stiedemann.info
                   customer_note:
                   currency: USD
                   locale: en
@@ -1058,8 +1089,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 576038
-                    slug: product-576038
+                    name: Product 825207
+                    slug: product-825207
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1084,7 +1115,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H14566689291
+                    number: H98781380235
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -1113,7 +1144,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Milissa Kutch
+                      name: Young West
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1256,8 +1287,8 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R582709141
-                token: sbMgF8VrnBNczXfdVscfNEDYvzNFowJwh2s
+                number: R319530089
+                token: vXZwiq43kwPRgMF4j4GENW3ZqQKe13j2g3g
                 email:
                 customer_note:
                 currency: USD
@@ -1412,9 +1443,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R911594733
-                token: A3bGmry4ZwaVKavBsi7VH9dHvdws3WTttaD
-                email: carmine_littel@kshlerin.ca
+                number: R759835307
+                token: YFMEQyRfA9f68iKC1edGzbsHQRhSsAsrZEo
+                email: sabrina_heathcote@pfannerstill.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -1441,7 +1472,7 @@ paths:
                 display_delivery_total: "$0.00"
                 warnings:
                 - code: line_item_removed
-                  message: Product 62216 was removed because it was sold out
+                  message: Product 879473 was removed because it was sold out
                   line_item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                 store_credit_total: '0.0'
@@ -1583,9 +1614,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R537545049
-                token: YAfcmRTUDf8ak8FPefKTgpqKXuur3RZrz5S
-                email: viola.dickens@mitchellcollier.com
+                number: R174029970
+                token: PBCAthebZu4iKwNEWrNHk4z2E7ubSWnHqWB
+                email: eugena@hermiston.com
                 customer_note: Leave at door
                 currency: USD
                 locale: en
@@ -1629,8 +1660,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 637993
-                  slug: product-637993
+                  name: Product 885746
+                  slug: product-885746
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -1655,7 +1686,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H35255737216
+                  number: H15282670883
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -1684,7 +1715,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Chung O'Keefe
+                    name: Amada Schuppe
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1921,9 +1952,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R231347948
-                token: RnHB5VgA21xi2SsJFvCKad7qbWLdo47QGnV
-                email: reinaldo@hesselschimmel.info
+                number: R161299580
+                token: Ndo7cgwrPYT44N6844Lyf2eAUFzevA4Lwnh
+                email: kelvin@beierbergnaum.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -1965,8 +1996,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 653132
-                  slug: product-653132
+                  name: Product 908099
+                  slug: product-908099
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -1991,7 +2022,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H45239248483
+                  number: H17401405738
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -2020,7 +2051,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Dexter Boyer
+                    name: Kristian Durgan
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2155,8 +2186,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R264397359
-                email: enda@becker.ca
+                number: R169779204
+                email: daphne.okuneva@bogan.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -2183,7 +2214,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: backorder
                 payment_status: paid
-                completed_at: '2026-05-21T18:12:04.119Z'
+                completed_at: '2026-05-26T15:18:29.801Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -2193,8 +2224,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 679791
-                  slug: product-679791
+                  name: Product 926059
+                  slug: product-926059
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -2219,7 +2250,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H72789993064
+                  number: H62448608797
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -2248,7 +2279,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Gabriela Kemmer
+                    name: Marna Boehm
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2277,8 +2308,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-6d4860421892
-                  number: PDDA4ACI
+                  response_code: BGS-877e14020a23
+                  number: P8RI17CO
                   amount: '29.99'
                   display_amount: "$29.99"
                   status: completed
@@ -2412,8 +2443,8 @@ paths:
               example:
                 data:
                 - id: ctg_UkLWZg9DAJ
-                  name: taxonomy_1
-                  permalink: taxonomy-1
+                  name: taxonomy_3
+                  permalink: taxonomy-3
                   position: 0
                   depth: 0
                   meta_title:
@@ -2429,8 +2460,8 @@ paths:
                   is_child: false
                   is_leaf: false
                 - id: ctg_gbHJdmfrXB
-                  name: taxon_1
-                  permalink: taxonomy-1/taxon-1
+                  name: taxon_3
+                  permalink: taxonomy-3/taxon-3
                   position: 0
                   depth: 1
                   meta_title:
@@ -2446,8 +2477,8 @@ paths:
                   is_child: true
                   is_leaf: false
                 - id: ctg_EfhxLZ9ck8
-                  name: taxon_2
-                  permalink: taxonomy-1/taxon-1/taxon-2
+                  name: taxon_4
+                  permalink: taxonomy-3/taxon-3/taxon-4
                   position: 0
                   depth: 2
                   meta_title:
@@ -2546,8 +2577,8 @@ paths:
             application/json:
               example:
                 id: ctg_gbHJdmfrXB
-                name: taxon_10
-                permalink: taxonomy-7/taxon-10
+                name: taxon_12
+                permalink: taxonomy-9/taxon-12
                 position: 0
                 depth: 1
                 meta_title:
@@ -3134,16 +3165,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImRhYjViODFiLWZkODQtNDU1NC1iZjJkLWFlYWUzZWJjYWEyZiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzMwfQ.A7ZqLfCc-PN69iuQHuMdSM6U_leCsrC5gV5ABpuwtbc
-                refresh_token: S8rzSN7cnzSAwzjbRFiTKHL8
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjEyZDM1YWNjLWY5ODQtNDYyYi05YjEzLTQ4ODZjNzRmN2VhMSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzE1fQ.ynX1AI2VeWCg7xRYVGCdtb06JFbgEFZD7o4z0Tq4yOo
+                refresh_token: pBQXxsimdEvXSBv3HbfCjXEV
                 user:
                   id: cus_UkLWZg9DAJ
                   email: customer@example.com
-                  first_name: Denita
-                  last_name: Rau
+                  first_name: America
+                  last_name: Ruecker
                   phone:
                   accepts_email_marketing: false
-                  full_name: Denita Rau
+                  full_name: America Ruecker
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -3316,8 +3347,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R600105954
-                  email: adria@okuneva.biz
+                  number: R640848252
+                  email: dong.considine@powlowski.name
                   customer_note:
                   currency: USD
                   locale: en
@@ -3344,7 +3375,7 @@ paths:
                   display_delivery_total: "$100.00"
                   fulfillment_status:
                   payment_status:
-                  completed_at: '2026-05-21T18:12:11.464Z'
+                  completed_at: '2026-05-26T15:18:36.842Z'
                   store_credit_total: '0.0'
                   display_store_credit_total: "$0.00"
                   covered_by_store_credit: false
@@ -3354,8 +3385,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 767917
-                    slug: product-767917
+                    name: Product 1014923
+                    slug: product-1014923
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -3380,7 +3411,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H90711662288
+                    number: H32758246803
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -3409,7 +3440,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Annie Marks
+                      name: Josefa Jakubowski
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -3572,8 +3603,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R060306455
-                email: josefine.friesen@armstrong.co.uk
+                number: R918052512
+                email: nakesha.beatty@nolan.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -3600,7 +3631,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-21T18:12:12.168Z'
+                completed_at: '2026-05-26T15:18:37.521Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -3610,8 +3641,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 787709
-                  slug: product-787709
+                  name: Product 1035339
+                  slug: product-1035339
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3636,7 +3667,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H26048702619
+                  number: H89370037960
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -3665,7 +3696,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Nyla Rau
+                    name: Georgann Boyle
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3785,8 +3816,8 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImVkNGE2MDhlLTdmNmUtNDc5NS1iNDc0LWU0MGQ2NGY1NjM0NCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5MzkwNzMzfQ.zdjx-98AkEn-FCaKaIeYCOa0VzQacbTGsoD8RtSVrIc
-                refresh_token: JmzdDVvP1CZnWvpsNvAwkEos
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk1Yjg3NjI0LWE3YjEtNDkzZi05YzU4LTAyNzVmNTFmYjlkZiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEyMzE4fQ.M8RoE9VIS-WgTrwnHG35LLwtqZLft8C7-Oe2mCwxTZY
+                refresh_token: LG1mA3CHWx7uBMQrWc7xKv14
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
@@ -3900,12 +3931,12 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: drew@skiles.ca
-                first_name: Zackary
-                last_name: Lind
+                email: bruno@gusikowski.com
+                first_name: Carmelita
+                last_name: Ortiz
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                full_name: Zackary Lind
+                full_name: Carmelita Ortiz
                 available_store_credit_total: '0'
                 display_available_store_credit_total: "$0.00"
                 addresses:
@@ -4039,7 +4070,7 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: mimi_marquardt@gibson.co.uk
+                email: zelda.shanahan@millsnienow.co.uk
                 first_name: Updated
                 last_name: Name
                 phone: 555-555-0199
@@ -4279,9 +4310,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R983640452
-                token: FUsN4w2fk57RAyQxK2uwVh1EFUSeoApoNWz
-                email: jamey@weberwalter.ca
+                number: R469093938
+                token: xikLpS3L51xVhCEPeZFsnQJtk3EuRxKnbB8
+                email: rivka_koelpin@paucekmoen.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -4330,8 +4361,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 868984
-                  slug: product-868984
+                  name: Product 1111413
+                  slug: product-1111413
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4356,7 +4387,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H01257048332
+                  number: H93637457615
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4385,7 +4416,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Idell Corkery
+                    name: Saul Lynch
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4539,9 +4570,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R506477402
-                token: ZbbF51wzUqPGTMG3ngYRzSSDbLK3Ee9wdcW
-                email: norris@wintheiser.us
+                number: R545084696
+                token: iCyC1iunB3FTmAr5bD3wc6FK2UGP9hrokv8
+                email: tanisha_doyle@gutmannmonahan.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -4583,8 +4614,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 883927
-                  slug: product-883927
+                  name: Product 1133189
+                  slug: product-1133189
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4609,7 +4640,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H66163861804
+                  number: H05571311130
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4638,7 +4669,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Faye Kertzmann
+                    name: Rosaura Breitenberg
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4781,9 +4812,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R787693305
-                token: naZG9yps6zPNYyBArZBgKKY6nnqYpGC5rTw
-                email: isabelle.gutmann@batzdaugherty.com
+                number: R097838778
+                token: FowNXKT85S6DtwNUunGAQ8pzDw1mCBxuNb5
+                email: kyra.upton@pfannerstillshanahan.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -4827,8 +4858,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 905832
-                  slug: product-905832
+                  name: Product 1154817
+                  slug: product-1154817
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4853,7 +4884,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H48213234073
+                  number: H63032637002
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4882,7 +4913,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Kerri Hahn
+                    name: Millie Ebert
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5039,9 +5070,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R501407956
-                token: mBMtKueSANaxHuT7o3H1zs5CWXfBtLZR76a
-                email: aldo.hickle@bode.co.uk
+                number: R930046502
+                token: iu4XzoHZHCYJ4uKksYJnHRgy4XmXJ3AfoYo
+                email: luella@okuneva.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -5080,8 +5111,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 923228
-                  slug: product-923228
+                  name: Product 1174119
+                  slug: product-1174119
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5106,7 +5137,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H63891944560
+                  number: H28447050387
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5135,7 +5166,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Julieann Kuhn
+                    name: Rafaela Wiza
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5164,8 +5195,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260521181222228580
-                  number: PLBPL882
+                  response_code: 1-SC-20260526151847106486
+                  number: P0843JCG
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: checkout
@@ -5344,9 +5375,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R971301843
-                token: TAXrAS6nE34CGB4J4SM9jYAC7D1LAfEdvuB
-                email: beatris@monahanconsidine.name
+                number: R977551241
+                token: RpTqDb5DBbtGa1KS9dyqsAu9iiiqxNs2sDB
+                email: mckinley.gutmann@gulgowski.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -5388,8 +5419,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 966445
-                  slug: product-966445
+                  name: Product 1215095
+                  slug: product-1215095
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5414,7 +5445,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H50426852278
+                  number: H48022064922
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5443,7 +5474,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Hilda Gorczany
+                    name: Laticia Crist
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5472,8 +5503,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260521181224917306
-                  number: P50IZG86
+                  response_code: 1-SC-20260526151849756905
+                  number: PXXO590U
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: invalid
@@ -5597,7 +5628,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: DFE1B771D0A9F320
+                  code: DDE21760979E4D26
                   status: active
                   currency: USD
                   amount: '10.0'
@@ -5693,7 +5724,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: B3971A4B112F7143
+                code: F83C2B7B5380C478
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -5784,9 +5815,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R881799706
-                token: RVbjRddtDRtcExjXQRpMB8Bim5LNSShGBH6
-                email: remona@effertzbauch.info
+                number: R092402852
+                token: qwBgb6XQM6zFgJLY2ojzech8vMy491CjCA6
+                email: nicole@abshire.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -5834,8 +5865,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 996441
-                  slug: product-996441
+                  name: Product 1242224
+                  slug: product-1242224
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5862,8 +5893,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 1009810
-                  slug: product-1009810
+                  name: Product 1254165
+                  slug: product-1254165
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -6006,9 +6037,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R794423726
-                token: 1sJMUmLYsh3UaeGjL4VQKgK3DMj8h2YAx2z
-                email: pablo_corwin@hillsstark.biz
+                number: R798905018
+                token: jnn6NUz7UFdi2ntAeMG1UdamJaECf1KWft1
+                email: justin_crooks@turnerhagenes.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -6053,8 +6084,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1039114
-                  slug: product-1039114
+                  name: Product 1285651
+                  slug: product-1285651
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6177,9 +6208,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R184817343
-                token: vPBcAwTjPCjFLRYvznh9D9dkaWZt8aapnyH
-                email: michael.lang@hackett.com
+                number: R516488661
+                token: gRdozv9x8DHnMSBEMY5iPiWy6LweyxWwma1
+                email: melani@mcdermott.com
                 customer_note:
                 currency: USD
                 locale: en
@@ -6370,6 +6401,8 @@ paths:
                   default_locale: en
                   tax_inclusive: false
                   default: true
+                  country_isos:
+                  - US
                   supported_locales:
                   - en
                   - es
@@ -6385,6 +6418,9 @@ paths:
                   default_locale: de
                   tax_inclusive: true
                   default: false
+                  country_isos:
+                  - DE
+                  - FR
                   supported_locales:
                   - de
                   - en
@@ -6469,6 +6505,9 @@ paths:
                 default_locale: de
                 tax_inclusive: true
                 default: false
+                country_isos:
+                - DE
+                - FR
                 supported_locales:
                 - de
                 - en
@@ -6549,6 +6588,9 @@ paths:
                 default_locale: de
                 tax_inclusive: true
                 default: false
+                country_isos:
+                - DE
+                - FR
                 supported_locales:
                 - de
                 - en
@@ -6757,9 +6799,6 @@ paths:
 
           const subscriber = await client.newsletterSubscribers.create({
             email: 'subscriber@example.com',
-            // Where the verification token should land. Must be in the store's
-            // allowed origins. The storefront's webhook handler will send the
-            // confirmation email with a link to `<redirect_url>?token=<token>`.
             redirect_url: 'https://your-store.com/newsletter/confirm',
           })
       parameters:
@@ -6782,11 +6821,11 @@ paths:
             application/json:
               example:
                 id: sub_UkLWZg9DAJ
-                email: eufemia@stoltenbergwalter.ca
-                created_at: '2026-05-21T18:12:32.551Z'
-                updated_at: '2026-05-21T18:12:32.553Z'
+                email: trang@wisoky.co.uk
+                created_at: '2026-05-26T15:18:58.261Z'
+                updated_at: '2026-05-26T15:18:58.263Z'
                 verified: true
-                verified_at: '2026-05-21T18:12:32Z'
+                verified_at: '2026-05-26T15:18:58Z'
                 customer_id: cus_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -6865,10 +6904,10 @@ paths:
               example:
                 id: sub_UkLWZg9DAJ
                 email: pending@example.com
-                created_at: '2026-05-21T18:12:32.578Z'
-                updated_at: '2026-05-21T18:12:32.591Z'
+                created_at: '2026-05-26T15:18:58.286Z'
+                updated_at: '2026-05-26T15:18:58.301Z'
                 verified: true
-                verified_at: '2026-05-21T18:12:32Z'
+                verified_at: '2026-05-26T15:18:58Z'
                 customer_id:
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -6966,7 +7005,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R444420762
+                number: R343738947
                 email: guest@example.com
                 customer_note:
                 currency: USD
@@ -6994,7 +7033,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-21T18:12:33.331Z'
+                completed_at: '2026-05-26T15:18:59.042Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -7004,8 +7043,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1079404
-                  slug: product-1079404
+                  name: Product 1329945
+                  slug: product-1329945
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7030,7 +7069,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H37244671113
+                  number: H28584229086
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -7059,7 +7098,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Bud Bartoletti
+                    name: Daina Hermann
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7204,9 +7243,9 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_799f9d0cdd2a024b44a972f2
+                external_id: bogus_0700e17faa1837c001511f81
                 external_data:
-                  client_secret: bogus_secret_e705380ff182660e
+                  client_secret: bogus_secret_9c77bde25df31471
                 customer_external_id:
                 expires_at:
                 amount: '110.0'
@@ -7304,7 +7343,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_aecf7276c91c09ca9e9ec79a
+                external_id: bogus_320015ac5c056ccc25aa2723
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7366,7 +7405,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_4d892ef9777434a81f39f60d
+                external_id: bogus_51b94c093e4c1ddd5fd3a920
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7468,7 +7507,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_a8a35246fb9e9da3d0a251b8
+                external_id: bogus_ef770656e1326eade8816880
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7553,8 +7592,8 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_c85316f2ab8114ec81687ed4
-                external_client_secret: bogus_seti_secret_a15e9cd71178a98c
+                external_id: bogus_seti_90862b635aec3b35fca6374c
+                external_client_secret: bogus_seti_secret_ca7ef34fe7a5ad16
                 external_data: {}
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
@@ -7653,8 +7692,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_674107c9a4a65317bbdc129d
-                external_client_secret: seti_secret_66eb1d151fa172598a741e14
+                external_id: seti_test_b355e93ced50c51e8e54f235
+                external_client_secret: seti_secret_fe9e9907cdb023c6e06ca883
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7730,8 +7769,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_047d39fe078d8f5dfb59fc7a
-                external_client_secret: seti_secret_8320035d2ef40c47c4e63f5b
+                external_id: seti_test_3c2fe35422bcb8663e9c7656
+                external_client_secret: seti_secret_8f096ee3dc62fd925aeaa4fb
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7825,7 +7864,7 @@ paths:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 response_code:
-                number: PDW8QZGM
+                number: PLT4ONYC
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7921,7 +7960,7 @@ paths:
                   body_html: ''
                 - id: pol_OIJLhNcSbf
                   name: Privacy Policy
-                  slug: privacy-policy-64c6fe11-a85d-4ac3-bcf3-2d7e2f51e471
+                  slug: privacy-policy-589e0a93-8fbc-4ac7-be33-2a43079cfc7c
                   body: We respect your privacy.
                   body_html: |
                     <div class="trix-content">
@@ -8165,13 +8204,13 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 117952
-                  slug: product-117952
+                  name: Product 1426035
+                  slug: product-1426035
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-05-21T18:12:43.946Z'
+                  available_on: '2025-05-26T15:19:09.467Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -8193,34 +8232,36 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 1184416
-                  slug: product-1184416
+                  name: Product 1436961
+                  slug: product-1436961
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-21T18:12:44.008Z'
+                  available_on: '2025-05-26T15:19:09.519Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Impedit quam aliquid ducimus magni. Quas nulla placeat
-                    totam suscipit doloribus quos inventore earum. Veniam officiis
-                    ad ipsum sed optio error perferendis. Doloremque molestias magnam
-                    harum consequatur at accusamus tempore sunt. Deleniti voluptatum
-                    laborum vero nisi. Sunt delectus soluta amet hic consequuntur
-                    occaecati. Molestias illum minima velit ullam. Modi animi temporibus
-                    adipisci veritatis voluptatum libero unde. Sunt mollitia tenetur
-                    fugit enim. Accusantium minima id culpa laudantium molestias.
-                    Rerum saepe necessitatibus repellat tempora quis. Unde saepe laborum
-                    iure non quisquam nesciunt sed. Voluptas debitis placeat asperiores
-                    dolorem quia facilis rem. Atque quae enim at quis accusamus sequi
-                    vel.
+                  description: Eius deleniti dolorum fugiat vitae et non. Totam a
+                    eligendi sit veniam facere sunt. Eveniet explicabo consequatur
+                    mollitia dicta molestias esse. Natus rem architecto cumque minima.
+                    Dolorum maxime maiores ad repellendus modi dolorem sint delectus.
+                    Recusandae quaerat quas perspiciatis adipisci eligendi. Aut dolore
+                    sint ipsam eligendi natus culpa eum. Deserunt eius animi voluptatem
+                    commodi quasi sint. Corporis repellendus atque autem quasi. Suscipit
+                    eveniet excepturi rerum hic illum perspiciatis nihil. Ad ratione
+                    voluptatibus quas est ducimus odio minima hic. Tempora recusandae
+                    ducimus saepe nobis accusantium nemo. Magni eos in corporis delectus
+                    molestiae quaerat. Aperiam inventore dolor cum provident aspernatur
+                    excepturi beatae tenetur. Maxime quos consectetur omnis pariatur
+                    quam dolor. Quod nemo totam quis modi consectetur nobis adipisci.
+                    Minima dignissimos ad nemo accusantium numquam distinctio modi.
                   description_html: |-
-                    Impedit quam aliquid ducimus magni. Quas nulla placeat totam suscipit doloribus quos inventore earum. Veniam officiis ad ipsum sed optio error perferendis.
-                    Doloremque molestias magnam harum consequatur at accusamus tempore sunt. Deleniti voluptatum laborum vero nisi. Sunt delectus soluta amet hic consequuntur occaecati.
-                    Molestias illum minima velit ullam. Modi animi temporibus adipisci veritatis voluptatum libero unde. Sunt mollitia tenetur fugit enim. Accusantium minima id culpa laudantium molestias.
-                    Rerum saepe necessitatibus repellat tempora quis. Unde saepe laborum iure non quisquam nesciunt sed. Voluptas debitis placeat asperiores dolorem quia facilis rem. Atque quae enim at quis accusamus sequi vel.
+                    Eius deleniti dolorum fugiat vitae et non. Totam a eligendi sit veniam facere sunt. Eveniet explicabo consequatur mollitia dicta molestias esse. Natus rem architecto cumque minima. Dolorum maxime maiores ad repellendus modi dolorem sint delectus.
+                    Recusandae quaerat quas perspiciatis adipisci eligendi. Aut dolore sint ipsam eligendi natus culpa eum. Deserunt eius animi voluptatem commodi quasi sint. Corporis repellendus atque autem quasi.
+                    Suscipit eveniet excepturi rerum hic illum perspiciatis nihil. Ad ratione voluptatibus quas est ducimus odio minima hic. Tempora recusandae ducimus saepe nobis accusantium nemo. Magni eos in corporis delectus molestiae quaerat. Aperiam inventore dolor cum provident aspernatur excepturi beatae tenetur.
+                    Maxime quos consectetur omnis pariatur quam dolor. Quod nemo totam quis modi consectetur nobis adipisci. Minima dignissimos ad nemo accusantium numquam distinctio modi.
                   default_variant_id: variant_EfhxLZ9ck8
                   thumbnail_url:
                   tags: []
@@ -8322,13 +8363,13 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 1453321
-                slug: product-1453321
+                name: Product 1707862
+                slug: product-1707862
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-05-21T18:12:45.816Z'
+                available_on: '2025-05-26T15:19:10.902Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -8355,7 +8396,7 @@ paths:
                   amount_in_cents: 999
                   currency: USD
                   display_amount: "$9.99"
-                  recorded_at: '2026-05-06T18:12:45Z'
+                  recorded_at: '2026-05-11T15:19:10Z'
               schema:
                 "$ref": "#/components/schemas/Product"
         '404':
@@ -8451,7 +8492,7 @@ paths:
                   options:
                   - id: ctg_EfhxLZ9ck8
                     name: Shirts
-                    permalink: taxonomy-25/taxon-32/shirts
+                    permalink: taxonomy-27/taxon-34/shirts
                     count: 2
                 sort_options:
                 - id: manual
@@ -8730,9 +8771,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R563436707
-                token: MEKMkDqDZiwtriHVLkLzxZ7hGj4nxCtmBig
-                email: renate_tromp@adams.biz
+                number: R161014377
+                token: Kubs8ysPbZpppfQzuui3QgKMzRYnWSmdMRB
+                email: maxwell@hauck.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -8771,8 +8812,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1657
-                  slug: product-1657
+                  name: Product 1904547
+                  slug: product-1904547
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -8797,7 +8838,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H22654230230
+                  number: H37207137670
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -8826,7 +8867,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Marissa Sipes
+                    name: Jeanne Carroll
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -8855,8 +8896,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260521181251050531
-                  number: PFR3QR4H
+                  response_code: 1-SC-20260526151916068791
+                  number: P41JGOY8
                   amount: '10.0'
                   display_amount: "$10.00"
                   status: checkout
@@ -8999,9 +9040,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R554787846
-                token: vfB6PnFw9cPg6LbJqQKBA7jHh5zQGzRLtnz
-                email: elvis@hyatt.ca
+                number: R121095421
+                token: 7k2A6E8uoxqnqHHEYhp7x9hWnVu8yvAnRvp
+                email: mozella@prosacco.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -9043,8 +9084,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1673494
-                  slug: product-1673494
+                  name: Product 1924302
+                  slug: product-1924302
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -9069,7 +9110,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H45381203670
+                  number: H09699694367
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -9098,7 +9139,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Ozella Hirthe
+                    name: Mirian Hand
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -9228,7 +9269,7 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: czkimqa2wGQpziZPiHu4TETD
+                  token: Nvi8s72a2YB45NeCjK7DGvZ4
                   is_default: false
                   is_private: true
                 meta:
@@ -9304,7 +9345,7 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: HkhGZqtmkmgvuTiENz7zMHwA
+                token: svZetprRURhh8BPnkeYASHQC
                 is_default: false
                 is_private: true
               schema:
@@ -9400,7 +9441,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: URczbyJbeCgRS1a82JhitHvQ
+                token: GWbrZqTpfyqcUNgbTfqYm9JT
                 is_default: false
                 is_private: true
               schema:
@@ -9462,7 +9503,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: RbsVopS8AJBteR6s51rRT9tN
+                token: uhSCTcyW2QHcPwhqG7FL61vV
                 is_default: false
                 is_private: true
               schema:
@@ -9577,7 +9618,7 @@ paths:
                 variant:
                   id: variant_gbHJdmfrXB
                   product_id: prod_gbHJdmfrXB
-                  sku: SKU-202
+                  sku: SKU-239
                   options_text: ''
                   track_inventory: true
                   media_count: 0
@@ -11001,6 +11042,10 @@ components:
           type: boolean
         default:
           type: boolean
+        country_isos:
+          type: array
+          items:
+            type: string
         supported_locales:
           type: array
           items:
@@ -11016,6 +11061,7 @@ components:
       - default_locale
       - tax_inclusive
       - default
+      - country_isos
       - supported_locales
       x-typelizer: true
     Media:

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -601,16 +601,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk1OTUwNTE2LTg0ZDMtNGIyNy1iZGFiLTZmYTBkYTNiZTE2NCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDU1fQ.UrTQMWKxKb9VeAXhlMwR8EpF6vezYhUDJ36jDCLCzV4
-                refresh_token: Sf1YLV9Vcs4Z7xF3ep2FdzLp
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjY0NjcwM2Q0LWY5ZjAtNDlmMi05ZmZkLTA3YTZhY2I5YWZkZiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjE1fQ.jlz2KHxYkB1Dd9ucl26zy6E5M7dFB5q9g-Qw0YjsX50
+                refresh_token: MQ9QZ1ToR8QocZoDd4ggC8yN
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Myesha
-                  last_name: McKenzie
+                  first_name: Colette
+                  last_name: Hegmann
                   phone:
                   accepts_email_marketing: false
-                  full_name: Myesha McKenzie
+                  full_name: Colette Hegmann
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -666,7 +666,8 @@ paths:
                     example: auth0
                     description: Registered provider key (anything other than `email`).
                     not:
-                      const: email
+                      enum:
+                      - email
                 required:
                 - provider
                 additionalProperties: true
@@ -705,16 +706,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6Ijk2YjQ4NDRlLTVlYTEtNDgwMS05YjZkLTdlYjEwYmU3ZTk5ZCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDU2fQ.dNUeqwWFo3WzVMAk7aap2VsFxe2qeUaRed2k86hfwfo
-                refresh_token: 2K3eLgPq6bWMmu4P8z6wTh64
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjNmZjU3NWU0LTVmNmItNDVjOC04MzIzLTIzMDMyMzVjZTkzMiIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjE2fQ.OuCk-UNe-asA8DvK2yKMkp94BQz9PN_Z7_SnReeIRYE
+                refresh_token: qLuZDRo8LqywXFThqPM5V2Ug
                 user:
                   id: cus_UkLWZg9DAJ
                   email: test@example.com
-                  first_name: Velma
-                  last_name: Johnston
+                  first_name: Debi
+                  last_name: Tillman
                   phone:
                   accepts_email_marketing: false
-                  full_name: Velma Johnston
+                  full_name: Debi Tillman
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -750,8 +751,9 @@ paths:
       - Authentication
       security:
       - api_key: []
-        bearer_auth: []
-      description: Revokes the refresh token, effectively logging the customer out.
+      description: Revokes the submitted refresh token. The refresh token itself is
+        the credential — no Authorization header is required, so a client with an
+        expired access JWT can still log out.
       x-codeSamples:
       - lang: javascript
         label: Spree SDK
@@ -768,11 +770,6 @@ paths:
           })
       parameters:
       - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
         in: header
         required: true
         schema:
@@ -878,9 +875,9 @@ paths:
                 data:
                 - id: cart_gbHJdmfrXB
                   market_id:
-                  number: R904109241
-                  token: Agyt2vfNgA5z1QdB1aCUHwa6hDFL3JLjxhX
-                  email: timika_simonis@yost.co.uk
+                  number: R537347983
+                  token: yasKz5u5Uc9LkM8L2qFcbBRhWQzwP1nNUBe
+                  email: orval_boyle@abernathybogisich.co.uk
                   customer_note:
                   currency: USD
                   locale: en
@@ -922,8 +919,8 @@ paths:
                     variant_id: variant_gbHJdmfrXB
                     quantity: 1
                     currency: USD
-                    name: Product 833845
-                    slug: product-833845
+                    name: Product 832050
+                    slug: product-832050
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -948,7 +945,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_gbHJdmfrXB
-                    number: H94704449388
+                    number: H02359090617
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -977,7 +974,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Fabiola Cormier
+                      name: Blair Moore
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1047,9 +1044,9 @@ paths:
                   market:
                 - id: cart_UkLWZg9DAJ
                   market_id:
-                  number: R036630490
-                  token: qsE8mSUKJNws9NnTgBDPUFQkwcr1HS5643h
-                  email: timika_simonis@yost.co.uk
+                  number: R807784030
+                  token: nXX7y8d9LZ1UXEmP8CxfE2vvLYZH9s6K9Y3
+                  email: orval_boyle@abernathybogisich.co.uk
                   customer_note:
                   currency: USD
                   locale: en
@@ -1091,8 +1088,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 823692
-                    slug: product-823692
+                    name: Product 821901
+                    slug: product-821901
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1117,7 +1114,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H40294182590
+                    number: H10388427867
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -1146,7 +1143,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Fabiola Cormier
+                      name: Blair Moore
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -1289,8 +1286,8 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R826900104
-                token: p9JT8xWtDbqHKZs788eLDt5GkFUsNCrySTJ
+                number: R386894669
+                token: AFTUr4LVpnRaQVPntcz4FE5S8AuFqksEEGH
                 email:
                 customer_note:
                 currency: USD
@@ -1445,9 +1442,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R038202138
-                token: 3vhBJdkoneVSJTq7AwmU4tZEENSJE8L1iDY
-                email: jarrett.jacobi@bradtke.name
+                number: R929020865
+                token: XrTGYYzWrW8pPm2d5SNuJgjFeHQ8MNN6Ufr
+                email: hattie_daniel@pfannerstillherzog.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -1474,7 +1471,7 @@ paths:
                 display_delivery_total: "$0.00"
                 warnings:
                 - code: line_item_removed
-                  message: Product 876858 was removed because it was sold out
+                  message: Product 874599 was removed because it was sold out
                   line_item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                 store_credit_total: '0.0'
@@ -1616,9 +1613,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R162129196
-                token: kacsDq5sAeA4bvHpEyWua3i2vxQm7U21jVv
-                email: edison_hermann@kuphal.info
+                number: R179766659
+                token: LwvBFt69BRKiAP4yjrdydKDiefspHrgEEWV
+                email: floria_corkery@heaney.com
                 customer_note: Leave at door
                 currency: USD
                 locale: en
@@ -1662,8 +1659,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 886755
-                  slug: product-886755
+                  name: Product 888308
+                  slug: product-888308
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -1688,7 +1685,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H75244992135
+                  number: H67729784924
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -1717,7 +1714,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Sunni McClure
+                    name: Corazon Luettgen
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -1954,9 +1951,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R231091983
-                token: DERZSb96LDTTB7bfJMY9s43jYAtVzAnhjCd
-                email: horacio@herman.ca
+                number: R741424210
+                token: BjQx3Mm7YsM51uEQTvTjE4Jkc9QKpdQ57A4
+                email: robbyn@thielkoepp.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -1998,8 +1995,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 902266
-                  slug: product-902266
+                  name: Product 907994
+                  slug: product-907994
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -2024,7 +2021,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H45937813483
+                  number: H95245243522
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -2053,7 +2050,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Teresa Stamm
+                    name: Agatha Hoppe
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2188,8 +2185,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R959851052
-                email: collin.bradtke@bayer.biz
+                number: R464982887
+                email: laila@okuneva.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -2216,7 +2213,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: backorder
                 payment_status: paid
-                completed_at: '2026-05-26T15:37:42.350Z'
+                completed_at: '2026-05-26T16:13:41.957Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -2226,8 +2223,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 922020
-                  slug: product-922020
+                  name: Product 924411
+                  slug: product-924411
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -2252,7 +2249,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_gbHJdmfrXB
-                  number: H50676292807
+                  number: H02978405768
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -2281,7 +2278,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Maudie Nitzsche
+                    name: Zachery Smith
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -2310,8 +2307,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-0ffdc30bdcb9
-                  number: PNNYCH80
+                  response_code: BGS-176dea87fe0d
+                  number: PYQMKAGA
                   amount: '29.99'
                   display_amount: "$29.99"
                   status: completed
@@ -3167,16 +3164,16 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjQ4NGQyYmMzLTg1ODUtNGI1Yy1iOTEwLWRhZTVmNGViNGIzMyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDY4fQ.nHnou945vpPDO4F4Avh7h0CEvoGgH3Zs4NTMbNkvirY
-                refresh_token: G4FPrYJGk1oyeJ38DFAj1K8j
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjU1YjA5Yzc4LTUzMTYtNDRjYy05ZjJiLThmN2E2MzViMmRlNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjI4fQ.FX2Te4WfdAu3kN_fvvfHsH92_axvIZTI1d8Zmw8R1mE
+                refresh_token: Be2HUCjiJVRjgidFuYU7GRRh
                 user:
                   id: cus_UkLWZg9DAJ
                   email: customer@example.com
-                  first_name: Cher
-                  last_name: Vandervort
+                  first_name: Randa
+                  last_name: O'Hara
                   phone:
                   accepts_email_marketing: false
-                  full_name: Cher Vandervort
+                  full_name: Randa O'Hara
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
                   addresses: []
@@ -3349,8 +3346,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R123781058
-                  email: shirlene.tremblay@bins.ca
+                  number: R096824993
+                  email: gena@ohara.biz
                   customer_note:
                   currency: USD
                   locale: en
@@ -3377,7 +3374,7 @@ paths:
                   display_delivery_total: "$100.00"
                   fulfillment_status:
                   payment_status:
-                  completed_at: '2026-05-26T15:37:49.679Z'
+                  completed_at: '2026-05-26T16:13:49.079Z'
                   store_credit_total: '0.0'
                   display_store_credit_total: "$0.00"
                   covered_by_store_credit: false
@@ -3387,8 +3384,8 @@ paths:
                     variant_id: variant_UkLWZg9DAJ
                     quantity: 1
                     currency: USD
-                    name: Product 101651
-                    slug: product-101651
+                    name: Product 1016128
+                    slug: product-1016128
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -3413,7 +3410,7 @@ paths:
                     digital_links: []
                   fulfillments:
                   - id: ful_UkLWZg9DAJ
-                    number: H80439451392
+                    number: H70742962050
                     tracking: U10000
                     tracking_url:
                     cost: '100.0'
@@ -3442,7 +3439,7 @@ paths:
                     stock_location:
                       id: sloc_UkLWZg9DAJ
                       state_abbr: NY
-                      name: Kathy Kshlerin
+                      name: Britany Halvorson
                       address1: 1600 Pennsylvania Ave NW
                       city: Washington
                       zipcode: '20500'
@@ -3605,8 +3602,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R866691797
-                email: ezra_cassin@nienow.ca
+                number: R695830260
+                email: jerica.wehner@wintheiser.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -3633,7 +3630,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:37:50.403Z'
+                completed_at: '2026-05-26T16:13:49.771Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -3643,8 +3640,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 103381
-                  slug: product-103381
+                  name: Product 1033099
+                  slug: product-1033099
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3669,7 +3666,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H15902875686
+                  number: H08221240082
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -3698,7 +3695,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Catina Kunde
+                    name: Aleen Reynolds
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -3818,8 +3815,8 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImMxOWU4OGE1LTM4YTktNGUwZi05MmNhLWU3ZjU1ZjFiNjlhNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODEzNDcxfQ.Jr-b1n0HSlEeVxJINXR_BpFVsZ5ag-s92cWpLwpqu9E
-                refresh_token: htQdQqRGe6yAeCMpRLJ6f6Th
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjlmZGNlNTdjLTY2NGQtNGZkNy1hOTU2LWQ1MjEzZjdhMjljYSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjMwfQ.vLRThKiR034rnZQYwpQGrIOeQSdrYNKnFVJZ86pCuUo
+                refresh_token: GVssZP2L5Zk7uKQzTmwSQ4i5
                 user:
                   id: cus_UkLWZg9DAJ
                   email: newuser@example.com
@@ -3933,12 +3930,12 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: brittani.prosacco@stoltenberg.name
-                first_name: Isa
-                last_name: Schowalter
+                email: jama.wolff@lynch.biz
+                first_name: Catarina
+                last_name: Padberg
                 phone: 555-555-0199
                 accepts_email_marketing: false
-                full_name: Isa Schowalter
+                full_name: Catarina Padberg
                 available_store_credit_total: '0'
                 display_available_store_credit_total: "$0.00"
                 addresses:
@@ -4072,7 +4069,7 @@ paths:
             application/json:
               example:
                 id: cus_UkLWZg9DAJ
-                email: josefine.cruickshank@schiller.com
+                email: kiera@treutel.com
                 first_name: Updated
                 last_name: Name
                 phone: 555-555-0199
@@ -4312,9 +4309,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R137828818
-                token: X9RAZky8SYrZbuwHxM6s3WnGWZrqneqr4Lh
-                email: nila.hegmann@price.com
+                number: R549797108
+                token: dtJjZuWMLKEesDsMRZvLQQgWuYY9MuUwL2U
+                email: jadwiga@dubuque.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -4363,8 +4360,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1118494
-                  slug: product-1118494
+                  name: Product 1111931
+                  slug: product-1111931
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4389,7 +4386,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H07536733782
+                  number: H10253682077
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4418,7 +4415,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Gigi Spencer
+                    name: Clark Gerlach
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4572,9 +4569,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R794685504
-                token: Ag3ebaf6kZai83zxwqXJtvRUukMNkiaFh69
-                email: eloise_hauck@emard.co.uk
+                number: R750836348
+                token: uesByPtiBKoM7CoRrEKxrNXDHDLP4WQHVEg
+                email: earlean@fay.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -4616,8 +4613,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1139442
-                  slug: product-1139442
+                  name: Product 1136391
+                  slug: product-1136391
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4642,7 +4639,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H98249401469
+                  number: H71965274390
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4671,7 +4668,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Lasandra Hartmann
+                    name: Drusilla Greenfelder
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -4814,9 +4811,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R392103802
-                token: CMfey9gE8TNTbWbwcxbUeHAZwb1WXVgiqax
-                email: tressa@spencer.biz
+                number: R495333435
+                token: vr5NsDydPesecXCDNmvqdhrE1FH96kV3K9s
+                email: emil@abshiremayer.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -4860,8 +4857,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1155243
-                  slug: product-1155243
+                  name: Product 1159495
+                  slug: product-1159495
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4886,7 +4883,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H19402011424
+                  number: H32451339376
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -4915,7 +4912,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Lashay Gibson
+                    name: Danika Wiza
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5072,9 +5069,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R753898035
-                token: akymx8RLCMAg8J56WjV3dRGqQvNcQKTSdvc
-                email: winnifred@gleason.com
+                number: R144554045
+                token: RuTHka2EQdEPmHa7PXXzb8EAr5c9vSivWun
+                email: claribel.funk@townekuhlman.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -5113,8 +5110,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 117861
-                  slug: product-117861
+                  name: Product 1174034
+                  slug: product-1174034
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5139,7 +5136,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H31605697508
+                  number: H20393389861
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5168,7 +5165,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Ilona Leuschke
+                    name: Gordon Pfeffer
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5197,8 +5194,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260526153800327758
-                  number: PVRT65UP
+                  response_code: 1-SC-20260526161400395109
+                  number: PGO55NWN
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: checkout
@@ -5377,9 +5374,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R206030460
-                token: GP7wS7WS4U31U8dgKxAU2zQns61k7BDrkFm
-                email: maple@schowalter.co.uk
+                number: R375402748
+                token: zK6CyYENcBq5VLBnwSXE35w1RrR7o2sTgky
+                email: tonita@klein.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -5421,8 +5418,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1219747
-                  slug: product-1219747
+                  name: Product 1215119
+                  slug: product-1215119
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5447,7 +5444,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H57934696315
+                  number: H49636801244
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -5476,7 +5473,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Kareem McKenzie
+                    name: Melvina Gottlieb
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -5505,8 +5502,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260526153802888161
-                  number: PH8B107A
+                  response_code: 1-SC-20260526161402955039
+                  number: PIQFGKXI
                   amount: '50.0'
                   display_amount: "$50.00"
                   status: invalid
@@ -5630,7 +5627,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: 89D6BB75EF9E64AE
+                  code: 91F1E57C6C99A62C
                   status: active
                   currency: USD
                   amount: '10.0'
@@ -5726,7 +5723,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: EA7BBE7AD1A2C2BD
+                code: 76D77B6CFFA255C8
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -5817,9 +5814,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R874771603
-                token: kBTVikFUtj784edEmZpNBefacp2BMvjcFW9
-                email: pamela@wiza.us
+                number: R128024977
+                token: snfWbJhSsShSGdMgtj6NVNbk7SVZvg984Xb
+                email: danica.trantow@mcglynndicki.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -5867,8 +5864,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1246172
-                  slug: product-1246172
+                  name: Product 1244584
+                  slug: product-1244584
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5895,8 +5892,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 1
                   currency: USD
-                  name: Product 1257042
-                  slug: product-1257042
+                  name: Product 1253628
+                  slug: product-1253628
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -6039,9 +6036,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R210411134
-                token: RmvBx39wicsHrzj6dHaUjUryykCqqQjuNqF
-                email: slyvia.schneider@harvey.info
+                number: R216067679
+                token: HBo9TtU6Kra7Pkqey8Rhw5WW93WSsLFKbcb
+                email: lowell@lakin.co.uk
                 customer_note:
                 currency: USD
                 locale: en
@@ -6086,8 +6083,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1285574
-                  slug: product-1285574
+                  name: Product 1289337
+                  slug: product-1289337
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -6210,9 +6207,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R269763917
-                token: 7bFMBSMVMzipBFrYknFjYBSdpXp4hqqVXve
-                email: rashad@haleygrimes.biz
+                number: R262930205
+                token: 6F91AsEuASghgSqqpwTgtCCF84SEMYm1ozP
+                email: gwenn_hessel@auerreilly.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -6823,11 +6820,11 @@ paths:
             application/json:
               example:
                 id: sub_UkLWZg9DAJ
-                email: margarette_considine@kris.biz
-                created_at: '2026-05-26T15:38:10.673Z'
-                updated_at: '2026-05-26T15:38:10.676Z'
+                email: harriet.conroy@mohr.co.uk
+                created_at: '2026-05-26T16:14:11.183Z'
+                updated_at: '2026-05-26T16:14:11.186Z'
                 verified: true
-                verified_at: '2026-05-26T15:38:10Z'
+                verified_at: '2026-05-26T16:14:11Z'
                 customer_id: cus_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -6906,10 +6903,10 @@ paths:
               example:
                 id: sub_UkLWZg9DAJ
                 email: pending@example.com
-                created_at: '2026-05-26T15:38:10.698Z'
-                updated_at: '2026-05-26T15:38:10.707Z'
+                created_at: '2026-05-26T16:14:11.236Z'
+                updated_at: '2026-05-26T16:14:11.255Z'
                 verified: true
-                verified_at: '2026-05-26T15:38:10Z'
+                verified_at: '2026-05-26T16:14:11Z'
                 customer_id:
               schema:
                 "$ref": "#/components/schemas/NewsletterSubscriber"
@@ -7007,7 +7004,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R917825879
+                number: R528526445
                 email: guest@example.com
                 customer_note:
                 currency: USD
@@ -7035,7 +7032,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-05-26T15:38:11.463Z'
+                completed_at: '2026-05-26T16:14:12.058Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -7045,8 +7042,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1329397
-                  slug: product-1329397
+                  name: Product 1325879
+                  slug: product-1325879
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7071,7 +7068,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H32620565377
+                  number: H26728427796
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -7100,7 +7097,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Genoveva Harber
+                    name: Maida Rogahn
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -7245,9 +7242,9 @@ paths:
                 id: ps_gbHJdmfrXB
                 status: pending
                 currency: USD
-                external_id: bogus_ff3f04085f7251909ff5a444
+                external_id: bogus_7d70cfacf0ae7492cf904547
                 external_data:
-                  client_secret: bogus_secret_0ca9845259e00e2e
+                  client_secret: bogus_secret_ede104f24aa5154c
                 customer_external_id:
                 expires_at:
                 amount: '110.0'
@@ -7345,7 +7342,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_4d76cceb5949aca1f607f39e
+                external_id: bogus_4c7d24178351b3d5952b3cf5
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7407,7 +7404,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: pending
                 currency: USD
-                external_id: bogus_8dcacbfb9c7eca45595b0d90
+                external_id: bogus_331c7200fe221193bf414698
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7509,7 +7506,7 @@ paths:
                 id: ps_UkLWZg9DAJ
                 status: completed
                 currency: USD
-                external_id: bogus_c9c27c106afde0b762dcb352
+                external_id: bogus_2ebf387c2f1e00f23440c181
                 external_data:
                   client_secret: secret_123
                 customer_external_id:
@@ -7594,8 +7591,8 @@ paths:
               example:
                 id: pss_gbHJdmfrXB
                 status: pending
-                external_id: bogus_seti_626428bd5f19304143c8d3e2
-                external_client_secret: bogus_seti_secret_eedfe4c913da1edb
+                external_id: bogus_seti_e60689fe4c66251e2b4dd2f4
+                external_client_secret: bogus_seti_secret_633045dc9ddab700
                 external_data: {}
                 payment_method_id: pm_UkLWZg9DAJ
                 payment_source_id:
@@ -7694,8 +7691,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: pending
-                external_id: seti_test_eca5d52087f5c77f56af6b94
-                external_client_secret: seti_secret_8120cbc70c9f7dbeaee7e5e5
+                external_id: seti_test_7ac50408dcea6ac09aa04e3d
+                external_client_secret: seti_secret_77e80c695165694be5ef56b9
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7771,8 +7768,8 @@ paths:
               example:
                 id: pss_UkLWZg9DAJ
                 status: completed
-                external_id: seti_test_896c062cc747863746b494d6
-                external_client_secret: seti_secret_6a5120adbea8fdbf136a2fdc
+                external_id: seti_test_6cb96d4ae6cdc1eadf02b1dc
+                external_client_secret: seti_secret_bb0a7727be4c699d8584292f
                 external_data:
                   client_secret: secret_123
                 payment_method_id: pm_UkLWZg9DAJ
@@ -7866,7 +7863,7 @@ paths:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 response_code:
-                number: PE18A1T6
+                number: P6M3ZHJE
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7962,7 +7959,7 @@ paths:
                   body_html: ''
                 - id: pol_OIJLhNcSbf
                   name: Privacy Policy
-                  slug: privacy-policy-b9cfe5a5-8d47-49b5-b8be-c111e206e077
+                  slug: privacy-policy-006f63da-6062-4a3f-9fd7-aa690f7b356c
                   body: We respect your privacy.
                   body_html: |
                     <div class="trix-content">
@@ -8206,13 +8203,13 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1429156
-                  slug: product-1429156
+                  name: Product 1421251
+                  slug: product-1421251
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 1
-                  available_on: '2025-05-26T15:38:21.861Z'
+                  available_on: '2025-05-26T16:14:22.402Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
@@ -8234,43 +8231,43 @@ paths:
                     price_list_id:
                   original_price:
                 - id: prod_gbHJdmfrXB
-                  name: Product 1431122
-                  slug: product-1431122
+                  name: Product 1435220
+                  slug: product-1435220
                   meta_title:
                   meta_description:
                   meta_keywords:
                   variant_count: 0
-                  available_on: '2025-05-26T15:38:21.927Z'
+                  available_on: '2025-05-26T16:14:22.472Z'
                   purchasable: true
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Architecto cupiditate voluptates quis fuga. Tenetur
-                    blanditiis asperiores consequuntur ab tempora. Sint id dignissimos
-                    occaecati maiores velit quam modi explicabo. Aut fugiat enim ab
-                    unde alias. Atque corporis repudiandae maiores molestiae laudantium
-                    eveniet suscipit laborum. Sunt necessitatibus assumenda fugit
-                    cumque itaque. Temporibus non totam quisquam perferendis itaque
-                    praesentium. Deserunt fugiat eveniet labore nulla commodi. Eligendi
-                    natus placeat molestias iste soluta molestiae veritatis cupiditate.
-                    Consectetur illo nisi sunt cupiditate recusandae possimus. Voluptates
-                    in doloribus officiis voluptate quibusdam rerum. Adipisci vel
-                    esse nam distinctio voluptatum veritatis impedit sit. Exercitationem
-                    sequi nostrum nemo voluptas blanditiis maxime soluta officia.
-                    Delectus cupiditate corrupti rem assumenda provident ab eveniet.
-                    Eaque veniam nemo unde atque quo. Quidem unde ipsum atque hic
-                    deleniti. Nobis animi possimus cumque doloribus iste eligendi
-                    impedit reiciendis. Inventore officiis nobis sunt fuga repellendus
-                    autem repudiandae. Molestiae magni repellendus illum voluptatum
-                    esse debitis libero. Sunt nulla harum nemo cum occaecati. Praesentium
-                    delectus consequatur voluptates consectetur. Eaque alias molestias
-                    expedita porro eum officiis quas quo.
+                  description: Architecto dignissimos nemo inventore incidunt enim.
+                    Odit accusamus repellat error saepe culpa unde eius. Cupiditate
+                    officiis voluptatem autem perferendis qui vitae omnis sunt. Debitis
+                    dolor tempore ad impedit itaque reprehenderit delectus. Doloremque
+                    laudantium iure recusandae iusto debitis laborum consequuntur.
+                    Impedit eum optio commodi tempora cum quidem. Facere voluptatum
+                    nam possimus veritatis nostrum explicabo dolore ex. Adipisci iure
+                    unde nobis itaque amet nesciunt voluptatibus impedit. Numquam
+                    in accusantium magni itaque exercitationem. Quas vero maxime voluptatem
+                    rem impedit inventore. Esse perferendis asperiores ea expedita
+                    aut tenetur soluta. Enim accusantium dolor adipisci impedit. Error
+                    maxime neque accusamus facere provident eum. Cum officia velit
+                    asperiores quod cupiditate fugiat. Possimus tenetur aut consequuntur
+                    iusto cumque quas. Ab velit ullam qui pariatur veritatis omnis.
+                    Accusantium vero occaecati explicabo neque animi commodi. Necessitatibus
+                    perspiciatis iste culpa totam quibusdam voluptate distinctio.
+                    Quod aliquam ut et autem. Saepe ut asperiores et quisquam perspiciatis
+                    molestiae. Vel recusandae sunt nemo et accusamus veniam ducimus.
+                    Laborum modi quasi perferendis culpa laboriosam quaerat magnam.
+                    Facere at tempora iusto ex magni aliquam modi debitis.
                   description_html: |-
-                    Architecto cupiditate voluptates quis fuga. Tenetur blanditiis asperiores consequuntur ab tempora. Sint id dignissimos occaecati maiores velit quam modi explicabo. Aut fugiat enim ab unde alias. Atque corporis repudiandae maiores molestiae laudantium eveniet suscipit laborum.
-                    Sunt necessitatibus assumenda fugit cumque itaque. Temporibus non totam quisquam perferendis itaque praesentium. Deserunt fugiat eveniet labore nulla commodi. Eligendi natus placeat molestias iste soluta molestiae veritatis cupiditate. Consectetur illo nisi sunt cupiditate recusandae possimus.
-                    Voluptates in doloribus officiis voluptate quibusdam rerum. Adipisci vel esse nam distinctio voluptatum veritatis impedit sit. Exercitationem sequi nostrum nemo voluptas blanditiis maxime soluta officia. Delectus cupiditate corrupti rem assumenda provident ab eveniet. Eaque veniam nemo unde atque quo.
-                    Quidem unde ipsum atque hic deleniti. Nobis animi possimus cumque doloribus iste eligendi impedit reiciendis. Inventore officiis nobis sunt fuga repellendus autem repudiandae.
-                    Molestiae magni repellendus illum voluptatum esse debitis libero. Sunt nulla harum nemo cum occaecati. Praesentium delectus consequatur voluptates consectetur. Eaque alias molestias expedita porro eum officiis quas quo.
+                    Architecto dignissimos nemo inventore incidunt enim. Odit accusamus repellat error saepe culpa unde eius. Cupiditate officiis voluptatem autem perferendis qui vitae omnis sunt. Debitis dolor tempore ad impedit itaque reprehenderit delectus. Doloremque laudantium iure recusandae iusto debitis laborum consequuntur.
+                    Impedit eum optio commodi tempora cum quidem. Facere voluptatum nam possimus veritatis nostrum explicabo dolore ex. Adipisci iure unde nobis itaque amet nesciunt voluptatibus impedit. Numquam in accusantium magni itaque exercitationem. Quas vero maxime voluptatem rem impedit inventore.
+                    Esse perferendis asperiores ea expedita aut tenetur soluta. Enim accusantium dolor adipisci impedit. Error maxime neque accusamus facere provident eum. Cum officia velit asperiores quod cupiditate fugiat. Possimus tenetur aut consequuntur iusto cumque quas.
+                    Ab velit ullam qui pariatur veritatis omnis. Accusantium vero occaecati explicabo neque animi commodi. Necessitatibus perspiciatis iste culpa totam quibusdam voluptate distinctio. Quod aliquam ut et autem. Saepe ut asperiores et quisquam perspiciatis molestiae.
+                    Vel recusandae sunt nemo et accusamus veniam ducimus. Laborum modi quasi perferendis culpa laboriosam quaerat magnam. Facere at tempora iusto ex magni aliquam modi debitis.
                   default_variant_id: variant_EfhxLZ9ck8
                   thumbnail_url:
                   tags: []
@@ -8372,13 +8369,13 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 1707032
-                slug: product-1707032
+                name: Product 1702106
+                slug: product-1702106
                 meta_title:
                 meta_description:
                 meta_keywords:
                 variant_count: 1
-                available_on: '2025-05-26T15:38:23.597Z'
+                available_on: '2025-05-26T16:14:24.749Z'
                 purchasable: true
                 in_stock: false
                 backorderable: true
@@ -8405,7 +8402,7 @@ paths:
                   amount_in_cents: 999
                   currency: USD
                   display_amount: "$9.99"
-                  recorded_at: '2026-05-11T15:38:23Z'
+                  recorded_at: '2026-05-11T16:14:24Z'
               schema:
                 "$ref": "#/components/schemas/Product"
         '404':
@@ -8780,9 +8777,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R431665319
-                token: y9RwVuYgeDcBkccKnX3kjdWKELzyzgTfege
-                email: rafael_paucek@casper.name
+                number: R903776007
+                token: oPFUDLqngFUNHBsLi5NZyBfVqQFVkab5S48
+                email: despina.ernser@leffler.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -8821,8 +8818,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1906245
-                  slug: product-1906245
+                  name: Product 1909153
+                  slug: product-1909153
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -8847,7 +8844,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H05530615606
+                  number: H71098380344
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -8876,7 +8873,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Lanora Hirthe
+                    name: Twanna Stamm
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -8905,8 +8902,8 @@ paths:
                 payments:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: 1-SC-20260526153828961175
-                  number: P9PHJKI7
+                  response_code: 1-SC-20260526161430523363
+                  number: P1X82P2A
                   amount: '10.0'
                   display_amount: "$10.00"
                   status: checkout
@@ -9049,9 +9046,9 @@ paths:
               example:
                 id: cart_UkLWZg9DAJ
                 market_id:
-                number: R701106151
-                token: d71VruvCcMbK4zcCD8TvvgmAZpBvQNzmBU7
-                email: huong_kessler@becker.name
+                number: R646602683
+                token: c5RmvpB42n2ZRwYZ246jBJSFzvFgSLjsY5V
+                email: kristle@vandervort.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -9093,8 +9090,8 @@ paths:
                   variant_id: variant_UkLWZg9DAJ
                   quantity: 1
                   currency: USD
-                  name: Product 1926273
-                  slug: product-1926273
+                  name: Product 1922421
+                  slug: product-1922421
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -9119,7 +9116,7 @@ paths:
                   digital_links: []
                 fulfillments:
                 - id: ful_UkLWZg9DAJ
-                  number: H54912924704
+                  number: H93482247486
                   tracking: U10000
                   tracking_url:
                   cost: '100.0'
@@ -9148,7 +9145,7 @@ paths:
                   stock_location:
                     id: sloc_UkLWZg9DAJ
                     state_abbr: NY
-                    name: Alberta Bashirian
+                    name: Carolina Kovacek
                     address1: 1600 Pennsylvania Ave NW
                     city: Washington
                     zipcode: '20500'
@@ -9278,7 +9275,7 @@ paths:
                 data:
                 - id: wl_UkLWZg9DAJ
                   name: My Wishlist
-                  token: crmx6PTbvJHbhpwuSBgB9bRF
+                  token: KrDYvpcWeMWWCVsEuRj9V8Xm
                   is_default: false
                   is_private: true
                 meta:
@@ -9354,7 +9351,7 @@ paths:
               example:
                 id: wl_gbHJdmfrXB
                 name: Birthday Ideas
-                token: VQV5AxYmsWCTu8uzR8a5cuqv
+                token: LoTGXDT4V69PBMZXRWaS9Sjg
                 is_default: false
                 is_private: true
               schema:
@@ -9450,7 +9447,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: My Wishlist
-                token: Sq8rjnm6ZdRFHiJRaEokNwRf
+                token: K1j4ej8u38Y4P9whWrjPs2R9
                 is_default: false
                 is_private: true
               schema:
@@ -9512,7 +9509,7 @@ paths:
               example:
                 id: wl_UkLWZg9DAJ
                 name: Updated Name
-                token: zXfbwrobotUvjVTpim8k4Anf
+                token: xVUpUiksViqHLiWcenRTEGZx
                 is_default: false
                 is_private: true
               schema:

--- a/docs/developer/how-to/custom-api-authentication.mdx
+++ b/docs/developer/how-to/custom-api-authentication.mdx
@@ -25,7 +25,7 @@ The same pattern works for Admin API integrations via `admin_authentication_stra
 ## Architecture
 
 ```
-Client → POST /api/v3/store/auth/oauth/callback
+Client → POST /api/v3/store/auth/login
             { provider: "my_idp", token: "<third-party JWT>" }
               │
               ▼
@@ -159,10 +159,10 @@ Spree.admin_authentication_strategies.add(:okta, MyApp::Auth::OktaStrategy)
 
 ## Step 3: Call the Exchange Endpoint
 
-Spree provides two endpoints that both dispatch through the strategy registry. Use `/oauth/callback` for third-party token exchange — it's the semantically correct route and skips email/password assumptions.
+`POST /api/v3/store/auth/login` is the single dispatcher. The `provider` field in the body selects the strategy — omit it for built-in email/password, set it to your registered key for everything else. The remaining body fields are whatever your strategy reads from `params`.
 
 ```http
-POST /api/v3/store/auth/oauth/callback
+POST /api/v3/store/auth/login
 X-Spree-API-Key: pk_your_publishable_key
 Content-Type: application/json
 
@@ -183,6 +183,21 @@ The response is the standard Spree auth payload:
 ```
 
 From here, the client sends `Authorization: Bearer <Spree JWT>` on every subsequent Store API call. When the JWT expires (default: 1 hour), the client hits `POST /api/v3/store/auth/refresh` with the refresh token to rotate both.
+
+From `@spree/sdk` the same call looks like:
+
+```ts
+import { createClient } from '@spree/sdk'
+
+const client = createClient({ baseUrl: 'https://your-store.com', publishableKey: '<pk>' })
+
+const auth = await client.auth.login({
+  provider: 'external_idp',
+  token:    thirdPartyJwt,
+})
+```
+
+`LoginCredentials` is a discriminated union — pass `{ email, password }` for the built-in strategy, or `{ provider, ...customFields }` for any strategy you registered.
 
 ## Account Linking
 
@@ -234,7 +249,7 @@ A few things worth getting right:
 - **JWKS caching and rotation.** Cache the JWKS (the example uses a 1-hour TTL) but make sure your loader honors the `invalidate: true` option so that an unrecognized `kid` triggers a refetch. Otherwise key rotation at the IdP locks users out for up to the TTL.
 - **Validate `iss` and `aud` claims.** Always. The example passes `verify_iss: true, verify_aud: true` to `JWT.decode` — don't drop those.
 - **Algorithm pinning.** Hard-code `algorithms: ['RS256']` (or whatever your IdP uses). Never let the token's own `alg` header decide — the classic `alg: none` and HS-as-RS confusion attacks both exploit lax algorithm selection.
-- **Rate limiting.** `POST /auth/oauth/callback` is already rate-limited per IP via `Spree::Api::Config[:rate_limit_oauth]`. Tune it in your app config if needed.
+- **Rate limiting.** `POST /auth/login` is rate-limited per IP via `Spree::Api::Config[:rate_limit_login]`. Tune it in your app config if needed — the same limit applies to email/password and provider-dispatched logins.
 
 ## Testing
 

--- a/docs/developer/how-to/custom-api-authentication.mdx
+++ b/docs/developer/how-to/custom-api-authentication.mdx
@@ -1,0 +1,293 @@
+---
+title: Integrate a Third-Party Identity Provider
+description: Step-by-step guide to plugging a custom identity provider (Auth0, Okta, Firebase, Cognito, or any JWT issuer) into the Spree Store API.
+---
+
+import { Since } from '/snippets/since.mdx';
+
+<Since version="5.5" />
+
+## Overview
+
+Spree's Store API ships with a pluggable authentication system. You register a **strategy class** for a named provider, and the existing login endpoints will dispatch to it — no controller patching, no route overrides, no fork.
+
+By the end of this guide you'll have:
+
+- A custom strategy that verifies a third-party JWT against a JWKS endpoint
+- A user account auto-provisioned on first login, reused on subsequent logins
+- A standard **Spree-issued JWT + refresh token** returned to the client
+- All Store API endpoints (cart, checkout, account) protected by Spree's own JWT — the third-party token is only used at the exchange step
+
+<Info>
+The same pattern works for Admin API integrations via `admin_authentication_strategies`. Examples in this guide target the Store API; substitute `Spree.admin_user_class` and the admin endpoints where noted.
+</Info>
+
+## Architecture
+
+```
+Client → POST /api/v3/store/auth/oauth/callback
+            { provider: "my_idp", token: "<third-party JWT>" }
+              │
+              ▼
+   AuthController looks up the strategy by `provider` key
+              │
+              ▼
+   YourStrategy#authenticate
+     • verifies the JWT against the IdP's JWKS
+     • finds or creates a Spree::UserIdentity → Spree user
+     • returns success(user) or failure(message)
+              │
+              ▼
+   Spree issues its own JWT (HS256, iss=spree, aud=store_api)
+   + a rotatable RefreshToken
+              │
+              ▼
+Client → subsequent calls with `Authorization: Bearer <Spree JWT>`
+```
+
+The third-party JWT proves identity **once, at login**. After that, the client uses the Spree JWT for everything, and `/auth/refresh` rotates it via Spree's own refresh-token mechanism. Your existing CanCanCan rules, `current_user`, and serializer params just work.
+
+## Step 1: Create the Strategy Class
+
+Subclass `Spree::Authentication::Strategies::BaseStrategy` and implement two methods: `provider` (a string identifier) and `authenticate` (returns a `Spree::ServiceModule::Result`).
+
+```ruby app/models/my_app/auth/external_jwt_strategy.rb
+module MyApp
+  module Auth
+    class ExternalJwtStrategy < Spree::Authentication::Strategies::BaseStrategy
+      PROVIDER = 'external_idp'.freeze
+
+      def provider
+        PROVIDER
+      end
+
+      def authenticate
+        token = params[:token] || extract_bearer
+        return failure(I18n.t('spree.api.unauthorized')) if token.blank?
+
+        payload = verify_with_jwks(token)
+
+        user = find_or_create_user_from_oauth(
+          provider: PROVIDER,
+          uid:      payload.fetch('sub'),
+          info:     {
+            email:      payload['email'],
+            first_name: payload['given_name'],
+            last_name:  payload['family_name']
+          }
+        )
+
+        success(user)
+      rescue JWT::DecodeError, JWT::ExpiredSignature, JWT::InvalidIssuerError, JWT::InvalidAudError, KeyError => e
+        failure(e.message)
+      end
+
+      private
+
+      def verify_with_jwks(token)
+        jwks_loader = ->(opts) { jwks(force: opts[:invalidate]) }
+
+        JWT.decode(
+          token, nil, true,
+          algorithms: ['RS256'],
+          iss:        ENV.fetch('EXTERNAL_IDP_ISSUER'),
+          aud:        ENV.fetch('EXTERNAL_IDP_AUDIENCE'),
+          verify_iss: true,
+          verify_aud: true,
+          jwks:       jwks_loader
+        ).first
+      end
+
+      def jwks(force: false)
+        Rails.cache.fetch('external_idp:jwks', expires_in: 1.hour, force: force) do
+          uri = URI(ENV.fetch('EXTERNAL_IDP_JWKS_URL'))
+          JSON.parse(Net::HTTP.get(uri))
+        end
+      end
+
+      def extract_bearer
+        header = request_env['HTTP_AUTHORIZATION'].to_s
+        header.start_with?('Bearer ') ? header.split(' ', 2).last : nil
+      end
+    end
+  end
+end
+```
+
+### What the base class gives you
+
+`Spree::Authentication::Strategies::BaseStrategy` (in `spree_core`) exposes a few helpers so your subclass stays small:
+
+| Helper | Purpose |
+|---|---|
+| `success(user)` | Wrap a user in a successful `ServiceModule::Result` |
+| `failure(message)` | Wrap an error message in a failed result |
+| `find_user_by_email(email)` | Lookup against `Spree.user_class` |
+| `find_or_create_user_from_oauth(provider:, uid:, info:, tokens: {})` | Calls `Spree::UserIdentity.find_or_create_from_oauth` with the right `user_class` |
+| `params`, `request_env`, `user_class` | Reader access to the controller-supplied inputs |
+
+`find_or_create_user_from_oauth` returns the **user**, not the identity. It creates the `Spree::UserIdentity` row on first login (mapping `provider + uid → user`) and reuses it on subsequent logins — so repeat sign-ins land on the same Spree customer.
+
+## Step 2: Register the Strategy
+
+Add the strategy to `Spree.store_authentication_strategies` in an initializer. The key you choose here is what clients will send as `provider` in the login payload.
+
+```ruby config/initializers/spree.rb
+Rails.application.config.after_initialize do
+  Spree.store_authentication_strategies.add(:external_idp, MyApp::Auth::ExternalJwtStrategy)
+end
+```
+
+`Spree.store_authentication_strategies` is a `Spree::Authentication::StrategyRegistry`. The full API:
+
+| Method | Purpose |
+|---|---|
+| `add(key, strategy_class)` | Register a strategy. Overwrites any existing entry under the same key — that's how you swap the built-in `:email` strategy. |
+| `remove(key)` | Unregister a strategy. Idempotent (returns `nil` if the key was never registered). |
+| `[key]` | Look up a registered class. |
+| `key?(key)`, `keys`, `values`, `each`, `to_h` | Standard introspection. |
+
+<Warning>
+`Spree::UserIdentity` validates that `provider` is a registered strategy key. Registration must happen during boot — before the first login attempt.
+</Warning>
+
+For an admin-side equivalent, register under `Spree.admin_authentication_strategies` instead and instantiate your strategy against `Spree.admin_user_class`:
+
+```ruby
+Spree.admin_authentication_strategies.add(:okta, MyApp::Auth::OktaStrategy)
+```
+
+## Step 3: Call the Exchange Endpoint
+
+Spree provides two endpoints that both dispatch through the strategy registry. Use `/oauth/callback` for third-party token exchange — it's the semantically correct route and skips email/password assumptions.
+
+```http
+POST /api/v3/store/auth/oauth/callback
+X-Spree-API-Key: pk_your_publishable_key
+Content-Type: application/json
+
+{
+  "provider": "external_idp",
+  "token":    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIs..."
+}
+```
+
+The response is the standard Spree auth payload:
+
+```json
+{
+  "token":         "<Spree HS256 JWT, aud=store_api>",
+  "refresh_token": "rt_xxxxxxxxxxxx",
+  "user":          { "id": "user_...", "email": "...", "first_name": "...", "...": "..." }
+}
+```
+
+From here, the client sends `Authorization: Bearer <Spree JWT>` on every subsequent Store API call. When the JWT expires (default: 1 hour), the client hits `POST /api/v3/store/auth/refresh` with the refresh token to rotate both.
+
+## Account Linking
+
+The naive flow above will create a brand new Spree user the first time a given `(provider, uid)` is seen — even if a user with the same email already exists from a password signup. If you want **same-email-means-same-customer**, look up by email first and attach an identity to the existing user:
+
+```ruby
+def authenticate
+  payload = verify_with_jwks(params[:token])
+  email   = payload.fetch('email')
+
+  user = find_user_by_email(email)
+
+  if user
+    user.identities.find_or_create_by!(provider: PROVIDER, uid: payload['sub']) do |identity|
+      identity.info = { email: email, name: payload['name'] }
+    end
+  else
+    user = find_or_create_user_from_oauth(
+      provider: PROVIDER,
+      uid:      payload['sub'],
+      info:     { email: email, first_name: payload['given_name'], last_name: payload['family_name'] }
+    )
+  end
+
+  success(user)
+end
+```
+
+<Warning>
+**Only link by email if your IdP guarantees `email_verified`.** Silent linking against an unverified email is a known account-takeover vector: an attacker registers `victim@example.com` at the IdP without proving ownership, then logs into Spree as the real victim. Check the `email_verified` claim (or equivalent) before linking, and reject otherwise.
+</Warning>
+
+## Logout
+
+```http
+POST /api/v3/store/auth/logout
+Content-Type: application/json
+
+{ "refresh_token": "rt_xxxxxxxxxxxx" }
+```
+
+This revokes the Spree refresh token. The Spree JWT itself remains valid until it expires naturally (short-lived by design — default 1 hour). Spree does **not** call the IdP's revocation endpoint; if you need single sign-out, do that from the client.
+
+## Security Notes
+
+A few things worth getting right:
+
+- **Don't try to pass the third-party JWT through to protected endpoints.** Spree's `JwtAuthentication` concern verifies `iss: 'spree'` and `aud: 'store_api'` with HS256 against the Spree secret — a foreign RS256 token will never validate, and you don't want it to. The exchange-at-login model is the right one.
+- **JWKS caching and rotation.** Cache the JWKS (the example uses a 1-hour TTL) but make sure your loader honors the `invalidate: true` option so that an unrecognized `kid` triggers a refetch. Otherwise key rotation at the IdP locks users out for up to the TTL.
+- **Validate `iss` and `aud` claims.** Always. The example passes `verify_iss: true, verify_aud: true` to `JWT.decode` — don't drop those.
+- **Algorithm pinning.** Hard-code `algorithms: ['RS256']` (or whatever your IdP uses). Never let the token's own `alg` header decide — the classic `alg: none` and HS-as-RS confusion attacks both exploit lax algorithm selection.
+- **Rate limiting.** `POST /auth/oauth/callback` is already rate-limited per IP via `Spree::Api::Config[:rate_limit_oauth]`. Tune it in your app config if needed.
+
+## Testing
+
+A strategy is a plain Ruby class — test it in isolation without booting a controller:
+
+```ruby spec/models/my_app/auth/external_jwt_strategy_spec.rb
+require 'rails_helper'
+
+RSpec.describe MyApp::Auth::ExternalJwtStrategy do
+  let(:rsa_private) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:jwks)        { { keys: [JWT::JWK.new(rsa_private).export] } }
+
+  let(:token) do
+    JWT.encode(
+      { sub: 'idp-user-123', email: 'alice@example.com', iss: 'https://idp.example', aud: 'spree' },
+      rsa_private, 'RS256'
+    )
+  end
+
+  before do
+    stub_request(:get, ENV['EXTERNAL_IDP_JWKS_URL']).to_return(body: jwks.to_json)
+  end
+
+  subject(:result) do
+    described_class.new(
+      params:      { provider: 'external_idp', token: token },
+      request_env: {}
+    ).authenticate
+  end
+
+  it 'provisions a Spree user on first login' do
+    expect { result }.to change(Spree.user_class, :count).by(1)
+    expect(result).to be_success
+    expect(result.value.email).to eq('alice@example.com')
+  end
+
+  it 'reuses the user on subsequent logins' do
+    described_class.new(params: { token: token }, request_env: {}).authenticate
+    expect { result }.not_to change(Spree.user_class, :count)
+  end
+
+  it 'fails on an expired token' do
+    expired = JWT.encode({ sub: 'x', exp: 1.hour.ago.to_i, iss: 'https://idp.example', aud: 'spree' }, rsa_private, 'RS256')
+    result  = described_class.new(params: { token: expired }, request_env: {}).authenticate
+    expect(result).not_to be_success
+  end
+end
+```
+
+## Reference
+
+- `Spree::Authentication::Strategies::BaseStrategy` — `spree/core/app/models/spree/authentication/strategies/base_strategy.rb`
+- `Spree::UserIdentity` — `spree/core/app/models/spree/user_identity.rb`
+- `Spree::Api::V3::Store::AuthController` — `spree/api/app/controllers/spree/api/v3/store/auth_controller.rb`
+- `Spree::Api::V3::JwtAuthentication` — `spree/api/app/controllers/concerns/spree/api/v3/jwt_authentication.rb`
+- See also: [Authentication](/developer/customization/authentication) for `Spree.user_class` integration.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -337,6 +337,11 @@
                 "group": "Search",
                 "icon": "search",
                 "pages": ["developer/how-to/custom-search-provider"]
+              },
+              {
+                "group": "Authentication",
+                "icon": "key",
+                "pages": ["developer/how-to/custom-api-authentication"]
               }
             ]
           },

--- a/docs/plans/6.0-platform-auth.md
+++ b/docs/plans/6.0-platform-auth.md
@@ -185,10 +185,9 @@ end
 
 ```
 # Store API
-POST   /api/v3/store/auth/login          # email+password → access JWT + refresh token
+POST   /api/v3/store/auth/login           # provider-dispatched login (email default, OAuth/SSO/custom JWT via `provider` key) → access JWT + refresh token
 POST   /api/v3/store/auth/refresh         # refresh token → new access JWT + rotated refresh token
 POST   /api/v3/store/auth/logout          # revoke refresh token
-POST   /api/v3/store/auth/oauth/callback  # OAuth provider callback → JWT + refresh token
 
 POST   /api/v3/store/customers            # register → JWT + refresh token
 POST   /api/v3/store/customer/password_resets          # request reset email

--- a/packages/admin-sdk/.changeset/login-provider-dispatch.md
+++ b/packages/admin-sdk/.changeset/login-provider-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@spree/admin-sdk': minor
+---
+
+Add provider-dispatched login. `client.auth.login()` now accepts third-party identity-provider payloads (e.g. `{ provider: 'okta', token: '<jwt>' }`) in addition to the existing `{ email, password }` shape — `LoginCredentials` is now a discriminated union of `EmailPasswordLogin | ProviderLogin`, both newly exported. Pairs with the server-side strategy registry at `Spree.admin_authentication_strategies`. Existing email/password calls are unchanged.

--- a/packages/admin-sdk/examples/auth/login.ts
+++ b/packages/admin-sdk/examples/auth/login.ts
@@ -1,0 +1,16 @@
+import { createAdminClient } from '@spree/admin-sdk'
+
+const client = createAdminClient({
+  baseUrl: 'https://your-store.com',
+  secretKey: 'sk_xxx',
+})
+
+// region:example
+// The refresh token is set as an HttpOnly cookie; only `token` and `user` come back in the body.
+const auth = await client.auth.login({
+  email: 'admin@example.com',
+  password: 'password123',
+})
+// endregion:example
+
+export { auth }

--- a/packages/admin-sdk/examples/auth/logout.ts
+++ b/packages/admin-sdk/examples/auth/logout.ts
@@ -1,0 +1,12 @@
+import { createAdminClient } from '@spree/admin-sdk'
+
+const client = createAdminClient({
+  baseUrl: 'https://your-store.com',
+  secretKey: 'sk_xxx',
+})
+
+// region:example
+await client.auth.logout()
+// endregion:example
+
+export {}

--- a/packages/admin-sdk/examples/auth/refresh.ts
+++ b/packages/admin-sdk/examples/auth/refresh.ts
@@ -1,0 +1,13 @@
+import { createAdminClient } from '@spree/admin-sdk'
+
+const client = createAdminClient({
+  baseUrl: 'https://your-store.com',
+  secretKey: 'sk_xxx',
+})
+
+// region:example
+// Driven entirely by the HttpOnly refresh-token cookie + CSRF header (set by the SDK).
+const auth = await client.auth.refresh()
+// endregion:example
+
+export { auth }

--- a/packages/admin-sdk/src/admin-client.ts
+++ b/packages/admin-sdk/src/admin-client.ts
@@ -46,7 +46,6 @@ export interface AuthTokens {
   user: AdminUser
 }
 
-
 export interface PermissionRule {
   /** true for `can`, false for `cannot` */
   allow: boolean
@@ -2049,4 +2048,11 @@ export class AdminClient {
 }
 
 // Re-export for type convenience
-export type { EmailPasswordLogin, ListParams, LoginCredentials, PaginatedResponse, ProviderLogin, RequestOptions }
+export type {
+  EmailPasswordLogin,
+  ListParams,
+  LoginCredentials,
+  PaginatedResponse,
+  ProviderLogin,
+  RequestOptions,
+}

--- a/packages/admin-sdk/src/admin-client.ts
+++ b/packages/admin-sdk/src/admin-client.ts
@@ -1,4 +1,12 @@
-import type { ListParams, PaginatedResponse, RequestFn, RequestOptions } from '@spree/sdk-core'
+import type {
+  EmailPasswordLogin,
+  ListParams,
+  LoginCredentials,
+  PaginatedResponse,
+  ProviderLogin,
+  RequestFn,
+  RequestOptions,
+} from '@spree/sdk-core'
 import { getParams, transformListParams } from '@spree/sdk-core'
 
 export interface DashboardAnalytics {
@@ -38,10 +46,6 @@ export interface AuthTokens {
   user: AdminUser
 }
 
-export interface LoginCredentials {
-  email: string
-  password: string
-}
 
 export interface PermissionRule {
   /** true for `can`, false for `cannot` */
@@ -2045,4 +2049,4 @@ export class AdminClient {
 }
 
 // Re-export for type convenience
-export type { ListParams, PaginatedResponse, RequestOptions }
+export type { EmailPasswordLogin, ListParams, LoginCredentials, PaginatedResponse, ProviderLogin, RequestOptions }

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -17,10 +17,13 @@ export { createRequestFn, SpreeError } from './request'
 // Shared types
 export type {
   AddressParams,
+  EmailPasswordLogin,
   ErrorResponse,
   ListParams,
   ListResponse,
   LocaleDefaults,
+  LoginCredentials,
   PaginatedResponse,
   PaginationMeta,
+  ProviderLogin,
 } from './types'

--- a/packages/sdk-core/src/types.ts
+++ b/packages/sdk-core/src/types.ts
@@ -69,3 +69,27 @@ export interface AddressParams {
   /** Set as default shipping address */
   is_default_shipping?: boolean
 }
+
+// Authentication
+
+/**
+ * Built-in email/password login. The default when `provider` is omitted.
+ */
+export interface EmailPasswordLogin {
+  provider?: 'email'
+  email: string
+  password: string
+}
+
+/**
+ * Provider-dispatched login. The `provider` field selects a strategy registered
+ * server-side in `Spree.store_authentication_strategies` (or `admin_authentication_strategies`).
+ * Additional fields are forwarded to the strategy's `authenticate` method — consult its
+ * documentation for the required shape (e.g. `{ provider: 'auth0', token: '<jwt>' }`).
+ */
+export interface ProviderLogin {
+  provider: string
+  [key: string]: unknown
+}
+
+export type LoginCredentials = EmailPasswordLogin | ProviderLogin

--- a/packages/sdk/.changeset/login-provider-dispatch.md
+++ b/packages/sdk/.changeset/login-provider-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@spree/sdk': minor
+---
+
+Add provider-dispatched login. `client.auth.login()` now accepts third-party identity-provider payloads (e.g. `{ provider: 'auth0', token: '<jwt>' }`) in addition to the existing `{ email, password }` shape — `LoginCredentials` is now a discriminated union of `EmailPasswordLogin | ProviderLogin`, both newly exported. Pairs with the server-side strategy registry at `Spree.store_authentication_strategies`. Existing email/password calls are unchanged.

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -85,10 +85,7 @@ export interface AuthTokens {
   }
 }
 
-export interface LoginCredentials {
-  email: string
-  password: string
-}
+export type { EmailPasswordLogin, LoginCredentials, ProviderLogin } from '@spree/sdk-core'
 
 export interface RequestPasswordResetParams {
   email: string

--- a/spree/api/app/controllers/spree/api/v3/admin/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/auth_controller.rb
@@ -76,7 +76,7 @@ module Spree
 
           def authentication_strategy
             provider = params[:provider].presence || 'email'
-            strategy_class = Rails.application.config.spree.admin_authentication_strategies[provider.to_sym]
+            strategy_class = Spree.admin_authentication_strategies[provider]
 
             unless strategy_class
               render_error(

--- a/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
@@ -6,10 +6,9 @@ module Spree
           # Tighter rate limits for auth endpoints (per IP to prevent brute force)
           rate_limit to: Spree::Api::Config[:rate_limit_login], within: Spree::Api::Config[:rate_limit_window].seconds, store: Rails.cache, only: :create, with: RATE_LIMIT_RESPONSE
           rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: Spree::Api::Config[:rate_limit_window].seconds, store: Rails.cache, only: :refresh, with: RATE_LIMIT_RESPONSE
-          rate_limit to: Spree::Api::Config[:rate_limit_oauth], within: Spree::Api::Config[:rate_limit_window].seconds, store: Rails.cache, only: :oauth_callback, with: RATE_LIMIT_RESPONSE
           rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: Spree::Api::Config[:rate_limit_window].seconds, store: Rails.cache, only: :logout, with: RATE_LIMIT_RESPONSE
 
-          skip_before_action :authenticate_user, only: [:create, :refresh, :oauth_callback]
+          skip_before_action :authenticate_user, only: [:create, :refresh]
 
           # POST  /api/v3/store/auth/login
           # Supports multiple authentication providers via :provider param
@@ -80,26 +79,6 @@ module Spree
             head :no_content
           end
 
-          # POST  /api/v3/store/auth/oauth/callback
-          # OAuth callback endpoint for server-side OAuth flows
-          def oauth_callback
-            strategy = authentication_strategy
-            return unless strategy # Error already rendered by determine_strategy
-
-            result = strategy.authenticate
-
-            if result.success?
-              user = result.value
-              render json: auth_response(user)
-            else
-              render_error(
-                code: ERROR_CODES[:authentication_failed],
-                message: result.error,
-                status: :unauthorized
-              )
-            end
-          end
-
           protected
 
           def serializer_params
@@ -133,6 +112,8 @@ module Spree
 
           def authentication_strategy
             strategy_class = determine_strategy
+            return nil unless strategy_class
+
             strategy_class.new(
               params: params,
               request_env: request.headers.env,

--- a/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
@@ -8,7 +8,7 @@ module Spree
           rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: Spree::Api::Config[:rate_limit_window].seconds, store: Rails.cache, only: :refresh, with: RATE_LIMIT_RESPONSE
           rate_limit to: Spree::Api::Config[:rate_limit_refresh], within: Spree::Api::Config[:rate_limit_window].seconds, store: Rails.cache, only: :logout, with: RATE_LIMIT_RESPONSE
 
-          skip_before_action :authenticate_user, only: [:create, :refresh]
+          skip_before_action :authenticate_user, only: [:create, :refresh, :logout]
 
           # POST  /api/v3/store/auth/login
           # Supports multiple authentication providers via :provider param
@@ -68,17 +68,14 @@ module Spree
 
           # POST  /api/v3/store/auth/logout
           # Accepts: { "refresh_token": "rt_xxx" }
-          # Revokes the refresh token. The token is looked up scoped to the
-          # authenticated user so one customer cannot revoke another's session.
+          # Revokes the submitted refresh token. The token itself is the
+          # credential — no access JWT is required, so clients with an expired
+          # access token can still log out. Matches Saleor's `tokenRevoke` and
+          # Shopify's `customerAccessTokenDelete` model.
           def logout
             refresh_token_value = params[:refresh_token]
 
-            if refresh_token_value.present? && current_user
-              Spree::RefreshToken
-                .where(user_id: current_user.id, user_type: current_user.class.name)
-                .find_by(token: refresh_token_value)
-                &.destroy
-            end
+            Spree::RefreshToken.find_by(token: refresh_token_value)&.destroy if refresh_token_value.present?
 
             head :no_content
           end

--- a/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
@@ -142,10 +142,9 @@ module Spree
 
           def determine_strategy
             provider = params[:provider].presence || 'email'
-            provider_key = provider.to_sym
 
             # Retrieve pre-loaded strategy class from configuration
-            strategy_class = Rails.application.config.spree.store_authentication_strategies[provider_key]
+            strategy_class = Spree.store_authentication_strategies[provider]
 
             unless strategy_class
               render_error(

--- a/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/auth_controller.rb
@@ -68,12 +68,16 @@ module Spree
 
           # POST  /api/v3/store/auth/logout
           # Accepts: { "refresh_token": "rt_xxx" }
-          # Revokes the refresh token
+          # Revokes the refresh token. The token is looked up scoped to the
+          # authenticated user so one customer cannot revoke another's session.
           def logout
             refresh_token_value = params[:refresh_token]
 
-            if refresh_token_value.present?
-              Spree::RefreshToken.find_by(token: refresh_token_value)&.destroy
+            if refresh_token_value.present? && current_user
+              Spree::RefreshToken
+                .where(user_id: current_user.id, user_type: current_user.class.name)
+                .find_by(token: refresh_token_value)
+                &.destroy
             end
 
             head :no_content

--- a/spree/api/config/routes.rb
+++ b/spree/api/config/routes.rb
@@ -6,7 +6,6 @@ Spree::Core::Engine.add_routes do
         post 'auth/login', to: 'auth#create'
         post 'auth/refresh', to: 'auth#refresh'
         post 'auth/logout', to: 'auth#logout'
-        post 'auth/oauth/callback', to: 'auth#oauth_callback'
 
         # Markets
         resources :markets, only: [:index, :show] do

--- a/spree/api/lib/spree/api/configuration.rb
+++ b/spree/api/lib/spree/api/configuration.rb
@@ -20,7 +20,6 @@ module Spree
       preference :rate_limit_login, :integer, default: 5 # per IP
       preference :rate_limit_register, :integer, default: 3 # per IP
       preference :rate_limit_refresh, :integer, default: 10 # per IP
-      preference :rate_limit_oauth, :integer, default: 5 # per IP
       preference :rate_limit_password_reset, :integer, default: 3 # per IP
 
       # Request body size limit in bytes

--- a/spree/api/lib/spree/api/openapi/schema_helper.rb
+++ b/spree/api/lib/spree/api/openapi/schema_helper.rb
@@ -195,8 +195,16 @@ module Spree
         def admin_schemas
           schemas = common_schemas
 
-          # Override AuthResponse to reference AdminUser instead of Customer
-          schemas[:AuthResponse][:properties][:user] = { '$ref' => '#/components/schemas/AdminUser' }
+          # Override AuthResponse for admin: reference AdminUser, and drop refresh_token from the body
+          # (admin sets the refresh token as an HttpOnly cookie, not in the JSON response).
+          schemas[:AuthResponse] = {
+            type: :object,
+            properties: {
+              token: { type: :string, description: 'JWT access token' },
+              user: { '$ref' => '#/components/schemas/AdminUser' }
+            },
+            required: %w[token user]
+          }
 
           begin
             schemas.merge!(typelizer_schemas(:admin))

--- a/spree/api/spec/controllers/concerns/spree/api/v3/rate_limiting_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/rate_limiting_spec.rb
@@ -47,10 +47,6 @@ RSpec.describe 'Rate Limiting', type: :controller do
       expect(Spree::Api::Config[:rate_limit_refresh]).to eq(10)
     end
 
-    it 'exposes rate_limit_oauth as a configurable preference' do
-      expect(Spree::Api::Config[:rate_limit_oauth]).to eq(5)
-    end
-
     it 'exposes rate_limit_window as a configurable preference' do
       expect(Spree::Api::Config[:rate_limit_window]).to eq(60)
     end

--- a/spree/api/spec/controllers/spree/api/v3/admin/auth_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/auth_controller_spec.rb
@@ -116,6 +116,85 @@ RSpec.describe Spree::Api::V3::Admin::AuthController, type: :controller do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'with a custom identity provider' do
+      let(:strategy_class) do
+        Class.new(Spree::Authentication::Strategies::BaseStrategy) do
+          def provider
+            'okta'
+          end
+
+          def authenticate
+            token = params[:token]
+            return failure('invalid_token') if token != 'valid-jwt'
+
+            user = find_or_create_user_from_oauth(
+              provider: 'okta',
+              uid:      'okta-admin-1',
+              info:     { email: 'sso-admin@example.com', first_name: 'Sso', last_name: 'Admin' }
+            )
+            success(user)
+          end
+        end
+      end
+
+      around do |example|
+        Spree.admin_authentication_strategies.add(:okta, strategy_class)
+        example.run
+      ensure
+        Spree.admin_authentication_strategies.remove(:okta)
+      end
+
+      it 'dispatches to the registered strategy and returns a Spree admin JWT' do
+        post :create, params: { provider: 'okta', token: 'valid-jwt' }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['token']).to be_present
+        expect(json_response['user']['email']).to eq('sso-admin@example.com')
+        payload = JWT.decode(json_response['token'], Rails.application.secret_key_base, true, algorithm: 'HS256').first
+        expect(payload['aud']).to eq('admin_api')
+        expect(payload['user_type']).to eq('admin')
+      end
+
+      it 'sets the HttpOnly refresh cookie on a strategy success' do
+        post :create, params: { provider: 'okta', token: 'valid-jwt' }
+
+        line = set_cookie_for('spree_admin_refresh_token')
+        expect(line).to be_present
+        expect(line).to include('httponly')
+      end
+
+      it 'creates a UserIdentity mapped to an admin user on first login' do
+        expect {
+          post :create, params: { provider: 'okta', token: 'valid-jwt' }
+        }.to change(Spree::UserIdentity, :count).by(1)
+
+        identity = Spree::UserIdentity.last
+        expect(identity.provider).to eq('okta')
+        expect(identity.uid).to eq('okta-admin-1')
+        expect(identity.user_type).to eq(Spree.admin_user_class.name)
+      end
+
+      it 'reuses the existing admin user on subsequent logins' do
+        post :create, params: { provider: 'okta', token: 'valid-jwt' }
+        first_user_id = json_response['user']['id']
+
+        expect {
+          post :create, params: { provider: 'okta', token: 'valid-jwt' }
+        }.not_to change(Spree.admin_user_class, :count)
+
+        expect(json_response['user']['id']).to eq(first_user_id)
+      end
+
+      it 'returns unauthorized when the strategy fails and sets no cookie' do
+        post :create, params: { provider: 'okta', token: 'bad-jwt' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(json_response['error']['code']).to eq('authentication_failed')
+        expect(json_response['error']['message']).to eq('invalid_token')
+        expect(set_cookie_for('spree_admin_refresh_token')).to be_nil
+      end
+    end
   end
 
   describe 'POST #refresh' do

--- a/spree/api/spec/controllers/spree/api/v3/admin/auth_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/auth_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Spree::Api::V3::Admin::AuthController, type: :controller do
   end
 
   describe 'POST #refresh' do
-    let(:refresh_token) { Spree::RefreshToken.create_for(admin_user, request_env: { ip_address: '127.0.0.1', user_agent: 'test' }) }
+    let(:refresh_token) { create(:refresh_token, user: admin_user, ip_address: '127.0.0.1', user_agent: 'test') }
 
     context 'with a valid refresh cookie' do
       before do
@@ -254,7 +254,7 @@ RSpec.describe Spree::Api::V3::Admin::AuthController, type: :controller do
   end
 
   describe 'POST #logout' do
-    let(:refresh_token) { Spree::RefreshToken.create_for(admin_user, request_env: { ip_address: '127.0.0.1', user_agent: 'test' }) }
+    let(:refresh_token) { create(:refresh_token, user: admin_user, ip_address: '127.0.0.1', user_agent: 'test') }
 
     context 'with a valid refresh cookie' do
       before do

--- a/spree/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
 
   describe 'POST #refresh' do
     let!(:existing_user) { create(:user, password: 'password123', password_confirmation: 'password123') }
-    let!(:refresh_token) { Spree::RefreshToken.create_for(existing_user) }
+    let!(:refresh_token) { create(:refresh_token, user: existing_user) }
 
     it 'returns a new access token and rotated refresh token' do
       post :refresh, params: { refresh_token: refresh_token.token }
@@ -231,7 +231,12 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
 
   describe 'POST #logout' do
     let!(:existing_user) { create(:user, password: 'password123', password_confirmation: 'password123') }
-    let!(:refresh_token) { Spree::RefreshToken.create_for(existing_user) }
+    let!(:refresh_token) { create(:refresh_token, user: existing_user) }
+    let(:user_jwt) { Spree::Api::V3::TestingSupport.generate_jwt(existing_user) }
+
+    before do
+      request.headers['Authorization'] = "Bearer #{user_jwt}"
+    end
 
     it 'revokes the refresh token' do
       expect {
@@ -249,6 +254,28 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
 
     it 'succeeds without refresh token param' do
       post :logout
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'cannot revoke another user\'s refresh token' do
+      other_user = create(:user, password: 'password123', password_confirmation: 'password123')
+      other_token = create(:refresh_token, user: other_user)
+
+      expect {
+        post :logout, params: { refresh_token: other_token.token }
+      }.not_to change(Spree::RefreshToken, :count)
+
+      expect(response).to have_http_status(:no_content)
+      expect(Spree::RefreshToken.find_by(id: other_token.id)).to be_present
+    end
+
+    it 'is a no-op when the request is unauthenticated' do
+      request.headers['Authorization'] = nil
+
+      expect {
+        post :logout, params: { refresh_token: refresh_token.token }
+      }.not_to change(Spree::RefreshToken, :count)
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spree/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
@@ -82,6 +82,88 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'with a custom identity provider' do
+      let(:strategy_class) do
+        Class.new(Spree::Authentication::Strategies::BaseStrategy) do
+          def provider
+            'external_idp'
+          end
+
+          def authenticate
+            token = params[:token]
+            return failure('invalid_token') if token != 'valid-jwt'
+
+            user = find_or_create_user_from_oauth(
+              provider: 'external_idp',
+              uid:      'idp-user-1',
+              info:     { email: 'sso@example.com', first_name: 'Alice' }
+            )
+            success(user)
+          end
+        end
+      end
+
+      around do |example|
+        Spree.store_authentication_strategies.add(:external_idp, strategy_class)
+        example.run
+      ensure
+        Spree.store_authentication_strategies.remove(:external_idp)
+      end
+
+      it 'dispatches to the registered strategy and returns a Spree JWT' do
+        post :create, params: { provider: 'external_idp', token: 'valid-jwt' }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['token']).to be_present
+        expect(json_response['refresh_token']).to be_present
+        expect(json_response['user']['email']).to eq('sso@example.com')
+      end
+
+      it 'creates a UserIdentity mapping on first login' do
+        expect {
+          post :create, params: { provider: 'external_idp', token: 'valid-jwt' }
+        }.to change(Spree::UserIdentity, :count).by(1)
+
+        identity = Spree::UserIdentity.last
+        expect(identity.provider).to eq('external_idp')
+        expect(identity.uid).to eq('idp-user-1')
+      end
+
+      it 'reuses the existing user on subsequent logins' do
+        post :create, params: { provider: 'external_idp', token: 'valid-jwt' }
+        first_user_id = json_response['user']['id']
+
+        expect {
+          post :create, params: { provider: 'external_idp', token: 'valid-jwt' }
+        }.not_to change(Spree.user_class, :count)
+
+        expect(json_response['user']['id']).to eq(first_user_id)
+      end
+
+      it 'returns unauthorized when the strategy fails' do
+        post :create, params: { provider: 'external_idp', token: 'bad-jwt' }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(json_response['error']['code']).to eq('authentication_failed')
+        expect(json_response['error']['message']).to eq('invalid_token')
+      end
+
+      it 'does not create a RefreshToken when the strategy fails' do
+        expect {
+          post :create, params: { provider: 'external_idp', token: 'bad-jwt' }
+        }.not_to change(Spree::RefreshToken, :count)
+      end
+    end
+
+    context 'with an unregistered provider' do
+      it 'returns bad_request' do
+        post :create, params: { provider: 'nope', token: 'whatever' }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json_response['error']['code']).to eq('invalid_provider')
+      end
+    end
   end
 
   describe 'POST #refresh' do

--- a/spree/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/auth_controller_spec.rb
@@ -232,13 +232,16 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
   describe 'POST #logout' do
     let!(:existing_user) { create(:user, password: 'password123', password_confirmation: 'password123') }
     let!(:refresh_token) { create(:refresh_token, user: existing_user) }
-    let(:user_jwt) { Spree::Api::V3::TestingSupport.generate_jwt(existing_user) }
-
-    before do
-      request.headers['Authorization'] = "Bearer #{user_jwt}"
-    end
 
     it 'revokes the refresh token' do
+      expect {
+        post :logout, params: { refresh_token: refresh_token.token }
+      }.to change(Spree::RefreshToken, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'works without an access token (the refresh token is the credential)' do
       expect {
         post :logout, params: { refresh_token: refresh_token.token }
       }.to change(Spree::RefreshToken, :count).by(-1)
@@ -254,28 +257,6 @@ RSpec.describe Spree::Api::V3::Store::AuthController, type: :controller do
 
     it 'succeeds without refresh token param' do
       post :logout
-
-      expect(response).to have_http_status(:no_content)
-    end
-
-    it 'cannot revoke another user\'s refresh token' do
-      other_user = create(:user, password: 'password123', password_confirmation: 'password123')
-      other_token = create(:refresh_token, user: other_user)
-
-      expect {
-        post :logout, params: { refresh_token: other_token.token }
-      }.not_to change(Spree::RefreshToken, :count)
-
-      expect(response).to have_http_status(:no_content)
-      expect(Spree::RefreshToken.find_by(id: other_token.id)).to be_present
-    end
-
-    it 'is a no-op when the request is unauthenticated' do
-      request.headers['Authorization'] = nil
-
-      expect {
-        post :logout, params: { refresh_token: refresh_token.token }
-      }.not_to change(Spree::RefreshToken, :count)
 
       expect(response).to have_http_status(:no_content)
     end

--- a/spree/api/spec/integration/spree/api/v3/admin/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/auth_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Admin Authentication API', type: :request, swagger_doc: 'api-reference/admin.yaml' do
+  include_context 'API v3 Admin'
+
+  let!(:existing_admin) { create(:admin_user, email: 'admin@example.com', password: 'password123') }
+
+  path '/api/v3/admin/auth/login' do
+    post 'Login' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+      security [api_key: []]
+      description <<~DESC
+        Authenticates an admin user and returns a short-lived JWT access token.
+        The rotatable refresh token is set in an HttpOnly cookie — it is not
+        included in the response body.
+
+        Dispatches by the `provider` field to a strategy registered in
+        `Spree.admin_authentication_strategies`. When `provider` is omitted it
+        defaults to `email`, which uses the built-in email/password strategy.
+
+        To plug in a third-party identity provider (Okta, Azure AD, Google
+        Workspace SSO, a custom JWT issuer, SAML, etc.), register a
+        `Spree::Authentication::Strategies::BaseStrategy` subclass under a
+        provider key, then send `{ "provider": "<your_key>", ... }` with the
+        fields your strategy requires. The endpoint returns the same Spree-issued
+        JWT regardless of which strategy authenticated the request.
+      DESC
+
+      admin_sdk_example 'auth/login'
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        oneOf: [
+          {
+            title: 'EmailPasswordLogin',
+            description: 'Built-in email/password authentication (default when `provider` is omitted).',
+            type: :object,
+            properties: {
+              provider: { type: :string, enum: ['email'], default: 'email' },
+              email: { type: :string, format: 'email', example: 'admin@example.com' },
+              password: { type: :string, example: 'password123' }
+            },
+            required: %w[email password]
+          },
+          {
+            title: 'ProviderLogin',
+            description: <<~D,
+              Provider-dispatched login. The `provider` key selects a registered
+              strategy class; the remaining fields are forwarded to the strategy's
+              `authenticate` method. Required fields depend on the registered strategy
+              — consult its documentation.
+            D
+            type: :object,
+            properties: {
+              provider: { type: :string, example: 'okta', description: 'Registered provider key (anything other than `email`).' }
+            },
+            required: %w[provider],
+            additionalProperties: true
+          }
+        ]
+      }
+
+      response '200', 'login successful' do
+        let(:'x-spree-api-key') { secret_api_key.plaintext_token }
+        let(:body) { { email: existing_admin.email, password: 'password123' } }
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data['user']).to be_present
+          expect(data['user']['email']).to eq(existing_admin.email)
+          expect(data).not_to have_key('refresh_token')
+        end
+      end
+
+      response '401', 'invalid credentials' do
+        let(:'x-spree-api-key') { secret_api_key.plaintext_token }
+        let(:body) { { email: existing_admin.email, password: 'wrong_password' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/admin/auth/refresh' do
+    post 'Refresh token' do
+      tags 'Authentication'
+      produces 'application/json'
+      security [api_key: []]
+      description <<~DESC
+        Exchanges the HttpOnly refresh-token cookie for a new access JWT and a
+        rotated refresh token cookie. No request body or Authorization header
+        is required — the cookie alone authenticates the call.
+      DESC
+
+      admin_sdk_example 'auth/refresh'
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+
+      response '401', 'missing or invalid refresh-token cookie' do
+        let(:'x-spree-api-key') { secret_api_key.plaintext_token }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/admin/auth/logout' do
+    post 'Logout' do
+      tags 'Authentication'
+      produces 'application/json'
+      security [api_key: []]
+      description 'Revokes the refresh-token cookie, effectively logging the admin out.'
+
+      admin_sdk_example 'auth/logout'
+
+      parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+
+      response '204', 'logout successful' do
+        let(:'x-spree-api-key') { secret_api_key.plaintext_token }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/admin/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/auth_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Admin Authentication API', type: :request, swagger_doc: 'api-ref
                 type: :string,
                 example: 'okta',
                 description: 'Registered provider key (anything other than `email`).',
-                not: { const: 'email' }
+                not: { enum: ['email'] }
               }
             },
             required: %w[provider],

--- a/spree/api/spec/integration/spree/api/v3/admin/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/auth_spec.rb
@@ -56,7 +56,12 @@ RSpec.describe 'Admin Authentication API', type: :request, swagger_doc: 'api-ref
             D
             type: :object,
             properties: {
-              provider: { type: :string, example: 'okta', description: 'Registered provider key (anything other than `email`).' }
+              provider: {
+                type: :string,
+                example: 'okta',
+                description: 'Registered provider key (anything other than `email`).',
+                not: { const: 'email' }
+              }
             },
             required: %w[provider],
             additionalProperties: true
@@ -104,6 +109,28 @@ RSpec.describe 'Admin Authentication API', type: :request, swagger_doc: 'api-ref
       admin_sdk_example 'auth/refresh'
 
       parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
+
+      response '200', 'refresh successful' do
+        let(:'x-spree-api-key') { secret_api_key.plaintext_token }
+        let(:refresh_token_record) { create(:refresh_token, user: existing_admin) }
+
+        # rswag drives requests through Rack::Test, whose cookie jar can't sign cookies the
+        # way Rails does. Stub the cookie reader on the controller concern so the integration
+        # test can exercise the refresh-success path without reimplementing Rails' signing.
+        before do
+          token = refresh_token_record.token
+          allow_any_instance_of(Spree::Api::V3::Admin::AuthCookies).to receive(:refresh_token_from_cookie).and_return(token)
+        end
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data['user']).to be_present
+          expect(data).not_to have_key('refresh_token')
+        end
+      end
 
       response '401', 'missing or invalid refresh-token cookie' do
         let(:'x-spree-api-key') { secret_api_key.plaintext_token }

--- a/spree/api/spec/integration/spree/api/v3/store/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/auth_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
                 type: :string,
                 example: 'auth0',
                 description: 'Registered provider key (anything other than `email`).',
-                not: { const: 'email' }
+                not: { enum: ['email'] }
               }
             },
             required: %w[provider],
@@ -160,13 +160,12 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
       tags 'Authentication'
       consumes 'application/json'
       produces 'application/json'
-      security [api_key: [], bearer_auth: []]
-      description 'Revokes the refresh token, effectively logging the customer out.'
+      security [api_key: []]
+      description 'Revokes the submitted refresh token. The refresh token itself is the credential — no Authorization header is required, so a client with an expired access JWT can still log out.'
 
       sdk_example 'auth/logout'
 
       parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
-      parameter name: 'Authorization', in: :header, type: :string, required: true
       parameter name: :body, in: :body, schema: {
         type: :object,
         properties: {
@@ -176,7 +175,6 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
 
       response '204', 'logout successful' do
         let(:'x-spree-api-key') { api_key.token }
-        let(:'Authorization') { "Bearer #{Spree::Api::V3::TestingSupport.generate_jwt(existing_user)}" }
         let(:refresh_token_record) { create(:refresh_token, user: existing_user) }
         let(:body) { { refresh_token: refresh_token_record.token } }
 
@@ -187,7 +185,6 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
 
       response '204', 'logout without refresh token (no-op)' do
         let(:'x-spree-api-key') { api_key.token }
-        let(:'Authorization') { "Bearer #{Spree::Api::V3::TestingSupport.generate_jwt(existing_user)}" }
         let(:body) { {} }
 
         run_test!

--- a/spree/api/spec/integration/spree/api/v3/store/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/auth_spec.rb
@@ -13,19 +13,53 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
       consumes 'application/json'
       produces 'application/json'
       security [api_key: []]
-      description 'Authenticates a customer with email/password and returns a JWT token'
+      description <<~DESC
+        Authenticates a customer and returns a JWT access token + refresh token.
+
+        Dispatches by the `provider` field to a strategy registered in
+        `Spree.store_authentication_strategies`. When `provider` is omitted it
+        defaults to `email`, which uses the built-in email/password strategy.
+
+        To plug in a third-party identity provider (Auth0, Okta, Firebase, a
+        custom JWT issuer, SAML, etc.), register a `Spree::Authentication::Strategies::BaseStrategy`
+        subclass under a provider key, then send `{ "provider": "<your_key>", ... }`
+        with the fields your strategy requires. The endpoint returns the same
+        Spree-issued JWT + refresh token regardless of which strategy authenticated
+        the request.
+      DESC
 
       sdk_example 'auth/login'
 
       parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
       parameter name: :body, in: :body, schema: {
-        type: :object,
-        properties: {
-          provider: { type: :string, example: 'email', description: 'Authentication provider (default: email)' },
-          email: { type: :string, format: 'email', example: 'customer@example.com' },
-          password: { type: :string, example: 'password123' }
-        },
-        required: %w[email password]
+        oneOf: [
+          {
+            title: 'EmailPasswordLogin',
+            description: 'Built-in email/password authentication (default when `provider` is omitted).',
+            type: :object,
+            properties: {
+              provider: { type: :string, enum: ['email'], default: 'email' },
+              email: { type: :string, format: 'email', example: 'customer@example.com' },
+              password: { type: :string, example: 'password123' }
+            },
+            required: %w[email password]
+          },
+          {
+            title: 'ProviderLogin',
+            description: <<~D,
+              Provider-dispatched login. The `provider` key selects a registered
+              strategy class; the remaining fields are forwarded to the strategy's
+              `authenticate` method. Required fields depend on the registered strategy
+              — consult its documentation.
+            D
+            type: :object,
+            properties: {
+              provider: { type: :string, example: 'auth0', description: 'Registered provider key (anything other than `email`).' }
+            },
+            required: %w[provider],
+            additionalProperties: true
+          }
+        ]
       }
 
       response '200', 'login successful' do

--- a/spree/api/spec/integration/spree/api/v3/store/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/auth_spec.rb
@@ -54,7 +54,12 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
             D
             type: :object,
             properties: {
-              provider: { type: :string, example: 'auth0', description: 'Registered provider key (anything other than `email`).' }
+              provider: {
+                type: :string,
+                example: 'auth0',
+                description: 'Registered provider key (anything other than `email`).',
+                not: { const: 'email' }
+              }
             },
             required: %w[provider],
             additionalProperties: true
@@ -126,7 +131,7 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
 
       response '200', 'token refreshed' do
         let(:'x-spree-api-key') { api_key.token }
-        let(:refresh_token_record) { Spree::RefreshToken.create_for(existing_user) }
+        let(:refresh_token_record) { create(:refresh_token, user: existing_user) }
         let(:body) { { refresh_token: refresh_token_record.token } }
 
         schema '$ref' => '#/components/schemas/AuthResponse'
@@ -171,8 +176,8 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
 
       response '204', 'logout successful' do
         let(:'x-spree-api-key') { api_key.token }
-        let(:'Authorization') { "Bearer #{jwt_token}" }
-        let(:refresh_token_record) { Spree::RefreshToken.create_for(existing_user) }
+        let(:'Authorization') { "Bearer #{Spree::Api::V3::TestingSupport.generate_jwt(existing_user)}" }
+        let(:refresh_token_record) { create(:refresh_token, user: existing_user) }
         let(:body) { { refresh_token: refresh_token_record.token } }
 
         run_test! do
@@ -182,7 +187,7 @@ RSpec.describe 'Authentication API', type: :request, swagger_doc: 'api-reference
 
       response '204', 'logout without refresh token (no-op)' do
         let(:'x-spree-api-key') { api_key.token }
-        let(:'Authorization') { "Bearer #{jwt_token}" }
+        let(:'Authorization') { "Bearer #{Spree::Api::V3::TestingSupport.generate_jwt(existing_user)}" }
         let(:body) { {} }
 
         run_test!

--- a/spree/core/app/models/spree/authentication/strategy_registry.rb
+++ b/spree/core/app/models/spree/authentication/strategy_registry.rb
@@ -1,0 +1,61 @@
+module Spree
+  module Authentication
+    # Keyed registry of authentication strategy classes for the Store and Admin APIs.
+    #
+    # Strategies are dispatched by the `provider` value the client sends to the auth
+    # endpoint, so the registry is a key → class map. The `:email` key is reserved for
+    # the built-in {Spree::Authentication::Strategies::EmailPasswordStrategy}; integrators
+    # can override it by adding a different class under the same key.
+    #
+    # @example Registering a custom provider
+    #   Spree.store_authentication_strategies.add(:auth0, MyApp::Auth::Auth0Strategy)
+    #
+    # @example Removing a provider
+    #   Spree.store_authentication_strategies.remove(:email)
+    #
+    # @example Reading a strategy class
+    #   Spree.store_authentication_strategies[:email]
+    class StrategyRegistry
+      extend Forwardable
+      include Enumerable
+
+      def_delegators :@strategies, :keys, :values, :each
+
+      def initialize(strategies = {})
+        @strategies = {}
+        strategies.each { |key, klass| add(key, klass) }
+      end
+
+      # Register a strategy class under the given provider key. Overwrites any
+      # existing entry for that key.
+      #
+      # @param key [Symbol, String] provider identifier sent by the client
+      # @param strategy_class [Class] strategy class (typically a subclass of
+      #   {Spree::Authentication::Strategies::BaseStrategy})
+      # @return [Class] the registered class
+      def add(key, strategy_class)
+        @strategies[key.to_sym] = strategy_class
+      end
+
+      # Unregister a strategy. Idempotent — returns `nil` if the key is not present.
+      #
+      # @param key [Symbol, String]
+      # @return [Class, nil] the removed class, or nil if no such key
+      def remove(key)
+        @strategies.delete(key.to_sym)
+      end
+
+      def [](key)
+        @strategies[key.to_sym]
+      end
+
+      def key?(key)
+        @strategies.key?(key.to_sym)
+      end
+
+      def to_h
+        @strategies.dup
+      end
+    end
+  end
+end

--- a/spree/core/app/models/spree/authentication/strategy_registry.rb
+++ b/spree/core/app/models/spree/authentication/strategy_registry.rb
@@ -45,14 +45,23 @@ module Spree
         @strategies.delete(key.to_sym)
       end
 
+      # Look up a registered strategy class.
+      #
+      # @param key [Symbol, String] provider identifier
+      # @return [Class, nil] the registered strategy class, or nil if no such key
       def [](key)
         @strategies[key.to_sym]
       end
 
+      # Whether a strategy is registered under the given provider key.
+      #
+      # @param key [Symbol, String]
+      # @return [Boolean]
       def key?(key)
         @strategies.key?(key.to_sym)
       end
 
+      # @return [Hash{Symbol => Class}] a shallow copy of the underlying map
       def to_h
         @strategies.dup
       end

--- a/spree/core/app/models/spree/authentication/strategy_registry.rb
+++ b/spree/core/app/models/spree/authentication/strategy_registry.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Spree
   module Authentication
     # Keyed registry of authentication strategy classes for the Store and Admin APIs.

--- a/spree/core/app/models/spree/user_identity.rb
+++ b/spree/core/app/models/spree/user_identity.rb
@@ -9,8 +9,7 @@ module Spree
 
     validates :provider, inclusion: {
       in: ->(_record) {
-        config = Rails.application.config.spree
-        (config.store_authentication_strategies.keys + config.admin_authentication_strategies.keys).uniq.map(&:to_s)
+        (Spree.store_authentication_strategies.keys + Spree.admin_authentication_strategies.keys).uniq.map(&:to_s)
       }
     }
 

--- a/spree/core/lib/spree/core.rb
+++ b/spree/core/lib/spree/core.rb
@@ -354,6 +354,32 @@ module Spree
     Rails.application.config.spree.pricing = value
   end
 
+  # Registry of authentication strategy classes for the Store API.
+  # @return [Spree::Authentication::StrategyRegistry]
+  # @example Registering a third-party identity provider
+  #   Spree.store_authentication_strategies.add(:auth0, MyApp::Auth::Auth0Strategy)
+  # @example Removing a strategy
+  #   Spree.store_authentication_strategies.remove(:email)
+  def self.store_authentication_strategies
+    Rails.application.config.spree.store_authentication_strategies
+  end
+
+  def self.store_authentication_strategies=(value)
+    Rails.application.config.spree.store_authentication_strategies = value
+  end
+
+  # Registry of authentication strategy classes for the Admin API.
+  # @return [Spree::Authentication::StrategyRegistry]
+  # @example Registering an SSO strategy for admin users
+  #   Spree.admin_authentication_strategies.add(:okta, MyApp::Auth::OktaStrategy)
+  def self.admin_authentication_strategies
+    Rails.application.config.spree.admin_authentication_strategies
+  end
+
+  def self.admin_authentication_strategies=(value)
+    Rails.application.config.spree.admin_authentication_strategies = value
+  end
+
   def self.analytics
     @analytics ||= AnalyticsConfig.new
   end

--- a/spree/core/lib/spree/core.rb
+++ b/spree/core/lib/spree/core.rb
@@ -364,6 +364,8 @@ module Spree
     Rails.application.config.spree.store_authentication_strategies
   end
 
+  # @param value [Spree::Authentication::StrategyRegistry] the registry to use for Store API authentication dispatch
+  # @return [Spree::Authentication::StrategyRegistry] the assigned registry
   def self.store_authentication_strategies=(value)
     Rails.application.config.spree.store_authentication_strategies = value
   end
@@ -376,6 +378,8 @@ module Spree
     Rails.application.config.spree.admin_authentication_strategies
   end
 
+  # @param value [Spree::Authentication::StrategyRegistry] the registry to use for Admin API authentication dispatch
+  # @return [Spree::Authentication::StrategyRegistry] the assigned registry
   def self.admin_authentication_strategies=(value)
     Rails.application.config.spree.admin_authentication_strategies = value
   end

--- a/spree/core/lib/spree/core/engine.rb
+++ b/spree/core/lib/spree/core/engine.rb
@@ -320,12 +320,12 @@ module Spree
         ]
 
         # Pre-load authentication strategy classes to avoid reflection at request time
-        Rails.application.config.spree.store_authentication_strategies = {
+        Rails.application.config.spree.store_authentication_strategies = Spree::Authentication::StrategyRegistry.new(
           email: Spree::Authentication::Strategies::EmailPasswordStrategy
-        }
-        Rails.application.config.spree.admin_authentication_strategies = {
+        )
+        Rails.application.config.spree.admin_authentication_strategies = Spree::Authentication::StrategyRegistry.new(
           email: Spree::Authentication::Strategies::EmailPasswordStrategy
-        }
+        )
       end
 
       initializer 'spree.promo.register.promotions.actions' do |app|

--- a/spree/core/lib/spree/testing_support/factories/refresh_token_factory.rb
+++ b/spree/core/lib/spree/testing_support/factories/refresh_token_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :refresh_token, class: 'Spree::RefreshToken' do
+    association :user, factory: :user
+    user_type { user.class.to_s }
+    expires_at { Spree::RefreshToken.default_expiry.from_now }
+
+    trait :for_admin do
+      association :user, factory: :admin_user
+    end
+
+    trait :expired do
+      expires_at { 1.minute.ago }
+    end
+  end
+end

--- a/spree/core/spec/models/spree/authentication/strategy_registry_spec.rb
+++ b/spree/core/spec/models/spree/authentication/strategy_registry_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe Spree::Authentication::StrategyRegistry do
+  let(:strategy_class) { Class.new }
+  let(:other_strategy_class) { Class.new }
+
+  describe '#add' do
+    it 'registers a strategy under the given key' do
+      registry = described_class.new
+      registry.add(:auth0, strategy_class)
+      expect(registry[:auth0]).to eq(strategy_class)
+    end
+
+    it 'symbolizes string keys' do
+      registry = described_class.new
+      registry.add('okta', strategy_class)
+      expect(registry[:okta]).to eq(strategy_class)
+    end
+
+    it 'overwrites an existing entry under the same key' do
+      registry = described_class.new(email: strategy_class)
+      registry.add(:email, other_strategy_class)
+      expect(registry[:email]).to eq(other_strategy_class)
+    end
+
+    it 'returns the registered class' do
+      registry = described_class.new
+      expect(registry.add(:auth0, strategy_class)).to eq(strategy_class)
+    end
+  end
+
+  describe '#remove' do
+    it 'unregisters the strategy and returns it' do
+      registry = described_class.new(email: strategy_class)
+      expect(registry.remove(:email)).to eq(strategy_class)
+      expect(registry[:email]).to be_nil
+    end
+
+    it 'returns nil for a missing key (idempotent)' do
+      registry = described_class.new
+      expect(registry.remove(:unknown)).to be_nil
+    end
+
+    it 'accepts string keys' do
+      registry = described_class.new(email: strategy_class)
+      expect(registry.remove('email')).to eq(strategy_class)
+    end
+  end
+
+  describe '#[]' do
+    it 'symbolizes string lookups' do
+      registry = described_class.new(email: strategy_class)
+      expect(registry['email']).to eq(strategy_class)
+    end
+
+    it 'returns nil for unknown keys' do
+      expect(described_class.new[:nope]).to be_nil
+    end
+  end
+
+  describe '#key?' do
+    it 'is true for registered keys' do
+      registry = described_class.new(email: strategy_class)
+      expect(registry.key?(:email)).to be true
+      expect(registry.key?('email')).to be true
+    end
+
+    it 'is false for unknown keys' do
+      expect(described_class.new.key?(:nope)).to be false
+    end
+  end
+
+  describe '#keys / #values / #each' do
+    let(:registry) { described_class.new(email: strategy_class, auth0: other_strategy_class) }
+
+    it 'exposes the registered keys' do
+      expect(registry.keys).to contain_exactly(:email, :auth0)
+    end
+
+    it 'exposes the registered classes' do
+      expect(registry.values).to contain_exactly(strategy_class, other_strategy_class)
+    end
+
+    it 'iterates key/class pairs (Enumerable)' do
+      expect(registry.map { |k, v| [k, v] }).to contain_exactly([:email, strategy_class], [:auth0, other_strategy_class])
+    end
+  end
+
+  describe '#to_h' do
+    it 'returns a copy of the underlying hash' do
+      registry = described_class.new(email: strategy_class)
+      copy = registry.to_h
+      copy[:tampered] = Object
+      expect(registry.key?(:tampered)).to be false
+    end
+  end
+end

--- a/spree/core/spec/models/spree/user_identity_spec.rb
+++ b/spree/core/spec/models/spree/user_identity_spec.rb
@@ -30,11 +30,11 @@ describe Spree::UserIdentity, type: :model do
       end
 
       it 'allows same uid for different providers' do
-        Rails.application.config.spree.store_authentication_strategies[:other] = Class.new
+        Spree.store_authentication_strategies.add(:other, Class.new)
         different_provider = build(:user_identity, user: user, provider: 'other', uid: '12345')
         expect(different_provider).to be_valid
       ensure
-        Rails.application.config.spree.store_authentication_strategies.delete(:other)
+        Spree.store_authentication_strategies.remove(:other)
       end
 
       it 'allows same uid for different user types' do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> OpenAPI changes define the admin auth contract (JWT in body, refresh via cookie, provider login); client/SDK integrators must follow the updated spec even though this diff is documentation-only.
> 
> **Overview**
> Documents **admin API authentication** in `admin.yaml`: new **`POST /api/v3/admin/auth/login`**, **`/refresh`**, and **`/logout`** under an **Authentication** tag, including provider-dispatched login (`provider` + strategy-specific fields), SDK samples, and error shapes.
> 
> **Auth contract in the reference:** successful login/refresh responses use **`AuthResponse` with only `token` and `user`**—**`refresh_token` is removed from the JSON schema** (refresh is described as an **HttpOnly cookie**, not the response body). Login request bodies use **`oneOf`** for email/password vs generic provider payloads.
> 
> **Store rate-limit docs:** removes the **`POST /auth/oauth/callback`** row from the default limits table in `rate-limitting.mdx`, matching dropped OAuth-callback throttling.
> 
> **Incidental OpenAPI churn:** regenerated example fixtures (timestamps, emails, tokens) across many admin paths; **`Market`** component field order/`required` list now lists **`country_isos` before `supported_locales`**; promotion **country** rule `preference_schema` key order adjusted in the catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7792fc9044baf709137e4db8a2582d3ba02642a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a developer guide for custom API authentication and an “Authentication” how-to; updated API reference and platform docs for provider-dispatched login, refresh, and logout behaviors.

* **New Features**
  * Store and Admin login now accept provider-dispatched credentials (third‑party IdP payloads); clients receive an access JWT plus refresh token. SDKs/types and examples updated.

* **Bug Fixes**
  * Logout revokes only the submitted refresh token; OAuth callback route removed.

* **Tests**
  * Added registry specs, expanded auth controller/integration tests, and a refresh-token test factory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->