### PR TITLE
Auto-assign default channel when importing products via CSV

### DIFF
--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -99,6 +99,9 @@ module Spree
             product.slug = attributes['slug']
             product.sku = attributes['sku'] if attributes['sku'].present? && options.empty?
             product.store = store
+            # Publish to the store's default channel so imported products surface
+            # in the storefront.
+            product.channels << store.default_channel if store.default_channel && product.channels.empty?
           end
 
           product.name = attributes['name'] if attributes['name'].present?

--- a/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/product_variant_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
       expect { subject.process! }.not_to change { store.reload.updated_at }
     end
 
+    it 'publishes the product to the store default channel' do
+      product = variant.product
+
+      expect(product.channels).to contain_exactly(store.default_channel)
+    end
+
+    context 'when the store has no default channel' do
+      # Simulate a store that predates channels: delete_all skips the
+      # before_destroy guard that protects the default channel.
+      before { store.channels.delete_all }
+
+      it 'imports the product without publishing it to any channel' do
+        product = variant.product
+
+        expect(product).to be_persisted
+        expect(product.channels).to be_empty
+      end
+    end
+
     context 'when updating an existing master variant' do
       let!(:existing_product) { create(:product, slug: 'denim-shirt', name: 'Old Name') }
 
@@ -84,6 +103,10 @@ RSpec.describe Spree::Imports::RowProcessors::ProductVariant, type: :service do
         expect(stock_item.count_on_hand).to eq 100
         expect(stock_item.backorderable).to eq true
         expect(existing_product.reload.name).to eq 'Denim Shirt'
+      end
+
+      it 'leaves the existing channel publication untouched' do
+        expect { subject.process! }.not_to change { existing_product.reload.channels.to_a }
       end
     end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow import-time change with guards for existing products and missing default channels; affects catalog visibility, not auth or payments.
> 
> **Overview**
> New products created from **master-variant CSV import rows** are now linked to the store’s **default channel** when one exists and the product has no channels yet, so imports show up on the storefront without a separate publish step.
> 
> The assignment runs only inside the **new product** path in `assign_attributes_to_product`; **re-imports / updates** to an existing slug do not change channel membership. If the store has **no default channel**, import behavior is unchanged and the product stays off all channels.
> 
> Specs cover default-channel publish, the no-channel store case, and unchanged channels on update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 592c1262b99d4aa10eefaf18a3eaedbaf4c8b134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Product variant imports now automatically publish newly created products to the store's default channel when available, ensuring proper visibility without manual configuration.
  * Existing product channel assignments remain unchanged when updating product variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->