### PR TITLE
Handle nil user in admin /me endpoint for secret API keys

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/me_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/me_controller.rb
@@ -15,7 +15,20 @@ module Spree
           # This is the JWT-admin half of "describe the current credential"; the
           # secret-key half is GET /api/v3/admin/api_keys/current (see
           # ApiKeysController#current), which returns the key + its scopes.
+          #
+          # A request authenticated by a secret API key has no Spree user to
+          # describe, so it gets a 404 pointing at the key endpoint rather than
+          # a 500 from serializing a nil user — mirroring how #current 404s for
+          # a JWT principal that has no single key.
           def show
+            unless current_user
+              return render_error(
+                code: ERROR_CODES[:record_not_found],
+                message: Spree.t(:me_no_current_user),
+                status: :not_found
+              )
+            end
+
             render json: {
               user: admin_user_serializer.new(current_user, params: serializer_params).to_h,
               permissions: serialize_permissions(current_ability)

--- a/spree/api/spec/controllers/spree/api/v3/admin/me_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/me_controller_spec.rb
@@ -74,5 +74,19 @@ RSpec.describe Spree::Api::V3::Admin::MeController, type: :controller do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'when authenticated via a secret API key (no Spree user)' do
+      # Regression: a secret-key principal has no user to introspect. The
+      # controller must 404 (pointing at /api_keys/current) rather than 500
+      # from serializing a nil user — see NoMethodError: undefined method 'email' for nil.
+      let(:secret_api_key) { create(:api_key, :secret, store: store) }
+      let(:headers) { { 'x-spree-api-key' => secret_api_key.plaintext_token } }
+
+      it 'returns not found instead of raising' do
+        expect { subject }.not_to raise_error
+        expect(response).to have_http_status(:not_found)
+        expect(json_response['error']['code']).to eq('record_not_found')
+      end
+    end
   end
 end

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1427,6 +1427,7 @@ en:
     max: Max
     max_items: Max Items
     max_quantity: Max Quantity
+    me_no_current_user: No admin user authenticated this request
     media: Media
     memo: Memo
     meta_description: Meta Description


### PR DESCRIPTION
## Summary
Fixes a regression where requests authenticated via secret API keys (which have no associated Spree user) would return a 500 error instead of a 404 when accessing the `GET /api/v3/admin/me` endpoint.

## Changes
- **MeController#show**: Added a guard clause to check for `current_user` and return a 404 with `record_not_found` error code when nil, preventing `NoMethodError` on nil user serialization
- **Localization**: Added `me_no_current_user` translation key explaining that no admin user was authenticated
- **Test coverage**: Added regression test verifying the endpoint returns 404 (not 500) for secret API key authentication

## Implementation Details
Secret API key principals have no user to introspect. The endpoint now mirrors the behavior of `ApiKeysController#current`, which also 404s when the principal has no single key to return. This provides consistent error handling across the two "describe current credential" endpoints:
- JWT admin: `GET /api/v3/admin/me` (user endpoint)
- Secret key: `GET /api/v3/admin/api_keys/current` (key endpoint)

https://claude.ai/code/session_0131gUqg9TDEvFLTZLx8pXLX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard on a single admin introspection endpoint with matching tests and i18n; no auth model or permission logic changes.
> 
> **Overview**
> **Fixes a 500 on `GET /api/v3/admin/me` when the caller authenticates with a secret API key** (no associated Spree admin user). `MeController#show` now returns **404** with `record_not_found` and the new `me_no_current_user` message instead of serializing a nil user.
> 
> Behavior is aligned with **`ApiKeysController#current`**, which 404s when there is no API key to describe for a JWT principal. A controller spec covers the secret-key case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5605656ae149ac3f56a92d079aa1d3c512061dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the me/user endpoint would fail when accessed without a valid authenticated user. Now returns a proper 404 error response with a descriptive message instead of attempting to serialize missing user data.

* **Tests**
  * Added test coverage for the me endpoint when accessed without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->