### PR TITLE
Fix duplicate saved credit cards added to customer wallet

### DIFF
--- a/spree/core/app/models/spree/credit_card.rb
+++ b/spree/core/app/models/spree/credit_card.rb
@@ -37,6 +37,8 @@ module Spree
       validates :name, presence: true
     end
 
+    validate :not_already_in_wallet, on: :create
+
     scope :with_payment_profile, -> { where.not(gateway_customer_profile_id: nil) }
     scope :capturable, -> { where.not(gateway_customer_profile_id: nil).or(where.not(gateway_payment_profile_id: nil)) }
     scope :default, -> { where(default: true) }
@@ -174,6 +176,19 @@ module Spree
         CreditCard.where(default: true, user_id: user_id).where.not(id: id).
           update_all(default: false)
       end
+    end
+
+    def not_already_in_wallet
+      return if imported || user_id.blank? || gateway_payment_profile_id.blank?
+
+      duplicates = self.class.where(
+        user_id: user_id,
+        payment_method_id: payment_method_id,
+        gateway_payment_profile_id: gateway_payment_profile_id
+      )
+      duplicates = duplicates.where.not(id: id) if persisted?
+
+      errors.add(:base, :already_saved) if duplicates.exists?
     end
   end
 end

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -270,6 +270,7 @@ en:
         spree/credit_card:
           attributes:
             base:
+              already_saved: This card is already saved to your account
               card_expired: Card has expired
               expiry_invalid: Card expiration is invalid
         spree/gift_card:

--- a/spree/core/spec/models/spree/credit_card_spec.rb
+++ b/spree/core/spec/models/spree/credit_card_spec.rb
@@ -146,6 +146,60 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
+  describe 'wallet card uniqueness' do
+    let(:user) { create(:user) }
+    let(:payment_method) { create(:credit_card_payment_method) }
+    let(:card_attributes) do
+      {
+        user: user,
+        payment_method: payment_method,
+        gateway_payment_profile_id: 'card_token_123'
+      }
+    end
+
+    around { |example| Timecop.freeze { example.run } }
+
+    before { create(:credit_card, card_attributes) }
+
+    it 'rejects a second card with the same gateway profile id for the same user' do
+      duplicate = build(:credit_card, card_attributes)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:base]).to include(I18n.t('activerecord.errors.models.spree/credit_card.attributes.base.already_saved'))
+    end
+
+    it 'allows a card with a different gateway profile id for the same user' do
+      expect(build(:credit_card, card_attributes.merge(gateway_payment_profile_id: 'card_token_456'))).to be_valid
+    end
+
+    it 'does not deduplicate cards without a gateway profile id' do
+      create(:credit_card, user: user, payment_method: payment_method, gateway_payment_profile_id: nil)
+
+      expect(build(:credit_card, user: user, payment_method: payment_method, gateway_payment_profile_id: nil)).to be_valid
+    end
+
+    it 'allows the same gateway profile id for a different user' do
+      expect(build(:credit_card, card_attributes.merge(user: create(:user)))).to be_valid
+    end
+
+    it 'allows a guest (no user) to reuse the same card' do
+      expect(build(:credit_card, card_attributes.merge(user: nil))).to be_valid
+    end
+
+    it 'allows re-adding the card once an existing one is removed' do
+      user.credit_cards.first.destroy
+
+      expect(build(:credit_card, card_attributes)).to be_valid
+    end
+
+    it 'allows removing a pre-existing duplicate without removing the other' do
+      duplicate = build(:credit_card, card_attributes)
+      duplicate.save(validate: false)
+
+      expect { duplicate.destroy }.to change { user.reload.credit_cards.count }.from(2).to(1)
+    end
+  end
+
   describe '#save' do
     before do
       credit_card.attributes = valid_credit_card_attributes


### PR DESCRIPTION
Customers could end up with duplicate saved cards after checking out multiple times with the same payment method. A new payment source was being created on each checkout without checking whether an equivalent card already existed for that user.

Prevent saving duplicate cards while still allowing any existing duplicates to be removed.

Adds specs covering duplicate detection, user scoping, guest checkouts, re-adding a card after removal, and removal of pre-existing duplicates.

Fixes #14037 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate credit cards from being saved to the same account when they match an existing wallet card.
  * Added a clear error message: “This card is already saved to your account.”
  * Duplicate checking remains skipped for imported entries, guest cards, and cards missing required identifiers.

* **Tests**
  * Added coverage for wallet card uniqueness, deletion and re-adding, guest behavior, and missing gateway profile IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->