### PR TITLE
Fixed rails admin product creation with publications

### DIFF
--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -490,6 +490,35 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         expect(product.store).to eq store
       end
     end
+
+    # Mirrors what the legacy Rails admin form submits from
+    # _publishing.html.erb on create: one nested row per channel, the
+    # default-channel row checked (_destroy=0) and the rest unchecked
+    # (_destroy=1). Regression test for V-3454.
+    describe 'publishing card (legacy_product_publications_attributes)' do
+      let(:pos_channel) { create(:channel, store: store, name: 'POS', code: 'pos') }
+      let(:default_channel) { store.default_channel }
+      let(:product_params) do
+        {
+          name: 'Product',
+          shipping_category_id: shipping_category.id,
+          legacy_product_publications_attributes: {
+            '0' => { channel_id: default_channel.id, _destroy: '0', published_at: '', unpublished_at: '' },
+            '1' => { channel_id: pos_channel.id,     _destroy: '1', published_at: '', unpublished_at: '' }
+          }
+        }
+      end
+
+      it 'creates the product and publishes only the checked channels' do
+        subject
+
+        product = Spree::Product.last
+        expect(product).to be_present
+        expect(product.errors.full_messages).to be_empty
+        expect(product.product_publications.count).to eq(1)
+        expect(product.channels).to contain_exactly(default_channel)
+      end
+    end
   end
 
   describe '#GET #edit' do

--- a/spree/admin/spec/features/spree/admin/products/products_spec.rb
+++ b/spree/admin/spec/features/spree/admin/products/products_spec.rb
@@ -105,6 +105,30 @@ describe 'Products', type: :feature do
       end
     end
 
+    # Regression test for V-3454. The publishing card renders one row per
+    # store channel, with the default channel pre-checked and others marked
+    # for destruction. Submitting that shape from a fresh product previously
+    # raised "Legacy product publications product can't be blank" because the
+    # nested children couldn't see the unsaved parent. Capybara round-trips
+    # the form so a controller-only regression doesn't slip through again.
+    context 'creating a product' do
+      let!(:shipping_category) { create(:shipping_category) }
+      let!(:pos_channel) { create(:channel, store: store, name: 'POS', code: 'pos') }
+
+      it 'creates a product and publishes it on the default channel' do
+        visit spree.new_admin_product_path
+
+        fill_in 'product_name', with: 'Captain Cap'
+        click_button 'Create'
+
+        expect(page).to have_content('successfully created')
+
+        product = Spree::Product.find_by(name: 'Captain Cap')
+        expect(product).to be_present
+        expect(product.channels).to contain_exactly(store.default_channel)
+      end
+    end
+
     context 'updating a product' do
       let(:product) { create(:product, stores: Spree::Store.all) }
 

--- a/spree/core/app/models/spree/product/channels.rb
+++ b/spree/core/app/models/spree/product/channels.rb
@@ -13,7 +13,13 @@ module Spree
 
         # No +dependent: :destroy+: Product uses +acts_as_paranoid+, so destroy
         # soft-deletes and publications outlive the product.
-        has_many :product_publications, class_name: 'Spree::ProductPublication', autosave: true
+        # +inverse_of: :product+ is what wires the parent into a child built off
+        # an unsaved Product (via +accepts_nested_attributes_for+ on the legacy
+        # alias below). Without it the child fails +validates :product,
+        # presence: true+ on +create+. Declared on both associations to keep
+        # the two in-memory caches symmetric (V-3454).
+        has_many :product_publications, class_name: 'Spree::ProductPublication',
+                                        inverse_of: :product, autosave: true
         has_many :channels, -> { distinct }, through: :product_publications, class_name: 'Spree::Channel'
 
         # Legacy Rails admin alias. The admin form submits
@@ -22,7 +28,8 @@ module Spree
         # and goes through the custom writer below. Two names, one table —
         # no +dependent:+ for the same +acts_as_paranoid+ reason as above.
         has_many :legacy_product_publications, class_name: 'Spree::ProductPublication',
-                                               foreign_key: :product_id, autosave: true
+                                               foreign_key: :product_id,
+                                               inverse_of: :product, autosave: true
         accepts_nested_attributes_for :legacy_product_publications,
                                       allow_destroy: true,
                                       reject_if: ->(attrs) { attrs[:channel_id].blank? }


### PR DESCRIPTION
Plus added a proper integration test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small association wiring fix plus tests; affects product create/update publication handling but does not change API writers or broader product logic.
> 
> **Overview**
> Fixes **Rails admin product create** when the publishing card submits nested `legacy_product_publications_attributes` (one row per channel, default checked, others `_destroy=1`). Creating a product used to fail with **"Legacy product publications product can't be blank"** because nested `Spree::ProductPublication` records could not see the unsaved parent during validation (V-3454).
> 
> The change adds **`inverse_of: :product`** on both `product_publications` and `legacy_product_publications` in `Spree::Product::Channels`, so children built via nested attributes get the in-memory product before save.
> 
> **Regression coverage:** a controller example that posts the legacy publishing payload on create, and a Capybara feature that creates a product through the new-product form and asserts publication on the store’s default channel only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a86a8ac29ec4515fd41b81c2ed07677a5374b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed product creation with store channel publishing assignments to ensure correct channel association

* **Tests**
  * Added regression test for product creation workflow with channel publishing
  * Added test coverage for admin product creation and channel assignment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->