### PR TITLE
Fix flaky VariantsController#search spec on unordered LIMIT

### DIFF
--- a/spree/admin/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Spree::Admin::VariantsController, type: :controller do
           expect(response).to render_template(partial: 'spree/admin/variants/_search_results')
 
           expect(assigns(:variants).size).to eq(2)
-          expect(assigns(:variants)).to match_array([variant, variant_2])
+          expect([variant, variant_2, variant_3]).to include(*assigns(:variants))
         end
       end
     end


### PR DESCRIPTION
The admin `VariantsController#search` "limits the number of variants returned" example asserted an exact subset (`match_array([variant, variant_2])`) of a capped search result. The endpoint applies `LIMIT` without an `ORDER BY` — the relation is built with `reorder('')` — so the database may return any matching rows up to the limit. On MySQL a different but equally valid subset comes back, so the example fails intermittently while passing on PostgreSQL/SQLite.

The assertion now checks the result count and that the returned variants are a subset of the eligible ones, which matches the endpoint's actual contract of a capped, unordered search result. No production code changes — the spec was over-specifying undefined ordering.

Test-only change; the existing example was updated in place.

Fixes #14176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated search test assertions for variant results validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->