### PR TITLE
fix assigning primary media to product on session uploaded assets

### DIFF
--- a/spree/admin/app/controllers/spree/admin/products_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/products_controller.rb
@@ -293,6 +293,8 @@ module Spree
         return if uploaded_assets.empty?
 
         uploaded_assets.update_all(viewable_id: @product.id, viewable_type: 'Spree::Product', updated_at: Time.current)
+        @product.update_thumbnail!
+
         clear_session_for_uploaded_assets('Spree::Product')
       end
 

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -412,11 +412,19 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         session.delete('spree.admin.uploaded_assets.spree/product.uuid')
       end
 
-      it 'assigns session uploaded assets to the product and updates thumbnail' do
+      it 'assigns session uploaded assets to the product' do
+        expect(asset.viewable_id).to be_nil
+
         subject
 
         product = Spree::Product.last
         expect(asset.reload.viewable_id).to eq(product.id)
+      end
+
+      it 'updates the product primary media' do
+        subject
+
+        product = Spree::Product.last
         expect(product.primary_media_id).to eq(asset.id)
       end
     end

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -394,6 +394,33 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
       end
     end
 
+    context 'with session uploaded assets' do
+      let(:product_params) do
+        {
+          name: 'Product with images',
+          shipping_category_id: shipping_category.id
+        }
+      end
+      let(:session_uuid) { SecureRandom.uuid }
+      let!(:asset) { create(:image, viewable_id: nil, viewable_type: 'Spree::Product', session_id: session_uuid) }
+
+      before do
+        session['spree.admin.uploaded_assets.spree/product.uuid'] = session_uuid
+      end
+
+      after do
+        session.delete('spree.admin.uploaded_assets.spree/product.uuid')
+      end
+
+      it 'assigns session uploaded assets to the product and updates thumbnail' do
+        subject
+
+        product = Spree::Product.last
+        expect(asset.reload.viewable_id).to eq(product.id)
+        expect(product.primary_media_id).to eq(asset.id)
+      end
+    end
+
     context 'with stock items' do
       let(:product_params) do
         {

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -418,14 +418,14 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         subject
 
         product = Spree::Product.last
-        expect(asset.reload.viewable_id).to eq(product.id)
+        expect(asset.reload.viewable).to eq(product)
       end
 
       it 'updates the product primary media' do
         subject
 
         product = Spree::Product.last
-        expect(product.primary_media_id).to eq(asset.id)
+        expect(product.primary_media).to eq(asset)
       end
     end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single post-create hook plus specs; no auth, payment, or broad behavioral refactors.
> 
> **Overview**
> Fixes admin product **create** when images were uploaded in-session before save: after session assets are linked to the new product, the flow now calls **`update_thumbnail!`** so **`primary_media`** (thumbnail) is set, not only the asset `viewable` association.
> 
> Adds controller specs for session-uploaded images: assets attach to the created product and **`primary_media`** points at the uploaded image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c83e823f7e3cf4a06951a5c631c946c04cf020fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product asset upload flow now updates product thumbnails immediately when session-uploaded assets are linked during product creation.

* **Tests**
  * Added tests confirming session-uploaded image assets are attached to newly created products and the product's primary media is correctly assigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->