### PR TITLE
[Admin product page] Add permission to publishing section

### DIFF
--- a/spree/admin/app/views/spree/admin/products/form/_publishing.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_publishing.html.erb
@@ -18,6 +18,7 @@
   tz_help        = Spree.t('admin.datetime_field_timezone_help', zone: store_timezone.name)
   store_channels = current_store.channels.order(:name).to_a
   publications_by_channel = @product.product_publications.includes(:channel).index_by(&:channel_id)
+  can_manage_publications = can?(:manage, Spree::ProductPublication)
 
   # Build one record per store channel: the existing publication when
   # attached, or a fresh ProductPublication when not. Stable channel-keyed
@@ -33,7 +34,7 @@
 <div class="card mb-6" data-controller="product-publishing">
   <div class="card-header d-flex align-items-center justify-content-between">
     <h6 class="card-title mb-0"><%= Spree.t('admin.publishing.title') %></h6>
-    <% if store_channels.any? %>
+    <% if store_channels.any? && can_manage_publications %>
       <button type="button"
               class="btn btn-sm btn-outline-secondary"
               data-action="product-publishing#toggleManage">
@@ -47,6 +48,7 @@
       <p class="text-xs text-muted mb-0"><%= Spree.t('admin.publishing.no_channels') %></p>
     <% else %>
       <%# ---- Manage panel (hidden by default) ---- %>
+      <% if can_manage_publications %>
       <div class="d-none flex flex-col gap-2 mb-3" data-product-publishing-target="manage">
         <p class="text-xs text-muted mb-1"><%= Spree.t('admin.publishing.manage_description') %></p>
         <% channel_rows.each_with_index do |(channel, publication), index| %>
@@ -73,6 +75,7 @@
           <% end %>
         <% end %>
       </div>
+      <% end %>
 
       <%# ---- Per-publication scheduling rows ---- %>
       <% if publications_by_channel.empty? %>
@@ -80,43 +83,57 @@
       <% else %>
         <% channel_rows.each_with_index do |(channel, publication), index| %>
           <% next unless publication.persisted? %>
-          <%= f.fields_for :legacy_product_publications, publication, child_index: index do |pf| %>
-            <details class="publication-row group rounded -mx-2 px-2 hover:bg-gray-50">
-              <summary class="flex items-start justify-between gap-3 py-2 cursor-pointer" style="list-style: none;">
-                <div class="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <div class="flex items-center gap-2">
-                    <span class="truncate text-sm font-medium"><%= channel.name %></span>
-                    <%= publication_status_badge(@product.status, publication) %>
+          <% if can_manage_publications %>
+            <%= f.fields_for :legacy_product_publications, publication, child_index: index do |pf| %>
+              <details class="publication-row group rounded -mx-2 px-2 hover:bg-gray-50">
+                <summary class="flex items-start justify-between gap-3 py-2 cursor-pointer" style="list-style: none;">
+                  <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <div class="flex items-center gap-2">
+                      <span class="truncate text-sm font-medium"><%= channel.name %></span>
+                      <%= publication_status_badge(@product.status, publication) %>
+                    </div>
+                    <span class="text-xs text-muted">
+                      <%= publication_caption(@product.status, publication, current_store) %>
+                    </span>
                   </div>
-                  <span class="text-xs text-muted">
-                    <%= publication_caption(@product.status, publication, current_store) %>
+                  <span class="shrink-0 mt-1 opacity-0 transition-opacity group-hover:opacity-100 text-muted">
+                    <%= icon('pencil', class: 'h-3.5 w-3.5') %>
                   </span>
+                </summary>
+                <div class="mt-2 ps-2 pb-2 flex flex-col gap-3">
+                  <div>
+                    <%= pf.label :published_at,
+                                 Spree.t('admin.publishing.published_at_label'),
+                                 class: 'form-label text-xs mb-1' %>
+                    <%= pf.datetime_field :published_at,
+                                          value: to_store_local.call(publication.published_at),
+                                          class: 'form-control form-control-sm' %>
+                    <small class="text-muted text-xs"><%= tz_help %></small>
+                  </div>
+                  <div>
+                    <%= pf.label :unpublished_at,
+                                 Spree.t('admin.publishing.unpublished_at_label'),
+                                 class: 'form-label text-xs mb-1' %>
+                    <%= pf.datetime_field :unpublished_at,
+                                          value: to_store_local.call(publication.unpublished_at),
+                                          class: 'form-control form-control-sm' %>
+                    <small class="text-muted text-xs"><%= tz_help %></small>
+                  </div>
                 </div>
-                <span class="shrink-0 mt-1 opacity-0 transition-opacity group-hover:opacity-100 text-muted">
-                  <%= icon('pencil', class: 'h-3.5 w-3.5') %>
+              </details>
+            <% end %>
+          <% else %>
+            <div class="publication-row -mx-2 px-2">
+              <div class="flex min-w-0 flex-1 flex-col gap-0.5 py-2">
+                <div class="flex items-center gap-2">
+                  <span class="truncate text-sm font-medium"><%= channel.name %></span>
+                  <%= publication_status_badge(@product.status, publication) %>
+                </div>
+                <span class="text-xs text-muted">
+                  <%= publication_caption(@product.status, publication, current_store) %>
                 </span>
-              </summary>
-              <div class="mt-2 ps-2 pb-2 flex flex-col gap-3">
-                <div>
-                  <%= pf.label :published_at,
-                               Spree.t('admin.publishing.published_at_label'),
-                               class: 'form-label text-xs mb-1' %>
-                  <%= pf.datetime_field :published_at,
-                                        value: to_store_local.call(publication.published_at),
-                                        class: 'form-control form-control-sm' %>
-                  <small class="text-muted text-xs"><%= tz_help %></small>
-                </div>
-                <div>
-                  <%= pf.label :unpublished_at,
-                               Spree.t('admin.publishing.unpublished_at_label'),
-                               class: 'form-label text-xs mb-1' %>
-                  <%= pf.datetime_field :unpublished_at,
-                                        value: to_store_local.call(publication.unpublished_at),
-                                        class: 'form-control form-control-sm' %>
-                  <small class="text-muted text-xs"><%= tz_help %></small>
-                </div>
               </div>
-            </details>
+            </div>
           <% end %>
         <% end %>
       <% end %>

--- a/spree/core/app/models/spree/permission_sets/product_management.rb
+++ b/spree/core/app/models/spree/permission_sets/product_management.rb
@@ -21,6 +21,7 @@ module Spree
         can :manage, Spree::PriceList
         can :manage, Spree::PriceRule
         can :manage, Spree::Asset
+        can :manage, Spree::ProductPublication
       end
     end
   end

--- a/spree/core/app/services/spree/products/prepare_nested_attributes.rb
+++ b/spree/core/app/services/spree/products/prepare_nested_attributes.rb
@@ -67,6 +67,8 @@ module Spree
           end
         end
 
+        params.delete(:legacy_product_publications_attributes) unless can?(:manage, Spree::ProductPublication)
+
         # ensure the product is owned by a store
         params[:store_id] = store.id if params[:store_id].blank? && product.store_id.blank?
 

--- a/spree/core/spec/models/spree/permission_sets/product_management_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/product_management_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Spree::PermissionSets::ProductManagement do
       expect(ability.can?(:manage, Spree::Price)).to be true
     end
 
+    it 'grants manage access to ProductPublication' do
+      expect(ability.can?(:manage, Spree::ProductPublication)).to be true
+    end
+
     it 'does not grant manage access to Order' do
       expect(ability.can?(:manage, Spree::Order)).to be false
     end

--- a/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
+++ b/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
@@ -242,6 +242,33 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
     end
   end
 
+  describe 'legacy_product_publications_attributes handling' do
+    let(:channel) { create(:channel, store: store) }
+    let(:raw_params) do
+      {
+        legacy_product_publications_attributes: {
+          '0' => { channel_id: channel.id, _destroy: '0' }
+        }
+      }
+    end
+
+    context 'when user cannot manage publications' do
+      before do
+        ability.cannot :manage, Spree::ProductPublication
+      end
+
+      it 'strips the publications attributes' do
+        expect(prepared_params).not_to have_key(:legacy_product_publications_attributes)
+      end
+    end
+
+    context 'when user can manage publications' do
+      it 'preserves the publications attributes' do
+        expect(prepared_params[:legacy_product_publications_attributes]['0'][:channel_id]).to eq(channel.id)
+      end
+    end
+  end
+
   describe 'stock_items_attributes handling' do
     let(:variant) { product.master }
 


### PR DESCRIPTION
When ON it is editable:
<img width="200" alt="Screenshot 2026-06-19 at 12 14 23" src="https://github.com/user-attachments/assets/a5db57b6-6a8a-42ff-98cc-4853b9f9e110" />

When OFF its pure text:
<img width="800" alt="Screenshot 2026-06-19 at 12 07 37" src="https://github.com/user-attachments/assets/bcf52066-b53f-4ab5-b194-b6e0862a0bb2" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can alter channel publications and schedule times on product save; backend stripping mitigates tampering but roles without the new ability may lose editing they had before if they only had product manage.
> 
> **Overview**
> **Product publishing** on the admin product form is now tied to `can?(:manage, Spree::ProductPublication)`.
> 
> Users with **ProductManagement** (and any role that gets the new ability) still see **Manage**, channel attach/detach, and expandable **published_at** / **unpublished_at** fields. Everyone else sees channel name, status badge, and caption only—no form fields and no manage affordances.
> 
> **`PrepareNestedAttributes`** drops `legacy_product_publications_attributes` when the user lacks that permission, matching how prices and stock nested attrs are stripped so POST tampering cannot change publications.
> 
> Specs cover the permission set grant and the strip/preserve behavior in the product update pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dcde752895a4ff4bb67d6eb368c9caab6377f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved the product publishing admin experience to consistently enforce publication management permissions.
  * The “Manage” action and channel attach/detach controls now display only when the store has channels and the user can manage product publications.
  * Publication scheduling fields are editable only for authorized users; otherwise, they render as read-only with current details shown.
* **Bug Fixes**
  * Prevented legacy publication scheduling data from being processed when the user lacks publication management permission.
* **Tests**
  * Added automated coverage for the permission behavior and authorization-based parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->