### PR TITLE
Dashboard: fixed displaying variant names in product form

### DIFF
--- a/packages/dashboard/e2e/products-new.spec.ts
+++ b/packages/dashboard/e2e/products-new.spec.ts
@@ -87,8 +87,8 @@ test.describe('new product — multi-variant', () => {
 
     // 4. Set prices via the inline Prices card.
     const prices = pricesCard(page)
-    await fillGridCell(prices.getByRole('textbox', { name: /^price for red$/i }), '20.00')
-    await fillGridCell(prices.getByRole('textbox', { name: /^price for blue$/i }), '22.50')
+    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bred$/i }), '20.00')
+    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bblue$/i }), '22.50')
     await page.getByRole('button', { name: /^create product$/i }).click()
 
     // Lands on the edit page.
@@ -96,8 +96,10 @@ test.describe('new product — multi-variant', () => {
       timeout: 30_000,
     })
 
-    // 5. Everything round-tripped — SKUs, inventory, prices.
-    await expect(card.getByText('red / red').or(card.getByText('Red')).first()).toBeVisible({
+    // 5. Everything round-tripped — SKUs, inventory, prices. The matrix row
+    // label uses `composeOptionsText` ("<Type>: <Value>"), so match the value
+    // label suffix instead of the slugged display the matrix used to render.
+    await expect(card.getByText(/\bRed$/).first()).toBeVisible({
       timeout: 15_000,
     })
     const reloadedSkus = card.getByRole('textbox', { name: /^sku$/i })
@@ -110,9 +112,11 @@ test.describe('new product — multi-variant', () => {
     await expect(reloadedOnHand.nth(0)).toHaveValue('3')
     await expect(reloadedOnHand.nth(cellsPerVariant)).toHaveValue('7')
 
-    await expect(prices.getByRole('textbox', { name: /^price for red$/i })).toHaveValue(
+    await expect(prices.getByRole('textbox', { name: /price for .*\bred$/i })).toHaveValue(
       /^20([.,]0+)?$/,
     )
-    await expect(prices.getByRole('textbox', { name: /^price for blue$/i })).toHaveValue(/^22[.,]5/)
+    await expect(prices.getByRole('textbox', { name: /price for .*\bblue$/i })).toHaveValue(
+      /^22[.,]5/,
+    )
   })
 })

--- a/packages/dashboard/e2e/products-prices-inventory.spec.ts
+++ b/packages/dashboard/e2e/products-prices-inventory.spec.ts
@@ -60,13 +60,12 @@ test.describe('product prices — multi-variant', () => {
     await addOptionToVariants(page, colorLabel, ['Red', 'Blue'])
 
     // The Prices card is inline — no dialog. Fill the two cells via their
-    // aria-labels ("Price for red" / "Price for blue"). The cell ariaLabel
-    // uses the lowercase option-value name (e.g. "red"), because
-    // variantDisplayLabel joins `options[].value` which the picker stores
-    // as the canonical name, not the display label.
+    // aria-labels. The cell ariaLabel is `Price for ${variant.label}`, where
+    // `label` comes from `composeOptionsText` ("<Type>: <Value>"), so we
+    // anchor on the trailing value label.
     const prices = pricesCard(page)
-    await fillGridCell(prices.getByRole('textbox', { name: /^price for red$/i }), '19.99')
-    await fillGridCell(prices.getByRole('textbox', { name: /^price for blue$/i }), '29.99')
+    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bred$/i }), '19.99')
+    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bblue$/i }), '29.99')
 
     // Save the product via the page-level Save button — prices ride the same
     // PATCH as everything else.
@@ -77,12 +76,12 @@ test.describe('product prices — multi-variant', () => {
 
     // Reload and re-check the inline cells — both prices must round-trip.
     await page.reload()
-    await expect(pricesCard(page).getByRole('textbox', { name: /^price for red$/i })).toHaveValue(
-      /^19[.,]99$/,
-    )
-    await expect(pricesCard(page).getByRole('textbox', { name: /^price for blue$/i })).toHaveValue(
-      /^29[.,]99$/,
-    )
+    await expect(
+      pricesCard(page).getByRole('textbox', { name: /price for .*\bred$/i }),
+    ).toHaveValue(/^19[.,]99$/)
+    await expect(
+      pricesCard(page).getByRole('textbox', { name: /price for .*\bblue$/i }),
+    ).toHaveValue(/^29[.,]99$/)
   })
 })
 
@@ -192,9 +191,9 @@ test.describe('product inventory — multi-variant', () => {
     const grid = inventoryCard(page)
     const headers = grid.locator('div.truncate.font-medium')
     await expect(headers).toHaveCount(3, { timeout: 15_000 })
-    await expect(headers.nth(0)).toHaveText('red')
-    await expect(headers.nth(1)).toHaveText('blue')
-    await expect(headers.nth(2)).toHaveText('green')
+    await expect(headers.nth(0)).toHaveText(/\bRed$/)
+    await expect(headers.nth(1)).toHaveText(/\bBlue$/)
+    await expect(headers.nth(2)).toHaveText(/\bGreen$/)
   })
 })
 
@@ -272,8 +271,8 @@ test.describe('product variants × prices × inventory', () => {
     //    product-level Save persists everything (SKUs, inventory, prices)
     //    in one PATCH.
     const prices = pricesCard(page)
-    await fillGridCell(prices.getByRole('textbox', { name: /^price for red$/i }), '15.00')
-    await fillGridCell(prices.getByRole('textbox', { name: /^price for blue$/i }), '17.50')
+    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bred$/i }), '15.00')
+    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bblue$/i }), '17.50')
     await page.getByRole('button', { name: /save product/i }).click()
     await expect(page.getByRole('button', { name: /save product/i })).toBeDisabled({
       timeout: 30_000,
@@ -287,11 +286,11 @@ test.describe('product variants × prices × inventory', () => {
     await expect(reloadedOnHand.nth(0)).toHaveValue('5')
     await expect(reloadedOnHand.nth(cellsPerVariant)).toHaveValue('10')
 
-    await expect(pricesCard(page).getByRole('textbox', { name: /^price for red$/i })).toHaveValue(
-      /^15([.,]0+)?$/,
-    )
-    await expect(pricesCard(page).getByRole('textbox', { name: /^price for blue$/i })).toHaveValue(
-      /^17[.,]5/,
-    )
+    await expect(
+      pricesCard(page).getByRole('textbox', { name: /price for .*\bred$/i }),
+    ).toHaveValue(/^15([.,]0+)?$/)
+    await expect(
+      pricesCard(page).getByRole('textbox', { name: /price for .*\bblue$/i }),
+    ).toHaveValue(/^17[.,]5/)
   })
 })

--- a/packages/dashboard/e2e/products-variants.spec.ts
+++ b/packages/dashboard/e2e/products-variants.spec.ts
@@ -20,14 +20,10 @@ test.describe('product variants', () => {
     await addOptionToVariants(page, colorLabel, ['Red', 'Blue', 'Green'])
     await addOptionToVariants(page, sizeLabel, ['S', 'M', 'L'])
 
-    // 3 × 3 = 9 generated rows. Each cell shows the joined label "Red / S".
+    // 3 × 3 = 9 generated rows. Each row shows composeOptionsText
+    // ("Color: Red, Size: S"); asserting on SKU input count is
+    // order-independent — 3 × 3 = 9 variants means 9 SKU inputs.
     const variantsCard = variantsCardLocator(page)
-
-    // The matrix row label joins canonical option value names with " / "
-    // (e.g. "red / s" or "s / red"). The slash order depends on the seeded
-    // option_type positions, which vary between local and CI. Asserting on
-    // the SKU input count is order-independent — 3 × 3 = 9 variants means
-    // 9 SKU inputs.
     const skuInputs = variantsCard.getByRole('textbox', { name: /^sku$/i })
     await expect(skuInputs).toHaveCount(9, { timeout: 15_000 })
 
@@ -67,8 +63,9 @@ test.describe('product variants', () => {
     await expect(variantsCard.getByText('Red').first()).toBeVisible({ timeout: 15_000 })
     await expect(variantsCard.getByText('Blue').first()).toBeVisible()
 
-    // Remove the Blue row via its row-level remove button.
-    await variantsCard.getByRole('button', { name: /^remove blue$/i }).click()
+    // Remove the Blue row via its row-level remove button. Aria-label is
+    // `Remove ${variant.label}` and label = composeOptionsText → "<Type>: Blue".
+    await variantsCard.getByRole('button', { name: /^remove .*\bblue$/i }).click()
     await expect(variantsCard.getByText('Blue')).toHaveCount(0)
 
     await page.getByRole('button', { name: /save product/i }).click()
@@ -93,9 +90,9 @@ test.describe('product variants', () => {
 
     const variantsCard = variantsCardLocator(page)
 
-    await variantsCard.getByRole('button', { name: /^edit red$/i }).click()
+    await variantsCard.getByRole('button', { name: /^edit .*\bred$/i }).click()
     const sheet = page.getByRole('dialog')
-    await expect(sheet.getByRole('heading', { name: /edit variant — red/i })).toBeVisible()
+    await expect(sheet.getByRole('heading', { name: /edit variant — .*\bred$/i })).toBeVisible()
 
     // Scope to the sheet so we don't fight with the matrix row's SKU input,
     // which is registered on the same form path (matrix uses register; the
@@ -113,7 +110,7 @@ test.describe('product variants', () => {
     })
 
     await page.reload()
-    await variantsCard.getByRole('button', { name: /^edit red$/i }).click()
+    await variantsCard.getByRole('button', { name: /^edit .*\bred$/i }).click()
     const reopened = page.getByRole('dialog')
     await expect(reopened.getByLabel(/^sku$/i)).toHaveValue('SKU-SHEET-1')
     await expect(reopened.getByLabel(/^weight$/i)).toHaveValue('1.5')

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -19,6 +19,8 @@
     "lint:fix": "biome check --fix .",
     "format": "biome format --write .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:install": "playwright install chromium"
@@ -76,7 +78,8 @@
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",
-    "vite": "^8.0.11"
+    "vite": "^8.0.11",
+    "vitest": "^4.1.5"
   },
   "pnpm": {
     "overrides": {

--- a/packages/dashboard/src/components/spree/bulk-price-editor/product-bulk-price-editor.tsx
+++ b/packages/dashboard/src/components/spree/bulk-price-editor/product-bulk-price-editor.tsx
@@ -2,6 +2,8 @@ import { type BulkPriceRow, BulkPriceTable } from '@spree/dashboard-ui'
 import { useCallback, useMemo } from 'react'
 import { type UseFormReturn, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { composeOptionsText } from '@/components/spree/products/variants-matrix'
+import { useOptionTypes } from '@/hooks/use-option-types'
 import type { ProductFormValues, VariantPriceFormValues } from '@/schemas/product'
 import { currencyParts } from './currency-parts'
 
@@ -31,6 +33,8 @@ interface Props {
 export function ProductBulkPriceEditor({ form, currency, productName }: Props) {
   const { t, i18n } = useTranslation()
   const variants = useWatch({ control: form.control, name: 'variants' }) ?? []
+  const { data: optionTypesData } = useOptionTypes({ limit: 100 })
+  const optionTypes = useMemo(() => optionTypesData?.data ?? [], [optionTypesData])
 
   const { symbol, decimal } = useMemo(
     () => currencyParts(currency, i18n.language || 'en'),
@@ -46,7 +50,7 @@ export function ProductBulkPriceEditor({ form, currency, productName }: Props) {
     const out: BulkPriceRow[] = [{ id: `header:product`, kind: 'header', groupLabel: productName }]
     variants.forEach((v, idx) => {
       const price = (v.prices ?? []).find((p) => p.currency === currency)
-      const label = v.options.length > 0 ? v.options.map((o) => o.value).join(' / ') : null
+      const label = v.options.length > 0 ? composeOptionsText(v.options, optionTypes) : null
       out.push({
         id: `variant:${idx}`,
         kind: 'item',
@@ -60,7 +64,7 @@ export function ProductBulkPriceEditor({ form, currency, productName }: Props) {
       })
     })
     return out
-  }, [variants, currency, productName, decimal])
+  }, [variants, currency, productName, decimal, optionTypes])
 
   const handleChange = useCallback(
     (rowId: string, field: 'amount' | 'compareAt', next: string | null) => {

--- a/packages/dashboard/src/components/spree/products/inventory-section.tsx
+++ b/packages/dashboard/src/components/spree/products/inventory-section.tsx
@@ -11,8 +11,10 @@ import { ExternalLinkIcon } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { type UseFormReturn, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useOptionTypes } from '@/hooks/use-option-types'
 import { useStockLocations } from '@/hooks/use-stock-locations'
 import type { ProductFormValues, StockItemFormValues } from '@/schemas/product'
+import { composeOptionsText } from './variants-matrix'
 
 interface InventoryRow {
   /** Composite ID `${variantIndex}.${stockLocationId}` (or `${variantIndex}.header` for headers). */
@@ -48,6 +50,8 @@ export function InventorySection({ form, storeId }: InventorySectionProps) {
   const variants = useWatch({ control: form.control, name: 'variants' }) ?? []
   const { data: stockLocationsData, isLoading: stockLocationsLoading } = useStockLocations()
   const stockLocations = stockLocationsData?.data ?? []
+  const { data: optionTypesData } = useOptionTypes({ limit: 100 })
+  const optionTypes = useMemo(() => optionTypesData?.data ?? [], [optionTypesData])
 
   // Derive "this product has real variants" from live form state, not the
   // API hydration — so adding options to a fresh product immediately groups
@@ -59,7 +63,7 @@ export function InventorySection({ form, storeId }: InventorySectionProps) {
     const out: InventoryRow[] = []
     variants.forEach((variant, variantIndex) => {
       const variantLabel =
-        variant.options.map((o) => o.value).join(' / ') ||
+        composeOptionsText(variant.options, optionTypes) ||
         variant.sku ||
         t('admin.products.variants.default_variant')
       if (hasMultipleVariants) {
@@ -89,7 +93,7 @@ export function InventorySection({ form, storeId }: InventorySectionProps) {
       })
     })
     return out
-  }, [variants, stockLocations, hasMultipleVariants, t])
+  }, [variants, stockLocations, hasMultipleVariants, optionTypes, t])
 
   // Find-or-create the stock_item entry for (variantIndex, stockLocationId)
   // and patch the given field. Uses form.setValue with the full updated

--- a/packages/dashboard/src/components/spree/products/variant-edit-sheet.tsx
+++ b/packages/dashboard/src/components/spree/products/variant-edit-sheet.tsx
@@ -18,6 +18,7 @@ import {
 import { useEffect, useRef } from 'react'
 import { Controller, type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useOptionTypes } from '@/hooks/use-option-types'
 import { useTaxCategories } from '@/hooks/use-tax-categories'
 import type { ProductFormValues, VariantFormValues } from '@/schemas/product'
 import { variantDisplayLabel } from './variants-matrix'
@@ -42,6 +43,8 @@ export function VariantEditSheet({ form, variantIndex, open, onOpenChange }: Pro
   const { data: taxCategoriesResponse } = useTaxCategories()
   const taxCategories = taxCategoriesResponse?.data ?? []
   const hasTaxCategories = taxCategories.length > 0
+  const { data: optionTypesData } = useOptionTypes({ limit: 100 })
+  const optionTypes = optionTypesData?.data ?? []
 
   // Snapshot the variant when the sheet opens so Cancel can restore it.
   // Re-snapshot if the user switches between variant rows without closing
@@ -73,7 +76,11 @@ export function VariantEditSheet({ form, variantIndex, open, onOpenChange }: Pro
   const variant = form.watch(`variants.${variantIndex}`)
   if (!variant) return null
 
-  const label = variantDisplayLabel(variant, t('admin.products.variants.default_variant'))
+  const label = variantDisplayLabel(
+    variant,
+    t('admin.products.variants.default_variant'),
+    optionTypes,
+  )
 
   const handleCancel = () => {
     const snap = snapshotRef.current

--- a/packages/dashboard/src/components/spree/products/variants-matrix.test.ts
+++ b/packages/dashboard/src/components/spree/products/variants-matrix.test.ts
@@ -4,6 +4,7 @@ import { composeOptionsText, type OptionTypeForLabel } from './variants-matrix'
 const COLOR: OptionTypeForLabel = {
   name: 'color',
   label: 'Color',
+  position: 0,
   option_values: [
     { name: 'red', label: 'Red' },
     { name: 'matte-black', label: 'Matte Black' },
@@ -13,10 +14,18 @@ const COLOR: OptionTypeForLabel = {
 const SIZE: OptionTypeForLabel = {
   name: 'size',
   label: 'Size',
+  position: 1,
   option_values: [
     { name: 'xs', label: 'XS' },
     { name: 'l', label: 'L' },
   ],
+}
+
+const MATERIAL: OptionTypeForLabel = {
+  name: 'material',
+  label: 'Material',
+  position: 2,
+  option_values: [{ name: 'steel', label: 'Steel' }],
 }
 
 describe('composeOptionsText', () => {
@@ -71,7 +80,7 @@ describe('composeOptionsText', () => {
     ).toBe('color: red, size: xs')
   })
 
-  it('preserves caller-provided option order (mirrors backend position ordering by registry)', () => {
+  it('reorders by option-type position regardless of input order (backend parity)', () => {
     expect(
       composeOptionsText(
         [
@@ -80,6 +89,32 @@ describe('composeOptionsText', () => {
         ],
         [COLOR, SIZE],
       ),
-    ).toBe('Size: L, Color: Red')
+    ).toBe('Color: Red, Size: L')
+  })
+
+  it('uses Oxford "and" for three or more options (matches Rails to_sentence)', () => {
+    expect(
+      composeOptionsText(
+        [
+          { name: 'color', value: 'red' },
+          { name: 'size', value: 'l' },
+          { name: 'material', value: 'steel' },
+        ],
+        [COLOR, SIZE, MATERIAL],
+      ),
+    ).toBe('Color: Red, Size: L, and Material: Steel')
+  })
+
+  it('appends unknown-type options after registry-known ones in input order', () => {
+    expect(
+      composeOptionsText(
+        [
+          { name: 'finish', value: 'matte' },
+          { name: 'color', value: 'red' },
+          { name: 'pattern', value: 'striped' },
+        ],
+        [COLOR],
+      ),
+    ).toBe('Color: Red, finish: matte, and pattern: striped')
   })
 })

--- a/packages/dashboard/src/components/spree/products/variants-matrix.test.ts
+++ b/packages/dashboard/src/components/spree/products/variants-matrix.test.ts
@@ -1,7 +1,10 @@
+import type { OptionType } from '@spree/admin-sdk'
 import { describe, expect, it } from 'vitest'
-import { composeOptionsText, type OptionTypeForLabel } from './variants-matrix'
+import { composeOptionsText } from './variants-matrix'
 
-const COLOR: OptionTypeForLabel = {
+// composeOptionsText only reads name/label/position/option_values; cast minimal
+// fixtures rather than fabricating timestamps + ids that the helper ignores.
+const COLOR = {
   name: 'color',
   label: 'Color',
   position: 0,
@@ -9,9 +12,9 @@ const COLOR: OptionTypeForLabel = {
     { name: 'red', label: 'Red' },
     { name: 'matte-black', label: 'Matte Black' },
   ],
-}
+} as OptionType
 
-const SIZE: OptionTypeForLabel = {
+const SIZE = {
   name: 'size',
   label: 'Size',
   position: 1,
@@ -19,14 +22,14 @@ const SIZE: OptionTypeForLabel = {
     { name: 'xs', label: 'XS' },
     { name: 'l', label: 'L' },
   ],
-}
+} as OptionType
 
-const MATERIAL: OptionTypeForLabel = {
+const MATERIAL = {
   name: 'material',
   label: 'Material',
   position: 2,
   option_values: [{ name: 'steel', label: 'Steel' }],
-}
+} as OptionType
 
 describe('composeOptionsText', () => {
   it('returns an empty string when there are no options', () => {
@@ -62,7 +65,7 @@ describe('composeOptionsText', () => {
   })
 
   it('falls back per-component when the type matches but option_values is missing', () => {
-    const colorNoValues: OptionTypeForLabel = { name: 'color', label: 'Color' }
+    const colorNoValues = { name: 'color', label: 'Color' } as OptionType
     expect(composeOptionsText([{ name: 'color', value: 'red' }], [colorNoValues])).toBe(
       'Color: red',
     )

--- a/packages/dashboard/src/components/spree/products/variants-matrix.test.ts
+++ b/packages/dashboard/src/components/spree/products/variants-matrix.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { composeOptionsText, type OptionTypeForLabel } from './variants-matrix'
+
+const COLOR: OptionTypeForLabel = {
+  name: 'color',
+  label: 'Color',
+  option_values: [
+    { name: 'red', label: 'Red' },
+    { name: 'matte-black', label: 'Matte Black' },
+  ],
+}
+
+const SIZE: OptionTypeForLabel = {
+  name: 'size',
+  label: 'Size',
+  option_values: [
+    { name: 'xs', label: 'XS' },
+    { name: 'l', label: 'L' },
+  ],
+}
+
+describe('composeOptionsText', () => {
+  it('returns an empty string when there are no options', () => {
+    expect(composeOptionsText([], [COLOR, SIZE])).toBe('')
+  })
+
+  it('formats a single option as "Type: Value"', () => {
+    expect(composeOptionsText([{ name: 'color', value: 'red' }], [COLOR])).toBe('Color: Red')
+  })
+
+  it('joins multiple options with ", " in input order', () => {
+    expect(
+      composeOptionsText(
+        [
+          { name: 'color', value: 'matte-black' },
+          { name: 'size', value: 'xs' },
+        ],
+        [COLOR, SIZE],
+      ),
+    ).toBe('Color: Matte Black, Size: XS')
+  })
+
+  it('falls back to the type slug when the option type is not in the registry', () => {
+    expect(composeOptionsText([{ name: 'material', value: 'steel' }], [COLOR])).toBe(
+      'material: steel',
+    )
+  })
+
+  it('falls back to the value slug when the value is not in the registry', () => {
+    expect(composeOptionsText([{ name: 'color', value: 'fuchsia' }], [COLOR])).toBe(
+      'Color: fuchsia',
+    )
+  })
+
+  it('falls back per-component when the type matches but option_values is missing', () => {
+    const colorNoValues: OptionTypeForLabel = { name: 'color', label: 'Color' }
+    expect(composeOptionsText([{ name: 'color', value: 'red' }], [colorNoValues])).toBe(
+      'Color: red',
+    )
+  })
+
+  it('handles registry-empty input by returning bare slugs', () => {
+    expect(
+      composeOptionsText(
+        [
+          { name: 'color', value: 'red' },
+          { name: 'size', value: 'xs' },
+        ],
+        [],
+      ),
+    ).toBe('color: red, size: xs')
+  })
+
+  it('preserves caller-provided option order (mirrors backend position ordering by registry)', () => {
+    expect(
+      composeOptionsText(
+        [
+          { name: 'size', value: 'l' },
+          { name: 'color', value: 'red' },
+        ],
+        [COLOR, SIZE],
+      ),
+    ).toBe('Size: L, Color: Red')
+  })
+})

--- a/packages/dashboard/src/components/spree/products/variants-matrix.ts
+++ b/packages/dashboard/src/components/spree/products/variants-matrix.ts
@@ -188,24 +188,36 @@ export function blankVariant(
 export interface OptionTypeForLabel {
   name: string
   label: string
+  position?: number
   option_values?: { name: string; label: string }[]
 }
 
-// Mirrors backend `Spree::Variant#options_text`: "Color: Silver, Size: XS".
-// Falls back to slugs when a label isn't in the registry (e.g. a value the
-// merchant just created in this session).
+// Mirrors backend `Spree::Variant#options_text`: "Color: Silver, Size: XS" or
+// "Color: Silver, Size: XS, and Material: Steel". Sorts by option-type position
+// (backend `option_values.sort_by(&:option_type.position)`) and joins with the
+// same `to_sentence(words_connector: ', ', two_words_connector: ', ')` rules —
+// `, ` between items and `, and ` before the last when there are 3+. Falls back
+// to slugs when a label isn't in the registry (e.g. a value the merchant just
+// created in this session) and to input order for types not in the registry.
 export function composeOptionsText(
   options: { name: string; value: string }[],
   optionTypes: OptionTypeForLabel[],
 ): string {
-  return options
-    .map((o) => {
+  const parts = options
+    .map((o, idx) => {
       const ot = optionTypes.find((x) => x.name === o.name)
       const typeLabel = ot?.label ?? o.name
       const valueLabel = ot?.option_values?.find((v) => v.name === o.value)?.label ?? o.value
-      return `${typeLabel}: ${valueLabel}`
+      // Stable position: registry value when present, otherwise the input index
+      // pushed above any registry value so unknown types trail in input order.
+      const position = ot?.position ?? Number.MAX_SAFE_INTEGER - options.length + idx
+      return { text: `${typeLabel}: ${valueLabel}`, position, idx }
     })
-    .join(', ')
+    .sort((a, b) => a.position - b.position || a.idx - b.idx)
+    .map((p) => p.text)
+
+  if (parts.length < 3) return parts.join(', ')
+  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`
 }
 
 export function variantDisplayLabel(

--- a/packages/dashboard/src/components/spree/products/variants-matrix.ts
+++ b/packages/dashboard/src/components/spree/products/variants-matrix.ts
@@ -2,8 +2,9 @@
 //
 // The matrix lets a merchant pick option types + values and writes the
 // resulting cartesian product as RHF form state. These helpers stay pure
-// (no React, no SDK) so they can evolve independently of the UI shell.
+// (no React) so they can evolve independently of the UI shell.
 
+import type { OptionType } from '@spree/admin-sdk'
 import type { VariantFormValues } from '@/schemas/product'
 
 export interface SelectedOptionValue {
@@ -185,13 +186,6 @@ export function blankVariant(
   }
 }
 
-export interface OptionTypeForLabel {
-  name: string
-  label: string
-  position?: number
-  option_values?: { name: string; label: string }[]
-}
-
 // Mirrors backend `Spree::Variant#options_text`: "Color: Silver, Size: XS" or
 // "Color: Silver, Size: XS, and Material: Steel". Sorts by option-type position
 // (backend `option_values.sort_by(&:option_type.position)`) and joins with the
@@ -201,7 +195,7 @@ export interface OptionTypeForLabel {
 // created in this session) and to input order for types not in the registry.
 export function composeOptionsText(
   options: { name: string; value: string }[],
-  optionTypes: OptionTypeForLabel[],
+  optionTypes: OptionType[],
 ): string {
   const parts = options
     .map((o, idx) => {
@@ -223,7 +217,7 @@ export function composeOptionsText(
 export function variantDisplayLabel(
   variant: Pick<VariantFormValues, 'options' | 'sku'>,
   fallback: string,
-  optionTypes: OptionTypeForLabel[],
+  optionTypes: OptionType[],
 ): string {
   if (variant.options.length > 0) {
     return composeOptionsText(variant.options, optionTypes)

--- a/packages/dashboard/src/components/spree/products/variants-matrix.ts
+++ b/packages/dashboard/src/components/spree/products/variants-matrix.ts
@@ -185,14 +185,36 @@ export function blankVariant(
   }
 }
 
-// Human-readable label for a variant row: "Red / Small". Falls back to
-// SKU, then to a placeholder so the row is never empty.
+export interface OptionTypeForLabel {
+  name: string
+  label: string
+  option_values?: { name: string; label: string }[]
+}
+
+// Mirrors backend `Spree::Variant#options_text`: "Color: Silver, Size: XS".
+// Falls back to slugs when a label isn't in the registry (e.g. a value the
+// merchant just created in this session).
+export function composeOptionsText(
+  options: { name: string; value: string }[],
+  optionTypes: OptionTypeForLabel[],
+): string {
+  return options
+    .map((o) => {
+      const ot = optionTypes.find((x) => x.name === o.name)
+      const typeLabel = ot?.label ?? o.name
+      const valueLabel = ot?.option_values?.find((v) => v.name === o.value)?.label ?? o.value
+      return `${typeLabel}: ${valueLabel}`
+    })
+    .join(', ')
+}
+
 export function variantDisplayLabel(
   variant: Pick<VariantFormValues, 'options' | 'sku'>,
   fallback: string,
+  optionTypes: OptionTypeForLabel[],
 ): string {
   if (variant.options.length > 0) {
-    return variant.options.map((o) => o.value).join(' / ')
+    return composeOptionsText(variant.options, optionTypes)
   }
   if (variant.sku) return variant.sku
   return fallback

--- a/packages/dashboard/src/components/spree/products/variants-section.tsx
+++ b/packages/dashboard/src/components/spree/products/variants-section.tsx
@@ -14,6 +14,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import type { OptionType } from '@spree/admin-sdk'
 import {
   Button,
   Card,
@@ -39,7 +40,6 @@ import type { ProductFormValues, VariantFormValues } from '@/schemas/product'
 import { VariantEditSheet } from './variant-edit-sheet'
 import {
   generateVariantCombinations,
-  type OptionTypeForLabel,
   optionsKey,
   reconcileVariants,
   type SelectedOptionType,
@@ -57,13 +57,7 @@ interface Props {
 // options; labels + ids are looked up against the global option-type registry.
 function deriveSelectedFromVariants(
   variants: VariantFormValues[],
-  allOptionTypes: {
-    id: string
-    name: string
-    label: string
-    position: number
-    option_values?: { name: string; label: string }[]
-  }[],
+  allOptionTypes: OptionType[],
 ): SelectedOptionType[] {
   const namesInOrder: string[] = []
   const valuesByName = new Map<string, Set<string>>()
@@ -354,7 +348,7 @@ interface SortableVariantRowProps {
   form: UseFormReturn<ProductFormValues, any, any>
   index: number
   isSimpleProduct: boolean
-  optionTypes: OptionTypeForLabel[]
+  optionTypes: OptionType[]
   onEdit: () => void
   onRemove: () => void
 }

--- a/packages/dashboard/src/components/spree/products/variants-section.tsx
+++ b/packages/dashboard/src/components/spree/products/variants-section.tsx
@@ -39,6 +39,7 @@ import type { ProductFormValues, VariantFormValues } from '@/schemas/product'
 import { VariantEditSheet } from './variant-edit-sheet'
 import {
   generateVariantCombinations,
+  type OptionTypeForLabel,
   optionsKey,
   reconcileVariants,
   type SelectedOptionType,
@@ -56,7 +57,13 @@ interface Props {
 // options; labels + ids are looked up against the global option-type registry.
 function deriveSelectedFromVariants(
   variants: VariantFormValues[],
-  allOptionTypes: { id: string; name: string; label: string; position: number }[],
+  allOptionTypes: {
+    id: string
+    name: string
+    label: string
+    position: number
+    option_values?: { name: string; label: string }[]
+  }[],
 ): SelectedOptionType[] {
   const namesInOrder: string[] = []
   const valuesByName = new Map<string, Set<string>>()
@@ -80,7 +87,10 @@ function deriveSelectedFromVariants(
         name: ot.name,
         label: ot.label,
         position: ot.position ?? idx,
-        values: Array.from(valuesByName.get(name) ?? []).map((value) => ({ name: value })),
+        values: Array.from(valuesByName.get(name) ?? []).map((value) => ({
+          name: value,
+          label: ot.option_values?.find((ov) => ov.name === value)?.label,
+        })),
       }
     })
     .filter((x): x is SelectedOptionType => x !== null)
@@ -89,7 +99,7 @@ function deriveSelectedFromVariants(
 export function VariantsSection({ form }: Props) {
   const { t } = useTranslation()
   const { data: optionTypesData } = useOptionTypes({ limit: 100 })
-  const allOptionTypes = optionTypesData?.data ?? []
+  const allOptionTypes = useMemo(() => optionTypesData?.data ?? [], [optionTypesData])
 
   const variantsArray = useFieldArray<ProductFormValues, 'variants', '_key'>({
     control: form.control,
@@ -230,11 +240,15 @@ export function VariantsSection({ form }: Props) {
         if (!variant) return null
         return {
           key,
-          label: variantDisplayLabel(variant, t('admin.products.variants.default_variant')),
+          label: variantDisplayLabel(
+            variant,
+            t('admin.products.variants.default_variant'),
+            allOptionTypes,
+          ),
         }
       })
       .filter((entry): entry is { key: string; label: string } => entry !== null)
-  }, [orphanedKeys, form, t])
+  }, [orphanedKeys, form, t, allOptionTypes])
 
   return (
     <Card>
@@ -306,6 +320,7 @@ export function VariantsSection({ form }: Props) {
                         form={form}
                         index={index}
                         isSimpleProduct={isSimpleProduct}
+                        optionTypes={allOptionTypes}
                         onEdit={() => handleEditRow(index)}
                         onRemove={() => handleRowRemove(index)}
                       />
@@ -339,6 +354,7 @@ interface SortableVariantRowProps {
   form: UseFormReturn<ProductFormValues, any, any>
   index: number
   isSimpleProduct: boolean
+  optionTypes: OptionTypeForLabel[]
   onEdit: () => void
   onRemove: () => void
 }
@@ -348,6 +364,7 @@ function SortableVariantRow({
   form,
   index,
   isSimpleProduct,
+  optionTypes,
   onEdit,
   onRemove,
 }: SortableVariantRowProps) {
@@ -363,7 +380,11 @@ function SortableVariantRow({
   const variant = form.watch(`variants.${index}`)
   if (!variant) return null
 
-  const label = variantDisplayLabel(variant, t('admin.products.variants.default_variant'))
+  const label = variantDisplayLabel(
+    variant,
+    t('admin.products.variants.default_variant'),
+    optionTypes,
+  )
 
   return (
     <TableRow

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(import.meta.dirname, 'src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules/**', 'e2e/**', 'dist/**'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ importers:
       vite:
         specifier: ^8.0.11
         version: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/dashboard-core:
     dependencies:


### PR DESCRIPTION
Same format as backend `Variant#options_text` method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only labeling on the product form with no API or save-payload changes; risk is mainly E2E brittleness if option-type data is slow to load.
> 
> **Overview**
> Variant labels across the product form (matrix, inventory headers, inline prices, bulk price editor, edit sheet) now use **`composeOptionsText`**, aligned with backend **`Variant#options_text`**: human-readable **"Type: Value"** segments, sorted by option-type position, with Rails-style joining (comma + Oxford **"and"** for three or more) and slug fallbacks when the registry is missing entries.
> 
> **`variantDisplayLabel`** takes the option-type registry and delegates to that helper instead of joining raw value slugs with **` / `**. Related screens load **`useOptionTypes`** so labels and aria text stay consistent.
> 
> Playwright specs were updated to match the new copy (e.g. **`Price for Color: Red`**, trailing value labels in headers/buttons). The dashboard package adds **Vitest** (`test` / `test:watch`, config) and unit tests for **`composeOptionsText`** ordering, fallbacks, and sentence rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7af623cf94f048d4e8c726e5194f82ed64fac38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variant options now show human-readable type and value labels across inventory, variant editing, bulk-price, and matrix views for clearer product identification.

* **Chores**
  * Added local test runner, package test scripts, and dashboard test configuration to enable faster iterative testing; updated e2e checks to be resilient to label composition and casing.

* **Tests**
  * Added unit tests for option-label composition, ordering, fallbacks, joining rules, and updated end-to-end assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->