### PR TITLE
Harden Admin API resource scopes and added missing permission checks

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/channels_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/channels_controller.rb
@@ -49,14 +49,12 @@ module Spree
 
           private
 
-          # Deliberately not scoped through `for_store` — this endpoint is the
-          # path by which a product *enters* the store, so requiring an
-          # existing publication would block first-time onboarding. The
-          # cross-store guard runs one level up: `find_resource` already
-          # restricted the channel to `current_store`.
+          # Scoped to the current store: a product can only be published to a
+          # channel of the store that owns it (products are single-owner via
+          # `belongs_to :store`). Foreign product IDs are silently dropped.
           def scoped_product_ids
             ids = decode_prefixed_ids(params[:product_ids])
-            Spree::Product.accessible_by(current_ability, :update).where(id: ids).ids
+            current_store.products.accessible_by(current_ability, :update).where(id: ids).ids
           end
         end
       end

--- a/spree/api/app/controllers/spree/api/v3/admin/coupon_codes_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/coupon_codes_controller.rb
@@ -19,8 +19,8 @@ module Spree
           end
 
           def set_parent
-            @parent = Spree::Promotion.accessible_by(current_ability, :show)
-                                      .find_by_prefix_id!(params[:promotion_id])
+            @parent = current_store.promotions.accessible_by(current_ability, :show)
+                                   .find_by_prefix_id!(params[:promotion_id])
           end
 
           def parent_association

--- a/spree/api/app/controllers/spree/api/v3/admin/custom_fields_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/custom_fields_controller.rb
@@ -54,7 +54,7 @@ module Spree
             raise ActiveRecord::RecordNotFound, 'Parent resource not found' unless parent_lookup
 
             @parent = parent_relation.find_by_prefix_id!(parent_lookup.value)
-            authorize!(:show, @parent)
+            authorize!(:update, @parent)
           end
 
           # Resolves the parent within the current store so a token for one

--- a/spree/api/app/controllers/spree/api/v3/admin/media_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/media_controller.rb
@@ -34,7 +34,7 @@ module Spree
 
           def set_parent
             @product = current_store.products.find_by_prefix_id!(params[:product_id])
-            authorize!(:show, @product)
+            authorize!(:update, @product)
 
             @parent = if params[:variant_id].present?
                         @product.variants_including_master.find_by_prefix_id!(params[:variant_id])

--- a/spree/api/app/controllers/spree/api/v3/admin/orders/fulfillments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders/fulfillments_controller.rb
@@ -57,11 +57,11 @@ module Spree
             # PATCH /api/v3/admin/orders/:order_id/fulfillments/:id/split
             def split
               with_order_lock do
-                variant = Spree::Variant.find_by_prefix_id!(params[:variant_id])
+                variant = current_store.variants.find_by_prefix_id!(params[:variant_id])
                 quantity = params[:quantity].to_i
 
                 stock_location = if params[:stock_location_id].present?
-                                   Spree::StockLocation.find_by_prefix_id!(params[:stock_location_id])
+                                   Spree::StockLocation.accessible_by(current_ability, :show).find_by_prefix_id!(params[:stock_location_id])
                                  else
                                    @resource.stock_location
                                  end

--- a/spree/api/app/controllers/spree/api/v3/admin/orders/payments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders/payments_controller.rb
@@ -15,7 +15,7 @@ module Spree
             # The source must belong to the customer assigned to the order.
             def create
               with_order_lock do
-                payment_method = Spree::PaymentMethod.find_by_prefix_id!(params[:payment_method_id])
+                payment_method = current_store.payment_methods.accessible_by(current_ability, :show).find_by_prefix_id!(params[:payment_method_id])
                 @resource = @parent.payments.build(
                   amount: params[:amount] || @parent.order_total_after_store_credit,
                   payment_method: payment_method

--- a/spree/api/app/controllers/spree/api/v3/admin/orders/refunds_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders/refunds_controller.rb
@@ -9,9 +9,9 @@ module Spree
             # POST /api/v3/admin/orders/:order_id/refunds
             def create
               with_order_lock do
-                payment = @parent.payments.find_by_prefix_id!(params[:payment_id])
-                reason = Spree::RefundReason.find_by_prefix_id!(params[:refund_reason_id]) if params[:refund_reason_id].present?
-                reason ||= Spree::RefundReason.first
+                payment = @parent.payments.accessible_by(current_ability, :update).find_by_prefix_id!(params[:payment_id])
+                reason = Spree::RefundReason.accessible_by(current_ability, :show).find_by_prefix_id!(params[:refund_reason_id]) if params[:refund_reason_id].present?
+                reason ||= Spree::RefundReason.accessible_by(current_ability, :show).first
 
                 @resource = payment.refunds.build(
                   amount: params[:amount],

--- a/spree/api/app/controllers/spree/api/v3/admin/prices_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/prices_controller.rb
@@ -35,7 +35,13 @@ module Spree
               )
             end
 
-            foreign = foreign_rows(rows)
+            store_variant_ids = store_variants.where(id: rows.map { |r| r[:variant_id] }).ids.map(&:to_s).to_set
+            store_price_list_ids = store_price_lists.where(id: rows.filter_map { |r| r[:price_list_id] }).ids.map(&:to_s).to_set
+            foreign = rows.each_with_index.filter_map do |row, idx|
+              variant_ok = store_variant_ids.include?(row[:variant_id].to_s)
+              price_list_ok = row[:price_list_id].blank? || store_price_list_ids.include?(row[:price_list_id].to_s)
+              { index: idx } unless variant_ok && price_list_ok
+            end
             if foreign.any?
               return render_error(
                 code: 'invalid_prices',
@@ -91,13 +97,25 @@ module Spree
             false
           end
 
+          # Resolves variant_id / price_list_id through the current store's
+          # scopes so a foreign or unknown id 404s instead of binding the
+          # price to another store's record.
           def permitted_params
-            normalize_params(
-              params.permit(:variant_id, :currency, :amount, :compare_at_amount, :price_list_id)
-            )
+            permitted = params.permit(:variant_id, :currency, :amount, :compare_at_amount, :price_list_id)
+            permitted[:variant_id] = store_variants.find_by_prefix_id!(permitted[:variant_id]).id if permitted[:variant_id].present?
+            permitted[:price_list_id] = store_price_lists.find_by_prefix_id!(permitted[:price_list_id]).id if permitted[:price_list_id].present?
+            permitted
           end
 
           private
+
+          def store_variants
+            current_store.variants.accessible_by(current_ability, :update)
+          end
+
+          def store_price_lists
+            Spree::PriceList.for_store(current_store).accessible_by(current_ability, :update)
+          end
 
           def bulk_record_count_key
             :price_count
@@ -131,24 +149,6 @@ module Spree
             return nil if value.blank?
 
             Spree::PrefixedId.prefixed_id?(value) ? Spree::PrefixedId.decode_prefixed_id(value) : value
-          end
-
-          # Rejects rows whose variant or price list belongs to another store.
-          # `Spree::Prices::BulkUpsert` writes rows keyed on the raw variant_id
-          # with no ownership check, so the store boundary is enforced here.
-          def foreign_rows(rows)
-            variant_ids = rows.map { |r| r[:variant_id] }.compact.uniq
-            price_list_ids = rows.map { |r| r[:price_list_id] }.compact.uniq
-
-            store_variant_ids = current_store.variants.where(id: variant_ids).pluck(:id).map(&:to_s).to_set
-            store_price_list_ids = Spree::PriceList.for_store(current_store).where(id: price_list_ids).pluck(:id).map(&:to_s).to_set
-
-            rows.each_with_index.filter_map do |row, idx|
-              variant_ok = store_variant_ids.include?(row[:variant_id].to_s)
-              price_list_ok = row[:price_list_id].blank? || store_price_list_ids.include?(row[:price_list_id].to_s)
-
-              { index: idx } unless variant_ok && price_list_ok
-            end
           end
         end
       end

--- a/spree/api/app/controllers/spree/api/v3/admin/prices_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/prices_controller.rb
@@ -114,7 +114,7 @@ module Spree
           end
 
           def store_price_lists
-            Spree::PriceList.for_store(current_store).accessible_by(current_ability, :update)
+            current_store.price_lists.accessible_by(current_ability, :update)
           end
 
           def bulk_record_count_key

--- a/spree/api/app/controllers/spree/api/v3/admin/promotion_actions_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/promotion_actions_controller.rb
@@ -58,8 +58,8 @@ module Spree
           def set_parent
             return if %w[types calculators].include?(action_name)
 
-            @parent = Spree::Promotion.accessible_by(current_ability, :show)
-                                      .find_by_prefix_id!(params[:promotion_id])
+            @parent = current_store.promotions.accessible_by(current_ability, :update)
+                                   .find_by_prefix_id!(params[:promotion_id])
           end
 
           def parent_association

--- a/spree/api/app/controllers/spree/api/v3/admin/promotion_rules_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/promotion_rules_controller.rb
@@ -36,8 +36,8 @@ module Spree
           def set_parent
             return if action_name == 'types'
 
-            @parent = Spree::Promotion.accessible_by(current_ability, :show)
-                                      .find_by_prefix_id!(params[:promotion_id])
+            @parent = current_store.promotions.accessible_by(current_ability, :update)
+                                   .find_by_prefix_id!(params[:promotion_id])
           end
 
           def parent_association

--- a/spree/api/app/controllers/spree/api/v3/admin/stock_transfers_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/stock_transfers_controller.rb
@@ -11,9 +11,10 @@ module Spree
           def create
             authorize!(:create, model_class)
 
-            destination = Spree::StockLocation.find_by_prefix_id!(params[:destination_location_id])
+            stock_locations = Spree::StockLocation.accessible_by(current_ability, :show)
+            destination = stock_locations.find_by_prefix_id!(params[:destination_location_id])
             source = params[:source_location_id].present? ?
-              Spree::StockLocation.find_by_prefix_id!(params[:source_location_id]) : nil
+              stock_locations.find_by_prefix_id!(params[:source_location_id]) : nil
 
             variants_map = build_variants_map
             if variants_map.empty?
@@ -63,7 +64,7 @@ module Spree
               hash[decoded.to_i] = entry[:quantity].to_i if decoded
             end
 
-            Spree::Variant.where(id: quantities_by_id.keys).each_with_object({}) do |variant, acc|
+            current_store.variants.accessible_by(current_ability, :update).where(id: quantities_by_id.keys).each_with_object({}) do |variant, acc|
               quantity = quantities_by_id[variant.id]
               acc[variant] = quantity if quantity&.positive?
             end

--- a/spree/api/app/controllers/spree/api/v3/store/customer/payment_setup_sessions_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/customer/payment_setup_sessions_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
             # POST /api/v3/store/customer/payment_setup_sessions
             def create
-              payment_method = current_store.payment_methods.accessible_by(current_ability, :show).find_by_prefix_id!(permitted_params[:payment_method_id])
+              payment_method = current_store.payment_methods.find_by_prefix_id!(permitted_params[:payment_method_id])
 
               @payment_setup_session = payment_method.create_payment_setup_session(
                 customer: current_user,

--- a/spree/api/app/controllers/spree/api/v3/store/customer/payment_setup_sessions_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/customer/payment_setup_sessions_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
             # POST /api/v3/store/customer/payment_setup_sessions
             def create
-              payment_method = current_store.payment_methods.find_by_prefix_id!(permitted_params[:payment_method_id])
+              payment_method = current_store.payment_methods.accessible_by(current_ability, :show).find_by_prefix_id!(permitted_params[:payment_method_id])
 
               @payment_setup_session = payment_method.create_payment_setup_session(
                 customer: current_user,

--- a/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Spree::Api::V3::Admin::ChannelsController, type: :controller do
       expect(channel.reload.products).to include(fresh)
     end
 
-    it 'co-publishes a product from another store onto this channel' do
+    it 'does not publish a product owned by another store' do
       other_store = create(:store)
       cross_store = create(:product, store: other_store)
 
@@ -60,7 +60,8 @@ RSpec.describe Spree::Api::V3::Admin::ChannelsController, type: :controller do
       }, as: :json
 
       expect(response).to have_http_status(:ok)
-      expect(channel.reload.products).to include(cross_store)
+      expect(json_response['product_count']).to eq(0)
+      expect(channel.reload.products).not_to include(cross_store)
     end
 
     it 'accepts an ISO8601 published_at window' do

--- a/spree/api/spec/controllers/spree/api/v3/admin/coupon_codes_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/coupon_codes_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Admin::CouponCodesController, type: :controller do
+  render_views
+
+  include_context 'API v3 Admin authenticated'
+
+  def multi_code_promotion(promo_store)
+    create(:promotion, stores: [promo_store], multi_codes: true, number_of_codes: 2, code_prefix: 'SAVE')
+  end
+
+  let!(:promotion) { multi_code_promotion(store) }
+
+  before { request.headers.merge!(headers) }
+
+  describe 'GET #index' do
+    it 'lists coupon codes for a promotion in the current store' do
+      get :index, params: { promotion_id: promotion.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data']).to be_present
+    end
+
+    it "404s when reading coupon codes of another store's promotion" do
+      foreign_promotion = multi_code_promotion(create(:store))
+
+      get :index, params: { promotion_id: foreign_promotion.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spree/api/spec/controllers/spree/api/v3/admin/orders/payments_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/orders/payments_controller_spec.rb
@@ -61,6 +61,24 @@ RSpec.describe Spree::Api::V3::Admin::Orders::PaymentsController, type: :control
       expect(response).to have_http_status(:not_found)
     end
 
+    context 'when payment_method belongs to a different store' do
+      let(:other_store) { create(:store) }
+      let(:other_store_payment_method) do
+        create(:check_payment_method, stores: [other_store])
+      end
+
+      it 'returns 404 and does not attach the cross-store method' do
+        post :create, params: {
+          order_id: order.prefixed_id,
+          payment_method_id: other_store_payment_method.prefixed_id,
+          amount: order.total
+        }, as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(order.reload.payments.count).to eq(0)
+      end
+    end
+
     context 'when payment_method does not require a source' do
       it 'ignores source_id silently' do
         post :create, params: {

--- a/spree/api/spec/controllers/spree/api/v3/admin/prices_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/prices_controller_spec.rb
@@ -324,6 +324,69 @@ RSpec.describe Spree::Api::V3::Admin::PricesController, type: :controller do
     end
   end
 
+  describe 'POST #create' do
+    it 'creates a price on a variant in the current store' do
+      eur_variant = create(:variant, product: product)
+
+      post :create, params: {
+        variant_id: eur_variant.prefixed_id, currency: 'EUR', amount: '9.99'
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(eur_variant.prices.find_by(currency: 'EUR')&.amount).to eq(BigDecimal('9.99'))
+    end
+
+    context 'cross-store IDOR' do
+      let(:other_store) { create(:store) }
+      let(:other_variant) { create(:product, store: other_store).master }
+
+      it "404s when writing a price on another store's variant" do
+        expect do
+          post :create, params: {
+            variant_id: other_variant.prefixed_id, currency: 'EUR', amount: '0.01'
+          }, as: :json
+        end.not_to change { other_variant.prices.where(currency: 'EUR').count }
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "404s when attaching a price to another store's price list" do
+        other_list = create(:price_list, store: other_store)
+
+        post :create, params: {
+          variant_id: variant.prefixed_id,
+          currency: 'EUR',
+          amount: '9.99',
+          price_list_id: other_list.prefixed_id
+        }, as: :json
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let!(:base_price) { variant.prices.find_by!(currency: 'USD', price_list_id: nil) }
+
+    it 'updates a price on a variant in the current store' do
+      patch :update, params: { id: base_price.prefixed_id, amount: '12.50' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(base_price.reload.amount).to eq(BigDecimal('12.50'))
+    end
+
+    it "404s when rebinding a price to another store's variant" do
+      other_variant = create(:product, store: create(:store)).master
+
+      patch :update, params: {
+        id: base_price.prefixed_id, variant_id: other_variant.prefixed_id
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(base_price.reload.variant_id).to eq(variant.id)
+    end
+  end
+
   describe 'DELETE #bulk_destroy' do
     let!(:to_delete) do
       create(:price, variant: variant, price_list: price_list, currency: 'USD', amount: 5.0)

--- a/spree/api/spec/controllers/spree/api/v3/admin/products_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/products_controller_spec.rb
@@ -753,6 +753,19 @@ RSpec.describe Spree::Api::V3::Admin::ProductsController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(product.reload.taxons.where(taxonomy: taxonomy)).to be_empty
       end
+
+      it "ignores a category that belongs to another store's taxonomy" do
+        foreign_taxon = create(:taxon, taxonomy: create(:taxonomy, store: create(:store)))
+
+        patch :update, params: {
+          id: product.prefixed_id,
+          category_ids: [category1.prefixed_id, foreign_taxon.prefixed_id]
+        }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(product.reload.taxons).to include(category1)
+        expect(product.reload.taxons).not_to include(foreign_taxon)
+      end
     end
 
     context 'with tags' do
@@ -837,6 +850,22 @@ RSpec.describe Spree::Api::V3::Admin::ProductsController, type: :controller do
 
         expect(response).to have_http_status(:ok)
         expect(product.reload.channels).to contain_exactly(default_channel)
+      end
+
+      it "ignores a channel that belongs to another store" do
+        foreign_channel = create(:channel, store: create(:store), code: 'foreign')
+
+        patch :update, params: {
+          id: product.prefixed_id,
+          product_publications: [
+            { channel_id: pos_channel.prefixed_id },
+            { channel_id: foreign_channel.prefixed_id }
+          ]
+        }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(product.reload.channels).to include(pos_channel)
+        expect(product.reload.channels).not_to include(foreign_channel)
       end
     end
 

--- a/spree/api/spec/controllers/spree/api/v3/admin/promotion_actions_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/promotion_actions_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Admin::PromotionActionsController, type: :controller do
+  render_views
+
+  include_context 'API v3 Admin authenticated'
+
+  let!(:promotion) { create(:promotion, stores: [store]) }
+
+  before { request.headers.merge!(headers) }
+
+  describe 'POST #create' do
+    it 'creates an action on a promotion in the current store' do
+      post :create, params: {
+        promotion_id: promotion.prefixed_id,
+        type: 'create_adjustment'
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(promotion.reload.promotion_actions.map(&:type))
+        .to include('Spree::Promotion::Actions::CreateAdjustment')
+    end
+
+    it "404s for a promotion that belongs to another store" do
+      foreign_promotion = create(:promotion, stores: [create(:store)])
+
+      post :create, params: {
+        promotion_id: foreign_promotion.prefixed_id,
+        type: 'create_adjustment'
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(foreign_promotion.reload.promotion_actions).to be_empty
+    end
+  end
+
+  describe 'GET #index' do
+    it "404s when listing actions of another store's promotion" do
+      foreign_promotion = create(:promotion, stores: [create(:store)])
+      create(:promotion_action_create_adjustment, promotion: foreign_promotion)
+
+      get :index, params: { promotion_id: foreign_promotion.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spree/api/spec/controllers/spree/api/v3/admin/promotion_rules_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/promotion_rules_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Admin::PromotionRulesController, type: :controller do
+  render_views
+
+  include_context 'API v3 Admin authenticated'
+
+  let!(:promotion) { create(:promotion, stores: [store]) }
+
+  before { request.headers.merge!(headers) }
+
+  describe 'POST #create' do
+    it 'creates a rule on a promotion in the current store' do
+      post :create, params: {
+        promotion_id: promotion.prefixed_id,
+        type: 'first_order'
+      }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(promotion.reload.promotion_rules.map(&:type)).to include('Spree::Promotion::Rules::FirstOrder')
+    end
+
+    it "404s for a promotion that belongs to another store" do
+      foreign_promotion = create(:promotion, stores: [create(:store)])
+
+      post :create, params: {
+        promotion_id: foreign_promotion.prefixed_id,
+        type: 'first_order'
+      }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(foreign_promotion.reload.promotion_rules).to be_empty
+    end
+  end
+
+  describe 'GET #index' do
+    it "404s when listing rules of another store's promotion" do
+      foreign_promotion = create(:promotion, stores: [create(:store)])
+      create(:promotion_rule_user, promotion: foreign_promotion)
+
+      get :index, params: { promotion_id: foreign_promotion.prefixed_id }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spree/api/spec/controllers/spree/api/v3/admin/stock_transfers_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/stock_transfers_controller_spec.rb
@@ -65,5 +65,18 @@ RSpec.describe Spree::Api::V3::Admin::StockTransfersController, type: :controlle
 
       expect(response).to have_http_status(:not_found)
     end
+
+    it "drops variants belonging to another store and surfaces invalid_variants" do
+      foreign_variant = create(:product, store: create(:store)).master
+
+      expect do
+        post :create, params: base_params.merge(
+          variants: [{ variant_id: foreign_variant.prefixed_id, quantity: 5 }]
+        ), as: :json
+      end.not_to change(Spree::StockTransfer, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response['error']['code']).to eq('invalid_variants')
+    end
   end
 end

--- a/spree/core/app/models/spree/product.rb
+++ b/spree/core/app/models/spree/product.rb
@@ -211,11 +211,14 @@ module Spree
     end
 
     # Maps 6.0 API name (category_ids) to model column (taxon_ids).
-    # Accepts both prefixed IDs and raw integer IDs.
+    # Accepts both prefixed IDs and raw integer IDs. Only taxons belonging to
+    # the product's own store are assigned — ids from another store's
+    # taxonomies are dropped, preventing cross-store category attachment.
     def category_ids=(ids)
-      self.taxon_ids = Array(ids).filter_map do |id|
+      decoded_ids = Array(ids).filter_map do |id|
         id.to_s.include?('_') ? Spree::Taxon.decode_prefixed_id(id) : id
       end
+      self.taxon_ids = Spree::Taxon.for_store(assignable_store).where(id: decoded_ids).ids
     end
 
     # Sync media inline. Entries with `id` patch the existing asset

--- a/spree/core/app/models/spree/product/channels.rb
+++ b/spree/core/app/models/spree/product/channels.rb
@@ -96,6 +96,13 @@ module Spree
         self.store ||= Spree::Current.store || Spree::Store.default
       end
 
+      # The store a product's associations (categories, channels) must belong
+      # to. Falls back to the request/default store for not-yet-persisted
+      # products whose `store` hasn't been assigned.
+      def assignable_store
+        store || Spree::Current.store || Spree::Store.default
+      end
+
       def pending_publications?
         @pending_publications_params.present?
       end
@@ -126,9 +133,14 @@ module Spree
             publication.update!(publication_data.slice(:published_at, :unpublished_at))
             publication_ids_in_payload << publication.id
           elsif channel_id.present?
+            # Only publish to channels owned by the product's store; ignore
+            # ids referencing another store's channel.
+            channel = publishable_channels.find_by(id: channel_id)
+            next unless channel
+
             # Upsert by channel_id so repeat submissions are idempotent
             # against the unique (product_id, channel_id) index.
-            publication = product_publications.find_or_initialize_by(channel_id: channel_id)
+            publication = product_publications.find_or_initialize_by(channel_id: channel.id)
             publication.assign_attributes(publication_data.slice(:published_at, :unpublished_at))
             publication.save!
             publication_ids_in_payload << publication.id
@@ -143,6 +155,11 @@ module Spree
         return value unless Spree::PrefixedId.prefixed_id?(value)
 
         Spree::PrefixedId.decode_prefixed_id(value) || value
+      end
+
+      # Channels the product may be published to — those owned by its store.
+      def publishable_channels
+        assignable_store.channels
       end
     end
   end

--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -82,6 +82,7 @@ module Spree
     has_many :variants, through: :products, class_name: 'Spree::Variant', source: :variants_including_master
     has_many :stock_items, through: :variants, class_name: 'Spree::StockItem'
     has_many :prices, through: :variants, class_name: 'Spree::Price'
+    has_many :price_lists, class_name: 'Spree::PriceList', inverse_of: :store
     has_many :inventory_units, through: :variants, class_name: 'Spree::InventoryUnit'
     has_many :option_value_variants, through: :variants, class_name: 'Spree::OptionValueVariant'
     has_many :customer_returns, class_name: 'Spree::CustomerReturn', inverse_of: :store

--- a/spree/core/spec/models/spree/product_spec.rb
+++ b/spree/core/spec/models/spree/product_spec.rb
@@ -1108,6 +1108,26 @@ describe Spree::Product, type: :model do
     end
   end
 
+  describe '#category_ids=' do
+    let(:product) { create(:product, store: store) }
+    let(:taxonomy) { create(:taxonomy, store: store) }
+    let(:category) { create(:taxon, taxonomy: taxonomy) }
+
+    it 'assigns categories belonging to the product store' do
+      product.update!(category_ids: [category.prefixed_id])
+      expect(product.reload.taxons).to include(category)
+    end
+
+    it "ignores categories from another store's taxonomy" do
+      foreign_taxon = create(:taxon, taxonomy: create(:taxonomy, store: create(:store)))
+
+      product.update!(category_ids: [category.prefixed_id, foreign_taxon.prefixed_id])
+
+      expect(product.reload.taxons).to include(category)
+      expect(product.reload.taxons).not_to include(foreign_taxon)
+    end
+  end
+
   describe '#any_variant_in_stock_or_backorderable?' do
     subject { product.any_variant_in_stock_or_backorderable? }
 
@@ -2165,6 +2185,20 @@ describe Spree::Product, type: :model do
           pub = fresh.product_publications.first
           fresh.product_publications = [pub]
           expect(fresh.product_publications).to include(pub)
+        end
+      end
+
+      context 'cross-store isolation' do
+        it "ignores a channel that belongs to another store" do
+          foreign_channel = create(:channel, store: create(:store), code: 'foreign')
+
+          product.product_publications = [
+            { channel_id: pos_channel.prefixed_id },
+            { channel_id: foreign_channel.prefixed_id }
+          ]
+
+          expect(product.reload.channels).to include(pos_channel)
+          expect(product.reload.channels).not_to include(foreign_channel)
         end
       end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes touch authorization and store boundaries on payments, refunds, prices, and promotions—security-sensitive paths where mistaken scoping could block legitimate admin actions or leave holes; behavior shifts (e.g. channel add_products no longer co-publishes foreign products).
> 
> **Overview**
> Tightens **multi-store isolation** and **write permissions** across Admin API v3 so prefixed IDs from another store cannot be used to read or mutate foreign data.
> 
> **Controllers** now resolve nested resources through `current_store` and CanCan (`accessible_by`) where they previously used global lookups: promotions (coupon codes, rules, actions), order payments/refunds/fulfillment splits, prices (create/update/bulk upsert), stock transfers, and channel `add_products` (cross-store products are dropped instead of co-published). **Custom fields** and **media** parents require `:update` on the parent, not `:show`.
> 
> **Product model** enforces the same boundaries when assigning `category_ids` and `product_publications` (foreign taxons/channels are ignored). **`Spree::Store`** gains `has_many :price_lists` to support store-scoped price list resolution in the prices API.
> 
> Specs are added or updated for cross-store **404**, silent drops, and IDOR regressions on payments, prices, channels, promotions, stock transfers, and product updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c21d6066d3772755b19292e3c43813480712a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->