### PR TITLE
Guard against missing locale in `Spree::Current` if both store and ma…

### DIFF
--- a/spree/core/app/models/spree/current.rb
+++ b/spree/core/app/models/spree/current.rb
@@ -32,10 +32,10 @@ module Spree
     end
 
     # Returns the current locale.
-    # Fallback: market default locale -> store default locale.
+    # Fallback: market default locale -> store default locale -> I18n default.
     # @return [String] locale code, e.g. +"en"+, +"de"+
     def locale
-      super || market&.default_locale || store&.default_locale
+      super || market&.default_locale.presence || store&.default_locale.presence || I18n.default_locale.to_s
     end
 
     # Returns the current tax zone.

--- a/spree/core/spec/models/spree/current_spec.rb
+++ b/spree/core/spec/models/spree/current_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe Spree::Current do
         expect(described_class.locale).to eq('en')
       end
     end
+
+    context 'when the store has no default locale' do
+      let!(:store) { create(:store, default: true, default_locale: nil) }
+
+      it 'falls back to the I18n default locale' do
+        expect(described_class.locale).to eq(I18n.default_locale.to_s)
+      end
+    end
   end
 
   describe '#market' do


### PR DESCRIPTION
…rket don't have it set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change to per-request locale resolution; behavior only differs when store/market locales are nil or blank, and aligns with existing I18n usage elsewhere.
> 
> **Overview**
> **`Spree::Current#locale`** no longer stops at a blank market or store default: those steps use **`.presence`**, and when neither yields a locale the method now returns **`I18n.default_locale.to_s`**.
> 
> A spec covers a default store with **`default_locale: nil`**, expecting the I18n default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c384dc8b2b8712c54b66bbe433921ec4bd532acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated locale resolution to properly fall back to the application's default locale when market and store defaults are blank or unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->