### PR TITLE
Fix/spree cli admin sdk dependency

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.2.1
+
+### Patch Changes
+
+- Fix `npm install` failing with `EUNSUPPORTEDPROTOCOL "workspace:"`. `@spree/admin-sdk` is bundled into the CLI at build time, so it's now a dev dependency — the published `package.json` no longer carries an unresolvable `workspace:` runtime dependency.
+
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",
-    "@spree/admin-sdk": "workspace:^",
     "commander": "^14.0.3",
     "console-table-printer": "^2.15.0",
     "execa": "^9.6.1",
@@ -56,6 +55,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
+    "@spree/admin-sdk": "workspace:^",
     "@types/node": "^25.6.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       '@clack/prompts':
         specifier: ^1.3.0
         version: 1.3.0
-      '@spree/admin-sdk':
-        specifier: workspace:^
-        version: link:../admin-sdk
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -85,6 +82,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
+      '@spree/admin-sdk':
+        specifier: workspace:^
+        version: link:../admin-sdk
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime CLI logic changes; lowers install risk for consumers.
> 
> **Overview**
> **@spree/cli 2.2.1** fixes installs from the registry: `@spree/admin-sdk` is moved from **dependencies** to **devDependencies** and the lockfile is updated to match.
> 
> Published `package.json` no longer lists a runtime `workspace:^` dependency, which caused **`npm install`** to fail with **`EUNSUPPORTEDPROTOCOL "workspace:"`**. The admin SDK is still used at build time and ends up in **`dist`** via **tsup**, so end users only need the built CLI, not a separate SDK package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3bc344d848079cf1fc9ad3ba30d212a01fea74e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `npm install` failure that was preventing successful CLI installation and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->