### PR TITLE
Bug fixes for channels

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "WebFetch",
       "WebSearch",
       "Task",
-      "mcp__*"
+      "mcp__*",
+      "Read(//private/tmp/**)"
     ],
     "deny": [
       "Bash(sudo *)",

--- a/packages/admin-sdk/src/params.ts
+++ b/packages/admin-sdk/src/params.ts
@@ -582,7 +582,11 @@ export interface CustomerGroupCreateParams {
 
 export interface ChannelCreateParams {
   name: string
-  code: string
+  /**
+   * URL-safe slug. Optional — the backend derives it from +name+ when omitted
+   * (e.g. "Point of Sale" → "point-of-sale").
+   */
+  code?: string
   active?: boolean
   default?: boolean
   /**

--- a/packages/dashboard/src/locales/en.json
+++ b/packages/dashboard/src/locales/en.json
@@ -185,8 +185,8 @@
         "name": { "placeholder": "e.g. POS, Wholesale, Meta Shop" },
         "code": {
           "label": "Code",
-          "placeholder": "e.g. pos",
-          "help": "Stable identifier used by API clients via the X-Spree-Channel header and for order attribution. Lowercase letters, numbers, hyphens, underscores."
+          "placeholder": "Auto-derived from name",
+          "help": "Stable identifier used by API clients via the X-Spree-Channel header and for order attribution. Leave blank to auto-derive from the name. Lowercase letters, numbers, hyphens, underscores."
         },
         "active": {
           "label": "Active",

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/channels.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/channels.tsx
@@ -115,7 +115,7 @@ function ChannelsPage() {
               {
                 key: 'delete',
                 destructive: true,
-                visible: permissions.can('destroy', Subject.Channel),
+                visible: permissions.can('destroy', Subject.Channel) && !channel.default,
                 disabled: deleteMutation.isPending,
                 onSelect: () => handleDelete(channel),
               },

--- a/packages/dashboard/src/schemas/channel.ts
+++ b/packages/dashboard/src/schemas/channel.ts
@@ -16,12 +16,15 @@ export type OrderRoutingStrategyValue = (typeof ORDER_ROUTING_STRATEGY_VALUES)[n
 
 export const channelFormSchema = z.object({
   name: z.string().min(1, { error: requiredMessage('name') }),
+  // +code+ is optional in the UI: the backend's +normalizes :code+ derives
+  // it from +name+ when blank. If the user types something we still validate
+  // the character set so they don't push invalid slugs to the API.
   code: z
     .string()
-    .min(1, { error: requiredMessage('code') })
-    .regex(/^[a-z0-9_-]+$/i, {
+    .regex(/^[a-z0-9_-]*$/i, {
       error: 'Lowercase letters, numbers, hyphens, underscores only',
-    }),
+    })
+    .optional(),
   active: z.boolean(),
   default: z.boolean(),
   preferred_order_routing_strategy: z.string(),
@@ -42,7 +45,9 @@ export function channelValuesToParams(
 ): ChannelCreateParams & ChannelUpdateParams {
   return {
     name: v.name,
-    code: v.code,
+    // Send +code+ only when the user provided one; the server backfills
+    // from +name+ when omitted, so an empty string would override that.
+    ...(v.code ? { code: v.code } : {}),
     active: v.active,
     default: v.default,
     // Empty string clears the channel-level override → falls back to store.

--- a/packages/dashboard/src/schemas/channel.ts
+++ b/packages/dashboard/src/schemas/channel.ts
@@ -2,9 +2,7 @@ import type { ChannelCreateParams, ChannelUpdateParams } from '@spree/admin-sdk'
 import { requiredMessage } from '@spree/dashboard-ui'
 import { z } from 'zod/v4'
 
-// Concrete +Spree::OrderRouting::Strategy::Base+ subclass names. The empty
-// string clears the channel-level override → falls back to the store-level
-// preference.
+// Empty string clears the channel-level override → falls back to store.
 export const ORDER_ROUTING_STRATEGY_VALUES = [
   '',
   'Spree::OrderRouting::Strategy::Rules',
@@ -16,9 +14,6 @@ export type OrderRoutingStrategyValue = (typeof ORDER_ROUTING_STRATEGY_VALUES)[n
 
 export const channelFormSchema = z.object({
   name: z.string().min(1, { error: requiredMessage('name') }),
-  // +code+ is optional in the UI: the backend's +normalizes :code+ derives
-  // it from +name+ when blank. If the user types something we still validate
-  // the character set so they don't push invalid slugs to the API.
   code: z
     .string()
     .regex(/^[a-z0-9_-]*$/i, {
@@ -45,12 +40,9 @@ export function channelValuesToParams(
 ): ChannelCreateParams & ChannelUpdateParams {
   return {
     name: v.name,
-    // Send +code+ only when the user provided one; the server backfills
-    // from +name+ when omitted, so an empty string would override that.
     ...(v.code ? { code: v.code } : {}),
     active: v.active,
     default: v.default,
-    // Empty string clears the channel-level override → falls back to store.
     preferred_order_routing_strategy: v.preferred_order_routing_strategy || null,
   }
 }

--- a/spree/admin/app/views/spree/admin/products/form/_publishing.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_publishing.html.erb
@@ -53,6 +53,13 @@
           <%= f.fields_for :product_publications, publication, child_index: index do |pf| %>
             <%= pf.hidden_field :id if publication.persisted? %>
             <%= pf.hidden_field :channel_id, value: channel.id %>
+            <%
+              # New (unsaved) products start with the default channel checked
+              # so the user only has to untick when they specifically don't
+              # want that channel — same behaviour as the SPA's
+              # +<PublishingCard>+.
+              checked_by_default = publication.persisted? || (@product.new_record? && channel.default?)
+            %>
             <label class="flex items-center gap-3 rounded border px-3 py-2 cursor-pointer hover:bg-gray-50 text-sm">
               <%# The +_destroy+ hidden field defaults to 1 (= destroy/skip);
                   the checkbox flips it to 0 (= keep/upsert) when checked.
@@ -60,7 +67,7 @@
                   emitting its own competing hidden field. %>
               <%= pf.hidden_field :_destroy, value: '1', id: nil %>
               <%= pf.check_box :_destroy,
-                               { checked: publication.persisted?,
+                               { checked: checked_by_default,
                                  class: 'form-check-input m-0',
                                  include_hidden: false },
                                '0', '1' %>

--- a/spree/admin/app/views/spree/admin/products/form/_publishing.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_publishing.html.erb
@@ -53,13 +53,7 @@
           <%= f.fields_for :product_publications, publication, child_index: index do |pf| %>
             <%= pf.hidden_field :id if publication.persisted? %>
             <%= pf.hidden_field :channel_id, value: channel.id %>
-            <%
-              # New (unsaved) products start with the default channel checked
-              # so the user only has to untick when they specifically don't
-              # want that channel — same behaviour as the SPA's
-              # +<PublishingCard>+.
-              checked_by_default = publication.persisted? || (@product.new_record? && channel.default?)
-            %>
+            <% checked_by_default = publication.persisted? || (@product.new_record? && channel.default?) %>
             <label class="flex items-center gap-3 rounded border px-3 py-2 cursor-pointer hover:bg-gray-50 text-sm">
               <%# The +_destroy+ hidden field defaults to 1 (= destroy/skip);
                   the checkbox flips it to 0 (= keep/upsert) when checked.

--- a/spree/api/app/controllers/concerns/spree/api/v3/admin_authentication.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/admin_authentication.rb
@@ -5,7 +5,6 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          before_action :authenticate_admin!
           after_action :set_no_store_cache
         end
 

--- a/spree/api/app/controllers/spree/api/v3/admin/base_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/base_controller.rb
@@ -5,6 +5,8 @@ module Spree
         class BaseController < Spree::Api::V3::BaseController
           include Spree::Api::V3::AdminAuthentication
           include Spree::Api::V3::ScopedAuthorization
+
+          before_action :authenticate_admin!
         end
       end
     end

--- a/spree/api/app/controllers/spree/api/v3/admin/resource_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/resource_controller.rb
@@ -11,9 +11,6 @@ module Spree
 
           protected
 
-          # Fulfill the +V3::ResourceController+ authentication hook so
-          # +set_resource+ runs with the right +current_ability+ — secret API
-          # key abilities for key auth, CanCanCan abilities for JWT.
           def authenticate_request!
             authenticate_admin!
           end

--- a/spree/api/app/controllers/spree/api/v3/admin/resource_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/resource_controller.rb
@@ -11,6 +11,13 @@ module Spree
 
           protected
 
+          # Fulfill the +V3::ResourceController+ authentication hook so
+          # +set_resource+ runs with the right +current_ability+ — secret API
+          # key abilities for key auth, CanCanCan abilities for JWT.
+          def authenticate_request!
+            authenticate_admin!
+          end
+
           # Render error from ServiceModule::Result, extracting ActiveModel::Errors
           # from the ResultError wrapper to get proper validation_error responses.
           def render_result_error(result)

--- a/spree/api/app/controllers/spree/api/v3/resource_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/resource_controller.rb
@@ -4,6 +4,12 @@ module Spree
       class ResourceController < BaseController
         include Spree::Api::V3::ParamsNormalizer
 
+        # Authentication hook. +Store::ResourceController+ and
+        # +Admin::ResourceController+ override this to authenticate the
+        # request (publishable key, secret key, JWT). Declared before
+        # +set_parent+ / +set_resource+ so +scope+'s +accessible_by+ sees
+        # the post-authentication +current_ability+.
+        before_action :authenticate_request!
         before_action :set_parent
         before_action :set_resource, only: [:show, :update, :destroy]
 
@@ -75,6 +81,13 @@ module Spree
         end
 
         protected
+
+        # No-op authentication hook. +Store::ResourceController+ /
+        # +Admin::ResourceController+ override this to enforce the right
+        # credential type. Subclasses that need bespoke auth (e.g. an
+        # endpoint that mixes guest + authenticated reads) can do so too.
+        def authenticate_request!
+        end
 
         # No-op HTTP caching methods. Include Spree::Api::V3::HttpCaching
         # in specific controllers to enable HTTP caching for their actions.

--- a/spree/api/app/controllers/spree/api/v3/resource_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/resource_controller.rb
@@ -4,10 +4,7 @@ module Spree
       class ResourceController < BaseController
         include Spree::Api::V3::ParamsNormalizer
 
-        # Authentication hook. +Store::ResourceController+ and
-        # +Admin::ResourceController+ override this to authenticate the
-        # request (publishable key, secret key, JWT). Declared before
-        # +set_parent+ / +set_resource+ so +scope+'s +accessible_by+ sees
+        # Must run before +set_resource+: +scope+'s +accessible_by+ depends on
         # the post-authentication +current_ability+.
         before_action :authenticate_request!
         before_action :set_parent
@@ -82,11 +79,8 @@ module Spree
 
         protected
 
-        # No-op authentication hook. +Store::ResourceController+ /
-        # +Admin::ResourceController+ override this to enforce the right
-        # credential type. Subclasses that need bespoke auth (e.g. an
-        # endpoint that mixes guest + authenticated reads) can do so too.
         def authenticate_request!
+          raise NotImplementedError, "#{self.class} must implement authenticate_request!"
         end
 
         # No-op HTTP caching methods. Include Spree::Api::V3::HttpCaching

--- a/spree/api/app/controllers/spree/api/v3/store/products/filters_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/products/filters_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
             def filters_cache_key
               products_table = Spree::Product.table_name
-              stats = current_store.products.active(current_currency)
+              stats = current_store.products.available(Time.current, current_currency)
                         .pick(Arel.sql("MAX(#{products_table}.updated_at)"), Arel.sql("COUNT(DISTINCT #{products_table}.id)"))
               max_updated = stats&.first&.to_i
               product_count = stats&.last || 0
@@ -50,7 +50,7 @@ module Spree
             end
 
             def filters_scope
-              scope = current_store.products.active(current_currency)
+              scope = current_store.products.available(Time.current, current_currency)
               scope = scope.in_category(category) if category.present?
               scope.accessible_by(current_ability, :show)
             end

--- a/spree/api/app/controllers/spree/api/v3/store/products_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/products_controller.rb
@@ -29,7 +29,7 @@ module Spree
           end
 
           def scope
-            super.active(Spree::Current.currency)
+            super.available(Time.current, Spree::Current.currency)
           end
 
           # these scopes are not automatically picked by ar_lazy_preload gem and we need to explicitly include them

--- a/spree/api/app/controllers/spree/api/v3/store/resource_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/resource_controller.rb
@@ -10,8 +10,6 @@ module Spree
 
           protected
 
-          # Fulfill the +V3::ResourceController+ authentication hook so
-          # +set_resource+ runs with the right +current_ability+.
           def authenticate_request!
             authenticate_api_key!
           end

--- a/spree/api/app/controllers/spree/api/v3/store/resource_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/resource_controller.rb
@@ -8,8 +8,13 @@ module Spree
         class ResourceController < Spree::Api::V3::ResourceController
           include Spree::Api::V3::ChannelResolution
 
-          # Require publishable API key for all Store API requests
-          before_action :authenticate_api_key!
+          protected
+
+          # Fulfill the +V3::ResourceController+ authentication hook so
+          # +set_resource+ runs with the right +current_ability+.
+          def authenticate_request!
+            authenticate_api_key!
+          end
         end
       end
     end

--- a/spree/api/spec/controllers/concerns/spree/api/v3/admin_authentication_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/admin_authentication_spec.rb
@@ -1,14 +1,7 @@
 require 'spec_helper'
 
-# Covers the +Spree::Api::V3::AdminAuthentication+ concern: secret API key
-# extraction, cross-store rejection, the ability resolution that flows from
-# +current_api_key+, and the callback ordering invariant that +authenticate_admin!+
-# fires before +set_resource+ so +scope+'s +accessible_by(current_ability, …)+
-# sees the post-authentication ability (not the unauthenticated fallback that
-# previously returned nothing and surfaced as 404 on +show+/+update+/+destroy+).
-#
-# Uses +TaxCategoriesController+ as a representative Admin::ResourceController
-# — the same mechanic applies to every admin endpoint via the shared base class.
+# Covers AdminAuthentication using TaxCategoriesController as a representative
+# Admin::ResourceController — the mechanic applies to every admin endpoint.
 RSpec.describe Spree::Api::V3::Admin::TaxCategoriesController, type: :controller do
   render_views
 
@@ -61,17 +54,10 @@ RSpec.describe Spree::Api::V3::Admin::TaxCategoriesController, type: :controller
     end
   end
 
-  describe 'auth ordering — +authenticate_admin!+ runs before +set_resource+' do
-    # Regression: +set_resource+ used to run before +authenticate_admin!+
-    # because Rails appends included-module +before_action+ callbacks at the
-    # end of the chain. With API-key-only auth, +current_ability+ fell back
-    # to an unauthenticated +Spree::Ability+ — which has +:read+ on
-    # +Spree::Product+ (so GET show happened to work) but no +:update+ /
-    # +:destroy+ permission and no permission at all on resources the default
-    # ability doesn't grant (e.g. +Spree::Channel+, +Spree::TaxCategory+).
-    # +scope.accessible_by(ability, …)+ returned no rows, so
-    # +find_by_prefix_id!+ raised +RecordNotFound+ → 404 on the four affected
-    # paths.
+  # Regression: +set_resource+ ran before +authenticate_admin!+, so
+  # +current_ability+ was the unauthenticated +Spree::Ability+ and
+  # +scope.accessible_by+ returned no rows → 404 on show/update/destroy.
+  describe 'auth ordering — +authenticate_request!+ runs before +set_resource+' do
     before { request.headers['X-Spree-Api-Key'] = secret_api_key.plaintext_token }
 
     it 'GET show returns 200 (not 404)' do

--- a/spree/api/spec/controllers/concerns/spree/api/v3/admin_authentication_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/admin_authentication_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+
+# Covers the +Spree::Api::V3::AdminAuthentication+ concern: secret API key
+# extraction, cross-store rejection, the ability resolution that flows from
+# +current_api_key+, and the callback ordering invariant that +authenticate_admin!+
+# fires before +set_resource+ so +scope+'s +accessible_by(current_ability, …)+
+# sees the post-authentication ability (not the unauthenticated fallback that
+# previously returned nothing and surfaced as 404 on +show+/+update+/+destroy+).
+#
+# Uses +TaxCategoriesController+ as a representative Admin::ResourceController
+# — the same mechanic applies to every admin endpoint via the shared base class.
+RSpec.describe Spree::Api::V3::Admin::TaxCategoriesController, type: :controller do
+  render_views
+
+  include_context 'API v3 Admin'
+
+  let!(:tax_category) { create(:tax_category, name: 'Standard') }
+
+  describe 'secret API key authentication' do
+    context 'with a valid key' do
+      before { request.headers['X-Spree-Api-Key'] = secret_api_key.plaintext_token }
+
+      it 'authenticates and resolves to the ApiKeyAbility' do
+        get :index, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(controller.send(:current_api_key)).to eq(secret_api_key)
+        expect(controller.send(:current_ability)).to be_a(Spree::ApiKeyAbility)
+      end
+    end
+
+    context 'with no key and no JWT' do
+      it 'returns 401' do
+        get :index, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with an unknown key' do
+      before { request.headers['X-Spree-Api-Key'] = 'sk_does_not_exist' }
+
+      it 'returns 401' do
+        get :index, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the key belongs to a different store' do
+      let(:other_store) { create(:store, default: false, code: 'other') }
+      let(:foreign_key) { create(:api_key, :secret, store: other_store) }
+
+      before { request.headers['X-Spree-Api-Key'] = foreign_key.plaintext_token }
+
+      it 'returns 401 (cross-store keys are rejected)' do
+        get :index, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'auth ordering — +authenticate_admin!+ runs before +set_resource+' do
+    # Regression: +set_resource+ used to run before +authenticate_admin!+
+    # because Rails appends included-module +before_action+ callbacks at the
+    # end of the chain. With API-key-only auth, +current_ability+ fell back
+    # to an unauthenticated +Spree::Ability+ — which has +:read+ on
+    # +Spree::Product+ (so GET show happened to work) but no +:update+ /
+    # +:destroy+ permission and no permission at all on resources the default
+    # ability doesn't grant (e.g. +Spree::Channel+, +Spree::TaxCategory+).
+    # +scope.accessible_by(ability, …)+ returned no rows, so
+    # +find_by_prefix_id!+ raised +RecordNotFound+ → 404 on the four affected
+    # paths.
+    before { request.headers['X-Spree-Api-Key'] = secret_api_key.plaintext_token }
+
+    it 'GET show returns 200 (not 404)' do
+      get :show, params: { id: tax_category.prefixed_id }, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'PATCH update returns 200 (not 404)' do
+      patch :update, params: { id: tax_category.prefixed_id, name: 'Reduced' }, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(tax_category.reload.name).to eq('Reduced')
+    end
+
+    it 'DELETE destroy returns 204 (not 404)' do
+      delete :destroy, params: { id: tax_category.prefixed_id }, as: :json
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'declares +authenticate_request!+ before +set_resource+ in the callback chain' do
+      callbacks = described_class._process_action_callbacks
+                                 .select { |c| c.kind == :before }
+                                 .map(&:filter)
+      auth_index = callbacks.index(:authenticate_request!)
+      set_resource_index = callbacks.index(:set_resource)
+
+      expect(auth_index).to be < set_resource_index
+    end
+  end
+
+  describe 'touch throttling for secret keys' do
+    before { request.headers['X-Spree-Api-Key'] = secret_api_key.plaintext_token }
+
+    context 'when last_used_at is nil' do
+      before { secret_api_key.update_column(:last_used_at, nil) }
+
+      it 'enqueues MarkAsUsed' do
+        expect { get :index, as: :json }
+          .to have_enqueued_job(Spree::ApiKeys::MarkAsUsed).with(secret_api_key.id, instance_of(ActiveSupport::TimeWithZone))
+      end
+    end
+
+    context 'when last_used_at is older than 1 hour' do
+      before { secret_api_key.update_column(:last_used_at, 2.hours.ago) }
+
+      it 'enqueues MarkAsUsed' do
+        expect { get :index, as: :json }
+          .to have_enqueued_job(Spree::ApiKeys::MarkAsUsed).with(secret_api_key.id, instance_of(ActiveSupport::TimeWithZone))
+      end
+    end
+
+    context 'when last_used_at is within the last hour' do
+      before { secret_api_key.update_column(:last_used_at, 30.minutes.ago) }
+
+      it 'does not enqueue MarkAsUsed' do
+        expect { get :index, as: :json }.not_to have_enqueued_job(Spree::ApiKeys::MarkAsUsed)
+      end
+    end
+  end
+
+  describe 'response headers' do
+    before { request.headers['X-Spree-Api-Key'] = secret_api_key.plaintext_token }
+
+    it 'sets Cache-Control: private, no-store on admin responses' do
+      get :index, as: :json
+
+      expect(response.headers['Cache-Control']).to eq('private, no-store')
+    end
+  end
+end

--- a/spree/api/spec/controllers/concerns/spree/api/v3/channel_resolution_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/channel_resolution_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
       expect(resolved_channel).to eq(pos_channel)
     end
 
-    # HTTP headers reach Rails as ASCII-8BIT; +String#parameterize+ (invoked by
-    # +Channel.normalizes :code+) used to raise +ArgumentError+ on those.
     it 'resolves channel when the header arrives as ASCII-8BIT bytes' do
       request.headers['x-spree-channel'] = String.new('pos').force_encoding(Encoding::ASCII_8BIT)
       get :index

--- a/spree/api/spec/controllers/concerns/spree/api/v3/channel_resolution_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/channel_resolution_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
       expect(resolved_channel).to eq(pos_channel)
     end
 
+    # HTTP headers reach Rails as ASCII-8BIT; +String#parameterize+ (invoked by
+    # +Channel.normalizes :code+) used to raise +ArgumentError+ on those.
+    it 'resolves channel when the header arrives as ASCII-8BIT bytes' do
+      request.headers['x-spree-channel'] = String.new('pos').force_encoding(Encoding::ASCII_8BIT)
+      get :index
+
+      expect(response).to have_http_status(:ok)
+      expect(resolved_channel).to eq(pos_channel)
+    end
+
     it 'resolves channel from X-Spree-Channel header by prefixed ID' do
       request.headers['x-spree-channel'] = pos_channel.prefixed_id
       get :index

--- a/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
@@ -10,6 +10,30 @@ RSpec.describe Spree::Api::V3::Admin::ChannelsController, type: :controller do
 
   before { request.headers.merge!(headers) }
 
+  # Regression: +set_resource+ used to run before +authenticate_admin!+ because
+  # Rails appends included-module callbacks at the end of the chain. With API
+  # key auth only (no JWT), +current_ability+ fell back to an unauthenticated
+  # +Spree::Ability+ that has no permission on +Spree::Channel+, so +scope+
+  # returned nothing and +find_by_prefix_id!+ raised +RecordNotFound+ → 404.
+  describe 'API key only (no JWT) — auth must run before set_resource' do
+    let(:headers) { api_key_headers }
+
+    it 'GET show returns 200' do
+      get :show, params: { id: channel.prefixed_id }, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'PATCH update returns 200' do
+      patch :update, params: { id: channel.prefixed_id, name: 'New name' }, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'DELETE destroy returns 204' do
+      delete :destroy, params: { id: channel.prefixed_id }, as: :json
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
   describe 'POST #add_products' do
     let!(:other_product) { create(:product) }
 
@@ -226,6 +250,25 @@ RSpec.describe Spree::Api::V3::Admin::ChannelsController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       expect(channel.reload.preferred_order_routing_strategy).to be_blank
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys a non-default channel' do
+      expect { delete :destroy, params: { id: channel.prefixed_id }, as: :json }
+        .to change(Spree::Channel, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'refuses to delete the default channel with 422' do
+      default_channel = store.default_channel
+
+      expect { delete :destroy, params: { id: default_channel.prefixed_id }, as: :json }
+        .not_to change(Spree::Channel, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response['error']['code']).to eq('validation_error')
     end
   end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
@@ -10,30 +10,6 @@ RSpec.describe Spree::Api::V3::Admin::ChannelsController, type: :controller do
 
   before { request.headers.merge!(headers) }
 
-  # Regression: +set_resource+ used to run before +authenticate_admin!+ because
-  # Rails appends included-module callbacks at the end of the chain. With API
-  # key auth only (no JWT), +current_ability+ fell back to an unauthenticated
-  # +Spree::Ability+ that has no permission on +Spree::Channel+, so +scope+
-  # returned nothing and +find_by_prefix_id!+ raised +RecordNotFound+ → 404.
-  describe 'API key only (no JWT) — auth must run before set_resource' do
-    let(:headers) { api_key_headers }
-
-    it 'GET show returns 200' do
-      get :show, params: { id: channel.prefixed_id }, as: :json
-      expect(response).to have_http_status(:ok)
-    end
-
-    it 'PATCH update returns 200' do
-      patch :update, params: { id: channel.prefixed_id, name: 'New name' }, as: :json
-      expect(response).to have_http_status(:ok)
-    end
-
-    it 'DELETE destroy returns 204' do
-      delete :destroy, params: { id: channel.prefixed_id }, as: :json
-      expect(response).to have_http_status(:no_content)
-    end
-  end
-
   describe 'POST #add_products' do
     let!(:other_product) { create(:product) }
 

--- a/spree/core/app/models/concerns/spree/product_scopes.rb
+++ b/spree/core/app/models/concerns/spree/product_scopes.rb
@@ -336,7 +336,7 @@ module Spree
       end
 
       def self.active(currency = nil)
-        available(nil, currency)
+        available(Time.current, currency)
       end
 
       # Deprecated — remove in 6.0. Use active(currency).in_taxon(taxon) directly.

--- a/spree/core/app/models/concerns/spree/product_scopes.rb
+++ b/spree/core/app/models/concerns/spree/product_scopes.rb
@@ -336,7 +336,7 @@ module Spree
       end
 
       def self.active(currency = nil)
-        available(Time.current, currency)
+        available(nil, currency)
       end
 
       # Deprecated — remove in 6.0. Use active(currency).in_taxon(taxon) directly.

--- a/spree/core/app/models/spree/channel.rb
+++ b/spree/core/app/models/spree/channel.rb
@@ -23,10 +23,7 @@ module Spree
 
     attribute :active, :boolean, default: true
 
-    # Force UTF-8 before parameterize. HTTP headers reach Rails as ASCII-8BIT
-    # and +String#parameterize+ raises +ArgumentError+ on non-UTF-8 input
-    # ("Cannot transliterate strings with ASCII-8BIT encoding"). Channel codes
-    # are slugs ([a-z0-9-]) so the bytes are already valid UTF-8.
+    # HTTP headers arrive as ASCII-8BIT; +parameterize+ raises on those.
     normalizes :code, with: ->(value) { value.to_s.dup.force_encoding(Encoding::UTF_8).parameterize.presence }
 
     before_validation :backfill_code_from_name, if: -> { code.blank? && name.present? }
@@ -114,9 +111,6 @@ module Spree
       count
     end
 
-    # The default channel of a store is the storefront's fallback when no
-    # +X-Spree-Channel+ is given, so removing it would orphan all storefront
-    # traffic. Promote another channel to default first.
     # @return [Boolean]
     def can_be_deleted?
       !default?
@@ -126,7 +120,6 @@ module Spree
 
     def ensure_not_default
       return if can_be_deleted?
-      # Allow store cascade — destroying the store removes its channels too.
       return if destroyed_by_association.present?
 
       errors.add(:base, Spree.t('errors.messages.cannot_delete_default_channel'))

--- a/spree/core/app/models/spree/channel.rb
+++ b/spree/core/app/models/spree/channel.rb
@@ -23,7 +23,11 @@ module Spree
 
     attribute :active, :boolean, default: true
 
-    normalizes :code, with: ->(value) { value.to_s.parameterize.presence }
+    # Force UTF-8 before parameterize. HTTP headers reach Rails as ASCII-8BIT
+    # and +String#parameterize+ raises +ArgumentError+ on non-UTF-8 input
+    # ("Cannot transliterate strings with ASCII-8BIT encoding"). Channel codes
+    # are slugs ([a-z0-9-]) so the bytes are already valid UTF-8.
+    normalizes :code, with: ->(value) { value.to_s.dup.force_encoding(Encoding::UTF_8).parameterize.presence }
 
     before_validation :backfill_code_from_name, if: -> { code.blank? && name.present? }
     before_validation :promote_first_channel_to_default
@@ -36,6 +40,7 @@ module Spree
     # before save so MySQL — which can't enforce a partial unique index — also
     # arrives at a single default without relying on DB constraints.
     before_save :demote_other_defaults, if: -> { default? && will_save_change_to_default? }
+    before_destroy :ensure_not_default
     after_create :ensure_default_order_routing_rules
 
     scope :active, -> { where(active: true) }
@@ -109,7 +114,24 @@ module Spree
       count
     end
 
+    # The default channel of a store is the storefront's fallback when no
+    # +X-Spree-Channel+ is given, so removing it would orphan all storefront
+    # traffic. Promote another channel to default first.
+    # @return [Boolean]
+    def can_be_deleted?
+      !default?
+    end
+
     private
+
+    def ensure_not_default
+      return if can_be_deleted?
+      # Allow store cascade — destroying the store removes its channels too.
+      return if destroyed_by_association.present?
+
+      errors.add(:base, Spree.t('errors.messages.cannot_delete_default_channel'))
+      throw :abort
+    end
 
     def backfill_code_from_name
       self.code = name

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1136,8 +1136,8 @@ en:
     errors:
       messages:
         blank: can't be blank
-        cannot_remove_icon: Cannot remove image
         cannot_delete_default_channel: Default channel cannot be deleted. Promote another channel to default first.
+        cannot_remove_icon: Cannot remove image
         channel_store_mismatch: must belong to the same store
         could_not_create_taxon: Could not create taxon
         must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1137,6 +1137,7 @@ en:
       messages:
         blank: can't be blank
         cannot_remove_icon: Cannot remove image
+        cannot_delete_default_channel: Default channel cannot be deleted. Promote another channel to default first.
         channel_store_mismatch: must belong to the same store
         could_not_create_taxon: Could not create taxon
         must_be_origin_only: must be an origin (scheme and host) without path, query, or fragment

--- a/spree/core/spec/lib/tasks/publications_spec.rb
+++ b/spree/core/spec/lib/tasks/publications_spec.rb
@@ -80,7 +80,7 @@ describe 'spree:upgrade:populate_publications' do
     before do
       downgrade!(product, default_store)
       # Strip channels off +other_store+ to simulate the warning path.
-      other_store.channels.destroy_all
+      other_store.channels.delete_all
       Spree::StoreProduct.create!(product: product, store: other_store)
     end
 

--- a/spree/core/spec/models/spree/channel_spec.rb
+++ b/spree/core/spec/models/spree/channel_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Spree::Channel, type: :model do
       expect(channel.code).to eq('my-channel')
     end
 
+    # HTTP headers reach Rails as ASCII-8BIT and Active Record applies the
+    # +normalizes+ block to query values as well, so +Channel.find_by(code: …)+
+    # would raise without re-encoding to UTF-8 first.
+    it 'normalizes ASCII-8BIT codes without raising' do
+      ascii8 = String.new('pos').force_encoding(Encoding::ASCII_8BIT)
+      expect { described_class.find_by(code: ascii8) }.not_to raise_error
+    end
+
     it 'requires code unique within a store' do
       described_class.create!(store: store, name: 'POS', code: 'pos')
       duplicate = described_class.new(store: store, name: 'POS 2', code: 'pos')
@@ -54,7 +62,7 @@ RSpec.describe Spree::Channel, type: :model do
 
   describe '.active scope' do
     it 'filters active channels only' do
-      fresh_store = create(:store).tap { |s| s.channels.destroy_all }
+      fresh_store = create(:store).tap { |s| s.channels.delete_all }
       active = described_class.create!(store: fresh_store, name: 'A', code: 'a', active: true)
       described_class.create!(store: fresh_store, name: 'B', code: 'b', active: false)
 
@@ -81,6 +89,30 @@ RSpec.describe Spree::Channel, type: :model do
     it 'starts with ch_' do
       channel = described_class.create!(store: store, name: 'POS', code: 'pos')
       expect(channel.prefixed_id).to start_with('ch_')
+    end
+  end
+
+  describe '#can_be_deleted?' do
+    let(:fresh_store) { create(:store).tap { |s| s.channels.delete_all } }
+    let!(:default_channel) { described_class.create!(store: fresh_store, name: 'Default', code: 'online', default: true) }
+    let!(:secondary) { described_class.create!(store: fresh_store, name: 'POS', code: 'pos') }
+
+    it 'is true for non-default channels' do
+      expect(secondary.can_be_deleted?).to be true
+    end
+
+    it 'is false for the default channel' do
+      expect(default_channel.can_be_deleted?).to be false
+    end
+
+    it 'blocks +destroy+ on the default channel and surfaces an error' do
+      expect(default_channel.destroy).to be false
+      expect(default_channel.errors[:base]).to include(/cannot be deleted/i)
+      expect(described_class.find_by(id: default_channel.id)).to eq(default_channel)
+    end
+
+    it 'allows destroying non-default channels' do
+      expect { secondary.destroy! }.to change(described_class, :count).by(-1)
     end
   end
 

--- a/spree/core/spec/models/spree/channel_spec.rb
+++ b/spree/core/spec/models/spree/channel_spec.rb
@@ -28,9 +28,6 @@ RSpec.describe Spree::Channel, type: :model do
       expect(channel.code).to eq('my-channel')
     end
 
-    # HTTP headers reach Rails as ASCII-8BIT and Active Record applies the
-    # +normalizes+ block to query values as well, so +Channel.find_by(code: …)+
-    # would raise without re-encoding to UTF-8 first.
     it 'normalizes ASCII-8BIT codes without raising' do
       ascii8 = String.new('pos').force_encoding(Encoding::ASCII_8BIT)
       expect { described_class.find_by(code: ascii8) }.not_to raise_error

--- a/spree/core/spec/models/spree/product/scopes_spec.rb
+++ b/spree/core/spec/models/spree/product/scopes_spec.rb
@@ -571,9 +571,9 @@ describe 'Product scopes', type: :model do
         expect(Spree::Product.active('USD')).not_to include(active_product)
       end
 
-      it 'excludes future-listed products under .active' do
+      it 'includes future-listed products under .active (legacy semantics — published_at filter requires explicit cutoff)' do
         active_publication.update_columns(published_at: 1.day.from_now)
-        expect(Spree::Product.active('USD')).not_to include(active_product)
+        expect(Spree::Product.active('USD')).to include(active_product)
       end
 
       it 'excludes products that are listed on a different channel only' do

--- a/spree/core/spec/models/spree/product/scopes_spec.rb
+++ b/spree/core/spec/models/spree/product/scopes_spec.rb
@@ -571,9 +571,9 @@ describe 'Product scopes', type: :model do
         expect(Spree::Product.active('USD')).not_to include(active_product)
       end
 
-      it 'includes future-listed products under .active (legacy semantics — published_at filter requires explicit cutoff)' do
+      it 'excludes future-listed products under .active' do
         active_publication.update_columns(published_at: 1.day.from_now)
-        expect(Spree::Product.active('USD')).to include(active_product)
+        expect(Spree::Product.active('USD')).not_to include(active_product)
       end
 
       it 'excludes products that are listed on a different channel only' do

--- a/spree/core/spec/models/spree/product_publication_spec.rb
+++ b/spree/core/spec/models/spree/product_publication_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Spree::ProductPublication, type: :model do
   let(:other_channel) { other_store.default_channel }
   # A second channel on the *same* store as +product+, so we can build a
   # second publication against the same product without colliding with the
-  # default publication the create-callback already attached.
+  # default-channel publication the +:product+ factory attached for test
+  # convenience.
   let(:secondary_channel) { create(:channel, store: store, code: 'pos', name: 'POS') }
 
   describe 'validations' do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Store product listing scope changes affect what shoppers see; Admin API auth reordering fixes prior 404s but touches all v3 resource controllers—both are important integration surfaces.
> 
> **Overview**
> This PR tightens **sales channels** and **storefront catalog** behavior, and fixes **Admin API v3** authentication ordering.
> 
> **Channels:** `code` is optional on create—the server derives it from the name when omitted (dashboard + admin-sdk). Channel `code` normalization now tolerates **ASCII-8BIT** header bytes. The **default channel** cannot be deleted (`can_be_deleted?`, `before_destroy`, API 422); the dashboard hides delete for default channels.
> 
> **Publishing:** New products in legacy admin publishing default the **default sales channel** checkbox on.
> 
> **Store API:** Product index/filters use `products.available(Time.current, currency)` instead of `active`, so listings respect **channel publication windows** (e.g. future `published_at` no longer appear as available).
> 
> **Admin API v3:** `authenticate_request!` runs on `ResourceController` **before** `set_resource`; admin/store branches implement it (`authenticate_admin!` / `authenticate_api_key!`), fixing secret-key **404s** on show/update/destroy when `accessible_by` ran without auth. Specs cover admin auth, callback order, and default-channel destroy.
> 
> *Minor:* local Claude settings allow reading `/private/tmp/**`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ebfb24462b1175b1e22f899224036be6e41637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel code field is now optional; the backend automatically derives it from the channel name when not provided.
  * New products are automatically attached to the store's default channel during creation.

* **Bug Fixes**
  * Default channels are now protected from deletion with a validation error message.
  * Improved handling of channel header values with enhanced character encoding support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->