### PR TITLE
Fixed: spree eject command with auto-heal

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.1.1
+
+### Patch Changes
+
+- `spree eject` now repairs dev compose files scaffolded with the broken `.:/rails` bind-mount and runs `db:prepare` after switching to the dev stack. The dev image bypasses the entrypoint that creates the database in the prebuilt image, so without this the ejected stack booted against a missing `spree_development` database.
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import pc from 'picocolors'
 import { detectProject } from '../context.js'
-import { dockerCompose } from '../docker.js'
+import { dockerCompose, dockerComposeExec } from '../docker.js'
 
 // Switch the project from the prebuilt-image compose to the bind-mounted
 // dev compose. Source under ./backend becomes live in the container —
@@ -35,14 +35,32 @@ export function registerEjectCommand(program: Command) {
       // Replace docker-compose.yml with the dev version. The dev compose has
       // `build:` defined, so `up -d` below will build on first invocation —
       // no separate explicit build step needed.
-      fs.copyFileSync(devCompose, path.join(ctx.projectDir, 'docker-compose.yml'))
+      //
+      // Projects scaffolded before create-spree-app 1.0.3 shipped a dev
+      // compose that bind-mounts the project root (`.:/rails`) instead of
+      // ./backend — rewrite it so the container finds bin/rails.
+      let composeContent = fs.readFileSync(devCompose, 'utf-8')
+      if (composeContent.includes('- .:/rails')) {
+        composeContent = composeContent.replace('- .:/rails', '- ./backend:/rails')
+        fs.writeFileSync(devCompose, composeContent)
+      }
+      fs.writeFileSync(path.join(ctx.projectDir, 'docker-compose.yml'), composeContent)
 
       console.log(`\n${pc.bold('Switching to dev compose (bind-mounts ./backend)...')}\n`)
       await dockerCompose(['up', '-d'], ctx.projectDir, { stdio: 'inherit' })
 
+      // The dev image bypasses bin/docker-entrypoint (which runs db:prepare
+      // in the prebuilt image), and the dev environment uses its own
+      // spree_development database — make sure it exists and is migrated.
+      console.log(`\n${pc.bold('Preparing the development database...')}\n`)
+      await dockerComposeExec(['bin/rails', 'db:prepare'], ctx.projectDir, { tty: false })
+
       p.note(
         [
           `Backend is now bind-mounted from ${pc.bold('./backend')} — edits are live.`,
+          '',
+          `The dev stack uses its own ${pc.bold('spree_development')} database (just`,
+          `created and seeded). Load demo products with ${pc.bold('spree sample-data')}.`,
           '',
           'You can now customize:',
           `  ${pc.dim('backend/app/')}             — models, controllers, services (instant reload)`,

--- a/packages/cli/tests/eject.test.ts
+++ b/packages/cli/tests/eject.test.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerEjectCommand } from '../src/commands/eject'
+import { dockerCompose, dockerComposeExec } from '../src/docker'
+
+const COMPOSE_DEV_STALE = `x-app: &app
+  build:
+    context: ./backend
+    dockerfile: Dockerfile
+  volumes:
+    - .:/rails
+    - bundle_cache:/usr/local/bundle
+
+services:
+  web:
+    <<: *app
+    command: ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+volumes:
+  bundle_cache:
+`
+
+const COMPOSE_DEV_FIXED = COMPOSE_DEV_STALE.replace('- .:/rails', '- ./backend:/rails')
+
+let projectDir: string
+
+vi.mock('../src/context', () => ({
+  detectProject: () => ({ mode: 'project', projectDir, port: 3000 }),
+}))
+
+vi.mock('../src/docker', () => ({
+  dockerCompose: vi.fn().mockResolvedValue(undefined),
+  dockerComposeExec: vi.fn().mockResolvedValue(undefined),
+}))
+
+function makeProject(devComposeContent: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spree-cli-eject-test-'))
+  fs.mkdirSync(path.join(dir, 'backend'))
+  fs.writeFileSync(path.join(dir, 'docker-compose.yml'), 'services: {} # prebuilt-image compose\n')
+  fs.writeFileSync(path.join(dir, 'docker-compose.dev.yml'), devComposeContent)
+  return dir
+}
+
+async function runEject(): Promise<void> {
+  const program = new Command()
+  registerEjectCommand(program)
+  await program.parseAsync(['eject'], { from: 'user' })
+}
+
+describe('spree eject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true })
+  })
+
+  it('repairs a stale .:/rails bind-mount in both compose files', async () => {
+    projectDir = makeProject(COMPOSE_DEV_STALE)
+
+    await runEject()
+
+    const active = fs.readFileSync(path.join(projectDir, 'docker-compose.yml'), 'utf-8')
+    const dev = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
+    expect(active).toContain('- ./backend:/rails')
+    expect(active).not.toContain('- .:/rails')
+    expect(dev).toContain('- ./backend:/rails')
+    expect(dev).not.toContain('- .:/rails')
+    // Named volumes are left untouched
+    expect(active).toContain('- bundle_cache:/usr/local/bundle')
+  })
+
+  it('copies an already-correct dev compose verbatim', async () => {
+    projectDir = makeProject(COMPOSE_DEV_FIXED)
+
+    await runEject()
+
+    const active = fs.readFileSync(path.join(projectDir, 'docker-compose.yml'), 'utf-8')
+    const dev = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
+    expect(active).toBe(COMPOSE_DEV_FIXED)
+    expect(dev).toBe(COMPOSE_DEV_FIXED)
+  })
+
+  it('brings the stack up and prepares the development database', async () => {
+    projectDir = makeProject(COMPOSE_DEV_STALE)
+
+    await runEject()
+
+    expect(dockerCompose).toHaveBeenCalledWith(['up', '-d'], projectDir, { stdio: 'inherit' })
+    expect(dockerComposeExec).toHaveBeenCalledWith(['bin/rails', 'db:prepare'], projectDir, {
+      tty: false,
+    })
+  })
+})

--- a/packages/cli/tests/eject.test.ts
+++ b/packages/cli/tests/eject.test.ts
@@ -55,7 +55,10 @@ describe('spree eject', () => {
   })
 
   afterEach(() => {
-    fs.rmSync(projectDir, { recursive: true, force: true })
+    if (projectDir) {
+      fs.rmSync(projectDir, { recursive: true, force: true })
+      projectDir = ''
+    }
   })
 
   it('repairs a stale .:/rails bind-mount in both compose files', async () => {

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-spree-app
 
+## 1.0.3
+
+### Patch Changes
+
+- Fix `docker-compose.dev.yml` to bind-mount `./backend` instead of the project root. The scaffolded dev compose adjusted the build context for the wrapper layout but kept the starter's `.:/rails` source mount, so `spree eject` failed with `exec: "bin/rails": stat bin/rails: no such file or directory`.
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -59,10 +59,14 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   const composeDev = fs.readFileSync(path.join(backendDir, 'docker-compose.dev.yml'), 'utf-8')
 
   fs.writeFileSync(path.join(projectDir, 'docker-compose.yml'), compose)
-  // Adjust build context from current dir to ./backend for the wrapper project
+  // Adjust build context and source bind-mount from current dir to ./backend
+  // for the wrapper project (in the starter repo the compose file lives in
+  // the Rails app root; here the app lives under backend/)
   fs.writeFileSync(
     path.join(projectDir, 'docker-compose.dev.yml'),
-    composeDev.replace('context: .', 'context: ./backend'),
+    composeDev
+      .replace('context: .', 'context: ./backend')
+      .replace('- .:/rails', '- ./backend:/rails'),
   )
 
   fs.writeFileSync(path.join(projectDir, '.env'), envContent(generateSecretKeyBase(), port))

--- a/packages/create-spree-app/tests/scaffold.test.ts
+++ b/packages/create-spree-app/tests/scaffold.test.ts
@@ -39,7 +39,10 @@ const FAKE_COMPOSE_DEV = `x-app: &app
       condition: service_healthy
   env_file: .env
   environment: &app-env
-    DATABASE_URL: postgres://postgres@postgres:5432/spree_production
+    DATABASE_URL: postgres://postgres@postgres:5432/spree_development
+  volumes:
+    - .:/rails
+    - bundle_cache:/usr/local/bundle
 
 services:
   postgres:
@@ -149,6 +152,25 @@ describe('scaffold (no-start)', () => {
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
     expect(compose).toContain('context: ./backend')
     expect(compose).not.toContain('ghcr.io/spree/spree')
+  })
+
+  it('adjusts docker-compose.dev.yml source bind-mount to ./backend', async () => {
+    const projectDir = getTempProjectDir()
+
+    await scaffold({
+      directory: projectDir,
+      storefront: true,
+      sampleData: false,
+      start: false,
+      packageManager: 'npm',
+      port: 3000,
+    })
+
+    const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
+    expect(compose).toContain('- ./backend:/rails')
+    expect(compose).not.toContain('- .:/rails')
+    // Named volumes are left untouched
+    expect(compose).toContain('- bundle_cache:/usr/local/bundle')
   })
 
   it('generates .env with SECRET_KEY_BASE and PORT', async () => {


### PR DESCRIPTION
- Eject heal + db:prepare: I reverted your spree550rc12 dev compose back to the broken .:/rails, ran the locally built spree eject — it rewrote both compose files to ./backend:/rails, ran db:prepare (idempotent), and /up stayed 200.
  - Scaffold fix: scaffolded a throwaway project against the live starter template — generated docker-compose.dev.yml now has both context: ./backend and - ./backend:/rails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CLI/scaffold compose file rewriting and a standard `db:prepare` after eject; no auth or production runtime changes.
> 
> **Overview**
> Fixes **`spree eject`** and new scaffolds so the dev Docker stack bind-mounts **`./backend`** instead of the project root, which previously broke `bin/rails` in the container.
> 
> **`create-spree-app`** now rewrites `- .:/rails` to `- ./backend:/rails` when generating `docker-compose.dev.yml` (alongside the existing build `context` adjustment). **`@spree/cli` `eject`** auto-repairs the same stale mount in `docker-compose.dev.yml` and the active `docker-compose.yml`, then runs **`bin/rails db:prepare`** after `docker compose up -d` because the dev image skips the prebuilt entrypoint that created the DB. Post-eject notes mention the separate **`spree_development`** database and **`spree sample-data`**.
> 
> Patch releases **@spree/cli 2.1.1** and **create-spree-app 1.0.3**, with Vitest coverage for compose repair and `db:prepare`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5064731e01985ae05f2ea379251626701b181b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repair dev compose bind-mounts during eject/scaffold so projects start reliably and named volumes are preserved.

* **New Features**
  * After switching to the dev stack, the CLI now runs database preparation automatically so the development database exists and demo products can be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->