### PR TITLE
`spree dev` now runs the app in the foreground like every other dev s…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,10 +10,10 @@
       "WebFetch",
       "WebSearch",
       "Task",
-      "mcp__*",
       "Bash(rm -rf server)",
       "Bash(git clone *)",
-      "Bash(rm -rf server/.git server/.gitignore)"
+      "Bash(rm -rf server/.git server/.gitignore)",
+      "Skill(update-config)"
     ],
     "deny": [
       "Bash(sudo *)",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -112,10 +112,11 @@ Which command after which change:
 | What changed | What to run |
 |---|---|
 | Ruby code in `spree/*` gems | Nothing — gems are bind-mounted; code reloads on the next request |
-| A new migration in a gem | `cd server && pnpm exec spree migrate` |
-| Gem dependencies (gemspec / Gemfile) | `cd server && pnpm exec spree bundle install` (persists in the `bundle_cache` volume) |
+| A new migration in a gem | Nothing — the next `pnpm server:dev` boot applies it (or `cd server && pnpm exec spree migrate` while the stack runs) |
+| Gem dependencies (gemspec / Gemfile / lock drift after `git pull`) | Nothing — the next `pnpm server:dev` boot self-heals via `bundle check || bundle install` (or `cd server && pnpm exec spree bundle install` while the stack runs) |
 | Compose files / `server/.env` | `pnpm server:dev` (force-recreates the containers) |
-| `server/Dockerfile` / `.ruby-version` | `pnpm server:build`, then `pnpm server:dev` |
+| `server/Dockerfile` / `.ruby-version` / starter update that breaks the image build ("lockfile can't be updated because frozen") | `pnpm server:build`, then `pnpm server:dev` — the build script handles the edge-rewritten `Gemfile.lock` automatically |
+| Meilisearch image bump ("database version … is incompatible") | Remove the `server_meilisearch_data` volume, boot, then reindex (`pnpm exec spree rake spree:search:reindex`) — the index is derived data |
 | Broken beyond repair | `pnpm server:setup` (full reset — wipes the database and volumes) |
 
 Re-run `pnpm server:setup` **only** to fully reset — it does `docker compose down -v` + `rm -rf ./server`, wiping all DB data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,11 @@ Day-to-day from the repo root: `pnpm server:dev` (foreground — streams web + w
 | What changed | What to run |
 |---|---|
 | Ruby code in `spree/*` gems | Nothing — bind-mounted, reloads on next request |
-| New migration in a gem | `cd server && pnpm exec spree migrate` |
-| Gem dependencies (gemspec / Gemfile) | `cd server && pnpm exec spree bundle install` (persists in the `bundle_cache` volume) |
+| New migration in a gem | Nothing — the next `pnpm server:dev` boot runs `spree:install:migrations db:prepare` (or `cd server && pnpm exec spree migrate` while running) |
+| Gem dependencies (gemspec / Gemfile / starter `Gemfile.lock` drift after a pull) | Nothing — the next `pnpm server:dev` boot self-heals (`bundle check || bundle install` into the `bundle_cache` volume); while running: `cd server && pnpm exec spree bundle install` |
 | Compose files / `server/.env` | `pnpm server:dev` (force-recreates web + worker) |
-| `server/Dockerfile` / `.ruby-version` | `pnpm server:build`, then `pnpm server:dev` |
+| `server/Dockerfile` / `.ruby-version` / starter update that breaks the image build (frozen-lockfile error) | `pnpm server:build`, then `pnpm server:dev` — the build script swaps the edge PATH lock for a RubyGems-resolved one and the next boot swaps it back |
+| Meilisearch image bump ("database version … is incompatible") | `docker compose -p server rm -sf meilisearch && docker volume rm server_meilisearch_data`, boot, then `cd server && pnpm exec spree rake spree:search:reindex` |
 | Broken beyond repair | `pnpm server:setup` (full reset — wipes DB + volumes) |
 
 Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.

--- a/docs/developer/contributing/developing-spree.mdx
+++ b/docs/developer/contributing/developing-spree.mdx
@@ -78,10 +78,11 @@ Which command after which change:
 | What changed | What to run |
 |---|---|
 | Ruby code in `spree/*` gems | Nothing — gems are bind-mounted; code reloads on the next request |
-| A new migration in a gem | `cd server && pnpm exec spree migrate` |
-| Gem dependencies (gemspec / Gemfile) | `cd server && pnpm exec spree bundle install` (persists in the `bundle_cache` volume) |
+| A new migration in a gem | Nothing — the next `pnpm server:dev` boot applies it (or `cd server && pnpm exec spree migrate` while the stack runs) |
+| Gem dependencies (gemspec / Gemfile / lock drift after `git pull`) | Nothing — the next `pnpm server:dev` boot self-heals via `bundle check || bundle install` (or `cd server && pnpm exec spree bundle install` while the stack runs) |
 | Compose files / `server/.env` | `pnpm server:dev` (force-recreates the containers) |
-| `server/Dockerfile` / `.ruby-version` | `pnpm server:build`, then `pnpm server:dev` |
+| `server/Dockerfile` / `.ruby-version` / starter update that breaks the image build ("lockfile can't be updated because frozen") | `pnpm server:build`, then `pnpm server:dev` — the build script handles the edge-rewritten `Gemfile.lock` automatically |
+| Meilisearch image bump ("database version … is incompatible") | Remove the `server_meilisearch_data` volume, boot, then reindex (`pnpm exec spree rake spree:search:reindex`) — the index is derived data |
 | Broken beyond repair | `pnpm server:setup` (full reset — wipes the database and volumes) |
 
 Re-run `pnpm server:setup` **only** to fully reset — it does `docker compose down -v` + `rm -rf ./server`, wiping all DB data.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "server:create": "git clone --depth 1 https://github.com/spree/spree-starter.git server && rm -rf server/.git server/.gitignore && printf 'SPREE_PATH=..\\nSECRET_KEY_BASE=%s\\n' \"$(openssl rand -hex 64)\" > server/.env",
     "server:setup": "bash scripts/server-setup.sh",
     "server:dev": "SPREE_PATH=$PWD docker compose -f server/docker-compose.dev.yml -f scripts/docker-compose.edge.yml up --force-recreate web worker",
-    "server:build": "SPREE_PATH=$PWD docker compose -f server/docker-compose.dev.yml -f scripts/docker-compose.edge.yml build web worker",
+    "server:build": "bash scripts/server-build.sh",
     "server:restart": "SPREE_PATH=$PWD docker compose -f server/docker-compose.dev.yml -f scripts/docker-compose.edge.yml restart web worker",
     "server:stop": "SPREE_PATH=$PWD docker compose -f server/docker-compose.dev.yml -f scripts/docker-compose.edge.yml down",
     "server:console": "cd server && spree console",

--- a/packages/cli/.changeset/cli-dev-foreground-and-resilience.md
+++ b/packages/cli/.changeset/cli-dev-foreground-and-resilience.md
@@ -1,0 +1,15 @@
+---
+"@spree/cli": minor
+---
+
+`spree dev` now runs the app in the foreground like every other dev server (`vite dev`, `bin/dev`): it streams web + worker logs and `Ctrl+C` stops them, while the database containers keep running for a fast next boot — `spree stop` remains the full shutdown. Previously `Ctrl+C` only detached from the logs and left everything running. Real compose failures (daemon down, port conflict, bad config) now exit with the underlying code instead of printing a clean shutdown message; a `Ctrl+C` stop still ends cleanly.
+
+Add `spree restart` — restarts `web` + `worker` in place (same image, same volumes, fresh Rails process). For `config/initializers` changes and anything Zeitwerk doesn't reload; it does not pick up Gemfile or compose changes.
+
+`spree bundle` now works when the stack is down: if the `web` container isn't running — for example after a `Gemfile.lock` change crash-loops the boot, which is exactly when bundler is needed — it runs bundler in a one-off container against the same `bundle_cache` volume instead of failing on `exec`.
+
+`spree dev` and `spree build` detect monorepo edge projects (`SPREE_PATH` in `.env`) and refuse with a pointer to the matching `pnpm server:*` script, instead of materializing the wrong compose config against the running edge stack.
+
+`spree migrate` prints a header for each step and a completion note — previously a fully up-to-date run produced no output at all, leaving no signal that anything ran.
+
+`spree upgrade`'s closing "Next steps" panel now includes the SDK side of the upgrade: when the project has the conventional `apps/storefront` consuming `@spree/sdk`, it names the currently-declared version and reminds you to bump it to the release matching the new Spree version.

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -1,6 +1,8 @@
+import * as p from '@clack/prompts'
 import type { Command } from 'commander'
-import { detectProject } from '../context.js'
-import { dockerComposeExec } from '../docker.js'
+import pc from 'picocolors'
+import { detectProject, hasMonorepoSpreePath } from '../context.js'
+import { dockerCompose, dockerComposeExec, isServiceRunning } from '../docker.js'
 
 // Run bundler inside the web container. Gems install into the bundle_cache
 // volume and persist across container restarts without an image rebuild.
@@ -16,6 +18,31 @@ export function registerBundleCommand(program: Command): void {
     .passThroughOptions(true)
     .action(async (args: string[]) => {
       const ctx = detectProject()
-      await dockerComposeExec(['bundle', ...args], ctx.projectDir)
+
+      if (await isServiceRunning('web', ctx.projectDir)) {
+        await dockerComposeExec(['bundle', ...args], ctx.projectDir)
+        return
+      }
+
+      // Gemfile.lock drift crashes the containers before `exec` can reach
+      // them — exactly the state where bundler is needed most. A one-off
+      // `compose run` container mounts the same bundle_cache volume, so
+      // gems land where the next boot expects them.
+      if (hasMonorepoSpreePath(ctx.projectDir)) {
+        p.cancel(
+          [
+            'The web container is not running, and this is a monorepo edge project.',
+            `Run ${pc.bold('pnpm server:dev')} from the monorepo root — the edge stack heals gem drift on boot.`,
+          ].join('\n'),
+        )
+        process.exit(1)
+      }
+
+      p.log.info(
+        'web container is not running — using a one-off container (`docker compose run`) instead.',
+      )
+      await dockerCompose(['run', '--rm', 'web', 'bundle', ...args], ctx.projectDir, {
+        stdio: 'inherit',
+      })
     })
 }

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -36,11 +36,9 @@ export async function rakeTask(
 // can fall back to `compose run` when the stack is down.
 export async function isServiceRunning(service: string, projectDir: string): Promise<boolean> {
   try {
-    const { stdout } = await execa(
-      'docker',
-      ['compose', 'ps', service, '--format', '{{.State}}'],
-      { cwd: projectDir },
-    )
+    const { stdout } = await execa('docker', ['compose', 'ps', service, '--format', '{{.State}}'], {
+      cwd: projectDir,
+    })
     return stdout.split('\n').some((line) => line.trim() === 'running')
   } catch {
     return false

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -32,6 +32,21 @@ export async function rakeTask(
     .trim()
 }
 
+// Whether a compose service has a running container — used by commands that
+// can fall back to `compose run` when the stack is down.
+export async function isServiceRunning(service: string, projectDir: string): Promise<boolean> {
+  try {
+    const { stdout } = await execa(
+      'docker',
+      ['compose', 'ps', service, '--format', '{{.State}}'],
+      { cwd: projectDir },
+    )
+    return stdout.split('\n').some((line) => line.trim() === 'running')
+  } catch {
+    return false
+  }
+}
+
 export interface DockerComposeExecOptions {
   service?: string
   tty?: boolean

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -33,16 +33,16 @@ export async function rakeTask(
 }
 
 // Whether a compose service has a running container — used by commands that
-// can fall back to `compose run` when the stack is down.
+// can fall back to `compose run` when the stack is down. A defined service
+// with no containers exits 0 with empty output (the legitimate false case);
+// anything that makes `compose ps` itself fail — daemon down, broken compose
+// file, unknown service — throws, so the caller surfaces the real error
+// instead of acting on a wrong "stopped" answer.
 export async function isServiceRunning(service: string, projectDir: string): Promise<boolean> {
-  try {
-    const { stdout } = await execa('docker', ['compose', 'ps', service, '--format', '{{.State}}'], {
-      cwd: projectDir,
-    })
-    return stdout.split('\n').some((line) => line.trim() === 'running')
-  } catch {
-    return false
-  }
+  const { stdout } = await execa('docker', ['compose', 'ps', service, '--format', '{{.State}}'], {
+    cwd: projectDir,
+  })
+  return stdout.split('\n').some((line) => line.trim() === 'running')
 }
 
 export interface DockerComposeExecOptions {

--- a/scripts/docker-compose.edge.yml
+++ b/scripts/docker-compose.edge.yml
@@ -30,8 +30,19 @@ services:
     # Hard-bypass the starter's bin/docker-entrypoint, which auto-runs
     # `db:prepare` when the command is `bin/rails server`. The dev compose
     # claims to bypass it but doesn't actually set entrypoint: [], so we
-    # do it here. server:setup runs DB prep explicitly via the CLI.
+    # do it here.
     entrypoint: []
+    # Self-healing boot. Monorepo pulls and starter updates routinely drift
+    # Gemfile.lock ahead of the bundle_cache volume and add new engine
+    # migrations — without this, web/worker crash-loop on Bundler::GemNotFound
+    # or 500 on ActiveRecord::PendingMigrationError after every such pull.
+    # `bundle check` is sub-second when clean; the rails invocation is one
+    # boot (~5s) that no-ops when nothing changed.
+    command:
+      [
+        "sh", "-c",
+        "bundle check || bundle install; bin/rails spree:install:migrations db:prepare && exec bin/rails server -b 0.0.0.0 -p 3000"
+      ]
 
   worker:
     environment:
@@ -39,3 +50,11 @@ services:
     volumes:
       - ${SPREE_PATH}:${SPREE_PATH}
     entrypoint: []
+    # Wait for web's bundle install to finish instead of racing it — two
+    # concurrent `bundle install`s into the same bundle_cache volume can
+    # corrupt each other.
+    command:
+      [
+        "sh", "-c",
+        "until bundle check >/dev/null 2>&1; do echo 'worker: waiting for bundle install (web is healing the bundle)…'; sleep 3; done; exec bundle exec sidekiq"
+      ]

--- a/scripts/docker-compose.edge.yml
+++ b/scripts/docker-compose.edge.yml
@@ -56,8 +56,11 @@ services:
     # a satisfied bundle (shared bundle_cache volume) AND a fully migrated,
     # seeded database. Gating on `bundle check` alone raced the migrations:
     # a clean bundle let Sidekiq run jobs against a half-prepared schema.
+    # The Host header matters: dev-mode HostAuthorization rejects the
+    # compose-internal hostname (`web`) with a 403, so curl presents an
+    # allowed host instead.
     command:
       [
         "sh", "-c",
-        "until curl -fsS -o /dev/null http://web:3000/up 2>/dev/null; do echo 'worker: waiting for web to finish booting (bundle + migrations + db:prepare)…'; sleep 3; done; exec bundle exec sidekiq"
+        "i=0; until curl -fsS -o /dev/null -H 'Host: localhost' http://web:3000/up 2>/dev/null; do i=$$((i+1)); if [ \"$$i\" -ge 200 ]; then echo 'worker: web did not become ready within 10 minutes — inspect with: docker compose logs web' >&2; exit 1; fi; echo 'worker: waiting for web to finish booting (bundle + migrations + db:prepare)…'; sleep 3; done; exec bundle exec sidekiq"
       ]

--- a/scripts/docker-compose.edge.yml
+++ b/scripts/docker-compose.edge.yml
@@ -41,7 +41,7 @@ services:
     command:
       [
         "sh", "-c",
-        "bundle check || bundle install; bin/rails spree:install:migrations db:prepare && exec bin/rails server -b 0.0.0.0 -p 3000"
+        "(bundle check || bundle install) && bin/rails spree:install:migrations db:prepare && exec bin/rails server -b 0.0.0.0 -p 3000"
       ]
 
   worker:

--- a/scripts/docker-compose.edge.yml
+++ b/scripts/docker-compose.edge.yml
@@ -50,11 +50,14 @@ services:
     volumes:
       - ${SPREE_PATH}:${SPREE_PATH}
     entrypoint: []
-    # Wait for web's bundle install to finish instead of racing it — two
-    # concurrent `bundle install`s into the same bundle_cache volume can
-    # corrupt each other.
+    # Gate Sidekiq on web actually serving: the web boot chain starts Puma
+    # only after bundle install + spree:install:migrations + db:prepare have
+    # all succeeded, so "/up answers" covers everything the worker needs —
+    # a satisfied bundle (shared bundle_cache volume) AND a fully migrated,
+    # seeded database. Gating on `bundle check` alone raced the migrations:
+    # a clean bundle let Sidekiq run jobs against a half-prepared schema.
     command:
       [
         "sh", "-c",
-        "until bundle check >/dev/null 2>&1; do echo 'worker: waiting for bundle install (web is healing the bundle)…'; sleep 3; done; exec bundle exec sidekiq"
+        "until curl -fsS -o /dev/null http://web:3000/up 2>/dev/null; do echo 'worker: waiting for web to finish booting (bundle + migrations + db:prepare)…'; sleep 3; done; exec bundle exec sidekiq"
       ]

--- a/scripts/server-build.sh
+++ b/scripts/server-build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# server-build.sh — rebuild the edge dev image (`pnpm server:build`).
+#
+# The edge flow rewrites server/Gemfile.lock with a PATH block pointing at
+# the host monorepo (an absolute path like /Users/you/spree/spree). The
+# Docker image build copies that lock into a context where SPREE_PATH is
+# unset and bundler runs in frozen mode — so the build fails with
+# "The list of sources changed, but the lockfile can't be updated".
+#
+# Fix: when the PATH block is present, regenerate a RubyGems-resolved lock
+# (bundle lock in a throwaway ruby container, no .env so the Gemfile's
+# SPREE_PATH branch stays inactive) and build with that. The next
+# `pnpm server:dev` boot self-heals the bundle and rewrites the PATH lock.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+LOCK="server/Gemfile.lock"
+
+if grep -q "remote: $ROOT/spree" "$LOCK" 2>/dev/null; then
+  RUBY_VERSION="$(cat server/.ruby-version)"
+  echo "→ Edge PATH block detected in $LOCK"
+  echo "→ Regenerating a RubyGems-resolved lock for the image build (ruby:${RUBY_VERSION}-slim)"
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  cp server/Gemfile server/.ruby-version "$TMP/"
+  docker run --rm -v "$TMP":/rails -w /rails "ruby:${RUBY_VERSION}-slim" bundle lock
+  cp "$TMP/Gemfile.lock" "$LOCK"
+  echo "→ Lock regenerated. (The next \`pnpm server:dev\` boot restores the monorepo PATH lock automatically.)"
+fi
+
+echo "→ Building web + worker"
+SPREE_PATH="$ROOT" docker compose -f server/docker-compose.dev.yml -f scripts/docker-compose.edge.yml build web worker

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -11,14 +11,15 @@
 #   3. Clone spree-starter into server/
 #   4. Write server/.env with SPREE_PATH=.. (for the native bin/dev path —
 #      Docker edge flow overrides via compose env) + a fresh SECRET_KEY_BASE
-#   5. Build @spree/cli so node ../packages/cli/dist/index.js works
-#   6. Start the edge stack
-#   7. Wait until web container is `running` (not `healthy` — healthcheck
-#      polls /up which 500s without a DB)
-#   8. CLI: bundle install (rewrites Gemfile.lock to use path-based gems)
-#   9. CLI: rake spree:install:migrations (copies migrations from edge gems
-#      into server/db/migrate/)
-#  10. CLI: rails db:prepare (create + migrate + seed)
+#   5. Build @spree/cli so `pnpm exec spree …` works in server/
+#   6. Start the edge stack and wait for it to finish booting. The edge web
+#      boot command (scripts/docker-compose.edge.yml) does the heavy lifting
+#      itself — bundle install against the monorepo gems (rewrites
+#      Gemfile.lock with the PATH block), spree:install:migrations, and
+#      db:prepare (create + migrate + seed) — so this script must NOT run
+#      those steps too: a second bundle install / db:prepare racing the
+#      boot's own can corrupt the bundle_cache volume or trip over a
+#      half-prepared database. We just wait until the web server answers.
 #
 # Idempotent: re-running this from any state should converge. The volume
 # nuke in step 1 is what makes it idempotent in the face of partially-failed
@@ -62,31 +63,27 @@ step "Starting the edge stack"
 # (streaming logs, Ctrl+C to stop); setup needs to continue past the boot.
 SPREE_PATH="$ROOT" docker compose -f "$DEV_COMPOSE" -f "$EDGE_OVERLAY" up -d --force-recreate web worker
 
-step "Waiting for web container to come up"
-WAIT_TIMEOUT=120
+step "Waiting for the stack to finish booting"
+# The edge web boot runs bundle install + spree:install:migrations +
+# db:prepare before starting Puma (see scripts/docker-compose.edge.yml), so
+# "web answers HTTP" means the whole bootstrap is done. First boot installs
+# the monorepo spree gems into the bundle_cache volume — give it minutes,
+# not seconds. Do NOT add exec-based setup steps here; they would race the
+# boot's own sequence.
+WAIT_TIMEOUT=600
 elapsed=0
-until docker compose -f "$DEV_COMPOSE" ps web --format '{{.State}}' | grep -q running; do
+until code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localhost:3000/ 2>/dev/null)" && [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; do
   if [ "$elapsed" -ge "$WAIT_TIMEOUT" ]; then
-    echo "✗ web container did not reach 'running' within ${WAIT_TIMEOUT}s." >&2
+    echo "✗ web did not respond within ${WAIT_TIMEOUT}s." >&2
     echo "  Inspect with: docker compose -f $DEV_COMPOSE logs web" >&2
     exit 1
   fi
-  sleep 1
-  elapsed=$((elapsed + 1))
+  if [ "$elapsed" -gt 0 ] && [ $((elapsed % 30)) -eq 0 ]; then
+    echo "  …still booting (${elapsed}s) — gems + migrations + seeds run on first boot."
+    echo "     Follow along: docker compose -f $DEV_COMPOSE logs -f web"
+  fi
+  sleep 3
+  elapsed=$((elapsed + 3))
 done
-# Even when running, Rails takes a few seconds to be ready to accept exec.
-# A quick warmup avoids the first `docker compose exec` racing the boot.
-sleep 5
-
-step "bundle install (rewrites Gemfile.lock against monorepo gems)"
-cd "$SERVER_DIR"
-SPREE_CLI="$ROOT/packages/cli/dist/index.js"
-node "$SPREE_CLI" bundle install
-
-step "spree:install:migrations (copies edge migrations into server/db/migrate/)"
-node "$SPREE_CLI" rake spree:install:migrations
-
-step "db:prepare (create + migrate + seed)"
-node "$SPREE_CLI" rails db:prepare
 
 printf '\nServer ready: http://localhost:3000\nAdmin:         http://localhost:3000/admin\n\n'


### PR DESCRIPTION
…erver

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default monorepo dev bootstrap timing, worker startup gating, and temporary Gemfile.lock rewriting during image builds—high impact for contributors but limited to local Docker tooling, not production Spree runtime.
> 
> **Overview**
> Makes the **monorepo edge Docker stack self-healing on boot** and aligns contributor docs with that workflow.
> 
> **Compose (`scripts/docker-compose.edge.yml`):** `web` now runs `bundle check || bundle install`, `spree:install:migrations`, and `db:prepare` before Puma. **Sidekiq** waits until `web` responds on `/up` (with `Host: localhost`) so jobs do not run against a half-migrated DB.
> 
> **Setup/build:** `server-setup.sh` drops redundant CLI `bundle` / migrate / `db:prepare` steps (they raced the new boot chain) and waits up to **10 minutes** for HTTP from the app. **`pnpm server:build`** goes through new **`scripts/server-build.sh`**, which temporarily regenerates `Gemfile.lock` when the monorepo PATH block would break a frozen image build.
> 
> **CLI:** `spree bundle` uses **`isServiceRunning`** and falls back to `docker compose run` when `web` is down (with a monorepo pointer to `pnpm server:dev`). Contributor tables in **CONTRIBUTING**, **CLAUDE.md**, and **developing-spree** now say migrations and gem drift are handled on the next `pnpm server:dev` boot, plus notes for Meilisearch volume resets and lockfile rebuilds.
> 
> The **@spree/cli** changeset documents related CLI behavior (foreground `spree dev`, `spree restart`, migrate output, upgrade SDK hints) that may ship in the same release even if not all of it appears in this diff hunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc8935ca0301db2af588577b690269fd150b043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alternative server build flow and new build script, safer in-place restart, improved bundler handling when stack is down, and worker startup gated on web readiness.

* **Bug Fixes**
  * Dev tooling streams logs and stops cleanly with Ctrl+C, returns proper error codes, and detects monorepo/edge setups with clear guidance.

* **Documentation**
  * Updated developer workflow guidance and “what to run” instructions for Docker, migrations, rebuilds, and search reindex workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->