### PR TITLE
Guard Admin API Admin Users endpoint for host app issues with json co…

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/admin_users_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/admin_users_controller.rb
@@ -61,12 +61,18 @@ module Spree
           end
 
           # Restrict to users with a role assignment on the current store.
-          # `accessible_by` enforces CanCanCan on top.
+          # `accessible_by` enforces CanCanCan on top. Deduplication happens via
+          # an ID subquery rather than `SELECT DISTINCT *` — the users table is
+          # host-app-defined and may contain `json` columns, which Postgres
+          # cannot compare for equality.
           def scope
-            model_class.
+            staff_ids = model_class.
               joins(:role_users).
-              where(spree_role_users: { resource: current_store }).
-              distinct.
+              where(Spree::RoleUser.table_name => { resource: current_store }).
+              select(:id)
+
+            model_class.
+              where(id: staff_ids).
               accessible_by(current_ability, :show)
           end
 


### PR DESCRIPTION
…lumns and other distinct issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows to query shape for the admin users index scope; authorization and store filtering behavior stay the same.
> 
> **Overview**
> Fixes staff listing for the v3 Admin **admin users** API when the host app’s user model includes **Postgres `json` columns**.
> 
> The store-scoped `scope` no longer uses **`DISTINCT` on the full user row** after joining `role_users`. It first loads matching **user IDs** for the current store, then loads users with **`where(id: …)`** and the existing **`accessible_by`** check. The join filter now keys off **`Spree::RoleUser.table_name`** instead of a hard-coded association table name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f293fed12c79e3f402c2004f8a7eaf7b4656bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of staff user filtering in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->