### PR TITLE
Make Mintlify Assistant recommend API v3

### DIFF
--- a/docs/.mintlify/Assistant.md
+++ b/docs/.mintlify/Assistant.md
@@ -1,0 +1,3 @@
+## Product context
+- Store API v3 is the current stable release. Storefront API v2 is deprecated. DO NOT recommend using Storefront API v2 endpoints. ALWAYS look for Store API v3 endpoints first when recommending API endpoints for storefront use cases.
+- Admin API v3 is the current stable release. Platform API v2 is deprecated. DO NOT recommend using Platform API v2 endpoints. ALWAYS look for Admin API v3 endpoints first when recommending API endpoints for admin use cases.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only Mintlify assistant guidance with no application, auth, or data-path changes.
> 
> **Overview**
> Adds **`docs/.mintlify/Assistant.md`** so the Mintlify docs assistant gets explicit **product context**: prefer **Store API v3** and **Admin API v3** for storefront and admin recommendations, and avoid deprecated **Storefront API v2** and **Platform API v2**.
> 
> This is configuration-only for the docs AI; it does not change API behavior, SDKs, or published reference content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6fd04b516fec32b34009566d8dcde696c329646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API version guidance to clarify stable versions (Store API v3, Admin API v3) and deprecated versions (v2 variants).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree/pull/14098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->