### PR TITLE
fix no products partial on product translations page

### DIFF
--- a/spree/admin/app/views/spree/admin/product_translations/index.html.erb
+++ b/spree/admin/app/views/spree/admin/product_translations/index.html.erb
@@ -101,7 +101,7 @@
           <%= render 'spree/admin/shared/index_table_options', collection: @products %>
         </div>
       <% else %>
-        <%= render 'spree/admin/shared/no_resource_found', new_object_url: nil, resource_name: Spree.t(:product), model_class: Spree::Product %>
+        <%= render 'spree/admin/shared/no_resource_found', new_object_url: nil, model_class: Spree::Product %>
       <% end %>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/product_translations/index.html.erb
+++ b/spree/admin/app/views/spree/admin/product_translations/index.html.erb
@@ -101,7 +101,7 @@
           <%= render 'spree/admin/shared/index_table_options', collection: @products %>
         </div>
       <% else %>
-        <%= render 'spree/admin/shared/no_resource_found', new_object_url: nil %>
+        <%= render 'spree/admin/shared/no_resource_found', new_object_url: nil, resource_name: Spree.t(:product), model_class: Spree::Product %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Error: https://vendo-connect.sentry.io/issues/7552177231

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-view argument fix for an empty-state partial; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes a crash on the product translations admin page when there are no products to list.
> 
> The empty-state partial `no_resource_found` derives its label from **`model_class`**; the translations index was rendering it with only `new_object_url: nil`, which triggered the reported Sentry error. It now passes **`model_class: Spree::Product`** so the “no products” message renders like other admin index empty states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5769ea4fb7271e7e689fb51a2c59fec0f62d239c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the empty state messaging in the product translations admin view when no products are found, providing clearer context and consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->