### PR TITLE
Unify Store <> Payment Method fetching via `store.payment_methods`

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/payment_methods_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/payment_methods_controller.rb
@@ -60,11 +60,9 @@ module Spree
 
           private
 
-          # New payment methods get scoped to the current store automatically.
+          # New payment methods are created through the current store.
           def build_subclassed_resource(klass, attrs)
-            resource = klass.new(attrs)
-            resource.stores = [current_store] if resource.stores.empty?
-            resource
+            current_store.payment_methods.build(attrs.merge(type: klass.sti_name))
           end
         end
       end

--- a/spree/api/spec/integration/spree/api/v3/admin/payment_methods_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/payment_methods_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Admin Payment Methods API', type: :request, swagger_doc: 'api-re
           # filters out providers that are already configured. (Check is
           # also installed via the let!(:payment_method), but other tests
           # in this file delete it, so it's order-dependent.)
-          Spree::PaymentMethod::StoreCredit.create!(name: 'Store Credit')
+          store.payment_methods.create!(type: 'Spree::PaymentMethod::StoreCredit', name: 'Store Credit')
         end
 
         run_test! do |response|

--- a/spree/core/app/models/concerns/spree/store_scoped_resource.rb
+++ b/spree/core/app/models/concerns/spree/store_scoped_resource.rb
@@ -12,7 +12,10 @@ module Spree
 
     def set_default_store
       return if disable_store_presence_validation?
-      return if stores.any?
+      # records built through a store's association (`store.payment_methods.build`)
+      # carry their link on the join association — `stores` can't see it until save
+      join_association = self.class.reflect_on_association(:stores).through_reflection.name
+      return if stores.any? || send(join_association).any?
 
       stores << Spree::Store.default
     end

--- a/spree/core/app/models/spree/payment_method.rb
+++ b/spree/core/app/models/spree/payment_method.rb
@@ -22,7 +22,7 @@ module Spree
     validates :name, presence: true
     normalizes :name, with: ->(value) { value&.to_s&.squish&.presence }
 
-    has_many :store_payment_methods, class_name: 'Spree::StorePaymentMethod'
+    has_many :store_payment_methods, class_name: 'Spree::StorePaymentMethod', inverse_of: :payment_method
     has_many :stores, class_name: 'Spree::Store', through: :store_payment_methods
 
     has_many :payments, class_name: 'Spree::Payment', inverse_of: :payment_method, dependent: :nullify

--- a/spree/core/app/models/spree/store_payment_method.rb
+++ b/spree/core/app/models/spree/store_payment_method.rb
@@ -3,7 +3,7 @@ module Spree
     self.table_name = 'spree_payment_methods_stores'
 
     belongs_to :store, class_name: 'Spree::Store', touch: true
-    belongs_to :payment_method, class_name: 'Spree::PaymentMethod', touch: true
+    belongs_to :payment_method, class_name: 'Spree::PaymentMethod', touch: true, inverse_of: :store_payment_methods
 
     validates :store, :payment_method, presence: true
     validates :store_id, uniqueness: { scope: :payment_method_id }

--- a/spree/core/app/services/spree/gift_cards/apply.rb
+++ b/spree/core/app/services/spree/gift_cards/apply.rb
@@ -69,10 +69,7 @@ module Spree
         payment_method.name ||= Spree.t(:store_credit_name)
         payment_method.active = true
 
-        if payment_method.new_record?
-          payment_method.stores << store unless payment_method.stores.include?(store)
-          payment_method.save!
-        end
+        payment_method.save! if payment_method.new_record?
 
         payment_method
       end

--- a/spree/core/app/services/spree/seeds/payment_methods.rb
+++ b/spree/core/app/services/spree/seeds/payment_methods.rb
@@ -4,14 +4,17 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call
-        payment_method = Spree::PaymentMethod::StoreCredit.find_or_initialize_by(
-          name: Spree.t(:store_credit_name),
-          description: Spree.t(:store_credit_name),
-          active: true
-        )
+        Spree::Store.all.find_each do |store|
+          payment_method = store.payment_methods.find_or_initialize_by(
+            type: 'Spree::PaymentMethod::StoreCredit'
+          )
+          next if payment_method.persisted?
 
-        payment_method.stores = Spree::Store.all if payment_method.new_record?
-        payment_method.save!
+          payment_method.name = Spree.t(:store_credit_name)
+          payment_method.description = Spree.t(:store_credit_name)
+          payment_method.active = true
+          payment_method.save!
+        end
       end
     end
   end

--- a/spree/core/db/sample_data/payment_methods.rb
+++ b/spree/core/db/sample_data/payment_methods.rb
@@ -1,19 +1,19 @@
-cc_payment_method = Spree::Gateway::Bogus.where(
-  name: 'Credit Card',
-  description: 'Bogus payment gateway.',
-  active: true
-).first_or_initialize
+Spree::Store.all.find_each do |store|
+  cc_payment_method = store.payment_methods.find_or_initialize_by(
+    type: 'Spree::Gateway::Bogus',
+    name: 'Credit Card',
+    description: 'Bogus payment gateway.',
+    active: true
+  )
+  cc_payment_method.display_on = 'back_end'
+  cc_payment_method.save!
 
-cc_payment_method.display_on = 'back_end'
-cc_payment_method.stores = Spree::Store.all
-cc_payment_method.save!
-
-check_payment_method = Spree::PaymentMethod::Check.where(
-  name: 'Check',
-  description: 'Pay by check.',
-  active: true
-).first_or_initialize
-
-check_payment_method.display_on = 'back_end'
-check_payment_method.stores = Spree::Store.all
-check_payment_method.save!
+  check_payment_method = store.payment_methods.find_or_initialize_by(
+    type: 'Spree::PaymentMethod::Check',
+    name: 'Check',
+    description: 'Pay by check.',
+    active: true
+  )
+  check_payment_method.display_on = 'back_end'
+  check_payment_method.save!
+end

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -869,28 +869,22 @@ describe Spree::Order, type: :model do
     let(:order_from_different_store) { create(:order, user: user, store: store_2) }
 
     it 'includes frontend payment methods' do
-      payment_method = Spree::PaymentMethod.create!(name: 'Fake',
-                                                    active: true,
-                                                    display_on: 'front_end',
-                                                    stores: [store])
+      payment_method = store.payment_methods.create!(name: 'Fake', active: true, display_on: 'front_end')
       expect(order.collect_frontend_payment_methods).to include(payment_method)
     end
 
     it "includes 'both' payment methods" do
-      payment_method = Spree::PaymentMethod.create!(name: 'Fake',
-                                                    active: true,
-                                                    display_on: 'both',
-                                                    stores: [store])
+      payment_method = store.payment_methods.create!(name: 'Fake', active: true, display_on: 'both')
       expect(order.collect_frontend_payment_methods).to include(payment_method)
     end
 
     it 'does not include backend payment method' do
-      Spree::PaymentMethod.create!(name: 'Fake', active: true, display_on: 'back_end')
+      store.payment_methods.create!(name: 'Fake', active: true, display_on: 'back_end')
       expect(order.collect_frontend_payment_methods.count).to eq(0)
     end
 
     it 'does not include inactive payment methods' do
-      Spree::PaymentMethod.create!(name: 'Fake', active: false, display_on: 'front_end')
+      store.payment_methods.create!(name: 'Fake', active: false, display_on: 'front_end')
       expect(order.collect_frontend_payment_methods.count).to eq(0)
     end
 
@@ -901,10 +895,7 @@ describe Spree::Order, type: :model do
     end
 
     it 'does not include a payment method from different stores' do
-      payment_method = Spree::PaymentMethod.create!(name: 'Fake',
-                                                    active: true,
-                                                    display_on: 'both',
-                                                    stores: [store_2])
+      payment_method = store_2.payment_methods.create!(name: 'Fake', active: true, display_on: 'both')
       expect(order.collect_frontend_payment_methods).not_to include(payment_method)
 
       expect(order_from_different_store.collect_frontend_payment_methods).to include(payment_method)

--- a/spree/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/spree/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -128,7 +128,7 @@ describe Spree::PaymentMethod::StoreCredit do
 
   context '#void' do
     subject do
-      described_class.new(stores: [store]).void(auth_code, gateway_options)
+      store.payment_methods.new(type: described_class.sti_name).void(auth_code, gateway_options)
     end
 
     let(:auth_code) { auth_event.authorization_code }

--- a/spree/core/spec/models/spree/payment_method_spec.rb
+++ b/spree/core/spec/models/spree/payment_method_spec.rb
@@ -14,12 +14,12 @@ describe Spree::PaymentMethod, type: :model do
   context 'visibility scopes' do
     before do
       ['both', 'front_end', 'back_end'].each do |display_on|
-        Spree::Gateway::Test.create(
+        store.payment_methods.create(
+          type: 'Spree::Gateway::Test',
           name: 'Display Both',
           display_on: display_on,
           active: true,
-          description: 'foofah',
-          stores: [store]
+          description: 'foofah'
         )
       end
     end
@@ -55,11 +55,11 @@ describe Spree::PaymentMethod, type: :model do
     describe '#for_store' do
       it 'returns all methods available to front-end/back-end for a store' do
         store_2 = create(:store)
-        method_from_other_store = Spree::Gateway::Test.create(
+        method_from_other_store = store_2.payment_methods.create(
+          type: 'Spree::Gateway::Test',
           name: 'Display Both',
           active: true,
-          description: 'foofah',
-          stores: [store_2]
+          description: 'foofah'
         )
         methods = Spree::PaymentMethod.for_store(store)
         expect(methods).not_to include(method_from_other_store)

--- a/spree/core/spec/models/spree/payment_spec.rb
+++ b/spree/core/spec/models/spree/payment_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Payment, type: :model do
   let(:refund_reason) { create(:refund_reason) }
 
   let(:gateway) do
-    gateway = Spree::Gateway::Bogus.new(active: true, stores: [store])
+    gateway = store.payment_methods.create!(type: 'Spree::Gateway::Bogus', active: true)
     allow(gateway).to receive_messages source_required: true
     gateway
   end

--- a/spree/core/spec/services/spree/seeds/payment_methods_spec.rb
+++ b/spree/core/spec/services/spree/seeds/payment_methods_spec.rb
@@ -3,22 +3,24 @@ require 'spec_helper'
 RSpec.describe Spree::Seeds::PaymentMethods do
   subject { described_class.call }
 
-  let(:store_credit_payment_method) { Spree::PaymentMethod::StoreCredit.last }
   let(:store) { @default_store }
 
   let!(:other_store) { create(:store) }
 
-  it 'creates a Store Credit payment method' do
-    expect { subject }.to change(Spree::PaymentMethod::StoreCredit, :count).by(1)
+  it 'creates a Store Credit payment method for each store' do
+    expect { subject }.to change(Spree::PaymentMethod::StoreCredit, :count).by(2)
 
-    expect(store_credit_payment_method).to be_present
-    expect(store_credit_payment_method).to be_active
-    expect(store_credit_payment_method.stores).to include(store, other_store)
-    expect(store_credit_payment_method.name).to eq('Store Credit')
-    expect(store_credit_payment_method.description).to eq('Store Credit')
+    [store, other_store].each do |s|
+      payment_method = s.payment_methods.store_credit.first
+      expect(payment_method).to be_present
+      expect(payment_method).to be_active
+      expect(payment_method.stores).to contain_exactly(s)
+      expect(payment_method.name).to eq('Store Credit')
+      expect(payment_method.description).to eq('Store Credit')
+    end
   end
 
-  context 'when the Store Credit payment method already exists' do
+  context 'when a store already has a Store Credit payment method' do
     before do
       create(
         :store_credit_payment_method,
@@ -31,12 +33,6 @@ RSpec.describe Spree::Seeds::PaymentMethods do
 
     it "doesn't create a new payment method" do
       expect { subject }.not_to change(Spree::PaymentMethod::StoreCredit, :count)
-
-      expect(store_credit_payment_method).to be_present
-      expect(store_credit_payment_method).to be_active
-      expect(store_credit_payment_method.stores).to include(store, other_store)
-      expect(store_credit_payment_method.name).to eq('Store Credit')
-      expect(store_credit_payment_method.description).to eq('Store Credit')
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches how payment methods are created and linked to stores across admin API, seeds, and checkout-related services; incorrect join handling could mis-scope methods, but the change is narrow and covered by updated specs.
> 
> **Overview**
> Payment methods are now created and looked up **through the store association** (`store.payment_methods.build` / `find_or_initialize_by`) instead of instantiating STI classes and manually attaching `stores`.
> 
> The v3 admin **create** path uses `current_store.payment_methods.build` with the provider STI type. **Seeds**, **sample data**, and **gift card apply** follow the same pattern, provisioning **one Store Credit (and sample gateways) per store** rather than a single record linked to every store.
> 
> `StoreScopedResource#set_default_store` now treats unsaved **join rows** (`store_payment_methods`) as already store-scoped so records built via `store.payment_methods` are not also assigned `Spree::Store.default`. **`inverse_of`** was added on `PaymentMethod` ↔ `StorePaymentMethod` for consistent association state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d6f923029b3fc2cd7d47315123a636d8732c336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved payment method association with stores to ensure each store maintains its own isolated set of payment methods rather than sharing global instances.
  * Fixed payment method creation flow to properly scope Store Credit and other payment method types to the current store context.

* **Tests**
  * Updated test suite to reflect improved per-store payment method handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->