### PR TITLE
Fixed `spree_user_identities` json to jsonb type for PosrgreSQL

### DIFF
--- a/spree/core/db/migrate/20260612000001_change_spree_user_identities_info_to_jsonb.rb
+++ b/spree/core/db/migrate/20260612000001_change_spree_user_identities_info_to_jsonb.rb
@@ -1,0 +1,13 @@
+class ChangeSpreeUserIdentitiesInfoToJsonb < ActiveRecord::Migration[7.2]
+  def up
+    change_table :spree_user_identities do |t|
+      t.change :info, :jsonb, using: 'info::jsonb' if t.respond_to?(:jsonb)
+    end
+  end
+
+  def down
+    change_table :spree_user_identities do |t|
+      t.change :info, :json, using: 'info::json' if t.respond_to?(:jsonb)
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema migration on OAuth identity metadata; requires a successful cast on existing rows and brief table lock during `ALTER COLUMN` in production.
> 
> **Overview**
> Adds a reversible migration that alters **`spree_user_identities.info`** from **`json`** to **`jsonb`** on PostgreSQL, using `info::jsonb` / `info::json` in **`up`** and **`down`**.
> 
> The change only runs when the adapter supports **`jsonb`** (`t.respond_to?(:jsonb)`), so non-PostgreSQL databases are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a249aab039bb8888920e051c89ed656d1e9f8a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the underlying storage format for user identity information, improving database performance and data handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->