### PR TITLE
Admin: translate nav sections

### DIFF
--- a/spree/admin/app/helpers/spree/admin/navigation_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/navigation_helper.rb
@@ -416,7 +416,7 @@ module Spree
       # @return [SafeBuffer] the section header HTML
       def render_nav_section_header(item)
         content_tag :li, class: 'nav-item nav-section-header mt-4 border-t pt-4 pl-2' do
-          content_tag :span, item.section_label, class: 'text-gray-600 uppercase font-light text-sm'
+          content_tag :span, Spree.t(item.section_label), class: 'text-gray-600 uppercase font-light text-sm'
         end
       end
 

--- a/spree/admin/config/initializers/spree_admin_navigation.rb
+++ b/spree/admin/config/initializers/spree_admin_navigation.rb
@@ -191,7 +191,7 @@ Rails.application.config.after_initialize do
 
   # Section divider before settings
   sidebar_nav.add :settings_section,
-          section_label: 'Settings',
+          section_label: :'admin.settings_section',
           position: 90
 
   # Settings (bottom of sidebar)

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -321,6 +321,7 @@ en:
       response_code: Response Code
       selected: selected
       send_payment_link: Send Payment Link
+      settings_section: Settings
       shipment:
         please_provide_tracking_details: Before marking shipment as shipped please provide tracking details
       shipment_transfer:

--- a/spree/admin/spec/helpers/spree/admin/navigation_helper_spec.rb
+++ b/spree/admin/spec/helpers/spree/admin/navigation_helper_spec.rb
@@ -262,6 +262,16 @@ describe Spree::Admin::NavigationHelper, type: :helper do
         expect(result).to have_selector('li.nav-section-header')
         expect(result).to include('Settings Section')
       end
+
+      it 'translates a symbol section label through Spree.t' do
+        nav.add :section, section_label: :'admin.settings_section'
+        item = nav.visible_items(helper).first
+
+        result = helper.render_navigation_item(item, :sidebar)
+
+        expect(result).to have_selector('li.nav-section-header')
+        expect(result).to include(Spree.t(:'admin.settings_section'))
+      end
     end
 
     context 'with children' do


### PR DESCRIPTION
Small change to allow admin sections ( currently only "settings" section ) to be translated using `spree_i18n` locale files.

I'm open if the team wants to have a better organization about the strings for the admin navigation like:
```yaml
spree:
  admin:
    navigation:
      getting_started: Getting started
      ...
      sections:
        settings: Settings
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced internationalization support for navigation labels, enabling proper translation of section headers in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->