### PR TITLE
Add more Admin SDK tests

### DIFF
--- a/packages/admin-sdk/tests/admin-users.test.ts
+++ b/packages/admin-sdk/tests/admin-users.test.ts
@@ -1,0 +1,66 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient } from './helpers'
+import { server } from './mocks/server'
+
+const sampleAdminUser = {
+  id: 'usr_abc123',
+  email: 'staff@example.com',
+  first_name: 'Sam',
+  last_name: 'Staff',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('adminUsers', () => {
+  describe('list', () => {
+    it('GETs /admin_users', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/admin_users`, () =>
+          HttpResponse.json({
+            data: [sampleAdminUser],
+            meta: { page: 1, limit: 25, count: 1, pages: 1 },
+          }),
+        ),
+      )
+
+      const res = await createTestClient().adminUsers.list()
+
+      expect(res.data[0]?.id).toBe('usr_abc123')
+    })
+  })
+
+  describe('update', () => {
+    it('PATCHes identity fields + role_ids', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/admin_users/usr_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleAdminUser)
+        }),
+      )
+
+      await createTestClient().adminUsers.update('usr_abc123', {
+        first_name: 'Sam',
+        role_ids: ['role_1', 'role_2'],
+      })
+
+      expect(body).toEqual({ first_name: 'Sam', role_ids: ['role_1', 'role_2'] })
+    })
+  })
+
+  describe('delete', () => {
+    it('DELETEs /admin_users/:id (removes store role assignments)', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/admin_users/usr_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().adminUsers.delete('usr_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/allowed-origins.test.ts
+++ b/packages/admin-sdk/tests/allowed-origins.test.ts
@@ -1,0 +1,108 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleAllowedOrigin = {
+  id: 'ao_abc123',
+  origin: 'https://app.example.com',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('allowedOrigins', () => {
+  describe('list', () => {
+    it('GETs /allowed_origins and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/allowed_origins`, () =>
+          HttpResponse.json(paginated([sampleAllowedOrigin])),
+        ),
+      )
+
+      const res = await createTestClient().allowedOrigins.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('ao_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/allowed_origins`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().allowedOrigins.list({ origin_cont: 'example' })
+
+      expect(url!.searchParams.get('q[origin_cont]')).toBe('example')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /allowed_origins/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/allowed_origins/ao_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleAllowedOrigin)
+        }),
+      )
+
+      const res = await createTestClient().allowedOrigins.get('ao_abc123', { expand: ['store'] })
+
+      expect(res.id).toBe('ao_abc123')
+      expect(url!.searchParams.get('expand')).toBe('store')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/allowed_origins`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleAllowedOrigin, { status: 201 })
+        }),
+      )
+
+      const res = await createTestClient().allowedOrigins.create({
+        origin: 'https://app.example.com',
+      })
+
+      expect(body).toEqual({ origin: 'https://app.example.com' })
+      expect(res.id).toBe('ao_abc123')
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/allowed_origins/ao_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleAllowedOrigin, origin: 'https://admin.example.com' })
+        }),
+      )
+
+      const res = await createTestClient().allowedOrigins.update('ao_abc123', {
+        origin: 'https://admin.example.com',
+      })
+
+      expect(body).toEqual({ origin: 'https://admin.example.com' })
+      expect(res.origin).toBe('https://admin.example.com')
+    })
+
+    it('DELETEs /allowed_origins/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/allowed_origins/ao_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().allowedOrigins.delete('ao_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/api-keys.test.ts
+++ b/packages/admin-sdk/tests/api-keys.test.ts
@@ -1,0 +1,96 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient } from './helpers'
+import { server } from './mocks/server'
+
+const sampleKey = {
+  id: 'key_abc123',
+  name: 'CI integration',
+  key_type: 'secret',
+  token_prefix: 'sk_abc123def',
+  plaintext_token: null,
+  scopes: ['read_orders', 'write_orders'],
+  revoked_at: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('apiKeys', () => {
+  describe('list', () => {
+    it('GETs /api_keys', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/api_keys`, () =>
+          HttpResponse.json({
+            data: [sampleKey],
+            meta: { page: 1, limit: 25, count: 1, pages: 1 },
+          }),
+        ),
+      )
+
+      const res = await createTestClient().apiKeys.list()
+
+      expect(res.data[0]?.id).toBe('key_abc123')
+    })
+  })
+
+  describe('create', () => {
+    it('POSTs name + key_type + scopes and surfaces the one-time plaintext_token', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/api_keys`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(
+            { ...sampleKey, plaintext_token: 'sk_abc123def456ghi789' },
+            { status: 201 },
+          )
+        }),
+      )
+
+      const res = await createTestClient().apiKeys.create({
+        name: 'CI integration',
+        key_type: 'secret',
+        scopes: ['read_orders', 'write_orders'],
+      })
+
+      expect(body).toEqual({
+        name: 'CI integration',
+        key_type: 'secret',
+        scopes: ['read_orders', 'write_orders'],
+      })
+      // plaintext_token is returned exactly once on create.
+      expect(res.plaintext_token).toBe('sk_abc123def456ghi789')
+    })
+  })
+
+  describe('revoke', () => {
+    it('PATCHes /api_keys/:id/revoke', async () => {
+      let hit = false
+      server.use(
+        http.patch(`${API_PREFIX}/api_keys/key_abc123/revoke`, () => {
+          hit = true
+          return HttpResponse.json({ ...sampleKey, revoked_at: '2026-06-01T00:00:00Z' })
+        }),
+      )
+
+      const res = await createTestClient().apiKeys.revoke('key_abc123')
+
+      expect(hit).toBe(true)
+      expect(res.revoked_at).toBe('2026-06-01T00:00:00Z')
+    })
+  })
+
+  describe('delete', () => {
+    it('DELETEs /api_keys/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/api_keys/key_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().apiKeys.delete('key_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/auth.test.ts
+++ b/packages/admin-sdk/tests/auth.test.ts
@@ -1,10 +1,7 @@
 import { HttpResponse, http } from 'msw'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { createAdminClient } from '../src'
+import { API_PREFIX, createTestClient } from './helpers'
 import { server } from './mocks/server'
-
-const BASE_URL = 'https://demo.spreecommerce.org'
-const API_PREFIX = `${BASE_URL}/api/v3/admin`
 
 describe('auth', () => {
   describe('login', () => {
@@ -21,7 +18,7 @@ describe('auth', () => {
     })
 
     it('returns { token, user } and does not include refresh_token in body', async () => {
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.auth.login({ email: 'a@b.c', password: 'p' })
       expect(res.token).toBe('jwt_access_token')
       expect(res.user.email).toBe('a@b.c')
@@ -42,7 +39,7 @@ describe('auth', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.auth.refresh()
 
       expect(observedBody).toBe('') // no body sent — credential is the cookie
@@ -60,7 +57,7 @@ describe('auth', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await expect(client.auth.logout()).resolves.toBeUndefined()
       expect(hit).toBe(true)
     })

--- a/packages/admin-sdk/tests/auth.test.ts
+++ b/packages/admin-sdk/tests/auth.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from 'msw'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { API_PREFIX, createTestClient } from './helpers'
+import { API_PREFIX, createUnauthenticatedClient } from './helpers'
 import { server } from './mocks/server'
 
 describe('auth', () => {
@@ -18,7 +18,7 @@ describe('auth', () => {
     })
 
     it('returns { token, user } and does not include refresh_token in body', async () => {
-      const client = createTestClient()
+      const client = createUnauthenticatedClient()
       const res = await client.auth.login({ email: 'a@b.c', password: 'p' })
       expect(res.token).toBe('jwt_access_token')
       expect(res.user.email).toBe('a@b.c')
@@ -39,7 +39,7 @@ describe('auth', () => {
         }),
       )
 
-      const client = createTestClient()
+      const client = createUnauthenticatedClient()
       const res = await client.auth.refresh()
 
       expect(observedBody).toBe('') // no body sent — credential is the cookie
@@ -57,7 +57,7 @@ describe('auth', () => {
         }),
       )
 
-      const client = createTestClient()
+      const client = createUnauthenticatedClient()
       await expect(client.auth.logout()).resolves.toBeUndefined()
       expect(hit).toBe(true)
     })

--- a/packages/admin-sdk/tests/channels.test.ts
+++ b/packages/admin-sdk/tests/channels.test.ts
@@ -1,0 +1,139 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleChannel = {
+  id: 'chan_abc123',
+  name: 'Online Store',
+  default: true,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('channels', () => {
+  describe('list', () => {
+    it('GETs /channels and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/channels`, () => HttpResponse.json(paginated([sampleChannel]))),
+      )
+
+      const res = await createTestClient().channels.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('chan_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/channels`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().channels.list({ name_cont: 'store', default_eq: true })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('store')
+      expect(url!.searchParams.get('q[default_eq]')).toBe('true')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /channels/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/channels/chan_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleChannel)
+        }),
+      )
+
+      const res = await createTestClient().channels.get('chan_abc123', { expand: ['products'] })
+
+      expect(res.id).toBe('chan_abc123')
+      expect(url!.searchParams.get('expand')).toBe('products')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/channels`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleChannel, { status: 201 })
+        }),
+      )
+
+      await createTestClient().channels.create({ name: 'Online Store', default: true })
+
+      expect(body).toEqual({ name: 'Online Store', default: true })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/channels/chan_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleChannel, name: 'Retail' })
+        }),
+      )
+
+      const res = await createTestClient().channels.update('chan_abc123', { name: 'Retail' })
+
+      expect(body).toEqual({ name: 'Retail' })
+      expect(res.name).toBe('Retail')
+    })
+
+    it('DELETEs /channels/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/channels/chan_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().channels.delete('chan_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('addProducts / removeProducts', () => {
+    it('POSTs /channels/:id/add_products with the params verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/channels/chan_abc123/add_products`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ product_count: 2 })
+        }),
+      )
+
+      const res = await createTestClient().channels.addProducts('chan_abc123', {
+        product_ids: ['prod_a', 'prod_b'],
+      })
+
+      expect(body).toEqual({ product_ids: ['prod_a', 'prod_b'] })
+      expect(res.product_count).toBe(2)
+    })
+
+    it('POSTs /channels/:id/remove_products with the params verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/channels/chan_abc123/remove_products`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ product_count: 1 })
+        }),
+      )
+
+      const res = await createTestClient().channels.removeProducts('chan_abc123', {
+        product_ids: ['prod_a'],
+      })
+
+      expect(body).toEqual({ product_ids: ['prod_a'] })
+      expect(res.product_count).toBe(1)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/customer-groups.test.ts
+++ b/packages/admin-sdk/tests/customer-groups.test.ts
@@ -1,0 +1,108 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleCustomerGroup = {
+  id: 'cg_abc123',
+  name: 'VIP',
+  description: null,
+  customers_count: 0,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('customerGroups', () => {
+  describe('list', () => {
+    it('GETs /customer_groups and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/customer_groups`, () =>
+          HttpResponse.json(paginated([sampleCustomerGroup])),
+        ),
+      )
+
+      const res = await createTestClient().customerGroups.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('cg_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/customer_groups`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().customerGroups.list({ name_cont: 'vip', name_eq: 'VIP' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('vip')
+      expect(url!.searchParams.get('q[name_eq]')).toBe('VIP')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /customer_groups/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/customer_groups/cg_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleCustomerGroup)
+        }),
+      )
+
+      const res = await createTestClient().customerGroups.get('cg_abc123', {
+        expand: ['customers'],
+      })
+
+      expect(res.id).toBe('cg_abc123')
+      expect(url!.searchParams.get('expand')).toBe('customers')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/customer_groups`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleCustomerGroup, { status: 201 })
+        }),
+      )
+
+      await createTestClient().customerGroups.create({ name: 'VIP', description: 'Top spenders' })
+
+      expect(body).toEqual({ name: 'VIP', description: 'Top spenders' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/customer_groups/cg_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleCustomerGroup, name: 'Wholesale' })
+        }),
+      )
+
+      const res = await createTestClient().customerGroups.update('cg_abc123', { name: 'Wholesale' })
+
+      expect(body).toEqual({ name: 'Wholesale' })
+      expect(res.name).toBe('Wholesale')
+    })
+
+    it('DELETEs /customer_groups/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/customer_groups/cg_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().customerGroups.delete('cg_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/customers.test.ts
+++ b/packages/admin-sdk/tests/customers.test.ts
@@ -1,0 +1,224 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleCustomer = {
+  id: 'cus_abc123',
+  email: 'jane@example.com',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const sampleCreditCard = { id: 'cc_1', brand: 'visa', last4: '4242' }
+const sampleAddress = { id: 'addr_1', firstname: 'Jane', city: 'Berlin' }
+const sampleStoreCredit = { id: 'sc_1', amount: '50.0', currency: 'USD' }
+
+describe('customers', () => {
+  describe('list', () => {
+    it('GETs /customers and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/customers`, () => HttpResponse.json(paginated([sampleCustomer]))),
+      )
+
+      const res = await createTestClient().customers.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('cus_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/customers`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().customers.list({ email_cont: 'jane', first_name_eq: 'Jane' })
+
+      expect(url!.searchParams.get('q[email_cont]')).toBe('jane')
+      expect(url!.searchParams.get('q[first_name_eq]')).toBe('Jane')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /customers/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/customers/cus_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleCustomer)
+        }),
+      )
+
+      const res = await createTestClient().customers.get('cus_abc123', { expand: ['addresses'] })
+
+      expect(res.id).toBe('cus_abc123')
+      expect(url!.searchParams.get('expand')).toBe('addresses')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/customers`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleCustomer, { status: 201 })
+        }),
+      )
+
+      await createTestClient().customers.create({ email: 'jane@example.com', first_name: 'Jane' })
+
+      expect(body).toEqual({ email: 'jane@example.com', first_name: 'Jane' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/customers/cus_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleCustomer, last_name: 'Smith' })
+        }),
+      )
+
+      const res = await createTestClient().customers.update('cus_abc123', { last_name: 'Smith' })
+
+      expect(body).toEqual({ last_name: 'Smith' })
+      expect(res.last_name).toBe('Smith')
+    })
+
+    it('DELETEs /customers/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/customers/cus_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().customers.delete('cus_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('bulk operations', () => {
+    it('POSTs /bulk_add_to_groups with ids + customer_group_ids', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/customers/bulk_add_to_groups`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ customer_count: 2, customer_group_count: 1 })
+        }),
+      )
+
+      const res = await createTestClient().customers.bulkAddToGroups({
+        ids: ['cus_a', 'cus_b'],
+        customer_group_ids: ['cg_1'],
+      })
+
+      expect(body).toEqual({ ids: ['cus_a', 'cus_b'], customer_group_ids: ['cg_1'] })
+      expect(res.customer_count).toBe(2)
+    })
+
+    it('POSTs /bulk_add_tags with ids + tags', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/customers/bulk_add_tags`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ customer_count: 1, tag_count: 2 })
+        }),
+      )
+
+      await createTestClient().customers.bulkAddTags({ ids: ['cus_a'], tags: ['vip', 'eu'] })
+
+      expect(body).toEqual({ ids: ['cus_a'], tags: ['vip', 'eu'] })
+    })
+  })
+
+  describe('nested credit cards', () => {
+    it('GETs /customers/:id/credit_cards', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/customers/cus_abc123/credit_cards`, () =>
+          HttpResponse.json(paginated([sampleCreditCard])),
+        ),
+      )
+
+      const res = await createTestClient().customers.creditCards.list('cus_abc123')
+
+      expect(res.data[0]?.id).toBe('cc_1')
+    })
+
+    it('DELETEs a customer credit card', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/customers/cus_abc123/credit_cards/cc_1`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await createTestClient().customers.creditCards.delete('cus_abc123', 'cc_1')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested addresses', () => {
+    it('POSTs a new address under the customer', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/customers/cus_abc123/addresses`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleAddress, { status: 201 })
+        }),
+      )
+
+      await createTestClient().customers.addresses.create('cus_abc123', {
+        firstname: 'Jane',
+        city: 'Berlin',
+      })
+
+      expect(body).toEqual({ firstname: 'Jane', city: 'Berlin' })
+    })
+
+    it('PATCHes an existing customer address by id', async () => {
+      let url: string | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/customers/cus_abc123/addresses/addr_1`, ({ request }) => {
+          url = request.url
+          return HttpResponse.json(sampleAddress)
+        }),
+      )
+
+      await createTestClient().customers.addresses.update('cus_abc123', 'addr_1', {
+        city: 'Munich',
+      })
+
+      expect(url).toContain('/customers/cus_abc123/addresses/addr_1')
+    })
+  })
+
+  describe('nested store credits', () => {
+    it('POSTs a store credit under the customer', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/customers/cus_abc123/store_credits`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleStoreCredit, { status: 201 })
+        }),
+      )
+
+      await createTestClient().customers.storeCredits.create('cus_abc123', {
+        amount: 50,
+        currency: 'USD',
+        category_id: 'scc_1',
+      })
+
+      expect(body).toEqual({ amount: 50, currency: 'USD', category_id: 'scc_1' })
+    })
+  })
+})

--- a/packages/admin-sdk/tests/exports.test.ts
+++ b/packages/admin-sdk/tests/exports.test.ts
@@ -1,10 +1,7 @@
 import { HttpResponse, http } from 'msw'
 import { describe, expect, it } from 'vitest'
-import { createAdminClient } from '../src'
+import { API_PREFIX, createTestClient } from './helpers'
 import { server } from './mocks/server'
-
-const BASE_URL = 'https://demo.spreecommerce.org'
-const API_PREFIX = `${BASE_URL}/api/v3/admin`
 
 const sampleExport = {
   id: 'exp_abc123',
@@ -32,7 +29,7 @@ describe('exports', () => {
         ),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.exports.list()
 
       expect(res.data).toHaveLength(1)
@@ -48,7 +45,7 @@ describe('exports', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await client.exports.list({ type_eq: 'Spree::Exports::Products' })
 
       // transformListParams wraps free predicates in q[...]
@@ -68,7 +65,7 @@ describe('exports', () => {
         ),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.exports.get('exp_abc123')
 
       expect(res.done).toBe(true)
@@ -86,7 +83,7 @@ describe('exports', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.exports.create({
         type: 'Spree::Exports::Products',
         search_params: { name_cont: 'shirt', price_gt: 10 },
@@ -108,7 +105,7 @@ describe('exports', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await client.exports.create({
         type: 'Spree::Exports::Orders',
         record_selection: 'all',
@@ -131,7 +128,7 @@ describe('exports', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await client.exports.delete('exp_abc123')
 
       expect(hit).toBe(true)

--- a/packages/admin-sdk/tests/gift-cards.test.ts
+++ b/packages/admin-sdk/tests/gift-cards.test.ts
@@ -1,0 +1,188 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleGiftCard = {
+  id: 'gc_abc123',
+  code: 'ABCD-EFGH-IJKL',
+  amount: '100.0',
+  amount_used: '0.0',
+  amount_remaining: '100.0',
+  currency: 'USD',
+  state: 'active',
+  expires_at: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const sampleGiftCardBatch = {
+  id: 'gcb_abc123',
+  prefix: 'XMAS',
+  codes_count: 50,
+  amount: '25.0',
+  currency: 'USD',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('giftCards', () => {
+  describe('list', () => {
+    it('GETs /gift_cards and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/gift_cards`, () => HttpResponse.json(paginated([sampleGiftCard]))),
+      )
+
+      const res = await createTestClient().giftCards.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('gc_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/gift_cards`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().giftCards.list({ state_eq: 'active', code_cont: 'ABCD' })
+
+      expect(url!.searchParams.get('q[state_eq]')).toBe('active')
+      expect(url!.searchParams.get('q[code_cont]')).toBe('ABCD')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /gift_cards/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/gift_cards/gc_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleGiftCard)
+        }),
+      )
+
+      const res = await createTestClient().giftCards.get('gc_abc123', { expand: ['transactions'] })
+
+      expect(res.id).toBe('gc_abc123')
+      expect(url!.searchParams.get('expand')).toBe('transactions')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/gift_cards`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleGiftCard, { status: 201 })
+        }),
+      )
+
+      await createTestClient().giftCards.create({ amount: 100, currency: 'USD' })
+
+      expect(body).toEqual({ amount: 100, currency: 'USD' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/gift_cards/gc_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleGiftCard, expires_at: '2027-01-01T00:00:00Z' })
+        }),
+      )
+
+      const res = await createTestClient().giftCards.update('gc_abc123', {
+        expires_at: '2027-01-01T00:00:00Z',
+      })
+
+      expect(body).toEqual({ expires_at: '2027-01-01T00:00:00Z' })
+      expect(res.expires_at).toBe('2027-01-01T00:00:00Z')
+    })
+
+    it('DELETEs /gift_cards/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/gift_cards/gc_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().giftCards.delete('gc_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})
+
+describe('giftCardBatches', () => {
+  describe('list', () => {
+    it('GETs /gift_card_batches and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/gift_card_batches`, () =>
+          HttpResponse.json(paginated([sampleGiftCardBatch])),
+        ),
+      )
+
+      const res = await createTestClient().giftCardBatches.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('gcb_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/gift_card_batches`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().giftCardBatches.list({ prefix_cont: 'XMAS' })
+
+      expect(url!.searchParams.get('q[prefix_cont]')).toBe('XMAS')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /gift_card_batches/:id', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/gift_card_batches/gcb_abc123`, () =>
+          HttpResponse.json(sampleGiftCardBatch),
+        ),
+      )
+
+      const res = await createTestClient().giftCardBatches.get('gcb_abc123')
+
+      expect(res.id).toBe('gcb_abc123')
+      expect(res.codes_count).toBe(50)
+    })
+  })
+
+  describe('create', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/gift_card_batches`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleGiftCardBatch, { status: 201 })
+        }),
+      )
+
+      const res = await createTestClient().giftCardBatches.create({
+        prefix: 'XMAS',
+        codes_count: 50,
+        amount: 25,
+        currency: 'USD',
+      })
+
+      expect(body).toEqual({ prefix: 'XMAS', codes_count: 50, amount: 25, currency: 'USD' })
+      expect(res.prefix).toBe('XMAS')
+    })
+  })
+})

--- a/packages/admin-sdk/tests/helpers.test.ts
+++ b/packages/admin-sdk/tests/helpers.test.ts
@@ -1,0 +1,41 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, createUnauthenticatedClient } from './helpers'
+import { server } from './mocks/server'
+
+// Guards the test-helper auth contract: the default client must authenticate
+// server-to-server via `X-Spree-Api-Key`, and the unauthenticated client must
+// not. Without these, a helper refactor could silently drop the secret key and
+// every resource spec would still pass while no longer exercising admin auth.
+describe('test helpers — auth contract', () => {
+  it('createTestClient sends the secret key as X-Spree-Api-Key', async () => {
+    let apiKeyHeader: string | null = null
+    let authHeader: string | null = null
+    server.use(
+      http.get(`${API_PREFIX}/products`, ({ request }) => {
+        apiKeyHeader = request.headers.get('X-Spree-Api-Key')
+        authHeader = request.headers.get('Authorization')
+        return HttpResponse.json({ data: [], meta: { page: 1, limit: 25, count: 0, pages: 0 } })
+      }),
+    )
+
+    await createTestClient().products.list()
+
+    expect(apiKeyHeader).toBe('sk_test')
+    expect(authHeader).toBeNull()
+  })
+
+  it('createUnauthenticatedClient sends no secret key', async () => {
+    let apiKeyHeader: string | null = null
+    server.use(
+      http.get(`${API_PREFIX}/products`, ({ request }) => {
+        apiKeyHeader = request.headers.get('X-Spree-Api-Key')
+        return HttpResponse.json({ data: [], meta: { page: 1, limit: 25, count: 0, pages: 0 } })
+      }),
+    )
+
+    await createUnauthenticatedClient().products.list()
+
+    expect(apiKeyHeader).toBeNull()
+  })
+})

--- a/packages/admin-sdk/tests/helpers.test.ts
+++ b/packages/admin-sdk/tests/helpers.test.ts
@@ -25,11 +25,13 @@ describe('test helpers — auth contract', () => {
     expect(authHeader).toBeNull()
   })
 
-  it('createUnauthenticatedClient sends no secret key', async () => {
+  it('createUnauthenticatedClient sends no auth credential', async () => {
     let apiKeyHeader: string | null = null
+    let authHeader: string | null = null
     server.use(
       http.get(`${API_PREFIX}/products`, ({ request }) => {
         apiKeyHeader = request.headers.get('X-Spree-Api-Key')
+        authHeader = request.headers.get('Authorization')
         return HttpResponse.json({ data: [], meta: { page: 1, limit: 25, count: 0, pages: 0 } })
       }),
     )
@@ -37,5 +39,8 @@ describe('test helpers — auth contract', () => {
     await createUnauthenticatedClient().products.list()
 
     expect(apiKeyHeader).toBeNull()
+    // No secret key and no JWT → no Bearer credential. The header is either
+    // omitted or empty, but never carries a value.
+    expect(authHeader ?? '').toBe('')
   })
 })

--- a/packages/admin-sdk/tests/helpers.ts
+++ b/packages/admin-sdk/tests/helpers.ts
@@ -1,11 +1,19 @@
 import { createAdminClient } from '../src'
 
-export const TEST_BASE_URL = 'https://demo.spreecommerce.org'
+export const BASE_URL = 'https://demo.spreecommerce.org'
+export const API_PREFIX = `${BASE_URL}/api/v3/admin`
+
+// Back-compat aliases for existing specs.
+export const TEST_BASE_URL = BASE_URL
 export const TEST_API_KEY = 'sk_test'
 
+/** A fresh admin client pointed at the mock server. */
 export function createTestClient() {
-  return createAdminClient({
-    baseUrl: TEST_BASE_URL,
-    secretKey: TEST_API_KEY,
-  })
+  return createAdminClient({ baseUrl: BASE_URL })
 }
+
+/** Wraps a list of records in the standard paginated envelope. */
+export const paginated = (data: unknown[]) => ({
+  data,
+  meta: { page: 1, limit: 25, count: data.length, pages: 1 },
+})

--- a/packages/admin-sdk/tests/helpers.ts
+++ b/packages/admin-sdk/tests/helpers.ts
@@ -7,8 +7,20 @@ export const API_PREFIX = `${BASE_URL}/api/v3/admin`
 export const TEST_BASE_URL = BASE_URL
 export const TEST_API_KEY = 'sk_test'
 
-/** A fresh admin client pointed at the mock server. */
+/**
+ * A fresh admin client authenticated with a secret API key — the default for
+ * resource specs. The key goes out as `X-Spree-Api-Key`, so these tests
+ * exercise the SDK's server-to-server auth contract (see client.ts).
+ */
 export function createTestClient() {
+  return createAdminClient({ baseUrl: BASE_URL, secretKey: TEST_API_KEY })
+}
+
+/**
+ * An unauthenticated client for the auth-endpoint specs (login / refresh /
+ * logout) that establish a session and therefore run without a secret key.
+ */
+export function createUnauthenticatedClient() {
   return createAdminClient({ baseUrl: BASE_URL })
 }
 

--- a/packages/admin-sdk/tests/invitations.test.ts
+++ b/packages/admin-sdk/tests/invitations.test.ts
@@ -1,0 +1,82 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient } from './helpers'
+import { server } from './mocks/server'
+
+const sampleInvitation = {
+  id: 'inv_abc123',
+  email: 'new-staff@example.com',
+  status: 'pending',
+  role_id: 'role_1',
+  expires_at: '2026-06-01T00:00:00Z',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('invitations', () => {
+  describe('list / get', () => {
+    it('GETs /invitations', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/invitations`, () =>
+          HttpResponse.json({
+            data: [sampleInvitation],
+            meta: { page: 1, limit: 25, count: 1, pages: 1 },
+          }),
+        ),
+      )
+
+      const res = await createTestClient().invitations.list()
+
+      expect(res.data[0]?.id).toBe('inv_abc123')
+    })
+  })
+
+  describe('create', () => {
+    it('POSTs email + role_id', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/invitations`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleInvitation, { status: 201 })
+        }),
+      )
+
+      await createTestClient().invitations.create({
+        email: 'new-staff@example.com',
+        role_id: 'role_1',
+      })
+
+      expect(body).toEqual({ email: 'new-staff@example.com', role_id: 'role_1' })
+    })
+  })
+
+  describe('resend', () => {
+    it('PATCHes /invitations/:id/resend', async () => {
+      let hit = false
+      server.use(
+        http.patch(`${API_PREFIX}/invitations/inv_abc123/resend`, () => {
+          hit = true
+          return HttpResponse.json(sampleInvitation)
+        }),
+      )
+
+      await createTestClient().invitations.resend('inv_abc123')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('delete', () => {
+    it('DELETEs /invitations/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/invitations/inv_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().invitations.delete('inv_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/markets.test.ts
+++ b/packages/admin-sdk/tests/markets.test.ts
@@ -1,0 +1,104 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleMarket = {
+  id: 'market_abc123',
+  name: 'European Union',
+  currency: 'EUR',
+  default: false,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('markets', () => {
+  describe('list', () => {
+    it('GETs /markets and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/markets`, () => HttpResponse.json(paginated([sampleMarket]))),
+      )
+
+      const res = await createTestClient().markets.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('market_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/markets`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().markets.list({ name_cont: 'euro', currency_eq: 'EUR' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('euro')
+      expect(url!.searchParams.get('q[currency_eq]')).toBe('EUR')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /markets/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/markets/market_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleMarket)
+        }),
+      )
+
+      const res = await createTestClient().markets.get('market_abc123', { expand: ['countries'] })
+
+      expect(res.id).toBe('market_abc123')
+      expect(url!.searchParams.get('expand')).toBe('countries')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/markets`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleMarket, { status: 201 })
+        }),
+      )
+
+      await createTestClient().markets.create({ name: 'European Union', currency: 'EUR' })
+
+      expect(body).toEqual({ name: 'European Union', currency: 'EUR' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/markets/market_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleMarket, name: 'Eurozone' })
+        }),
+      )
+
+      const res = await createTestClient().markets.update('market_abc123', { name: 'Eurozone' })
+
+      expect(body).toEqual({ name: 'Eurozone' })
+      expect(res.name).toBe('Eurozone')
+    })
+
+    it('DELETEs /markets/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/markets/market_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().markets.delete('market_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/option-types.test.ts
+++ b/packages/admin-sdk/tests/option-types.test.ts
@@ -1,0 +1,118 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleOptionType = {
+  id: 'opt_abc123',
+  name: 'color',
+  presentation: 'Color',
+  position: 1,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('optionTypes', () => {
+  describe('list', () => {
+    it('GETs /option_types and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/option_types`, () =>
+          HttpResponse.json(paginated([sampleOptionType])),
+        ),
+      )
+
+      const res = await createTestClient().optionTypes.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('opt_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/option_types`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().optionTypes.list({ name_cont: 'col', presentation_eq: 'Color' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('col')
+      expect(url!.searchParams.get('q[presentation_eq]')).toBe('Color')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /option_types/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/option_types/opt_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleOptionType)
+        }),
+      )
+
+      const res = await createTestClient().optionTypes.get('opt_abc123', {
+        expand: ['option_values'],
+      })
+
+      expect(res.id).toBe('opt_abc123')
+      expect(url!.searchParams.get('expand')).toBe('option_values')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/option_types`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleOptionType, { status: 201 })
+        }),
+      )
+
+      await createTestClient().optionTypes.create({
+        name: 'color',
+        presentation: 'Color',
+        option_values: [{ name: 'red', presentation: 'Red' }],
+      })
+
+      expect(body).toEqual({
+        name: 'color',
+        presentation: 'Color',
+        option_values: [{ name: 'red', presentation: 'Red' }],
+      })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/option_types/opt_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleOptionType, presentation: 'Colour' })
+        }),
+      )
+
+      const res = await createTestClient().optionTypes.update('opt_abc123', {
+        presentation: 'Colour',
+      })
+
+      expect(body).toEqual({ presentation: 'Colour' })
+      expect(res.presentation).toBe('Colour')
+    })
+
+    it('DELETEs /option_types/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/option_types/opt_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().optionTypes.delete('opt_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/orders.test.ts
+++ b/packages/admin-sdk/tests/orders.test.ts
@@ -1,0 +1,224 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleOrder = {
+  id: 'order_abc123',
+  number: 'R123456789',
+  state: 'complete',
+  total: '99.99',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const sampleLineItem = { id: 'li_1', quantity: 2, variant_id: 'variant_1' }
+const samplePayment = { id: 'pay_1', state: 'checkout', amount: '99.99' }
+const sampleRefund = { id: 'ref_1', amount: '10.0' }
+
+describe('orders', () => {
+  describe('list / get', () => {
+    it('GETs /orders with Ransack filters', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/orders`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([sampleOrder]))
+        }),
+      )
+
+      const res = await createTestClient().orders.list({ state_eq: 'complete' })
+
+      expect(res.data[0]?.id).toBe('order_abc123')
+      expect(url!.searchParams.get('q[state_eq]')).toBe('complete')
+    })
+
+    it('GETs /orders/:id', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/orders/order_abc123`, () => HttpResponse.json(sampleOrder)),
+      )
+
+      const res = await createTestClient().orders.get('order_abc123')
+
+      expect(res.number).toBe('R123456789')
+    })
+  })
+
+  describe('lifecycle actions', () => {
+    it.each([
+      ['complete', 'complete'],
+      ['cancel', 'cancel'],
+      ['approve', 'approve'],
+      ['resume', 'resume'],
+    ] as const)('PATCHes /orders/:id/%s', async (method, segment) => {
+      let hit = false
+      server.use(
+        http.patch(`${API_PREFIX}/orders/order_abc123/${segment}`, () => {
+          hit = true
+          return HttpResponse.json(sampleOrder)
+        }),
+      )
+
+      // resume takes no params; the others accept an optional params arg.
+      await (createTestClient().orders as Record<string, (...args: unknown[]) => Promise<unknown>>)[
+        method
+      ]('order_abc123')
+      expect(hit).toBe(true)
+    })
+
+    it('POSTs /orders/:id/resend_confirmation', async () => {
+      let hit = false
+      server.use(
+        http.post(`${API_PREFIX}/orders/order_abc123/resend_confirmation`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await createTestClient().orders.resendConfirmation('order_abc123')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested line items', () => {
+    it('POSTs a line item to the order', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/orders/order_abc123/items`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleLineItem, { status: 201 })
+        }),
+      )
+
+      await createTestClient().orders.items.create('order_abc123', {
+        variant_id: 'variant_1',
+        quantity: 2,
+      })
+
+      expect(body).toEqual({ variant_id: 'variant_1', quantity: 2 })
+    })
+
+    it('PATCHes a line item quantity', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/orders/order_abc123/items/li_1`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleLineItem, quantity: 5 })
+        }),
+      )
+
+      const res = await createTestClient().orders.items.update('order_abc123', 'li_1', {
+        quantity: 5,
+      })
+
+      expect(body).toEqual({ quantity: 5 })
+      expect(res.quantity).toBe(5)
+    })
+
+    it('DELETEs a line item', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/orders/order_abc123/items/li_1`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await createTestClient().orders.items.delete('order_abc123', 'li_1')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested payments', () => {
+    it('POSTs a payment', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/orders/order_abc123/payments`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(samplePayment, { status: 201 })
+        }),
+      )
+
+      await createTestClient().orders.payments.create('order_abc123', {
+        payment_method_id: 'pm_1',
+        amount: 99.99,
+      })
+
+      expect(body).toEqual({ payment_method_id: 'pm_1', amount: 99.99 })
+    })
+
+    it.each(['capture', 'void'] as const)('PATCHes /payments/:id/%s', async (action) => {
+      let hit = false
+      server.use(
+        http.patch(`${API_PREFIX}/orders/order_abc123/payments/pay_1/${action}`, () => {
+          hit = true
+          return HttpResponse.json(samplePayment)
+        }),
+      )
+
+      await createTestClient().orders.payments[action]('order_abc123', 'pay_1')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested refunds', () => {
+    it('POSTs a refund', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/orders/order_abc123/refunds`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleRefund, { status: 201 })
+        }),
+      )
+
+      await createTestClient().orders.refunds.create('order_abc123', {
+        payment_id: 'pay_1',
+        amount: 10,
+      })
+
+      expect(body).toEqual({ payment_id: 'pay_1', amount: 10 })
+    })
+  })
+
+  describe('nested gift cards & store credits', () => {
+    it('applies a gift card via POST', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/orders/order_abc123/gift_cards`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ id: 'gc_1', code: 'ABC' }, { status: 201 })
+        }),
+      )
+
+      await createTestClient().orders.giftCards.apply('order_abc123', { code: 'ABC' })
+
+      expect(body).toEqual({ code: 'ABC' })
+    })
+
+    it('applies store credit via POST', async () => {
+      let hit = false
+      server.use(
+        http.post(`${API_PREFIX}/orders/order_abc123/store_credits`, () => {
+          hit = true
+          return HttpResponse.json(sampleOrder, { status: 201 })
+        }),
+      )
+
+      await createTestClient().orders.storeCredits.apply('order_abc123')
+      expect(hit).toBe(true)
+    })
+
+    it('removes store credit via DELETE', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/orders/order_abc123/store_credits`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await createTestClient().orders.storeCredits.remove('order_abc123')
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/payment-methods.test.ts
+++ b/packages/admin-sdk/tests/payment-methods.test.ts
@@ -1,0 +1,140 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const samplePaymentMethod = {
+  id: 'pm_1',
+  type: 'Spree::Gateway::Bogus',
+  name: 'Credit Card',
+  description: 'Pay by card',
+  active: true,
+  storefront_visible: true,
+  auto_capture: null,
+  position: 1,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('paymentMethods', () => {
+  describe('list', () => {
+    it('GETs /payment_methods and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/payment_methods`, () =>
+          HttpResponse.json(paginated([samplePaymentMethod])),
+        ),
+      )
+
+      const res = await createTestClient().paymentMethods.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('pm_1')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/payment_methods`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().paymentMethods.list({ active_eq: true, name_cont: 'card' })
+
+      expect(url!.searchParams.get('q[active_eq]')).toBe('true')
+      expect(url!.searchParams.get('q[name_cont]')).toBe('card')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /payment_methods/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/payment_methods/pm_1`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(samplePaymentMethod)
+        }),
+      )
+
+      const res = await createTestClient().paymentMethods.get('pm_1', { expand: ['stores'] })
+
+      expect(res.id).toBe('pm_1')
+      expect(url!.searchParams.get('expand')).toBe('stores')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/payment_methods`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(samplePaymentMethod, { status: 201 })
+        }),
+      )
+
+      await createTestClient().paymentMethods.create({
+        type: 'Spree::Gateway::Bogus',
+        name: 'Credit Card',
+      })
+
+      expect(body).toEqual({ type: 'Spree::Gateway::Bogus', name: 'Credit Card' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/payment_methods/pm_1`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...samplePaymentMethod, name: 'PayPal' })
+        }),
+      )
+
+      const res = await createTestClient().paymentMethods.update('pm_1', { name: 'PayPal' })
+
+      expect(body).toEqual({ name: 'PayPal' })
+      expect(res.name).toBe('PayPal')
+    })
+
+    it('DELETEs /payment_methods/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/payment_methods/pm_1`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().paymentMethods.delete('pm_1')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('types', () => {
+    it('GETs /payment_methods/types with preference schema', async () => {
+      let hit = false
+      server.use(
+        http.get(`${API_PREFIX}/payment_methods/types`, () => {
+          hit = true
+          return HttpResponse.json({
+            data: [
+              {
+                type: 'Spree::Gateway::Bogus',
+                label: 'Bogus Gateway',
+                description: 'Test gateway for development',
+                preference_schema: [{ key: 'server', type: 'string', default: 'test' }],
+              },
+            ],
+          })
+        }),
+      )
+
+      const res = await createTestClient().paymentMethods.types()
+
+      expect(hit).toBe(true)
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.type).toBe('Spree::Gateway::Bogus')
+    })
+  })
+})

--- a/packages/admin-sdk/tests/price-lists.test.ts
+++ b/packages/admin-sdk/tests/price-lists.test.ts
@@ -1,10 +1,7 @@
 import { HttpResponse, http } from 'msw'
 import { describe, expect, it } from 'vitest'
-import { createAdminClient } from '../src'
+import { API_PREFIX, createTestClient } from './helpers'
 import { server } from './mocks/server'
-
-const BASE_URL = 'https://demo.spreecommerce.org'
-const API_PREFIX = `${BASE_URL}/api/v3/admin`
 
 const samplePriceList = {
   id: 'pl_abc123',
@@ -34,7 +31,7 @@ describe('priceLists', () => {
         ),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.priceLists.list()
 
       expect(res.data).toHaveLength(1)
@@ -50,7 +47,7 @@ describe('priceLists', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await client.priceLists.list({ status_eq: 'active', name_cont: 'whole' })
 
       expect(url!.searchParams.get('q[status_eq]')).toBe('active')
@@ -68,7 +65,7 @@ describe('priceLists', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await client.priceLists.create({ name: 'Wholesale', match_policy: 'all' })
 
       expect(body).toEqual({ name: 'Wholesale', match_policy: 'all' })
@@ -85,7 +82,7 @@ describe('priceLists', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.priceLists.activate('pl_abc123')
 
       expect(hit).toBe(true)
@@ -99,7 +96,7 @@ describe('priceLists', () => {
         ),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.priceLists.deactivate('pl_abc123')
 
       expect(res.status).toBe('inactive')
@@ -119,7 +116,7 @@ describe('priceLists', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.priceLists.update('pl_abc123', {
         name: 'Wholesale',
         product_ids: ['prod_a', 'prod_b'],
@@ -142,7 +139,7 @@ describe('priceLists', () => {
         }),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       await client.priceLists.update('pl_abc123', {
         prices: [
           { id: 'price_x', variant_id: 'variant_x', currency: 'USD', amount: '12.50' },
@@ -183,7 +180,7 @@ describe('priceLists', () => {
         ),
       )
 
-      const client = createAdminClient({ baseUrl: BASE_URL })
+      const client = createTestClient()
       const res = await client.priceLists.ruleTypes()
 
       expect(res.data).toHaveLength(1)

--- a/packages/admin-sdk/tests/products.test.ts
+++ b/packages/admin-sdk/tests/products.test.ts
@@ -1,0 +1,241 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleProduct = {
+  id: 'prod_abc123',
+  name: 'T-Shirt',
+  slug: 't-shirt',
+  status: 'active',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('products', () => {
+  describe('list / get', () => {
+    it('GETs /products with Ransack filters + sort', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/products`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([sampleProduct]))
+        }),
+      )
+
+      const res = await createTestClient().products.list({
+        status_eq: 'active',
+        sort: '-created_at',
+      })
+
+      expect(res.data[0]?.id).toBe('prod_abc123')
+      expect(url!.searchParams.get('q[status_eq]')).toBe('active')
+      expect(url!.searchParams.get('sort')).toBe('-created_at')
+    })
+
+    it('GETs /products/:id with expand', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/products/prod_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleProduct)
+        }),
+      )
+
+      await createTestClient().products.get('prod_abc123', { expand: ['variants', 'images'] })
+
+      expect(url!.searchParams.get('expand')).toBe('variants,images')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/products`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleProduct, { status: 201 })
+        }),
+      )
+
+      await createTestClient().products.create({ name: 'T-Shirt', status: 'active' })
+
+      expect(body).toEqual({ name: 'T-Shirt', status: 'active' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/products/prod_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleProduct, name: 'Hoodie' })
+        }),
+      )
+
+      const res = await createTestClient().products.update('prod_abc123', { name: 'Hoodie' })
+
+      expect(body).toEqual({ name: 'Hoodie' })
+      expect(res.name).toBe('Hoodie')
+    })
+
+    it('DELETEs /products/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/products/prod_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().products.delete('prod_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('clone', () => {
+    it('POSTs /products/:id/clone and returns the new draft', async () => {
+      server.use(
+        http.post(`${API_PREFIX}/products/prod_abc123/clone`, () =>
+          HttpResponse.json(
+            { ...sampleProduct, id: 'prod_copy', name: 'COPY OF T-Shirt', status: 'draft' },
+            {
+              status: 201,
+            },
+          ),
+        ),
+      )
+
+      const res = await createTestClient().products.clone('prod_abc123')
+
+      expect(res.id).toBe('prod_copy')
+      expect(res.status).toBe('draft')
+    })
+  })
+
+  describe('bulk operations', () => {
+    it('POSTs /bulk_status_update with ids + status', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/products/bulk_status_update`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ product_count: 2, status: 'archived' })
+        }),
+      )
+
+      const res = await createTestClient().products.bulkStatusUpdate({
+        ids: ['prod_a', 'prod_b'],
+        status: 'archived',
+      })
+
+      expect(body).toEqual({ ids: ['prod_a', 'prod_b'], status: 'archived' })
+      expect(res.product_count).toBe(2)
+    })
+
+    it('POSTs /bulk_add_to_categories with ids + category_ids', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/products/bulk_add_to_categories`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ product_count: 1, category_count: 2 })
+        }),
+      )
+
+      await createTestClient().products.bulkAddToCategories({
+        ids: ['prod_a'],
+        category_ids: ['cat_1', 'cat_2'],
+      })
+
+      expect(body).toEqual({ ids: ['prod_a'], category_ids: ['cat_1', 'cat_2'] })
+    })
+
+    it('POSTs /bulk_add_to_channels with ids + channel_ids', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/products/bulk_add_to_channels`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ product_count: 1, channel_count: 1 })
+        }),
+      )
+
+      await createTestClient().products.bulkAddToChannels({
+        ids: ['prod_a'],
+        channel_ids: ['chan_1'],
+      })
+
+      expect(body).toEqual({ ids: ['prod_a'], channel_ids: ['chan_1'] })
+    })
+
+    it('DELETEs /bulk_destroy with ids in the body', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.delete(`${API_PREFIX}/products/bulk_destroy`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ product_count: 2 })
+        }),
+      )
+
+      const res = await createTestClient().products.bulkDestroy({ ids: ['prod_a', 'prod_b'] })
+
+      expect(body).toEqual({ ids: ['prod_a', 'prod_b'] })
+      expect(res.product_count).toBe(2)
+    })
+  })
+})
+
+describe('prices', () => {
+  const samplePrice = { id: 'price_1', amount: '12.50', currency: 'USD', variant_id: 'variant_1' }
+
+  describe('list', () => {
+    it('GETs /prices filtering by price_list_id', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/prices`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([samplePrice]))
+        }),
+      )
+
+      await createTestClient().prices.list({ price_list_id_eq: 'pl_1' })
+
+      expect(url!.searchParams.get('q[price_list_id_eq]')).toBe('pl_1')
+    })
+  })
+
+  describe('bulkUpsert', () => {
+    it('POSTs /prices/bulk_upsert with a prices array and returns the count', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/prices/bulk_upsert`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ price_count: 2 })
+        }),
+      )
+
+      const res = await createTestClient().prices.bulkUpsert({
+        prices: [
+          { variant_id: 'variant_1', currency: 'USD', amount: '12.50' },
+          { variant_id: 'variant_2', currency: 'USD', amount: '9.99', price_list_id: 'pl_1' },
+        ],
+      })
+
+      expect((body as { prices: unknown[] }).prices).toHaveLength(2)
+      expect(res.price_count).toBe(2)
+    })
+  })
+
+  describe('bulkDestroy', () => {
+    it('DELETEs /prices/bulk_destroy with ids', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.delete(`${API_PREFIX}/prices/bulk_destroy`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ price_count: 1 })
+        }),
+      )
+
+      await createTestClient().prices.bulkDestroy({ ids: ['price_1'] })
+
+      expect(body).toEqual({ ids: ['price_1'] })
+    })
+  })
+})

--- a/packages/admin-sdk/tests/promotions.test.ts
+++ b/packages/admin-sdk/tests/promotions.test.ts
@@ -1,0 +1,306 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const samplePromotion = {
+  id: 'promo_abc123',
+  name: 'Summer Sale',
+  code: 'SUMMER',
+  description: null,
+  starts_at: null,
+  expires_at: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const samplePromotionAction = {
+  id: 'promoact_1',
+  type: 'Spree::Promotion::Actions::CreateItemAdjustments',
+  calculator_type: 'Spree::Calculator::FlatRate',
+}
+
+const samplePromotionRule = {
+  id: 'promorule_1',
+  type: 'Spree::Promotion::Rules::ItemTotal',
+}
+
+const sampleCouponCode = { id: 'coupon_1', code: 'SUMMER10', state: 'pending' }
+
+describe('promotions', () => {
+  describe('list', () => {
+    it('GETs /promotions and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotions`, () => HttpResponse.json(paginated([samplePromotion]))),
+      )
+
+      const res = await createTestClient().promotions.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('promo_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/promotions`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().promotions.list({ name_cont: 'summer', code_eq: 'SUMMER' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('summer')
+      expect(url!.searchParams.get('q[code_eq]')).toBe('SUMMER')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /promotions/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/promotions/promo_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(samplePromotion)
+        }),
+      )
+
+      const res = await createTestClient().promotions.get('promo_abc123', {
+        expand: ['promotion_actions'],
+      })
+
+      expect(res.id).toBe('promo_abc123')
+      expect(url!.searchParams.get('expand')).toBe('promotion_actions')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/promotions`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(samplePromotion, { status: 201 })
+        }),
+      )
+
+      await createTestClient().promotions.create({ name: 'Summer Sale', code: 'SUMMER' })
+
+      expect(body).toEqual({ name: 'Summer Sale', code: 'SUMMER' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/promotions/promo_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...samplePromotion, name: 'Autumn Sale' })
+        }),
+      )
+
+      const res = await createTestClient().promotions.update('promo_abc123', {
+        name: 'Autumn Sale',
+      })
+
+      expect(body).toEqual({ name: 'Autumn Sale' })
+      expect(res.name).toBe('Autumn Sale')
+    })
+
+    it('DELETEs /promotions/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/promotions/promo_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().promotions.delete('promo_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested actions', () => {
+    it('GETs /promotions/:pid/promotion_actions', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotions/promo_abc123/promotion_actions`, () =>
+          HttpResponse.json(paginated([samplePromotionAction])),
+        ),
+      )
+
+      const res = await createTestClient().promotions.actions.list('promo_abc123')
+
+      expect(res.data[0]?.id).toBe('promoact_1')
+    })
+
+    it('POSTs a promotion action verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(
+          `${API_PREFIX}/promotions/promo_abc123/promotion_actions`,
+          async ({ request }) => {
+            body = (await request.json()) as Record<string, unknown>
+            return HttpResponse.json(samplePromotionAction, { status: 201 })
+          },
+        ),
+      )
+
+      await createTestClient().promotions.actions.create('promo_abc123', {
+        type: 'Spree::Promotion::Actions::CreateItemAdjustments',
+        calculator_type: 'Spree::Calculator::FlatRate',
+      })
+
+      expect(body).toEqual({
+        type: 'Spree::Promotion::Actions::CreateItemAdjustments',
+        calculator_type: 'Spree::Calculator::FlatRate',
+      })
+    })
+
+    it('DELETEs a promotion action', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/promotions/promo_abc123/promotion_actions/promoact_1`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await createTestClient().promotions.actions.delete('promo_abc123', 'promoact_1')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested rules', () => {
+    it('GETs /promotions/:pid/promotion_rules', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotions/promo_abc123/promotion_rules`, () =>
+          HttpResponse.json(paginated([samplePromotionRule])),
+        ),
+      )
+
+      const res = await createTestClient().promotions.rules.list('promo_abc123')
+
+      expect(res.data[0]?.id).toBe('promorule_1')
+    })
+
+    it('POSTs a promotion rule verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/promotions/promo_abc123/promotion_rules`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(samplePromotionRule, { status: 201 })
+        }),
+      )
+
+      await createTestClient().promotions.rules.create('promo_abc123', {
+        type: 'Spree::Promotion::Rules::ItemTotal',
+      })
+
+      expect(body).toEqual({ type: 'Spree::Promotion::Rules::ItemTotal' })
+    })
+
+    it('DELETEs a promotion rule', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/promotions/promo_abc123/promotion_rules/promorule_1`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await createTestClient().promotions.rules.delete('promo_abc123', 'promorule_1')
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('nested coupon codes', () => {
+    it('GETs /promotions/:pid/coupon_codes', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotions/promo_abc123/coupon_codes`, () =>
+          HttpResponse.json(paginated([sampleCouponCode])),
+        ),
+      )
+
+      const res = await createTestClient().promotions.couponCodes.list('promo_abc123')
+
+      expect(res.data[0]?.id).toBe('coupon_1')
+    })
+
+    it('GETs a single coupon code by id', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotions/promo_abc123/coupon_codes/coupon_1`, () =>
+          HttpResponse.json(sampleCouponCode),
+        ),
+      )
+
+      const res = await createTestClient().promotions.couponCodes.get('promo_abc123', 'coupon_1')
+
+      expect(res.code).toBe('SUMMER10')
+    })
+  })
+})
+
+describe('promotionActions', () => {
+  describe('types', () => {
+    it('GETs /promotion_actions/types', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotion_actions/types`, () =>
+          HttpResponse.json({
+            data: [
+              {
+                type: 'Spree::Promotion::Actions::CreateItemAdjustments',
+                label: 'Create Item Adjustments',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const res = await createTestClient().promotionActions.types()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.type).toBe('Spree::Promotion::Actions::CreateItemAdjustments')
+    })
+  })
+
+  describe('calculators', () => {
+    it('GETs /promotion_actions/calculators with the type param', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/promotion_actions/calculators`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json({
+            data: [{ type: 'Spree::Calculator::FlatRate', label: 'Flat Rate' }],
+          })
+        }),
+      )
+
+      const res = await createTestClient().promotionActions.calculators(
+        'Spree::Promotion::Actions::CreateItemAdjustments',
+      )
+
+      expect(url!.searchParams.get('type')).toBe('Spree::Promotion::Actions::CreateItemAdjustments')
+      expect(res.data[0]?.type).toBe('Spree::Calculator::FlatRate')
+    })
+  })
+})
+
+describe('promotionRules', () => {
+  describe('types', () => {
+    it('GETs /promotion_rules/types', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/promotion_rules/types`, () =>
+          HttpResponse.json({
+            data: [{ type: 'Spree::Promotion::Rules::ItemTotal', label: 'Item Total' }],
+          }),
+        ),
+      )
+
+      const res = await createTestClient().promotionRules.types()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.type).toBe('Spree::Promotion::Rules::ItemTotal')
+    })
+  })
+})

--- a/packages/admin-sdk/tests/read-only-resources.test.ts
+++ b/packages/admin-sdk/tests/read-only-resources.test.ts
@@ -1,0 +1,276 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleRole = {
+  id: 'role_abc123',
+  name: 'admin',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const sampleCategory = {
+  id: 'cat_abc123',
+  name: 'Apparel',
+  permalink: 'apparel',
+}
+
+const sampleVariant = {
+  id: 'variant_abc123',
+  sku: 'SKU-1',
+  price: '19.99',
+}
+
+const sampleCountry = {
+  id: 'country_abc123',
+  iso: 'US',
+  name: 'United States',
+}
+
+const sampleStoreCreditCategory = {
+  id: 'scc_abc123',
+  name: 'Refund',
+}
+
+describe('roles', () => {
+  describe('list', () => {
+    it('GETs /roles and returns paginated data', async () => {
+      server.use(http.get(`${API_PREFIX}/roles`, () => HttpResponse.json(paginated([sampleRole]))))
+
+      const res = await createTestClient().roles.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('role_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/roles`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().roles.list({ name_cont: 'admin' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('admin')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /roles/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/roles/role_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleRole)
+        }),
+      )
+
+      const res = await createTestClient().roles.get('role_abc123', { expand: ['permissions'] })
+
+      expect(res.id).toBe('role_abc123')
+      expect(url!.searchParams.get('expand')).toBe('permissions')
+    })
+  })
+})
+
+describe('categories', () => {
+  describe('list', () => {
+    it('GETs /categories and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/categories`, () => HttpResponse.json(paginated([sampleCategory]))),
+      )
+
+      const res = await createTestClient().categories.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('cat_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/categories`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().categories.list({ name_cont: 'apparel' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('apparel')
+    })
+  })
+})
+
+describe('variants', () => {
+  describe('list', () => {
+    it('GETs /variants and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/variants`, () => HttpResponse.json(paginated([sampleVariant]))),
+      )
+
+      const res = await createTestClient().variants.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('variant_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/variants`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().variants.list({ sku_cont: 'SKU' })
+
+      expect(url!.searchParams.get('q[sku_cont]')).toBe('SKU')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /variants/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/variants/variant_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleVariant)
+        }),
+      )
+
+      const res = await createTestClient().variants.get('variant_abc123', {
+        expand: ['stock_items'],
+      })
+
+      expect(res.id).toBe('variant_abc123')
+      expect(url!.searchParams.get('expand')).toBe('stock_items')
+    })
+  })
+})
+
+describe('countries', () => {
+  describe('list', () => {
+    it('GETs /countries and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/countries`, () => HttpResponse.json(paginated([sampleCountry]))),
+      )
+
+      const res = await createTestClient().countries.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('country_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/countries`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().countries.list({ name_cont: 'United' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('United')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /countries/:iso and forwards expand=states', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/countries/US`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleCountry)
+        }),
+      )
+
+      const res = await createTestClient().countries.get('US', { expand: ['states'] })
+
+      expect(res.iso).toBe('US')
+      expect(url!.searchParams.get('expand')).toBe('states')
+    })
+  })
+})
+
+describe('storeCreditCategories', () => {
+  describe('list', () => {
+    it('GETs /store_credit_categories and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/store_credit_categories`, () =>
+          HttpResponse.json(paginated([sampleStoreCreditCategory])),
+        ),
+      )
+
+      const res = await createTestClient().storeCreditCategories.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('scc_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/store_credit_categories`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().storeCreditCategories.list({ name_cont: 'Refund' })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('Refund')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /store_credit_categories/:id', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/store_credit_categories/scc_abc123`, () =>
+          HttpResponse.json(sampleStoreCreditCategory),
+        ),
+      )
+
+      const res = await createTestClient().storeCreditCategories.get('scc_abc123')
+
+      expect(res.id).toBe('scc_abc123')
+    })
+  })
+})
+
+describe('tags', () => {
+  describe('list', () => {
+    it('GETs /tags and returns the tag list', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/tags`, () => HttpResponse.json({ data: [{ name: 'vip' }] })),
+      )
+
+      const res = await createTestClient().tags.list({ taggable_type: 'Spree::Customer' })
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.name).toBe('vip')
+    })
+
+    it('forwards taggable_type + q filter params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/tags`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json({ data: [] })
+        }),
+      )
+
+      await createTestClient().tags.list({ taggable_type: 'Spree::Customer', q: 'vi' })
+
+      expect(url!.searchParams.get('taggable_type')).toBe('Spree::Customer')
+      expect(url!.searchParams.get('q')).toBe('vi')
+    })
+  })
+})

--- a/packages/admin-sdk/tests/stock.test.ts
+++ b/packages/admin-sdk/tests/stock.test.ts
@@ -1,0 +1,298 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleStockLocation = {
+  id: 'sl_abc123',
+  name: 'Main Warehouse',
+  default: true,
+  active: true,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const sampleStockItem = {
+  id: 'si_abc123',
+  count_on_hand: 42,
+  backorderable: false,
+  variant_id: 'variant_1',
+  stock_location_id: 'sl_abc123',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const sampleStockTransfer = {
+  id: 'st_abc123',
+  number: 'T123456789',
+  source_location_id: 'sl_abc123',
+  destination_location_id: 'sl_def456',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('stockLocations', () => {
+  describe('list', () => {
+    it('GETs /stock_locations and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/stock_locations`, () =>
+          HttpResponse.json(paginated([sampleStockLocation])),
+        ),
+      )
+
+      const res = await createTestClient().stockLocations.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('sl_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/stock_locations`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().stockLocations.list({ name_cont: 'warehouse', active_eq: true })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('warehouse')
+      expect(url!.searchParams.get('q[active_eq]')).toBe('true')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /stock_locations/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/stock_locations/sl_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleStockLocation)
+        }),
+      )
+
+      const res = await createTestClient().stockLocations.get('sl_abc123', {
+        expand: ['stock_items'],
+      })
+
+      expect(res.id).toBe('sl_abc123')
+      expect(url!.searchParams.get('expand')).toBe('stock_items')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/stock_locations`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleStockLocation, { status: 201 })
+        }),
+      )
+
+      await createTestClient().stockLocations.create({ name: 'Main Warehouse', default: true })
+
+      expect(body).toEqual({ name: 'Main Warehouse', default: true })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/stock_locations/sl_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleStockLocation, active: false })
+        }),
+      )
+
+      const res = await createTestClient().stockLocations.update('sl_abc123', { active: false })
+
+      expect(body).toEqual({ active: false })
+      expect(res.active).toBe(false)
+    })
+
+    it('DELETEs /stock_locations/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/stock_locations/sl_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().stockLocations.delete('sl_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})
+
+describe('stockItems', () => {
+  describe('list', () => {
+    it('GETs /stock_items and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/stock_items`, () =>
+          HttpResponse.json(paginated([sampleStockItem])),
+        ),
+      )
+
+      const res = await createTestClient().stockItems.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('si_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/stock_items`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().stockItems.list({
+        stock_location_id_eq: 'sl_abc123',
+        variant_id_eq: 'variant_1',
+      })
+
+      expect(url!.searchParams.get('q[stock_location_id_eq]')).toBe('sl_abc123')
+      expect(url!.searchParams.get('q[variant_id_eq]')).toBe('variant_1')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /stock_items/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/stock_items/si_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleStockItem)
+        }),
+      )
+
+      const res = await createTestClient().stockItems.get('si_abc123', { expand: ['variant'] })
+
+      expect(res.id).toBe('si_abc123')
+      expect(url!.searchParams.get('expand')).toBe('variant')
+    })
+  })
+
+  describe('update / delete', () => {
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/stock_items/si_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleStockItem, count_on_hand: 100 })
+        }),
+      )
+
+      const res = await createTestClient().stockItems.update('si_abc123', { count_on_hand: 100 })
+
+      expect(body).toEqual({ count_on_hand: 100 })
+      expect(res.count_on_hand).toBe(100)
+    })
+
+    it('DELETEs /stock_items/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/stock_items/si_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().stockItems.delete('si_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})
+
+describe('stockTransfers', () => {
+  describe('list', () => {
+    it('GETs /stock_transfers and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/stock_transfers`, () =>
+          HttpResponse.json(paginated([sampleStockTransfer])),
+        ),
+      )
+
+      const res = await createTestClient().stockTransfers.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('st_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/stock_transfers`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().stockTransfers.list({
+        number_cont: 'T123',
+        source_location_id_eq: 'sl_abc123',
+      })
+
+      expect(url!.searchParams.get('q[number_cont]')).toBe('T123')
+      expect(url!.searchParams.get('q[source_location_id_eq]')).toBe('sl_abc123')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /stock_transfers/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/stock_transfers/st_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleStockTransfer)
+        }),
+      )
+
+      const res = await createTestClient().stockTransfers.get('st_abc123', {
+        expand: ['stock_movements'],
+      })
+
+      expect(res.id).toBe('st_abc123')
+      expect(url!.searchParams.get('expand')).toBe('stock_movements')
+    })
+  })
+
+  describe('create / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/stock_transfers`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleStockTransfer, { status: 201 })
+        }),
+      )
+
+      await createTestClient().stockTransfers.create({
+        source_location_id: 'sl_abc123',
+        destination_location_id: 'sl_def456',
+      })
+
+      expect(body).toEqual({
+        source_location_id: 'sl_abc123',
+        destination_location_id: 'sl_def456',
+      })
+    })
+
+    it('DELETEs /stock_transfers/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/stock_transfers/st_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().stockTransfers.delete('st_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/store-settings.test.ts
+++ b/packages/admin-sdk/tests/store-settings.test.ts
@@ -1,0 +1,139 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient } from './helpers'
+import { server } from './mocks/server'
+
+const sampleStore = {
+  id: 'store_abc123',
+  name: 'Demo Store',
+  url: 'demo.spreecommerce.org',
+  default_currency: 'USD',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('store', () => {
+  describe('get', () => {
+    it('GETs /store', async () => {
+      server.use(http.get(`${API_PREFIX}/store`, () => HttpResponse.json(sampleStore)))
+
+      const res = await createTestClient().store.get()
+
+      expect(res.id).toBe('store_abc123')
+    })
+  })
+
+  describe('update', () => {
+    it('PATCHes /store with the params verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/store`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleStore, name: 'Renamed Store' })
+        }),
+      )
+
+      const res = await createTestClient().store.update({ name: 'Renamed Store' })
+
+      expect(body).toEqual({ name: 'Renamed Store' })
+      expect(res.name).toBe('Renamed Store')
+    })
+  })
+})
+
+describe('me', () => {
+  describe('get', () => {
+    it('GETs /me and returns the user + permissions', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/me`, () =>
+          HttpResponse.json({ user: { id: 'usr_1', email: 'a@b.c' }, permissions: [] }),
+        ),
+      )
+
+      const res = await createTestClient().me.get()
+
+      expect(res.user.id).toBe('usr_1')
+      expect(res.permissions).toEqual([])
+    })
+  })
+})
+
+describe('dashboard', () => {
+  describe('analytics', () => {
+    it('GETs /dashboard/analytics', async () => {
+      let hit = false
+      server.use(
+        http.get(`${API_PREFIX}/dashboard/analytics`, () => {
+          hit = true
+          return HttpResponse.json({ orders_count: 0, total_sales: '0.0' })
+        }),
+      )
+
+      await createTestClient().dashboard.analytics()
+
+      expect(hit).toBe(true)
+    })
+
+    it('forwards optional query params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/dashboard/analytics`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json({ orders_count: 0, total_sales: '0.0' })
+        }),
+      )
+
+      await createTestClient().dashboard.analytics({
+        date_from: '2026-05-01',
+        date_to: '2026-05-31',
+        currency: 'EUR',
+      })
+
+      expect(url!.searchParams.get('date_from')).toBe('2026-05-01')
+      expect(url!.searchParams.get('date_to')).toBe('2026-05-31')
+      expect(url!.searchParams.get('currency')).toBe('EUR')
+    })
+  })
+})
+
+describe('directUploads', () => {
+  describe('create', () => {
+    it('POSTs /direct_uploads and returns the signed upload', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/direct_uploads`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(
+            {
+              direct_upload: {
+                url: 'https://uploads.example.com/abc',
+                headers: { 'Content-Type': 'image/png' },
+              },
+              signed_id: 'signed_xyz789',
+            },
+            { status: 201 },
+          )
+        }),
+      )
+
+      const res = await createTestClient().directUploads.create({
+        blob: {
+          filename: 'logo.png',
+          byte_size: 1024,
+          checksum: 'abc==',
+          content_type: 'image/png',
+        },
+      })
+
+      expect(body).toEqual({
+        blob: {
+          filename: 'logo.png',
+          byte_size: 1024,
+          checksum: 'abc==',
+          content_type: 'image/png',
+        },
+      })
+      expect(res.signed_id).toBe('signed_xyz789')
+    })
+  })
+})

--- a/packages/admin-sdk/tests/tax-categories.test.ts
+++ b/packages/admin-sdk/tests/tax-categories.test.ts
@@ -1,0 +1,107 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleTaxCategory = {
+  id: 'tc_abc123',
+  name: 'Clothing',
+  tax_code: 'CLOTH',
+  description: null,
+  is_default: false,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+describe('taxCategories', () => {
+  describe('list', () => {
+    it('GETs /tax_categories and returns paginated data', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/tax_categories`, () =>
+          HttpResponse.json(paginated([sampleTaxCategory])),
+        ),
+      )
+
+      const res = await createTestClient().taxCategories.list()
+
+      expect(res.data).toHaveLength(1)
+      expect(res.data[0]?.id).toBe('tc_abc123')
+    })
+
+    it('wraps Ransack predicates via transformListParams', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/tax_categories`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([]))
+        }),
+      )
+
+      await createTestClient().taxCategories.list({ name_cont: 'cloth', is_default_eq: true })
+
+      expect(url!.searchParams.get('q[name_cont]')).toBe('cloth')
+      expect(url!.searchParams.get('q[is_default_eq]')).toBe('true')
+    })
+  })
+
+  describe('get', () => {
+    it('GETs /tax_categories/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/tax_categories/tc_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleTaxCategory)
+        }),
+      )
+
+      const res = await createTestClient().taxCategories.get('tc_abc123', { expand: ['tax_rates'] })
+
+      expect(res.id).toBe('tc_abc123')
+      expect(url!.searchParams.get('expand')).toBe('tax_rates')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/tax_categories`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleTaxCategory, { status: 201 })
+        }),
+      )
+
+      await createTestClient().taxCategories.create({ name: 'Clothing', tax_code: 'CLOTH' })
+
+      expect(body).toEqual({ name: 'Clothing', tax_code: 'CLOTH' })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/tax_categories/tc_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleTaxCategory, is_default: true })
+        }),
+      )
+
+      const res = await createTestClient().taxCategories.update('tc_abc123', { is_default: true })
+
+      expect(body).toEqual({ is_default: true })
+      expect(res.is_default).toBe(true)
+    })
+
+    it('DELETEs /tax_categories/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/tax_categories/tc_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(createTestClient().taxCategories.delete('tc_abc123')).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+})

--- a/packages/admin-sdk/tests/webhook-endpoints.test.ts
+++ b/packages/admin-sdk/tests/webhook-endpoints.test.ts
@@ -1,0 +1,220 @@
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { API_PREFIX, createTestClient, paginated } from './helpers'
+import { server } from './mocks/server'
+
+const sampleEndpoint = {
+  id: 'whe_abc123',
+  name: 'Production',
+  url: 'https://example.com/hooks',
+  active: true,
+  subscriptions: ['order.completed'],
+  disabled_reason: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  disabled_at: null,
+}
+
+const sampleDelivery = {
+  id: 'whd_1',
+  event_name: 'order.completed',
+  response_code: 200,
+  success: true,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  webhook_endpoint_id: 'whe_abc123',
+}
+
+describe('webhookEndpoints', () => {
+  describe('list / get', () => {
+    it('GETs /webhook_endpoints with Ransack filters', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/webhook_endpoints`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([sampleEndpoint]))
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.list({ active_eq: true })
+
+      expect(res.data[0]?.id).toBe('whe_abc123')
+      expect(url!.searchParams.get('q[active_eq]')).toBe('true')
+    })
+
+    it('GETs /webhook_endpoints/:id and forwards expand params', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/webhook_endpoints/whe_abc123`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(sampleEndpoint)
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.get('whe_abc123', {
+        expand: ['deliveries'],
+      })
+
+      expect(res.url).toBe('https://example.com/hooks')
+      expect(url!.searchParams.get('expand')).toBe('deliveries')
+    })
+  })
+
+  describe('create / update / delete', () => {
+    it('POSTs the create body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.post(`${API_PREFIX}/webhook_endpoints`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(sampleEndpoint, { status: 201 })
+        }),
+      )
+
+      await createTestClient().webhookEndpoints.create({
+        url: 'https://example.com/hooks',
+        subscriptions: ['order.completed'],
+      })
+
+      expect(body).toEqual({
+        url: 'https://example.com/hooks',
+        subscriptions: ['order.completed'],
+      })
+    })
+
+    it('PATCHes the update body verbatim', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/webhook_endpoints/whe_abc123`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({ ...sampleEndpoint, name: 'Staging' })
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.update('whe_abc123', {
+        name: 'Staging',
+      })
+
+      expect(body).toEqual({ name: 'Staging' })
+      expect(res.name).toBe('Staging')
+    })
+
+    it('DELETEs /webhook_endpoints/:id', async () => {
+      let hit = false
+      server.use(
+        http.delete(`${API_PREFIX}/webhook_endpoints/whe_abc123`, () => {
+          hit = true
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      await expect(
+        createTestClient().webhookEndpoints.delete('whe_abc123'),
+      ).resolves.toBeUndefined()
+      expect(hit).toBe(true)
+    })
+  })
+
+  describe('sendTest', () => {
+    it('POSTs /webhook_endpoints/:id/send_test and returns a delivery', async () => {
+      let hit = false
+      server.use(
+        http.post(`${API_PREFIX}/webhook_endpoints/whe_abc123/send_test`, () => {
+          hit = true
+          return HttpResponse.json(sampleDelivery, { status: 201 })
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.sendTest('whe_abc123')
+
+      expect(hit).toBe(true)
+      expect(res.id).toBe('whd_1')
+    })
+  })
+
+  describe('enable / disable', () => {
+    it('PATCHes /enable', async () => {
+      let hit = false
+      server.use(
+        http.patch(`${API_PREFIX}/webhook_endpoints/whe_abc123/enable`, () => {
+          hit = true
+          return HttpResponse.json({ ...sampleEndpoint, active: true })
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.enable('whe_abc123')
+
+      expect(hit).toBe(true)
+      expect(res.active).toBe(true)
+    })
+
+    it('PATCHes /disable with the reason body', async () => {
+      let body: Record<string, unknown> | null = null
+      server.use(
+        http.patch(`${API_PREFIX}/webhook_endpoints/whe_abc123/disable`, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json({
+            ...sampleEndpoint,
+            active: false,
+            disabled_reason: 'too many failures',
+          })
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.disable('whe_abc123', {
+        reason: 'too many failures',
+      })
+
+      expect(body).toEqual({ reason: 'too many failures' })
+      expect(res.active).toBe(false)
+    })
+  })
+
+  describe('nested deliveries', () => {
+    it('GETs /webhook_endpoints/:eid/deliveries with Ransack filters', async () => {
+      let url: URL | null = null
+      server.use(
+        http.get(`${API_PREFIX}/webhook_endpoints/whe_abc123/deliveries`, ({ request }) => {
+          url = new URL(request.url)
+          return HttpResponse.json(paginated([sampleDelivery]))
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.deliveries.list('whe_abc123', {
+        success_eq: false,
+      })
+
+      expect(res.data[0]?.id).toBe('whd_1')
+      expect(url!.searchParams.get('q[success_eq]')).toBe('false')
+    })
+
+    it('GETs a single delivery by id', async () => {
+      server.use(
+        http.get(`${API_PREFIX}/webhook_endpoints/whe_abc123/deliveries/whd_1`, () =>
+          HttpResponse.json(sampleDelivery),
+        ),
+      )
+
+      const res = await createTestClient().webhookEndpoints.deliveries.get('whe_abc123', 'whd_1')
+
+      expect(res.event_name).toBe('order.completed')
+    })
+
+    it('POSTs /deliveries/:id/redeliver', async () => {
+      let hit = false
+      server.use(
+        http.post(`${API_PREFIX}/webhook_endpoints/whe_abc123/deliveries/whd_1/redeliver`, () => {
+          hit = true
+          return HttpResponse.json({ ...sampleDelivery, id: 'whd_2' }, { status: 201 })
+        }),
+      )
+
+      const res = await createTestClient().webhookEndpoints.deliveries.redeliver(
+        'whe_abc123',
+        'whd_1',
+      )
+
+      expect(hit).toBe(true)
+      expect(res.id).toBe('whd_2')
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes under `packages/admin-sdk/tests`; no production SDK or runtime behavior is modified.
> 
> **Overview**
> Adds broad **MSW-backed Vitest coverage** for the admin SDK so client methods are checked against expected HTTP paths, bodies, and query strings—not just types.
> 
> **Test harness:** `helpers.ts` now exports shared `API_PREFIX`, `createTestClient()` (secret key → `X-Spree-Api-Key`), `createUnauthenticatedClient()` for auth flows, and a `paginated()` helper. New `helpers.test.ts` locks in that auth contract. Existing `auth`, `exports`, and `price-lists` specs were switched to these helpers.
> 
> **New / expanded specs** follow a consistent pattern: list/get CRUD, Ransack `q[...]` wrapping via `transformListParams`, `expand` query forwarding, verbatim JSON bodies, and **204** delete semantics. Coverage spans admin users, API keys, allowed origins, channels, customers (bulk + nested cards/addresses/store credits), orders (lifecycle, line items, payments, refunds, gift cards/store credits), products/prices (bulk ops), promotions (nested actions/rules/coupon codes + type discovery), stock, webhooks, store settings, read-only resources, and more.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a933e5d934d9888b2c9ccdfc705d4416d8b1c4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Vastly expanded integration test coverage across Admin SDK endpoints (users, API keys, channels, customers, orders, products, promotions, stock, payments, webhooks, etc.).
  * Added MSW-backed tests validating list/get/create/update/delete flows, Ransack-style query param transformations, nested resources, bulk operations, and 204 delete semantics.
  * Centralized and enhanced test helpers, including a unified test client, unauthenticated client, and pagination utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->