### PR TITLE
Make order routing strategy resolution graceful with fallback

### DIFF
--- a/docs/developer/how-to/custom-order-routing.mdx
+++ b/docs/developer/how-to/custom-order-routing.mdx
@@ -243,7 +243,7 @@ store.channels.find_by(code: 'pos').update!(
 )
 ```
 
-Resolution order: `channel.preferred_order_routing_strategy` → `store.preferred_order_routing_strategy`. The class is `safe_constantize`-d and rejected if it doesn't subclass `Strategy::Base`.
+Resolution order: `channel.preferred_order_routing_strategy` → `store.preferred_order_routing_strategy`. Each preference is `safe_constantize`-d and only used if it resolves to a concrete `Strategy::Base` subclass; a blank, missing, or non-strategy value is logged and skipped, falling back to the next preference and ultimately the default `Strategy::Rules`. A misconfigured strategy never raises at checkout.
 
 ### Step 3: Test the Strategy
 

--- a/docs/developer/how-to/custom-order-routing.mdx
+++ b/docs/developer/how-to/custom-order-routing.mdx
@@ -243,7 +243,7 @@ store.channels.find_by(code: 'pos').update!(
 )
 ```
 
-Resolution order: `channel.preferred_order_routing_strategy` → `store.preferred_order_routing_strategy`. Each preference is `safe_constantize`-d and only used if it resolves to a concrete `Strategy::Base` subclass; a blank, missing, or non-strategy value is logged and skipped, falling back to the next preference and ultimately the default `Strategy::Rules`. A misconfigured strategy never raises at checkout.
+Resolution order: `channel.preferred_order_routing_strategy` → `store.preferred_order_routing_strategy` → the default `Strategy::Rules`. Only a value that points to a real `Strategy::Base` subclass is used; anything unset or invalid is skipped, so a misconfigured strategy falls back to the default instead of breaking checkout.
 
 ### Step 3: Test the Strategy
 

--- a/packages/dashboard/src/locales/en.json
+++ b/packages/dashboard/src/locales/en.json
@@ -228,7 +228,6 @@
           "inherit": "Inherit from store",
           "options": {
             "Spree::OrderRouting::Strategy::Rules": "Rules (ordered)",
-            "Spree::OrderRouting::Strategy::Reducer": "Reducer (greedy)",
             "Spree::OrderRouting::Strategy::Legacy": "Legacy"
           }
         }

--- a/packages/dashboard/src/schemas/channel.ts
+++ b/packages/dashboard/src/schemas/channel.ts
@@ -6,7 +6,6 @@ import { z } from 'zod/v4'
 export const ORDER_ROUTING_STRATEGY_VALUES = [
   '',
   'Spree::OrderRouting::Strategy::Rules',
-  'Spree::OrderRouting::Strategy::Reducer',
   'Spree::OrderRouting::Strategy::Legacy',
 ] as const
 

--- a/spree/admin/app/helpers/spree/admin/channels_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/channels_helper.rb
@@ -7,7 +7,6 @@ module Spree
       def channel_order_routing_strategy_options
         [
           [Spree.t('admin.channels.order_routing_strategies.rules'),    'Spree::OrderRouting::Strategy::Rules'],
-          [Spree.t('admin.channels.order_routing_strategies.reducer'),  'Spree::OrderRouting::Strategy::Reducer'],
           [Spree.t('admin.channels.order_routing_strategies.legacy'),   'Spree::OrderRouting::Strategy::Legacy']
         ]
       end

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -81,7 +81,6 @@ en:
         default_hint: Exactly one channel per store is the default. Used as the fallback when no channel is selected and as the auto-publish target for new products.
         order_routing_strategies:
           legacy: Legacy
-          reducer: Reducer (greedy)
           rules: Rules (ordered)
         order_routing_strategy: Order routing strategy
         order_routing_strategy_hint: Overrides the store-level routing strategy for orders attributed to this channel.

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -1044,9 +1044,6 @@ module Spree
 
     private
 
-    # @param klass_name [String, nil]
-    # @return [Class, nil] the strategy class when it's a valid
-    #   Spree::OrderRouting::Strategy::Base subclass, nil otherwise
     def valid_order_routing_strategy_class(klass_name)
       return if klass_name.blank?
 

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -776,15 +776,18 @@ module Spree
       end
     end
 
+    # Resolves the routing strategy from the channel override first, then the
+    # store default. Any preference that doesn't resolve to a concrete
+    # Spree::OrderRouting::Strategy::Base subclass (e.g. an internal collaborator
+    # like Reducer that was never a strategy, or a typo'd custom class) is logged
+    # and skipped rather than raised, falling back to the default Rules strategy
+    # so a misconfiguration can't take down cart display or checkout.
+    #
     # @return [Spree::OrderRouting::Strategy::Base]
     def order_routing_strategy
-      klass_name = channel&.preferred_order_routing_strategy.presence ||
-                   store.preferred_order_routing_strategy
-      klass = klass_name&.safe_constantize
-
-      unless klass && klass <= Spree::OrderRouting::Strategy::Base
-        raise ArgumentError, "Invalid order routing strategy: #{klass_name.inspect}"
-      end
+      klass = valid_order_routing_strategy_class(channel&.preferred_order_routing_strategy) ||
+              valid_order_routing_strategy_class(store.preferred_order_routing_strategy) ||
+              Spree::OrderRouting::Strategy::Rules
 
       klass.new(order: self)
     end
@@ -1040,6 +1043,22 @@ module Spree
     end
 
     private
+
+    # @param klass_name [String, nil]
+    # @return [Class, nil] the strategy class when it's a valid
+    #   Spree::OrderRouting::Strategy::Base subclass, nil otherwise
+    def valid_order_routing_strategy_class(klass_name)
+      return if klass_name.blank?
+
+      klass = klass_name.safe_constantize
+      return klass if klass && klass < Spree::OrderRouting::Strategy::Base
+
+      Rails.logger.warn(
+        "[Spree] Ignoring invalid order routing strategy #{klass_name.inspect} " \
+        "for order #{number.inspect}; falling back to the default strategy."
+      )
+      nil
+    end
 
     def link_by_email
       self.email = user.email if user

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -1612,6 +1612,26 @@ describe Spree::Order, type: :model do
       expect(channel.preferred_order_routing_strategy).to be_blank
       expect(isolated_order.order_routing_strategy).to be_a(Spree::OrderRouting::Strategy::Rules)
     end
+
+    it 'skips an invalid channel preference and uses the store preference' do
+      stub_const('StorePreferredStrategy', Class.new(Spree::OrderRouting::Strategy::Base))
+      isolated_store = create(:store)
+      isolated_store.preferred_order_routing_strategy = 'StorePreferredStrategy'
+      channel = isolated_store.channels.first
+      # Reducer is an internal collaborator of Rules, not a Strategy::Base.
+      channel.update!(preferred_order_routing_strategy: 'Spree::OrderRouting::Strategy::Reducer')
+      isolated_order = create(:order, store: isolated_store, channel: channel)
+
+      expect(isolated_order.order_routing_strategy).to be_a(StorePreferredStrategy)
+    end
+
+    it 'falls back to the default Rules strategy when the persisted value is invalid' do
+      isolated_store = create(:store)
+      isolated_store.preferred_order_routing_strategy = 'Spree::OrderRouting::Strategy::Reducer'
+      isolated_order = create(:order, store: isolated_store)
+
+      expect(isolated_order.order_routing_strategy).to be_a(Spree::OrderRouting::Strategy::Rules)
+    end
   end
 
   describe '#ensure_channel_presence' do

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -1616,7 +1616,7 @@ describe Spree::Order, type: :model do
     it 'skips an invalid channel preference and uses the store preference' do
       stub_const('StorePreferredStrategy', Class.new(Spree::OrderRouting::Strategy::Base))
       isolated_store = create(:store)
-      isolated_store.preferred_order_routing_strategy = 'StorePreferredStrategy'
+      isolated_store.update!(preferred_order_routing_strategy: 'StorePreferredStrategy')
       channel = isolated_store.channels.first
       # Reducer is an internal collaborator of Rules, not a Strategy::Base.
       channel.update!(preferred_order_routing_strategy: 'Spree::OrderRouting::Strategy::Reducer')
@@ -1627,7 +1627,7 @@ describe Spree::Order, type: :model do
 
     it 'falls back to the default Rules strategy when the persisted value is invalid' do
       isolated_store = create(:store)
-      isolated_store.preferred_order_routing_strategy = 'Spree::OrderRouting::Strategy::Reducer'
+      isolated_store.update!(preferred_order_routing_strategy: 'Spree::OrderRouting::Strategy::Reducer')
       isolated_order = create(:order, store: isolated_store)
 
       expect(isolated_order.order_routing_strategy).to be_a(Spree::OrderRouting::Strategy::Rules)


### PR DESCRIPTION
## Summary

Changes the order routing strategy resolution to be resilient to misconfiguration. Instead of raising an `ArgumentError` when an invalid strategy class is encountered, the system now logs a warning and falls back to the next preference or the default `Rules` strategy. This prevents cart display or checkout from breaking due to typos or stale references to internal collaborators (like `Reducer`) that were never meant to be user-configurable strategies.

## Key Changes

- **Core logic refactor** (`spree/core/app/models/spree/order.rb`):
  - Extracted strategy validation into a new private method `valid_order_routing_strategy_class` that returns `nil` for invalid classes instead of raising
  - Updated `order_routing_strategy` to chain resolution: channel preference → store preference → default `Rules` strategy
  - Invalid preferences are logged as warnings with order number context rather than raising exceptions

- **Test coverage** (`spree/core/spec/models/spree/order_spec.rb`):
  - Added test for skipping invalid channel preference and falling back to store preference
  - Added test for falling back to default `Rules` strategy when store preference is invalid

- **Documentation** (`docs/developer/how-to/custom-order-routing.mdx`):
  - Updated resolution order documentation to clarify the graceful fallback behavior

- **UI cleanup** (dashboard, admin):
  - Removed `Spree::OrderRouting::Strategy::Reducer` from channel strategy options in:
    - `packages/dashboard/src/locales/en.json`
    - `packages/dashboard/src/schemas/channel.ts`
    - `spree/admin/app/helpers/spree/admin/channels_helper.rb`
    - `spree/admin/config/locales/en.yml`
  - `Reducer` was an internal implementation detail of the `Rules` strategy, not a user-facing strategy option

## Implementation Details

The new `valid_order_routing_strategy_class` method:
- Returns early if the preference is blank
- Uses `safe_constantize` to avoid exceptions on typos or missing classes
- Validates that the resolved class is a subclass of `Spree::OrderRouting::Strategy::Base`
- Logs a warning with the order number when a preference is invalid
- Returns `nil` to allow the next preference in the chain to be tried

This approach ensures that misconfigured strategies never interrupt the checkout flow while still providing visibility into configuration issues through logs.

https://claude.ai/code/session_019cqvuJC8ehZFMazxB76WqZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout shipment allocation via `order_routing_strategy`; misconfigured stores silently use Rules instead of erroring, which is safer for uptime but can mask config mistakes until logs are checked.
> 
> **Overview**
> **Order routing strategy resolution** no longer raises when channel or store preferences point at invalid classes (typos, or internal names like `Reducer`). `Order#order_routing_strategy` now walks channel → store → default `Spree::OrderRouting::Strategy::Rules`, using a new `valid_order_routing_strategy_class` helper that logs a warning and returns `nil` instead of failing checkout or cart flows.
> 
> **Admin and dashboard** drop **Reducer (greedy)** from channel strategy pickers (locales, Zod schema, Rails helper, admin YAML) because it was an internal collaborator, not a user-facing `Strategy::Base` option.
> 
> **Docs** in `custom-order-routing.mdx` describe the full resolution chain and graceful fallback. **Specs** cover invalid channel vs store preferences and defaulting to Rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4ad959cd9817d6d6908b49f433e9e948ab273e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channels can inherit order routing strategy from store-level settings (admin option and locale support added).

* **Bug Fixes**
  * Removed the “Reducer” order routing strategy option.
  * Invalid or unset preferences are skipped (logged) and selection falls back to the default rules strategy so checkout isn’t interrupted.

* **Documentation**
  * Clarified resolution order and fallback behavior for order routing strategies.

* **Tests**
  * Added tests for invalid preference handling and fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->