### PR TITLE
Improved 5.5 migration path

### DIFF
--- a/spree/core/app/models/spree/store_product.rb
+++ b/spree/core/app/models/spree/store_product.rb
@@ -1,0 +1,17 @@
+module Spree
+  # Thin AR wrapper over the legacy +spree_products_stores+ join table.
+  # Pre-5.5 core used this table to attach products to stores; 5.5+ moved
+  # that responsibility onto +Spree::Product#store_id+ + +ProductPublication+.
+  #
+  # The model exists only to power the 5.4 → 5.5 backfill rake task
+  # (+spree:upgrade:populate_publications+). Host apps upgrading from 5.4
+  # still have the table; after the backfill runs, +spree_multi_store+ (for
+  # multi-store catalogs) keeps the table around, and single-store
+  # installations may drop it.
+  class StoreProduct < Spree.base_class
+    self.table_name = 'spree_products_stores'
+
+    belongs_to :product, class_name: 'Spree::Product'
+    belongs_to :store, class_name: 'Spree::Store'
+  end
+end

--- a/spree/core/lib/tasks/publications.rake
+++ b/spree/core/lib/tasks/publications.rake
@@ -8,78 +8,53 @@ namespace :spree do
 
       Run once after upgrading to Spree 5.5+. Multi-store merchants must install
       +spree_multi_store+ before running; running on a multi-store catalog without
-      the extension picks one "home" store per product per the rules below:
-
-        1. The store flagged +default: true+ if the product is published there
-        2. Otherwise the first store (by +spree_products_stores.created_at+)
+      the extension picks the earliest +spree_products_stores+ row (by
+      +created_at+) as the product's home store.
     DESC
     task populate_publications: :environment do
-      legacy_table = 'spree_products_stores'
-
-      unless ActiveRecord::Base.connection.table_exists?(legacy_table)
-        puts "  #{legacy_table} table not found — nothing to migrate."
+      unless ActiveRecord::Base.connection.table_exists?(Spree::StoreProduct.table_name)
+        puts "  #{Spree::StoreProduct.table_name} table not found — nothing to migrate."
         next
       end
 
-      products_processed = 0
+      batch_size = (ENV['BATCH_SIZE'] || 1_000).to_i
       publications_created = 0
 
-      # Legacy +spree_products_stores+ pre-5.5 carries only product_id,
-      # store_id, created_at (plus the +units_sold_count+/+revenue+ columns
-      # we no longer read here). Channel attribution + publication windows
-      # are derived from the destination store's default channel.
-      Spree::Product.where(store_id: nil).find_each do |product|
-        sql = ActiveRecord::Base.sanitize_sql_array([
-          "SELECT store_id, created_at FROM #{legacy_table} WHERE product_id = ? ORDER BY created_at ASC",
-          product.id
-        ])
-        rows = ActiveRecord::Base.connection.select_all(sql).to_a
-
-        next if rows.empty?
-
-        home_store_id = pick_home_store(rows)
-        store_ids = rows.map { |r| r['store_id'] }.uniq
-
-        # Build publications + store_id assignment atomically. If the
-        # publication writes fail (validation, deadlock, etc.) we rollback
-        # so a re-run can retry — the +store_id IS NULL+ filter at the top
-        # of the loop only matches products that didn't finish.
-        ActiveRecord::Base.transaction do
-          store_ids.each do |store_id|
-            channel = Spree::Store.find(store_id).default_channel
-            next unless channel
-
-            publication = Spree::ProductPublication.find_or_initialize_by(
-              product_id: product.id,
-              channel_id: channel.id
-            )
-
-            next if publication.persisted?
-
-            publication.save!
-            publications_created += 1
-          end
-
-          product.update_column(:store_id, home_store_id)
+      # Pass 1: per store, batch-publish products onto the store's default
+      # channel via +Channel#add_products+. One upsert + one touch_all per
+      # batch beats the previous per-product loop by orders of magnitude on
+      # large catalogs. +add_products+ is upsert-based with +on_duplicate:
+      # :skip+, so existing publications on re-run are no-ops.
+      Spree::Store.find_each do |store|
+        channel = store.default_channel
+        unless channel
+          puts "  Store '#{store.name}' has no default channel — skipping."
+          next
         end
 
+        store_publications = 0
+        Spree::StoreProduct.where(store_id: store.id).in_batches(of: batch_size) do |batch|
+          store_publications += channel.add_products(batch.pluck(:product_id))
+        end
+
+        publications_created += store_publications
+        puts "  Store '#{store.name}': created #{store_publications} publication(s)" if store_publications.positive?
+      end
+
+      # Pass 2: assign +store_id+ on products that still don't have one,
+      # using the earliest legacy row per product.
+      products_processed = 0
+
+      Spree::Product.where(store_id: nil).find_each(batch_size: batch_size) do |product|
+        store_id = Spree::StoreProduct.where(product_id: product.id).order(:created_at).limit(1).pick(:store_id)
+        next unless store_id
+
+        product.update_column(:store_id, store_id)
         products_processed += 1
       end
 
       puts "  Processed #{products_processed} products"
       puts "  Created #{publications_created} publications"
-    end
-
-    # When a product was attached to multiple stores via the legacy join,
-    # pick the default store if it's in the list — otherwise the earliest
-    # row (rows are pre-sorted by +created_at+).
-    def pick_home_store(rows)
-      default_store_id = Spree::Store.find_by(default: true)&.id
-      if default_store_id && rows.any? { |r| r['store_id'] == default_store_id }
-        default_store_id
-      else
-        rows.first['store_id']
-      end
     end
   end
 end

--- a/spree/core/spec/lib/tasks/publications_spec.rb
+++ b/spree/core/spec/lib/tasks/publications_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'spree:upgrade:populate_publications' do
+  subject { Rake::Task[task_name] }
+
+  let(:task_name) { 'spree:upgrade:populate_publications' }
+
+  before(:all) do
+    Rake::Task.define_task(:environment)
+    load Spree::Core::Engine.root.join('lib', 'tasks', 'publications.rake')
+  end
+
+  before { subject.reenable }
+
+  # Simulate the pre-5.5 catalog state: a row in +spree_products_stores+ for
+  # the product/store pair, +Product#store_id+ nil, and no +ProductPublication+
+  # for the store's default channel. The product factory auto-attaches both,
+  # so we strip them and rebuild the legacy join row directly.
+  def downgrade!(product, store)
+    product.product_publications.destroy_all
+    product.update_columns(store_id: nil)
+    Spree::StoreProduct.create!(product: product, store: store)
+  end
+
+  let!(:default_store) { Spree::Store.default || create(:store, default: true) }
+
+  context 'single store' do
+    let!(:channel) { default_store.default_channel || create(:channel, store: default_store) }
+    let!(:product) { create(:product, store: default_store) }
+
+    before { downgrade!(product, default_store) }
+
+    it 'creates a publication on the default channel' do
+      expect { subject.invoke }.to change {
+        Spree::ProductPublication.where(product_id: product.id, channel_id: channel.id).exists?
+      }.from(false).to(true)
+    end
+
+    it 'sets store_id on the product' do
+      expect { subject.invoke }.to change { product.reload.store_id }.from(nil).to(default_store.id)
+    end
+
+    it 'is idempotent — a re-run creates no extra publications' do
+      subject.invoke
+      subject.reenable
+      expect { subject.invoke }.not_to change { Spree::ProductPublication.count }
+    end
+  end
+
+  context 'multi-store catalog (single-store backfill mode)' do
+    let!(:other_store) { create(:store, default: false) }
+    let!(:default_channel) { default_store.default_channel || create(:channel, store: default_store) }
+    let!(:other_channel) { other_store.default_channel || create(:channel, store: other_store) }
+    let!(:product) { create(:product, store: default_store) }
+
+    before do
+      downgrade!(product, default_store)
+      # Earliest legacy row wins for store_id. Backdate +default_store+'s
+      # row so it's older than +other_store+'s and assert it's chosen.
+      Spree::StoreProduct.where(product_id: product.id).update_all(created_at: 2.days.ago)
+      Spree::StoreProduct.create!(product: product, store: other_store, created_at: 1.day.ago)
+    end
+
+    it 'publishes the product on every store it was attached to' do
+      subject.invoke
+      expect(Spree::ProductPublication.where(product_id: product.id).pluck(:channel_id))
+        .to match_array([default_channel.id, other_channel.id])
+    end
+
+    it 'sets product.store_id from the earliest legacy row' do
+      expect { subject.invoke }.to change { product.reload.store_id }.from(nil).to(default_store.id)
+    end
+  end
+
+  context 'store without a default channel' do
+    let!(:other_store) { create(:store, default: false) }
+    let!(:product) { create(:product, store: default_store) }
+
+    before do
+      downgrade!(product, default_store)
+      # Strip channels off +other_store+ to simulate the warning path.
+      other_store.channels.destroy_all
+      Spree::StoreProduct.create!(product: product, store: other_store)
+    end
+
+    it 'skips that store with a warning and still processes the rest' do
+      expect { subject.invoke }
+        .to output(/has no default channel/).to_stdout
+        .and change { product.reload.store_id }.from(nil).to(default_store.id)
+    end
+  end
+
+  context 'legacy table not present' do
+    before do
+      allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_call_original
+      allow(ActiveRecord::Base.connection)
+        .to receive(:table_exists?).with('spree_products_stores').and_return(false)
+    end
+
+    it 'no-ops with a message' do
+      expect { subject.invoke }.to output(/nothing to migrate/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes upgrade-time catalog and store assignment behavior (default-store preference removed) and bulk-writes publications/store_id during migrations.
> 
> **Overview**
> Refactors the **5.4 → 5.5** upgrade rake task `spree:upgrade:populate_publications` for large catalogs and clearer legacy data access.
> 
> Introduces **`Spree::StoreProduct`** as a thin ActiveRecord model over `spree_products_stores`, used only for this backfill instead of raw SQL on the join table.
> 
> The task now runs in **two passes**: batch-create publications per store via each store’s default channel and **`Channel#add_products`** (configurable **`BATCH_SIZE`**, default 1000), then set **`product.store_id`** from the earliest legacy join row by **`created_at`**. **Home store** selection no longer prefers the default store when a product was in multiple stores—only the earliest row wins. Per-product transactions and **`pick_home_store`** are removed.
> 
> Adds **`publications_spec`** covering single-store migration, multi-store publications + home store, missing default channel, idempotency, and missing legacy table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4713d809b5f503269bbf9d7b19db7faf4d22028a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the 5.4 to 5.5 upgrade process to correctly migrate product availability across multiple stores and their associated channels, with support for configurable batch processing.

* **Tests**
  * Added comprehensive test suite for the upgrade migration task, verifying data integrity across multiple store configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->