### PR TITLE
Fixed E2E dashboard tests

### DIFF
--- a/packages/dashboard/e2e/products-new.spec.ts
+++ b/packages/dashboard/e2e/products-new.spec.ts
@@ -87,8 +87,8 @@ test.describe('new product — multi-variant', () => {
 
     // 4. Set prices via the inline Prices card.
     const prices = pricesCard(page)
-    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bred$/i }), '20.00')
-    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bblue$/i }), '22.50')
+    await fillGridCell(prices.getByRole('textbox', { name: /^price for .*\bred$/i }), '20.00')
+    await fillGridCell(prices.getByRole('textbox', { name: /^price for .*\bblue$/i }), '22.50')
     await page.getByRole('button', { name: /^create product$/i }).click()
 
     // Lands on the edit page.
@@ -112,10 +112,10 @@ test.describe('new product — multi-variant', () => {
     await expect(reloadedOnHand.nth(0)).toHaveValue('3')
     await expect(reloadedOnHand.nth(cellsPerVariant)).toHaveValue('7')
 
-    await expect(prices.getByRole('textbox', { name: /price for .*\bred$/i })).toHaveValue(
+    await expect(prices.getByRole('textbox', { name: /^price for .*\bred$/i })).toHaveValue(
       /^20([.,]0+)?$/,
     )
-    await expect(prices.getByRole('textbox', { name: /price for .*\bblue$/i })).toHaveValue(
+    await expect(prices.getByRole('textbox', { name: /^price for .*\bblue$/i })).toHaveValue(
       /^22[.,]5/,
     )
   })

--- a/packages/dashboard/e2e/products-prices-inventory.spec.ts
+++ b/packages/dashboard/e2e/products-prices-inventory.spec.ts
@@ -64,8 +64,8 @@ test.describe('product prices — multi-variant', () => {
     // `label` comes from `composeOptionsText` ("<Type>: <Value>"), so we
     // anchor on the trailing value label.
     const prices = pricesCard(page)
-    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bred$/i }), '19.99')
-    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bblue$/i }), '29.99')
+    await fillGridCell(prices.getByRole('textbox', { name: /^price for .*\bred$/i }), '19.99')
+    await fillGridCell(prices.getByRole('textbox', { name: /^price for .*\bblue$/i }), '29.99')
 
     // Save the product via the page-level Save button — prices ride the same
     // PATCH as everything else.
@@ -77,10 +77,10 @@ test.describe('product prices — multi-variant', () => {
     // Reload and re-check the inline cells — both prices must round-trip.
     await page.reload()
     await expect(
-      pricesCard(page).getByRole('textbox', { name: /price for .*\bred$/i }),
+      pricesCard(page).getByRole('textbox', { name: /^price for .*\bred$/i }),
     ).toHaveValue(/^19[.,]99$/)
     await expect(
-      pricesCard(page).getByRole('textbox', { name: /price for .*\bblue$/i }),
+      pricesCard(page).getByRole('textbox', { name: /^price for .*\bblue$/i }),
     ).toHaveValue(/^29[.,]99$/)
   })
 })
@@ -271,8 +271,8 @@ test.describe('product variants × prices × inventory', () => {
     //    product-level Save persists everything (SKUs, inventory, prices)
     //    in one PATCH.
     const prices = pricesCard(page)
-    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bred$/i }), '15.00')
-    await fillGridCell(prices.getByRole('textbox', { name: /price for .*\bblue$/i }), '17.50')
+    await fillGridCell(prices.getByRole('textbox', { name: /^price for .*\bred$/i }), '15.00')
+    await fillGridCell(prices.getByRole('textbox', { name: /^price for .*\bblue$/i }), '17.50')
     await page.getByRole('button', { name: /save product/i }).click()
     await expect(page.getByRole('button', { name: /save product/i })).toBeDisabled({
       timeout: 30_000,
@@ -287,10 +287,10 @@ test.describe('product variants × prices × inventory', () => {
     await expect(reloadedOnHand.nth(cellsPerVariant)).toHaveValue('10')
 
     await expect(
-      pricesCard(page).getByRole('textbox', { name: /price for .*\bred$/i }),
+      pricesCard(page).getByRole('textbox', { name: /^price for .*\bred$/i }),
     ).toHaveValue(/^15([.,]0+)?$/)
     await expect(
-      pricesCard(page).getByRole('textbox', { name: /price for .*\bblue$/i }),
+      pricesCard(page).getByRole('textbox', { name: /^price for .*\bblue$/i }),
     ).toHaveValue(/^17[.,]5/)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only selector tweaks with no production code or runtime behavior changes.
> 
> **Overview**
> Tightens Playwright locators for inline **Prices** grid cells in product E2E specs by anchoring variant price `aria-label` regexes with **`^`** (e.g. `/^price for .*\bred$/i` instead of `/price for .*\bred$/i`).
> 
> **Affected specs:** `products-new.spec.ts` and `products-prices-inventory.spec.ts` — create/save/reload flows for Red/Blue variant prices now require labels that start with `Price for`, avoiding accidental matches on longer composed variant text.
> 
> No application or test-helper logic changes beyond these selector patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc75a145aa20dfac2b781596658b1234e948875b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of variant pricing tests by refining selector matching for product price inputs across multi-variant product configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->