### PR TITLE
Fixed N+1s in Store API Products endpoint after adding Channels

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/store/products_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/products_controller.rb
@@ -35,6 +35,7 @@ module Spree
           # these scopes are not automatically picked by ar_lazy_preload gem and we need to explicitly include them
           def scope_includes
             [
+              product_publications: [],
               primary_media: [attachment_attachment: :blob],
               master: [:prices, stock_items: [:stock_location, :active_stock_reservations]],
               variants: [:prices, stock_items: [:stock_location, :active_stock_reservations]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single association added to existing eager-load configuration; no API contract or business logic changes.
> 
> **Overview**
> Adds **`product_publications`** to `scope_includes` on the Store API **products** index/show eager-load list so channel publication data is preloaded with each product.
> 
> This follows the existing pattern for associations that **ar_lazy_preload** does not infer automatically, and removes **N+1** queries introduced when products started touching publications for channel visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0572f492fbb6aeae072cf4fc3b368db7f89439c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced products API response handling to properly include product publications data in preload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->