### PR TITLE
Docs fixes for CLI usage

### DIFF
--- a/docs/developer/admin/admin.mdx
+++ b/docs/developer/admin/admin.mdx
@@ -175,13 +175,25 @@ The Admin Dashboard uses [Tailwind CSS v4](https://tailwindcss.com/) for styling
 
 ### Generator Commands
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+# Generate a complete admin section (controller, views, routes)
+spree generate spree:admin:scaffold Spree::Brand
+
+# Generate just a controller
+spree generate controller Spree::Admin::Brands --skip-routes
+```
+
+```bash Without Spree CLI
 # Generate a complete admin section (controller, views, routes)
 bin/rails g spree:admin:scaffold Spree::Brand
 
 # Generate just a controller
 bin/rails g controller Spree::Admin::Brands --skip-routes
 ```
+
+</CodeGroup>
 
 ## Authentication & Authorization
 

--- a/docs/developer/admin/custom-css.mdx
+++ b/docs/developer/admin/custom-css.mdx
@@ -147,15 +147,31 @@ If you have admin-related code in non-standard locations, add additional `@sourc
 
 During development, run the Tailwind CSS watcher to automatically rebuild styles when you make changes:
 
-```bash
-bin/rails spree:admin:tailwindcss:watch
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:admin:tailwindcss:watch
 ```
 
-Or if you're using `Procfile.dev` with foreman:
+```bash Without Spree CLI
+bundle exec rake spree:admin:tailwindcss:watch
+```
 
-```bash
+</CodeGroup>
+
+Or run the full development process, which includes the watcher when it's defined in `Procfile.dev`:
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree dev
+```
+
+```bash Without Spree CLI
 bin/dev
 ```
+
+</CodeGroup>
 
 The watcher monitors:
 - Your host app's CSS files in `app/assets/tailwind/`

--- a/docs/developer/core-concepts/pricing.mdx
+++ b/docs/developer/core-concepts/pricing.mdx
@@ -230,17 +230,33 @@ end
 
 Price history retention defaults to 30 days and can be configured globally. A Rake task is provided for cleanup:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:price_history:prune
+```
+
+```bash Without Spree CLI
 bundle exec rake spree:price_history:prune
 ```
+
+</CodeGroup>
 
 ### Seeding Existing Prices
 
 After enabling price history on an existing store, seed the current prices as a baseline:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:price_history:seed
+```
+
+```bash Without Spree CLI
 bundle exec rake spree:price_history:seed
 ```
+
+</CodeGroup>
 
 ## Related Documentation
 

--- a/docs/developer/core-concepts/translations.mdx
+++ b/docs/developer/core-concepts/translations.mdx
@@ -106,9 +106,17 @@ Spree stores UI translation strings in a separate project: [Spree I18n](https://
 
 To install UI translations:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_i18n
+```
+
+```bash Without Spree CLI
 bundle add spree_i18n
 ```
+
+</CodeGroup>
 
 Once installed, all translation files are available automatically — no need to copy any files.
 

--- a/docs/developer/customization/authentication.mdx
+++ b/docs/developer/customization/authentication.mdx
@@ -20,9 +20,17 @@ Spree.user_class = 'User'
 
 Now, run the generator to set up Spree integration with Devise:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:authentication:devise
+```
+
+```bash Without Spree CLI
 bin/rails g spree:authentication:devise
 ```
+
+</CodeGroup>
 
 This will create a new file in `lib/spree/authentication_helpers.rb` that serves as a bridge between Spree and your existing authentication system routes. You can then use this file to customize the routes to your liking. It should automatically pick up standard Devise routes.
 
@@ -64,9 +72,17 @@ Spree.user_class = 'User'
 
 Now, run the generator to set up Spree integration with your custom authentication system:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:authentication:custom
+```
+
+```bash Without Spree CLI
 bin/rails g spree:authentication:custom
 ```
+
+</CodeGroup>
 
 This will create a new file in `lib/spree/authentication_helpers.rb` that serves as a bridge between Spree and your existing authentication system routes. You will need to customize this file to fit your needs.
 

--- a/docs/developer/customization/decorators.mdx
+++ b/docs/developer/customization/decorators.mdx
@@ -90,9 +90,17 @@ Spree provides generators to create decorator files with the correct structure:
 
 ### Model Decorator Generator
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:model_decorator Spree::Product
+```
+
+```bash Without Spree CLI
 bin/rails g spree:model_decorator Spree::Product
 ```
+
+</CodeGroup>
 
 This creates `app/models/spree/product_decorator.rb`:
 
@@ -110,9 +118,17 @@ end
 
 ### Controller Decorator Generator
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:controller_decorator Spree::Admin::ProductsController
+```
+
+```bash Without Spree CLI
 bin/rails g spree:controller_decorator Spree::Admin::ProductsController
 ```
+
+</CodeGroup>
 
 This creates `app/controllers/spree/admin/products_controller_decorator.rb`:
 

--- a/docs/developer/customization/emails.mdx
+++ b/docs/developer/customization/emails.mdx
@@ -14,9 +14,17 @@ Spree uses [postmark templates](https://github.com/wildbit/postmark-templates), 
 
 Spree offers an emails preview generator for development purposes. To generate them, use the command:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:emails:install
+```
+
+```bash Without Spree CLI
 bin/rails g spree:emails:install
 ```
+
+</CodeGroup>
 
 After that, start the rails server locally and go to: `localhost:3000/rails/mailers`
 

--- a/docs/developer/customization/model-preferences.mdx
+++ b/docs/developer/customization/model-preferences.mdx
@@ -15,15 +15,31 @@ To define a model preference, you need to add them to your model class.
 
 Make sure to generate a migration to add the `preferences` column to the table. This column will store the preferences in a serialized format.
 
-```ruby
-rails g migration AddPreferencesToSpreeUsers preferences:text
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate migration AddPreferencesToSpreeUsers preferences:text
 ```
+
+```bash Without Spree CLI
+bin/rails g migration AddPreferencesToSpreeUsers preferences:text
+```
+
+</CodeGroup>
 
 Run the migration.
 
-```ruby
-rails db:migrate
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree migrate
 ```
+
+```bash Without Spree CLI
+bin/rails db:migrate
+```
+
+</CodeGroup>
 
 ```ruby
 class Spree::User < ApplicationRecord

--- a/docs/developer/deployment/caching.mdx
+++ b/docs/developer/deployment/caching.mdx
@@ -19,9 +19,16 @@ When `REDIS_URL` is set, Spree automatically uses it for caching. When not set, 
 
 To enable caching in the development environment:
 
-```bash
-cd server
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rails dev:cache
+```
+
+```bash Without Spree CLI
 bin/rails dev:cache
 ```
+
+</CodeGroup>
 
 You will need to restart your web server after this.

--- a/docs/developer/deployment/environment_variables.mdx
+++ b/docs/developer/deployment/environment_variables.mdx
@@ -86,9 +86,17 @@ After setting these, enable the provider and reindex:
 Spree.search_provider = 'Spree::SearchProvider::Meilisearch'
 ```
 
-```bash
-rake spree:search:reindex
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:search:reindex
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:search:reindex
+```
+
+</CodeGroup>
 
 ## Error Tracking (Sentry)
 

--- a/docs/developer/multi-store/quickstart.mdx
+++ b/docs/developer/multi-store/quickstart.mdx
@@ -5,9 +5,17 @@ sidebarTitle: Quickstart
 
 To enable multiple stores, you will need to add the `spree_multi_store` gem to your project via:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_multi_store
+```
+
+```bash Without Spree CLI
 bundle add spree_multi_store
 ```
+
+</CodeGroup>
 
 <Info>
 Spree Multi-Store is licensed under the [AGPL v3 License](https://opensource.org/licenses/AGPL-3.0). 

--- a/docs/developer/multi-tenant/core-concepts.mdx
+++ b/docs/developer/multi-tenant/core-concepts.mdx
@@ -17,9 +17,17 @@ All models that are tenanted inherit from `SpreeMultiTenant::Base` class. `spree
 
 When creating a new model that you want to be tenanted remember to inherit from `SpreeMultiTenant::Base` and not from `Spree::Base` and add `tenant_id` column to the table, eg.
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate model Spree::NewModel tenant:references name:string --parent SpreeMultiTenant::Base
+```
+
+```bash Without Spree CLI
 bin/rails g model Spree::NewModel tenant:references name:string --parent SpreeMultiTenant::Base
 ```
+
+</CodeGroup>
 
 <Info>
   You don't need to add `belongs_to :tenant` to the model, it's handled by gem.

--- a/docs/developer/multi-tenant/installation.mdx
+++ b/docs/developer/multi-tenant/installation.mdx
@@ -43,9 +43,17 @@ Admin user classes will be shared across tenants allowing them to manage multipl
 
 Let's create a new model with Devise (unless you already have one):
 
-```bash
-rails g devise Spree::AdminUser
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rails g devise Spree::AdminUser
 ```
+
+```bash Without Spree CLI
+bin/rails g devise Spree::AdminUser
+```
+
+</CodeGroup>
 
 Replace the generated Devise code with the following:
 
@@ -89,15 +97,31 @@ Spree.admin_user_class = "Spree::AdminUser"
 
 2. Install gems:
 
-    ```bash
+    <CodeGroup>
+
+    ```bash Spree CLI (Docker)
+    spree bundle install
+    ```
+
+    ```bash Without Spree CLI
     bundle install
     ```
 
+    </CodeGroup>
+
 3. Run generators:
 
-    ```bash
-    bundle exec rails g spree_enterprise:install && bundle exec rails g spree_multi_tenant:install
+    <CodeGroup>
+
+    ```bash Spree CLI (Docker)
+    spree generate spree_enterprise:install && spree generate spree_multi_tenant:install
     ```
+
+    ```bash Without Spree CLI
+    bin/rails g spree_enterprise:install && bin/rails g spree_multi_tenant:install
+    ```
+
+    </CodeGroup>
 
     <Info>
       This will copy and run migrations for `spree_enterprise` and `spree_multi_tenant` gems.

--- a/docs/developer/multi-vendor/installation.mdx
+++ b/docs/developer/multi-vendor/installation.mdx
@@ -38,15 +38,31 @@ description: Learn how to set up a multi-vendor marketplace with Spree
 
 2. Install gems:
 
-    ```bash
+    <CodeGroup>
+
+    ```bash Spree CLI (Docker)
+    spree bundle install
+    ```
+
+    ```bash Without Spree CLI
     bundle install
     ```
 
+    </CodeGroup>
+
 3. Run generators:
 
-    ```bash
-    bundle exec rails g spree_enterprise:install && bundle exec rails g spree_multi_vendor:install
+    <CodeGroup>
+
+    ```bash Spree CLI (Docker)
+    spree generate spree_enterprise:install && spree generate spree_multi_vendor:install
     ```
+
+    ```bash Without Spree CLI
+    bin/rails g spree_enterprise:install && bin/rails g spree_multi_vendor:install
+    ```
+
+    </CodeGroup>
 
     <Info>
       This will copy and run migrations for `spree_enterprise` and `spree_multi_vendor` gems.

--- a/docs/developer/storefront/rails/custom-css.mdx
+++ b/docs/developer/storefront/rails/custom-css.mdx
@@ -10,9 +10,17 @@ Spree Storefront is built on top of [Tailwind CSS 4](https://tailwindcss.com/). 
 
 If you're missing this file, or migrating from a previous version of Spree, you can generate it using the following command:
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:storefront:install
+```
+
+```bash Without Spree CLI
 bin/rails g spree:storefront:install
 ```
+
+</CodeGroup>
 
 <Info>
   Tailwind 4 uses a CSS-first configuration approach. There's no `tailwind.config.js` file - all configuration is done directly in CSS using the `@theme` directive.

--- a/docs/developer/storefront/rails/storefront.mdx
+++ b/docs/developer/storefront/rails/storefront.mdx
@@ -22,23 +22,53 @@ Rails Storefront is a mobile-first storefront that is fully customizable & theme
 
 You can install it by running
 
-  ```bash
-  bundle add spree_storefront
-  ```
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_storefront
+```
+
+```bash Without Spree CLI
+bundle add spree_storefront
+```
+
+</CodeGroup>
 
 Then run the install generator:
 
-  ```bash
-  bin/rails g spree:storefront:install
-  ```
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:storefront:install
+```
+
+```bash Without Spree CLI
+bin/rails g spree:storefront:install
+```
+
+</CodeGroup>
 
 This will set up the storefront views, Tailwind CSS configuration, and page builder migrations.
 
-You will also need to create your first theme:
+You will also need to create your first theme. Open the Rails console:
 
-  ```bash
-  Spree::Store.default.send(:create_default_theme)
-  ```
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree console
+```
+
+```bash Without Spree CLI
+bin/rails console
+```
+
+</CodeGroup>
+
+And run:
+
+```ruby
+Spree::Store.default.send(:create_default_theme)
+```
 
 ### Architecture
 

--- a/docs/developer/storefront/rails/themes.mdx
+++ b/docs/developer/storefront/rails/themes.mdx
@@ -18,9 +18,17 @@ Spree comes with a default theme called `default`. It is used as a base for all 
 
 You can create your custom themes by following the steps below.
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree generate spree:storefront:theme MyTheme
+```
+
+```bash Without Spree CLI
 bin/rails g spree:storefront:theme MyTheme
 ```
+
+</CodeGroup>
 
 This command will create a new theme called `my_theme` in the `app/views/themes` directory and copy the default theme files to the new theme.
 

--- a/docs/developer/upgrades/5.4-to-5.5.mdx
+++ b/docs/developer/upgrades/5.4-to-5.5.mdx
@@ -20,15 +20,15 @@ For applications created via `create-spree-app` command we greatly recommend usi
 
 <CodeGroup>
 
-```bash Spree CLI
+```bash Spree CLI (Docker)
 spree upgrade
 ```
 
 ```bash Without Spree CLI
 # cd backend if you're in the monorepo root
 bundle update
-bin/rake spree:install:migrations && bin/rails db:migrate
-bin/rake spree:upgrade
+bundle exec rake spree:install:migrations && bin/rails db:migrate
+bundle exec rake spree:upgrade
 ```
 
 </CodeGroup>
@@ -43,29 +43,45 @@ npm install -g @spree/cli
 npx @spree/cli upgrade
 ```
 
-The **Without Spree CLI** path is the bare equivalent. Use this on production: `bundle update` and `db:migrate` are part of your existing deploy pipeline (Heroku release phase, K8s init container, Capistrano hook, Render auto-migrate). Once the 5.5 release is up, run `bin/rake spree:upgrade` from a one-off dyno / job container / `kubectl exec` to perform the data backfills.
+The **Without Spree CLI** path is the bare equivalent. Use this on production: `bundle update` and `db:migrate` are part of your existing deploy pipeline (Heroku release phase, K8s init container, Capistrano hook, Render auto-migrate). Once the 5.5 release is up, run `bundle exec rake spree:upgrade` from a one-off dyno / job container / `kubectl exec` to perform the data backfills.
 
-Skipping versions and re-running are both safe — `bin/rake spree:upgrade` figures out what still needs to happen and does nothing on data that's already migrated.
+Skipping versions and re-running are both safe — `bundle exec rake spree:upgrade` figures out what still needs to happen and does nothing on data that's already migrated.
 
 ## What the upgrade does
 
-This is reference material — what `bin/rake spree:upgrade` (and equivalently `spree upgrade`) actually executes on your data. Skip if you trust the tool; read on if something failed or you're curious.
+This is reference material — what `bundle exec rake spree:upgrade` (and equivalently `spree upgrade`) actually executes on your data. Skip if you trust the tool; read on if something failed or you're curious.
 
 ### Migrate legacy variant-pinned media
 
 In 5.5 the [product is the default owner of media](/developer/core-concepts/media#product-level-gallery). Existing variant-pinned images keep rendering, but new admin uploads attach to the product. To consolidate both into a single gallery, the upgrade runs:
 
-```bash
-bin/rails spree:media:migrate_master_images_to_product_media
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:media:migrate_master_images_to_product_media
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:media:migrate_master_images_to_product_media
+```
+
+</CodeGroup>
 
 The task enqueues one `Spree::Media::MigrateProductAssetsJob` per product onto the `images` queue — make sure your job runner is processing that queue. Each job is idempotent, so re-running the task is safe; it skips products that no longer have variant-pinned assets.
 
 For larger catalogs, tune the batching with `BATCH_SIZE`:
 
-```bash
-bin/rails spree:media:migrate_master_images_to_product_media BATCH_SIZE=1000
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:media:migrate_master_images_to_product_media BATCH_SIZE=1000
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:media:migrate_master_images_to_product_media BATCH_SIZE=1000
+```
+
+</CodeGroup>
 
 <Warning>
   Run the task locally and on production. It does not block storefront rendering — new uploads attach to the product immediately — but until the enqueued jobs finish, old assets remain pinned to variants.
@@ -77,9 +93,17 @@ Spree 5.5 introduces [Sales Channels](/developer/core-concepts/channels) — a p
 
 The migrations add a `default` boolean on `spree_channels`, a `store_id` column on `spree_products`, and create the new `spree_product_publications` table — **but they do not seed default channels, attach existing products to a store, or backfill order channels**. That work is done by an idempotent rake task:
 
-```bash
-bin/rake spree:channels:upgrade
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:channels:upgrade
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:channels:upgrade
+```
+
+</CodeGroup>
 
 The task runs four sub-tasks in order:
 
@@ -98,9 +122,17 @@ The task is fully idempotent — safe to re-run if it fails partway, and a no-op
 
 The last step rebuilds the search index against the configured [search provider](/developer/core-concepts/search-filtering):
 
-```bash
-bin/rake spree:search:reindex
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:search:reindex
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:search:reindex
+```
+
+</CodeGroup>
 
 This is a no-op on the default Database provider (there is no external index to maintain). For Meilisearch — or any other external search provider — it is required, and it must run **after** the Channels upgrade: products only become visible to `Product.for_store` once they have a `store_id`, so reindexing before the channels step would index zero products. The manifest orders the steps accordingly.
 
@@ -140,7 +172,7 @@ The SDK bump pairs with one storefront code change in this release: the [payment
 
 ## Required post-upgrade configuration
 
-`bin/rake spree:upgrade` doesn't touch your job-runner config — every app uses a different scheduler, so this one is on you.
+`bundle exec rake spree:upgrade` doesn't touch your job-runner config — every app uses a different scheduler, so this one is on you.
 
 ### Schedule the Stock Reservations expiry job
 

--- a/docs/integrations/analytics/google-analytics.mdx
+++ b/docs/integrations/analytics/google-analytics.mdx
@@ -16,9 +16,17 @@ With minimal setup required, you can gain valuable insights into how visitors in
 
 Before you can enable Google Analytics 4, it must be installed. To do so, you need to run the following command:
 
-```bash
-bundle add spree_google_analytics && bundle exec rails g spree_google_analytics:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_google_analytics && spree generate spree_google_analytics:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_google_analytics && bin/rails g spree_google_analytics:install
+```
+
+</CodeGroup>
 
 After that, make sure to restart your server if it was running.
 

--- a/docs/integrations/analytics/google-tag-manager.mdx
+++ b/docs/integrations/analytics/google-tag-manager.mdx
@@ -26,9 +26,17 @@ Spree will automatically push ecommerce events to the dataLayer, but it’s up t
 
 Before you can enable Google Tag Manager, it must be installed. To do so, you need to run the following command:
 
-```bash
-bundle add spree_google_analytics && bundle exec rails g spree_google_analytics:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_google_analytics && spree generate spree_google_analytics:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_google_analytics && bin/rails g spree_google_analytics:install
+```
+
+</CodeGroup>
 
 After that, make sure to restart your server if it was running.
 

--- a/docs/integrations/marketing/klaviyo.mdx
+++ b/docs/integrations/marketing/klaviyo.mdx
@@ -16,9 +16,17 @@ With Spree’s native integration, you can start collecting meaningful data for 
 
 To install the Klaviyo integration, you need to run the following command:
 
-```bash
-bundle add spree_klaviyo && bundle exec rails g spree_klaviyo:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_klaviyo && spree generate spree_klaviyo:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_klaviyo && bin/rails g spree_klaviyo:install
+```
+
+</CodeGroup>
 
 After that, you need to make sure to restart the server.
 

--- a/docs/integrations/payments/adyen.mdx
+++ b/docs/integrations/payments/adyen.mdx
@@ -10,9 +10,17 @@ Adyen is a global payment platform that enables businesses to accept payments ac
 
 Before you can enable Adyen, it must be installed. To do so, you need to run the following command:
 
-```bash
-bundle add spree_adyen --github spree/spree_adyen && bundle exec rails g spree_adyen:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_adyen --github spree/spree_adyen && spree generate spree_adyen:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_adyen --github spree/spree_adyen && bin/rails g spree_adyen:install
+```
+
+</CodeGroup>
 
 After that, you need to make sure to restart the server.
 

--- a/docs/integrations/payments/paypal.mdx
+++ b/docs/integrations/payments/paypal.mdx
@@ -10,9 +10,17 @@ PayPal is a global online payment system that allows your customers to pay using
 
 Before you can enable PayPal, it must be installed. To do so, you need to run the following command:
 
-```bash
-bundle add spree_paypal_checkout && bundle exec rails g spree_paypal_checkout:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_paypal_checkout && spree generate spree_paypal_checkout:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_paypal_checkout && bin/rails g spree_paypal_checkout:install
+```
+
+</CodeGroup>
 
 After that, you need to make sure to restart the server.
 

--- a/docs/integrations/payments/razorpay.mdx
+++ b/docs/integrations/payments/razorpay.mdx
@@ -14,11 +14,19 @@ Razorpay is a secure payment gateway that enables businesses to accept online pa
 
 ## Installation
 
-Before you can enable Razorpay, it must be installed. To do so, you need to add this line in Gemfile:
+Before you can enable Razorpay, it must be installed. To do so, you need to run the following command:
 
-```bash
-bundle add spree_razorpay_checkout && bundle exec rails g spree_razorpay_checkout:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_razorpay_checkout && spree generate spree_razorpay_checkout:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_razorpay_checkout && bin/rails g spree_razorpay_checkout:install
+```
+
+</CodeGroup>
 
 After that, you need to make sure to restart the server.
 

--- a/docs/integrations/payments/stripe.mdx
+++ b/docs/integrations/payments/stripe.mdx
@@ -14,9 +14,17 @@ Stripe is a widely used payment processor that enables secure and seamless trans
 
 Before you can enable Stripe, it must be installed. To do so, you need to run the following command:
 
-```bash
-bundle add spree_stripe && bundle exec rails g spree_stripe:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_stripe && spree generate spree_stripe:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_stripe && bin/rails g spree_stripe:install
+```
+
+</CodeGroup>
 
 After that, you need to make sure to restart the server.
 

--- a/docs/integrations/search/meilisearch.mdx
+++ b/docs/integrations/search/meilisearch.mdx
@@ -55,9 +55,17 @@ For local development, Meilisearch runs without authentication by default — no
 gem 'meilisearch', '>= 0.28'
 ```
 
-```bash
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle install
+```
+
+```bash Without Spree CLI
 bundle install
 ```
+
+</CodeGroup>
 
 ### 3. Configure environment variables
 
@@ -80,9 +88,17 @@ Spree.search_provider = 'Spree::SearchProvider::Meilisearch'
 
 ### 5. Index your products
 
-```bash
-rake spree:search:reindex
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:search:reindex
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:search:reindex
+```
+
+</CodeGroup>
 
 That's it. Your Store API now uses Meilisearch for all product search, filtering, and faceted navigation.
 
@@ -142,9 +158,17 @@ Each store gets its own Meilisearch index: `{store_code}_products`. For a store 
 
 ### Reindex all products
 
-```bash
-rake spree:search:reindex
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:search:reindex
 ```
+
+```bash Without Spree CLI
+bundle exec rake spree:search:reindex
+```
+
+</CodeGroup>
 
 ### Index a single product
 

--- a/docs/integrations/tax/avalara.mdx
+++ b/docs/integrations/tax/avalara.mdx
@@ -12,9 +12,17 @@ Avalara AvaTax is an automated tax compliance platform that calculates accurate 
 
 Before you can enable Avalara AvaTax, it must be installed. To do so, run the following command:
 
-```bash
-bundle add spree_avatax_official && bundle exec rails g spree_avatax_official:install
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree bundle add spree_avatax_official && spree generate spree_avatax_official:install
 ```
+
+```bash Without Spree CLI
+bundle add spree_avatax_official && bin/rails g spree_avatax_official:install
+```
+
+</CodeGroup>
 
 After that, make sure to restart the server.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.1.2
+
+### Patch Changes
+
+- `spree generate controller` now forwards to the Rails `controller` generator instead of the non-existent `spree:controller`.
+
 ## 2.1.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -7,6 +7,7 @@ import { dockerComposeExec } from '../docker.js'
 // intentionally absent — Spree provides `spree:model`.
 const RAILS_BUILTIN_GENERATORS = new Set([
   'migration',
+  'controller',
   'scaffold',
   'scaffold_controller',
   'mailer',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and a small CLI generator routing change only; no runtime application logic changes.
> 
> **Overview**
> Developer and integration docs now show **paired command examples** in `CodeGroup` blocks: **Spree CLI (Docker)** (`spree generate`, `spree rake`, `spree bundle`, `spree dev`, etc.) alongside **Without Spree CLI** (`bin/rails`, `bundle exec rake`, `bin/dev`).
> 
> Coverage spans admin, customization, deployment, multi-store/tenant, storefront, upgrades (including relabeling the CLI tab and tightening manual upgrade steps to `bundle exec rake`), and payment/analytics/search integrations.
> 
> **`@spree/cli` 2.1.2** adds `controller` to the Rails built-in generators forwarded by `spree generate`, so `spree generate controller …` hits Rails’ `controller` generator instead of a missing `spree:controller` — matching the updated admin docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d520416b1aa971ec2096c0c164856076d42b35c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced installation and configuration instructions across developer guides and integration documentation by presenting both Spree CLI (Docker) and standard Rails command options in a consistent, side-by-side format for ease of use.

* **Bug Fixes**
  * Fixed CLI generator commands to properly forward to Rails generators instead of attempting non-existent command variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->