### PR TITLE
Fix order routing reducer constant lookup

### DIFF
--- a/spree/core/app/models/spree/order_routing/strategy/rules.rb
+++ b/spree/core/app/models/spree/order_routing/strategy/rules.rb
@@ -13,7 +13,9 @@ module Spree
           locations = eligible_locations
           return [] if locations.empty?
 
-          ordered = Reducer.new(applicable_rules.to_a, order: order).rank_all(locations)
+          ordered = Spree::OrderRouting::Strategy::Reducer
+            .new(applicable_rules.to_a, order: order)
+            .rank_all(locations)
           return [] if ordered.empty?
 
           packages = build_packages(ordered)

--- a/spree/core/spec/models/spree/order_routing/strategy/rules_spec.rb
+++ b/spree/core/spec/models/spree/order_routing/strategy/rules_spec.rb
@@ -35,5 +35,21 @@ RSpec.describe Spree::OrderRouting::Strategy::Rules, type: :model do
       packages = subject.for_allocation
       expect(packages.map(&:stock_location)).to all(eq(preferred_loc))
     end
+
+    it 'resolves the reducer from the strategy namespace' do
+      stub_const(
+        "#{described_class}::Reducer",
+        Class.new do
+          def initialize(*); end
+
+          def rank_all(*)
+            raise 'nested reducer should not be used'
+          end
+        end
+      )
+
+      packages = subject.for_allocation
+      expect(packages.map(&:stock_location)).to all(eq(default_loc))
+    end
   end
 end


### PR DESCRIPTION
* Ensure the rules strategy resolves the reducer from the strategy namespace so checkout allocation remains stable under lazy loading.

* Add a regression spec covering namespace resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization in order routing logic for better maintainability.

* **Tests**
  * Added test to verify order routing strategy correctly resolves to default stock location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->