### PR TITLE
Guard Admin API Admin Users endpoint for host app issues with json co…

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/admin_users_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/admin_users_controller.rb
@@ -61,12 +61,18 @@ module Spree
           end
 
           # Restrict to users with a role assignment on the current store.
-          # `accessible_by` enforces CanCanCan on top.
+          # `accessible_by` enforces CanCanCan on top. Deduplication happens via
+          # an ID subquery rather than `SELECT DISTINCT *` — the users table is
+          # host-app-defined and may contain `json` columns, which Postgres
+          # cannot compare for equality.
           def scope
-            model_class.
+            staff_ids = model_class.
               joins(:role_users).
-              where(spree_role_users: { resource: current_store }).
-              distinct.
+              where(Spree::RoleUser.table_name => { resource: current_store }).
+              select(:id)
+
+            model_class.
+              where(id: staff_ids).
               accessible_by(current_ability, :show)
           end
 


### PR DESCRIPTION
…lumns and other distinct issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow query-shape change in one controller scope; same authorization and store filtering, lower risk of Postgres errors on custom user schemas.
> 
> **Overview**
> Fixes staff listing on **v3 admin admin users** when the host app’s user model adds **Postgres `json` columns** (or other types that break row equality).
> 
> The `scope` no longer chains `joins(:role_users)` with `.distinct`, which can emit `SELECT DISTINCT *` and fail on `json`. It now builds a **`staff_ids` subquery** (`select(:id)` for users with a `RoleUser` on `current_store`), then loads users with `where(id: staff_ids)` and `accessible_by`. The role-user filter uses **`Spree::RoleUser.table_name`** instead of a hardcoded table name. Comments document why deduplication is done this way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f293fed12c79e3f402c2004f8a7eaf7b4656bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized admin user selection logic to improve performance and stability with database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->