### PR TITLE
Restructure Admin API docs for more clarity

### DIFF
--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -39,18 +39,28 @@ info:
     ```
   version: v3
 paths:
-  "/api/v3/admin/admin_users":
-    get:
-      summary: List staff
+  "/api/v3/admin/auth/login":
+    post:
+      summary: Login
       tags:
-      - Staff
+      - Authentication
       security:
       - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns admin users with at least one role assignment on the current store.
+      description: |
+        Authenticates an admin user and returns a short-lived JWT access token.
+        The rotatable refresh token is set in an HttpOnly cookie — it is not
+        included in the response body.
 
-        **Required scope:** `read_settings` (for API-key authentication).
+        Dispatches by the `provider` field to a strategy registered in
+        `Spree.admin_authentication_strategies`. When `provider` is omitted it
+        defaults to `email`, which uses the built-in email/password strategy.
+
+        To plug in a third-party identity provider (Okta, Azure AD, Google
+        Workspace SSO, a custom JWT issuer, SAML, etc.), register a
+        `Spree::Authentication::Strategies::BaseStrategy` subclass under a
+        provider key, then send `{ "provider": "<your_key>", ... }` with the
+        fields your strategy requires. The endpoint returns the same Spree-issued
+        JWT regardless of which strategy authenticated the request.
       x-codeSamples:
       - lang: javascript
         label: Spree Admin SDK
@@ -62,183 +72,101 @@ paths:
             secretKey: 'sk_xxx',
           })
 
-          const { data: staff } = await client.adminUsers.list()
+          // The refresh token is set as an HttpOnly cookie; only `token` and `user` come back in the body.
+          const auth = await client.auth.login({
+            email: 'admin@example.com',
+            password: 'password123',
+          })
       parameters:
       - name: x-spree-api-key
         in: header
         required: true
         schema:
           type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
       responses:
         '200':
-          description: staff found
+          description: login successful
           content:
             application/json:
               example:
-                data:
-                - id: admin_UkLWZg9DAJ
-                  email: odessa@nader.co.uk
-                  first_name: Harrison
-                  last_name: Parisian
-                  full_name: Harrison Parisian
-                  created_at: '2026-06-08T10:56:30.306Z'
-                  updated_at: '2026-06-08T10:56:30.306Z'
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjRlZjA1MzY0LTY2ODctNDY3My1hNDI4LWNjZDI1ODc4YjVjZSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwOTE2NDk2fQ.4EH3Xu8aKDP0u0jtmqrcOOR9okXtEtJFZLw-YdP4sPM
+                user:
+                  id: admin_UkLWZg9DAJ
+                  email: admin@example.com
+                  first_name: Daina
+                  last_name: Braun
+                  full_name: Daina Braun
+                  created_at: '2026-06-08T10:56:35.975Z'
+                  updated_at: '2026-06-08T10:56:35.975Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-  "/api/v3/admin/admin_users/{id}":
-    get:
-      summary: Show a staff member
-      tags:
-      - Staff
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: "**Required scope:** `read_settings` (for API-key authentication)."
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const staff = await client.adminUsers.get('admin_xxx')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: staff member found
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '401':
+          description: invalid credentials
           content:
             application/json:
               example:
-                id: admin_UkLWZg9DAJ
-                email: nancey@feil.info
-                first_name: Burt
-                last_name: Cole
-                full_name: Burt Cole
-                created_at: '2026-06-08T10:56:30.644Z'
-                updated_at: '2026-06-08T10:56:30.644Z'
-                roles:
-                - id: role_UkLWZg9DAJ
-                  name: admin
-    patch:
-      summary: Update a staff member
-      tags:
-      - Staff
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Updates name fields and reassigns roles for the current store. `role_ids` is a complete replacement — roles not in the array are removed for this store.
-
-        **Required scope:** `write_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const staff = await client.adminUsers.update('admin_xxx', {
-            first_name: 'Ada',
-            role_ids: ['role_xxx']
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: staff member updated
-          content:
-            application/json:
-              example:
-                id: admin_UkLWZg9DAJ
-                email: candace@braunmayert.ca
-                first_name: Renamed
-                last_name: Rodriguez
-                full_name: Renamed Rodriguez
-                created_at: '2026-06-08T10:56:30.927Z'
-                updated_at: '2026-06-08T10:56:30.946Z'
-                roles:
-                - id: role_UkLWZg9DAJ
-                  name: admin
+                error:
+                  code: authentication_failed
+                  message: Invalid email or password
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                first_name:
-                  type: string
-                  example: Ada
-                last_name:
-                  type: string
-                  example: Lovelace
-                role_ids:
-                  type: array
-                  items:
+              oneOf:
+              - title: EmailPasswordLogin
+                description: Built-in email/password authentication (default when
+                  `provider` is omitted).
+                type: object
+                properties:
+                  provider:
                     type: string
-    delete:
-      summary: Remove a staff member from this store
+                    enum:
+                    - email
+                    default: email
+                  email:
+                    type: string
+                    format: email
+                    example: admin@example.com
+                  password:
+                    type: string
+                    example: password123
+                required:
+                - email
+                - password
+              - title: ProviderLogin
+                description: |
+                  Provider-dispatched login. The `provider` key selects a registered
+                  strategy class; the remaining fields are forwarded to the strategy's
+                  `authenticate` method. Required fields depend on the registered strategy
+                  — consult its documentation.
+                type: object
+                properties:
+                  provider:
+                    type: string
+                    example: okta
+                    description: Registered provider key (anything other than `email`).
+                    not:
+                      enum:
+                      - email
+                required:
+                - provider
+                additionalProperties: true
+  "/api/v3/admin/auth/refresh":
+    post:
+      summary: Refresh token
       tags:
-      - Staff
+      - Authentication
       security:
       - api_key: []
-        bearer_auth: []
-      description: |-
-        Removes the user's role assignments on the current store. The account is preserved — the user keeps access to any other stores.
-
-        **Required scope:** `write_settings` (for API-key authentication).
+      description: |
+        Exchanges the HttpOnly refresh-token cookie for a new access JWT and a
+        rotated refresh token cookie. No request body or Authorization header
+        is required — the cookie alone authenticates the call.
       x-codeSamples:
       - lang: javascript
         label: Spree Admin SDK
@@ -250,26 +178,192 @@ paths:
             secretKey: 'sk_xxx',
           })
 
-          await client.adminUsers.delete('admin_xxx')
+          // Driven entirely by the HttpOnly refresh-token cookie + CSRF header (set by the SDK).
+          const auth = await client.auth.refresh()
       parameters:
       - name: x-spree-api-key
         in: header
         required: true
         schema:
           type: string
-      - name: Authorization
+      responses:
+        '200':
+          description: refresh successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjBhNTEyYmI5LTlkNjAtNDdjYi04ZjlhLTFiYTM0MWY4MjIzZSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwOTE2NDk3fQ.eNWcAS3Rm1pAljK2jUjWhfYkqzjk6wraljD5m4DgKvM
+                user:
+                  id: admin_UkLWZg9DAJ
+                  email: admin@example.com
+                  first_name: Roman
+                  last_name: Cruickshank
+                  full_name: Roman Cruickshank
+                  created_at: '2026-06-08T10:56:37.206Z'
+                  updated_at: '2026-06-08T10:56:37.206Z'
+                  roles:
+                  - id: role_UkLWZg9DAJ
+                    name: admin
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '401':
+          description: missing or invalid refresh-token cookie
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_refresh_token
+                  message: Refresh token cookie missing
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/admin/auth/logout":
+    post:
+      summary: Logout
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+      description: Revokes the refresh-token cookie, effectively logging the admin
+        out.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          await client.auth.logout()
+      parameters:
+      - name: x-spree-api-key
         in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
         required: true
         schema:
           type: string
       responses:
         '204':
-          description: staff removed from store
+          description: logout successful
+  "/api/v3/admin/me":
+    get:
+      summary: Get current admin user and permissions
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns the current admin user profile and a serialized list of
+        permissions (CanCanCan rules). The SPA uses these to drive UI permission checks.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const me = await client.me.get()
+          if (me.permissions.some((r) => r.allow && r.actions.includes('manage') && r.subjects.includes('Spree::Product'))) {
+            // show "Create product" button
+          }
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      responses:
+        '200':
+          description: current admin user and permissions
+          content:
+            application/json:
+              example:
+                user:
+                  id: admin_UkLWZg9DAJ
+                  email: karole.ratke@darekovacek.name
+                  first_name: Corazon
+                  last_name: O'Hara
+                  full_name: Corazon O'Hara
+                  created_at: '2026-06-08T10:57:08.989Z'
+                  updated_at: '2026-06-08T10:57:08.989Z'
+                  roles:
+                  - id: role_UkLWZg9DAJ
+                    name: admin
+                permissions:
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - all
+                  has_conditions: false
+                - allow: false
+                  actions:
+                  - cancel
+                  subjects:
+                  - Spree::Order
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - cancel
+                  subjects:
+                  - Spree::Order
+                  has_conditions: true
+                - allow: false
+                  actions:
+                  - destroy
+                  subjects:
+                  - Spree::Order
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - destroy
+                  subjects:
+                  - Spree::Order
+                  has_conditions: true
+                - allow: false
+                  actions:
+                  - edit
+                  - update
+                  subjects:
+                  - Spree::RefundReason
+                  has_conditions: true
+                - allow: false
+                  actions:
+                  - edit
+                  - update
+                  subjects:
+                  - Spree::ReimbursementType
+                  has_conditions: true
+                - allow: false
+                  actions:
+                  - update
+                  - destroy
+                  subjects:
+                  - Spree::Role
+                  has_conditions: true
+              schema:
+                "$ref": "#/components/schemas/MeResponse"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/admin/allowed_origins":
     get:
       summary: List allowed origins
@@ -976,213 +1070,6 @@ paths:
                 last_used_at:
                 plaintext_token:
                 created_by_email:
-  "/api/v3/admin/auth/login":
-    post:
-      summary: Login
-      tags:
-      - Authentication
-      security:
-      - api_key: []
-      description: |
-        Authenticates an admin user and returns a short-lived JWT access token.
-        The rotatable refresh token is set in an HttpOnly cookie — it is not
-        included in the response body.
-
-        Dispatches by the `provider` field to a strategy registered in
-        `Spree.admin_authentication_strategies`. When `provider` is omitted it
-        defaults to `email`, which uses the built-in email/password strategy.
-
-        To plug in a third-party identity provider (Okta, Azure AD, Google
-        Workspace SSO, a custom JWT issuer, SAML, etc.), register a
-        `Spree::Authentication::Strategies::BaseStrategy` subclass under a
-        provider key, then send `{ "provider": "<your_key>", ... }` with the
-        fields your strategy requires. The endpoint returns the same Spree-issued
-        JWT regardless of which strategy authenticated the request.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          // The refresh token is set as an HttpOnly cookie; only `token` and `user` come back in the body.
-          const auth = await client.auth.login({
-            email: 'admin@example.com',
-            password: 'password123',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: login successful
-          content:
-            application/json:
-              example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjRlZjA1MzY0LTY2ODctNDY3My1hNDI4LWNjZDI1ODc4YjVjZSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwOTE2NDk2fQ.4EH3Xu8aKDP0u0jtmqrcOOR9okXtEtJFZLw-YdP4sPM
-                user:
-                  id: admin_UkLWZg9DAJ
-                  email: admin@example.com
-                  first_name: Daina
-                  last_name: Braun
-                  full_name: Daina Braun
-                  created_at: '2026-06-08T10:56:35.975Z'
-                  updated_at: '2026-06-08T10:56:35.975Z'
-                  roles:
-                  - id: role_UkLWZg9DAJ
-                    name: admin
-              schema:
-                "$ref": "#/components/schemas/AuthResponse"
-        '401':
-          description: invalid credentials
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_failed
-                  message: Invalid email or password
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - title: EmailPasswordLogin
-                description: Built-in email/password authentication (default when
-                  `provider` is omitted).
-                type: object
-                properties:
-                  provider:
-                    type: string
-                    enum:
-                    - email
-                    default: email
-                  email:
-                    type: string
-                    format: email
-                    example: admin@example.com
-                  password:
-                    type: string
-                    example: password123
-                required:
-                - email
-                - password
-              - title: ProviderLogin
-                description: |
-                  Provider-dispatched login. The `provider` key selects a registered
-                  strategy class; the remaining fields are forwarded to the strategy's
-                  `authenticate` method. Required fields depend on the registered strategy
-                  — consult its documentation.
-                type: object
-                properties:
-                  provider:
-                    type: string
-                    example: okta
-                    description: Registered provider key (anything other than `email`).
-                    not:
-                      enum:
-                      - email
-                required:
-                - provider
-                additionalProperties: true
-  "/api/v3/admin/auth/refresh":
-    post:
-      summary: Refresh token
-      tags:
-      - Authentication
-      security:
-      - api_key: []
-      description: |
-        Exchanges the HttpOnly refresh-token cookie for a new access JWT and a
-        rotated refresh token cookie. No request body or Authorization header
-        is required — the cookie alone authenticates the call.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          // Driven entirely by the HttpOnly refresh-token cookie + CSRF header (set by the SDK).
-          const auth = await client.auth.refresh()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: refresh successful
-          content:
-            application/json:
-              example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjBhNTEyYmI5LTlkNjAtNDdjYi04ZjlhLTFiYTM0MWY4MjIzZSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwOTE2NDk3fQ.eNWcAS3Rm1pAljK2jUjWhfYkqzjk6wraljD5m4DgKvM
-                user:
-                  id: admin_UkLWZg9DAJ
-                  email: admin@example.com
-                  first_name: Roman
-                  last_name: Cruickshank
-                  full_name: Roman Cruickshank
-                  created_at: '2026-06-08T10:56:37.206Z'
-                  updated_at: '2026-06-08T10:56:37.206Z'
-                  roles:
-                  - id: role_UkLWZg9DAJ
-                    name: admin
-              schema:
-                "$ref": "#/components/schemas/AuthResponse"
-        '401':
-          description: missing or invalid refresh-token cookie
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_refresh_token
-                  message: Refresh token cookie missing
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/admin/auth/logout":
-    post:
-      summary: Logout
-      tags:
-      - Authentication
-      security:
-      - api_key: []
-      description: Revokes the refresh-token cookie, effectively logging the admin
-        out.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          await client.auth.logout()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: logout successful
   "/api/v3/admin/channels":
     get:
       summary: List channels
@@ -1544,78 +1431,6 @@ paths:
                   type: array
                   items:
                     type: string
-  "/api/v3/admin/promotions/{promotion_id}/coupon_codes":
-    parameters:
-    - name: promotion_id
-      in: path
-      required: true
-      schema:
-        type: string
-    get:
-      summary: List coupon codes for a promotion
-      tags:
-      - Promotions
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns the auto-generated coupon codes for a multi-code promotion. Single-code promotions store the code on the promotion itself; this endpoint returns an empty list for them.
-
-        **Required scope:** `read_promotions` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: coupons } = await client.promotions.couponCodes.list('promo_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: coupon codes found
-          content:
-            application/json:
-              example:
-                data:
-                - id: coupon_UkLWZg9DAJ
-                  code: AAA111
-                  state: unused
-                  created_at: '2026-06-08T10:56:40.010Z'
-                  updated_at: '2026-06-08T10:56:40.010Z'
-                  promotion_id: promo_UkLWZg9DAJ
-                  order_id:
-                - id: coupon_gbHJdmfrXB
-                  code: BBB222
-                  state: unused
-                  created_at: '2026-06-08T10:56:40.011Z'
-                  updated_at: '2026-06-08T10:56:40.011Z'
-                  promotion_id: promo_UkLWZg9DAJ
-                  order_id:
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 2
-                  pages: 1
-                  from: 1
-                  to: 2
-                  in: 2
-                  previous:
-                  next:
   "/api/v3/admin/custom_field_definitions":
     get:
       summary: List custom field definitions
@@ -4298,6 +4113,662 @@ paths:
               schema:
                 type: string
                 format: binary
+  "/api/v3/admin/orders/{order_id}/fulfillments":
+    get:
+      summary: List fulfillments
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns all shipments for an order.
+
+        **Required scope:** `read_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: fulfillments } = await client.orders.fulfillments.list('or_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (e.g., inventory_units,
+          stock_location, shipping_rates). Use dot notation for nested expand (max
+          4 levels).
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., number,status,tracking,cost).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: fulfillments found
+          content:
+            application/json:
+              example:
+                data:
+                - id: ful_UkLWZg9DAJ
+                  number: H37428731748
+                  tracking: U10000
+                  tracking_url:
+                  cost: '10.0'
+                  display_cost: "$10.00"
+                  total: '10.0'
+                  display_total: "$10.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  tax_total: '0.0'
+                  display_tax_total: "$0.00"
+                  status: ready
+                  fulfillment_type: shipping
+                  fulfilled_at:
+                  items:
+                  - item_id: li_UkLWZg9DAJ
+                    variant_id: variant_UkLWZg9DAJ
+                    quantity: 1
+                  metadata: {}
+                  adjustment_total: '0.0'
+                  pre_tax_amount: '0.0'
+                  created_at: '2026-06-08T10:57:11.692Z'
+                  updated_at: '2026-06-08T10:57:11.766Z'
+                  order_id: or_UkLWZg9DAJ
+                  stock_location_id: sloc_UkLWZg9DAJ
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+  "/api/v3/admin/orders/{order_id}/fulfillments/{id}":
+    get:
+      summary: Show a shipment
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns details of a specific shipment.
+
+        **Required scope:** `read_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const fulfillment = await client.orders.fulfillments.get('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Fulfillment ID
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (e.g., inventory_units,
+          stock_location, shipping_rates). Use dot notation for nested expand (max
+          4 levels).
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., number,status,tracking,cost).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: shipment found
+          content:
+            application/json:
+              example:
+                id: ful_UkLWZg9DAJ
+                number: H58592161546
+                tracking: U10000
+                tracking_url:
+                cost: '10.0'
+                display_cost: "$10.00"
+                total: '10.0'
+                display_total: "$10.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                status: ready
+                fulfillment_type: shipping
+                fulfilled_at:
+                items:
+                - item_id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                metadata: {}
+                adjustment_total: '0.0'
+                pre_tax_amount: '0.0'
+                created_at: '2026-06-08T10:57:12.372Z'
+                updated_at: '2026-06-08T10:57:12.428Z'
+                order_id: or_UkLWZg9DAJ
+                stock_location_id: sloc_UkLWZg9DAJ
+    patch:
+      summary: Update a shipment
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Updates a shipment (tracking, shipping rate).
+
+        **Required scope:** `write_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const fulfillment = await client.orders.fulfillments.update('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ', {
+            tracking: '1Z999AA10123456784',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Fulfillment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: shipment updated
+          content:
+            application/json:
+              example:
+                id: ful_UkLWZg9DAJ
+                number: H48155201967
+                tracking: 1Z999AA10123456784
+                tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
+                cost: '10.0'
+                display_cost: "$10.00"
+                total: '10.0'
+                display_total: "$10.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                status: ready
+                fulfillment_type: shipping
+                fulfilled_at:
+                items:
+                - item_id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                metadata: {}
+                adjustment_total: '0.0'
+                pre_tax_amount: '0.0'
+                created_at: '2026-06-08T10:57:13.024Z'
+                updated_at: '2026-06-08T10:57:13.385Z'
+                order_id: or_UkLWZg9DAJ
+                stock_location_id: sloc_UkLWZg9DAJ
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tracking:
+                  type: string
+                  example: 1Z999AA10123456784
+                selected_shipping_rate_id:
+                  type: string
+  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/fulfill":
+    patch:
+      summary: Fulfill a fulfillment
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Marks a fulfillment as fulfilled.
+
+        **Required scope:** `write_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const fulfillment = await client.orders.fulfillments.fulfill('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Fulfillment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: fulfillment fulfilled
+          content:
+            application/json:
+              example:
+                id: ful_UkLWZg9DAJ
+                number: H51880549825
+                tracking: U10000
+                tracking_url:
+                cost: '10.0'
+                display_cost: "$10.00"
+                total: '10.0'
+                display_total: "$10.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                status: shipped
+                fulfillment_type: shipping
+                fulfilled_at: '2026-06-08T10:57:14Z'
+                items:
+                - item_id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                metadata: {}
+                adjustment_total: '0.0'
+                pre_tax_amount: '0.0'
+                created_at: '2026-06-08T10:57:13.742Z'
+                updated_at: '2026-06-08T10:57:14.099Z'
+                order_id: or_UkLWZg9DAJ
+                stock_location_id: sloc_UkLWZg9DAJ
+  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
+    patch:
+      summary: Cancel a fulfillment
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Cancels a fulfillment.
+
+        **Required scope:** `write_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const fulfillment = await client.orders.fulfillments.cancel('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Fulfillment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: fulfillment canceled
+          content:
+            application/json:
+              example:
+                id: ful_UkLWZg9DAJ
+                number: H11992775783
+                tracking: U10000
+                tracking_url:
+                cost: '10.0'
+                display_cost: "$10.00"
+                total: '10.0'
+                display_total: "$10.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                status: canceled
+                fulfillment_type: shipping
+                fulfilled_at:
+                items:
+                - item_id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                metadata: {}
+                adjustment_total: '0.0'
+                pre_tax_amount: '0.0'
+                created_at: '2026-06-08T10:57:14.457Z'
+                updated_at: '2026-06-08T10:57:14.855Z'
+                order_id: or_UkLWZg9DAJ
+                stock_location_id: sloc_UkLWZg9DAJ
+  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
+    patch:
+      summary: Resume a fulfillment
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Resumes a canceled fulfillment.
+
+        **Required scope:** `write_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const fulfillment = await client.orders.fulfillments.resume('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Fulfillment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: fulfillment resumed
+          content:
+            application/json:
+              example:
+                id: ful_UkLWZg9DAJ
+                number: H79014622748
+                tracking: U10000
+                tracking_url:
+                cost: '10.0'
+                display_cost: "$10.00"
+                total: '10.0'
+                display_total: "$10.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                status: pending
+                fulfillment_type: shipping
+                fulfilled_at:
+                items:
+                - item_id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                metadata: {}
+                adjustment_total: '0.0'
+                pre_tax_amount: '0.0'
+                created_at: '2026-06-08T10:57:15.195Z'
+                updated_at: '2026-06-08T10:57:15.547Z'
+                order_id: or_UkLWZg9DAJ
+                stock_location_id: sloc_UkLWZg9DAJ
+  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
+    patch:
+      summary: Split a fulfillment
+      tags:
+      - Fulfillments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Transfers items from this shipment to a new shipment at a different stock location.
+
+        **Required scope:** `write_fulfillments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const fulfillment = await client.orders.fulfillments.split('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ', {
+            quantity: 1,
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Fulfillment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: fulfillment split
+          content:
+            application/json:
+              example:
+                data:
+                - id: ful_gbHJdmfrXB
+                  number: H05613456699
+                  tracking:
+                  tracking_url:
+                  cost: '10.0'
+                  display_cost: "$10.00"
+                  total: '10.0'
+                  display_total: "$10.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  tax_total: '0.0'
+                  display_tax_total: "$0.00"
+                  status: ready
+                  fulfillment_type: shipping
+                  fulfilled_at:
+                  items:
+                  - item_id: li_UkLWZg9DAJ
+                    variant_id: variant_UkLWZg9DAJ
+                    quantity: 1
+                  metadata: {}
+                  adjustment_total: '0.0'
+                  pre_tax_amount: '0.0'
+                  created_at: '2026-06-08T10:57:16.243Z'
+                  updated_at: '2026-06-08T10:57:16.326Z'
+                  order_id: or_UkLWZg9DAJ
+                  stock_location_id: sloc_gbHJdmfrXB
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - variant_id
+              - quantity
+              properties:
+                variant_id:
+                  type: string
+                  description: Variant ID
+                quantity:
+                  type: integer
+                  example: 1
+                stock_location_id:
+                  type: string
+                  description: Target stock location ID
   "/api/v3/admin/gift_card_batches":
     get:
       summary: List gift card batches
@@ -5060,244 +5531,6 @@ paths:
                 error:
                   code: validation_error
                   message: Gift card cannot be deleted
-  "/api/v3/admin/invitations":
-    get:
-      summary: List invitations
-      tags:
-      - Staff
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns invitations for the current store, including pending and accepted.
-
-        **Required scope:** `read_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: invitations } = await client.invitations.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: invitations found
-          content:
-            application/json:
-              example:
-                data:
-                - id: inv_UkLWZg9DAJ
-                  email: dorthy.emmerich@bradtke.info
-                  status: pending
-                  created_at: '2026-06-08T10:57:05.016Z'
-                  updated_at: '2026-06-08T10:57:05.016Z'
-                  expires_at: '2026-06-22T10:57:05.014Z'
-                  role_id: role_UkLWZg9DAJ
-                  role_name: admin
-                  inviter_email: brigette@sporer.us
-                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=YJnLJxUSrtebeM9iYcT2mb9P"
-                  invitee_exists: false
-                  store:
-                    id: store_UkLWZg9DAJ
-                    name: Spree Test Store
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-    post:
-      summary: Create an invitation
-      tags:
-      - Staff
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Invites a teammate by email. The invitation is scoped to the current store and carries the chosen role; on accept, a `RoleUser` is created via the invitation's `after_accept` callback.
-
-        **Required scope:** `write_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const invitation = await client.invitations.create({
-            email: 'ada@example.com',
-            role_id: 'role_xxx'
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: invitation created
-          content:
-            application/json:
-              example:
-                id: inv_gbHJdmfrXB
-                email: new-staff@example.com
-                status: pending
-                created_at: '2026-06-08T10:57:05.335Z'
-                updated_at: '2026-06-08T10:57:05.335Z'
-                expires_at: '2026-06-22T10:57:05.333Z'
-                role_id: role_UkLWZg9DAJ
-                role_name: admin
-                inviter_email: aracelis.mosciski@barrows.biz
-                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=ttUpsLEE1U6sfGhhu1bU7G62"
-                invitee_exists: false
-                store:
-                  id: store_UkLWZg9DAJ
-                  name: Spree Test Store
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - email
-              - role_id
-              properties:
-                email:
-                  type: string
-                  example: ada@example.com
-                role_id:
-                  type: string
-                  example: role_xxx
-  "/api/v3/admin/invitations/{id}":
-    delete:
-      summary: Revoke an invitation
-      tags:
-      - Staff
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: "**Required scope:** `write_settings` (for API-key authentication)."
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          await client.invitations.delete('inv_xxx')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: invitation revoked
-  "/api/v3/admin/invitations/{id}/resend":
-    patch:
-      summary: Resend an invitation
-      tags:
-      - Staff
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Issues a fresh token and dispatches the invitation email again.
-
-        **Required scope:** `write_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const invitation = await client.invitations.resend('inv_xxx')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: invitation resent
-          content:
-            application/json:
-              example:
-                id: inv_UkLWZg9DAJ
-                email: carlita.stokes@fay.com
-                status: pending
-                created_at: '2026-06-08T10:57:05.902Z'
-                updated_at: '2026-06-08T10:57:05.902Z'
-                expires_at: '2026-06-22T10:57:05.900Z'
-                role_id: role_UkLWZg9DAJ
-                role_name: admin
-                inviter_email: chris@metzkilback.com
-                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=GZQipgFcLGqh5JQj54ouvodx"
-                invitee_exists: false
-                store:
-                  id: store_UkLWZg9DAJ
-                  name: Spree Test Store
   "/api/v3/admin/markets":
     get:
       summary: List markets
@@ -5774,124 +6007,6 @@ paths:
                 error:
                   code: validation_error
                   message: Market cannot be deleted
-  "/api/v3/admin/me":
-    get:
-      summary: Get current admin user and permissions
-      tags:
-      - Authentication
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns the current admin user profile and a serialized list of
-        permissions (CanCanCan rules). The SPA uses these to drive UI permission checks.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const me = await client.me.get()
-          if (me.permissions.some((r) => r.allow && r.actions.includes('manage') && r.subjects.includes('Spree::Product'))) {
-            // show "Create product" button
-          }
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      responses:
-        '200':
-          description: current admin user and permissions
-          content:
-            application/json:
-              example:
-                user:
-                  id: admin_UkLWZg9DAJ
-                  email: karole.ratke@darekovacek.name
-                  first_name: Corazon
-                  last_name: O'Hara
-                  full_name: Corazon O'Hara
-                  created_at: '2026-06-08T10:57:08.989Z'
-                  updated_at: '2026-06-08T10:57:08.989Z'
-                  roles:
-                  - id: role_UkLWZg9DAJ
-                    name: admin
-                permissions:
-                - allow: true
-                  actions:
-                  - manage
-                  subjects:
-                  - all
-                  has_conditions: false
-                - allow: false
-                  actions:
-                  - cancel
-                  subjects:
-                  - Spree::Order
-                  has_conditions: false
-                - allow: true
-                  actions:
-                  - cancel
-                  subjects:
-                  - Spree::Order
-                  has_conditions: true
-                - allow: false
-                  actions:
-                  - destroy
-                  subjects:
-                  - Spree::Order
-                  has_conditions: false
-                - allow: true
-                  actions:
-                  - destroy
-                  subjects:
-                  - Spree::Order
-                  has_conditions: true
-                - allow: false
-                  actions:
-                  - edit
-                  - update
-                  subjects:
-                  - Spree::RefundReason
-                  has_conditions: true
-                - allow: false
-                  actions:
-                  - edit
-                  - update
-                  subjects:
-                  - Spree::ReimbursementType
-                  has_conditions: true
-                - allow: false
-                  actions:
-                  - update
-                  - destroy
-                  subjects:
-                  - Spree::Role
-                  has_conditions: true
-              schema:
-                "$ref": "#/components/schemas/MeResponse"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/admin/option_types":
     get:
       summary: List option types
@@ -6356,662 +6471,6 @@ paths:
       responses:
         '204':
           description: option type deleted
-  "/api/v3/admin/orders/{order_id}/fulfillments":
-    get:
-      summary: List fulfillments
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns all shipments for an order.
-
-        **Required scope:** `read_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: fulfillments } = await client.orders.fulfillments.list('or_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (e.g., inventory_units,
-          stock_location, shipping_rates). Use dot notation for nested expand (max
-          4 levels).
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., number,status,tracking,cost).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: fulfillments found
-          content:
-            application/json:
-              example:
-                data:
-                - id: ful_UkLWZg9DAJ
-                  number: H37428731748
-                  tracking: U10000
-                  tracking_url:
-                  cost: '10.0'
-                  display_cost: "$10.00"
-                  total: '10.0'
-                  display_total: "$10.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  tax_total: '0.0'
-                  display_tax_total: "$0.00"
-                  status: ready
-                  fulfillment_type: shipping
-                  fulfilled_at:
-                  items:
-                  - item_id: li_UkLWZg9DAJ
-                    variant_id: variant_UkLWZg9DAJ
-                    quantity: 1
-                  metadata: {}
-                  adjustment_total: '0.0'
-                  pre_tax_amount: '0.0'
-                  created_at: '2026-06-08T10:57:11.692Z'
-                  updated_at: '2026-06-08T10:57:11.766Z'
-                  order_id: or_UkLWZg9DAJ
-                  stock_location_id: sloc_UkLWZg9DAJ
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-  "/api/v3/admin/orders/{order_id}/fulfillments/{id}":
-    get:
-      summary: Show a shipment
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns details of a specific shipment.
-
-        **Required scope:** `read_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const fulfillment = await client.orders.fulfillments.get('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Fulfillment ID
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (e.g., inventory_units,
-          stock_location, shipping_rates). Use dot notation for nested expand (max
-          4 levels).
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., number,status,tracking,cost).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: shipment found
-          content:
-            application/json:
-              example:
-                id: ful_UkLWZg9DAJ
-                number: H58592161546
-                tracking: U10000
-                tracking_url:
-                cost: '10.0'
-                display_cost: "$10.00"
-                total: '10.0'
-                display_total: "$10.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                status: ready
-                fulfillment_type: shipping
-                fulfilled_at:
-                items:
-                - item_id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                metadata: {}
-                adjustment_total: '0.0'
-                pre_tax_amount: '0.0'
-                created_at: '2026-06-08T10:57:12.372Z'
-                updated_at: '2026-06-08T10:57:12.428Z'
-                order_id: or_UkLWZg9DAJ
-                stock_location_id: sloc_UkLWZg9DAJ
-    patch:
-      summary: Update a shipment
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Updates a shipment (tracking, shipping rate).
-
-        **Required scope:** `write_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const fulfillment = await client.orders.fulfillments.update('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ', {
-            tracking: '1Z999AA10123456784',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Fulfillment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: shipment updated
-          content:
-            application/json:
-              example:
-                id: ful_UkLWZg9DAJ
-                number: H48155201967
-                tracking: 1Z999AA10123456784
-                tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
-                cost: '10.0'
-                display_cost: "$10.00"
-                total: '10.0'
-                display_total: "$10.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                status: ready
-                fulfillment_type: shipping
-                fulfilled_at:
-                items:
-                - item_id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                metadata: {}
-                adjustment_total: '0.0'
-                pre_tax_amount: '0.0'
-                created_at: '2026-06-08T10:57:13.024Z'
-                updated_at: '2026-06-08T10:57:13.385Z'
-                order_id: or_UkLWZg9DAJ
-                stock_location_id: sloc_UkLWZg9DAJ
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                tracking:
-                  type: string
-                  example: 1Z999AA10123456784
-                selected_shipping_rate_id:
-                  type: string
-  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/fulfill":
-    patch:
-      summary: Fulfill a fulfillment
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Marks a fulfillment as fulfilled.
-
-        **Required scope:** `write_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const fulfillment = await client.orders.fulfillments.fulfill('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Fulfillment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: fulfillment fulfilled
-          content:
-            application/json:
-              example:
-                id: ful_UkLWZg9DAJ
-                number: H51880549825
-                tracking: U10000
-                tracking_url:
-                cost: '10.0'
-                display_cost: "$10.00"
-                total: '10.0'
-                display_total: "$10.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                status: shipped
-                fulfillment_type: shipping
-                fulfilled_at: '2026-06-08T10:57:14Z'
-                items:
-                - item_id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                metadata: {}
-                adjustment_total: '0.0'
-                pre_tax_amount: '0.0'
-                created_at: '2026-06-08T10:57:13.742Z'
-                updated_at: '2026-06-08T10:57:14.099Z'
-                order_id: or_UkLWZg9DAJ
-                stock_location_id: sloc_UkLWZg9DAJ
-  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
-    patch:
-      summary: Cancel a fulfillment
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Cancels a fulfillment.
-
-        **Required scope:** `write_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const fulfillment = await client.orders.fulfillments.cancel('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Fulfillment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: fulfillment canceled
-          content:
-            application/json:
-              example:
-                id: ful_UkLWZg9DAJ
-                number: H11992775783
-                tracking: U10000
-                tracking_url:
-                cost: '10.0'
-                display_cost: "$10.00"
-                total: '10.0'
-                display_total: "$10.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                status: canceled
-                fulfillment_type: shipping
-                fulfilled_at:
-                items:
-                - item_id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                metadata: {}
-                adjustment_total: '0.0'
-                pre_tax_amount: '0.0'
-                created_at: '2026-06-08T10:57:14.457Z'
-                updated_at: '2026-06-08T10:57:14.855Z'
-                order_id: or_UkLWZg9DAJ
-                stock_location_id: sloc_UkLWZg9DAJ
-  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
-    patch:
-      summary: Resume a fulfillment
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Resumes a canceled fulfillment.
-
-        **Required scope:** `write_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const fulfillment = await client.orders.fulfillments.resume('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Fulfillment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: fulfillment resumed
-          content:
-            application/json:
-              example:
-                id: ful_UkLWZg9DAJ
-                number: H79014622748
-                tracking: U10000
-                tracking_url:
-                cost: '10.0'
-                display_cost: "$10.00"
-                total: '10.0'
-                display_total: "$10.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                status: pending
-                fulfillment_type: shipping
-                fulfilled_at:
-                items:
-                - item_id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                metadata: {}
-                adjustment_total: '0.0'
-                pre_tax_amount: '0.0'
-                created_at: '2026-06-08T10:57:15.195Z'
-                updated_at: '2026-06-08T10:57:15.547Z'
-                order_id: or_UkLWZg9DAJ
-                stock_location_id: sloc_UkLWZg9DAJ
-  "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
-    patch:
-      summary: Split a fulfillment
-      tags:
-      - Fulfillments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Transfers items from this shipment to a new shipment at a different stock location.
-
-        **Required scope:** `write_fulfillments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const fulfillment = await client.orders.fulfillments.split('or_UkLWZg9DAJ', 'ful_UkLWZg9DAJ', {
-            quantity: 1,
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Fulfillment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: fulfillment split
-          content:
-            application/json:
-              example:
-                data:
-                - id: ful_gbHJdmfrXB
-                  number: H05613456699
-                  tracking:
-                  tracking_url:
-                  cost: '10.0'
-                  display_cost: "$10.00"
-                  total: '10.0'
-                  display_total: "$10.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  tax_total: '0.0'
-                  display_tax_total: "$0.00"
-                  status: ready
-                  fulfillment_type: shipping
-                  fulfilled_at:
-                  items:
-                  - item_id: li_UkLWZg9DAJ
-                    variant_id: variant_UkLWZg9DAJ
-                    quantity: 1
-                  metadata: {}
-                  adjustment_total: '0.0'
-                  pre_tax_amount: '0.0'
-                  created_at: '2026-06-08T10:57:16.243Z'
-                  updated_at: '2026-06-08T10:57:16.326Z'
-                  order_id: or_UkLWZg9DAJ
-                  stock_location_id: sloc_gbHJdmfrXB
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - variant_id
-              - quantity
-              properties:
-                variant_id:
-                  type: string
-                  description: Variant ID
-                quantity:
-                  type: integer
-                  example: 1
-                stock_location_id:
-                  type: string
-                  description: Target stock location ID
   "/api/v3/admin/orders/{order_id}/gift_cards":
     post:
       summary: Apply a gift card to an order
@@ -7642,626 +7101,6 @@ paths:
       responses:
         '204':
           description: line item removed
-  "/api/v3/admin/orders/{order_id}/payments":
-    get:
-      summary: List payments
-      tags:
-      - Payments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns all payments for an order.
-
-        **Required scope:** `read_payments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: payments } = await client.orders.payments.list('or_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (e.g., payment_method,
-          source). Use dot notation for nested expand (max 4 levels).
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., amount,status,number,response_code).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: payments found
-          content:
-            application/json:
-              example:
-                data:
-                - id: py_UkLWZg9DAJ
-                  payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-8a4389715a82
-                  number: P4WYE9BN
-                  amount: '110.0'
-                  display_amount: "$110.00"
-                  status: completed
-                  source_type: credit_card
-                  source_id: card_UkLWZg9DAJ
-                  source:
-                    id: card_UkLWZg9DAJ
-                    brand: visa
-                    last4: '1111'
-                    month: 12
-                    year: 2027
-                    name: Spree Commerce
-                    default: false
-                    gateway_payment_profile_id:
-                    customer_id:
-                    payment_method_id: pm_gbHJdmfrXB
-                    metadata: {}
-                    created_at: '2026-06-08T10:57:21.449Z'
-                    updated_at: '2026-06-08T10:57:21.453Z'
-                  metadata: {}
-                  avs_response:
-                  cvv_response_code:
-                  cvv_response_message:
-                  created_at: '2026-06-08T10:57:21.451Z'
-                  updated_at: '2026-06-08T10:57:21.451Z'
-                  captured_amount: '0.0'
-                  order_id: or_UkLWZg9DAJ
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-    post:
-      summary: Create a payment
-      tags:
-      - Payments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Creates a new payment for the order.
-
-        **Required scope:** `write_payments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const payment = await client.orders.payments.create('or_UkLWZg9DAJ', {
-            payment_method_id: 'pm_UkLWZg9DAJ',
-            amount: 99.99,
-            source_id: 'cc_UkLWZg9DAJ',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      responses:
-        '201':
-          description: payment created
-          content:
-            application/json:
-              example:
-                id: py_gbHJdmfrXB
-                payment_method_id: pm_EfhxLZ9ck8
-                response_code:
-                number: P9YJWKYL
-                amount: '110.0'
-                display_amount: "$110.00"
-                status: checkout
-                source_type:
-                source_id:
-                source:
-                metadata: {}
-                avs_response:
-                cvv_response_code:
-                cvv_response_message:
-                created_at: '2026-06-08T10:57:22.839Z'
-                updated_at: '2026-06-08T10:57:22.839Z'
-                captured_amount: '0.0'
-                order_id: or_gbHJdmfrXB
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - payment_method_id
-              properties:
-                payment_method_id:
-                  type: string
-                  description: Payment method ID
-                amount:
-                  type: number
-                  example: 99.99
-                source_id:
-                  type: string
-                  description: Payment source ID
-  "/api/v3/admin/orders/{order_id}/payments/{id}":
-    get:
-      summary: Show a payment
-      tags:
-      - Payments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns details of a specific payment.
-
-        **Required scope:** `read_payments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const payment = await client.orders.payments.get('or_UkLWZg9DAJ', 'pay_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Payment ID
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (e.g., payment_method,
-          source). Use dot notation for nested expand (max 4 levels).
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., amount,status,number,response_code).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: payment found
-          content:
-            application/json:
-              example:
-                id: py_UkLWZg9DAJ
-                payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-593d862e96f0
-                number: PG90UG3I
-                amount: '110.0'
-                display_amount: "$110.00"
-                status: completed
-                source_type: credit_card
-                source_id: card_UkLWZg9DAJ
-                source:
-                  id: card_UkLWZg9DAJ
-                  brand: visa
-                  last4: '1111'
-                  month: 12
-                  year: 2027
-                  name: Spree Commerce
-                  default: false
-                  gateway_payment_profile_id:
-                  customer_id:
-                  payment_method_id: pm_gbHJdmfrXB
-                  metadata: {}
-                  created_at: '2026-06-08T10:57:23.214Z'
-                  updated_at: '2026-06-08T10:57:23.217Z'
-                metadata: {}
-                avs_response:
-                cvv_response_code:
-                cvv_response_message:
-                created_at: '2026-06-08T10:57:23.216Z'
-                updated_at: '2026-06-08T10:57:23.216Z'
-                captured_amount: '0.0'
-                order_id: or_UkLWZg9DAJ
-  "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
-    patch:
-      summary: Capture a payment
-      tags:
-      - Payments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Captures a pending payment.
-
-        **Required scope:** `write_payments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const payment = await client.orders.payments.capture('or_UkLWZg9DAJ', 'pay_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Payment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: payment captured
-          content:
-            application/json:
-              example:
-                id: py_UkLWZg9DAJ
-                payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-0a1bdc7c0459
-                number: PKBIGM2X
-                amount: '110.0'
-                display_amount: "$110.00"
-                status: completed
-                source_type: credit_card
-                source_id: card_UkLWZg9DAJ
-                source:
-                  id: card_UkLWZg9DAJ
-                  brand: visa
-                  last4: '1111'
-                  month: 12
-                  year: 2027
-                  name: Spree Commerce
-                  default: false
-                  gateway_payment_profile_id:
-                  customer_id:
-                  payment_method_id: pm_gbHJdmfrXB
-                  metadata: {}
-                  created_at: '2026-06-08T10:57:23.864Z'
-                  updated_at: '2026-06-08T10:57:23.866Z'
-                metadata: {}
-                avs_response:
-                cvv_response_code:
-                cvv_response_message:
-                created_at: '2026-06-08T10:57:23.865Z'
-                updated_at: '2026-06-08T10:57:24.186Z'
-                captured_amount: '110.0'
-                order_id: or_UkLWZg9DAJ
-        '422':
-          description: capture failed
-          content:
-            application/json:
-              example:
-                error:
-                  code: processing_error
-                  message: 'Bogus Gateway: Forced failure'
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/admin/orders/{order_id}/payments/{id}/void":
-    patch:
-      summary: Void a payment
-      tags:
-      - Payments
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Voids a payment.
-
-        **Required scope:** `write_payments` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const payment = await client.orders.payments.void('or_UkLWZg9DAJ', 'pay_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Payment ID
-        schema:
-          type: string
-      responses:
-        '200':
-          description: payment voided
-          content:
-            application/json:
-              example:
-                id: py_UkLWZg9DAJ
-                payment_method_id: pm_UkLWZg9DAJ
-                response_code: void-BGS-1fec0a04658a
-                number: P122PQX0
-                amount: '110.0'
-                display_amount: "$110.00"
-                status: void
-                source_type: credit_card
-                source_id: card_UkLWZg9DAJ
-                source:
-                  id: card_UkLWZg9DAJ
-                  brand: visa
-                  last4: '1111'
-                  month: 12
-                  year: 2027
-                  name: Spree Commerce
-                  default: false
-                  gateway_payment_profile_id:
-                  customer_id:
-                  payment_method_id: pm_gbHJdmfrXB
-                  metadata: {}
-                  created_at: '2026-06-08T10:57:25.233Z'
-                  updated_at: '2026-06-08T10:57:25.235Z'
-                metadata: {}
-                avs_response:
-                cvv_response_code:
-                cvv_response_message:
-                created_at: '2026-06-08T10:57:25.234Z'
-                updated_at: '2026-06-08T10:57:25.532Z'
-                captured_amount: '0.0'
-                order_id: or_UkLWZg9DAJ
-  "/api/v3/admin/orders/{order_id}/refunds":
-    get:
-      summary: List refunds
-      tags:
-      - Refunds
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns all refunds for an order.
-
-        **Required scope:** `read_refunds` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: refunds } = await client.orders.refunds.list('or_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (e.g., payment, refund_reason).
-          Use dot notation for nested expand (max 4 levels).
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., amount,reason,transaction_id).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: refunds found
-          content:
-            application/json:
-              example:
-                data: []
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 0
-                  pages: 1
-                  from: 0
-                  to: 0
-                  in: 0
-                  previous:
-                  next:
-    post:
-      summary: Create a refund
-      tags:
-      - Refunds
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Creates a refund for a payment on the order. The refund is automatically processed via the payment gateway.
-
-        **Required scope:** `write_refunds` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const refund = await client.orders.refunds.create('or_UkLWZg9DAJ', {
-            payment_id: 'pay_UkLWZg9DAJ',
-            amount: 5.00,
-            refund_reason_id: 'refrsn_UkLWZg9DAJ',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: order_id
-        in: path
-        required: true
-        description: Order ID
-        schema:
-          type: string
-      responses:
-        '201':
-          description: refund created
-          content:
-            application/json:
-              example:
-                id: re_UkLWZg9DAJ
-                transaction_id: BGS-cfd82a13871d
-                amount: '5.0'
-                payment_id: py_UkLWZg9DAJ
-                refund_reason_id: rr_UkLWZg9DAJ
-                reimbursement_id:
-                metadata: {}
-                created_at: '2026-06-08T10:57:26.844Z'
-                updated_at: '2026-06-08T10:57:26.844Z'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - payment_id
-              - amount
-              properties:
-                payment_id:
-                  type: string
-                  description: Payment ID
-                amount:
-                  type: number
-                  example: 10.0
-                refund_reason_id:
-                  type: string
-                  description: Refund reason ID
   "/api/v3/admin/orders/{order_id}/store_credits":
     post:
       summary: Apply customer's store credit to an order
@@ -9993,6 +8832,475 @@ paths:
                 updated_at: '2026-06-08T10:57:37.722Z'
                 preferences: {}
                 preference_schema: []
+  "/api/v3/admin/orders/{order_id}/payments":
+    get:
+      summary: List payments
+      tags:
+      - Payments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns all payments for an order.
+
+        **Required scope:** `read_payments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: payments } = await client.orders.payments.list('or_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (e.g., payment_method,
+          source). Use dot notation for nested expand (max 4 levels).
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., amount,status,number,response_code).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: payments found
+          content:
+            application/json:
+              example:
+                data:
+                - id: py_UkLWZg9DAJ
+                  payment_method_id: pm_UkLWZg9DAJ
+                  response_code: BGS-8a4389715a82
+                  number: P4WYE9BN
+                  amount: '110.0'
+                  display_amount: "$110.00"
+                  status: completed
+                  source_type: credit_card
+                  source_id: card_UkLWZg9DAJ
+                  source:
+                    id: card_UkLWZg9DAJ
+                    brand: visa
+                    last4: '1111'
+                    month: 12
+                    year: 2027
+                    name: Spree Commerce
+                    default: false
+                    gateway_payment_profile_id:
+                    customer_id:
+                    payment_method_id: pm_gbHJdmfrXB
+                    metadata: {}
+                    created_at: '2026-06-08T10:57:21.449Z'
+                    updated_at: '2026-06-08T10:57:21.453Z'
+                  metadata: {}
+                  avs_response:
+                  cvv_response_code:
+                  cvv_response_message:
+                  created_at: '2026-06-08T10:57:21.451Z'
+                  updated_at: '2026-06-08T10:57:21.451Z'
+                  captured_amount: '0.0'
+                  order_id: or_UkLWZg9DAJ
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+    post:
+      summary: Create a payment
+      tags:
+      - Payments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Creates a new payment for the order.
+
+        **Required scope:** `write_payments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const payment = await client.orders.payments.create('or_UkLWZg9DAJ', {
+            payment_method_id: 'pm_UkLWZg9DAJ',
+            amount: 99.99,
+            source_id: 'cc_UkLWZg9DAJ',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      responses:
+        '201':
+          description: payment created
+          content:
+            application/json:
+              example:
+                id: py_gbHJdmfrXB
+                payment_method_id: pm_EfhxLZ9ck8
+                response_code:
+                number: P9YJWKYL
+                amount: '110.0'
+                display_amount: "$110.00"
+                status: checkout
+                source_type:
+                source_id:
+                source:
+                metadata: {}
+                avs_response:
+                cvv_response_code:
+                cvv_response_message:
+                created_at: '2026-06-08T10:57:22.839Z'
+                updated_at: '2026-06-08T10:57:22.839Z'
+                captured_amount: '0.0'
+                order_id: or_gbHJdmfrXB
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - payment_method_id
+              properties:
+                payment_method_id:
+                  type: string
+                  description: Payment method ID
+                amount:
+                  type: number
+                  example: 99.99
+                source_id:
+                  type: string
+                  description: Payment source ID
+  "/api/v3/admin/orders/{order_id}/payments/{id}":
+    get:
+      summary: Show a payment
+      tags:
+      - Payments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns details of a specific payment.
+
+        **Required scope:** `read_payments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const payment = await client.orders.payments.get('or_UkLWZg9DAJ', 'pay_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Payment ID
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (e.g., payment_method,
+          source). Use dot notation for nested expand (max 4 levels).
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., amount,status,number,response_code).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: payment found
+          content:
+            application/json:
+              example:
+                id: py_UkLWZg9DAJ
+                payment_method_id: pm_UkLWZg9DAJ
+                response_code: BGS-593d862e96f0
+                number: PG90UG3I
+                amount: '110.0'
+                display_amount: "$110.00"
+                status: completed
+                source_type: credit_card
+                source_id: card_UkLWZg9DAJ
+                source:
+                  id: card_UkLWZg9DAJ
+                  brand: visa
+                  last4: '1111'
+                  month: 12
+                  year: 2027
+                  name: Spree Commerce
+                  default: false
+                  gateway_payment_profile_id:
+                  customer_id:
+                  payment_method_id: pm_gbHJdmfrXB
+                  metadata: {}
+                  created_at: '2026-06-08T10:57:23.214Z'
+                  updated_at: '2026-06-08T10:57:23.217Z'
+                metadata: {}
+                avs_response:
+                cvv_response_code:
+                cvv_response_message:
+                created_at: '2026-06-08T10:57:23.216Z'
+                updated_at: '2026-06-08T10:57:23.216Z'
+                captured_amount: '0.0'
+                order_id: or_UkLWZg9DAJ
+  "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
+    patch:
+      summary: Capture a payment
+      tags:
+      - Payments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Captures a pending payment.
+
+        **Required scope:** `write_payments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const payment = await client.orders.payments.capture('or_UkLWZg9DAJ', 'pay_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Payment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: payment captured
+          content:
+            application/json:
+              example:
+                id: py_UkLWZg9DAJ
+                payment_method_id: pm_UkLWZg9DAJ
+                response_code: BGS-0a1bdc7c0459
+                number: PKBIGM2X
+                amount: '110.0'
+                display_amount: "$110.00"
+                status: completed
+                source_type: credit_card
+                source_id: card_UkLWZg9DAJ
+                source:
+                  id: card_UkLWZg9DAJ
+                  brand: visa
+                  last4: '1111'
+                  month: 12
+                  year: 2027
+                  name: Spree Commerce
+                  default: false
+                  gateway_payment_profile_id:
+                  customer_id:
+                  payment_method_id: pm_gbHJdmfrXB
+                  metadata: {}
+                  created_at: '2026-06-08T10:57:23.864Z'
+                  updated_at: '2026-06-08T10:57:23.866Z'
+                metadata: {}
+                avs_response:
+                cvv_response_code:
+                cvv_response_message:
+                created_at: '2026-06-08T10:57:23.865Z'
+                updated_at: '2026-06-08T10:57:24.186Z'
+                captured_amount: '110.0'
+                order_id: or_UkLWZg9DAJ
+        '422':
+          description: capture failed
+          content:
+            application/json:
+              example:
+                error:
+                  code: processing_error
+                  message: 'Bogus Gateway: Forced failure'
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/admin/orders/{order_id}/payments/{id}/void":
+    patch:
+      summary: Void a payment
+      tags:
+      - Payments
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Voids a payment.
+
+        **Required scope:** `write_payments` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const payment = await client.orders.payments.void('or_UkLWZg9DAJ', 'pay_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Payment ID
+        schema:
+          type: string
+      responses:
+        '200':
+          description: payment voided
+          content:
+            application/json:
+              example:
+                id: py_UkLWZg9DAJ
+                payment_method_id: pm_UkLWZg9DAJ
+                response_code: void-BGS-1fec0a04658a
+                number: P122PQX0
+                amount: '110.0'
+                display_amount: "$110.00"
+                status: void
+                source_type: credit_card
+                source_id: card_UkLWZg9DAJ
+                source:
+                  id: card_UkLWZg9DAJ
+                  brand: visa
+                  last4: '1111'
+                  month: 12
+                  year: 2027
+                  name: Spree Commerce
+                  default: false
+                  gateway_payment_profile_id:
+                  customer_id:
+                  payment_method_id: pm_gbHJdmfrXB
+                  metadata: {}
+                  created_at: '2026-06-08T10:57:25.233Z'
+                  updated_at: '2026-06-08T10:57:25.235Z'
+                metadata: {}
+                avs_response:
+                cvv_response_code:
+                cvv_response_message:
+                created_at: '2026-06-08T10:57:25.234Z'
+                updated_at: '2026-06-08T10:57:25.532Z'
+                captured_amount: '0.0'
+                order_id: or_UkLWZg9DAJ
   "/api/v3/admin/price_lists":
     get:
       summary: List price lists
@@ -12658,6 +11966,78 @@ paths:
                   type: array
                   items:
                     type: string
+  "/api/v3/admin/promotions/{promotion_id}/coupon_codes":
+    parameters:
+    - name: promotion_id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: List coupon codes for a promotion
+      tags:
+      - Promotions
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns the auto-generated coupon codes for a multi-code promotion. Single-code promotions store the code on the promotion itself; this endpoint returns an empty list for them.
+
+        **Required scope:** `read_promotions` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: coupons } = await client.promotions.couponCodes.list('promo_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: coupon codes found
+          content:
+            application/json:
+              example:
+                data:
+                - id: coupon_UkLWZg9DAJ
+                  code: AAA111
+                  state: unused
+                  created_at: '2026-06-08T10:56:40.010Z'
+                  updated_at: '2026-06-08T10:56:40.010Z'
+                  promotion_id: promo_UkLWZg9DAJ
+                  order_id:
+                - id: coupon_gbHJdmfrXB
+                  code: BBB222
+                  state: unused
+                  created_at: '2026-06-08T10:56:40.011Z'
+                  updated_at: '2026-06-08T10:56:40.011Z'
+                  promotion_id: promo_UkLWZg9DAJ
+                  order_id:
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 2
+                  pages: 1
+                  from: 1
+                  to: 2
+                  in: 2
+                  previous:
+                  next:
   "/api/v3/admin/promotions/{promotion_id}/promotion_actions":
     parameters:
     - name: promotion_id
@@ -13813,6 +13193,1056 @@ paths:
                   - key: match_policy
                     type: string
                     default: any
+  "/api/v3/admin/orders/{order_id}/refunds":
+    get:
+      summary: List refunds
+      tags:
+      - Refunds
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns all refunds for an order.
+
+        **Required scope:** `read_refunds` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: refunds } = await client.orders.refunds.list('or_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (e.g., payment, refund_reason).
+          Use dot notation for nested expand (max 4 levels).
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., amount,reason,transaction_id).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: refunds found
+          content:
+            application/json:
+              example:
+                data: []
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 0
+                  pages: 1
+                  from: 0
+                  to: 0
+                  in: 0
+                  previous:
+                  next:
+    post:
+      summary: Create a refund
+      tags:
+      - Refunds
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Creates a refund for a payment on the order. The refund is automatically processed via the payment gateway.
+
+        **Required scope:** `write_refunds` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const refund = await client.orders.refunds.create('or_UkLWZg9DAJ', {
+            payment_id: 'pay_UkLWZg9DAJ',
+            amount: 5.00,
+            refund_reason_id: 'refrsn_UkLWZg9DAJ',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: order_id
+        in: path
+        required: true
+        description: Order ID
+        schema:
+          type: string
+      responses:
+        '201':
+          description: refund created
+          content:
+            application/json:
+              example:
+                id: re_UkLWZg9DAJ
+                transaction_id: BGS-cfd82a13871d
+                amount: '5.0'
+                payment_id: py_UkLWZg9DAJ
+                refund_reason_id: rr_UkLWZg9DAJ
+                reimbursement_id:
+                metadata: {}
+                created_at: '2026-06-08T10:57:26.844Z'
+                updated_at: '2026-06-08T10:57:26.844Z'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - payment_id
+              - amount
+              properties:
+                payment_id:
+                  type: string
+                  description: Payment ID
+                amount:
+                  type: number
+                  example: 10.0
+                refund_reason_id:
+                  type: string
+                  description: Refund reason ID
+  "/api/v3/admin/store_credit_categories":
+    get:
+      summary: List store credit categories
+      tags:
+      - Settings
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns the configured store credit categories. Categories classify
+        store credits (e.g., "Goodwill", "Gift Card", "Refund") and surface
+        in the admin UI as a dropdown when issuing or editing a store
+        credit. Category names matching `Spree::Config[:non_expiring_credit_types]`
+        are flagged via `non_expiring: true`.
+
+
+        **Required scope:** `read_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: categories } = await client.storeCreditCategories.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: Page number
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        description: Number of records per page
+        schema:
+          type: integer
+      - name: q[name_cont]
+        in: query
+        required: false
+        description: Filter by name (contains)
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        description: Sort by field. Prefix with `-` for descending (e.g., `-created_at`).
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include. id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: store credit categories found
+          content:
+            application/json:
+              example:
+                data:
+                - id: sccat_UkLWZg9DAJ
+                  name: Goodwill
+                  created_at: '2026-06-08T10:58:03.244Z'
+                  updated_at: '2026-06-08T10:58:03.244Z'
+                  non_expiring: false
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/StoreCreditCategory"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+                required:
+                - data
+                - meta
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/admin/store_credit_categories/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      description: Store credit category ID
+      schema:
+        type: string
+    get:
+      summary: Get a store credit category
+      tags:
+      - Settings
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns a single store credit category by prefixed ID.
+
+        **Required scope:** `read_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const category = await client.storeCreditCategories.get('sccat_UkLWZg9DAJ')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include. id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: store credit category found
+          content:
+            application/json:
+              example:
+                id: sccat_UkLWZg9DAJ
+                name: Goodwill
+                created_at: '2026-06-08T10:58:03.544Z'
+                updated_at: '2026-06-08T10:58:03.544Z'
+                non_expiring: false
+              schema:
+                "$ref": "#/components/schemas/StoreCreditCategory"
+        '404':
+          description: store credit category not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Store credit category not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/admin/store":
+    get:
+      summary: Get the current store
+      tags:
+      - Settings
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns the current store configuration. The store is resolved from the request context (host or admin selection); there is no `id` parameter.
+
+        **Required scope:** `read_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const store = await client.store.get()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      responses:
+        '200':
+          description: current store
+          content:
+            application/json:
+              example:
+                id: store_UkLWZg9DAJ
+                metadata: {}
+                name: Spree Test Store
+                default_currency: USD
+                default_locale: en
+                mail_from_address: no-reply@example.com
+                customer_support_email: support@example.com
+                new_order_notifications_email: store-owner@example.com
+                preferred_send_consumer_transactional_emails: true
+                preferred_admin_locale:
+                preferred_timezone: UTC
+                preferred_weight_unit: lb
+                preferred_unit_system: imperial
+                created_at: '2026-06-08T10:56:29.978Z'
+                updated_at: '2026-06-08T10:58:04.145Z'
+                url: http://www.example.com:3000
+                supported_currencies:
+                - USD
+                supported_locales:
+                - en
+                logo_url:
+                mailer_logo_url:
+              schema:
+                "$ref": "#/components/schemas/Store"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update the current store
+      tags:
+      - Settings
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Updates the current store configuration.
+
+        **Required scope:** `write_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const store = await client.store.update({
+            name: 'My Store'
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token for admin authentication
+        schema:
+          type: string
+      responses:
+        '200':
+          description: store updated
+          content:
+            application/json:
+              example:
+                id: store_UkLWZg9DAJ
+                metadata: {}
+                name: Renamed Store
+                default_currency: USD
+                default_locale: en
+                mail_from_address: no-reply@example.com
+                customer_support_email: support@example.com
+                new_order_notifications_email: store-owner@example.com
+                preferred_send_consumer_transactional_emails: true
+                preferred_admin_locale:
+                preferred_timezone: UTC
+                preferred_weight_unit: lb
+                preferred_unit_system: imperial
+                created_at: '2026-06-08T10:56:29.978Z'
+                updated_at: '2026-06-08T10:58:04.762Z'
+                url: http://www.example.com:3000
+                supported_currencies:
+                - USD
+                supported_locales:
+                - en
+                logo_url:
+                mailer_logo_url:
+              schema:
+                "$ref": "#/components/schemas/Store"
+        '422':
+          description: validation error
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Site Name can't be blank
+                  details:
+                    name:
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: My Store
+                preferred_admin_locale:
+                  type: string
+                  example: en
+                preferred_timezone:
+                  type: string
+                  example: UTC
+                preferred_weight_unit:
+                  type: string
+                  example: kg
+                preferred_unit_system:
+                  type: string
+                  example: metric
+  "/api/v3/admin/tags":
+    get:
+      summary: List tags
+      tags:
+      - Settings
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns tag names for a given taggable type. Used for autocomplete
+        in tag inputs on products, orders, and customers.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: tags } = await client.tags.list({
+            taggable_type: 'Spree::User',
+            q: 'vip',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: taggable_type
+        in: query
+        required: true
+        description: Taggable type (`Spree::Product`, `Spree::Order`, or `Spree::User`)
+        schema:
+          type: string
+      - name: q
+        in: query
+        required: false
+        description: Optional case-insensitive substring filter
+        schema:
+          type: string
+      responses:
+        '200':
+          description: tags found
+          content:
+            application/json:
+              example:
+                data:
+                - name: vip
+                - name: wholesale
+        '422':
+          description: invalid taggable type
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_taggable_type
+                  message: taggable_type must be one of Spree::Product, Spree::Order,
+                    Spree::LegacyUser
+  "/api/v3/admin/admin_users":
+    get:
+      summary: List staff
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns admin users with at least one role assignment on the current store.
+
+        **Required scope:** `read_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: staff } = await client.adminUsers.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: staff found
+          content:
+            application/json:
+              example:
+                data:
+                - id: admin_UkLWZg9DAJ
+                  email: odessa@nader.co.uk
+                  first_name: Harrison
+                  last_name: Parisian
+                  full_name: Harrison Parisian
+                  created_at: '2026-06-08T10:56:30.306Z'
+                  updated_at: '2026-06-08T10:56:30.306Z'
+                  roles:
+                  - id: role_UkLWZg9DAJ
+                    name: admin
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+  "/api/v3/admin/admin_users/{id}":
+    get:
+      summary: Show a staff member
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: "**Required scope:** `read_settings` (for API-key authentication)."
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const staff = await client.adminUsers.get('admin_xxx')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: staff member found
+          content:
+            application/json:
+              example:
+                id: admin_UkLWZg9DAJ
+                email: nancey@feil.info
+                first_name: Burt
+                last_name: Cole
+                full_name: Burt Cole
+                created_at: '2026-06-08T10:56:30.644Z'
+                updated_at: '2026-06-08T10:56:30.644Z'
+                roles:
+                - id: role_UkLWZg9DAJ
+                  name: admin
+    patch:
+      summary: Update a staff member
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Updates name fields and reassigns roles for the current store. `role_ids` is a complete replacement — roles not in the array are removed for this store.
+
+        **Required scope:** `write_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const staff = await client.adminUsers.update('admin_xxx', {
+            first_name: 'Ada',
+            role_ids: ['role_xxx']
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: staff member updated
+          content:
+            application/json:
+              example:
+                id: admin_UkLWZg9DAJ
+                email: candace@braunmayert.ca
+                first_name: Renamed
+                last_name: Rodriguez
+                full_name: Renamed Rodriguez
+                created_at: '2026-06-08T10:56:30.927Z'
+                updated_at: '2026-06-08T10:56:30.946Z'
+                roles:
+                - id: role_UkLWZg9DAJ
+                  name: admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                  example: Ada
+                last_name:
+                  type: string
+                  example: Lovelace
+                role_ids:
+                  type: array
+                  items:
+                    type: string
+    delete:
+      summary: Remove a staff member from this store
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Removes the user's role assignments on the current store. The account is preserved — the user keeps access to any other stores.
+
+        **Required scope:** `write_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          await client.adminUsers.delete('admin_xxx')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: staff removed from store
+  "/api/v3/admin/invitations":
+    get:
+      summary: List invitations
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Returns invitations for the current store, including pending and accepted.
+
+        **Required scope:** `read_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const { data: invitations } = await client.invitations.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: invitations found
+          content:
+            application/json:
+              example:
+                data:
+                - id: inv_UkLWZg9DAJ
+                  email: dorthy.emmerich@bradtke.info
+                  status: pending
+                  created_at: '2026-06-08T10:57:05.016Z'
+                  updated_at: '2026-06-08T10:57:05.016Z'
+                  expires_at: '2026-06-22T10:57:05.014Z'
+                  role_id: role_UkLWZg9DAJ
+                  role_name: admin
+                  inviter_email: brigette@sporer.us
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=YJnLJxUSrtebeM9iYcT2mb9P"
+                  invitee_exists: false
+                  store:
+                    id: store_UkLWZg9DAJ
+                    name: Spree Test Store
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+    post:
+      summary: Create an invitation
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Invites a teammate by email. The invitation is scoped to the current store and carries the chosen role; on accept, a `RoleUser` is created via the invitation's `after_accept` callback.
+
+        **Required scope:** `write_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const invitation = await client.invitations.create({
+            email: 'ada@example.com',
+            role_id: 'role_xxx'
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: invitation created
+          content:
+            application/json:
+              example:
+                id: inv_gbHJdmfrXB
+                email: new-staff@example.com
+                status: pending
+                created_at: '2026-06-08T10:57:05.335Z'
+                updated_at: '2026-06-08T10:57:05.335Z'
+                expires_at: '2026-06-22T10:57:05.333Z'
+                role_id: role_UkLWZg9DAJ
+                role_name: admin
+                inviter_email: aracelis.mosciski@barrows.biz
+                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=ttUpsLEE1U6sfGhhu1bU7G62"
+                invitee_exists: false
+                store:
+                  id: store_UkLWZg9DAJ
+                  name: Spree Test Store
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - email
+              - role_id
+              properties:
+                email:
+                  type: string
+                  example: ada@example.com
+                role_id:
+                  type: string
+                  example: role_xxx
+  "/api/v3/admin/invitations/{id}":
+    delete:
+      summary: Revoke an invitation
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: "**Required scope:** `write_settings` (for API-key authentication)."
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          await client.invitations.delete('inv_xxx')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: invitation revoked
+  "/api/v3/admin/invitations/{id}/resend":
+    patch:
+      summary: Resend an invitation
+      tags:
+      - Staff
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: |-
+        Issues a fresh token and dispatches the invitation email again.
+
+        **Required scope:** `write_settings` (for API-key authentication).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree Admin SDK
+        source: |-
+          import { createAdminClient } from '@spree/admin-sdk'
+
+          const client = createAdminClient({
+            baseUrl: 'https://your-store.com',
+            secretKey: 'sk_xxx',
+          })
+
+          const invitation = await client.invitations.resend('inv_xxx')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: invitation resent
+          content:
+            application/json:
+              example:
+                id: inv_UkLWZg9DAJ
+                email: carlita.stokes@fay.com
+                status: pending
+                created_at: '2026-06-08T10:57:05.902Z'
+                updated_at: '2026-06-08T10:57:05.902Z'
+                expires_at: '2026-06-22T10:57:05.900Z'
+                role_id: role_UkLWZg9DAJ
+                role_name: admin
+                inviter_email: chris@metzkilback.com
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=GZQipgFcLGqh5JQj54ouvodx"
+                invitee_exists: false
+                store:
+                  id: store_UkLWZg9DAJ
+                  name: Spree Test Store
   "/api/v3/admin/roles":
     get:
       summary: List roles
@@ -14490,436 +14920,6 @@ paths:
       responses:
         '204':
           description: stock location deleted
-  "/api/v3/admin/store_credit_categories":
-    get:
-      summary: List store credit categories
-      tags:
-      - Settings
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns the configured store credit categories. Categories classify
-        store credits (e.g., "Goodwill", "Gift Card", "Refund") and surface
-        in the admin UI as a dropdown when issuing or editing a store
-        credit. Category names matching `Spree::Config[:non_expiring_credit_types]`
-        are flagged via `non_expiring: true`.
-
-
-        **Required scope:** `read_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: categories } = await client.storeCreditCategories.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: Page number
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        description: Number of records per page
-        schema:
-          type: integer
-      - name: q[name_cont]
-        in: query
-        required: false
-        description: Filter by name (contains)
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        description: Sort by field. Prefix with `-` for descending (e.g., `-created_at`).
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include. id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: store credit categories found
-          content:
-            application/json:
-              example:
-                data:
-                - id: sccat_UkLWZg9DAJ
-                  name: Goodwill
-                  created_at: '2026-06-08T10:58:03.244Z'
-                  updated_at: '2026-06-08T10:58:03.244Z'
-                  non_expiring: false
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/StoreCreditCategory"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-                required:
-                - data
-                - meta
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/admin/store_credit_categories/{id}":
-    parameters:
-    - name: id
-      in: path
-      required: true
-      description: Store credit category ID
-      schema:
-        type: string
-    get:
-      summary: Get a store credit category
-      tags:
-      - Settings
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns a single store credit category by prefixed ID.
-
-        **Required scope:** `read_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const category = await client.storeCreditCategories.get('sccat_UkLWZg9DAJ')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include. id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: store credit category found
-          content:
-            application/json:
-              example:
-                id: sccat_UkLWZg9DAJ
-                name: Goodwill
-                created_at: '2026-06-08T10:58:03.544Z'
-                updated_at: '2026-06-08T10:58:03.544Z'
-                non_expiring: false
-              schema:
-                "$ref": "#/components/schemas/StoreCreditCategory"
-        '404':
-          description: store credit category not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Store credit category not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/admin/store":
-    get:
-      summary: Get the current store
-      tags:
-      - Settings
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Returns the current store configuration. The store is resolved from the request context (host or admin selection); there is no `id` parameter.
-
-        **Required scope:** `read_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const store = await client.store.get()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      responses:
-        '200':
-          description: current store
-          content:
-            application/json:
-              example:
-                id: store_UkLWZg9DAJ
-                metadata: {}
-                name: Spree Test Store
-                default_currency: USD
-                default_locale: en
-                mail_from_address: no-reply@example.com
-                customer_support_email: support@example.com
-                new_order_notifications_email: store-owner@example.com
-                preferred_send_consumer_transactional_emails: true
-                preferred_admin_locale:
-                preferred_timezone: UTC
-                preferred_weight_unit: lb
-                preferred_unit_system: imperial
-                created_at: '2026-06-08T10:56:29.978Z'
-                updated_at: '2026-06-08T10:58:04.145Z'
-                url: http://www.example.com:3000
-                supported_currencies:
-                - USD
-                supported_locales:
-                - en
-                logo_url:
-                mailer_logo_url:
-              schema:
-                "$ref": "#/components/schemas/Store"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-    patch:
-      summary: Update the current store
-      tags:
-      - Settings
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: |-
-        Updates the current store configuration.
-
-        **Required scope:** `write_settings` (for API-key authentication).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const store = await client.store.update({
-            name: 'My Store'
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer token for admin authentication
-        schema:
-          type: string
-      responses:
-        '200':
-          description: store updated
-          content:
-            application/json:
-              example:
-                id: store_UkLWZg9DAJ
-                metadata: {}
-                name: Renamed Store
-                default_currency: USD
-                default_locale: en
-                mail_from_address: no-reply@example.com
-                customer_support_email: support@example.com
-                new_order_notifications_email: store-owner@example.com
-                preferred_send_consumer_transactional_emails: true
-                preferred_admin_locale:
-                preferred_timezone: UTC
-                preferred_weight_unit: lb
-                preferred_unit_system: imperial
-                created_at: '2026-06-08T10:56:29.978Z'
-                updated_at: '2026-06-08T10:58:04.762Z'
-                url: http://www.example.com:3000
-                supported_currencies:
-                - USD
-                supported_locales:
-                - en
-                logo_url:
-                mailer_logo_url:
-              schema:
-                "$ref": "#/components/schemas/Store"
-        '422':
-          description: validation error
-          content:
-            application/json:
-              example:
-                error:
-                  code: validation_error
-                  message: Site Name can't be blank
-                  details:
-                    name:
-                    - can't be blank
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  example: My Store
-                preferred_admin_locale:
-                  type: string
-                  example: en
-                preferred_timezone:
-                  type: string
-                  example: UTC
-                preferred_weight_unit:
-                  type: string
-                  example: kg
-                preferred_unit_system:
-                  type: string
-                  example: metric
-  "/api/v3/admin/tags":
-    get:
-      summary: List tags
-      tags:
-      - Settings
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns tag names for a given taggable type. Used for autocomplete
-        in tag inputs on products, orders, and customers.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree Admin SDK
-        source: |-
-          import { createAdminClient } from '@spree/admin-sdk'
-
-          const client = createAdminClient({
-            baseUrl: 'https://your-store.com',
-            secretKey: 'sk_xxx',
-          })
-
-          const { data: tags } = await client.tags.list({
-            taggable_type: 'Spree::User',
-            q: 'vip',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: taggable_type
-        in: query
-        required: true
-        description: Taggable type (`Spree::Product`, `Spree::Order`, or `Spree::User`)
-        schema:
-          type: string
-      - name: q
-        in: query
-        required: false
-        description: Optional case-insensitive substring filter
-        schema:
-          type: string
-      responses:
-        '200':
-          description: tags found
-          content:
-            application/json:
-              example:
-                data:
-                - name: vip
-                - name: wholesale
-        '422':
-          description: invalid taggable type
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_taggable_type
-                  message: taggable_type must be one of Spree::Product, Spree::Order,
-                    Spree::LegacyUser
   "/api/v3/admin/products/{product_id}/variants":
     get:
       summary: List product variants

--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -43,7 +43,7 @@ paths:
     get:
       summary: List staff
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -82,12 +82,12 @@ paths:
               example:
                 data:
                 - id: admin_UkLWZg9DAJ
-                  email: iliana_wiza@hickle.info
-                  first_name: Cristine
-                  last_name: Kutch
-                  full_name: Cristine Kutch
-                  created_at: '2026-06-05T13:11:36.683Z'
-                  updated_at: '2026-06-05T13:11:36.683Z'
+                  email: odessa@nader.co.uk
+                  first_name: Harrison
+                  last_name: Parisian
+                  full_name: Harrison Parisian
+                  created_at: '2026-06-08T10:56:30.306Z'
+                  updated_at: '2026-06-08T10:56:30.306Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -105,7 +105,7 @@ paths:
     get:
       summary: Show a staff member
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -145,19 +145,19 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: september@flatley.co.uk
-                first_name: Ernie
-                last_name: Hammes
-                full_name: Ernie Hammes
-                created_at: '2026-06-05T13:11:37.020Z'
-                updated_at: '2026-06-05T13:11:37.020Z'
+                email: nancey@feil.info
+                first_name: Burt
+                last_name: Cole
+                full_name: Burt Cole
+                created_at: '2026-06-08T10:56:30.644Z'
+                updated_at: '2026-06-08T10:56:30.644Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
     patch:
       summary: Update a staff member
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -203,12 +203,12 @@ paths:
             application/json:
               example:
                 id: admin_UkLWZg9DAJ
-                email: halley@sanford.name
+                email: candace@braunmayert.ca
                 first_name: Renamed
-                last_name: Bruen
-                full_name: Renamed Bruen
-                created_at: '2026-06-05T13:11:37.300Z'
-                updated_at: '2026-06-05T13:11:37.317Z'
+                last_name: Rodriguez
+                full_name: Renamed Rodriguez
+                created_at: '2026-06-08T10:56:30.927Z'
+                updated_at: '2026-06-08T10:56:30.946Z'
                 roles:
                 - id: role_UkLWZg9DAJ
                   name: admin
@@ -231,7 +231,7 @@ paths:
     delete:
       summary: Remove a staff member from this store
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -274,7 +274,7 @@ paths:
     get:
       summary: List allowed origins
       tags:
-      - Configuration
+      - Allowed Origins
       security:
       - api_key: []
         bearer_auth: []
@@ -350,8 +350,8 @@ paths:
                 data:
                 - id: ao_UkLWZg9DAJ
                   origin: https://shop.example.com
-                  created_at: '2026-06-05T13:11:37.617Z'
-                  updated_at: '2026-06-05T13:11:37.617Z'
+                  created_at: '2026-06-08T10:56:31.241Z'
+                  updated_at: '2026-06-08T10:56:31.241Z'
                 meta:
                   page: 1
                   limit: 25
@@ -387,7 +387,7 @@ paths:
     post:
       summary: Create an allowed origin
       tags:
-      - Configuration
+      - Allowed Origins
       security:
       - api_key: []
         bearer_auth: []
@@ -432,8 +432,8 @@ paths:
               example:
                 id: ao_gbHJdmfrXB
                 origin: https://admin.example.com
-                created_at: '2026-06-05T13:11:38.223Z'
-                updated_at: '2026-06-05T13:11:38.223Z'
+                created_at: '2026-06-08T10:56:31.844Z'
+                updated_at: '2026-06-08T10:56:31.844Z'
               schema:
                 "$ref": "#/components/schemas/AllowedOrigin"
         '422':
@@ -471,7 +471,7 @@ paths:
     get:
       summary: Get an allowed origin
       tags:
-      - Configuration
+      - Allowed Origins
       security:
       - api_key: []
         bearer_auth: []
@@ -517,8 +517,8 @@ paths:
               example:
                 id: ao_UkLWZg9DAJ
                 origin: https://shop.example.com
-                created_at: '2026-06-05T13:11:38.548Z'
-                updated_at: '2026-06-05T13:11:38.548Z'
+                created_at: '2026-06-08T10:56:32.140Z'
+                updated_at: '2026-06-08T10:56:32.140Z'
               schema:
                 "$ref": "#/components/schemas/AllowedOrigin"
         '404':
@@ -534,7 +534,7 @@ paths:
     patch:
       summary: Update an allowed origin
       tags:
-      - Configuration
+      - Allowed Origins
       security:
       - api_key: []
         bearer_auth: []
@@ -576,8 +576,8 @@ paths:
               example:
                 id: ao_UkLWZg9DAJ
                 origin: https://www.example.com
-                created_at: '2026-06-05T13:11:39.123Z'
-                updated_at: '2026-06-05T13:11:39.399Z'
+                created_at: '2026-06-08T10:56:32.711Z'
+                updated_at: '2026-06-08T10:56:33.092Z'
               schema:
                 "$ref": "#/components/schemas/AllowedOrigin"
         '422':
@@ -606,7 +606,7 @@ paths:
     delete:
       summary: Delete an allowed origin
       tags:
-      - Configuration
+      - Allowed Origins
       security:
       - api_key: []
         bearer_auth: []
@@ -648,7 +648,7 @@ paths:
     get:
       summary: List API keys
       tags:
-      - Configuration
+      - API Keys
       security:
       - api_key: []
         bearer_auth: []
@@ -691,32 +691,32 @@ paths:
                   key_type: publishable
                   token_prefix:
                   scopes: []
-                  created_at: '2026-06-05T13:11:39.966Z'
-                  updated_at: '2026-06-05T13:11:39.966Z'
+                  created_at: '2026-06-08T10:56:33.709Z'
+                  updated_at: '2026-06-08T10:56:33.709Z'
                   revoked_at:
                   last_used_at:
-                  plaintext_token: pk_vwf79N3EbY55iFtDfBjti1ue
+                  plaintext_token: pk_WvcXSjJcJDQJRqu1Yu1vp5yS
                   created_by_email:
                 - id: key_gbHJdmfrXB
                   name: Backend integration
                   key_type: secret
-                  token_prefix: sk_SQrcKStFC
+                  token_prefix: sk_uXxj3uHMQ
                   scopes:
                   - write_all
-                  created_at: '2026-06-05T13:11:39.967Z'
-                  updated_at: '2026-06-05T13:11:39.967Z'
+                  created_at: '2026-06-08T10:56:33.710Z'
+                  updated_at: '2026-06-08T10:56:33.710Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
                   created_by_email:
                 - id: key_EfhxLZ9ck8
-                  name: officiis
+                  name: porro
                   key_type: secret
-                  token_prefix: sk_CbfihKFYJ
+                  token_prefix: sk_94S7QchKz
                   scopes:
                   - write_all
-                  created_at: '2026-06-05T13:11:39.968Z'
-                  updated_at: '2026-06-05T13:11:39.968Z'
+                  created_at: '2026-06-08T10:56:33.711Z'
+                  updated_at: '2026-06-08T10:56:33.711Z'
                   revoked_at:
                   last_used_at:
                   plaintext_token:
@@ -734,7 +734,7 @@ paths:
     post:
       summary: Create an API key
       tags:
-      - Configuration
+      - API Keys
       security:
       - api_key: []
         bearer_auth: []
@@ -779,15 +779,15 @@ paths:
                 id: key_VqXmZF31wY
                 name: CI key
                 key_type: secret
-                token_prefix: sk_nRJk8UWAr
+                token_prefix: sk_F2iuHSN5C
                 scopes:
                 - read_orders
-                created_at: '2026-06-05T13:11:40.519Z'
-                updated_at: '2026-06-05T13:11:40.519Z'
+                created_at: '2026-06-08T10:56:34.280Z'
+                updated_at: '2026-06-08T10:56:34.280Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: sk_nRJk8UWAreSGDgitF8WmLkW6
-                created_by_email: cathie@brown.co.uk
+                plaintext_token: sk_F2iuHSN5CzK3PoX8AeCMNnAZ
+                created_by_email: edra@kris.biz
         '422':
           description: validation error
           content:
@@ -829,7 +829,7 @@ paths:
     get:
       summary: Show an API key
       tags:
-      - Configuration
+      - API Keys
       security:
       - api_key: []
         bearer_auth: []
@@ -873,16 +873,16 @@ paths:
                 key_type: publishable
                 token_prefix:
                 scopes: []
-                created_at: '2026-06-05T13:11:40.807Z'
-                updated_at: '2026-06-05T13:11:40.807Z'
+                created_at: '2026-06-08T10:56:34.628Z'
+                updated_at: '2026-06-08T10:56:34.628Z'
                 revoked_at:
                 last_used_at:
-                plaintext_token: pk_rMmsAxGPjseAjBerbb8tbLHB
+                plaintext_token: pk_T4HNwJvZLLhdNZnbqgti7bem
                 created_by_email:
     delete:
       summary: Delete an API key
       tags:
-      - Configuration
+      - API Keys
       security:
       - api_key: []
         bearer_auth: []
@@ -922,7 +922,7 @@ paths:
     patch:
       summary: Revoke an API key
       tags:
-      - Configuration
+      - API Keys
       security:
       - api_key: []
         bearer_auth: []
@@ -967,12 +967,12 @@ paths:
                 id: key_gbHJdmfrXB
                 name: Backend integration
                 key_type: secret
-                token_prefix: sk_DdooMj4rL
+                token_prefix: sk_oZErCBJ7u
                 scopes:
                 - write_all
-                created_at: '2026-06-05T13:11:41.386Z'
-                updated_at: '2026-06-05T13:11:41.661Z'
-                revoked_at: '2026-06-05T13:11:41.660Z'
+                created_at: '2026-06-08T10:56:35.282Z'
+                updated_at: '2026-06-08T10:56:35.644Z'
+                revoked_at: '2026-06-08T10:56:35.643Z'
                 last_used_at:
                 plaintext_token:
                 created_by_email:
@@ -1026,15 +1026,15 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjA1MDE2NWYyLWIxMzgtNGUxNS1hODQzLTViOGQ3ZmQwNDRiNiIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwNjY1NDAyfQ.kRkK_K3OdO_o-Nt1pqtAYJSsL0xmTAby07V95YGqhQU
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjRlZjA1MzY0LTY2ODctNDY3My1hNDI4LWNjZDI1ODc4YjVjZSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwOTE2NDk2fQ.4EH3Xu8aKDP0u0jtmqrcOOR9okXtEtJFZLw-YdP4sPM
                 user:
                   id: admin_UkLWZg9DAJ
                   email: admin@example.com
-                  first_name: Ingrid
-                  last_name: Powlowski
-                  full_name: Ingrid Powlowski
-                  created_at: '2026-06-05T13:11:41.926Z'
-                  updated_at: '2026-06-05T13:11:41.926Z'
+                  first_name: Daina
+                  last_name: Braun
+                  full_name: Daina Braun
+                  created_at: '2026-06-08T10:56:35.975Z'
+                  updated_at: '2026-06-08T10:56:35.975Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -1129,15 +1129,15 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImNiOGQ2OWI5LWQzNzMtNDFkYy1iZWRhLWZmMjk2MDQ1MGQ5MiIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwNjY1NDAzfQ.Y008gMr0LiwTlG-IYbvK9jrpa33-dRJ95ZvYHguEG20
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjBhNTEyYmI5LTlkNjAtNDdjYi04ZjlhLTFiYTM0MWY4MjIzZSIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzgwOTE2NDk3fQ.eNWcAS3Rm1pAljK2jUjWhfYkqzjk6wraljD5m4DgKvM
                 user:
                   id: admin_UkLWZg9DAJ
                   email: admin@example.com
-                  first_name: Grayce
-                  last_name: Muller
-                  full_name: Grayce Muller
-                  created_at: '2026-06-05T13:11:43.008Z'
-                  updated_at: '2026-06-05T13:11:43.008Z'
+                  first_name: Roman
+                  last_name: Cruickshank
+                  full_name: Roman Cruickshank
+                  created_at: '2026-06-08T10:56:37.206Z'
+                  updated_at: '2026-06-08T10:56:37.206Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -1229,16 +1229,16 @@ paths:
                   active: true
                   default: true
                   preferred_order_routing_strategy:
-                  created_at: '2026-06-05T13:11:36.367Z'
-                  updated_at: '2026-06-05T13:11:36.367Z'
+                  created_at: '2026-06-08T10:56:29.986Z'
+                  updated_at: '2026-06-08T10:56:29.986Z'
                 - id: ch_gbHJdmfrXB
                   name: Wholesale
                   code: wholesale
                   active: true
                   default: false
                   preferred_order_routing_strategy:
-                  created_at: '2026-06-05T13:11:43.589Z'
-                  updated_at: '2026-06-05T13:11:43.589Z'
+                  created_at: '2026-06-08T10:56:37.801Z'
+                  updated_at: '2026-06-08T10:56:37.801Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1298,8 +1298,8 @@ paths:
                 active: true
                 default: false
                 preferred_order_routing_strategy:
-                created_at: '2026-06-05T13:11:44.163Z'
-                updated_at: '2026-06-05T13:11:44.163Z'
+                created_at: '2026-06-08T10:56:38.384Z'
+                updated_at: '2026-06-08T10:56:38.384Z'
       requestBody:
         content:
           application/json:
@@ -1356,8 +1356,8 @@ paths:
                 active: true
                 default: false
                 preferred_order_routing_strategy:
-                created_at: '2026-06-05T13:11:44.190Z'
-                updated_at: '2026-06-05T13:11:44.190Z'
+                created_at: '2026-06-08T10:56:38.395Z'
+                updated_at: '2026-06-08T10:56:38.395Z'
     patch:
       summary: Update a channel
       tags:
@@ -1389,8 +1389,8 @@ paths:
                 active: true
                 default: false
                 preferred_order_routing_strategy:
-                created_at: '2026-06-05T13:11:44.493Z'
-                updated_at: '2026-06-05T13:11:44.841Z'
+                created_at: '2026-06-08T10:56:38.681Z'
+                updated_at: '2026-06-08T10:56:38.986Z'
       requestBody:
         content:
           application/json:
@@ -1595,15 +1595,15 @@ paths:
                 - id: coupon_UkLWZg9DAJ
                   code: AAA111
                   state: unused
-                  created_at: '2026-06-05T13:11:45.879Z'
-                  updated_at: '2026-06-05T13:11:45.879Z'
+                  created_at: '2026-06-08T10:56:40.010Z'
+                  updated_at: '2026-06-08T10:56:40.010Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 - id: coupon_gbHJdmfrXB
                   code: BBB222
                   state: unused
-                  created_at: '2026-06-05T13:11:45.879Z'
-                  updated_at: '2026-06-05T13:11:45.879Z'
+                  created_at: '2026-06-08T10:56:40.011Z'
+                  updated_at: '2026-06-08T10:56:40.011Z'
                   promotion_id: promo_UkLWZg9DAJ
                   order_id:
                 meta:
@@ -1681,8 +1681,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Product
                   storefront_visible: true
-                  created_at: '2026-06-05T13:11:46.203Z'
-                  updated_at: '2026-06-05T13:11:46.203Z'
+                  created_at: '2026-06-08T10:56:40.300Z'
+                  updated_at: '2026-06-08T10:56:40.300Z'
                 - id: cfdef_gbHJdmfrXB
                   namespace: custom
                   key: order_notes
@@ -1690,8 +1690,8 @@ paths:
                   field_type: short_text
                   resource_type: Spree::Order
                   storefront_visible: true
-                  created_at: '2026-06-05T13:11:46.204Z'
-                  updated_at: '2026-06-05T13:11:46.204Z'
+                  created_at: '2026-06-08T10:56:40.301Z'
+                  updated_at: '2026-06-08T10:56:40.301Z'
                 meta:
                   page: 1
                   limit: 25
@@ -1754,8 +1754,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-06-05T13:11:46.788Z'
-                updated_at: '2026-06-05T13:11:46.788Z'
+                created_at: '2026-06-08T10:56:40.884Z'
+                updated_at: '2026-06-08T10:56:40.884Z'
       requestBody:
         content:
           application/json:
@@ -1838,8 +1838,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: true
-                created_at: '2026-06-05T13:11:46.793Z'
-                updated_at: '2026-06-05T13:11:46.793Z'
+                created_at: '2026-06-08T10:56:40.891Z'
+                updated_at: '2026-06-08T10:56:40.891Z'
     patch:
       summary: Update a custom field definition
       tags:
@@ -1878,8 +1878,8 @@ paths:
                 field_type: short_text
                 resource_type: Spree::Product
                 storefront_visible: false
-                created_at: '2026-06-05T13:11:47.078Z'
-                updated_at: '2026-06-05T13:11:47.360Z'
+                created_at: '2026-06-08T10:56:41.172Z'
+                updated_at: '2026-06-08T10:56:41.449Z'
       requestBody:
         content:
           application/json:
@@ -1924,7 +1924,7 @@ paths:
     get:
       summary: List customer groups
       tags:
-      - Customers
+      - Customer Groups
       security:
       - api_key: []
         bearer_auth: []
@@ -2003,14 +2003,14 @@ paths:
                   name: VIPs
                   description: Top spenders
                   customers_count: 0
-                  created_at: '2026-06-05T13:11:47.654Z'
-                  updated_at: '2026-06-05T13:11:47.654Z'
+                  created_at: '2026-06-08T10:56:41.734Z'
+                  updated_at: '2026-06-08T10:56:41.734Z'
                 - id: cg_gbHJdmfrXB
                   name: Wholesale
                   description:
                   customers_count: 0
-                  created_at: '2026-06-05T13:11:47.655Z'
-                  updated_at: '2026-06-05T13:11:47.655Z'
+                  created_at: '2026-06-08T10:56:41.735Z'
+                  updated_at: '2026-06-08T10:56:41.735Z'
                 meta:
                   page: 1
                   limit: 25
@@ -2046,7 +2046,7 @@ paths:
     post:
       summary: Create a customer group
       tags:
-      - Customers
+      - Customer Groups
       security:
       - api_key: []
         bearer_auth: []
@@ -2095,8 +2095,8 @@ paths:
                 name: Wholesale 2
                 description: B2B accounts
                 customers_count: 1
-                created_at: '2026-06-05T13:11:48.527Z'
-                updated_at: '2026-06-05T13:11:48.527Z'
+                created_at: '2026-06-08T10:56:42.582Z'
+                updated_at: '2026-06-08T10:56:42.582Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -2144,7 +2144,7 @@ paths:
     get:
       summary: Get a customer group
       tags:
-      - Customers
+      - Customer Groups
       security:
       - api_key: []
         bearer_auth: []
@@ -2202,24 +2202,24 @@ paths:
                 name: VIPs
                 description: Top spenders
                 customers_count: 1
-                created_at: '2026-06-05T13:11:49.112Z'
-                updated_at: '2026-06-05T13:11:49.112Z'
+                created_at: '2026-06-08T10:56:43.161Z'
+                updated_at: '2026-06-08T10:56:43.161Z'
                 customers:
                 - id: cus_UkLWZg9DAJ
-                  email: anamaria@williamsongoyette.ca
-                  first_name: Adella
-                  last_name: Mertz
+                  email: renna.hills@pfannerstillheaney.biz
+                  first_name: Santo
+                  last_name: Walsh
                   phone:
                   accepts_email_marketing: false
-                  full_name: Adella Mertz
+                  full_name: Santo Walsh
                   available_store_credit_total: '0'
                   display_available_store_credit_total: "$0.00"
-                  login: anamaria@williamsongoyette.ca
+                  login: renna.hills@pfannerstillheaney.biz
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-06-05T13:11:49.376Z'
-                  updated_at: '2026-06-05T13:11:49.376Z'
+                  created_at: '2026-06-08T10:56:43.423Z'
+                  updated_at: '2026-06-08T10:56:43.423Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -2247,7 +2247,7 @@ paths:
     patch:
       summary: Update a customer group
       tags:
-      - Customers
+      - Customer Groups
       security:
       - api_key: []
         bearer_auth: []
@@ -2297,8 +2297,8 @@ paths:
                 name: VIP customers (Q1)
                 description: Top spenders
                 customers_count: 0
-                created_at: '2026-06-05T13:11:49.974Z'
-                updated_at: '2026-06-05T13:11:50.254Z'
+                created_at: '2026-06-08T10:56:44.004Z'
+                updated_at: '2026-06-08T10:56:44.278Z'
               schema:
                 "$ref": "#/components/schemas/CustomerGroup"
         '422':
@@ -2336,7 +2336,7 @@ paths:
     delete:
       summary: Delete a customer group
       tags:
-      - Customers
+      - Customer Groups
       security:
       - api_key: []
         bearer_auth: []
@@ -2451,8 +2451,8 @@ paths:
                   state_name: New York
                   label:
                   metadata: {}
-                  created_at: '2026-06-05T13:11:51.157Z'
-                  updated_at: '2026-06-05T13:11:51.157Z'
+                  created_at: '2026-06-08T10:56:45.123Z'
+                  updated_at: '2026-06-08T10:56:45.123Z'
                   customer_id: cus_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -2540,8 +2540,8 @@ paths:
                 state_name: New York
                 label: Office
                 metadata: {}
-                created_at: '2026-06-05T13:11:52.510Z'
-                updated_at: '2026-06-05T13:11:52.510Z'
+                created_at: '2026-06-08T10:56:46.478Z'
+                updated_at: '2026-06-08T10:56:46.478Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -2652,8 +2652,8 @@ paths:
                 state_name: New York
                 label:
                 metadata: {}
-                created_at: '2026-06-05T13:11:52.780Z'
-                updated_at: '2026-06-05T13:11:53.330Z'
+                created_at: '2026-06-08T10:56:46.752Z'
+                updated_at: '2026-06-08T10:56:47.297Z'
                 customer_id: cus_UkLWZg9DAJ
       requestBody:
         content:
@@ -2786,8 +2786,8 @@ paths:
                   customer_id: cus_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
                   metadata: {}
-                  created_at: '2026-06-05T13:11:54.435Z'
-                  updated_at: '2026-06-05T13:11:54.435Z'
+                  created_at: '2026-06-08T10:56:48.396Z'
+                  updated_at: '2026-06-08T10:56:48.396Z'
                 meta:
                   page: 1
                   limit: 25
@@ -2874,8 +2874,8 @@ paths:
                 customer_id: cus_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
                 metadata: {}
-                created_at: '2026-06-05T13:11:54.997Z'
-                updated_at: '2026-06-05T13:11:54.997Z'
+                created_at: '2026-06-08T10:56:48.944Z'
+                updated_at: '2026-06-08T10:56:48.944Z'
     delete:
       summary: Delete a customer credit card
       tags:
@@ -2994,8 +2994,8 @@ paths:
                   currency: USD
                   memo:
                   metadata: {}
-                  created_at: '2026-06-05T13:11:56.393Z'
-                  updated_at: '2026-06-05T13:11:56.393Z'
+                  created_at: '2026-06-08T10:56:50.298Z'
+                  updated_at: '2026-06-08T10:56:50.298Z'
                   customer_id: cus_UkLWZg9DAJ
                   created_by_id: admin_UkLWZg9DAJ
                   category_id: sccat_UkLWZg9DAJ
@@ -3070,8 +3070,8 @@ paths:
                 currency: USD
                 memo: Goodwill
                 metadata: {}
-                created_at: '2026-06-05T13:11:57.509Z'
-                updated_at: '2026-06-05T13:11:57.509Z'
+                created_at: '2026-06-08T10:56:51.478Z'
+                updated_at: '2026-06-08T10:56:51.478Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_gbHJdmfrXB
                 category_id: sccat_UkLWZg9DAJ
@@ -3162,8 +3162,8 @@ paths:
                 currency: USD
                 memo: Updated
                 metadata: {}
-                created_at: '2026-06-05T13:11:58.047Z'
-                updated_at: '2026-06-05T13:11:58.336Z'
+                created_at: '2026-06-08T10:56:52.025Z'
+                updated_at: '2026-06-08T10:56:52.343Z'
                 customer_id: cus_UkLWZg9DAJ
                 created_by_id: admin_UkLWZg9DAJ
                 category_id: sccat_UkLWZg9DAJ
@@ -3317,8 +3317,8 @@ paths:
                   metadata: {}
                   last_sign_in_at:
                   current_sign_in_at:
-                  created_at: '2026-06-05T13:11:59.447Z'
-                  updated_at: '2026-06-05T13:11:59.447Z'
+                  created_at: '2026-06-08T10:56:53.476Z'
+                  updated_at: '2026-06-08T10:56:53.476Z'
                   sign_in_count: 0
                   failed_attempts: 0
                   last_sign_in_ip:
@@ -3401,8 +3401,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-06-05T13:12:00.292Z'
-                updated_at: '2026-06-05T13:12:00.292Z'
+                created_at: '2026-06-08T10:56:54.324Z'
+                updated_at: '2026-06-08T10:56:54.324Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -3518,8 +3518,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-06-05T13:12:00.565Z'
-                updated_at: '2026-06-05T13:12:00.565Z'
+                created_at: '2026-06-08T10:56:54.595Z'
+                updated_at: '2026-06-08T10:56:54.595Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -3593,8 +3593,8 @@ paths:
                 metadata: {}
                 last_sign_in_at:
                 current_sign_in_at:
-                created_at: '2026-06-05T13:12:01.125Z'
-                updated_at: '2026-06-05T13:12:01.412Z'
+                created_at: '2026-06-08T10:56:55.159Z'
+                updated_at: '2026-06-08T10:56:55.444Z'
                 sign_in_count: 0
                 failed_attempts: 0
                 last_sign_in_ip:
@@ -4024,11 +4024,11 @@ paths:
               example:
                 data:
                 - id: exp_UkLWZg9DAJ
-                  number: EF364027755
+                  number: EF093047115
                   type: Spree::Exports::Products
                   format: csv
-                  created_at: '2026-06-05T13:12:05.577Z'
-                  updated_at: '2026-06-05T13:12:05.577Z'
+                  created_at: '2026-06-08T10:56:59.677Z'
+                  updated_at: '2026-06-08T10:56:59.677Z'
                   user_id: admin_UkLWZg9DAJ
                   done: false
                   filename:
@@ -4095,11 +4095,11 @@ paths:
             application/json:
               example:
                 id: exp_gbHJdmfrXB
-                number: EF329172445
+                number: EF199522264
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-06-05T13:12:05.895Z'
-                updated_at: '2026-06-05T13:12:05.895Z'
+                created_at: '2026-06-08T10:57:00.017Z'
+                updated_at: '2026-06-08T10:57:00.017Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -4186,11 +4186,11 @@ paths:
             application/json:
               example:
                 id: exp_UkLWZg9DAJ
-                number: EF518550027
+                number: EF025250323
                 type: Spree::Exports::Products
                 format: csv
-                created_at: '2026-06-05T13:12:06.180Z'
-                updated_at: '2026-06-05T13:12:06.180Z'
+                created_at: '2026-06-08T10:57:00.306Z'
+                updated_at: '2026-06-08T10:57:00.306Z'
                 user_id: admin_UkLWZg9DAJ
                 done: false
                 filename:
@@ -4373,8 +4373,8 @@ paths:
                   codes_count: 2
                   currency: USD
                   prefix: WELCOME
-                  created_at: '2026-06-05T13:12:06.832Z'
-                  updated_at: '2026-06-05T13:12:06.832Z'
+                  created_at: '2026-06-08T10:57:00.931Z'
+                  updated_at: '2026-06-08T10:57:00.931Z'
                   amount: '50.0'
                   expires_at:
                   created_by_id:
@@ -4455,8 +4455,8 @@ paths:
                 codes_count: 5
                 currency: USD
                 prefix: NEWCAMP
-                created_at: '2026-06-05T13:12:07.399Z'
-                updated_at: '2026-06-05T13:12:07.399Z'
+                created_at: '2026-06-08T10:57:01.503Z'
+                updated_at: '2026-06-08T10:57:01.503Z'
                 amount: '25.0'
                 expires_at: '2030-12-31'
                 created_by_id: admin_UkLWZg9DAJ
@@ -4557,8 +4557,8 @@ paths:
                 codes_count: 2
                 currency: USD
                 prefix: WELCOME
-                created_at: '2026-06-05T13:12:07.697Z'
-                updated_at: '2026-06-05T13:12:07.697Z'
+                created_at: '2026-06-08T10:57:01.792Z'
+                updated_at: '2026-06-08T10:57:01.792Z'
                 amount: '50.0'
                 expires_at:
                 created_by_id:
@@ -4661,7 +4661,7 @@ paths:
               example:
                 data:
                 - id: gc_UkLWZg9DAJ
-                  code: 6951A14B300CEC04
+                  code: BAA028CDF578F746
                   status: active
                   currency: USD
                   amount: '50.0'
@@ -4675,12 +4675,12 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-06-05T13:12:08.266Z'
-                  updated_at: '2026-06-05T13:12:08.266Z'
+                  created_at: '2026-06-08T10:57:02.369Z'
+                  updated_at: '2026-06-08T10:57:02.369Z'
                   customer_id:
                   created_by_id:
                 - id: gc_gbHJdmfrXB
-                  code: 3E031B73A4AE32CD
+                  code: B7B9C97DAE77E96A
                   status: active
                   currency: USD
                   amount: '25.0'
@@ -4694,8 +4694,8 @@ paths:
                   redeemed_at:
                   expired: false
                   active: true
-                  created_at: '2026-06-05T13:12:08.267Z'
-                  updated_at: '2026-06-05T13:12:08.267Z'
+                  created_at: '2026-06-08T10:57:02.370Z'
+                  updated_at: '2026-06-08T10:57:02.370Z'
                   customer_id:
                   created_by_id:
                 meta:
@@ -4780,7 +4780,7 @@ paths:
             application/json:
               example:
                 id: gc_EfhxLZ9ck8
-                code: CC7C00B458CBFC8F
+                code: E983499BEFF8FE2F
                 status: active
                 currency: USD
                 amount: '25.0'
@@ -4794,8 +4794,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-06-05T13:12:08.868Z'
-                updated_at: '2026-06-05T13:12:08.868Z'
+                created_at: '2026-06-08T10:57:02.961Z'
+                updated_at: '2026-06-08T10:57:02.961Z'
                 customer_id:
                 created_by_id: admin_UkLWZg9DAJ
               schema:
@@ -4901,7 +4901,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: A45E8E4B11DA9DBD
+                code: 415FB670C81E9D04
                 status: active
                 currency: USD
                 amount: '50.0'
@@ -4915,8 +4915,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-06-05T13:12:09.160Z'
-                updated_at: '2026-06-05T13:12:09.160Z'
+                created_at: '2026-06-08T10:57:03.255Z'
+                updated_at: '2026-06-08T10:57:03.255Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -4976,7 +4976,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: E6E13513E44B8807
+                code: 8BDA7FE50F533A90
                 status: active
                 currency: USD
                 amount: '75.0'
@@ -4990,8 +4990,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-06-05T13:12:09.749Z'
-                updated_at: '2026-06-05T13:12:10.070Z'
+                created_at: '2026-06-08T10:57:03.831Z'
+                updated_at: '2026-06-08T10:57:04.125Z'
                 customer_id:
                 created_by_id:
               schema:
@@ -5064,7 +5064,7 @@ paths:
     get:
       summary: List invitations
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -5103,15 +5103,15 @@ paths:
               example:
                 data:
                 - id: inv_UkLWZg9DAJ
-                  email: kattie.kertzmann@jakubowskimcdermott.com
+                  email: dorthy.emmerich@bradtke.info
                   status: pending
-                  created_at: '2026-06-05T13:12:10.949Z'
-                  updated_at: '2026-06-05T13:12:10.949Z'
-                  expires_at: '2026-06-19T13:12:10.946Z'
+                  created_at: '2026-06-08T10:57:05.016Z'
+                  updated_at: '2026-06-08T10:57:05.016Z'
+                  expires_at: '2026-06-22T10:57:05.014Z'
                   role_id: role_UkLWZg9DAJ
                   role_name: admin
-                  inviter_email: norris@effertz.info
-                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=N3LaaRRjJKwDAC53Q7d7XQHE"
+                  inviter_email: brigette@sporer.us
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=YJnLJxUSrtebeM9iYcT2mb9P"
                   invitee_exists: false
                   store:
                     id: store_UkLWZg9DAJ
@@ -5129,7 +5129,7 @@ paths:
     post:
       summary: Create an invitation
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -5172,13 +5172,13 @@ paths:
                 id: inv_gbHJdmfrXB
                 email: new-staff@example.com
                 status: pending
-                created_at: '2026-06-05T13:12:11.261Z'
-                updated_at: '2026-06-05T13:12:11.261Z'
-                expires_at: '2026-06-19T13:12:11.258Z'
+                created_at: '2026-06-08T10:57:05.335Z'
+                updated_at: '2026-06-08T10:57:05.335Z'
+                expires_at: '2026-06-22T10:57:05.333Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: sanora.donnelly@beckermckenzie.co.uk
-                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=wYFYKSZ6g8os2yNZ47uq9AKt"
+                inviter_email: aracelis.mosciski@barrows.biz
+                acceptance_url: "/accept-invitation/inv_gbHJdmfrXB?token=ttUpsLEE1U6sfGhhu1bU7G62"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -5202,7 +5202,7 @@ paths:
     delete:
       summary: Revoke an invitation
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -5242,7 +5242,7 @@ paths:
     patch:
       summary: Resend an invitation
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -5285,15 +5285,15 @@ paths:
             application/json:
               example:
                 id: inv_UkLWZg9DAJ
-                email: laurinda_welch@romagueracrona.us
+                email: carlita.stokes@fay.com
                 status: pending
-                created_at: '2026-06-05T13:12:11.821Z'
-                updated_at: '2026-06-05T13:12:11.821Z'
-                expires_at: '2026-06-19T13:12:11.819Z'
+                created_at: '2026-06-08T10:57:05.902Z'
+                updated_at: '2026-06-08T10:57:05.902Z'
+                expires_at: '2026-06-22T10:57:05.900Z'
                 role_id: role_UkLWZg9DAJ
                 role_name: admin
-                inviter_email: vera.stanton@bashirian.us
-                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=Yc4V21BzHSZrGdscgN1Nqty3"
+                inviter_email: chris@metzkilback.com
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=GZQipgFcLGqh5JQj54ouvodx"
                 invitee_exists: false
                 store:
                   id: store_UkLWZg9DAJ
@@ -5302,7 +5302,7 @@ paths:
     get:
       summary: List markets
       tags:
-      - Pricing
+      - Markets
       security:
       - api_key: []
         bearer_auth: []
@@ -5379,8 +5379,8 @@ paths:
                   - DE
                   supported_locales:
                   - en
-                  created_at: '2026-06-05T13:12:11.873Z'
-                  updated_at: '2026-06-05T13:12:11.873Z'
+                  created_at: '2026-06-08T10:57:05.954Z'
+                  updated_at: '2026-06-08T10:57:05.954Z'
                 meta:
                   page: 1
                   limit: 25
@@ -5406,7 +5406,7 @@ paths:
     post:
       summary: Create a market
       tags:
-      - Pricing
+      - Markets
       security:
       - api_key: []
         bearer_auth: []
@@ -5470,8 +5470,8 @@ paths:
                 supported_locales:
                 - en
                 - fr
-                created_at: '2026-06-05T13:12:12.481Z'
-                updated_at: '2026-06-05T13:12:12.481Z'
+                created_at: '2026-06-08T10:57:06.548Z'
+                updated_at: '2026-06-08T10:57:06.548Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -5555,7 +5555,7 @@ paths:
     get:
       summary: Get a market
       tags:
-      - Pricing
+      - Markets
       security:
       - api_key: []
         bearer_auth: []
@@ -5604,8 +5604,8 @@ paths:
                 - DE
                 supported_locales:
                 - en
-                created_at: '2026-06-05T13:12:12.806Z'
-                updated_at: '2026-06-05T13:12:12.806Z'
+                created_at: '2026-06-08T10:57:06.885Z'
+                updated_at: '2026-06-08T10:57:06.885Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '404':
@@ -5621,7 +5621,7 @@ paths:
     patch:
       summary: Update a market
       tags:
-      - Pricing
+      - Markets
       security:
       - api_key: []
         bearer_auth: []
@@ -5681,8 +5681,8 @@ paths:
                 - DE
                 supported_locales:
                 - en
-                created_at: '2026-06-05T13:12:13.407Z'
-                updated_at: '2026-06-05T13:12:13.691Z'
+                created_at: '2026-06-08T10:57:07.498Z'
+                updated_at: '2026-06-08T10:57:07.783Z'
               schema:
                 "$ref": "#/components/schemas/Market"
         '422':
@@ -5727,7 +5727,7 @@ paths:
     delete:
       summary: Delete a market
       tags:
-      - Pricing
+      - Markets
       security:
       - api_key: []
         bearer_auth: []
@@ -5819,12 +5819,12 @@ paths:
               example:
                 user:
                   id: admin_UkLWZg9DAJ
-                  email: brooke_zulauf@smithamsauer.biz
-                  first_name: Contessa
-                  last_name: Wilkinson
-                  full_name: Contessa Wilkinson
-                  created_at: '2026-06-05T13:12:14.933Z'
-                  updated_at: '2026-06-05T13:12:14.933Z'
+                  email: karole.ratke@darekovacek.name
+                  first_name: Corazon
+                  last_name: O'Hara
+                  full_name: Corazon O'Hara
+                  created_at: '2026-06-08T10:57:08.989Z'
+                  updated_at: '2026-06-08T10:57:08.989Z'
                   roles:
                   - id: role_UkLWZg9DAJ
                     name: admin
@@ -5896,7 +5896,7 @@ paths:
     get:
       summary: List option types
       tags:
-      - Product Catalog
+      - Option Types
       security:
       - api_key: []
         bearer_auth: []
@@ -5974,8 +5974,8 @@ paths:
                   kind: dropdown
                   metadata: {}
                   filterable: true
-                  created_at: '2026-06-05T13:12:14.971Z'
-                  updated_at: '2026-06-05T13:12:14.971Z'
+                  created_at: '2026-06-08T10:57:09.036Z'
+                  updated_at: '2026-06-08T10:57:09.036Z'
                 meta:
                   page: 1
                   limit: 25
@@ -6011,7 +6011,7 @@ paths:
     post:
       summary: Create an option type
       tags:
-      - Product Catalog
+      - Option Types
       security:
       - api_key: []
         bearer_auth: []
@@ -6066,8 +6066,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-06-05T13:12:15.556Z'
-                updated_at: '2026-06-05T13:12:15.556Z'
+                created_at: '2026-06-08T10:57:09.626Z'
+                updated_at: '2026-06-08T10:57:09.626Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -6123,7 +6123,7 @@ paths:
     get:
       summary: Get an option type
       tags:
-      - Product Catalog
+      - Option Types
       security:
       - api_key: []
         bearer_auth: []
@@ -6188,8 +6188,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-06-05T13:12:15.850Z'
-                updated_at: '2026-06-05T13:12:15.850Z'
+                created_at: '2026-06-08T10:57:09.919Z'
+                updated_at: '2026-06-08T10:57:09.919Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '404':
@@ -6205,7 +6205,7 @@ paths:
     patch:
       summary: Update an option type
       tags:
-      - Product Catalog
+      - Option Types
       security:
       - api_key: []
         bearer_auth: []
@@ -6261,8 +6261,8 @@ paths:
                 kind: dropdown
                 metadata: {}
                 filterable: true
-                created_at: '2026-06-05T13:12:16.438Z'
-                updated_at: '2026-06-05T13:12:16.733Z'
+                created_at: '2026-06-08T10:57:10.492Z'
+                updated_at: '2026-06-08T10:57:10.771Z'
               schema:
                 "$ref": "#/components/schemas/OptionType"
         '422':
@@ -6315,7 +6315,7 @@ paths:
     delete:
       summary: Delete an option type
       tags:
-      - Product Catalog
+      - Option Types
       security:
       - api_key: []
         bearer_auth: []
@@ -6360,7 +6360,7 @@ paths:
     get:
       summary: List fulfillments
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6421,7 +6421,7 @@ paths:
               example:
                 data:
                 - id: ful_UkLWZg9DAJ
-                  number: H66206934403
+                  number: H37428731748
                   tracking: U10000
                   tracking_url:
                   cost: '10.0'
@@ -6446,8 +6446,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-06-05T13:12:17.678Z'
-                  updated_at: '2026-06-05T13:12:17.764Z'
+                  created_at: '2026-06-08T10:57:11.692Z'
+                  updated_at: '2026-06-08T10:57:11.766Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_UkLWZg9DAJ
                 meta:
@@ -6464,7 +6464,7 @@ paths:
     get:
       summary: Show a shipment
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6530,7 +6530,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H71788811584
+                number: H58592161546
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6555,14 +6555,14 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-06-05T13:12:18.394Z'
-                updated_at: '2026-06-05T13:12:18.461Z'
+                created_at: '2026-06-08T10:57:12.372Z'
+                updated_at: '2026-06-08T10:57:12.428Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
     patch:
       summary: Update a shipment
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6615,7 +6615,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H67296446384
+                number: H48155201967
                 tracking: 1Z999AA10123456784
                 tracking_url: https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums=1Z999AA10123456784
                 cost: '10.0'
@@ -6640,8 +6640,8 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-06-05T13:12:19.053Z'
-                updated_at: '2026-06-05T13:12:19.401Z'
+                created_at: '2026-06-08T10:57:13.024Z'
+                updated_at: '2026-06-08T10:57:13.385Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
       requestBody:
@@ -6659,7 +6659,7 @@ paths:
     patch:
       summary: Fulfill a fulfillment
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6710,7 +6710,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H69393047882
+                number: H51880549825
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6727,7 +6727,7 @@ paths:
                 display_tax_total: "$0.00"
                 status: shipped
                 fulfillment_type: shipping
-                fulfilled_at: '2026-06-05T13:12:20Z'
+                fulfilled_at: '2026-06-08T10:57:14Z'
                 items:
                 - item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
@@ -6735,15 +6735,15 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-06-05T13:12:19.753Z'
-                updated_at: '2026-06-05T13:12:20.121Z'
+                created_at: '2026-06-08T10:57:13.742Z'
+                updated_at: '2026-06-08T10:57:14.099Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel":
     patch:
       summary: Cancel a fulfillment
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6794,7 +6794,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H10254297058
+                number: H11992775783
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6819,15 +6819,15 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-06-05T13:12:20.465Z'
-                updated_at: '2026-06-05T13:12:20.820Z'
+                created_at: '2026-06-08T10:57:14.457Z'
+                updated_at: '2026-06-08T10:57:14.855Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume":
     patch:
       summary: Resume a fulfillment
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6878,7 +6878,7 @@ paths:
             application/json:
               example:
                 id: ful_UkLWZg9DAJ
-                number: H16692131444
+                number: H79014622748
                 tracking: U10000
                 tracking_url:
                 cost: '10.0'
@@ -6903,15 +6903,15 @@ paths:
                 metadata: {}
                 adjustment_total: '0.0'
                 pre_tax_amount: '0.0'
-                created_at: '2026-06-05T13:12:21.205Z'
-                updated_at: '2026-06-05T13:12:21.558Z'
+                created_at: '2026-06-08T10:57:15.195Z'
+                updated_at: '2026-06-08T10:57:15.547Z'
                 order_id: or_UkLWZg9DAJ
                 stock_location_id: sloc_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/fulfillments/{id}/split":
     patch:
       summary: Split a fulfillment
       tags:
-      - Orders
+      - Fulfillments
       security:
       - api_key: []
         bearer_auth: []
@@ -6965,7 +6965,7 @@ paths:
               example:
                 data:
                 - id: ful_gbHJdmfrXB
-                  number: H35539389110
+                  number: H05613456699
                   tracking:
                   tracking_url:
                   cost: '10.0'
@@ -6990,8 +6990,8 @@ paths:
                   metadata: {}
                   adjustment_total: '0.0'
                   pre_tax_amount: '0.0'
-                  created_at: '2026-06-05T13:12:22.230Z'
-                  updated_at: '2026-06-05T13:12:22.284Z'
+                  created_at: '2026-06-08T10:57:16.243Z'
+                  updated_at: '2026-06-08T10:57:16.326Z'
                   order_id: or_UkLWZg9DAJ
                   stock_location_id: sloc_gbHJdmfrXB
       requestBody:
@@ -7063,7 +7063,7 @@ paths:
             application/json:
               example:
                 id: gc_UkLWZg9DAJ
-                code: 0F23E851245D7551
+                code: D1978DA92B314BFD
                 status: active
                 currency: USD
                 amount: '10.0'
@@ -7077,8 +7077,8 @@ paths:
                 redeemed_at:
                 expired: false
                 active: true
-                created_at: '2026-06-05T13:12:22.652Z'
-                updated_at: '2026-06-05T13:12:22.951Z'
+                created_at: '2026-06-08T10:57:16.764Z'
+                updated_at: '2026-06-08T10:57:17.068Z'
                 customer_id:
                 created_by_id:
       requestBody:
@@ -7211,8 +7211,8 @@ paths:
                   variant_id: variant_gbHJdmfrXB
                   quantity: 2
                   currency: USD
-                  name: Product 123949
-                  slug: product-123949
+                  name: Product 121399
+                  slug: product-121399
                   options_text: 'Size: S'
                   price: '10.0'
                   display_price: "$10.00"
@@ -7244,12 +7244,12 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-06-05T13:12:23.640Z'
-                    updated_at: '2026-06-05T13:12:23.640Z'
+                    created_at: '2026-06-08T10:57:17.775Z'
+                    updated_at: '2026-06-08T10:57:17.775Z'
                   digital_links: []
                   metadata: {}
-                  created_at: '2026-06-05T13:12:23.928Z'
-                  updated_at: '2026-06-05T13:12:23.928Z'
+                  created_at: '2026-06-08T10:57:18.061Z'
+                  updated_at: '2026-06-08T10:57:18.061Z'
                   cost_price: '17.0'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
@@ -7316,8 +7316,8 @@ paths:
                 variant_id: variant_VqXmZF31wY
                 quantity: 3
                 currency: USD
-                name: Product 146023
-                slug: product-146023
+                name: Product 14285
+                slug: product-14285
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -7349,12 +7349,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-06-05T13:12:24.866Z'
-                  updated_at: '2026-06-05T13:12:24.866Z'
+                  created_at: '2026-06-08T10:57:19.059Z'
+                  updated_at: '2026-06-08T10:57:19.059Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-06-05T13:12:24.902Z'
-                updated_at: '2026-06-05T13:12:24.902Z'
+                created_at: '2026-06-08T10:57:19.089Z'
+                updated_at: '2026-06-08T10:57:19.089Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -7443,8 +7443,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 2
                 currency: USD
-                name: Product 154567
-                slug: product-154567
+                name: Product 158509
+                slug: product-158509
                 options_text: 'Size: S'
                 price: '10.0'
                 display_price: "$10.00"
@@ -7476,12 +7476,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-06-05T13:12:24.995Z'
-                  updated_at: '2026-06-05T13:12:24.995Z'
+                  created_at: '2026-06-08T10:57:19.183Z'
+                  updated_at: '2026-06-08T10:57:19.183Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-06-05T13:12:25.281Z'
-                updated_at: '2026-06-05T13:12:25.281Z'
+                created_at: '2026-06-08T10:57:19.496Z'
+                updated_at: '2026-06-08T10:57:19.496Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
     patch:
@@ -7543,8 +7543,8 @@ paths:
                 variant_id: variant_gbHJdmfrXB
                 quantity: 5
                 currency: USD
-                name: Product 163612
-                slug: product-163612
+                name: Product 164071
+                slug: product-164071
                 options_text: 'Size: S'
                 price: '19.99'
                 display_price: "$19.99"
@@ -7576,12 +7576,12 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-06-05T13:12:25.675Z'
-                  updated_at: '2026-06-05T13:12:25.675Z'
+                  created_at: '2026-06-08T10:57:19.842Z'
+                  updated_at: '2026-06-08T10:57:19.842Z'
                 digital_links: []
                 metadata: {}
-                created_at: '2026-06-05T13:12:25.974Z'
-                updated_at: '2026-06-05T13:12:26.297Z'
+                created_at: '2026-06-08T10:57:20.129Z'
+                updated_at: '2026-06-08T10:57:20.438Z'
                 cost_price: '17.0'
                 tax_category_id: taxcat_UkLWZg9DAJ
       requestBody:
@@ -7646,7 +7646,7 @@ paths:
     get:
       summary: List payments
       tags:
-      - Orders
+      - Payments
       security:
       - api_key: []
         bearer_auth: []
@@ -7707,8 +7707,8 @@ paths:
                 data:
                 - id: py_UkLWZg9DAJ
                   payment_method_id: pm_UkLWZg9DAJ
-                  response_code: BGS-610e4508ff71
-                  number: PA2ZJ1PN
+                  response_code: BGS-8a4389715a82
+                  number: P4WYE9BN
                   amount: '110.0'
                   display_amount: "$110.00"
                   status: completed
@@ -7726,14 +7726,14 @@ paths:
                     customer_id:
                     payment_method_id: pm_gbHJdmfrXB
                     metadata: {}
-                    created_at: '2026-06-05T13:12:27.286Z'
-                    updated_at: '2026-06-05T13:12:27.289Z'
+                    created_at: '2026-06-08T10:57:21.449Z'
+                    updated_at: '2026-06-08T10:57:21.453Z'
                   metadata: {}
                   avs_response:
                   cvv_response_code:
                   cvv_response_message:
-                  created_at: '2026-06-05T13:12:27.288Z'
-                  updated_at: '2026-06-05T13:12:27.288Z'
+                  created_at: '2026-06-08T10:57:21.451Z'
+                  updated_at: '2026-06-08T10:57:21.451Z'
                   captured_amount: '0.0'
                   order_id: or_UkLWZg9DAJ
                 meta:
@@ -7749,7 +7749,7 @@ paths:
     post:
       summary: Create a payment
       tags:
-      - Orders
+      - Payments
       security:
       - api_key: []
         bearer_auth: []
@@ -7800,7 +7800,7 @@ paths:
                 id: py_gbHJdmfrXB
                 payment_method_id: pm_EfhxLZ9ck8
                 response_code:
-                number: PXM5FBY9
+                number: P9YJWKYL
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: checkout
@@ -7811,8 +7811,8 @@ paths:
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-06-05T13:12:28.585Z'
-                updated_at: '2026-06-05T13:12:28.585Z'
+                created_at: '2026-06-08T10:57:22.839Z'
+                updated_at: '2026-06-08T10:57:22.839Z'
                 captured_amount: '0.0'
                 order_id: or_gbHJdmfrXB
       requestBody:
@@ -7836,7 +7836,7 @@ paths:
     get:
       summary: Show a payment
       tags:
-      - Orders
+      - Payments
       security:
       - api_key: []
         bearer_auth: []
@@ -7902,8 +7902,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-30f317a77b37
-                number: P02PKLSP
+                response_code: BGS-593d862e96f0
+                number: PG90UG3I
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -7921,21 +7921,21 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-06-05T13:12:28.956Z'
-                  updated_at: '2026-06-05T13:12:28.958Z'
+                  created_at: '2026-06-08T10:57:23.214Z'
+                  updated_at: '2026-06-08T10:57:23.217Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-06-05T13:12:28.957Z'
-                updated_at: '2026-06-05T13:12:28.957Z'
+                created_at: '2026-06-08T10:57:23.216Z'
+                updated_at: '2026-06-08T10:57:23.216Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/payments/{id}/capture":
     patch:
       summary: Capture a payment
       tags:
-      - Orders
+      - Payments
       security:
       - api_key: []
         bearer_auth: []
@@ -7987,8 +7987,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: BGS-8274fb792a75
-                number: PACXCPQH
+                response_code: BGS-0a1bdc7c0459
+                number: PKBIGM2X
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: completed
@@ -8006,14 +8006,14 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-06-05T13:12:29.611Z'
-                  updated_at: '2026-06-05T13:12:29.614Z'
+                  created_at: '2026-06-08T10:57:23.864Z'
+                  updated_at: '2026-06-08T10:57:23.866Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-06-05T13:12:29.613Z'
-                updated_at: '2026-06-05T13:12:29.973Z'
+                created_at: '2026-06-08T10:57:23.865Z'
+                updated_at: '2026-06-08T10:57:24.186Z'
                 captured_amount: '110.0'
                 order_id: or_UkLWZg9DAJ
         '422':
@@ -8030,7 +8030,7 @@ paths:
     patch:
       summary: Void a payment
       tags:
-      - Orders
+      - Payments
       security:
       - api_key: []
         bearer_auth: []
@@ -8082,8 +8082,8 @@ paths:
               example:
                 id: py_UkLWZg9DAJ
                 payment_method_id: pm_UkLWZg9DAJ
-                response_code: void-BGS-c5cdfced60ed
-                number: PX8LJ7IH
+                response_code: void-BGS-1fec0a04658a
+                number: P122PQX0
                 amount: '110.0'
                 display_amount: "$110.00"
                 status: void
@@ -8101,21 +8101,21 @@ paths:
                   customer_id:
                   payment_method_id: pm_gbHJdmfrXB
                   metadata: {}
-                  created_at: '2026-06-05T13:12:31.062Z'
-                  updated_at: '2026-06-05T13:12:31.065Z'
+                  created_at: '2026-06-08T10:57:25.233Z'
+                  updated_at: '2026-06-08T10:57:25.235Z'
                 metadata: {}
                 avs_response:
                 cvv_response_code:
                 cvv_response_message:
-                created_at: '2026-06-05T13:12:31.064Z'
-                updated_at: '2026-06-05T13:12:31.376Z'
+                created_at: '2026-06-08T10:57:25.234Z'
+                updated_at: '2026-06-08T10:57:25.532Z'
                 captured_amount: '0.0'
                 order_id: or_UkLWZg9DAJ
   "/api/v3/admin/orders/{order_id}/refunds":
     get:
       summary: List refunds
       tags:
-      - Orders
+      - Refunds
       security:
       - api_key: []
         bearer_auth: []
@@ -8187,7 +8187,7 @@ paths:
     post:
       summary: Create a refund
       tags:
-      - Orders
+      - Refunds
       security:
       - api_key: []
         bearer_auth: []
@@ -8236,14 +8236,14 @@ paths:
             application/json:
               example:
                 id: re_UkLWZg9DAJ
-                transaction_id: BGS-fc6b3e38ec30
+                transaction_id: BGS-cfd82a13871d
                 amount: '5.0'
                 payment_id: py_UkLWZg9DAJ
                 refund_reason_id: rr_UkLWZg9DAJ
                 reimbursement_id:
                 metadata: {}
-                created_at: '2026-06-05T13:12:32.755Z'
-                updated_at: '2026-06-05T13:12:32.755Z'
+                created_at: '2026-06-08T10:57:26.844Z'
+                updated_at: '2026-06-08T10:57:26.844Z'
       requestBody:
         content:
           application/json:
@@ -8315,8 +8315,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R368133355
-                email: erwin_effertz@pouros.co.uk
+                number: R970913639
+                email: johanne@mcdermotthuels.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -8359,8 +8359,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-06-05T13:12:33.082Z'
-                updated_at: '2026-06-05T13:12:33.137Z'
+                created_at: '2026-06-08T10:57:27.159Z'
+                updated_at: '2026-06-08T10:57:27.226Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -8531,8 +8531,8 @@ paths:
                 - id: or_UkLWZg9DAJ
                   market_id:
                   channel_id: ch_UkLWZg9DAJ
-                  number: R114520773
-                  email: elicia_von@kuvalis.com
+                  number: R311015146
+                  email: lavon_zieme@hamillward.us
                   customer_note:
                   currency: USD
                   locale: en
@@ -8575,8 +8575,8 @@ paths:
                   metadata: {}
                   canceled_at:
                   approved_at:
-                  created_at: '2026-06-05T13:12:34.902Z'
-                  updated_at: '2026-06-05T13:12:34.902Z'
+                  created_at: '2026-06-08T10:57:29.022Z'
+                  updated_at: '2026-06-08T10:57:29.022Z'
                   preferred_stock_location_id:
                   tags: []
                   internal_note:
@@ -8719,7 +8719,7 @@ paths:
                 id: or_gbHJdmfrXB
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R773205198
+                number: R734764741
                 email: pinned@example.com
                 customer_note:
                 currency: USD
@@ -8763,8 +8763,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-06-05T13:12:36.601Z'
-                updated_at: '2026-06-05T13:12:36.605Z'
+                created_at: '2026-06-08T10:57:30.750Z'
+                updated_at: '2026-06-08T10:57:30.753Z'
                 preferred_stock_location_id: sloc_UkLWZg9DAJ
                 tags: []
                 internal_note:
@@ -8948,8 +8948,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R639530153
-                email: danika@lindgren.com
+                number: R377667939
+                email: norberto@bergstromkuhic.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -8992,8 +8992,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-06-05T13:12:36.884Z'
-                updated_at: '2026-06-05T13:12:36.884Z'
+                created_at: '2026-06-08T10:57:31.030Z'
+                updated_at: '2026-06-08T10:57:31.030Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9064,7 +9064,7 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R770729281
+                number: R109563285
                 email: updated@example.com
                 customer_note:
                 currency: USD
@@ -9108,8 +9108,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-06-05T13:12:37.996Z'
-                updated_at: '2026-06-05T13:12:38.281Z'
+                created_at: '2026-06-08T10:57:32.132Z'
+                updated_at: '2026-06-08T10:57:32.439Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9290,8 +9290,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R150931097
-                email: austin_gleichner@zemlak.com
+                number: R852541066
+                email: scotty_predovic@bechtelar.us
                 customer_note:
                 currency: USD
                 locale: en
@@ -9318,7 +9318,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status: ready
                 payment_status: paid
-                completed_at: '2026-06-05T13:12:39.240Z'
+                completed_at: '2026-06-08T10:57:33.412Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9334,8 +9334,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-06-05T13:12:39.156Z'
-                updated_at: '2026-06-05T13:12:39.289Z'
+                created_at: '2026-06-08T10:57:33.311Z'
+                updated_at: '2026-06-08T10:57:33.471Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9416,8 +9416,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R477684328
-                email: hiroko@klein.us
+                number: R706412366
+                email: shirl@king.biz
                 customer_note:
                 currency: USD
                 locale: en
@@ -9444,7 +9444,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-06-05T13:12:40.644Z'
+                completed_at: '2026-06-08T10:57:34.738Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9458,10 +9458,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-06-05T13:12:40.934Z'
+                canceled_at: '2026-06-08T10:57:35.022Z'
                 approved_at:
-                created_at: '2026-06-05T13:12:40.589Z'
-                updated_at: '2026-06-05T13:12:40.972Z'
+                created_at: '2026-06-08T10:57:34.691Z'
+                updated_at: '2026-06-08T10:57:35.060Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9520,8 +9520,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R292529403
-                email: misha@barrows.biz
+                number: R211398927
+                email: gabrielle_will@collins.info
                 customer_note:
                 currency: USD
                 locale: en
@@ -9548,7 +9548,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-06-05T13:12:41.327Z'
+                completed_at: '2026-06-08T10:57:35.417Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9563,9 +9563,9 @@ paths:
                 display_payment_total: "$0.00"
                 metadata: {}
                 canceled_at:
-                approved_at: '2026-06-05T13:12:41.625Z'
-                created_at: '2026-06-05T13:12:41.271Z'
-                updated_at: '2026-06-05T13:12:41.327Z'
+                approved_at: '2026-06-08T10:57:35.719Z'
+                created_at: '2026-06-08T10:57:35.357Z'
+                updated_at: '2026-06-08T10:57:35.417Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9624,8 +9624,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R684756853
-                email: deidra@kohlercarter.ca
+                number: R155035324
+                email: millie@windler.ca
                 customer_note:
                 currency: USD
                 locale: en
@@ -9652,7 +9652,7 @@ paths:
                 display_delivery_total: "$10.00"
                 fulfillment_status: canceled
                 payment_status: void
-                completed_at: '2026-06-05T13:12:41.987Z'
+                completed_at: '2026-06-08T10:57:36.085Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9666,10 +9666,10 @@ paths:
                 payment_total: '0.0'
                 display_payment_total: "$0.00"
                 metadata: {}
-                canceled_at: '2026-06-05T13:12:42.318Z'
+                canceled_at: '2026-06-08T10:57:36.371Z'
                 approved_at:
-                created_at: '2026-06-05T13:12:41.911Z'
-                updated_at: '2026-06-05T13:12:42.409Z'
+                created_at: '2026-06-08T10:57:36.023Z'
+                updated_at: '2026-06-08T10:57:36.451Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9728,8 +9728,8 @@ paths:
                 id: or_UkLWZg9DAJ
                 market_id:
                 channel_id: ch_UkLWZg9DAJ
-                number: R815365085
-                email: sarai@raynorwehner.com
+                number: R297088709
+                email: cassie@monahan.name
                 customer_note:
                 currency: USD
                 locale: en
@@ -9756,7 +9756,7 @@ paths:
                 display_delivery_total: "$100.00"
                 fulfillment_status:
                 payment_status:
-                completed_at: '2026-06-05T13:12:42.746Z'
+                completed_at: '2026-06-08T10:57:36.813Z'
                 store_credit_total: '0.0'
                 display_store_credit_total: "$0.00"
                 covered_by_store_credit: false
@@ -9772,8 +9772,8 @@ paths:
                 metadata: {}
                 canceled_at:
                 approved_at:
-                created_at: '2026-06-05T13:12:42.695Z'
-                updated_at: '2026-06-05T13:12:42.746Z'
+                created_at: '2026-06-08T10:57:36.746Z'
+                updated_at: '2026-06-08T10:57:36.812Z'
                 preferred_stock_location_id:
                 tags: []
                 internal_note:
@@ -9785,7 +9785,7 @@ paths:
     get:
       summary: List payment methods
       tags:
-      - Configuration
+      - Payment Methods
       security:
       - api_key: []
         bearer_auth: []
@@ -9848,8 +9848,8 @@ paths:
                   auto_capture:
                   storefront_visible: true
                   position: 1
-                  created_at: '2026-06-05T13:12:43.046Z'
-                  updated_at: '2026-06-05T13:12:43.047Z'
+                  created_at: '2026-06-08T10:57:37.124Z'
+                  updated_at: '2026-06-08T10:57:37.125Z'
                   preferences: {}
                   preference_schema: []
                 meta:
@@ -9866,7 +9866,7 @@ paths:
     get:
       summary: List available payment provider types
       tags:
-      - Configuration
+      - Payment Methods
       security:
       - api_key: []
         bearer_auth: []
@@ -9922,7 +9922,7 @@ paths:
     get:
       summary: Show a payment method
       tags:
-      - Configuration
+      - Payment Methods
       security:
       - api_key: []
         bearer_auth: []
@@ -9989,8 +9989,8 @@ paths:
                 auto_capture:
                 storefront_visible: true
                 position: 1
-                created_at: '2026-06-05T13:12:43.637Z'
-                updated_at: '2026-06-05T13:12:43.638Z'
+                created_at: '2026-06-08T10:57:37.721Z'
+                updated_at: '2026-06-08T10:57:37.722Z'
                 preferences: {}
                 preference_schema: []
   "/api/v3/admin/price_lists":
@@ -10063,8 +10063,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-06-05T13:12:43.927Z'
-                  updated_at: '2026-06-05T13:12:43.927Z'
+                  created_at: '2026-06-08T10:57:38.019Z'
+                  updated_at: '2026-06-08T10:57:38.019Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -10078,8 +10078,8 @@ paths:
                   starts_at:
                   ends_at:
                   deleted_at:
-                  created_at: '2026-06-05T13:12:43.928Z'
-                  updated_at: '2026-06-05T13:12:43.928Z'
+                  created_at: '2026-06-08T10:57:38.020Z'
+                  updated_at: '2026-06-08T10:57:38.020Z'
                   currently_active: false
                   products_count: 0
                   prices_count: 0
@@ -10143,8 +10143,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-06-05T13:12:44.932Z'
-                updated_at: '2026-06-05T13:12:44.934Z'
+                created_at: '2026-06-08T10:57:38.996Z'
+                updated_at: '2026-06-08T10:57:38.998Z'
                 currently_active: false
                 products_count: 1
                 prices_count: 2
@@ -10292,8 +10292,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-06-05T13:12:45.249Z'
-                updated_at: '2026-06-05T13:12:45.249Z'
+                created_at: '2026-06-08T10:57:39.301Z'
+                updated_at: '2026-06-08T10:57:39.301Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -10351,8 +10351,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-06-05T13:12:46.832Z'
-                updated_at: '2026-06-05T13:12:47.116Z'
+                created_at: '2026-06-08T10:57:40.918Z'
+                updated_at: '2026-06-08T10:57:41.207Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -10510,8 +10510,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-06-05T13:12:47.414Z'
-                updated_at: '2026-06-05T13:12:47.693Z'
+                created_at: '2026-06-08T10:57:41.507Z'
+                updated_at: '2026-06-08T10:57:41.796Z'
                 currently_active: true
                 products_count: 0
                 prices_count: 0
@@ -10559,8 +10559,8 @@ paths:
                 starts_at:
                 ends_at:
                 deleted_at:
-                created_at: '2026-06-05T13:12:47.702Z'
-                updated_at: '2026-06-05T13:12:47.980Z'
+                created_at: '2026-06-08T10:57:41.806Z'
+                updated_at: '2026-06-08T10:57:42.092Z'
                 currently_active: false
                 products_count: 0
                 prices_count: 0
@@ -10671,8 +10671,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-06-05T13:12:48.033Z'
-                  updated_at: '2026-06-05T13:12:48.033Z'
+                  created_at: '2026-06-08T10:57:42.151Z'
+                  updated_at: '2026-06-08T10:57:42.151Z'
                 - id: price_EfhxLZ9ck8
                   amount: '5.0'
                   amount_in_cents: 500
@@ -10683,8 +10683,8 @@ paths:
                   display_compare_at_amount:
                   price_list_id: pl_UkLWZg9DAJ
                   variant_id: variant_gbHJdmfrXB
-                  created_at: '2026-06-05T13:12:48.037Z'
-                  updated_at: '2026-06-05T13:12:48.037Z'
+                  created_at: '2026-06-08T10:57:42.159Z'
+                  updated_at: '2026-06-08T10:57:42.159Z'
                 meta:
                   page: 1
                   limit: 25
@@ -10763,8 +10763,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id:
                 variant_id: variant_EfhxLZ9ck8
-                created_at: '2026-06-05T13:12:48.724Z'
-                updated_at: '2026-06-05T13:12:48.724Z'
+                created_at: '2026-06-08T10:57:42.971Z'
+                updated_at: '2026-06-08T10:57:42.971Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -10848,8 +10848,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-06-05T13:12:48.822Z'
-                updated_at: '2026-06-05T13:12:48.822Z'
+                created_at: '2026-06-08T10:57:43.043Z'
+                updated_at: '2026-06-08T10:57:43.043Z'
               schema:
                 "$ref": "#/components/schemas/Price"
         '404':
@@ -10911,8 +10911,8 @@ paths:
                 display_compare_at_amount:
                 price_list_id: pl_UkLWZg9DAJ
                 variant_id: variant_gbHJdmfrXB
-                created_at: '2026-06-05T13:12:49.490Z'
-                updated_at: '2026-06-05T13:12:49.771Z'
+                created_at: '2026-06-08T10:57:43.751Z'
+                updated_at: '2026-06-08T10:57:44.076Z'
               schema:
                 "$ref": "#/components/schemas/Price"
       requestBody:
@@ -11212,8 +11212,8 @@ paths:
                   field_type: short_text
                   key: custom.title
                   value: wool
-                  created_at: '2026-06-05T13:12:51.254Z'
-                  updated_at: '2026-06-05T13:12:51.254Z'
+                  created_at: '2026-06-08T10:57:45.538Z'
+                  updated_at: '2026-06-08T10:57:45.538Z'
                   storefront_visible: true
                   custom_field_definition_id: cfdef_UkLWZg9DAJ
                 meta:
@@ -11280,8 +11280,8 @@ paths:
                 field_type: long_text
                 key: custom.description
                 value: A longer description
-                created_at: '2026-06-05T13:12:51.866Z'
-                updated_at: '2026-06-05T13:12:51.866Z'
+                created_at: '2026-06-08T10:57:46.140Z'
+                updated_at: '2026-06-08T10:57:46.140Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_gbHJdmfrXB
         '422':
@@ -11365,8 +11365,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: wool
-                created_at: '2026-06-05T13:12:52.251Z'
-                updated_at: '2026-06-05T13:12:52.251Z'
+                created_at: '2026-06-08T10:57:46.496Z'
+                updated_at: '2026-06-08T10:57:46.496Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
     patch:
@@ -11413,8 +11413,8 @@ paths:
                 field_type: short_text
                 key: custom.title
                 value: cotton
-                created_at: '2026-06-05T13:12:52.572Z'
-                updated_at: '2026-06-05T13:12:52.858Z'
+                created_at: '2026-06-08T10:57:46.820Z'
+                updated_at: '2026-06-08T10:57:47.180Z'
                 storefront_visible: true
                 custom_field_definition_id: cfdef_UkLWZg9DAJ
       requestBody:
@@ -11463,7 +11463,7 @@ paths:
     get:
       summary: List products
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -11552,8 +11552,8 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 574995
-                  slug: product-574995
+                  name: Product 57785
+                  slug: product-57785
                   meta_title:
                   meta_description:
                   meta_keywords:
@@ -11563,19 +11563,14 @@ paths:
                   in_stock: false
                   backorderable: true
                   available: true
-                  description: Exercitationem necessitatibus eaque perspiciatis voluptates
-                    dolore. Non fugiat alias saepe possimus cum atque velit itaque.
-                    Id quod eos eius possimus. Quis id reiciendis numquam voluptatibus.
-                    Similique nisi quod omnis optio quaerat tempore commodi. Dolorum
-                    officia labore architecto laudantium magnam eligendi a quis. Praesentium
-                    minus facere voluptates a magni repellat. Quo neque necessitatibus
-                    autem nostrum laboriosam. Excepturi aspernatur commodi amet voluptatum
-                    doloribus. Tempore itaque numquam nihil corrupti eum veniam. Soluta
-                    minus temporibus laboriosam facere sit itaque.
-                  description_html: |-
-                    Exercitationem necessitatibus eaque perspiciatis voluptates dolore. Non fugiat alias saepe possimus cum atque velit itaque. Id quod eos eius possimus. Quis id reiciendis numquam voluptatibus.
-                    Similique nisi quod omnis optio quaerat tempore commodi. Dolorum officia labore architecto laudantium magnam eligendi a quis. Praesentium minus facere voluptates a magni repellat. Quo neque necessitatibus autem nostrum laboriosam.
-                    Excepturi aspernatur commodi amet voluptatum doloribus. Tempore itaque numquam nihil corrupti eum veniam. Soluta minus temporibus laboriosam facere sit itaque.
+                  description: Explicabo inventore laboriosam iure maxime sed placeat.
+                    Corporis at perferendis animi maiores illum quisquam. Odit saepe
+                    non vel cupiditate. Sapiente harum inventore expedita cumque adipisci.
+                    Amet perspiciatis quod aliquam eos.
+                  description_html: Explicabo inventore laboriosam iure maxime sed
+                    placeat. Corporis at perferendis animi maiores illum quisquam.
+                    Odit saepe non vel cupiditate. Sapiente harum inventore expedita
+                    cumque adipisci. Amet perspiciatis quod aliquam eos.
                   default_variant_id: variant_UkLWZg9DAJ
                   thumbnail_url:
                   tags: []
@@ -11590,14 +11585,14 @@ paths:
                     display_compare_at_amount:
                     price_list_id:
                     variant_id: variant_UkLWZg9DAJ
-                    created_at: '2026-06-05T13:12:53.204Z'
-                    updated_at: '2026-06-05T13:12:53.204Z'
+                    created_at: '2026-06-08T10:57:47.555Z'
+                    updated_at: '2026-06-08T10:57:47.555Z'
                   original_price:
                   status: active
                   metadata: {}
                   deleted_at:
-                  created_at: '2026-06-05T13:12:53.193Z'
-                  updated_at: '2026-06-05T13:12:53.211Z'
+                  created_at: '2026-06-08T10:57:47.542Z'
+                  updated_at: '2026-06-08T10:57:47.562Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                 meta:
                   page: 1
@@ -11634,7 +11629,7 @@ paths:
     post:
       summary: Create a product
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -11729,8 +11724,8 @@ paths:
                 status: draft
                 metadata: {}
                 deleted_at:
-                created_at: '2026-06-05T13:12:53.859Z'
-                updated_at: '2026-06-05T13:12:53.860Z'
+                created_at: '2026-06-08T10:57:48.313Z'
+                updated_at: '2026-06-08T10:57:48.314Z'
                 tax_category_id:
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11849,7 +11844,7 @@ paths:
     get:
       summary: Get a product
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -11910,8 +11905,8 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 613292
-                slug: product-613292
+                name: Product 614200
+                slug: product-614200
                 meta_title:
                 meta_description:
                 meta_keywords:
@@ -11921,25 +11916,16 @@ paths:
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Corrupti incidunt recusandae tenetur impedit asperiores
-                  in culpa error. Ea quod incidunt inventore reiciendis molestiae
-                  error voluptatem. Assumenda sint adipisci odit et quisquam dicta
-                  nemo. Quas expedita voluptatem corrupti facere harum porro. Quia
-                  cumque natus inventore quam odit. Sint amet eum inventore quae soluta
-                  maxime. At excepturi placeat ipsum harum quo nemo. Voluptate ullam
-                  officiis iste aut. Ex fuga similique id commodi dolorem. Placeat
-                  dolor quasi consequatur iste nesciunt voluptatem. Omnis aspernatur
-                  consequatur aperiam est sequi. Officia vel nesciunt quaerat delectus.
-                  Laboriosam quis itaque debitis deserunt. Sed nesciunt occaecati
-                  veniam voluptas voluptatem nostrum architecto. Dolores in temporibus
-                  earum culpa. Fugit a eum natus odio libero. Doloribus dolor animi
-                  explicabo ullam sunt accusamus ipsa assumenda. Cum suscipit magnam
-                  expedita dolorum unde dicta odio.
+                description: Odio impedit nobis rerum nostrum numquam sit illum quae.
+                  Necessitatibus autem nisi ipsa reiciendis itaque. In earum maiores
+                  animi placeat debitis. Modi sapiente quas perspiciatis quae labore.
+                  Laudantium dolorum debitis earum occaecati. Quam in voluptatem deleniti
+                  distinctio. Reiciendis maiores libero a perferendis delectus exercitationem
+                  omnis. Occaecati cupiditate eligendi consequatur debitis. Impedit
+                  laboriosam odit quisquam dignissimos est blanditiis ratione.
                 description_html: |-
-                  Corrupti incidunt recusandae tenetur impedit asperiores in culpa error. Ea quod incidunt inventore reiciendis molestiae error voluptatem. Assumenda sint adipisci odit et quisquam dicta nemo. Quas expedita voluptatem corrupti facere harum porro. Quia cumque natus inventore quam odit.
-                  Sint amet eum inventore quae soluta maxime. At excepturi placeat ipsum harum quo nemo. Voluptate ullam officiis iste aut. Ex fuga similique id commodi dolorem. Placeat dolor quasi consequatur iste nesciunt voluptatem.
-                  Omnis aspernatur consequatur aperiam est sequi. Officia vel nesciunt quaerat delectus. Laboriosam quis itaque debitis deserunt. Sed nesciunt occaecati veniam voluptas voluptatem nostrum architecto.
-                  Dolores in temporibus earum culpa. Fugit a eum natus odio libero. Doloribus dolor animi explicabo ullam sunt accusamus ipsa assumenda. Cum suscipit magnam expedita dolorum unde dicta odio.
+                  Odio impedit nobis rerum nostrum numquam sit illum quae. Necessitatibus autem nisi ipsa reiciendis itaque. In earum maiores animi placeat debitis. Modi sapiente quas perspiciatis quae labore.
+                  Laudantium dolorum debitis earum occaecati. Quam in voluptatem deleniti distinctio. Reiciendis maiores libero a perferendis delectus exercitationem omnis. Occaecati cupiditate eligendi consequatur debitis. Impedit laboriosam odit quisquam dignissimos est blanditiis ratione.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -11954,14 +11940,14 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-06-05T13:12:54.236Z'
-                  updated_at: '2026-06-05T13:12:54.236Z'
+                  created_at: '2026-06-08T10:57:48.860Z'
+                  updated_at: '2026-06-08T10:57:48.860Z'
                 original_price:
                 status: active
                 metadata: {}
                 deleted_at:
-                created_at: '2026-06-05T13:12:54.226Z'
-                updated_at: '2026-06-05T13:12:54.241Z'
+                created_at: '2026-06-08T10:57:48.847Z'
+                updated_at: '2026-06-08T10:57:48.868Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -11978,7 +11964,7 @@ paths:
     patch:
       summary: Update a product
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12028,7 +12014,7 @@ paths:
               example:
                 id: prod_UkLWZg9DAJ
                 name: Updated Name
-                slug: product-632707
+                slug: product-632303
                 meta_title:
                 meta_description:
                 meta_keywords:
@@ -12038,21 +12024,16 @@ paths:
                 in_stock: false
                 backorderable: true
                 available: true
-                description: Soluta praesentium earum assumenda commodi illo voluptatibus
-                  necessitatibus. Tempore nobis cum quaerat expedita. Ipsa labore
-                  nisi odio non eveniet quae aperiam nesciunt. Impedit non expedita
-                  inventore odio veritatis voluptas aliquid quia. Officia repudiandae
-                  suscipit impedit ipsam provident illo nobis. Ad magnam a at temporibus
-                  molestias exercitationem esse. Repellat facilis aliquid eligendi
-                  nulla molestiae officia error deleniti. Repellat dicta natus voluptates
-                  incidunt labore qui. Illo maiores illum nostrum voluptatibus perferendis.
-                  Maxime nihil iste inventore provident. Voluptas ab assumenda quisquam
-                  fugiat non magnam laudantium. Eum vitae sed incidunt ad repellat
-                  atque sint exercitationem. Quam saepe sint nulla atque.
+                description: Magni repellendus magnam quasi nemo molestias quia corrupti.
+                  Debitis dolorum unde aliquam asperiores eius sit incidunt. Ducimus
+                  esse ipsam neque error rem. Alias esse beatae eum aperiam. Qui exercitationem
+                  in repudiandae est laboriosam alias quam officia. Aut corporis temporibus
+                  dolor dolorem repellat debitis. Assumenda ut cumque labore enim
+                  deleniti adipisci consectetur. Nesciunt laudantium iste tempore
+                  reprehenderit distinctio.
                 description_html: |-
-                  Soluta praesentium earum assumenda commodi illo voluptatibus necessitatibus. Tempore nobis cum quaerat expedita. Ipsa labore nisi odio non eveniet quae aperiam nesciunt. Impedit non expedita inventore odio veritatis voluptas aliquid quia. Officia repudiandae suscipit impedit ipsam provident illo nobis.
-                  Ad magnam a at temporibus molestias exercitationem esse. Repellat facilis aliquid eligendi nulla molestiae officia error deleniti. Repellat dicta natus voluptates incidunt labore qui. Illo maiores illum nostrum voluptatibus perferendis. Maxime nihil iste inventore provident.
-                  Voluptas ab assumenda quisquam fugiat non magnam laudantium. Eum vitae sed incidunt ad repellat atque sint exercitationem. Quam saepe sint nulla atque.
+                  Magni repellendus magnam quasi nemo molestias quia corrupti. Debitis dolorum unde aliquam asperiores eius sit incidunt. Ducimus esse ipsam neque error rem. Alias esse beatae eum aperiam.
+                  Qui exercitationem in repudiandae est laboriosam alias quam officia. Aut corporis temporibus dolor dolorem repellat debitis. Assumenda ut cumque labore enim deleniti adipisci consectetur. Nesciunt laudantium iste tempore reprehenderit distinctio.
                 default_variant_id: variant_UkLWZg9DAJ
                 thumbnail_url:
                 tags: []
@@ -12067,14 +12048,14 @@ paths:
                   display_compare_at_amount:
                   price_list_id:
                   variant_id: variant_UkLWZg9DAJ
-                  created_at: '2026-06-05T13:12:54.904Z'
-                  updated_at: '2026-06-05T13:12:54.904Z'
+                  created_at: '2026-06-08T10:57:49.569Z'
+                  updated_at: '2026-06-08T10:57:49.569Z'
                 original_price:
                 status: active
                 metadata: {}
                 deleted_at:
-                created_at: '2026-06-05T13:12:54.891Z'
-                updated_at: '2026-06-05T13:12:55.197Z'
+                created_at: '2026-06-08T10:57:49.558Z'
+                updated_at: '2026-06-08T10:57:49.867Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
               schema:
                 "$ref": "#/components/schemas/Product"
@@ -12190,7 +12171,7 @@ paths:
     delete:
       summary: Delete a product
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12235,7 +12216,7 @@ paths:
     post:
       summary: Bulk-update product status
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12307,7 +12288,7 @@ paths:
     post:
       summary: Bulk-add products to categories
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12364,7 +12345,7 @@ paths:
     post:
       summary: Bulk-remove products from categories
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12412,7 +12393,7 @@ paths:
     post:
       summary: Bulk-add products to channels
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12470,7 +12451,7 @@ paths:
     post:
       summary: Bulk-remove products from channels
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12528,7 +12509,7 @@ paths:
     post:
       summary: Bulk-add tags to products
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12586,7 +12567,7 @@ paths:
     post:
       summary: Bulk-remove tags from products
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12634,7 +12615,7 @@ paths:
     delete:
       summary: Bulk-delete products
       tags:
-      - Product Catalog
+      - Products
       security:
       - api_key: []
         bearer_auth: []
@@ -12723,8 +12704,8 @@ paths:
               example:
                 data:
                 - id: pact_UkLWZg9DAJ
-                  created_at: '2026-06-05T13:12:59.224Z'
-                  updated_at: '2026-06-05T13:12:59.224Z'
+                  created_at: '2026-06-08T10:57:54.179Z'
+                  updated_at: '2026-06-08T10:57:54.179Z'
                   type: free_shipping
                   promotion_id: promo_UkLWZg9DAJ
                   preferences: {}
@@ -12785,8 +12766,8 @@ paths:
             application/json:
               example:
                 id: pact_UkLWZg9DAJ
-                created_at: '2026-06-05T13:12:59.785Z'
-                updated_at: '2026-06-05T13:12:59.785Z'
+                created_at: '2026-06-08T10:57:54.745Z'
+                updated_at: '2026-06-08T10:57:54.745Z'
                 type: free_shipping
                 promotion_id: promo_UkLWZg9DAJ
                 preferences: {}
@@ -12896,8 +12877,8 @@ paths:
               example:
                 data:
                 - id: prorule_UkLWZg9DAJ
-                  created_at: '2026-06-05T13:13:00.378Z'
-                  updated_at: '2026-06-05T13:13:00.378Z'
+                  created_at: '2026-06-08T10:57:55.356Z'
+                  updated_at: '2026-06-08T10:57:55.356Z'
                   type: currency
                   promotion_id: promo_UkLWZg9DAJ
                   preferences:
@@ -12964,8 +12945,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-06-05T13:13:00.940Z'
-                updated_at: '2026-06-05T13:13:00.940Z'
+                created_at: '2026-06-08T10:57:55.935Z'
+                updated_at: '2026-06-08T10:57:55.935Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -13038,8 +13019,8 @@ paths:
             application/json:
               example:
                 id: prorule_UkLWZg9DAJ
-                created_at: '2026-06-05T13:13:01.231Z'
-                updated_at: '2026-06-05T13:13:01.523Z'
+                created_at: '2026-06-08T10:57:56.238Z'
+                updated_at: '2026-06-08T10:57:56.638Z'
                 type: currency
                 promotion_id: promo_UkLWZg9DAJ
                 preferences:
@@ -13129,7 +13110,7 @@ paths:
                   name: Summer Sale
                   description:
                   code: summer
-                  starts_at: '2026-06-05T13:13:01.832Z'
+                  starts_at: '2026-06-08T10:57:57.000Z'
                   expires_at:
                   usage_limit:
                   match_policy: all
@@ -13140,8 +13121,8 @@ paths:
                   code_prefix:
                   promotion_category_id:
                   metadata: {}
-                  created_at: '2026-06-05T13:13:01.833Z'
-                  updated_at: '2026-06-05T13:13:01.835Z'
+                  created_at: '2026-06-08T10:57:57.003Z'
+                  updated_at: '2026-06-08T10:57:57.004Z'
                   action_ids: []
                   rule_ids: []
                 meta:
@@ -13245,7 +13226,7 @@ paths:
                 name: Black Friday
                 description:
                 code: blackfriday-os
-                starts_at: '2026-06-05T13:13:02.777Z'
+                starts_at: '2026-06-08T10:57:58.125Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -13256,8 +13237,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-06-05T13:13:02.779Z'
-                updated_at: '2026-06-05T13:13:02.797Z'
+                created_at: '2026-06-08T10:57:58.126Z'
+                updated_at: '2026-06-08T10:57:58.145Z'
                 action_ids:
                 - pact_UkLWZg9DAJ
                 - pact_gbHJdmfrXB
@@ -13408,7 +13389,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-06-05T13:13:03.094Z'
+                starts_at: '2026-06-08T10:57:58.456Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -13419,8 +13400,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-06-05T13:13:03.096Z'
-                updated_at: '2026-06-05T13:13:03.097Z'
+                created_at: '2026-06-08T10:57:58.457Z'
+                updated_at: '2026-06-08T10:57:58.460Z'
                 action_ids: []
                 rule_ids: []
     patch:
@@ -13514,7 +13495,7 @@ paths:
                 name: Summer Sale
                 description:
                 code: summer
-                starts_at: '2026-06-05T13:13:03.976Z'
+                starts_at: '2026-06-08T10:57:59.375Z'
                 expires_at:
                 usage_limit:
                 match_policy: all
@@ -13525,8 +13506,8 @@ paths:
                 code_prefix:
                 promotion_category_id:
                 metadata: {}
-                created_at: '2026-06-05T13:13:03.977Z'
-                updated_at: '2026-06-05T13:13:04.254Z'
+                created_at: '2026-06-08T10:57:59.376Z'
+                updated_at: '2026-06-08T10:57:59.658Z'
                 action_ids: []
                 rule_ids: []
       requestBody:
@@ -13836,7 +13817,7 @@ paths:
     get:
       summary: List roles
       tags:
-      - Configuration
+      - Staff
       security:
       - api_key: []
         bearer_auth: []
@@ -13876,8 +13857,8 @@ paths:
                 data:
                 - id: role_UkLWZg9DAJ
                   name: admin
-                  created_at: '2026-06-05T13:13:05.141Z'
-                  updated_at: '2026-06-05T13:13:05.141Z'
+                  created_at: '2026-06-08T10:58:00.563Z'
+                  updated_at: '2026-06-08T10:58:00.563Z'
                 meta:
                   page: 1
                   limit: 25
@@ -13892,7 +13873,7 @@ paths:
     get:
       summary: List stock locations
       tags:
-      - Configuration
+      - Stock Locations
       security:
       - api_key: []
         bearer_auth: []
@@ -14012,8 +13993,8 @@ paths:
                   pickup_stock_policy: local
                   pickup_ready_in_minutes:
                   pickup_instructions:
-                  created_at: '2026-06-05T13:13:05.424Z'
-                  updated_at: '2026-06-05T13:13:05.424Z'
+                  created_at: '2026-06-08T10:58:00.850Z'
+                  updated_at: '2026-06-08T10:58:00.850Z'
                 meta:
                   page: 1
                   limit: 25
@@ -14049,7 +14030,7 @@ paths:
     post:
       summary: Create a stock location
       tags:
-      - Configuration
+      - Stock Locations
       security:
       - api_key: []
         bearer_auth: []
@@ -14124,8 +14105,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 30
                 pickup_instructions:
-                created_at: '2026-06-05T13:13:05.993Z'
-                updated_at: '2026-06-05T13:13:05.993Z'
+                created_at: '2026-06-08T10:58:01.432Z'
+                updated_at: '2026-06-08T10:58:01.432Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -14232,7 +14213,7 @@ paths:
     get:
       summary: Get a stock location
       tags:
-      - Configuration
+      - Stock Locations
       security:
       - api_key: []
         bearer_auth: []
@@ -14299,8 +14280,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes:
                 pickup_instructions:
-                created_at: '2026-06-05T13:13:06.281Z'
-                updated_at: '2026-06-05T13:13:06.281Z'
+                created_at: '2026-06-08T10:58:01.761Z'
+                updated_at: '2026-06-08T10:58:01.761Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '404':
@@ -14316,7 +14297,7 @@ paths:
     patch:
       summary: Update a stock location
       tags:
-      - Configuration
+      - Stock Locations
       security:
       - api_key: []
         bearer_auth: []
@@ -14385,8 +14366,8 @@ paths:
                 pickup_stock_policy: local
                 pickup_ready_in_minutes: 45
                 pickup_instructions:
-                created_at: '2026-06-05T13:13:06.840Z'
-                updated_at: '2026-06-05T13:13:07.113Z'
+                created_at: '2026-06-08T10:58:02.382Z'
+                updated_at: '2026-06-08T10:58:02.663Z'
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -14471,7 +14452,7 @@ paths:
     delete:
       summary: Delete a stock location
       tags:
-      - Configuration
+      - Stock Locations
       security:
       - api_key: []
         bearer_auth: []
@@ -14513,7 +14494,7 @@ paths:
     get:
       summary: List store credit categories
       tags:
-      - Configuration
+      - Settings
       security:
       - api_key: []
         bearer_auth: []
@@ -14589,8 +14570,8 @@ paths:
                 data:
                 - id: sccat_UkLWZg9DAJ
                   name: Goodwill
-                  created_at: '2026-06-05T13:13:07.692Z'
-                  updated_at: '2026-06-05T13:13:07.692Z'
+                  created_at: '2026-06-08T10:58:03.244Z'
+                  updated_at: '2026-06-08T10:58:03.244Z'
                   non_expiring: false
                 meta:
                   page: 1
@@ -14635,7 +14616,7 @@ paths:
     get:
       summary: Get a store credit category
       tags:
-      - Configuration
+      - Settings
       security:
       - api_key: []
         bearer_auth: []
@@ -14681,8 +14662,8 @@ paths:
               example:
                 id: sccat_UkLWZg9DAJ
                 name: Goodwill
-                created_at: '2026-06-05T13:13:08.000Z'
-                updated_at: '2026-06-05T13:13:08.000Z'
+                created_at: '2026-06-08T10:58:03.544Z'
+                updated_at: '2026-06-08T10:58:03.544Z'
                 non_expiring: false
               schema:
                 "$ref": "#/components/schemas/StoreCreditCategory"
@@ -14700,7 +14681,7 @@ paths:
     get:
       summary: Get the current store
       tags:
-      - Configuration
+      - Settings
       security:
       - api_key: []
         bearer_auth: []
@@ -14751,8 +14732,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-06-05T13:11:36.359Z'
-                updated_at: '2026-06-05T13:13:08.602Z'
+                created_at: '2026-06-08T10:56:29.978Z'
+                updated_at: '2026-06-08T10:58:04.145Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -14775,7 +14756,7 @@ paths:
     patch:
       summary: Update the current store
       tags:
-      - Configuration
+      - Settings
       security:
       - api_key: []
         bearer_auth: []
@@ -14828,8 +14809,8 @@ paths:
                 preferred_timezone: UTC
                 preferred_weight_unit: lb
                 preferred_unit_system: imperial
-                created_at: '2026-06-05T13:11:36.359Z'
-                updated_at: '2026-06-05T13:13:09.214Z'
+                created_at: '2026-06-08T10:56:29.978Z'
+                updated_at: '2026-06-08T10:58:04.762Z'
                 url: http://www.example.com:3000
                 supported_currencies:
                 - USD
@@ -14877,7 +14858,7 @@ paths:
     get:
       summary: List tags
       tags:
-      - Configuration
+      - Settings
       security:
       - api_key: []
         bearer_auth: []
@@ -14943,7 +14924,7 @@ paths:
     get:
       summary: List product variants
       tags:
-      - Product Catalog
+      - Variants
       security:
       - api_key: []
         bearer_auth: []
@@ -15050,13 +15031,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-06-05T13:13:10.660Z'
-                  updated_at: '2026-06-05T13:13:10.670Z'
+                  created_at: '2026-06-08T10:58:06.223Z'
+                  updated_at: '2026-06-08T10:58:06.232Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 791516
+                  product_name: Product 791409
                 - id: variant_gbHJdmfrXB
                   product_id: prod_UkLWZg9DAJ
                   sku: SKU-98
@@ -15067,10 +15048,10 @@ paths:
                   purchasable: true
                   in_stock: false
                   backorderable: true
-                  weight: 126.85
-                  height: 146.34
-                  width: 142.5
-                  depth: 131.31
+                  weight: 92.25
+                  height: 22.97
+                  width: 108.5
+                  depth: 180.4
                   price:
                     id: price_gbHJdmfrXB
                     amount: '19.99'
@@ -15093,8 +15074,8 @@ paths:
                     option_type_label: Size
                     image_url:
                     metadata: {}
-                    created_at: '2026-06-05T13:13:10.695Z'
-                    updated_at: '2026-06-05T13:13:10.695Z'
+                    created_at: '2026-06-08T10:58:06.245Z'
+                    updated_at: '2026-06-08T10:58:06.245Z'
                   metadata: {}
                   position: 2
                   cost_price: '17.0'
@@ -15103,13 +15084,13 @@ paths:
                   weight_unit: lb
                   dimensions_unit:
                   deleted_at:
-                  created_at: '2026-06-05T13:13:10.692Z'
-                  updated_at: '2026-06-05T13:13:10.708Z'
+                  created_at: '2026-06-08T10:58:06.242Z'
+                  updated_at: '2026-06-08T10:58:06.252Z'
                   tax_category_id: taxcat_UkLWZg9DAJ
                   available_stock: 0
                   reserved_quantity: 0
                   total_on_hand: 0
-                  product_name: Product 791516
+                  product_name: Product 791409
                 meta:
                   page: 1
                   limit: 25
@@ -15123,7 +15104,7 @@ paths:
     post:
       summary: Create a variant
       tags:
-      - Product Catalog
+      - Variants
       security:
       - api_key: []
         bearer_auth: []
@@ -15220,8 +15201,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-06-05T13:13:11.398Z'
-                  updated_at: '2026-06-05T13:13:11.398Z'
+                  created_at: '2026-06-08T10:58:06.920Z'
+                  updated_at: '2026-06-08T10:58:06.920Z'
                 metadata: {}
                 position: 3
                 cost_price:
@@ -15230,13 +15211,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-06-05T13:13:11.402Z'
-                updated_at: '2026-06-05T13:13:11.404Z'
+                created_at: '2026-06-08T10:58:06.924Z'
+                updated_at: '2026-06-08T10:58:06.925Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 806635
+                product_name: Product 802281
         '422':
           description: validation error
           content:
@@ -15347,7 +15328,7 @@ paths:
     get:
       summary: Get a variant
       tags:
-      - Product Catalog
+      - Variants
       security:
       - api_key: []
         bearer_auth: []
@@ -15423,10 +15404,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 93.41
-                height: 11.74
-                width: 180.52
-                depth: 114.88
+                weight: 188.6
+                height: 96.46
+                width: 19.96
+                depth: 26.58
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -15449,8 +15430,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-06-05T13:13:11.790Z'
-                  updated_at: '2026-06-05T13:13:11.790Z'
+                  created_at: '2026-06-08T10:58:07.349Z'
+                  updated_at: '2026-06-08T10:58:07.349Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -15459,13 +15440,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-06-05T13:13:11.788Z'
-                updated_at: '2026-06-05T13:13:11.797Z'
+                created_at: '2026-06-08T10:58:07.347Z'
+                updated_at: '2026-06-08T10:58:07.368Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 826512
+                product_name: Product 826595
         '404':
           description: variant not found
           content:
@@ -15479,7 +15460,7 @@ paths:
     patch:
       summary: Update a variant
       tags:
-      - Product Catalog
+      - Variants
       security:
       - api_key: []
         bearer_auth: []
@@ -15544,10 +15525,10 @@ paths:
                 purchasable: true
                 in_stock: false
                 backorderable: true
-                weight: 198.83
-                height: 53.66
-                width: 153.45
-                depth: 63.96
+                weight: 10.18
+                height: 91.91
+                width: 190.0
+                depth: 145.3
                 price:
                   id: price_gbHJdmfrXB
                   amount: '19.99'
@@ -15570,8 +15551,8 @@ paths:
                   option_type_label: Size
                   image_url:
                   metadata: {}
-                  created_at: '2026-06-05T13:13:12.465Z'
-                  updated_at: '2026-06-05T13:13:12.465Z'
+                  created_at: '2026-06-08T10:58:08.060Z'
+                  updated_at: '2026-06-08T10:58:08.060Z'
                 metadata: {}
                 position: 2
                 cost_price: '17.0'
@@ -15580,13 +15561,13 @@ paths:
                 weight_unit: lb
                 dimensions_unit:
                 deleted_at:
-                created_at: '2026-06-05T13:13:12.462Z'
-                updated_at: '2026-06-05T13:13:12.750Z'
+                created_at: '2026-06-08T10:58:08.058Z'
+                updated_at: '2026-06-08T10:58:08.365Z'
                 tax_category_id: taxcat_UkLWZg9DAJ
                 available_stock: 0
                 reserved_quantity: 0
                 total_on_hand: 0
-                product_name: Product 842857
+                product_name: Product 843476
       requestBody:
         content:
           application/json:
@@ -15673,7 +15654,7 @@ paths:
     delete:
       summary: Delete a variant
       tags:
-      - Product Catalog
+      - Variants
       security:
       - api_key: []
         bearer_auth: []
@@ -15731,7 +15712,7 @@ paths:
     get:
       summary: List webhook deliveries
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -15824,9 +15805,9 @@ paths:
                     event: order.created
                     data:
                       id: 1
-                  created_at: '2026-06-05T13:13:13.136Z'
-                  updated_at: '2026-06-05T13:13:13.136Z'
-                  delivered_at: '2026-06-05T13:13:13.136Z'
+                  created_at: '2026-06-08T10:58:08.780Z'
+                  updated_at: '2026-06-08T10:58:08.780Z'
+                  delivered_at: '2026-06-08T10:58:08.780Z'
                   webhook_endpoint_id: whe_UkLWZg9DAJ
                   webhook_endpoint_url: https://shop.example.com/webhooks
                 - id: whd_UkLWZg9DAJ
@@ -15842,9 +15823,9 @@ paths:
                     event: order.created
                     data:
                       id: 1
-                  created_at: '2026-06-05T13:13:13.135Z'
-                  updated_at: '2026-06-05T13:13:13.135Z'
-                  delivered_at: '2026-06-05T13:13:13.135Z'
+                  created_at: '2026-06-08T10:58:08.779Z'
+                  updated_at: '2026-06-08T10:58:08.779Z'
+                  delivered_at: '2026-06-08T10:58:08.779Z'
                   webhook_endpoint_id: whe_UkLWZg9DAJ
                   webhook_endpoint_url: https://shop.example.com/webhooks
                 meta:
@@ -15884,7 +15865,7 @@ paths:
     get:
       summary: Get a webhook delivery
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -15944,9 +15925,9 @@ paths:
                   event: order.created
                   data:
                     id: 1
-                created_at: '2026-06-05T13:13:13.753Z'
-                updated_at: '2026-06-05T13:13:13.753Z'
-                delivered_at: '2026-06-05T13:13:13.753Z'
+                created_at: '2026-06-08T10:58:09.417Z'
+                updated_at: '2026-06-08T10:58:09.417Z'
+                delivered_at: '2026-06-08T10:58:09.417Z'
                 webhook_endpoint_id: whe_UkLWZg9DAJ
                 webhook_endpoint_url: https://shop.example.com/webhooks
         '404':
@@ -15976,7 +15957,7 @@ paths:
     post:
       summary: Redeliver a webhook delivery
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16031,8 +16012,8 @@ paths:
                   event: order.created
                   data:
                     id: 1
-                created_at: '2026-06-05T13:13:14.655Z'
-                updated_at: '2026-06-05T13:13:14.655Z'
+                created_at: '2026-06-08T10:58:10.346Z'
+                updated_at: '2026-06-08T10:58:10.346Z'
                 delivered_at:
                 webhook_endpoint_id: whe_UkLWZg9DAJ
                 webhook_endpoint_url: https://shop.example.com/webhooks
@@ -16040,7 +16021,7 @@ paths:
     get:
       summary: List webhook endpoints
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16128,8 +16109,8 @@ paths:
                   - order.completed
                   - product.created
                   disabled_reason:
-                  created_at: '2026-06-05T13:13:14.683Z'
-                  updated_at: '2026-06-05T13:13:14.683Z'
+                  created_at: '2026-06-08T10:58:10.400Z'
+                  updated_at: '2026-06-08T10:58:10.400Z'
                   disabled_at:
                   secret_key:
                   last_delivery_at:
@@ -16161,7 +16142,7 @@ paths:
     post:
       summary: Create a webhook endpoint
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16221,10 +16202,10 @@ paths:
                 subscriptions:
                 - order.completed
                 disabled_reason:
-                created_at: '2026-06-05T13:13:15.322Z'
-                updated_at: '2026-06-05T13:13:15.322Z'
+                created_at: '2026-06-08T10:58:11.114Z'
+                updated_at: '2026-06-08T10:58:11.114Z'
                 disabled_at:
-                secret_key: 81a1cd93ff52f5e579fa149c0621ca1f15817eead13ebdd8f807f5a71ec43353
+                secret_key: 5ad2424be15f9d7e024dd5e7fcd8d36ed1845791aa2dcaa51b58498eca77c37c
                 last_delivery_at:
                 recent_delivery_count: 0
                 recent_failure_count: 0
@@ -16291,7 +16272,7 @@ paths:
     get:
       summary: Get a webhook endpoint
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16344,8 +16325,8 @@ paths:
                 - order.completed
                 - product.created
                 disabled_reason:
-                created_at: '2026-06-05T13:13:15.645Z'
-                updated_at: '2026-06-05T13:13:15.645Z'
+                created_at: '2026-06-08T10:58:11.626Z'
+                updated_at: '2026-06-08T10:58:11.626Z'
                 disabled_at:
                 secret_key:
                 last_delivery_at:
@@ -16367,7 +16348,7 @@ paths:
     patch:
       summary: Update a webhook endpoint
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16420,8 +16401,8 @@ paths:
                 - order.completed
                 - product.created
                 disabled_reason:
-                created_at: '2026-06-05T13:13:16.252Z'
-                updated_at: '2026-06-05T13:13:16.530Z'
+                created_at: '2026-06-08T10:58:12.303Z'
+                updated_at: '2026-06-08T10:58:12.587Z'
                 disabled_at:
                 secret_key:
                 last_delivery_at:
@@ -16474,7 +16455,7 @@ paths:
     delete:
       summary: Delete a webhook endpoint
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16520,7 +16501,7 @@ paths:
     post:
       summary: Send a test delivery
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16573,15 +16554,15 @@ paths:
                 response_body:
                 success:
                 payload:
-                  id: 9ac8d08d-e321-4228-98c1-5e4bd30d7e16
+                  id: a948973d-8e57-4e1e-86bc-c8cdeb435e70
                   name: webhook.test
-                  created_at: '2026-06-05T13:13:17Z'
+                  created_at: '2026-06-08T10:58:13Z'
                   data:
                     message: This is a test webhook from Spree.
                   metadata:
                     spree_version: 5.5.0.beta
-                created_at: '2026-06-05T13:13:17.450Z'
-                updated_at: '2026-06-05T13:13:17.450Z'
+                created_at: '2026-06-08T10:58:13.620Z'
+                updated_at: '2026-06-08T10:58:13.620Z'
                 delivered_at:
                 webhook_endpoint_id: whe_UkLWZg9DAJ
                 webhook_endpoint_url: https://shop.example.com/webhooks/orders
@@ -16596,7 +16577,7 @@ paths:
     patch:
       summary: Re-enable a webhook endpoint
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16644,8 +16625,8 @@ paths:
                 - order.completed
                 - product.created
                 disabled_reason:
-                created_at: '2026-06-05T13:13:17.480Z'
-                updated_at: '2026-06-05T13:13:17.770Z'
+                created_at: '2026-06-08T10:58:13.678Z'
+                updated_at: '2026-06-08T10:58:13.960Z'
                 disabled_at:
                 secret_key:
                 last_delivery_at:
@@ -16665,7 +16646,7 @@ paths:
     patch:
       summary: Disable a webhook endpoint
       tags:
-      - Configuration
+      - Webhooks
       security:
       - api_key: []
         bearer_auth: []
@@ -16718,9 +16699,9 @@ paths:
                 - order.completed
                 - product.created
                 disabled_reason: Investigating
-                created_at: '2026-06-05T13:13:17.803Z'
-                updated_at: '2026-06-05T13:13:18.094Z'
-                disabled_at: '2026-06-05T13:13:18.094Z'
+                created_at: '2026-06-08T10:58:14.003Z'
+                updated_at: '2026-06-08T10:58:14.290Z'
+                disabled_at: '2026-06-08T10:58:14.290Z'
                 secret_key:
                 last_delivery_at:
                 recent_delivery_count: 0
@@ -16744,32 +16725,101 @@ servers:
       default: localhost:3000
 tags:
 - name: Authentication
-  description: Admin user authentication
-- name: Product Catalog
-  description: Products, variants, and option types
-- name: Orders
-  description: Order management — orders, items, payments, fulfillments, refunds,
-    gift cards, store credits
+  description: Admin user login, logout, token refresh, and current user profile
+- name: Allowed Origins
+  description: CORS allowlist for storefront and admin client origins
+- name: API Keys
+  description: Secret and publishable API keys
+- name: Channels
+  description: Sales channels and product publication across channels
+- name: Custom Fields
+  description: Custom field definitions for products, variants, customers, and other
+    resources
+- name: Customer Groups
+  description: Customer groups for segmenting customers (e.g. wholesale, VIP) used
+    by pricing and promotions
 - name: Customers
-  description: Customer management — profiles, addresses, store credits, credit cards
-- name: Configuration
-  description: Store configuration — payment methods, tag autocomplete
+  description: Customer profiles, addresses, credit cards, and store credits
+- name: Exports
+  description: Async CSV exports of admin resources
+- name: Fulfillments
+  description: Order fulfillments — shipments, fulfill, cancel, resume, split
+- name: Gift Cards
+  description: Gift cards and gift card batches
+- name: Markets
+  description: Markets — geographic groupings of countries used for pricing, tax,
+    and fulfillment rules
+- name: Option Types
+  description: Option types and option values used to build product variants (e.g.
+    Size, Color)
+- name: Orders
+  description: Orders, order items, applied gift cards, and applied store credits
+- name: Payment Methods
+  description: Configured payment providers and their available types
+- name: Payments
+  description: Order payments — list, capture, void
+- name: Pricing
+  description: Prices and price lists for currency-, market-, and customer-group-specific
+    pricing
+- name: Products
+  description: Products, taxons/categories, product custom field values, and bulk
+    product operations
+- name: Promotions
+  description: Promotions, promotion rules, promotion actions, and coupon codes
+- name: Refunds
+  description: Order refunds
+- name: Settings
+  description: Store-level settings — store profile, tags, store credit categories
+- name: Staff
+  description: Admin users, roles, and invitations to the store
+- name: Stock Locations
+  description: Warehouses and physical fulfillment locations
+- name: Variants
+  description: Product variants — the individual SKUs (size/color combinations) sold
+    under a product
+- name: Webhooks
+  description: Webhook endpoints and webhook delivery history
 x-tagGroups:
 - name: Authentication
   tags:
   - Authentication
-- name: Product Catalog
+- name: Products & Catalog
   tags:
-  - Product Catalog
-- name: Orders
+  - Products
+  - Variants
+  - Option Types
+  - Custom Fields
+  - Channels
+- name: Pricing
+  tags:
+  - Pricing
+  - Markets
+- name: Orders & Fulfillment
   tags:
   - Orders
+  - Payments
+  - Fulfillments
+  - Refunds
 - name: Customers
   tags:
   - Customers
+  - Customer Groups
+- name: Promotions & Gift Cards
+  tags:
+  - Promotions
+  - Gift Cards
+- name: Data
+  tags:
+  - Exports
 - name: Configuration
   tags:
-  - Configuration
+  - Settings
+  - Stock Locations
+  - Payment Methods
+  - Staff
+  - API Keys
+  - Allowed Origins
+  - Webhooks
 components:
   securitySchemes:
     api_key:

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -40,520 +40,6 @@ info:
     ```
   version: v3
 paths:
-  "/api/v3/store/customers/me/addresses":
-    get:
-      summary: List customer addresses
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns all addresses in the customer address book
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const addresses = await client.customer.addresses.list({}, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: addresses found
-          content:
-            application/json:
-              example:
-                data:
-                - id: addr_EfhxLZ9ck8
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 72 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: false
-                  state_name: New York
-                - id: addr_gbHJdmfrXB
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 71 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: true
-                  is_default_shipping: false
-                  state_name: New York
-                - id: addr_UkLWZg9DAJ
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 70 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: true
-                  state_name: New York
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 3
-                  pages: 1
-                  from: 1
-                  to: 3
-                  in: 3
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Address"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-    post:
-      summary: Create an address
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Adds a new address to the customer address book
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const address = await client.customer.addresses.create({
-            first_name: 'John',
-            last_name: 'Doe',
-            address1: '123 Main St',
-            city: 'New York',
-            postal_code: '10001',
-            country_iso: 'US',
-            state_abbr: 'NY',
-            phone: '+1 555 123 4567',
-          }, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: address created
-          content:
-            application/json:
-              example:
-                id: addr_VqXmZF31wY
-                first_name: John
-                last_name: Doe
-                full_name: John Doe
-                address1: 123 Main St
-                address2:
-                postal_code: '10001'
-                city: New York
-                phone: "+1 555 123 4567"
-                company:
-                country_name: United States of America
-                country_iso: US
-                state_text: NY
-                state_abbr: NY
-                quick_checkout: false
-                is_default_billing: false
-                is_default_shipping: false
-                state_name: New York
-              schema:
-                "$ref": "#/components/schemas/Address"
-        '422':
-          description: validation error
-          content:
-            application/json:
-              example:
-                error:
-                  code: validation_error
-                  message: First Name can't be blank, Last Name can't be blank, Address
-                    can't be blank, City can't be blank, Country can't be blank, and
-                    Zip Code can't be blank
-                  details:
-                    firstname:
-                    - can't be blank
-                    lastname:
-                    - can't be blank
-                    address1:
-                    - can't be blank
-                    city:
-                    - can't be blank
-                    country:
-                    - can't be blank
-                    zipcode:
-                    - can't be blank
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                first_name:
-                  type: string
-                  example: John
-                last_name:
-                  type: string
-                  example: Doe
-                address1:
-                  type: string
-                  example: 123 Main St
-                address2:
-                  type: string
-                  example: Apt 4B
-                city:
-                  type: string
-                  example: New York
-                postal_code:
-                  type: string
-                  example: '10001'
-                phone:
-                  type: string
-                  example: "+1 555 123 4567"
-                company:
-                  type: string
-                  example: Acme Inc
-                country_iso:
-                  type: string
-                  example: US
-                  description: ISO 3166-1 alpha-2 country code (e.g., "US", "DE")
-                state_abbr:
-                  type: string
-                  example: NY
-                  description: ISO 3166-2 subdivision code without country prefix
-                    (e.g., "CA", "NY")
-                state_name:
-                  type: string
-                  example: New York
-                  description: State name - for countries without predefined states
-                is_default_billing:
-                  type: boolean
-                  example: true
-                  description: Set as default billing address
-                is_default_shipping:
-                  type: boolean
-                  example: true
-                  description: Set as default shipping address
-              required:
-              - first_name
-              - last_name
-              - address1
-              - city
-              - postal_code
-              - country_iso
-  "/api/v3/store/customers/me/addresses/{id}":
-    get:
-      summary: Get an address
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const address = await client.customer.addresses.get('addr_abc123', {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: address found
-          content:
-            application/json:
-              example:
-                id: addr_EfhxLZ9ck8
-                first_name: John
-                last_name: Doe
-                full_name: John Doe
-                address1: 84 Lovely Street
-                address2: Northwest
-                postal_code: '10118'
-                city: New York
-                phone: 555-555-0199
-                company: Company
-                country_name: United States of America
-                country_iso: US
-                state_text: NY
-                state_abbr: NY
-                quick_checkout: false
-                is_default_billing: false
-                is_default_shipping: false
-                state_name: New York
-              schema:
-                "$ref": "#/components/schemas/Address"
-        '404':
-          description: address not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Address not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-    patch:
-      summary: Update an address
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const address = await client.customer.addresses.update('addr_abc123', {
-            city: 'Los Angeles',
-          }, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: address updated
-          content:
-            application/json:
-              example:
-                id: addr_EfhxLZ9ck8
-                first_name: John
-                last_name: Doe
-                full_name: John Doe
-                address1: 90 Lovely Street
-                address2: Northwest
-                postal_code: '10118'
-                city: Los Angeles
-                phone: 555-555-0199
-                company: Company
-                country_name: United States of America
-                country_iso: US
-                state_text: NY
-                state_abbr: NY
-                quick_checkout: false
-                is_default_billing: false
-                is_default_shipping: false
-                state_name: New York
-              schema:
-                "$ref": "#/components/schemas/Address"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                first_name:
-                  type: string
-                  example: John
-                last_name:
-                  type: string
-                  example: Doe
-                address1:
-                  type: string
-                  example: 456 Oak Ave
-                city:
-                  type: string
-                  example: Los Angeles
-                is_default_billing:
-                  type: boolean
-                  example: true
-                  description: Set as default billing address
-                is_default_shipping:
-                  type: boolean
-                  example: true
-                  description: Set as default shipping address
-    delete:
-      summary: Delete an address
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          await client.customer.addresses.delete('addr_abc123', {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: address deleted
-        '404':
-          description: address not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Address not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/auth/login":
     post:
       summary: Login
@@ -786,6 +272,880 @@ paths:
                 refresh_token:
                   type: string
                   description: Refresh token to revoke
+  "/api/v3/store/password_resets":
+    post:
+      summary: Request a password reset
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+      description: Sends a password reset email if an account exists for the given
+        email address. Always returns 202 Accepted to prevent email enumeration.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          await client.passwordResets.create({
+            email: 'customer@example.com',
+            redirect_url: 'https://myshop.com/reset-password',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          description: email not found (same response to prevent enumeration)
+          content:
+            application/json:
+              example:
+                message: If an account exists for that email, password reset instructions
+                  have been sent.
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '401':
+          description: missing API key
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: customer@example.com
+                  description: Email address of the account to reset
+                redirect_url:
+                  type: string
+                  format: uri
+                  example: https://myshop.com/reset-password
+                  description: URL to redirect the user to after clicking the reset
+                    link. Validated against the store's allowed origins.
+              required:
+              - email
+  "/api/v3/store/password_resets/{token}":
+    patch:
+      summary: Reset password with token
+      tags:
+      - Authentication
+      security:
+      - api_key: []
+      description: Resets the password using a token received via email. Returns a
+        JWT token on success (auto-login).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const auth = await client.passwordResets.update(
+            'reset-token-from-email',
+            {
+              password: 'newsecurepassword',
+              password_confirmation: 'newsecurepassword',
+            }
+          )
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: token
+        in: path
+        required: true
+        description: Password reset token from the email
+        schema:
+          type: string
+      responses:
+        '200':
+          description: password reset successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjU1YjA5Yzc4LTUzMTYtNDRjYy05ZjJiLThmN2E2MzViMmRlNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjI4fQ.FX2Te4WfdAu3kN_fvvfHsH92_axvIZTI1d8Zmw8R1mE
+                refresh_token: Be2HUCjiJVRjgidFuYU7GRRh
+                user:
+                  id: cus_UkLWZg9DAJ
+                  email: customer@example.com
+                  first_name: Randa
+                  last_name: O'Hara
+                  phone:
+                  accepts_email_marketing: false
+                  full_name: Randa O'Hara
+                  available_store_credit_total: '0'
+                  display_available_store_credit_total: "$0.00"
+                  addresses: []
+                  default_billing_address:
+                  default_shipping_address:
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '422':
+          description: password confirmation mismatch
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Password confirmation doesn't match Password
+                  details:
+                    password_confirmation:
+                    - doesn't match Password
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '401':
+          description: missing API key
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  minLength: 6
+                  example: newsecurepassword
+                password_confirmation:
+                  type: string
+                  example: newsecurepassword
+              required:
+              - password
+              - password_confirmation
+  "/api/v3/store/categories":
+    get:
+      summary: List categories
+      tags:
+      - Product Catalog
+      security:
+      - api_key: []
+      description: Returns a paginated list of categories for the current store
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const categories = await client.categories.list({
+            page: 1,
+            limit: 25,
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: q[name_cont]
+        in: query
+        required: false
+        description: Filter by name
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: categories found
+          content:
+            application/json:
+              example:
+                data:
+                - id: ctg_UkLWZg9DAJ
+                  name: taxonomy_3
+                  permalink: taxonomy-3
+                  position: 0
+                  depth: 0
+                  meta_title:
+                  meta_description:
+                  meta_keywords:
+                  children_count: 1
+                  parent_id:
+                  description: ''
+                  description_html: ''
+                  image_url:
+                  square_image_url:
+                  is_root: true
+                  is_child: false
+                  is_leaf: false
+                - id: ctg_gbHJdmfrXB
+                  name: taxon_3
+                  permalink: taxonomy-3/taxon-3
+                  position: 0
+                  depth: 1
+                  meta_title:
+                  meta_description:
+                  meta_keywords:
+                  children_count: 1
+                  parent_id: ctg_UkLWZg9DAJ
+                  description: ''
+                  description_html: ''
+                  image_url:
+                  square_image_url:
+                  is_root: false
+                  is_child: true
+                  is_leaf: false
+                - id: ctg_EfhxLZ9ck8
+                  name: taxon_4
+                  permalink: taxonomy-3/taxon-3/taxon-4
+                  position: 0
+                  depth: 2
+                  meta_title:
+                  meta_description:
+                  meta_keywords:
+                  children_count: 0
+                  parent_id: ctg_gbHJdmfrXB
+                  description: ''
+                  description_html: ''
+                  image_url:
+                  square_image_url:
+                  is_root: false
+                  is_child: true
+                  is_leaf: true
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 3
+                  pages: 1
+                  from: 1
+                  to: 3
+                  in: 3
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Category"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/categories/{id}":
+    get:
+      summary: Get a category
+      tags:
+      - Product Catalog
+      security:
+      - api_key: []
+      description: Returns a single category by permalink or prefix ID
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const category = await client.categories.get('categories/clothing/shirts', {
+            expand: ['children'],
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Category permalink (e.g., clothing/shirts) or prefix ID (e.g.,
+          ctg_abc123)
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Expand associations (children, parent, ancestors, custom_fields)
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: category found by prefix ID
+          content:
+            application/json:
+              example:
+                id: ctg_gbHJdmfrXB
+                name: taxon_12
+                permalink: taxonomy-9/taxon-12
+                position: 0
+                depth: 1
+                meta_title:
+                meta_description:
+                meta_keywords:
+                children_count: 1
+                parent_id: ctg_UkLWZg9DAJ
+                description: ''
+                description_html: ''
+                image_url:
+                square_image_url:
+                is_root: false
+                is_child: true
+                is_leaf: false
+              schema:
+                "$ref": "#/components/schemas/Category"
+        '404':
+          description: category from other store not accessible
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Category not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/products":
+    get:
+      summary: List products
+      tags:
+      - Product Catalog
+      security:
+      - api_key: []
+      description: Returns a paginated list of active products for the current store
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const products = await client.products.list({
+            page: 1,
+            limit: 25,
+            sort: 'price',
+            name_cont: 'shirt',
+            price_gte: 20,
+            price_lte: 100,
+            with_option_value_ids: ['optval_abc', 'optval_def'],
+            expand: ['variants', 'media'],
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        description: Publishable API key
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: 'Page number (default: 1)'
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        description: 'Number of items per page (default: 25, max: 100)'
+        schema:
+          type: integer
+      - name: sort
+        in: query
+        required: false
+        description: 'Sort order. Prefix with - for descending. Values: price, -price,
+          best_selling, name, -name, -available_on, available_on'
+        schema:
+          type: string
+      - name: q[name_cont]
+        in: query
+        required: false
+        description: Filter by name containing string
+        schema:
+          type: string
+      - name: q[in_category]
+        in: query
+        required: false
+        description: Filter by category prefixed ID (includes descendants)
+        schema:
+          type: string
+      - name: q[in_categories][]
+        in: query
+        required: false
+        description: Filter by multiple category prefixed IDs (OR logic, includes
+          descendants)
+        schema:
+          type: string
+      - name: q[price_gte]
+        in: query
+        required: false
+        description: Filter by minimum price
+        schema:
+          type: number
+      - name: q[price_lte]
+        in: query
+        required: false
+        description: Filter by maximum price
+        schema:
+          type: number
+      - name: q[with_option_value_ids][]
+        in: query
+        required: false
+        description: Filter by option value prefix IDs (e.g., optval_abc). Pass multiple
+          values for OR logic.
+        schema:
+          type: string
+      - name: q[in_stock]
+        in: query
+        required: false
+        description: Filter to only in-stock products
+        schema:
+          type: boolean
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (variants, media, categories,
+          option_types)
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: products found
+          content:
+            application/json:
+              example:
+                data:
+                - id: prod_UkLWZg9DAJ
+                  name: Product 1421251
+                  slug: product-1421251
+                  meta_title:
+                  meta_description:
+                  meta_keywords:
+                  variant_count: 1
+                  available_on: '2025-05-26T16:14:22.402Z'
+                  purchasable: true
+                  in_stock: false
+                  backorderable: true
+                  available: true
+                  description: A comfortable cotton t-shirt.
+                  description_html: "<p>A <strong>comfortable</strong> cotton t-shirt.</p>"
+                  default_variant_id: variant_gbHJdmfrXB
+                  thumbnail_url:
+                  tags: []
+                  price:
+                    id: price_gbHJdmfrXB
+                    amount: '19.99'
+                    amount_in_cents: 1999
+                    compare_at_amount:
+                    compare_at_amount_in_cents:
+                    currency: USD
+                    display_amount: "$19.99"
+                    display_compare_at_amount:
+                    price_list_id:
+                  original_price:
+                - id: prod_gbHJdmfrXB
+                  name: Product 1435220
+                  slug: product-1435220
+                  meta_title:
+                  meta_description:
+                  meta_keywords:
+                  variant_count: 0
+                  available_on: '2025-05-26T16:14:22.472Z'
+                  purchasable: true
+                  in_stock: false
+                  backorderable: true
+                  available: true
+                  description: Architecto dignissimos nemo inventore incidunt enim.
+                    Odit accusamus repellat error saepe culpa unde eius. Cupiditate
+                    officiis voluptatem autem perferendis qui vitae omnis sunt. Debitis
+                    dolor tempore ad impedit itaque reprehenderit delectus. Doloremque
+                    laudantium iure recusandae iusto debitis laborum consequuntur.
+                    Impedit eum optio commodi tempora cum quidem. Facere voluptatum
+                    nam possimus veritatis nostrum explicabo dolore ex. Adipisci iure
+                    unde nobis itaque amet nesciunt voluptatibus impedit. Numquam
+                    in accusantium magni itaque exercitationem. Quas vero maxime voluptatem
+                    rem impedit inventore. Esse perferendis asperiores ea expedita
+                    aut tenetur soluta. Enim accusantium dolor adipisci impedit. Error
+                    maxime neque accusamus facere provident eum. Cum officia velit
+                    asperiores quod cupiditate fugiat. Possimus tenetur aut consequuntur
+                    iusto cumque quas. Ab velit ullam qui pariatur veritatis omnis.
+                    Accusantium vero occaecati explicabo neque animi commodi. Necessitatibus
+                    perspiciatis iste culpa totam quibusdam voluptate distinctio.
+                    Quod aliquam ut et autem. Saepe ut asperiores et quisquam perspiciatis
+                    molestiae. Vel recusandae sunt nemo et accusamus veniam ducimus.
+                    Laborum modi quasi perferendis culpa laboriosam quaerat magnam.
+                    Facere at tempora iusto ex magni aliquam modi debitis.
+                  description_html: |-
+                    Architecto dignissimos nemo inventore incidunt enim. Odit accusamus repellat error saepe culpa unde eius. Cupiditate officiis voluptatem autem perferendis qui vitae omnis sunt. Debitis dolor tempore ad impedit itaque reprehenderit delectus. Doloremque laudantium iure recusandae iusto debitis laborum consequuntur.
+                    Impedit eum optio commodi tempora cum quidem. Facere voluptatum nam possimus veritatis nostrum explicabo dolore ex. Adipisci iure unde nobis itaque amet nesciunt voluptatibus impedit. Numquam in accusantium magni itaque exercitationem. Quas vero maxime voluptatem rem impedit inventore.
+                    Esse perferendis asperiores ea expedita aut tenetur soluta. Enim accusantium dolor adipisci impedit. Error maxime neque accusamus facere provident eum. Cum officia velit asperiores quod cupiditate fugiat. Possimus tenetur aut consequuntur iusto cumque quas.
+                    Ab velit ullam qui pariatur veritatis omnis. Accusantium vero occaecati explicabo neque animi commodi. Necessitatibus perspiciatis iste culpa totam quibusdam voluptate distinctio. Quod aliquam ut et autem. Saepe ut asperiores et quisquam perspiciatis molestiae.
+                    Vel recusandae sunt nemo et accusamus veniam ducimus. Laborum modi quasi perferendis culpa laboriosam quaerat magnam. Facere at tempora iusto ex magni aliquam modi debitis.
+                  default_variant_id: variant_EfhxLZ9ck8
+                  thumbnail_url:
+                  tags: []
+                  price:
+                    id: price_EfhxLZ9ck8
+                    amount: '19.99'
+                    amount_in_cents: 1999
+                    compare_at_amount:
+                    compare_at_amount_in_cents:
+                    currency: USD
+                    display_amount: "$19.99"
+                    display_compare_at_amount:
+                    price_list_id:
+                  original_price:
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 2
+                  pages: 1
+                  from: 1
+                  to: 2
+                  in: 2
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Product"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+                required:
+                - data
+                - meta
+        '401':
+          description: unauthorized - invalid or missing API key
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/products/{id}":
+    get:
+      summary: Get a product
+      tags:
+      - Product Catalog
+      security:
+      - api_key: []
+      description: Returns a single product by slug or prefix ID
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const product = await client.products.get('spree-tote', {
+            expand: ['variants', 'media'],
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        description: Publishable API key
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Product slug (e.g., spree-tote) or prefix ID (e.g., product_abc123)
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: product without prior_price expanded does not include field
+          content:
+            application/json:
+              example:
+                id: prod_UkLWZg9DAJ
+                name: Product 1702106
+                slug: product-1702106
+                meta_title:
+                meta_description:
+                meta_keywords:
+                variant_count: 1
+                available_on: '2025-05-26T16:14:24.749Z'
+                purchasable: true
+                in_stock: false
+                backorderable: true
+                available: true
+                description: A comfortable cotton t-shirt.
+                description_html: "<p>A <strong>comfortable</strong> cotton t-shirt.</p>"
+                default_variant_id: variant_gbHJdmfrXB
+                thumbnail_url:
+                tags: []
+                price:
+                  id: price_gbHJdmfrXB
+                  amount: '19.99'
+                  amount_in_cents: 1999
+                  compare_at_amount:
+                  compare_at_amount_in_cents:
+                  currency: USD
+                  display_amount: "$19.99"
+                  display_compare_at_amount:
+                  price_list_id:
+                original_price:
+                prior_price:
+                  id: _AXs1igzRC6
+                  amount: '9.99'
+                  amount_in_cents: 999
+                  currency: USD
+                  display_amount: "$9.99"
+                  recorded_at: '2026-05-11T16:14:24Z'
+              schema:
+                "$ref": "#/components/schemas/Product"
+        '404':
+          description: draft product not visible
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Product not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/products/filters":
+    get:
+      summary: Get product filters
+      tags:
+      - Product Catalog
+      security:
+      - api_key: []
+      description: |
+        Returns available filters for products with their options and counts.
+        Use this endpoint to build filter UIs for product listing pages.
+
+        The filters are context-aware - when a category_id is provided, only filters
+        relevant to products in that category are returned.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const filters = await client.products.filters({
+            category_id: 'ctg_abc123',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        description: Publishable API key
+        schema:
+          type: string
+      - name: category_id
+        in: query
+        required: false
+        description: Scope filters to products in this category (prefix ID)
+        schema:
+          type: string
+      - name: q[name_cont]
+        in: query
+        required: false
+        description: Filter by name containing string
+        schema:
+          type: string
+      responses:
+        '200':
+          description: filters scoped to category
+          content:
+            application/json:
+              example:
+                filters:
+                - id: price
+                  type: price_range
+                  min: 19.99
+                  max: 19.99
+                  currency: USD
+                - id: availability
+                  type: availability
+                  options:
+                  - id: in_stock
+                    count: 2
+                  - id: out_of_stock
+                    count: 0
+                - id: opt_UkLWZg9DAJ
+                  type: option
+                  name: size
+                  label: Size
+                  kind: dropdown
+                  options:
+                  - id: optval_UkLWZg9DAJ
+                    name: small
+                    label: S
+                    position: 1
+                    color_code:
+                    image_url:
+                    count: 1
+                - id: categories
+                  type: category
+                  options:
+                  - id: ctg_EfhxLZ9ck8
+                    name: Shirts
+                    permalink: taxonomy-27/taxon-34/shirts
+                    count: 2
+                sort_options:
+                - id: manual
+                - id: best_selling
+                - id: price
+                - id: "-price"
+                - id: "-available_on"
+                - id: available_on
+                - id: name
+                - id: "-name"
+                default_sort: manual
+                total_count: 2
+              schema:
+                type: object
+                properties:
+                  filters:
+                    type: array
+                    description: Available filters (price_range, availability, option,
+                      category)
+                    items:
+                      type: object
+                  sort_options:
+                    type: array
+                    description: Available sort options
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                      required:
+                      - id
+                  default_sort:
+                    type: string
+                    description: Default sort option ID
+                  total_count:
+                    type: integer
+                    description: Total products matching current filters
+                required:
+                - filters
+                - sort_options
+                - default_sort
+                - total_count
+        '401':
+          description: unauthorized - invalid or missing API key
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/carts":
     get:
       summary: List active carts
@@ -2382,1869 +2742,6 @@ paths:
                   message: No payment found
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/categories":
-    get:
-      summary: List categories
-      tags:
-      - Product Catalog
-      security:
-      - api_key: []
-      description: Returns a paginated list of categories for the current store
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const categories = await client.categories.list({
-            page: 1,
-            limit: 25,
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: q[name_cont]
-        in: query
-        required: false
-        description: Filter by name
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: categories found
-          content:
-            application/json:
-              example:
-                data:
-                - id: ctg_UkLWZg9DAJ
-                  name: taxonomy_3
-                  permalink: taxonomy-3
-                  position: 0
-                  depth: 0
-                  meta_title:
-                  meta_description:
-                  meta_keywords:
-                  children_count: 1
-                  parent_id:
-                  description: ''
-                  description_html: ''
-                  image_url:
-                  square_image_url:
-                  is_root: true
-                  is_child: false
-                  is_leaf: false
-                - id: ctg_gbHJdmfrXB
-                  name: taxon_3
-                  permalink: taxonomy-3/taxon-3
-                  position: 0
-                  depth: 1
-                  meta_title:
-                  meta_description:
-                  meta_keywords:
-                  children_count: 1
-                  parent_id: ctg_UkLWZg9DAJ
-                  description: ''
-                  description_html: ''
-                  image_url:
-                  square_image_url:
-                  is_root: false
-                  is_child: true
-                  is_leaf: false
-                - id: ctg_EfhxLZ9ck8
-                  name: taxon_4
-                  permalink: taxonomy-3/taxon-3/taxon-4
-                  position: 0
-                  depth: 2
-                  meta_title:
-                  meta_description:
-                  meta_keywords:
-                  children_count: 0
-                  parent_id: ctg_gbHJdmfrXB
-                  description: ''
-                  description_html: ''
-                  image_url:
-                  square_image_url:
-                  is_root: false
-                  is_child: true
-                  is_leaf: true
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 3
-                  pages: 1
-                  from: 1
-                  to: 3
-                  in: 3
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Category"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/categories/{id}":
-    get:
-      summary: Get a category
-      tags:
-      - Product Catalog
-      security:
-      - api_key: []
-      description: Returns a single category by permalink or prefix ID
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const category = await client.categories.get('categories/clothing/shirts', {
-            expand: ['children'],
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Category permalink (e.g., clothing/shirts) or prefix ID (e.g.,
-          ctg_abc123)
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Expand associations (children, parent, ancestors, custom_fields)
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: category found by prefix ID
-          content:
-            application/json:
-              example:
-                id: ctg_gbHJdmfrXB
-                name: taxon_12
-                permalink: taxonomy-9/taxon-12
-                position: 0
-                depth: 1
-                meta_title:
-                meta_description:
-                meta_keywords:
-                children_count: 1
-                parent_id: ctg_UkLWZg9DAJ
-                description: ''
-                description_html: ''
-                image_url:
-                square_image_url:
-                is_root: false
-                is_child: true
-                is_leaf: false
-              schema:
-                "$ref": "#/components/schemas/Category"
-        '404':
-          description: category from other store not accessible
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Category not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/countries":
-    get:
-      summary: List countries
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns countries available in the store. Use ?expand=market to
-        include market details (currency, locale, tax_inclusive).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const countries = await client.countries.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: countries found
-          content:
-            application/json:
-              example:
-                data:
-                - iso: DE
-                  iso3: IS39
-                  name: Germany
-                  states_required: false
-                  zipcode_required: true
-                - iso: US
-                  iso3: USA
-                  name: United States of America
-                  states_required: true
-                  zipcode_required: true
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Country"
-                required:
-                - data
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/countries/{iso}":
-    get:
-      summary: Get a country
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns a single country by ISO code. Supports ?expand=states for
-        address forms and ?expand=market for market details.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const country = await client.countries.get('US')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: iso
-        in: path
-        required: true
-        description: Country ISO 3166-1 alpha-2 code (e.g., "US", "DE")
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: country found
-          content:
-            application/json:
-              example:
-                iso: US
-                iso3: USA
-                name: United States of America
-                states_required: true
-                zipcode_required: true
-              schema:
-                type: object
-                properties:
-                  iso:
-                    type: string
-                  iso3:
-                    type: string
-                  name:
-                    type: string
-                  states_required:
-                    type: boolean
-                  zipcode_required:
-                    type: boolean
-                required:
-                - iso
-                - iso3
-                - name
-                - states_required
-                - zipcode_required
-        '404':
-          description: country not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Country not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/credit_cards":
-    get:
-      summary: List saved credit cards
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns all saved credit cards for the authenticated customer
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const cards = await client.customer.creditCards.list({}, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: credit cards found
-          content:
-            application/json:
-              example:
-                data:
-                - id: card_UkLWZg9DAJ
-                  brand: visa
-                  last4: '1111'
-                  month: 12
-                  year: 2027
-                  name: Spree Commerce
-                  default: false
-                  gateway_payment_profile_id:
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/CreditCard"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/credit_cards/{id}":
-    get:
-      summary: Get a credit card
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns a saved credit card by its ID
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const card = await client.customer.creditCards.get('card_abc123', {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: credit card found
-          content:
-            application/json:
-              example:
-                id: card_UkLWZg9DAJ
-                brand: visa
-                last4: '1111'
-                month: 12
-                year: 2027
-                name: Spree Commerce
-                default: false
-                gateway_payment_profile_id:
-              schema:
-                "$ref": "#/components/schemas/CreditCard"
-        '404':
-          description: credit card not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Credit card not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-    delete:
-      summary: Delete a credit card
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Removes a saved credit card from the customer account
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          await client.customer.creditCards.delete('card_abc123', {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: credit card deleted
-        '404':
-          description: credit card not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Credit card not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/currencies":
-    get:
-      summary: List supported currencies
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns currencies supported by the store (derived from markets)
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const currencies = await client.currencies.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: currencies found
-          content:
-            application/json:
-              example:
-                data:
-                - iso_code: USD
-                  name: United States Dollar
-                  symbol: "$"
-                - iso_code: EUR
-                  name: Euro
-                  symbol: "€"
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Currency"
-                required:
-                - data
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/password_resets":
-    post:
-      summary: Request a password reset
-      tags:
-      - Authentication
-      security:
-      - api_key: []
-      description: Sends a password reset email if an account exists for the given
-        email address. Always returns 202 Accepted to prevent email enumeration.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          await client.passwordResets.create({
-            email: 'customer@example.com',
-            redirect_url: 'https://myshop.com/reset-password',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '202':
-          description: email not found (same response to prevent enumeration)
-          content:
-            application/json:
-              example:
-                message: If an account exists for that email, password reset instructions
-                  have been sent.
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-        '401':
-          description: missing API key
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  example: customer@example.com
-                  description: Email address of the account to reset
-                redirect_url:
-                  type: string
-                  format: uri
-                  example: https://myshop.com/reset-password
-                  description: URL to redirect the user to after clicking the reset
-                    link. Validated against the store's allowed origins.
-              required:
-              - email
-  "/api/v3/store/password_resets/{token}":
-    patch:
-      summary: Reset password with token
-      tags:
-      - Authentication
-      security:
-      - api_key: []
-      description: Resets the password using a token received via email. Returns a
-        JWT token on success (auto-login).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const auth = await client.passwordResets.update(
-            'reset-token-from-email',
-            {
-              password: 'newsecurepassword',
-              password_confirmation: 'newsecurepassword',
-            }
-          )
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: token
-        in: path
-        required: true
-        description: Password reset token from the email
-        schema:
-          type: string
-      responses:
-        '200':
-          description: password reset successful
-          content:
-            application/json:
-              example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjU1YjA5Yzc4LTUzMTYtNDRjYy05ZjJiLThmN2E2MzViMmRlNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjI4fQ.FX2Te4WfdAu3kN_fvvfHsH92_axvIZTI1d8Zmw8R1mE
-                refresh_token: Be2HUCjiJVRjgidFuYU7GRRh
-                user:
-                  id: cus_UkLWZg9DAJ
-                  email: customer@example.com
-                  first_name: Randa
-                  last_name: O'Hara
-                  phone:
-                  accepts_email_marketing: false
-                  full_name: Randa O'Hara
-                  available_store_credit_total: '0'
-                  display_available_store_credit_total: "$0.00"
-                  addresses: []
-                  default_billing_address:
-                  default_shipping_address:
-              schema:
-                "$ref": "#/components/schemas/AuthResponse"
-        '422':
-          description: password confirmation mismatch
-          content:
-            application/json:
-              example:
-                error:
-                  code: validation_error
-                  message: Password confirmation doesn't match Password
-                  details:
-                    password_confirmation:
-                    - doesn't match Password
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '401':
-          description: missing API key
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                password:
-                  type: string
-                  minLength: 6
-                  example: newsecurepassword
-                password_confirmation:
-                  type: string
-                  example: newsecurepassword
-              required:
-              - password
-              - password_confirmation
-  "/api/v3/store/customers/me/orders":
-    get:
-      summary: List orders
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns a paginated list of completed orders for the authenticated
-        customer.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const orders = await client.customer.orders.list(
-            {
-              completed_at_gt: '2026-01-01',
-              sort: '-completed_at',
-            },
-            { token: '<token>' },
-          )
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: 'Page number (default: 1)'
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        description: 'Number of results per page (default: 25, max: 100)'
-        schema:
-          type: integer
-      - name: sort
-        in: query
-        required: false
-        description: 'Sort order. Prefix with - for descending. Values: completed_at,
-          -completed_at, total, -total, number, -number'
-        schema:
-          type: string
-      - name: q[completed_at_gt]
-        in: query
-        required: false
-        description: Filter by completed after date (ISO 8601)
-        schema:
-          type: string
-      - name: q[completed_at_lt]
-        in: query
-        required: false
-        description: Filter by completed before date (ISO 8601)
-        schema:
-          type: string
-      - name: q[number_eq]
-        in: query
-        required: false
-        description: Filter by exact order number (e.g., R123456)
-        schema:
-          type: string
-      - name: q[state_eq]
-        in: query
-        required: false
-        description: Filter by order state (complete, returned, canceled)
-        schema:
-          type: string
-      - name: q[payment_state_eq]
-        in: query
-        required: false
-        description: Filter by payment state (paid, balance_due, credit_owed, void,
-          failed)
-        schema:
-          type: string
-      - name: q[total_gteq]
-        in: query
-        required: false
-        description: Filter by minimum total
-        schema:
-          type: number
-      - name: q[total_lteq]
-        in: query
-        required: false
-        description: Filter by maximum total
-        schema:
-          type: number
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (items, fulfillments,
-          payments, discounts, billing_address, shipping_address, gift_card). Use
-          "none" to skip associations.
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., total,amount_due,item_count).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: orders listed
-          content:
-            application/json:
-              example:
-                data:
-                - id: or_UkLWZg9DAJ
-                  market_id:
-                  channel_id: ch_UkLWZg9DAJ
-                  number: R096824993
-                  email: gena@ohara.biz
-                  customer_note:
-                  currency: USD
-                  locale: en
-                  total_quantity: 1
-                  item_total: '10.0'
-                  display_item_total: "$10.00"
-                  adjustment_total: '0.0'
-                  display_adjustment_total: "$0.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  tax_total: '0.0'
-                  display_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  total: '110.0'
-                  display_total: "$110.00"
-                  gift_card_total: '0.0'
-                  display_gift_card_total: "$0.00"
-                  amount_due: '110.0'
-                  display_amount_due: "$110.00"
-                  delivery_total: '100.0'
-                  display_delivery_total: "$100.00"
-                  fulfillment_status:
-                  payment_status:
-                  completed_at: '2026-05-26T16:13:49.079Z'
-                  store_credit_total: '0.0'
-                  display_store_credit_total: "$0.00"
-                  covered_by_store_credit: false
-                  discounts: []
-                  items:
-                  - id: li_UkLWZg9DAJ
-                    variant_id: variant_UkLWZg9DAJ
-                    quantity: 1
-                    currency: USD
-                    name: Product 1016128
-                    slug: product-1016128
-                    options_text: ''
-                    price: '10.0'
-                    display_price: "$10.00"
-                    total: '10.0'
-                    display_total: "$10.00"
-                    adjustment_total: '0.0'
-                    display_adjustment_total: "$0.00"
-                    additional_tax_total: '0.0'
-                    display_additional_tax_total: "$0.00"
-                    included_tax_total: '0.0'
-                    display_included_tax_total: "$0.00"
-                    discount_total: '0.0'
-                    display_discount_total: "$0.00"
-                    pre_tax_amount: '10.0'
-                    display_pre_tax_amount: "$10.00"
-                    discounted_amount: '10.0'
-                    display_discounted_amount: "$10.00"
-                    display_compare_at_amount: "$0.00"
-                    compare_at_amount:
-                    thumbnail_url:
-                    option_values: []
-                    digital_links: []
-                  fulfillments:
-                  - id: ful_UkLWZg9DAJ
-                    number: H70742962050
-                    tracking: U10000
-                    tracking_url:
-                    cost: '100.0'
-                    display_cost: "$100.00"
-                    total: '100.0'
-                    display_total: "$100.00"
-                    discount_total: '0.0'
-                    display_discount_total: "$0.00"
-                    additional_tax_total: '0.0'
-                    display_additional_tax_total: "$0.00"
-                    included_tax_total: '0.0'
-                    display_included_tax_total: "$0.00"
-                    tax_total: '0.0'
-                    display_tax_total: "$0.00"
-                    status: pending
-                    fulfillment_type: shipping
-                    fulfilled_at:
-                    items:
-                    - item_id: li_UkLWZg9DAJ
-                      variant_id: variant_UkLWZg9DAJ
-                      quantity: 1
-                    delivery_method:
-                      id: dm_UkLWZg9DAJ
-                      name: UPS Ground
-                      code: UPS_GROUND
-                    stock_location:
-                      id: sloc_UkLWZg9DAJ
-                      state_abbr: NY
-                      name: Britany Halvorson
-                      address1: 1600 Pennsylvania Ave NW
-                      city: Washington
-                      zipcode: '20500'
-                      country_iso: US
-                      country_name: United States of America
-                      state_text: NY
-                    delivery_rates:
-                    - id: dr_gbHJdmfrXB
-                      delivery_method_id: dm_UkLWZg9DAJ
-                      name: UPS Ground
-                      selected: true
-                      cost: '10.0'
-                      total: '10.0'
-                      additional_tax_total: '0.0'
-                      included_tax_total: '0.0'
-                      tax_total: '0.0'
-                      display_cost: "$10.00"
-                      display_total: "$10.00"
-                      display_additional_tax_total: "$0.00"
-                      display_included_tax_total: "$0.00"
-                      display_tax_total: "$0.00"
-                      delivery_method:
-                        id: dm_UkLWZg9DAJ
-                        name: UPS Ground
-                        code: UPS_GROUND
-                  payments: []
-                  billing_address:
-                    id: addr_EfhxLZ9ck8
-                    first_name: John
-                    last_name: Doe
-                    full_name: John Doe
-                    address1: 147 Lovely Street
-                    address2: Northwest
-                    postal_code: '10118'
-                    city: New York
-                    phone: 555-555-0199
-                    company: Company
-                    country_name: United States of America
-                    country_iso: US
-                    state_text: NY
-                    state_abbr: NY
-                    quick_checkout: false
-                    is_default_billing: false
-                    is_default_shipping: false
-                    state_name: New York
-                  shipping_address:
-                    id: addr_VqXmZF31wY
-                    first_name: John
-                    last_name: Doe
-                    full_name: John Doe
-                    address1: 148 Lovely Street
-                    address2: Northwest
-                    postal_code: '10118'
-                    city: New York
-                    phone: 555-555-0199
-                    company: Company
-                    country_name: United States of America
-                    country_iso: US
-                    state_text: NY
-                    state_abbr: NY
-                    quick_checkout: false
-                    is_default_billing: false
-                    is_default_shipping: false
-                    state_name: New York
-                  gift_card:
-                  market:
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Order"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-                required:
-                - data
-                - meta
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/orders/{id}":
-    get:
-      summary: Get an order
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns a single completed order for the authenticated customer.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const order = await client.customer.orders.get('or_abc123', {}, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Order prefixed ID
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (items, fulfillments,
-          payments, discounts, billing_address, shipping_address, gift_card). Use
-          "none" to skip associations.
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., total,amount_due,item_count).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: order found
-          content:
-            application/json:
-              example:
-                id: or_UkLWZg9DAJ
-                market_id:
-                channel_id: ch_UkLWZg9DAJ
-                number: R695830260
-                email: jerica.wehner@wintheiser.biz
-                customer_note:
-                currency: USD
-                locale: en
-                total_quantity: 1
-                item_total: '10.0'
-                display_item_total: "$10.00"
-                adjustment_total: '0.0'
-                display_adjustment_total: "$0.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                total: '110.0'
-                display_total: "$110.00"
-                gift_card_total: '0.0'
-                display_gift_card_total: "$0.00"
-                amount_due: '110.0'
-                display_amount_due: "$110.00"
-                delivery_total: '100.0'
-                display_delivery_total: "$100.00"
-                fulfillment_status:
-                payment_status:
-                completed_at: '2026-05-26T16:13:49.771Z'
-                store_credit_total: '0.0'
-                display_store_credit_total: "$0.00"
-                covered_by_store_credit: false
-                discounts: []
-                items:
-                - id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                  currency: USD
-                  name: Product 1033099
-                  slug: product-1033099
-                  options_text: ''
-                  price: '10.0'
-                  display_price: "$10.00"
-                  total: '10.0'
-                  display_total: "$10.00"
-                  adjustment_total: '0.0'
-                  display_adjustment_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  pre_tax_amount: '10.0'
-                  display_pre_tax_amount: "$10.00"
-                  discounted_amount: '10.0'
-                  display_discounted_amount: "$10.00"
-                  display_compare_at_amount: "$0.00"
-                  compare_at_amount:
-                  thumbnail_url:
-                  option_values: []
-                  digital_links: []
-                fulfillments:
-                - id: ful_UkLWZg9DAJ
-                  number: H08221240082
-                  tracking: U10000
-                  tracking_url:
-                  cost: '100.0'
-                  display_cost: "$100.00"
-                  total: '100.0'
-                  display_total: "$100.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  tax_total: '0.0'
-                  display_tax_total: "$0.00"
-                  status: pending
-                  fulfillment_type: shipping
-                  fulfilled_at:
-                  items:
-                  - item_id: li_UkLWZg9DAJ
-                    variant_id: variant_UkLWZg9DAJ
-                    quantity: 1
-                  delivery_method:
-                    id: dm_UkLWZg9DAJ
-                    name: UPS Ground
-                    code: UPS_GROUND
-                  stock_location:
-                    id: sloc_UkLWZg9DAJ
-                    state_abbr: NY
-                    name: Aleen Reynolds
-                    address1: 1600 Pennsylvania Ave NW
-                    city: Washington
-                    zipcode: '20500'
-                    country_iso: US
-                    country_name: United States of America
-                    state_text: NY
-                  delivery_rates:
-                  - id: dr_gbHJdmfrXB
-                    delivery_method_id: dm_UkLWZg9DAJ
-                    name: UPS Ground
-                    selected: true
-                    cost: '10.0'
-                    total: '10.0'
-                    additional_tax_total: '0.0'
-                    included_tax_total: '0.0'
-                    tax_total: '0.0'
-                    display_cost: "$10.00"
-                    display_total: "$10.00"
-                    display_additional_tax_total: "$0.00"
-                    display_included_tax_total: "$0.00"
-                    display_tax_total: "$0.00"
-                    delivery_method:
-                      id: dm_UkLWZg9DAJ
-                      name: UPS Ground
-                      code: UPS_GROUND
-                payments: []
-                billing_address:
-                  id: addr_EfhxLZ9ck8
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 153 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: false
-                  state_name: New York
-                shipping_address:
-                  id: addr_VqXmZF31wY
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 154 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: false
-                  state_name: New York
-                gift_card:
-                market:
-              schema:
-                "$ref": "#/components/schemas/Order"
-        '404':
-          description: order belongs to another user
-          content:
-            application/json:
-              example:
-                error:
-                  code: order_not_found
-                  message: Order not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers":
-    post:
-      summary: Register a new customer
-      tags:
-      - Customers
-      security:
-      - api_key: []
-      description: Creates a new customer account and returns a JWT token
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const auth = await client.customers.create({
-            email: 'newuser@example.com',
-            password: 'password123',
-            password_confirmation: 'password123',
-            first_name: 'John',
-            last_name: 'Doe',
-            phone: '+1234567890',
-            accepts_email_marketing: true,
-            metadata: { source: 'storefront' },
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: registration successful
-          content:
-            application/json:
-              example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjlmZGNlNTdjLTY2NGQtNGZkNy1hOTU2LWQ1MjEzZjdhMjljYSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjMwfQ.vLRThKiR034rnZQYwpQGrIOeQSdrYNKnFVJZ86pCuUo
-                refresh_token: GVssZP2L5Zk7uKQzTmwSQ4i5
-                user:
-                  id: cus_UkLWZg9DAJ
-                  email: newuser@example.com
-                  first_name: John
-                  last_name: Doe
-                  phone: "+1234567890"
-                  accepts_email_marketing: true
-                  full_name: John Doe
-                  available_store_credit_total: '0'
-                  display_available_store_credit_total: "$0.00"
-                  addresses: []
-                  default_billing_address:
-                  default_shipping_address:
-              schema:
-                "$ref": "#/components/schemas/AuthResponse"
-        '422':
-          description: email already taken
-          content:
-            application/json:
-              example:
-                error:
-                  code: validation_error
-                  message: Email has already been taken
-                  details:
-                    email:
-                    - has already been taken
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  example: newuser@example.com
-                password:
-                  type: string
-                  minLength: 6
-                  example: password123
-                password_confirmation:
-                  type: string
-                  example: password123
-                first_name:
-                  type: string
-                  example: John
-                last_name:
-                  type: string
-                  example: Doe
-                phone:
-                  type: string
-                  example: "+1234567890"
-                accepts_email_marketing:
-                  type: boolean
-                  example: true
-                metadata:
-                  type: object
-                  example:
-                    source: storefront
-              required:
-              - email
-              - password
-  "/api/v3/store/customers/me":
-    get:
-      summary: Get current customer profile
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns the profile of the currently authenticated customer
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const customer = await client.customer.get({
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer JWT token
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: profile found
-          content:
-            application/json:
-              example:
-                id: cus_UkLWZg9DAJ
-                email: jama.wolff@lynch.biz
-                first_name: Catarina
-                last_name: Padberg
-                phone: 555-555-0199
-                accepts_email_marketing: false
-                full_name: Catarina Padberg
-                available_store_credit_total: '0'
-                display_available_store_credit_total: "$0.00"
-                addresses:
-                - id: addr_gbHJdmfrXB
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 160 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: true
-                  is_default_shipping: false
-                  state_name: New York
-                - id: addr_UkLWZg9DAJ
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 159 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: true
-                  state_name: New York
-                default_billing_address:
-                  id: addr_gbHJdmfrXB
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 160 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: true
-                  is_default_shipping: false
-                  state_name: New York
-                default_shipping_address:
-                  id: addr_UkLWZg9DAJ
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 159 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: true
-                  state_name: New York
-              schema:
-                "$ref": "#/components/schemas/Customer"
-        '401':
-          description: unauthorized - invalid token
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-    patch:
-      summary: Update current customer profile
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Updates the profile of the currently authenticated customer
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const customer = await client.customer.update({
-            first_name: 'John',
-            last_name: 'Doe',
-            metadata: { preferred_contact: 'email' },
-          }, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: profile updated
-          content:
-            application/json:
-              example:
-                id: cus_UkLWZg9DAJ
-                email: kiera@treutel.com
-                first_name: Updated
-                last_name: Name
-                phone: 555-555-0199
-                accepts_email_marketing: false
-                full_name: Updated Name
-                available_store_credit_total: '0'
-                display_available_store_credit_total: "$0.00"
-                addresses:
-                - id: addr_gbHJdmfrXB
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 162 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: true
-                  is_default_shipping: false
-                  state_name: New York
-                - id: addr_UkLWZg9DAJ
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 161 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: true
-                  state_name: New York
-                default_billing_address:
-                  id: addr_gbHJdmfrXB
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 162 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: true
-                  is_default_shipping: false
-                  state_name: New York
-                default_shipping_address:
-                  id: addr_UkLWZg9DAJ
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 161 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: true
-                  state_name: New York
-              schema:
-                "$ref": "#/components/schemas/Customer"
-        '422':
-          description: validation error
-          content:
-            application/json:
-              example:
-                error:
-                  code: validation_error
-                  message: Email can't be blank
-                  details:
-                    email:
-                    - can't be blank
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                first_name:
-                  type: string
-                  example: John
-                last_name:
-                  type: string
-                  example: Doe
-                email:
-                  type: string
-                  format: email
-                  example: customer@example.com
-                password:
-                  type: string
-                  example: newpassword123
-                password_confirmation:
-                  type: string
-                  example: newpassword123
-                accepts_email_marketing:
-                  type: boolean
-                  example: true
-                phone:
-                  type: string
-                  example: "+1 555 123 4567"
-                metadata:
-                  type: object
-                  example:
-                    preferred_contact: email
-  "/api/v3/store/digitals/{token}":
-    get:
-      summary: Download a digital product
-      tags:
-      - Digitals
-      description: |
-        Downloads a digital product file using the digital link token.
-        The token is provided via the `download_url` field on digital links
-        returned with order line items. No API key or authentication required —
-        the token itself grants access.
-        Each download increments the access counter. Downloads may be limited by
-        store settings (number of downloads and/or time-based expiration).
-      parameters:
-      - name: token
-        in: path
-        required: true
-        description: Digital link token
-        schema:
-          type: string
-      responses:
-        '200':
-          description: file downloaded
-          content:
-            application/json: {}
-        '403':
-          description: download link expired or limit exceeded
-          content:
-            application/json:
-              example:
-                error:
-                  code: digital_link_expired
-                  message: Download link expired or invalid
-            application/octet-stream:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '404':
-          description: digital link not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Digital link not found
-            application/octet-stream:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/carts/{cart_id}/discount_codes":
     post:
       summary: Apply discount code
@@ -5568,187 +4065,6 @@ paths:
                 market:
               schema:
                 "$ref": "#/components/schemas/Cart"
-  "/api/v3/store/customers/me/gift_cards":
-    get:
-      summary: List gift cards
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns all gift cards for the authenticated customer
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const giftCards = await client.customer.giftCards.list({}, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: gift cards found
-          content:
-            application/json:
-              example:
-                data:
-                - id: gc_UkLWZg9DAJ
-                  code: 91F1E57C6C99A62C
-                  status: active
-                  currency: USD
-                  amount: '10.0'
-                  amount_used: '0.0'
-                  amount_authorized: '0.0'
-                  amount_remaining: '10.0'
-                  display_amount: "$10.00"
-                  display_amount_used: "$0.00"
-                  display_amount_remaining: "$10.00"
-                  expires_at:
-                  redeemed_at:
-                  expired: false
-                  active: true
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/GiftCard"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/gift_cards/{id}":
-    get:
-      summary: Get a gift card
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns a gift card by its ID
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const giftCard = await client.customer.giftCards.get('gc_abc123', {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: gift card found
-          content:
-            application/json:
-              example:
-                id: gc_UkLWZg9DAJ
-                code: 76D77B6CFFA255C8
-                status: active
-                currency: USD
-                amount: '10.0'
-                amount_used: '0.0'
-                amount_authorized: '0.0'
-                amount_remaining: '10.0'
-                display_amount: "$10.00"
-                display_amount_used: "$0.00"
-                display_amount_remaining: "$10.00"
-                expires_at:
-                redeemed_at:
-                expired: false
-                active: true
-              schema:
-                "$ref": "#/components/schemas/GiftCard"
-        '404':
-          description: gift card not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Gift card not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/carts/{cart_id}/items":
     post:
       summary: Add item to cart
@@ -6290,892 +4606,6 @@ paths:
                   message: Line item not found
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/locales":
-    get:
-      summary: List supported locales
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns locales supported by the store (derived from markets)
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const locales = await client.locales.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: locales found
-          content:
-            application/json:
-              example:
-                data:
-                - code: de
-                  name: de
-                - code: en
-                  name: English (US)
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Locale"
-                required:
-                - data
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/markets":
-    get:
-      summary: List markets
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns all markets for the current store with their countries,
-        currency, locales, and tax configuration.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const markets = await client.markets.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: markets found
-          content:
-            application/json:
-              example:
-                data:
-                - id: mkt_UkLWZg9DAJ
-                  name: North America
-                  currency: USD
-                  default_locale: en
-                  tax_inclusive: false
-                  default: true
-                  country_isos:
-                  - US
-                  supported_locales:
-                  - en
-                  - es
-                  countries:
-                  - iso: US
-                    iso3: USA
-                    name: United States of America
-                    states_required: true
-                    zipcode_required: true
-                - id: mkt_gbHJdmfrXB
-                  name: Europe
-                  currency: EUR
-                  default_locale: de
-                  tax_inclusive: true
-                  default: false
-                  country_isos:
-                  - DE
-                  - FR
-                  supported_locales:
-                  - de
-                  - en
-                  - fr
-                  countries:
-                  - iso: DE
-                    iso3: IS66
-                    name: Germany
-                    states_required: false
-                    zipcode_required: true
-                  - iso: FR
-                    iso3: IS67
-                    name: France
-                    states_required: false
-                    zipcode_required: true
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                required:
-                - data
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/markets/{id}":
-    get:
-      summary: Get a market
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns a single market by prefixed ID with its countries, currency,
-        locales, and tax configuration.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const market = await client.markets.get('mkt_xxx')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Market prefixed ID (e.g., "mkt_k5nR8xLq")
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: market found
-          content:
-            application/json:
-              example:
-                id: mkt_gbHJdmfrXB
-                name: Europe
-                currency: EUR
-                default_locale: de
-                tax_inclusive: true
-                default: false
-                country_isos:
-                - DE
-                - FR
-                supported_locales:
-                - de
-                - en
-                - fr
-                countries:
-                - iso: DE
-                  iso3: IS70
-                  name: Germany
-                  states_required: false
-                  zipcode_required: true
-                - iso: FR
-                  iso3: IS71
-                  name: France
-                  states_required: false
-                  zipcode_required: true
-              schema:
-                type: object
-        '404':
-          description: market not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Market not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/markets/resolve":
-    get:
-      summary: Resolve market by country
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Determine which market applies for a given country ISO code. Useful
-        for auto-selecting the correct currency and locale when a customer's location
-        is known.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const market = await client.markets.resolve('DE')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: country
-        in: query
-        required: true
-        description: Country ISO 3166-1 alpha-2 code (e.g., "DE", "US")
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: market resolved
-          content:
-            application/json:
-              example:
-                id: mkt_gbHJdmfrXB
-                name: Europe
-                currency: EUR
-                default_locale: de
-                tax_inclusive: true
-                default: false
-                country_isos:
-                - DE
-                - FR
-                supported_locales:
-                - de
-                - en
-                - fr
-                countries:
-                - iso: DE
-                  iso3: IS74
-                  name: Germany
-                  states_required: false
-                  zipcode_required: true
-                - iso: FR
-                  iso3: IS75
-                  name: France
-                  states_required: false
-                  zipcode_required: true
-              schema:
-                type: object
-        '404':
-          description: no market for country
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Country not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/markets/{market_id}/countries":
-    get:
-      summary: List countries in a market
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns countries belonging to a specific market. Use this for
-        address form country dropdowns during checkout.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const countries = await client.markets.countries.list('mkt_xxx')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: market_id
-        in: path
-        required: true
-        description: Market prefixed ID
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: countries found
-          content:
-            application/json:
-              example:
-                data:
-                - iso: FR
-                  iso3: IS79
-                  name: France
-                  states_required: false
-                  zipcode_required: true
-                - iso: DE
-                  iso3: IS78
-                  name: Germany
-                  states_required: false
-                  zipcode_required: true
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                required:
-                - data
-  "/api/v3/store/markets/{market_id}/countries/{id}":
-    get:
-      summary: Get a country in a market
-      tags:
-      - Markets
-      security:
-      - api_key: []
-      description: Returns a single country by ISO code within a market. Supports
-        ?expand=states for address forms.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const country = await client.markets.countries.get('mkt_xxx', 'DE')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: market_id
-        in: path
-        required: true
-        description: Market prefixed ID
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Country ISO 3166-1 alpha-2 code (e.g., "DE")
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: country found
-          content:
-            application/json:
-              example:
-                iso: US
-                iso3: USA
-                name: United States of America
-                states_required: true
-                zipcode_required: true
-              schema:
-                type: object
-        '404':
-          description: country not in market
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Country not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/newsletter_subscribers":
-    post:
-      summary: Subscribe to the newsletter
-      tags:
-      - Newsletter Subscribers
-      security:
-      - api_key: []
-      description: |
-        Subscribes an email address to the newsletter for the current store.
-
-        Behavior:
-
-        - If the email is already verified for this store, the existing subscription is returned unchanged.
-        - If the request is unauthenticated (guest), the subscription is created in an unverified state
-          and two events are published: `newsletter_subscriber.subscription_requested` (carrying the
-          `verification_token` and the validated `redirect_url`, intended for headless storefronts that
-          want to send the confirmation email themselves via a webhook handler) and the legacy
-          `newsletter_subscriber.subscribed` lifecycle event (which the bundled `spree_emails` package
-          listens to and uses to send a default confirmation email). The confirmation link should point
-          at `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
-          when the user clicks it.
-        - If the request is authenticated via JWT and the customer's email matches the subscribed email,
-          the subscription is auto-verified and no events are fired — the JWT already proves email
-          ownership, so no confirmation email is needed.
-
-        The optional `redirect_url` is where the verification token should land on the storefront. The
-        server does not return a validation error when the URL is outside the store's
-        [Allowed Origins](/developer/core-concepts/allowed-origins); instead, the URL is silently
-        omitted from the webhook payload (secure-by-default). When no allow-list is configured on the
-        store, the URL is also omitted. Callers therefore receive the same 201 regardless, and the
-        webhook handler should fall back to the store's storefront URL when `redirect_url` is missing
-        from the payload.
-
-        Newsletter consent is preserved across registration: if a guest subscribes and later registers
-        with the same email, the existing subscriber record is reused.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const subscriber = await client.newsletterSubscribers.create({
-            email: 'subscriber@example.com',
-            redirect_url: 'https://your-store.com/newsletter/confirm',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: false
-        description: Optional Bearer JWT — when present, links the subscription to
-          that customer
-        schema:
-          type: string
-      responses:
-        '201':
-          description: auto-verified when JWT matches subscribed email
-          content:
-            application/json:
-              example:
-                id: sub_UkLWZg9DAJ
-                email: harriet.conroy@mohr.co.uk
-                created_at: '2026-05-26T16:14:11.183Z'
-                updated_at: '2026-05-26T16:14:11.186Z'
-                verified: true
-                verified_at: '2026-05-26T16:14:11Z'
-                customer_id: cus_UkLWZg9DAJ
-              schema:
-                "$ref": "#/components/schemas/NewsletterSubscriber"
-        '422':
-          description: invalid email format
-          content:
-            application/json:
-              example:
-                error:
-                  code: validation_error
-                  message: Email is invalid
-                  details:
-                    email:
-                    - is invalid
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                email:
-                  type: string
-                  format: email
-                  example: subscriber@example.com
-                redirect_url:
-                  type: string
-                  format: uri
-                  example: https://your-store.com/newsletter/confirm
-                  description: Storefront URL the verification token should be appended
-                    to. Silently omitted from the webhook payload when the store has
-                    allowed origins configured and this URL does not match one of
-                    them, or when no allowed origins are configured at all.
-              required:
-              - email
-  "/api/v3/store/newsletter_subscribers/verify":
-    post:
-      summary: Verify a newsletter subscription
-      tags:
-      - Newsletter Subscribers
-      security:
-      - api_key: []
-      description: |
-        Confirms a pending newsletter subscription using the verification token sent by email.
-
-        After successful verification:
-        - The subscriber record is marked verified.
-        - If the subscription is associated with a customer, that customer's `accepts_email_marketing`
-          flag is set to `true`.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const subscriber = await client.newsletterSubscribers.verify({
-            token: 'abc123def456',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: subscription verified
-          content:
-            application/json:
-              example:
-                id: sub_UkLWZg9DAJ
-                email: pending@example.com
-                created_at: '2026-05-26T16:14:11.236Z'
-                updated_at: '2026-05-26T16:14:11.255Z'
-                verified: true
-                verified_at: '2026-05-26T16:14:11Z'
-                customer_id:
-              schema:
-                "$ref": "#/components/schemas/NewsletterSubscriber"
-        '422':
-          description: missing token
-          content:
-            application/json:
-              example:
-                error:
-                  code: parameter_missing
-                  message: token is required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                token:
-                  type: string
-                  example: abc123def456
-                  description: Verification token from the confirmation email
-              required:
-              - token
-  "/api/v3/store/orders/{id}":
-    get:
-      summary: Get an order
-      tags:
-      - Orders
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns a single completed order by prefixed ID. Accessible via
-        JWT (authenticated users) or order token header (guests).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const order = await client.orders.get('or_abc123', {}, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: false
-        description: Bearer token for authenticated customers
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Order prefixed ID
-        schema:
-          type: string
-      - name: x-spree-token
-        in: header
-        required: false
-        description: Order token for guest access
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (items, fulfillments,
-          payments, discounts, billing_address, shipping_address, gift_card). Use
-          "none" to skip associations.
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., total,amount_due,item_count).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: order found (guest via order token)
-          content:
-            application/json:
-              example:
-                id: or_UkLWZg9DAJ
-                market_id:
-                channel_id: ch_UkLWZg9DAJ
-                number: R528526445
-                email: guest@example.com
-                customer_note:
-                currency: USD
-                locale: en
-                total_quantity: 1
-                item_total: '10.0'
-                display_item_total: "$10.00"
-                adjustment_total: '0.0'
-                display_adjustment_total: "$0.00"
-                discount_total: '0.0'
-                display_discount_total: "$0.00"
-                tax_total: '0.0'
-                display_tax_total: "$0.00"
-                included_tax_total: '0.0'
-                display_included_tax_total: "$0.00"
-                additional_tax_total: '0.0'
-                display_additional_tax_total: "$0.00"
-                total: '110.0'
-                display_total: "$110.00"
-                gift_card_total: '0.0'
-                display_gift_card_total: "$0.00"
-                amount_due: '110.0'
-                display_amount_due: "$110.00"
-                delivery_total: '100.0'
-                display_delivery_total: "$100.00"
-                fulfillment_status:
-                payment_status:
-                completed_at: '2026-05-26T16:14:12.058Z'
-                store_credit_total: '0.0'
-                display_store_credit_total: "$0.00"
-                covered_by_store_credit: false
-                discounts: []
-                items:
-                - id: li_UkLWZg9DAJ
-                  variant_id: variant_UkLWZg9DAJ
-                  quantity: 1
-                  currency: USD
-                  name: Product 1325879
-                  slug: product-1325879
-                  options_text: ''
-                  price: '10.0'
-                  display_price: "$10.00"
-                  total: '10.0'
-                  display_total: "$10.00"
-                  adjustment_total: '0.0'
-                  display_adjustment_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  pre_tax_amount: '10.0'
-                  display_pre_tax_amount: "$10.00"
-                  discounted_amount: '10.0'
-                  display_discounted_amount: "$10.00"
-                  display_compare_at_amount: "$0.00"
-                  compare_at_amount:
-                  thumbnail_url:
-                  option_values: []
-                  digital_links: []
-                fulfillments:
-                - id: ful_UkLWZg9DAJ
-                  number: H26728427796
-                  tracking: U10000
-                  tracking_url:
-                  cost: '100.0'
-                  display_cost: "$100.00"
-                  total: '100.0'
-                  display_total: "$100.00"
-                  discount_total: '0.0'
-                  display_discount_total: "$0.00"
-                  additional_tax_total: '0.0'
-                  display_additional_tax_total: "$0.00"
-                  included_tax_total: '0.0'
-                  display_included_tax_total: "$0.00"
-                  tax_total: '0.0'
-                  display_tax_total: "$0.00"
-                  status: pending
-                  fulfillment_type: shipping
-                  fulfilled_at:
-                  items:
-                  - item_id: li_UkLWZg9DAJ
-                    variant_id: variant_UkLWZg9DAJ
-                    quantity: 1
-                  delivery_method:
-                    id: dm_UkLWZg9DAJ
-                    name: UPS Ground
-                    code: UPS_GROUND
-                  stock_location:
-                    id: sloc_UkLWZg9DAJ
-                    state_abbr: NY
-                    name: Maida Rogahn
-                    address1: 1600 Pennsylvania Ave NW
-                    city: Washington
-                    zipcode: '20500'
-                    country_iso: US
-                    country_name: United States of America
-                    state_text: NY
-                  delivery_rates:
-                  - id: dr_gbHJdmfrXB
-                    delivery_method_id: dm_UkLWZg9DAJ
-                    name: UPS Ground
-                    selected: true
-                    cost: '10.0'
-                    total: '10.0'
-                    additional_tax_total: '0.0'
-                    included_tax_total: '0.0'
-                    tax_total: '0.0'
-                    display_cost: "$10.00"
-                    display_total: "$10.00"
-                    display_additional_tax_total: "$0.00"
-                    display_included_tax_total: "$0.00"
-                    display_tax_total: "$0.00"
-                    delivery_method:
-                      id: dm_UkLWZg9DAJ
-                      name: UPS Ground
-                      code: UPS_GROUND
-                payments: []
-                billing_address:
-                  id: addr_UkLWZg9DAJ
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 256 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: false
-                  state_name: New York
-                shipping_address:
-                  id: addr_gbHJdmfrXB
-                  first_name: John
-                  last_name: Doe
-                  full_name: John Doe
-                  address1: 257 Lovely Street
-                  address2: Northwest
-                  postal_code: '10118'
-                  city: New York
-                  phone: 555-555-0199
-                  company: Company
-                  country_name: United States of America
-                  country_iso: US
-                  state_text: NY
-                  state_abbr: NY
-                  quick_checkout: false
-                  is_default_billing: false
-                  is_default_shipping: false
-                  state_name: New York
-                gift_card:
-                market:
-              schema:
-                "$ref": "#/components/schemas/Order"
-        '404':
-          description: incomplete order not accessible
-          content:
-            application/json:
-              example:
-                error:
-                  code: order_not_found
-                  message: Order not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/carts/{cart_id}/payment_sessions":
     post:
       summary: Create payment session
@@ -7545,265 +4975,6 @@ paths:
                 external_data:
                   type: object
                   description: Provider-specific completion data
-  "/api/v3/store/customers/me/payment_setup_sessions":
-    post:
-      summary: Create payment setup session
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Creates a new payment setup session for saving a payment method
-        for future use. Delegates to the payment gateway to initialize a provider-specific
-        setup flow (e.g. Stripe SetupIntent, Adyen zero-auth tokenization).
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const session = await client.customer.paymentSetupSessions.create({
-            payment_method_id: 'pm_abc123',
-          }, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: payment setup session created
-          content:
-            application/json:
-              example:
-                id: pss_gbHJdmfrXB
-                status: pending
-                external_id: bogus_seti_e60689fe4c66251e2b4dd2f4
-                external_client_secret: bogus_seti_secret_633045dc9ddab700
-                external_data: {}
-                payment_method_id: pm_UkLWZg9DAJ
-                payment_source_id:
-                payment_source_type:
-                customer_id: cus_UkLWZg9DAJ
-                payment_method:
-                  id: pm_UkLWZg9DAJ
-                  name: Credit Card
-                  description:
-                  type: bogus
-                  session_required: true
-                  source_required: true
-              schema:
-                "$ref": "#/components/schemas/PaymentSetupSession"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '404':
-          description: payment method not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Payment method not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                payment_method_id:
-                  type: string
-                  example: pm_abc123
-                  description: Payment method ID
-                external_data:
-                  type: object
-                  description: Provider-specific data passed to the gateway
-              required:
-              - payment_method_id
-  "/api/v3/store/customers/me/payment_setup_sessions/{id}":
-    parameters:
-    - name: x-spree-api-key
-      in: header
-      required: true
-      schema:
-        type: string
-    - name: Authorization
-      in: header
-      required: true
-      schema:
-        type: string
-    - name: id
-      in: path
-      required: true
-      description: Payment setup session ID
-      schema:
-        type: string
-    get:
-      summary: Get payment setup session
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns a payment setup session with its current status and provider
-        data.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const session = await client.customer.paymentSetupSessions.get('pss_abc123', {
-            token: '<token>',
-          })
-      responses:
-        '200':
-          description: payment setup session found
-          content:
-            application/json:
-              example:
-                id: pss_UkLWZg9DAJ
-                status: pending
-                external_id: seti_test_7ac50408dcea6ac09aa04e3d
-                external_client_secret: seti_secret_77e80c695165694be5ef56b9
-                external_data:
-                  client_secret: secret_123
-                payment_method_id: pm_UkLWZg9DAJ
-                payment_source_id:
-                payment_source_type:
-                customer_id: cus_UkLWZg9DAJ
-                payment_method:
-                  id: pm_UkLWZg9DAJ
-                  name: Credit Card
-                  description:
-                  type: bogus
-                  session_required: true
-                  source_required: true
-              schema:
-                "$ref": "#/components/schemas/PaymentSetupSession"
-        '404':
-          description: payment setup session not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Payment setup session not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/payment_setup_sessions/{id}/complete":
-    parameters:
-    - name: x-spree-api-key
-      in: header
-      required: true
-      schema:
-        type: string
-    - name: Authorization
-      in: header
-      required: true
-      schema:
-        type: string
-    - name: id
-      in: path
-      required: true
-      description: Payment setup session ID
-      schema:
-        type: string
-    patch:
-      summary: Complete payment setup session
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Completes a payment setup session by confirming the setup with
-        the provider, resulting in a saved payment method.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const session = await client.customer.paymentSetupSessions.complete('pss_abc123', {}, {
-            token: '<token>',
-          })
-      parameters: []
-      responses:
-        '200':
-          description: payment setup session completed
-          content:
-            application/json:
-              example:
-                id: pss_UkLWZg9DAJ
-                status: completed
-                external_id: seti_test_6cb96d4ae6cdc1eadf02b1dc
-                external_client_secret: seti_secret_bb0a7727be4c699d8584292f
-                external_data:
-                  client_secret: secret_123
-                payment_method_id: pm_UkLWZg9DAJ
-                payment_source_id: card_UkLWZg9DAJ
-                payment_source_type: Spree::CreditCard
-                customer_id: cus_UkLWZg9DAJ
-                payment_method:
-                  id: pm_UkLWZg9DAJ
-                  name: Credit Card
-                  description:
-                  type: bogus
-                  session_required: true
-                  source_required: true
-              schema:
-                "$ref": "#/components/schemas/PaymentSetupSession"
-        '404':
-          description: payment setup session not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Payment setup session not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                external_data:
-                  type: object
-                  description: Provider-specific completion data
   "/api/v3/store/carts/{cart_id}/payments":
     post:
       summary: Create payment
@@ -7910,814 +5081,6 @@ paths:
                   description: Arbitrary metadata to attach to the payment
               required:
               - payment_method_id
-  "/api/v3/store/policies":
-    get:
-      summary: List store policies
-      tags:
-      - Policies
-      security:
-      - api_key: []
-      description: |
-        Returns all policies for the current store (e.g., return policy, privacy policy, terms of service).
-        Policies are managed in Spree Admin and contain rich text content.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const policies = await client.policies.list()
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: policies listed
-          content:
-            application/json:
-              example:
-                data:
-                - id: pol_gbHJdmfrXB
-                  name: Privacy Policy
-                  slug: privacy-policy
-                  body: ''
-                  body_html: ''
-                - id: pol_OIJLhNcSbf
-                  name: Privacy Policy
-                  slug: privacy-policy-006f63da-6062-4a3f-9fd7-aa690f7b356c
-                  body: We respect your privacy.
-                  body_html: |
-                    <div class="trix-content">
-                      We respect your privacy.
-                    </div>
-                - id: pol_uw2YK1rnl0
-                  name: Return Policy
-                  slug: return-policy
-                  body: You can return items within 30 days.
-                  body_html: |
-                    <div class="trix-content">
-                      You can return items within 30 days.
-                    </div>
-                - id: pol_EfhxLZ9ck8
-                  name: Returns Policy
-                  slug: returns-policy
-                  body: ''
-                  body_html: ''
-                - id: pol_VqXmZF31wY
-                  name: Shipping Policy
-                  slug: shipping-policy
-                  body: ''
-                  body_html: ''
-                - id: pol_UkLWZg9DAJ
-                  name: Terms of Service
-                  slug: terms-of-service
-                  body: ''
-                  body_html: ''
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 6
-                  pages: 1
-                  from: 1
-                  to: 6
-                  in: 6
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Policy"
-                required:
-                - data
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/policies/{id}":
-    get:
-      summary: Get a policy
-      tags:
-      - Policies
-      security:
-      - api_key: []
-      description: Returns a single policy by slug or prefixed ID. Includes the full
-        rich text body.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const policy = await client.policies.get('return-policy')
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Policy slug (e.g., return-policy) or prefixed ID (e.g., pol_abc123)
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include. id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: policy found
-          content:
-            application/json:
-              example:
-                id: pol_uw2YK1rnl0
-                name: Return Policy
-                slug: return-policy
-                body: You can return items within 30 days.
-                body_html: |
-                  <div class="trix-content">
-                    You can return items within 30 days.
-                  </div>
-              schema:
-                "$ref": "#/components/schemas/Policy"
-        '404':
-          description: policy not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Policy not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/products":
-    get:
-      summary: List products
-      tags:
-      - Product Catalog
-      security:
-      - api_key: []
-      description: Returns a paginated list of active products for the current store
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const products = await client.products.list({
-            page: 1,
-            limit: 25,
-            sort: 'price',
-            name_cont: 'shirt',
-            price_gte: 20,
-            price_lte: 100,
-            with_option_value_ids: ['optval_abc', 'optval_def'],
-            expand: ['variants', 'media'],
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        description: Publishable API key
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: 'Page number (default: 1)'
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        description: 'Number of items per page (default: 25, max: 100)'
-        schema:
-          type: integer
-      - name: sort
-        in: query
-        required: false
-        description: 'Sort order. Prefix with - for descending. Values: price, -price,
-          best_selling, name, -name, -available_on, available_on'
-        schema:
-          type: string
-      - name: q[name_cont]
-        in: query
-        required: false
-        description: Filter by name containing string
-        schema:
-          type: string
-      - name: q[in_category]
-        in: query
-        required: false
-        description: Filter by category prefixed ID (includes descendants)
-        schema:
-          type: string
-      - name: q[in_categories][]
-        in: query
-        required: false
-        description: Filter by multiple category prefixed IDs (OR logic, includes
-          descendants)
-        schema:
-          type: string
-      - name: q[price_gte]
-        in: query
-        required: false
-        description: Filter by minimum price
-        schema:
-          type: number
-      - name: q[price_lte]
-        in: query
-        required: false
-        description: Filter by maximum price
-        schema:
-          type: number
-      - name: q[with_option_value_ids][]
-        in: query
-        required: false
-        description: Filter by option value prefix IDs (e.g., optval_abc). Pass multiple
-          values for OR logic.
-        schema:
-          type: string
-      - name: q[in_stock]
-        in: query
-        required: false
-        description: Filter to only in-stock products
-        schema:
-          type: boolean
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand (variants, media, categories,
-          option_types)
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: products found
-          content:
-            application/json:
-              example:
-                data:
-                - id: prod_UkLWZg9DAJ
-                  name: Product 1421251
-                  slug: product-1421251
-                  meta_title:
-                  meta_description:
-                  meta_keywords:
-                  variant_count: 1
-                  available_on: '2025-05-26T16:14:22.402Z'
-                  purchasable: true
-                  in_stock: false
-                  backorderable: true
-                  available: true
-                  description: A comfortable cotton t-shirt.
-                  description_html: "<p>A <strong>comfortable</strong> cotton t-shirt.</p>"
-                  default_variant_id: variant_gbHJdmfrXB
-                  thumbnail_url:
-                  tags: []
-                  price:
-                    id: price_gbHJdmfrXB
-                    amount: '19.99'
-                    amount_in_cents: 1999
-                    compare_at_amount:
-                    compare_at_amount_in_cents:
-                    currency: USD
-                    display_amount: "$19.99"
-                    display_compare_at_amount:
-                    price_list_id:
-                  original_price:
-                - id: prod_gbHJdmfrXB
-                  name: Product 1435220
-                  slug: product-1435220
-                  meta_title:
-                  meta_description:
-                  meta_keywords:
-                  variant_count: 0
-                  available_on: '2025-05-26T16:14:22.472Z'
-                  purchasable: true
-                  in_stock: false
-                  backorderable: true
-                  available: true
-                  description: Architecto dignissimos nemo inventore incidunt enim.
-                    Odit accusamus repellat error saepe culpa unde eius. Cupiditate
-                    officiis voluptatem autem perferendis qui vitae omnis sunt. Debitis
-                    dolor tempore ad impedit itaque reprehenderit delectus. Doloremque
-                    laudantium iure recusandae iusto debitis laborum consequuntur.
-                    Impedit eum optio commodi tempora cum quidem. Facere voluptatum
-                    nam possimus veritatis nostrum explicabo dolore ex. Adipisci iure
-                    unde nobis itaque amet nesciunt voluptatibus impedit. Numquam
-                    in accusantium magni itaque exercitationem. Quas vero maxime voluptatem
-                    rem impedit inventore. Esse perferendis asperiores ea expedita
-                    aut tenetur soluta. Enim accusantium dolor adipisci impedit. Error
-                    maxime neque accusamus facere provident eum. Cum officia velit
-                    asperiores quod cupiditate fugiat. Possimus tenetur aut consequuntur
-                    iusto cumque quas. Ab velit ullam qui pariatur veritatis omnis.
-                    Accusantium vero occaecati explicabo neque animi commodi. Necessitatibus
-                    perspiciatis iste culpa totam quibusdam voluptate distinctio.
-                    Quod aliquam ut et autem. Saepe ut asperiores et quisquam perspiciatis
-                    molestiae. Vel recusandae sunt nemo et accusamus veniam ducimus.
-                    Laborum modi quasi perferendis culpa laboriosam quaerat magnam.
-                    Facere at tempora iusto ex magni aliquam modi debitis.
-                  description_html: |-
-                    Architecto dignissimos nemo inventore incidunt enim. Odit accusamus repellat error saepe culpa unde eius. Cupiditate officiis voluptatem autem perferendis qui vitae omnis sunt. Debitis dolor tempore ad impedit itaque reprehenderit delectus. Doloremque laudantium iure recusandae iusto debitis laborum consequuntur.
-                    Impedit eum optio commodi tempora cum quidem. Facere voluptatum nam possimus veritatis nostrum explicabo dolore ex. Adipisci iure unde nobis itaque amet nesciunt voluptatibus impedit. Numquam in accusantium magni itaque exercitationem. Quas vero maxime voluptatem rem impedit inventore.
-                    Esse perferendis asperiores ea expedita aut tenetur soluta. Enim accusantium dolor adipisci impedit. Error maxime neque accusamus facere provident eum. Cum officia velit asperiores quod cupiditate fugiat. Possimus tenetur aut consequuntur iusto cumque quas.
-                    Ab velit ullam qui pariatur veritatis omnis. Accusantium vero occaecati explicabo neque animi commodi. Necessitatibus perspiciatis iste culpa totam quibusdam voluptate distinctio. Quod aliquam ut et autem. Saepe ut asperiores et quisquam perspiciatis molestiae.
-                    Vel recusandae sunt nemo et accusamus veniam ducimus. Laborum modi quasi perferendis culpa laboriosam quaerat magnam. Facere at tempora iusto ex magni aliquam modi debitis.
-                  default_variant_id: variant_EfhxLZ9ck8
-                  thumbnail_url:
-                  tags: []
-                  price:
-                    id: price_EfhxLZ9ck8
-                    amount: '19.99'
-                    amount_in_cents: 1999
-                    compare_at_amount:
-                    compare_at_amount_in_cents:
-                    currency: USD
-                    display_amount: "$19.99"
-                    display_compare_at_amount:
-                    price_list_id:
-                  original_price:
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 2
-                  pages: 1
-                  from: 1
-                  to: 2
-                  in: 2
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/Product"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-                required:
-                - data
-                - meta
-        '401':
-          description: unauthorized - invalid or missing API key
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/products/{id}":
-    get:
-      summary: Get a product
-      tags:
-      - Product Catalog
-      security:
-      - api_key: []
-      description: Returns a single product by slug or prefix ID
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const product = await client.products.get('spree-tote', {
-            expand: ['variants', 'media'],
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        description: Publishable API key
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        description: Product slug (e.g., spree-tote) or prefix ID (e.g., product_abc123)
-        schema:
-          type: string
-      - name: expand
-        in: query
-        required: false
-        description: Comma-separated associations to expand
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., name,slug,price).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: product without prior_price expanded does not include field
-          content:
-            application/json:
-              example:
-                id: prod_UkLWZg9DAJ
-                name: Product 1702106
-                slug: product-1702106
-                meta_title:
-                meta_description:
-                meta_keywords:
-                variant_count: 1
-                available_on: '2025-05-26T16:14:24.749Z'
-                purchasable: true
-                in_stock: false
-                backorderable: true
-                available: true
-                description: A comfortable cotton t-shirt.
-                description_html: "<p>A <strong>comfortable</strong> cotton t-shirt.</p>"
-                default_variant_id: variant_gbHJdmfrXB
-                thumbnail_url:
-                tags: []
-                price:
-                  id: price_gbHJdmfrXB
-                  amount: '19.99'
-                  amount_in_cents: 1999
-                  compare_at_amount:
-                  compare_at_amount_in_cents:
-                  currency: USD
-                  display_amount: "$19.99"
-                  display_compare_at_amount:
-                  price_list_id:
-                original_price:
-                prior_price:
-                  id: _AXs1igzRC6
-                  amount: '9.99'
-                  amount_in_cents: 999
-                  currency: USD
-                  display_amount: "$9.99"
-                  recorded_at: '2026-05-11T16:14:24Z'
-              schema:
-                "$ref": "#/components/schemas/Product"
-        '404':
-          description: draft product not visible
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Product not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/products/filters":
-    get:
-      summary: Get product filters
-      tags:
-      - Product Catalog
-      security:
-      - api_key: []
-      description: |
-        Returns available filters for products with their options and counts.
-        Use this endpoint to build filter UIs for product listing pages.
-
-        The filters are context-aware - when a category_id is provided, only filters
-        relevant to products in that category are returned.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const filters = await client.products.filters({
-            category_id: 'ctg_abc123',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        description: Publishable API key
-        schema:
-          type: string
-      - name: category_id
-        in: query
-        required: false
-        description: Scope filters to products in this category (prefix ID)
-        schema:
-          type: string
-      - name: q[name_cont]
-        in: query
-        required: false
-        description: Filter by name containing string
-        schema:
-          type: string
-      responses:
-        '200':
-          description: filters scoped to category
-          content:
-            application/json:
-              example:
-                filters:
-                - id: price
-                  type: price_range
-                  min: 19.99
-                  max: 19.99
-                  currency: USD
-                - id: availability
-                  type: availability
-                  options:
-                  - id: in_stock
-                    count: 2
-                  - id: out_of_stock
-                    count: 0
-                - id: opt_UkLWZg9DAJ
-                  type: option
-                  name: size
-                  label: Size
-                  kind: dropdown
-                  options:
-                  - id: optval_UkLWZg9DAJ
-                    name: small
-                    label: S
-                    position: 1
-                    color_code:
-                    image_url:
-                    count: 1
-                - id: categories
-                  type: category
-                  options:
-                  - id: ctg_EfhxLZ9ck8
-                    name: Shirts
-                    permalink: taxonomy-27/taxon-34/shirts
-                    count: 2
-                sort_options:
-                - id: manual
-                - id: best_selling
-                - id: price
-                - id: "-price"
-                - id: "-available_on"
-                - id: available_on
-                - id: name
-                - id: "-name"
-                default_sort: manual
-                total_count: 2
-              schema:
-                type: object
-                properties:
-                  filters:
-                    type: array
-                    description: Available filters (price_range, availability, option,
-                      category)
-                    items:
-                      type: object
-                  sort_options:
-                    type: array
-                    description: Available sort options
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                      required:
-                      - id
-                  default_sort:
-                    type: string
-                    description: Default sort option ID
-                  total_count:
-                    type: integer
-                    description: Total products matching current filters
-                required:
-                - filters
-                - sort_options
-                - default_sort
-                - total_count
-        '401':
-          description: unauthorized - invalid or missing API key
-          content:
-            application/json:
-              example:
-                error:
-                  code: invalid_token
-                  message: Valid API key required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/store_credits":
-    get:
-      summary: List store credits
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      description: Returns store credits for the authenticated customer, filtered
-        by current store and currency. Supports Ransack filtering.
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const credits = await client.customer.storeCredits.list({}, {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., amount,currency).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: store credits found
-          content:
-            application/json:
-              example:
-                data:
-                - id: credit_UkLWZg9DAJ
-                  amount: '100.0'
-                  amount_used: '0.0'
-                  amount_remaining: '100.0'
-                  display_amount: "$100.00"
-                  display_amount_used: "$0.00"
-                  display_amount_remaining: "$100.00"
-                  currency: USD
-                meta:
-                  page: 1
-                  limit: 25
-                  count: 1
-                  pages: 1
-                  from: 1
-                  to: 1
-                  in: 1
-                  previous:
-                  next:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/StoreCredit"
-                  meta:
-                    "$ref": "#/components/schemas/PaginationMeta"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              example:
-                error:
-                  code: authentication_required
-                  message: Authentication required
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v3/store/customers/me/store_credits/{id}":
-    get:
-      summary: Get a store credit
-      tags:
-      - Customers
-      security:
-      - api_key: []
-        bearer_auth: []
-      x-codeSamples:
-      - lang: javascript
-        label: Spree SDK
-        source: |-
-          import { createClient } from '@spree/sdk'
-
-          const client = createClient({
-            baseUrl: 'https://your-store.com',
-            publishableKey: '<api-key>',
-          })
-
-          const credit = await client.customer.storeCredits.get('credit_abc123', {
-            token: '<token>',
-          })
-      parameters:
-      - name: x-spree-api-key
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: fields
-        in: query
-        required: false
-        description: Comma-separated list of fields to include (e.g., amount,currency).
-          id is always included.
-        schema:
-          type: string
-      responses:
-        '200':
-          description: store credit found
-          content:
-            application/json:
-              example:
-                id: credit_UkLWZg9DAJ
-                amount: '100.0'
-                amount_used: '0.0'
-                amount_remaining: '100.0'
-                display_amount: "$100.00"
-                display_amount_used: "$0.00"
-                display_amount_remaining: "$100.00"
-                currency: USD
-              schema:
-                "$ref": "#/components/schemas/StoreCredit"
-        '404':
-          description: store credit not found
-          content:
-            application/json:
-              example:
-                error:
-                  code: record_not_found
-                  message: Store credit not found
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/carts/{cart_id}/store_credits":
     post:
       summary: Apply store credit
@@ -9215,6 +5578,3243 @@ paths:
                 market:
               schema:
                 "$ref": "#/components/schemas/Cart"
+  "/api/v3/store/orders/{id}":
+    get:
+      summary: Get an order
+      tags:
+      - Orders
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns a single completed order by prefixed ID. Accessible via
+        JWT (authenticated users) or order token header (guests).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const order = await client.orders.get('or_abc123', {}, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: false
+        description: Bearer token for authenticated customers
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Order prefixed ID
+        schema:
+          type: string
+      - name: x-spree-token
+        in: header
+        required: false
+        description: Order token for guest access
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (items, fulfillments,
+          payments, discounts, billing_address, shipping_address, gift_card). Use
+          "none" to skip associations.
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., total,amount_due,item_count).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: order found (guest via order token)
+          content:
+            application/json:
+              example:
+                id: or_UkLWZg9DAJ
+                market_id:
+                channel_id: ch_UkLWZg9DAJ
+                number: R528526445
+                email: guest@example.com
+                customer_note:
+                currency: USD
+                locale: en
+                total_quantity: 1
+                item_total: '10.0'
+                display_item_total: "$10.00"
+                adjustment_total: '0.0'
+                display_adjustment_total: "$0.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                total: '110.0'
+                display_total: "$110.00"
+                gift_card_total: '0.0'
+                display_gift_card_total: "$0.00"
+                amount_due: '110.0'
+                display_amount_due: "$110.00"
+                delivery_total: '100.0'
+                display_delivery_total: "$100.00"
+                fulfillment_status:
+                payment_status:
+                completed_at: '2026-05-26T16:14:12.058Z'
+                store_credit_total: '0.0'
+                display_store_credit_total: "$0.00"
+                covered_by_store_credit: false
+                discounts: []
+                items:
+                - id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                  currency: USD
+                  name: Product 1325879
+                  slug: product-1325879
+                  options_text: ''
+                  price: '10.0'
+                  display_price: "$10.00"
+                  total: '10.0'
+                  display_total: "$10.00"
+                  adjustment_total: '0.0'
+                  display_adjustment_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  pre_tax_amount: '10.0'
+                  display_pre_tax_amount: "$10.00"
+                  discounted_amount: '10.0'
+                  display_discounted_amount: "$10.00"
+                  display_compare_at_amount: "$0.00"
+                  compare_at_amount:
+                  thumbnail_url:
+                  option_values: []
+                  digital_links: []
+                fulfillments:
+                - id: ful_UkLWZg9DAJ
+                  number: H26728427796
+                  tracking: U10000
+                  tracking_url:
+                  cost: '100.0'
+                  display_cost: "$100.00"
+                  total: '100.0'
+                  display_total: "$100.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  tax_total: '0.0'
+                  display_tax_total: "$0.00"
+                  status: pending
+                  fulfillment_type: shipping
+                  fulfilled_at:
+                  items:
+                  - item_id: li_UkLWZg9DAJ
+                    variant_id: variant_UkLWZg9DAJ
+                    quantity: 1
+                  delivery_method:
+                    id: dm_UkLWZg9DAJ
+                    name: UPS Ground
+                    code: UPS_GROUND
+                  stock_location:
+                    id: sloc_UkLWZg9DAJ
+                    state_abbr: NY
+                    name: Maida Rogahn
+                    address1: 1600 Pennsylvania Ave NW
+                    city: Washington
+                    zipcode: '20500'
+                    country_iso: US
+                    country_name: United States of America
+                    state_text: NY
+                  delivery_rates:
+                  - id: dr_gbHJdmfrXB
+                    delivery_method_id: dm_UkLWZg9DAJ
+                    name: UPS Ground
+                    selected: true
+                    cost: '10.0'
+                    total: '10.0'
+                    additional_tax_total: '0.0'
+                    included_tax_total: '0.0'
+                    tax_total: '0.0'
+                    display_cost: "$10.00"
+                    display_total: "$10.00"
+                    display_additional_tax_total: "$0.00"
+                    display_included_tax_total: "$0.00"
+                    display_tax_total: "$0.00"
+                    delivery_method:
+                      id: dm_UkLWZg9DAJ
+                      name: UPS Ground
+                      code: UPS_GROUND
+                payments: []
+                billing_address:
+                  id: addr_UkLWZg9DAJ
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 256 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: false
+                  state_name: New York
+                shipping_address:
+                  id: addr_gbHJdmfrXB
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 257 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: false
+                  state_name: New York
+                gift_card:
+                market:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '404':
+          description: incomplete order not accessible
+          content:
+            application/json:
+              example:
+                error:
+                  code: order_not_found
+                  message: Order not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/addresses":
+    get:
+      summary: List customer addresses
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns all addresses in the customer address book
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const addresses = await client.customer.addresses.list({}, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: addresses found
+          content:
+            application/json:
+              example:
+                data:
+                - id: addr_EfhxLZ9ck8
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 72 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: false
+                  state_name: New York
+                - id: addr_gbHJdmfrXB
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 71 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: true
+                  is_default_shipping: false
+                  state_name: New York
+                - id: addr_UkLWZg9DAJ
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 70 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: true
+                  state_name: New York
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 3
+                  pages: 1
+                  from: 1
+                  to: 3
+                  in: 3
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Address"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    post:
+      summary: Create an address
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Adds a new address to the customer address book
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const address = await client.customer.addresses.create({
+            first_name: 'John',
+            last_name: 'Doe',
+            address1: '123 Main St',
+            city: 'New York',
+            postal_code: '10001',
+            country_iso: 'US',
+            state_abbr: 'NY',
+            phone: '+1 555 123 4567',
+          }, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: address created
+          content:
+            application/json:
+              example:
+                id: addr_VqXmZF31wY
+                first_name: John
+                last_name: Doe
+                full_name: John Doe
+                address1: 123 Main St
+                address2:
+                postal_code: '10001'
+                city: New York
+                phone: "+1 555 123 4567"
+                company:
+                country_name: United States of America
+                country_iso: US
+                state_text: NY
+                state_abbr: NY
+                quick_checkout: false
+                is_default_billing: false
+                is_default_shipping: false
+                state_name: New York
+              schema:
+                "$ref": "#/components/schemas/Address"
+        '422':
+          description: validation error
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: First Name can't be blank, Last Name can't be blank, Address
+                    can't be blank, City can't be blank, Country can't be blank, and
+                    Zip Code can't be blank
+                  details:
+                    firstname:
+                    - can't be blank
+                    lastname:
+                    - can't be blank
+                    address1:
+                    - can't be blank
+                    city:
+                    - can't be blank
+                    country:
+                    - can't be blank
+                    zipcode:
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                  example: John
+                last_name:
+                  type: string
+                  example: Doe
+                address1:
+                  type: string
+                  example: 123 Main St
+                address2:
+                  type: string
+                  example: Apt 4B
+                city:
+                  type: string
+                  example: New York
+                postal_code:
+                  type: string
+                  example: '10001'
+                phone:
+                  type: string
+                  example: "+1 555 123 4567"
+                company:
+                  type: string
+                  example: Acme Inc
+                country_iso:
+                  type: string
+                  example: US
+                  description: ISO 3166-1 alpha-2 country code (e.g., "US", "DE")
+                state_abbr:
+                  type: string
+                  example: NY
+                  description: ISO 3166-2 subdivision code without country prefix
+                    (e.g., "CA", "NY")
+                state_name:
+                  type: string
+                  example: New York
+                  description: State name - for countries without predefined states
+                is_default_billing:
+                  type: boolean
+                  example: true
+                  description: Set as default billing address
+                is_default_shipping:
+                  type: boolean
+                  example: true
+                  description: Set as default shipping address
+              required:
+              - first_name
+              - last_name
+              - address1
+              - city
+              - postal_code
+              - country_iso
+  "/api/v3/store/customers/me/addresses/{id}":
+    get:
+      summary: Get an address
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const address = await client.customer.addresses.get('addr_abc123', {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: address found
+          content:
+            application/json:
+              example:
+                id: addr_EfhxLZ9ck8
+                first_name: John
+                last_name: Doe
+                full_name: John Doe
+                address1: 84 Lovely Street
+                address2: Northwest
+                postal_code: '10118'
+                city: New York
+                phone: 555-555-0199
+                company: Company
+                country_name: United States of America
+                country_iso: US
+                state_text: NY
+                state_abbr: NY
+                quick_checkout: false
+                is_default_billing: false
+                is_default_shipping: false
+                state_name: New York
+              schema:
+                "$ref": "#/components/schemas/Address"
+        '404':
+          description: address not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Address not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update an address
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const address = await client.customer.addresses.update('addr_abc123', {
+            city: 'Los Angeles',
+          }, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: address updated
+          content:
+            application/json:
+              example:
+                id: addr_EfhxLZ9ck8
+                first_name: John
+                last_name: Doe
+                full_name: John Doe
+                address1: 90 Lovely Street
+                address2: Northwest
+                postal_code: '10118'
+                city: Los Angeles
+                phone: 555-555-0199
+                company: Company
+                country_name: United States of America
+                country_iso: US
+                state_text: NY
+                state_abbr: NY
+                quick_checkout: false
+                is_default_billing: false
+                is_default_shipping: false
+                state_name: New York
+              schema:
+                "$ref": "#/components/schemas/Address"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                  example: John
+                last_name:
+                  type: string
+                  example: Doe
+                address1:
+                  type: string
+                  example: 456 Oak Ave
+                city:
+                  type: string
+                  example: Los Angeles
+                is_default_billing:
+                  type: boolean
+                  example: true
+                  description: Set as default billing address
+                is_default_shipping:
+                  type: boolean
+                  example: true
+                  description: Set as default shipping address
+    delete:
+      summary: Delete an address
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          await client.customer.addresses.delete('addr_abc123', {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: address deleted
+        '404':
+          description: address not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Address not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/credit_cards":
+    get:
+      summary: List saved credit cards
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns all saved credit cards for the authenticated customer
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const cards = await client.customer.creditCards.list({}, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: credit cards found
+          content:
+            application/json:
+              example:
+                data:
+                - id: card_UkLWZg9DAJ
+                  brand: visa
+                  last4: '1111'
+                  month: 12
+                  year: 2027
+                  name: Spree Commerce
+                  default: false
+                  gateway_payment_profile_id:
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/CreditCard"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/credit_cards/{id}":
+    get:
+      summary: Get a credit card
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns a saved credit card by its ID
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const card = await client.customer.creditCards.get('card_abc123', {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: credit card found
+          content:
+            application/json:
+              example:
+                id: card_UkLWZg9DAJ
+                brand: visa
+                last4: '1111'
+                month: 12
+                year: 2027
+                name: Spree Commerce
+                default: false
+                gateway_payment_profile_id:
+              schema:
+                "$ref": "#/components/schemas/CreditCard"
+        '404':
+          description: credit card not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Credit card not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    delete:
+      summary: Delete a credit card
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Removes a saved credit card from the customer account
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          await client.customer.creditCards.delete('card_abc123', {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: credit card deleted
+        '404':
+          description: credit card not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Credit card not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/orders":
+    get:
+      summary: List orders
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns a paginated list of completed orders for the authenticated
+        customer.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const orders = await client.customer.orders.list(
+            {
+              completed_at_gt: '2026-01-01',
+              sort: '-completed_at',
+            },
+            { token: '<token>' },
+          )
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: 'Page number (default: 1)'
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        description: 'Number of results per page (default: 25, max: 100)'
+        schema:
+          type: integer
+      - name: sort
+        in: query
+        required: false
+        description: 'Sort order. Prefix with - for descending. Values: completed_at,
+          -completed_at, total, -total, number, -number'
+        schema:
+          type: string
+      - name: q[completed_at_gt]
+        in: query
+        required: false
+        description: Filter by completed after date (ISO 8601)
+        schema:
+          type: string
+      - name: q[completed_at_lt]
+        in: query
+        required: false
+        description: Filter by completed before date (ISO 8601)
+        schema:
+          type: string
+      - name: q[number_eq]
+        in: query
+        required: false
+        description: Filter by exact order number (e.g., R123456)
+        schema:
+          type: string
+      - name: q[state_eq]
+        in: query
+        required: false
+        description: Filter by order state (complete, returned, canceled)
+        schema:
+          type: string
+      - name: q[payment_state_eq]
+        in: query
+        required: false
+        description: Filter by payment state (paid, balance_due, credit_owed, void,
+          failed)
+        schema:
+          type: string
+      - name: q[total_gteq]
+        in: query
+        required: false
+        description: Filter by minimum total
+        schema:
+          type: number
+      - name: q[total_lteq]
+        in: query
+        required: false
+        description: Filter by maximum total
+        schema:
+          type: number
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (items, fulfillments,
+          payments, discounts, billing_address, shipping_address, gift_card). Use
+          "none" to skip associations.
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., total,amount_due,item_count).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: orders listed
+          content:
+            application/json:
+              example:
+                data:
+                - id: or_UkLWZg9DAJ
+                  market_id:
+                  channel_id: ch_UkLWZg9DAJ
+                  number: R096824993
+                  email: gena@ohara.biz
+                  customer_note:
+                  currency: USD
+                  locale: en
+                  total_quantity: 1
+                  item_total: '10.0'
+                  display_item_total: "$10.00"
+                  adjustment_total: '0.0'
+                  display_adjustment_total: "$0.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  tax_total: '0.0'
+                  display_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  total: '110.0'
+                  display_total: "$110.00"
+                  gift_card_total: '0.0'
+                  display_gift_card_total: "$0.00"
+                  amount_due: '110.0'
+                  display_amount_due: "$110.00"
+                  delivery_total: '100.0'
+                  display_delivery_total: "$100.00"
+                  fulfillment_status:
+                  payment_status:
+                  completed_at: '2026-05-26T16:13:49.079Z'
+                  store_credit_total: '0.0'
+                  display_store_credit_total: "$0.00"
+                  covered_by_store_credit: false
+                  discounts: []
+                  items:
+                  - id: li_UkLWZg9DAJ
+                    variant_id: variant_UkLWZg9DAJ
+                    quantity: 1
+                    currency: USD
+                    name: Product 1016128
+                    slug: product-1016128
+                    options_text: ''
+                    price: '10.0'
+                    display_price: "$10.00"
+                    total: '10.0'
+                    display_total: "$10.00"
+                    adjustment_total: '0.0'
+                    display_adjustment_total: "$0.00"
+                    additional_tax_total: '0.0'
+                    display_additional_tax_total: "$0.00"
+                    included_tax_total: '0.0'
+                    display_included_tax_total: "$0.00"
+                    discount_total: '0.0'
+                    display_discount_total: "$0.00"
+                    pre_tax_amount: '10.0'
+                    display_pre_tax_amount: "$10.00"
+                    discounted_amount: '10.0'
+                    display_discounted_amount: "$10.00"
+                    display_compare_at_amount: "$0.00"
+                    compare_at_amount:
+                    thumbnail_url:
+                    option_values: []
+                    digital_links: []
+                  fulfillments:
+                  - id: ful_UkLWZg9DAJ
+                    number: H70742962050
+                    tracking: U10000
+                    tracking_url:
+                    cost: '100.0'
+                    display_cost: "$100.00"
+                    total: '100.0'
+                    display_total: "$100.00"
+                    discount_total: '0.0'
+                    display_discount_total: "$0.00"
+                    additional_tax_total: '0.0'
+                    display_additional_tax_total: "$0.00"
+                    included_tax_total: '0.0'
+                    display_included_tax_total: "$0.00"
+                    tax_total: '0.0'
+                    display_tax_total: "$0.00"
+                    status: pending
+                    fulfillment_type: shipping
+                    fulfilled_at:
+                    items:
+                    - item_id: li_UkLWZg9DAJ
+                      variant_id: variant_UkLWZg9DAJ
+                      quantity: 1
+                    delivery_method:
+                      id: dm_UkLWZg9DAJ
+                      name: UPS Ground
+                      code: UPS_GROUND
+                    stock_location:
+                      id: sloc_UkLWZg9DAJ
+                      state_abbr: NY
+                      name: Britany Halvorson
+                      address1: 1600 Pennsylvania Ave NW
+                      city: Washington
+                      zipcode: '20500'
+                      country_iso: US
+                      country_name: United States of America
+                      state_text: NY
+                    delivery_rates:
+                    - id: dr_gbHJdmfrXB
+                      delivery_method_id: dm_UkLWZg9DAJ
+                      name: UPS Ground
+                      selected: true
+                      cost: '10.0'
+                      total: '10.0'
+                      additional_tax_total: '0.0'
+                      included_tax_total: '0.0'
+                      tax_total: '0.0'
+                      display_cost: "$10.00"
+                      display_total: "$10.00"
+                      display_additional_tax_total: "$0.00"
+                      display_included_tax_total: "$0.00"
+                      display_tax_total: "$0.00"
+                      delivery_method:
+                        id: dm_UkLWZg9DAJ
+                        name: UPS Ground
+                        code: UPS_GROUND
+                  payments: []
+                  billing_address:
+                    id: addr_EfhxLZ9ck8
+                    first_name: John
+                    last_name: Doe
+                    full_name: John Doe
+                    address1: 147 Lovely Street
+                    address2: Northwest
+                    postal_code: '10118'
+                    city: New York
+                    phone: 555-555-0199
+                    company: Company
+                    country_name: United States of America
+                    country_iso: US
+                    state_text: NY
+                    state_abbr: NY
+                    quick_checkout: false
+                    is_default_billing: false
+                    is_default_shipping: false
+                    state_name: New York
+                  shipping_address:
+                    id: addr_VqXmZF31wY
+                    first_name: John
+                    last_name: Doe
+                    full_name: John Doe
+                    address1: 148 Lovely Street
+                    address2: Northwest
+                    postal_code: '10118'
+                    city: New York
+                    phone: 555-555-0199
+                    company: Company
+                    country_name: United States of America
+                    country_iso: US
+                    state_text: NY
+                    state_abbr: NY
+                    quick_checkout: false
+                    is_default_billing: false
+                    is_default_shipping: false
+                    state_name: New York
+                  gift_card:
+                  market:
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Order"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+                required:
+                - data
+                - meta
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/orders/{id}":
+    get:
+      summary: Get an order
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns a single completed order for the authenticated customer.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const order = await client.customer.orders.get('or_abc123', {}, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Order prefixed ID
+        schema:
+          type: string
+      - name: expand
+        in: query
+        required: false
+        description: Comma-separated associations to expand (items, fulfillments,
+          payments, discounts, billing_address, shipping_address, gift_card). Use
+          "none" to skip associations.
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., total,amount_due,item_count).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: order found
+          content:
+            application/json:
+              example:
+                id: or_UkLWZg9DAJ
+                market_id:
+                channel_id: ch_UkLWZg9DAJ
+                number: R695830260
+                email: jerica.wehner@wintheiser.biz
+                customer_note:
+                currency: USD
+                locale: en
+                total_quantity: 1
+                item_total: '10.0'
+                display_item_total: "$10.00"
+                adjustment_total: '0.0'
+                display_adjustment_total: "$0.00"
+                discount_total: '0.0'
+                display_discount_total: "$0.00"
+                tax_total: '0.0'
+                display_tax_total: "$0.00"
+                included_tax_total: '0.0'
+                display_included_tax_total: "$0.00"
+                additional_tax_total: '0.0'
+                display_additional_tax_total: "$0.00"
+                total: '110.0'
+                display_total: "$110.00"
+                gift_card_total: '0.0'
+                display_gift_card_total: "$0.00"
+                amount_due: '110.0'
+                display_amount_due: "$110.00"
+                delivery_total: '100.0'
+                display_delivery_total: "$100.00"
+                fulfillment_status:
+                payment_status:
+                completed_at: '2026-05-26T16:13:49.771Z'
+                store_credit_total: '0.0'
+                display_store_credit_total: "$0.00"
+                covered_by_store_credit: false
+                discounts: []
+                items:
+                - id: li_UkLWZg9DAJ
+                  variant_id: variant_UkLWZg9DAJ
+                  quantity: 1
+                  currency: USD
+                  name: Product 1033099
+                  slug: product-1033099
+                  options_text: ''
+                  price: '10.0'
+                  display_price: "$10.00"
+                  total: '10.0'
+                  display_total: "$10.00"
+                  adjustment_total: '0.0'
+                  display_adjustment_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  pre_tax_amount: '10.0'
+                  display_pre_tax_amount: "$10.00"
+                  discounted_amount: '10.0'
+                  display_discounted_amount: "$10.00"
+                  display_compare_at_amount: "$0.00"
+                  compare_at_amount:
+                  thumbnail_url:
+                  option_values: []
+                  digital_links: []
+                fulfillments:
+                - id: ful_UkLWZg9DAJ
+                  number: H08221240082
+                  tracking: U10000
+                  tracking_url:
+                  cost: '100.0'
+                  display_cost: "$100.00"
+                  total: '100.0'
+                  display_total: "$100.00"
+                  discount_total: '0.0'
+                  display_discount_total: "$0.00"
+                  additional_tax_total: '0.0'
+                  display_additional_tax_total: "$0.00"
+                  included_tax_total: '0.0'
+                  display_included_tax_total: "$0.00"
+                  tax_total: '0.0'
+                  display_tax_total: "$0.00"
+                  status: pending
+                  fulfillment_type: shipping
+                  fulfilled_at:
+                  items:
+                  - item_id: li_UkLWZg9DAJ
+                    variant_id: variant_UkLWZg9DAJ
+                    quantity: 1
+                  delivery_method:
+                    id: dm_UkLWZg9DAJ
+                    name: UPS Ground
+                    code: UPS_GROUND
+                  stock_location:
+                    id: sloc_UkLWZg9DAJ
+                    state_abbr: NY
+                    name: Aleen Reynolds
+                    address1: 1600 Pennsylvania Ave NW
+                    city: Washington
+                    zipcode: '20500'
+                    country_iso: US
+                    country_name: United States of America
+                    state_text: NY
+                  delivery_rates:
+                  - id: dr_gbHJdmfrXB
+                    delivery_method_id: dm_UkLWZg9DAJ
+                    name: UPS Ground
+                    selected: true
+                    cost: '10.0'
+                    total: '10.0'
+                    additional_tax_total: '0.0'
+                    included_tax_total: '0.0'
+                    tax_total: '0.0'
+                    display_cost: "$10.00"
+                    display_total: "$10.00"
+                    display_additional_tax_total: "$0.00"
+                    display_included_tax_total: "$0.00"
+                    display_tax_total: "$0.00"
+                    delivery_method:
+                      id: dm_UkLWZg9DAJ
+                      name: UPS Ground
+                      code: UPS_GROUND
+                payments: []
+                billing_address:
+                  id: addr_EfhxLZ9ck8
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 153 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: false
+                  state_name: New York
+                shipping_address:
+                  id: addr_VqXmZF31wY
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 154 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: false
+                  state_name: New York
+                gift_card:
+                market:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '404':
+          description: order belongs to another user
+          content:
+            application/json:
+              example:
+                error:
+                  code: order_not_found
+                  message: Order not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers":
+    post:
+      summary: Register a new customer
+      tags:
+      - Customers
+      security:
+      - api_key: []
+      description: Creates a new customer account and returns a JWT token
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const auth = await client.customers.create({
+            email: 'newuser@example.com',
+            password: 'password123',
+            password_confirmation: 'password123',
+            first_name: 'John',
+            last_name: 'Doe',
+            phone: '+1234567890',
+            accepts_email_marketing: true,
+            metadata: { source: 'storefront' },
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: registration successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjlmZGNlNTdjLTY2NGQtNGZkNy1hOTU2LWQ1MjEzZjdhMjljYSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzc5ODE1NjMwfQ.vLRThKiR034rnZQYwpQGrIOeQSdrYNKnFVJZ86pCuUo
+                refresh_token: GVssZP2L5Zk7uKQzTmwSQ4i5
+                user:
+                  id: cus_UkLWZg9DAJ
+                  email: newuser@example.com
+                  first_name: John
+                  last_name: Doe
+                  phone: "+1234567890"
+                  accepts_email_marketing: true
+                  full_name: John Doe
+                  available_store_credit_total: '0'
+                  display_available_store_credit_total: "$0.00"
+                  addresses: []
+                  default_billing_address:
+                  default_shipping_address:
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '422':
+          description: email already taken
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Email has already been taken
+                  details:
+                    email:
+                    - has already been taken
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: newuser@example.com
+                password:
+                  type: string
+                  minLength: 6
+                  example: password123
+                password_confirmation:
+                  type: string
+                  example: password123
+                first_name:
+                  type: string
+                  example: John
+                last_name:
+                  type: string
+                  example: Doe
+                phone:
+                  type: string
+                  example: "+1234567890"
+                accepts_email_marketing:
+                  type: boolean
+                  example: true
+                metadata:
+                  type: object
+                  example:
+                    source: storefront
+              required:
+              - email
+              - password
+  "/api/v3/store/customers/me":
+    get:
+      summary: Get current customer profile
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns the profile of the currently authenticated customer
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const customer = await client.customer.get({
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer JWT token
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: profile found
+          content:
+            application/json:
+              example:
+                id: cus_UkLWZg9DAJ
+                email: jama.wolff@lynch.biz
+                first_name: Catarina
+                last_name: Padberg
+                phone: 555-555-0199
+                accepts_email_marketing: false
+                full_name: Catarina Padberg
+                available_store_credit_total: '0'
+                display_available_store_credit_total: "$0.00"
+                addresses:
+                - id: addr_gbHJdmfrXB
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 160 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: true
+                  is_default_shipping: false
+                  state_name: New York
+                - id: addr_UkLWZg9DAJ
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 159 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: true
+                  state_name: New York
+                default_billing_address:
+                  id: addr_gbHJdmfrXB
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 160 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: true
+                  is_default_shipping: false
+                  state_name: New York
+                default_shipping_address:
+                  id: addr_UkLWZg9DAJ
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 159 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: true
+                  state_name: New York
+              schema:
+                "$ref": "#/components/schemas/Customer"
+        '401':
+          description: unauthorized - invalid token
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update current customer profile
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Updates the profile of the currently authenticated customer
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const customer = await client.customer.update({
+            first_name: 'John',
+            last_name: 'Doe',
+            metadata: { preferred_contact: 'email' },
+          }, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: profile updated
+          content:
+            application/json:
+              example:
+                id: cus_UkLWZg9DAJ
+                email: kiera@treutel.com
+                first_name: Updated
+                last_name: Name
+                phone: 555-555-0199
+                accepts_email_marketing: false
+                full_name: Updated Name
+                available_store_credit_total: '0'
+                display_available_store_credit_total: "$0.00"
+                addresses:
+                - id: addr_gbHJdmfrXB
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 162 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: true
+                  is_default_shipping: false
+                  state_name: New York
+                - id: addr_UkLWZg9DAJ
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 161 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: true
+                  state_name: New York
+                default_billing_address:
+                  id: addr_gbHJdmfrXB
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 162 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: true
+                  is_default_shipping: false
+                  state_name: New York
+                default_shipping_address:
+                  id: addr_UkLWZg9DAJ
+                  first_name: John
+                  last_name: Doe
+                  full_name: John Doe
+                  address1: 161 Lovely Street
+                  address2: Northwest
+                  postal_code: '10118'
+                  city: New York
+                  phone: 555-555-0199
+                  company: Company
+                  country_name: United States of America
+                  country_iso: US
+                  state_text: NY
+                  state_abbr: NY
+                  quick_checkout: false
+                  is_default_billing: false
+                  is_default_shipping: true
+                  state_name: New York
+              schema:
+                "$ref": "#/components/schemas/Customer"
+        '422':
+          description: validation error
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Email can't be blank
+                  details:
+                    email:
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                  example: John
+                last_name:
+                  type: string
+                  example: Doe
+                email:
+                  type: string
+                  format: email
+                  example: customer@example.com
+                password:
+                  type: string
+                  example: newpassword123
+                password_confirmation:
+                  type: string
+                  example: newpassword123
+                accepts_email_marketing:
+                  type: boolean
+                  example: true
+                phone:
+                  type: string
+                  example: "+1 555 123 4567"
+                metadata:
+                  type: object
+                  example:
+                    preferred_contact: email
+  "/api/v3/store/customers/me/gift_cards":
+    get:
+      summary: List gift cards
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns all gift cards for the authenticated customer
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const giftCards = await client.customer.giftCards.list({}, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: gift cards found
+          content:
+            application/json:
+              example:
+                data:
+                - id: gc_UkLWZg9DAJ
+                  code: 91F1E57C6C99A62C
+                  status: active
+                  currency: USD
+                  amount: '10.0'
+                  amount_used: '0.0'
+                  amount_authorized: '0.0'
+                  amount_remaining: '10.0'
+                  display_amount: "$10.00"
+                  display_amount_used: "$0.00"
+                  display_amount_remaining: "$10.00"
+                  expires_at:
+                  redeemed_at:
+                  expired: false
+                  active: true
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/GiftCard"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/gift_cards/{id}":
+    get:
+      summary: Get a gift card
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns a gift card by its ID
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const giftCard = await client.customer.giftCards.get('gc_abc123', {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: gift card found
+          content:
+            application/json:
+              example:
+                id: gc_UkLWZg9DAJ
+                code: 76D77B6CFFA255C8
+                status: active
+                currency: USD
+                amount: '10.0'
+                amount_used: '0.0'
+                amount_authorized: '0.0'
+                amount_remaining: '10.0'
+                display_amount: "$10.00"
+                display_amount_used: "$0.00"
+                display_amount_remaining: "$10.00"
+                expires_at:
+                redeemed_at:
+                expired: false
+                active: true
+              schema:
+                "$ref": "#/components/schemas/GiftCard"
+        '404':
+          description: gift card not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Gift card not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/payment_setup_sessions":
+    post:
+      summary: Create payment setup session
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Creates a new payment setup session for saving a payment method
+        for future use. Delegates to the payment gateway to initialize a provider-specific
+        setup flow (e.g. Stripe SetupIntent, Adyen zero-auth tokenization).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const session = await client.customer.paymentSetupSessions.create({
+            payment_method_id: 'pm_abc123',
+          }, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: payment setup session created
+          content:
+            application/json:
+              example:
+                id: pss_gbHJdmfrXB
+                status: pending
+                external_id: bogus_seti_e60689fe4c66251e2b4dd2f4
+                external_client_secret: bogus_seti_secret_633045dc9ddab700
+                external_data: {}
+                payment_method_id: pm_UkLWZg9DAJ
+                payment_source_id:
+                payment_source_type:
+                customer_id: cus_UkLWZg9DAJ
+                payment_method:
+                  id: pm_UkLWZg9DAJ
+                  name: Credit Card
+                  description:
+                  type: bogus
+                  session_required: true
+                  source_required: true
+              schema:
+                "$ref": "#/components/schemas/PaymentSetupSession"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: payment method not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Payment method not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                payment_method_id:
+                  type: string
+                  example: pm_abc123
+                  description: Payment method ID
+                external_data:
+                  type: object
+                  description: Provider-specific data passed to the gateway
+              required:
+              - payment_method_id
+  "/api/v3/store/customers/me/payment_setup_sessions/{id}":
+    parameters:
+    - name: x-spree-api-key
+      in: header
+      required: true
+      schema:
+        type: string
+    - name: Authorization
+      in: header
+      required: true
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      description: Payment setup session ID
+      schema:
+        type: string
+    get:
+      summary: Get payment setup session
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns a payment setup session with its current status and provider
+        data.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const session = await client.customer.paymentSetupSessions.get('pss_abc123', {
+            token: '<token>',
+          })
+      responses:
+        '200':
+          description: payment setup session found
+          content:
+            application/json:
+              example:
+                id: pss_UkLWZg9DAJ
+                status: pending
+                external_id: seti_test_7ac50408dcea6ac09aa04e3d
+                external_client_secret: seti_secret_77e80c695165694be5ef56b9
+                external_data:
+                  client_secret: secret_123
+                payment_method_id: pm_UkLWZg9DAJ
+                payment_source_id:
+                payment_source_type:
+                customer_id: cus_UkLWZg9DAJ
+                payment_method:
+                  id: pm_UkLWZg9DAJ
+                  name: Credit Card
+                  description:
+                  type: bogus
+                  session_required: true
+                  source_required: true
+              schema:
+                "$ref": "#/components/schemas/PaymentSetupSession"
+        '404':
+          description: payment setup session not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Payment setup session not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/payment_setup_sessions/{id}/complete":
+    parameters:
+    - name: x-spree-api-key
+      in: header
+      required: true
+      schema:
+        type: string
+    - name: Authorization
+      in: header
+      required: true
+      schema:
+        type: string
+    - name: id
+      in: path
+      required: true
+      description: Payment setup session ID
+      schema:
+        type: string
+    patch:
+      summary: Complete payment setup session
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Completes a payment setup session by confirming the setup with
+        the provider, resulting in a saved payment method.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const session = await client.customer.paymentSetupSessions.complete('pss_abc123', {}, {
+            token: '<token>',
+          })
+      parameters: []
+      responses:
+        '200':
+          description: payment setup session completed
+          content:
+            application/json:
+              example:
+                id: pss_UkLWZg9DAJ
+                status: completed
+                external_id: seti_test_6cb96d4ae6cdc1eadf02b1dc
+                external_client_secret: seti_secret_bb0a7727be4c699d8584292f
+                external_data:
+                  client_secret: secret_123
+                payment_method_id: pm_UkLWZg9DAJ
+                payment_source_id: card_UkLWZg9DAJ
+                payment_source_type: Spree::CreditCard
+                customer_id: cus_UkLWZg9DAJ
+                payment_method:
+                  id: pm_UkLWZg9DAJ
+                  name: Credit Card
+                  description:
+                  type: bogus
+                  session_required: true
+                  source_required: true
+              schema:
+                "$ref": "#/components/schemas/PaymentSetupSession"
+        '404':
+          description: payment setup session not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Payment setup session not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                external_data:
+                  type: object
+                  description: Provider-specific completion data
+  "/api/v3/store/customers/me/store_credits":
+    get:
+      summary: List store credits
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      description: Returns store credits for the authenticated customer, filtered
+        by current store and currency. Supports Ransack filtering.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const credits = await client.customer.storeCredits.list({}, {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., amount,currency).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: store credits found
+          content:
+            application/json:
+              example:
+                data:
+                - id: credit_UkLWZg9DAJ
+                  amount: '100.0'
+                  amount_used: '0.0'
+                  amount_remaining: '100.0'
+                  display_amount: "$100.00"
+                  display_amount_used: "$0.00"
+                  display_amount_remaining: "$100.00"
+                  currency: USD
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/StoreCredit"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/customers/me/store_credits/{id}":
+    get:
+      summary: Get a store credit
+      tags:
+      - Customers
+      security:
+      - api_key: []
+        bearer_auth: []
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const credit = await client.customer.storeCredits.get('credit_abc123', {
+            token: '<token>',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., amount,currency).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: store credit found
+          content:
+            application/json:
+              example:
+                id: credit_UkLWZg9DAJ
+                amount: '100.0'
+                amount_used: '0.0'
+                amount_remaining: '100.0'
+                display_amount: "$100.00"
+                display_amount_used: "$0.00"
+                display_amount_remaining: "$100.00"
+                currency: USD
+              schema:
+                "$ref": "#/components/schemas/StoreCredit"
+        '404':
+          description: store credit not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Store credit not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/countries":
+    get:
+      summary: List countries
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns countries available in the store. Use ?expand=market to
+        include market details (currency, locale, tax_inclusive).
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const countries = await client.countries.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: countries found
+          content:
+            application/json:
+              example:
+                data:
+                - iso: DE
+                  iso3: IS39
+                  name: Germany
+                  states_required: false
+                  zipcode_required: true
+                - iso: US
+                  iso3: USA
+                  name: United States of America
+                  states_required: true
+                  zipcode_required: true
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Country"
+                required:
+                - data
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/countries/{iso}":
+    get:
+      summary: Get a country
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns a single country by ISO code. Supports ?expand=states for
+        address forms and ?expand=market for market details.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const country = await client.countries.get('US')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: iso
+        in: path
+        required: true
+        description: Country ISO 3166-1 alpha-2 code (e.g., "US", "DE")
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: country found
+          content:
+            application/json:
+              example:
+                iso: US
+                iso3: USA
+                name: United States of America
+                states_required: true
+                zipcode_required: true
+              schema:
+                type: object
+                properties:
+                  iso:
+                    type: string
+                  iso3:
+                    type: string
+                  name:
+                    type: string
+                  states_required:
+                    type: boolean
+                  zipcode_required:
+                    type: boolean
+                required:
+                - iso
+                - iso3
+                - name
+                - states_required
+                - zipcode_required
+        '404':
+          description: country not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Country not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/currencies":
+    get:
+      summary: List supported currencies
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns currencies supported by the store (derived from markets)
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const currencies = await client.currencies.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: currencies found
+          content:
+            application/json:
+              example:
+                data:
+                - iso_code: USD
+                  name: United States Dollar
+                  symbol: "$"
+                - iso_code: EUR
+                  name: Euro
+                  symbol: "€"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Currency"
+                required:
+                - data
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/locales":
+    get:
+      summary: List supported locales
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns locales supported by the store (derived from markets)
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const locales = await client.locales.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: locales found
+          content:
+            application/json:
+              example:
+                data:
+                - code: de
+                  name: de
+                - code: en
+                  name: English (US)
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Locale"
+                required:
+                - data
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/markets":
+    get:
+      summary: List markets
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns all markets for the current store with their countries,
+        currency, locales, and tax configuration.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const markets = await client.markets.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: markets found
+          content:
+            application/json:
+              example:
+                data:
+                - id: mkt_UkLWZg9DAJ
+                  name: North America
+                  currency: USD
+                  default_locale: en
+                  tax_inclusive: false
+                  default: true
+                  country_isos:
+                  - US
+                  supported_locales:
+                  - en
+                  - es
+                  countries:
+                  - iso: US
+                    iso3: USA
+                    name: United States of America
+                    states_required: true
+                    zipcode_required: true
+                - id: mkt_gbHJdmfrXB
+                  name: Europe
+                  currency: EUR
+                  default_locale: de
+                  tax_inclusive: true
+                  default: false
+                  country_isos:
+                  - DE
+                  - FR
+                  supported_locales:
+                  - de
+                  - en
+                  - fr
+                  countries:
+                  - iso: DE
+                    iso3: IS66
+                    name: Germany
+                    states_required: false
+                    zipcode_required: true
+                  - iso: FR
+                    iso3: IS67
+                    name: France
+                    states_required: false
+                    zipcode_required: true
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                required:
+                - data
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/markets/{id}":
+    get:
+      summary: Get a market
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns a single market by prefixed ID with its countries, currency,
+        locales, and tax configuration.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const market = await client.markets.get('mkt_xxx')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Market prefixed ID (e.g., "mkt_k5nR8xLq")
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: market found
+          content:
+            application/json:
+              example:
+                id: mkt_gbHJdmfrXB
+                name: Europe
+                currency: EUR
+                default_locale: de
+                tax_inclusive: true
+                default: false
+                country_isos:
+                - DE
+                - FR
+                supported_locales:
+                - de
+                - en
+                - fr
+                countries:
+                - iso: DE
+                  iso3: IS70
+                  name: Germany
+                  states_required: false
+                  zipcode_required: true
+                - iso: FR
+                  iso3: IS71
+                  name: France
+                  states_required: false
+                  zipcode_required: true
+              schema:
+                type: object
+        '404':
+          description: market not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Market not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/markets/resolve":
+    get:
+      summary: Resolve market by country
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Determine which market applies for a given country ISO code. Useful
+        for auto-selecting the correct currency and locale when a customer's location
+        is known.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const market = await client.markets.resolve('DE')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: country
+        in: query
+        required: true
+        description: Country ISO 3166-1 alpha-2 code (e.g., "DE", "US")
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: market resolved
+          content:
+            application/json:
+              example:
+                id: mkt_gbHJdmfrXB
+                name: Europe
+                currency: EUR
+                default_locale: de
+                tax_inclusive: true
+                default: false
+                country_isos:
+                - DE
+                - FR
+                supported_locales:
+                - de
+                - en
+                - fr
+                countries:
+                - iso: DE
+                  iso3: IS74
+                  name: Germany
+                  states_required: false
+                  zipcode_required: true
+                - iso: FR
+                  iso3: IS75
+                  name: France
+                  states_required: false
+                  zipcode_required: true
+              schema:
+                type: object
+        '404':
+          description: no market for country
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Country not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/markets/{market_id}/countries":
+    get:
+      summary: List countries in a market
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns countries belonging to a specific market. Use this for
+        address form country dropdowns during checkout.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const countries = await client.markets.countries.list('mkt_xxx')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: market_id
+        in: path
+        required: true
+        description: Market prefixed ID
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: countries found
+          content:
+            application/json:
+              example:
+                data:
+                - iso: FR
+                  iso3: IS79
+                  name: France
+                  states_required: false
+                  zipcode_required: true
+                - iso: DE
+                  iso3: IS78
+                  name: Germany
+                  states_required: false
+                  zipcode_required: true
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                required:
+                - data
+  "/api/v3/store/markets/{market_id}/countries/{id}":
+    get:
+      summary: Get a country in a market
+      tags:
+      - Markets
+      security:
+      - api_key: []
+      description: Returns a single country by ISO code within a market. Supports
+        ?expand=states for address forms.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const country = await client.markets.countries.get('mkt_xxx', 'DE')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: market_id
+        in: path
+        required: true
+        description: Market prefixed ID
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Country ISO 3166-1 alpha-2 code (e.g., "DE")
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug,price).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: country found
+          content:
+            application/json:
+              example:
+                iso: US
+                iso3: USA
+                name: United States of America
+                states_required: true
+                zipcode_required: true
+              schema:
+                type: object
+        '404':
+          description: country not in market
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Country not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/wishlists":
     get:
       summary: List wishlists
@@ -9718,6 +9318,406 @@ paths:
                 error:
                   code: record_not_found
                   message: Wished item not found
+  "/api/v3/store/newsletter_subscribers":
+    post:
+      summary: Subscribe to the newsletter
+      tags:
+      - Newsletter Subscribers
+      security:
+      - api_key: []
+      description: |
+        Subscribes an email address to the newsletter for the current store.
+
+        Behavior:
+
+        - If the email is already verified for this store, the existing subscription is returned unchanged.
+        - If the request is unauthenticated (guest), the subscription is created in an unverified state
+          and two events are published: `newsletter_subscriber.subscription_requested` (carrying the
+          `verification_token` and the validated `redirect_url`, intended for headless storefronts that
+          want to send the confirmation email themselves via a webhook handler) and the legacy
+          `newsletter_subscriber.subscribed` lifecycle event (which the bundled `spree_emails` package
+          listens to and uses to send a default confirmation email). The confirmation link should point
+          at `redirect_url?token=<verification_token>` and call `POST /newsletter_subscribers/verify`
+          when the user clicks it.
+        - If the request is authenticated via JWT and the customer's email matches the subscribed email,
+          the subscription is auto-verified and no events are fired — the JWT already proves email
+          ownership, so no confirmation email is needed.
+
+        The optional `redirect_url` is where the verification token should land on the storefront. The
+        server does not return a validation error when the URL is outside the store's
+        [Allowed Origins](/developer/core-concepts/allowed-origins); instead, the URL is silently
+        omitted from the webhook payload (secure-by-default). When no allow-list is configured on the
+        store, the URL is also omitted. Callers therefore receive the same 201 regardless, and the
+        webhook handler should fall back to the store's storefront URL when `redirect_url` is missing
+        from the payload.
+
+        Newsletter consent is preserved across registration: if a guest subscribes and later registers
+        with the same email, the existing subscriber record is reused.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const subscriber = await client.newsletterSubscribers.create({
+            email: 'subscriber@example.com',
+            redirect_url: 'https://your-store.com/newsletter/confirm',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        required: false
+        description: Optional Bearer JWT — when present, links the subscription to
+          that customer
+        schema:
+          type: string
+      responses:
+        '201':
+          description: auto-verified when JWT matches subscribed email
+          content:
+            application/json:
+              example:
+                id: sub_UkLWZg9DAJ
+                email: harriet.conroy@mohr.co.uk
+                created_at: '2026-05-26T16:14:11.183Z'
+                updated_at: '2026-05-26T16:14:11.186Z'
+                verified: true
+                verified_at: '2026-05-26T16:14:11Z'
+                customer_id: cus_UkLWZg9DAJ
+              schema:
+                "$ref": "#/components/schemas/NewsletterSubscriber"
+        '422':
+          description: invalid email format
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Email is invalid
+                  details:
+                    email:
+                    - is invalid
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: subscriber@example.com
+                redirect_url:
+                  type: string
+                  format: uri
+                  example: https://your-store.com/newsletter/confirm
+                  description: Storefront URL the verification token should be appended
+                    to. Silently omitted from the webhook payload when the store has
+                    allowed origins configured and this URL does not match one of
+                    them, or when no allowed origins are configured at all.
+              required:
+              - email
+  "/api/v3/store/newsletter_subscribers/verify":
+    post:
+      summary: Verify a newsletter subscription
+      tags:
+      - Newsletter Subscribers
+      security:
+      - api_key: []
+      description: |
+        Confirms a pending newsletter subscription using the verification token sent by email.
+
+        After successful verification:
+        - The subscriber record is marked verified.
+        - If the subscription is associated with a customer, that customer's `accepts_email_marketing`
+          flag is set to `true`.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const subscriber = await client.newsletterSubscribers.verify({
+            token: 'abc123def456',
+          })
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: subscription verified
+          content:
+            application/json:
+              example:
+                id: sub_UkLWZg9DAJ
+                email: pending@example.com
+                created_at: '2026-05-26T16:14:11.236Z'
+                updated_at: '2026-05-26T16:14:11.255Z'
+                verified: true
+                verified_at: '2026-05-26T16:14:11Z'
+                customer_id:
+              schema:
+                "$ref": "#/components/schemas/NewsletterSubscriber"
+        '422':
+          description: missing token
+          content:
+            application/json:
+              example:
+                error:
+                  code: parameter_missing
+                  message: token is required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  example: abc123def456
+                  description: Verification token from the confirmation email
+              required:
+              - token
+  "/api/v3/store/policies":
+    get:
+      summary: List store policies
+      tags:
+      - Policies
+      security:
+      - api_key: []
+      description: |
+        Returns all policies for the current store (e.g., return policy, privacy policy, terms of service).
+        Policies are managed in Spree Admin and contain rich text content.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const policies = await client.policies.list()
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include (e.g., name,slug).
+          id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: policies listed
+          content:
+            application/json:
+              example:
+                data:
+                - id: pol_gbHJdmfrXB
+                  name: Privacy Policy
+                  slug: privacy-policy
+                  body: ''
+                  body_html: ''
+                - id: pol_OIJLhNcSbf
+                  name: Privacy Policy
+                  slug: privacy-policy-006f63da-6062-4a3f-9fd7-aa690f7b356c
+                  body: We respect your privacy.
+                  body_html: |
+                    <div class="trix-content">
+                      We respect your privacy.
+                    </div>
+                - id: pol_uw2YK1rnl0
+                  name: Return Policy
+                  slug: return-policy
+                  body: You can return items within 30 days.
+                  body_html: |
+                    <div class="trix-content">
+                      You can return items within 30 days.
+                    </div>
+                - id: pol_EfhxLZ9ck8
+                  name: Returns Policy
+                  slug: returns-policy
+                  body: ''
+                  body_html: ''
+                - id: pol_VqXmZF31wY
+                  name: Shipping Policy
+                  slug: shipping-policy
+                  body: ''
+                  body_html: ''
+                - id: pol_UkLWZg9DAJ
+                  name: Terms of Service
+                  slug: terms-of-service
+                  body: ''
+                  body_html: ''
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 6
+                  pages: 1
+                  from: 1
+                  to: 6
+                  in: 6
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Policy"
+                required:
+                - data
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_token
+                  message: Valid API key required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/policies/{id}":
+    get:
+      summary: Get a policy
+      tags:
+      - Policies
+      security:
+      - api_key: []
+      description: Returns a single policy by slug or prefixed ID. Includes the full
+        rich text body.
+      x-codeSamples:
+      - lang: javascript
+        label: Spree SDK
+        source: |-
+          import { createClient } from '@spree/sdk'
+
+          const client = createClient({
+            baseUrl: 'https://your-store.com',
+            publishableKey: '<api-key>',
+          })
+
+          const policy = await client.policies.get('return-policy')
+      parameters:
+      - name: x-spree-api-key
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        description: Policy slug (e.g., return-policy) or prefixed ID (e.g., pol_abc123)
+        schema:
+          type: string
+      - name: fields
+        in: query
+        required: false
+        description: Comma-separated list of fields to include. id is always included.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: policy found
+          content:
+            application/json:
+              example:
+                id: pol_uw2YK1rnl0
+                name: Return Policy
+                slug: return-policy
+                body: You can return items within 30 days.
+                body_html: |
+                  <div class="trix-content">
+                    You can return items within 30 days.
+                  </div>
+              schema:
+                "$ref": "#/components/schemas/Policy"
+        '404':
+          description: policy not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Policy not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/store/digitals/{token}":
+    get:
+      summary: Download a digital product
+      tags:
+      - Digitals
+      description: |
+        Downloads a digital product file using the digital link token.
+        The token is provided via the `download_url` field on digital links
+        returned with order line items. No API key or authentication required —
+        the token itself grants access.
+        Each download increments the access counter. Downloads may be limited by
+        store settings (number of downloads and/or time-based expiration).
+      parameters:
+      - name: token
+        in: path
+        required: true
+        description: Digital link token
+        schema:
+          type: string
+      responses:
+        '200':
+          description: file downloaded
+          content:
+            application/json: {}
+        '403':
+          description: download link expired or limit exceeded
+          content:
+            application/json:
+              example:
+                error:
+                  code: digital_link_expired
+                  message: Download link expired or invalid
+            application/octet-stream:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: digital link not found
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Digital link not found
+            application/octet-stream:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
 servers:
 - url: http://{defaultHost}
   variables:

--- a/spree/api/Rakefile
+++ b/spree/api/Rakefile
@@ -27,6 +27,25 @@ namespace :rswag do
       ENV['OPENAPI'] = 'true'
       t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--order defined']
     end
+
+    # rswag emits paths in spec-load order (alphabetical by filename), which doesn't
+    # match the curated order in swagger_helper.rb's `tags:` array. Mintlify groups
+    # sidebar sections by first-tag-appearance in `paths:`, so reorder paths here
+    # so the sidebar follows the `tags:` array.
+    Rake::Task['rswag:specs:swaggerize'].enhance do
+      $LOAD_PATH.unshift(File.expand_path('lib', __dir__))
+      require 'spree/api/openapi/path_sorter'
+
+      docs = File.expand_path('../../docs/api-reference', __dir__)
+      %w[admin.yaml store.yaml].each do |name|
+        path = File.join(docs, name)
+        next unless File.exist?(path)
+
+        if Spree::Api::OpenAPI::PathSorter.sort_file!(path)
+          puts "Reordered paths by tag → #{path}"
+        end
+      end
+    end
   end
 end
 

--- a/spree/api/lib/spree/api/openapi/path_sorter.rb
+++ b/spree/api/lib/spree/api/openapi/path_sorter.rb
@@ -111,8 +111,9 @@ module Spree
             next unless line.match?(/\A {6}tags:\s*$/)
 
             slice[(idx + 1)..].each do |next_line|
-              if (m = next_line.match(/\A {6}-\s+(.+?)\s*\z/))
-                return m[1]
+              if next_line.start_with?('      - ')
+                value = next_line[8..].strip
+                return value unless value.empty?
               end
               break if next_line.match?(/\A {0,4}\S/)
             end

--- a/spree/api/lib/spree/api/openapi/path_sorter.rb
+++ b/spree/api/lib/spree/api/openapi/path_sorter.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module OpenAPI
+      # Reorders the `paths:` block of a generated OpenAPI YAML so paths are grouped
+      # by tag, in the same order as the top-level `tags:` array.
+      #
+      # rswag emits paths in the order specs are loaded (alphabetical by filename),
+      # which doesn't match the curated `tags:` array order in swagger_helper.rb.
+      # Mintlify groups sidebar sections by the *first appearance* of each tag in
+      # `paths:` — so after this sort runs, the sidebar matches the `tags:` array.
+      #
+      # The reorder is line-based to preserve the exact text formatting that
+      # rswag/Psych produced (indentation, multi-line string wrapping, etc.).
+      module PathSorter
+        module_function
+
+        # Sort the `paths:` block in `path` so each path's first-operation primary
+        # tag follows the order defined in the document's top-level `tags:` array.
+        # Returns true if the file was rewritten, false if already sorted.
+        def sort_file!(path)
+          original = File.read(path)
+          sorted = sort_text(original)
+          return false if sorted == original
+
+          File.write(path, sorted)
+          true
+        end
+
+        # Pure-string variant: sort a YAML document's `paths:` block by tag order.
+        def sort_text(yaml)
+          lines = yaml.lines
+          tag_rank = extract_tag_rank(lines)
+          return yaml if tag_rank.empty?
+
+          paths_start = lines.index { |l| l.start_with?('paths:') }
+          return yaml unless paths_start
+
+          paths_end_exclusive = (paths_start + 1...lines.size).find do |i|
+            line = lines[i]
+            line.match?(/\A[A-Za-z]/) || line.start_with?('x-')
+          end || lines.size
+
+          blocks = collect_path_blocks(lines, paths_start + 1, paths_end_exclusive)
+          return yaml if blocks.empty?
+
+          unknown_rank = tag_rank.size
+          sorted_blocks = blocks.each_with_index.sort_by do |block, original_index|
+            [tag_rank.fetch(block[:tag], unknown_rank), original_index]
+          end.map(&:first)
+
+          prefix = lines[0..paths_start].join
+          suffix = lines[paths_end_exclusive..].to_a.join
+          prefix + sorted_blocks.map { |b| b[:text] }.join + suffix
+        end
+
+        # Parse the top-level `tags:` block and return { tag_name => index } in
+        # declared order. Returns {} if not found.
+        def extract_tag_rank(lines)
+          start = lines.index { |l| l.start_with?('tags:') }
+          return {} unless start
+
+          rank = {}
+          i = start + 1
+          while i < lines.size
+            line = lines[i]
+            if line.start_with?('- name: ')
+              rank[line.sub('- name: ', '').strip] = rank.size
+            elsif line.match?(/\A[A-Za-z]/) || line.start_with?('x-')
+              break
+            end
+            i += 1
+          end
+          rank
+        end
+
+        # Collect each path block as { tag:, text: } from lines[range].
+        # A path block starts on a line beginning with two spaces + a quote.
+        def collect_path_blocks(lines, start_idx, end_idx_exclusive)
+          blocks = []
+          current_start = nil
+
+          (start_idx...end_idx_exclusive).each do |i|
+            if path_header?(lines[i])
+              blocks << build_block(lines, current_start, i) if current_start
+              current_start = i
+            end
+          end
+          blocks << build_block(lines, current_start, end_idx_exclusive) if current_start
+
+          blocks
+        end
+
+        def path_header?(line)
+          line.start_with?('  "/') || line.start_with?('  /')
+        end
+
+        def build_block(lines, from, to_exclusive)
+          slice = lines[from...to_exclusive]
+          {
+            tag: extract_primary_tag(slice),
+            text: slice.join
+          }
+        end
+
+        # Within a path block, find the first `tags:` line and return the first
+        # tag value following it (the path block's "primary" tag).
+        def extract_primary_tag(slice)
+          slice.each_with_index do |line, idx|
+            next unless line.match?(/\A {6}tags:\s*$/)
+
+            slice[(idx + 1)..].each do |next_line|
+              if (m = next_line.match(/\A {6}-\s+(.+?)\s*\z/))
+                return m[1]
+              end
+              break if next_line.match?(/\A {0,4}\S/)
+            end
+          end
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/admin/admin_users_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/admin_users_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Admin Staff API', type: :request, swagger_doc: 'api-reference/ad
 
   path '/api/v3/admin/admin_users' do
     get 'List staff' do
-      tags 'Configuration'
+      tags 'Staff'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns admin users with at least one role assignment on the current store.'
@@ -47,7 +47,7 @@ RSpec.describe 'Admin Staff API', type: :request, swagger_doc: 'api-reference/ad
     let(:id) { staff_member.prefixed_id }
 
     get 'Show a staff member' do
-      tags 'Configuration'
+      tags 'Staff'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       admin_scope :read, :settings
@@ -71,7 +71,7 @@ RSpec.describe 'Admin Staff API', type: :request, swagger_doc: 'api-reference/ad
     end
 
     patch 'Update a staff member' do
-      tags 'Configuration'
+      tags 'Staff'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -106,7 +106,7 @@ RSpec.describe 'Admin Staff API', type: :request, swagger_doc: 'api-reference/ad
     end
 
     delete 'Remove a staff member from this store' do
-      tags 'Configuration'
+      tags 'Staff'
       security [api_key: [], bearer_auth: []]
       description "Removes the user's role assignments on the current store. The account is preserved — the user keeps access to any other stores."
       admin_scope :write, :settings

--- a/spree/api/spec/integration/spree/api/v3/admin/allowed_origins_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/allowed_origins_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Allowed Origins API', type: :request, swagger_doc: 'api-re
 
   path '/api/v3/admin/allowed_origins' do
     get 'List allowed origins' do
-      tags 'Configuration'
+      tags 'Allowed Origins'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -59,7 +59,7 @@ RSpec.describe 'Admin Allowed Origins API', type: :request, swagger_doc: 'api-re
     end
 
     post 'Create an allowed origin' do
-      tags 'Configuration'
+      tags 'Allowed Origins'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -110,7 +110,7 @@ RSpec.describe 'Admin Allowed Origins API', type: :request, swagger_doc: 'api-re
     parameter name: :id, in: :path, type: :string, required: true, description: 'Allowed origin ID'
 
     get 'Get an allowed origin' do
-      tags 'Configuration'
+      tags 'Allowed Origins'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single allowed origin by prefixed ID.'
@@ -147,7 +147,7 @@ RSpec.describe 'Admin Allowed Origins API', type: :request, swagger_doc: 'api-re
     end
 
     patch 'Update an allowed origin' do
-      tags 'Configuration'
+      tags 'Allowed Origins'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -191,7 +191,7 @@ RSpec.describe 'Admin Allowed Origins API', type: :request, swagger_doc: 'api-re
     end
 
     delete 'Delete an allowed origin' do
-      tags 'Configuration'
+      tags 'Allowed Origins'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
         Removes an origin from the admin CORS allowlist. After deletion the

--- a/spree/api/spec/integration/spree/api/v3/admin/api_keys_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/api_keys_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin API Keys API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/api_keys' do
     get 'List API keys' do
-      tags 'Configuration'
+      tags 'API Keys'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns publishable and secret API keys for the current store. ' \
@@ -43,7 +43,7 @@ RSpec.describe 'Admin API Keys API', type: :request, swagger_doc: 'api-reference
     end
 
     post 'Create an API key' do
-      tags 'Configuration'
+      tags 'API Keys'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -92,7 +92,7 @@ RSpec.describe 'Admin API Keys API', type: :request, swagger_doc: 'api-reference
     let(:id) { publishable_key.prefixed_id }
 
     get 'Show an API key' do
-      tags 'Configuration'
+      tags 'API Keys'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       admin_scope :read, :settings
@@ -114,7 +114,7 @@ RSpec.describe 'Admin API Keys API', type: :request, swagger_doc: 'api-reference
     end
 
     delete 'Delete an API key' do
-      tags 'Configuration'
+      tags 'API Keys'
       security [api_key: [], bearer_auth: []]
       admin_scope :write, :settings
 
@@ -136,7 +136,7 @@ RSpec.describe 'Admin API Keys API', type: :request, swagger_doc: 'api-reference
     let(:id) { secret_key_record.prefixed_id }
 
     patch 'Revoke an API key' do
-      tags 'Configuration'
+      tags 'API Keys'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Marks the key revoked. Future requests using its token will fail; the row is preserved for audit.'

--- a/spree/api/spec/integration/spree/api/v3/admin/customer_groups_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/customer_groups_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Admin Customer Groups API', type: :request, swagger_doc: 'api-re
 
   path '/api/v3/admin/customer_groups' do
     get 'List customer groups' do
-      tags 'Customers'
+      tags 'Customer Groups'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -64,7 +64,7 @@ RSpec.describe 'Admin Customer Groups API', type: :request, swagger_doc: 'api-re
     end
 
     post 'Create a customer group' do
-      tags 'Customers'
+      tags 'Customer Groups'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -120,7 +120,7 @@ RSpec.describe 'Admin Customer Groups API', type: :request, swagger_doc: 'api-re
     parameter name: :id, in: :path, type: :string, required: true, description: 'Customer group prefixed ID'
 
     get 'Get a customer group' do
-      tags 'Customers'
+      tags 'Customer Groups'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -182,7 +182,7 @@ RSpec.describe 'Admin Customer Groups API', type: :request, swagger_doc: 'api-re
     end
 
     patch 'Update a customer group' do
-      tags 'Customers'
+      tags 'Customer Groups'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -232,7 +232,7 @@ RSpec.describe 'Admin Customer Groups API', type: :request, swagger_doc: 'api-re
     end
 
     delete 'Delete a customer group' do
-      tags 'Customers'
+      tags 'Customer Groups'
       security [api_key: [], bearer_auth: []]
       description 'Soft-deletes the group. Member users are not deleted; their `customer_group_users` rows are dropped.'
       admin_scope :write, :customers

--- a/spree/api/spec/integration/spree/api/v3/admin/invitations_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/invitations_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin Invitations API', type: :request, swagger_doc: 'api-refere
 
   path '/api/v3/admin/invitations' do
     get 'List invitations' do
-      tags 'Configuration'
+      tags 'Staff'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns invitations for the current store, including pending and accepted.'
@@ -36,7 +36,7 @@ RSpec.describe 'Admin Invitations API', type: :request, swagger_doc: 'api-refere
     end
 
     post 'Create an invitation' do
-      tags 'Configuration'
+      tags 'Staff'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -75,7 +75,7 @@ RSpec.describe 'Admin Invitations API', type: :request, swagger_doc: 'api-refere
     let(:id) { invitation.prefixed_id }
 
     delete 'Revoke an invitation' do
-      tags 'Configuration'
+      tags 'Staff'
       security [api_key: [], bearer_auth: []]
       admin_scope :write, :settings
 
@@ -97,7 +97,7 @@ RSpec.describe 'Admin Invitations API', type: :request, swagger_doc: 'api-refere
     let(:id) { invitation.prefixed_id }
 
     patch 'Resend an invitation' do
-      tags 'Configuration'
+      tags 'Staff'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Issues a fresh token and dispatches the invitation email again.'

--- a/spree/api/spec/integration/spree/api/v3/admin/markets_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/markets_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Admin Markets API', type: :request, swagger_doc: 'api-reference/
 
   path '/api/v3/admin/markets' do
     get 'List markets' do
-      tags 'Pricing'
+      tags 'Markets'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -61,7 +61,7 @@ RSpec.describe 'Admin Markets API', type: :request, swagger_doc: 'api-reference/
     end
 
     post 'Create a market' do
-      tags 'Pricing'
+      tags 'Markets'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -147,7 +147,7 @@ RSpec.describe 'Admin Markets API', type: :request, swagger_doc: 'api-reference/
     parameter name: :id, in: :path, type: :string, required: true
 
     get 'Get a market' do
-      tags 'Pricing'
+      tags 'Markets'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       admin_scope :read, :settings
@@ -181,7 +181,7 @@ RSpec.describe 'Admin Markets API', type: :request, swagger_doc: 'api-reference/
     end
 
     patch 'Update a market' do
-      tags 'Pricing'
+      tags 'Markets'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -239,7 +239,7 @@ RSpec.describe 'Admin Markets API', type: :request, swagger_doc: 'api-reference/
     end
 
     delete 'Delete a market' do
-      tags 'Pricing'
+      tags 'Markets'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
         Soft-deletes the market (sets `deleted_at`). The default market and

--- a/spree/api/spec/integration/spree/api/v3/admin/option_types_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/option_types_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Option Types API', type: :request, swagger_doc: 'api-refer
 
   path '/api/v3/admin/option_types' do
     get 'List option types' do
-      tags 'Product Catalog'
+      tags 'Option Types'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a paginated list of option types.'
@@ -53,7 +53,7 @@ RSpec.describe 'Admin Option Types API', type: :request, swagger_doc: 'api-refer
     end
 
     post 'Create an option type' do
-      tags 'Product Catalog'
+      tags 'Option Types'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -117,7 +117,7 @@ RSpec.describe 'Admin Option Types API', type: :request, swagger_doc: 'api-refer
 
   path '/api/v3/admin/option_types/{id}' do
     get 'Get an option type' do
-      tags 'Product Catalog'
+      tags 'Option Types'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single option type by ID, including its option values.'
@@ -157,7 +157,7 @@ RSpec.describe 'Admin Option Types API', type: :request, swagger_doc: 'api-refer
     end
 
     patch 'Update an option type' do
-      tags 'Product Catalog'
+      tags 'Option Types'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -217,7 +217,7 @@ RSpec.describe 'Admin Option Types API', type: :request, swagger_doc: 'api-refer
     end
 
     delete 'Delete an option type' do
-      tags 'Product Catalog'
+      tags 'Option Types'
       security [api_key: [], bearer_auth: []]
       description 'Deletes an option type.'
       admin_scope :write, :products

--- a/spree/api/spec/integration/spree/api/v3/admin/orders/fulfillments_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/orders/fulfillments_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
     let(:order_id) { order.prefixed_id }
 
     get 'List fulfillments' do
-      tags 'Orders'
+      tags 'Fulfillments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns all shipments for an order.'
@@ -48,7 +48,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
     let(:id) { shipment.prefixed_id }
 
     get 'Show a shipment' do
-      tags 'Orders'
+      tags 'Fulfillments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns details of a specific shipment.'
@@ -80,7 +80,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
     end
 
     patch 'Update a shipment' do
-      tags 'Orders'
+      tags 'Fulfillments'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -118,7 +118,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
 
   path '/api/v3/admin/orders/{order_id}/fulfillments/{id}/fulfill' do
     patch 'Fulfill a fulfillment' do
-      tags 'Orders'
+      tags 'Fulfillments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Marks a fulfillment as fulfilled.'
@@ -153,7 +153,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
 
   path '/api/v3/admin/orders/{order_id}/fulfillments/{id}/cancel' do
     patch 'Cancel a fulfillment' do
-      tags 'Orders'
+      tags 'Fulfillments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Cancels a fulfillment.'
@@ -184,7 +184,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
 
   path '/api/v3/admin/orders/{order_id}/fulfillments/{id}/resume' do
     patch 'Resume a fulfillment' do
-      tags 'Orders'
+      tags 'Fulfillments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Resumes a canceled fulfillment.'
@@ -219,7 +219,7 @@ RSpec.describe 'Admin Order Fulfillments API', type: :request, swagger_doc: 'api
 
   path '/api/v3/admin/orders/{order_id}/fulfillments/{id}/split' do
     patch 'Split a fulfillment' do
-      tags 'Orders'
+      tags 'Fulfillments'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]

--- a/spree/api/spec/integration/spree/api/v3/admin/orders/payments_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/orders/payments_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin Order Payments API', type: :request, swagger_doc: 'api-ref
     let(:order_id) { order.prefixed_id }
 
     get 'List payments' do
-      tags 'Orders'
+      tags 'Payments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns all payments for an order.'
@@ -43,7 +43,7 @@ RSpec.describe 'Admin Order Payments API', type: :request, swagger_doc: 'api-ref
     end
 
     post 'Create a payment' do
-      tags 'Orders'
+      tags 'Payments'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -87,7 +87,7 @@ RSpec.describe 'Admin Order Payments API', type: :request, swagger_doc: 'api-ref
     let(:id) { payment.prefixed_id }
 
     get 'Show a payment' do
-      tags 'Orders'
+      tags 'Payments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns details of a specific payment.'
@@ -120,7 +120,7 @@ RSpec.describe 'Admin Order Payments API', type: :request, swagger_doc: 'api-ref
 
   path '/api/v3/admin/orders/{order_id}/payments/{id}/capture' do
     patch 'Capture a payment' do
-      tags 'Orders'
+      tags 'Payments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Captures a pending payment.'
@@ -176,7 +176,7 @@ RSpec.describe 'Admin Order Payments API', type: :request, swagger_doc: 'api-ref
 
   path '/api/v3/admin/orders/{order_id}/payments/{id}/void' do
     patch 'Void a payment' do
-      tags 'Orders'
+      tags 'Payments'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Voids a payment.'

--- a/spree/api/spec/integration/spree/api/v3/admin/orders/refunds_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/orders/refunds_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin Order Refunds API', type: :request, swagger_doc: 'api-refe
     let(:order_id) { order.prefixed_id }
 
     get 'List refunds' do
-      tags 'Orders'
+      tags 'Refunds'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns all refunds for an order.'
@@ -43,7 +43,7 @@ RSpec.describe 'Admin Order Refunds API', type: :request, swagger_doc: 'api-refe
     end
 
     post 'Create a refund' do
-      tags 'Orders'
+      tags 'Refunds'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]

--- a/spree/api/spec/integration/spree/api/v3/admin/payment_methods_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/payment_methods_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Payment Methods API', type: :request, swagger_doc: 'api-re
 
   path '/api/v3/admin/payment_methods' do
     get 'List payment methods' do
-      tags 'Configuration'
+      tags 'Payment Methods'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns the store\'s configured payment methods. Use `source_required: true` to know which methods need a saved source.'
@@ -38,7 +38,7 @@ RSpec.describe 'Admin Payment Methods API', type: :request, swagger_doc: 'api-re
 
   path '/api/v3/admin/payment_methods/types' do
     get 'List available payment provider types' do
-      tags 'Configuration'
+      tags 'Payment Methods'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns the registered Spree::PaymentMethod subclasses that can be used to create new payment methods. Useful for populating a "Provider" dropdown in admin UIs.'
@@ -77,7 +77,7 @@ RSpec.describe 'Admin Payment Methods API', type: :request, swagger_doc: 'api-re
     let(:id) { payment_method.prefixed_id }
 
     get 'Show a payment method' do
-      tags 'Configuration'
+      tags 'Payment Methods'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a payment method by ID.'

--- a/spree/api/spec/integration/spree/api/v3/admin/products_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/products_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products' do
     get 'List products' do
-      tags 'Product Catalog'
+      tags 'Products'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a paginated list of products for the current store.'
@@ -57,7 +57,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
     end
 
     post 'Create a product' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -161,7 +161,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/{id}' do
     get 'Get a product' do
-      tags 'Product Catalog'
+      tags 'Products'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single product by ID.'
@@ -201,7 +201,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
     end
 
     patch 'Update a product' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -300,7 +300,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
     end
 
     delete 'Delete a product' do
-      tags 'Product Catalog'
+      tags 'Products'
       security [api_key: [], bearer_auth: []]
       description 'Soft-deletes a product.'
       admin_scope :write, :products
@@ -325,7 +325,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_status_update' do
     post 'Bulk-update product status' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -387,7 +387,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_add_to_categories' do
     post 'Bulk-add products to categories' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -430,7 +430,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_remove_from_categories' do
     post 'Bulk-remove products from categories' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -467,7 +467,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_add_to_channels' do
     post 'Bulk-add products to channels' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -510,7 +510,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_remove_from_channels' do
     post 'Bulk-remove products from channels' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -552,7 +552,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_add_tags' do
     post 'Bulk-add tags to products' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -590,7 +590,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_remove_tags' do
     post 'Bulk-remove tags from products' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -625,7 +625,7 @@ RSpec.describe 'Admin Products API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/bulk_destroy' do
     delete 'Bulk-delete products' do
-      tags 'Product Catalog'
+      tags 'Products'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]

--- a/spree/api/spec/integration/spree/api/v3/admin/roles_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/roles_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Roles API', type: :request, swagger_doc: 'api-reference/ad
 
   path '/api/v3/admin/roles' do
     get 'List roles' do
-      tags 'Configuration'
+      tags 'Staff'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns the roles available for staff role pickers. Roles are global, not per-store.'

--- a/spree/api/spec/integration/spree/api/v3/admin/stock_locations_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/stock_locations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Stock Locations API', type: :request, swagger_doc: 'api-re
 
   path '/api/v3/admin/stock_locations' do
     get 'List stock locations' do
-      tags 'Configuration'
+      tags 'Stock Locations'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -70,7 +70,7 @@ RSpec.describe 'Admin Stock Locations API', type: :request, swagger_doc: 'api-re
     end
 
     post 'Create a stock location' do
-      tags 'Configuration'
+      tags 'Stock Locations'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -160,7 +160,7 @@ RSpec.describe 'Admin Stock Locations API', type: :request, swagger_doc: 'api-re
     parameter name: :id, in: :path, type: :string, required: true, description: 'Stock location ID'
 
     get 'Get a stock location' do
-      tags 'Configuration'
+      tags 'Stock Locations'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single stock location by prefixed ID.'
@@ -197,7 +197,7 @@ RSpec.describe 'Admin Stock Locations API', type: :request, swagger_doc: 'api-re
     end
 
     patch 'Update a stock location' do
-      tags 'Configuration'
+      tags 'Stock Locations'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -267,7 +267,7 @@ RSpec.describe 'Admin Stock Locations API', type: :request, swagger_doc: 'api-re
     end
 
     delete 'Delete a stock location' do
-      tags 'Configuration'
+      tags 'Stock Locations'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
         Soft-deletes the stock location (sets `deleted_at`). Existing

--- a/spree/api/spec/integration/spree/api/v3/admin/store_credit_categories_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/store_credit_categories_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Store Credit Categories API', type: :request, swagger_doc:
 
   path '/api/v3/admin/store_credit_categories' do
     get 'List store credit categories' do
-      tags 'Configuration'
+      tags 'Settings'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -63,7 +63,7 @@ RSpec.describe 'Admin Store Credit Categories API', type: :request, swagger_doc:
     parameter name: :id, in: :path, type: :string, required: true, description: 'Store credit category ID'
 
     get 'Get a store credit category' do
-      tags 'Configuration'
+      tags 'Settings'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single store credit category by prefixed ID.'

--- a/spree/api/spec/integration/spree/api/v3/admin/store_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/store_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Admin Store API', type: :request, swagger_doc: 'api-reference/ad
 
   path '/api/v3/admin/store' do
     get 'Get the current store' do
-      tags 'Configuration'
+      tags 'Settings'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns the current store configuration. The store is resolved from the request context (host or admin selection); there is no `id` parameter.'
@@ -53,7 +53,7 @@ RSpec.describe 'Admin Store API', type: :request, swagger_doc: 'api-reference/ad
     end
 
     patch 'Update the current store' do
-      tags 'Configuration'
+      tags 'Settings'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]

--- a/spree/api/spec/integration/spree/api/v3/admin/tags_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/tags_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Admin Tags API', type: :request, swagger_doc: 'api-reference/adm
 
   path '/api/v3/admin/tags' do
     get 'List tags' do
-      tags 'Configuration'
+      tags 'Settings'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns tag names for a given taggable type. Used for autocomplete in tag inputs on products, orders, and customers.'

--- a/spree/api/spec/integration/spree/api/v3/admin/variants_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/variants_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Admin Variants API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/{product_id}/variants' do
     get 'List product variants' do
-      tags 'Product Catalog'
+      tags 'Variants'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a paginated list of variants for a product, including the master variant.'
@@ -42,7 +42,7 @@ RSpec.describe 'Admin Variants API', type: :request, swagger_doc: 'api-reference
     end
 
     post 'Create a variant' do
-      tags 'Product Catalog'
+      tags 'Variants'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -144,7 +144,7 @@ RSpec.describe 'Admin Variants API', type: :request, swagger_doc: 'api-reference
 
   path '/api/v3/admin/products/{product_id}/variants/{id}' do
     get 'Get a variant' do
-      tags 'Product Catalog'
+      tags 'Variants'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single variant by ID.'
@@ -185,7 +185,7 @@ RSpec.describe 'Admin Variants API', type: :request, swagger_doc: 'api-reference
     end
 
     patch 'Update a variant' do
-      tags 'Product Catalog'
+      tags 'Variants'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -268,7 +268,7 @@ RSpec.describe 'Admin Variants API', type: :request, swagger_doc: 'api-reference
     end
 
     delete 'Delete a variant' do
-      tags 'Product Catalog'
+      tags 'Variants'
       security [api_key: [], bearer_auth: []]
       description 'Soft-deletes a variant.'
       admin_scope :write, :products

--- a/spree/api/spec/integration/spree/api/v3/admin/webhook_deliveries_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/webhook_deliveries_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Admin Webhook Deliveries API', type: :request, swagger_doc: 'api
               description: 'Parent webhook endpoint ID'
 
     get 'List webhook deliveries' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -74,7 +74,7 @@ RSpec.describe 'Admin Webhook Deliveries API', type: :request, swagger_doc: 'api
     parameter name: :id, in: :path, type: :string, required: true, description: 'Webhook delivery ID'
 
     get 'Get a webhook delivery' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -126,7 +126,7 @@ RSpec.describe 'Admin Webhook Deliveries API', type: :request, swagger_doc: 'api
               description: 'Webhook delivery ID to redeliver'
 
     post 'Redeliver a webhook delivery' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC

--- a/spree/api/spec/integration/spree/api/v3/admin/webhook_endpoints_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/webhook_endpoints_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
 
   path '/api/v3/admin/webhook_endpoints' do
     get 'List webhook endpoints' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -72,7 +72,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     end
 
     post 'Create a webhook endpoint' do
-      tags 'Configuration'
+      tags 'Webhooks'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -139,7 +139,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     parameter name: :id, in: :path, type: :string, required: true, description: 'Webhook endpoint ID'
 
     get 'Get a webhook endpoint' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Returns a single webhook endpoint by prefixed ID.'
@@ -181,7 +181,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     end
 
     patch 'Update a webhook endpoint' do
-      tags 'Configuration'
+      tags 'Webhooks'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
@@ -230,7 +230,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     end
 
     delete 'Delete a webhook endpoint' do
-      tags 'Configuration'
+      tags 'Webhooks'
       security [api_key: [], bearer_auth: []]
       description 'Soft-deletes the endpoint and stops future deliveries.'
       admin_scope :write, :settings
@@ -254,7 +254,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     parameter name: :id, in: :path, type: :string, required: true, description: 'Webhook endpoint ID'
 
     post 'Send a test delivery' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description <<~DESC
@@ -293,7 +293,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     parameter name: :id, in: :path, type: :string, required: true, description: 'Webhook endpoint ID'
 
     patch 'Re-enable a webhook endpoint' do
-      tags 'Configuration'
+      tags 'Webhooks'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]
       description 'Re-enables an endpoint that was manually or automatically disabled.'
@@ -324,7 +324,7 @@ RSpec.describe 'Admin Webhook Endpoints API', type: :request, swagger_doc: 'api-
     parameter name: :id, in: :path, type: :string, required: true, description: 'Webhook endpoint ID'
 
     patch 'Disable a webhook endpoint' do
-      tags 'Configuration'
+      tags 'Webhooks'
       consumes 'application/json'
       produces 'application/json'
       security [api_key: [], bearer_auth: []]

--- a/spree/api/spec/swagger_helper.rb
+++ b/spree/api/spec/swagger_helper.rb
@@ -166,18 +166,40 @@ RSpec.configure do |config|
         }
       ],
       tags: [
-        { name: 'Authentication', description: 'Admin user authentication' },
-        { name: 'Product Catalog', description: 'Products, variants, and option types' },
-        { name: 'Orders', description: 'Order management — orders, items, payments, fulfillments, refunds, gift cards, store credits' },
-        { name: 'Customers', description: 'Customer management — profiles, addresses, store credits, credit cards' },
-        { name: 'Configuration', description: 'Store configuration — payment methods, tag autocomplete' }
+        { name: 'Authentication', description: 'Admin user login, logout, token refresh, and current user profile' },
+        { name: 'Allowed Origins', description: 'CORS allowlist for storefront and admin client origins' },
+        { name: 'API Keys', description: 'Secret and publishable API keys' },
+        { name: 'Channels', description: 'Sales channels and product publication across channels' },
+        { name: 'Custom Fields', description: 'Custom field definitions for products, variants, customers, and other resources' },
+        { name: 'Customer Groups', description: 'Customer groups for segmenting customers (e.g. wholesale, VIP) used by pricing and promotions' },
+        { name: 'Customers', description: 'Customer profiles, addresses, credit cards, and store credits' },
+        { name: 'Exports', description: 'Async CSV exports of admin resources' },
+        { name: 'Fulfillments', description: 'Order fulfillments — shipments, fulfill, cancel, resume, split' },
+        { name: 'Gift Cards', description: 'Gift cards and gift card batches' },
+        { name: 'Markets', description: 'Markets — geographic groupings of countries used for pricing, tax, and fulfillment rules' },
+        { name: 'Option Types', description: 'Option types and option values used to build product variants (e.g. Size, Color)' },
+        { name: 'Orders', description: 'Orders, order items, applied gift cards, and applied store credits' },
+        { name: 'Payment Methods', description: 'Configured payment providers and their available types' },
+        { name: 'Payments', description: 'Order payments — list, capture, void' },
+        { name: 'Pricing', description: 'Prices and price lists for currency-, market-, and customer-group-specific pricing' },
+        { name: 'Products', description: 'Products, taxons/categories, product custom field values, and bulk product operations' },
+        { name: 'Promotions', description: 'Promotions, promotion rules, promotion actions, and coupon codes' },
+        { name: 'Refunds', description: 'Order refunds' },
+        { name: 'Settings', description: 'Store-level settings — store profile, tags, store credit categories' },
+        { name: 'Staff', description: 'Admin users, roles, and invitations to the store' },
+        { name: 'Stock Locations', description: 'Warehouses and physical fulfillment locations' },
+        { name: 'Variants', description: 'Product variants — the individual SKUs (size/color combinations) sold under a product' },
+        { name: 'Webhooks', description: 'Webhook endpoints and webhook delivery history' }
       ],
       'x-tagGroups': [
         { name: 'Authentication', tags: ['Authentication'] },
-        { name: 'Product Catalog', tags: ['Product Catalog'] },
-        { name: 'Orders', tags: ['Orders'] },
-        { name: 'Customers', tags: ['Customers'] },
-        { name: 'Configuration', tags: ['Configuration'] }
+        { name: 'Products & Catalog', tags: ['Products', 'Variants', 'Option Types', 'Custom Fields', 'Channels'] },
+        { name: 'Pricing', tags: ['Pricing', 'Markets'] },
+        { name: 'Orders & Fulfillment', tags: ['Orders', 'Payments', 'Fulfillments', 'Refunds'] },
+        { name: 'Customers', tags: ['Customers', 'Customer Groups'] },
+        { name: 'Promotions & Gift Cards', tags: ['Promotions', 'Gift Cards'] },
+        { name: 'Data', tags: ['Exports'] },
+        { name: 'Configuration', tags: ['Settings', 'Stock Locations', 'Payment Methods', 'Staff', 'API Keys', 'Allowed Origins', 'Webhooks'] }
       ],
       components: {
         securitySchemes: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI metadata only; no API routes, auth, or response behavior changes.
> 
> **Overview**
> **Admin API reference navigation** is reworked so Mintlify groups endpoints by domain instead of a few catch-all sections.
> 
> Integration specs now assign **finer OpenAPI tags** (e.g. **Staff**, **Payments**, **Fulfillments**, **Webhooks**, **Products**, **Settings**) instead of lumping routes under broad labels. `swagger_helper.rb` defines the full **tag catalog with descriptions** and **`x-tagGroups`** (Authentication, Products & Catalog, Orders & Fulfillment, Configuration, etc.) so the sidebar matches how merchants think about the API.
> 
> After `rswag:specs:swaggerize`, a **`PathSorter` post-step** reorders `paths` in `admin.yaml` (and `store.yaml`) to follow the curated `tags` array—because rswag emits paths in spec load order and Mintlify keys off first tag appearance. The generated **`docs/api-reference/admin.yaml`** reflects the new grouping; runtime Admin API behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47aa90a28507491349fdaad7b302771082bcc14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Admin API docs into many more specific tags (e.g., Staff, Payments, Fulfillments, Webhooks, Products, Settings, etc.) for clearer grouping and discoverability
  * Updated OpenAPI/Swagger metadata so endpoints are grouped under clearer functional topics instead of generic categories

* **Chores**
  * Ensured generated API reference preserves and applies the curated tag ordering during doc generation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->