### PR TITLE
Fixed setting store locale in react dashboard

### DIFF
--- a/packages/dashboard-core/src/components/top-bar.tsx
+++ b/packages/dashboard-core/src/components/top-bar.tsx
@@ -22,12 +22,11 @@ import {
   UserIcon,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
-import { adminClient } from '../client'
 import { useAuth } from '../hooks/use-auth'
 import { useCommandPalette } from '../hooks/use-command-palette'
+import { useSwitchAdminLocale } from '../hooks/use-switch-admin-locale'
 import { getInitials } from '../lib/formatters'
-import { i18n, switchLocale } from '../lib/i18n'
+import { i18n } from '../lib/i18n'
 import { useStore } from '../providers/store-provider'
 
 const IS_MAC = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform ?? '')
@@ -119,22 +118,16 @@ function TopBarUser({ uiLocales }: { uiLocales: ReadonlyArray<{ code: string; na
   const { t } = useTranslation()
   const { user, logout } = useAuth()
   const { store } = useStore()
+  const switchAdminLocale = useSwitchAdminLocale()
   if (!user) return null
 
   const initials = getInitials(user.full_name, user.email)
 
-  // Persist the chosen language to the account (PATCH /me) before reloading.
-  // This must update the account — not just localStorage — otherwise the
-  // auth provider, which treats the account's saved `selected_locale` as the
-  // source of truth, would revert the switch on the next page load. Only
-  // switch on success: reloading after a failed PATCH would desync localStorage
-  // from the server and bounce the locale back on the next session bootstrap.
+  // Switching the admin UI language persists to the account, mirrors it into
+  // the auth context, and reloads — see useSwitchAdminLocale for why all three
+  // steps are required.
   const handleSelectLocale = (code: string) => {
-    if (code === i18n.language) return
-    void adminClient.me.update({ selected_locale: code }).then(
-      () => switchLocale(code),
-      () => toast.error(t('admin.account.language.update_failed')),
-    )
+    void switchAdminLocale(code)
   }
 
   return (

--- a/packages/dashboard-core/src/hooks/use-switch-admin-locale.ts
+++ b/packages/dashboard-core/src/hooks/use-switch-admin-locale.ts
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { adminClient } from '../client'
+import { i18n, switchLocale } from '../lib/i18n'
+import { useAuth } from './use-auth'
+
+/**
+ * Returns a function that switches the admin UI language and makes it stick.
+ *
+ * Switching the UI language is a three-step operation that every entry point
+ * (top-bar switcher, profile form, store settings) must perform identically:
+ *
+ *  1. Persist `selected_locale` to the ACCOUNT (`PATCH /me`) — not just
+ *     localStorage. The auth provider treats the account's `selected_locale`
+ *     as the cross-device source of truth and reverts a localStorage-only
+ *     switch on the next session bootstrap.
+ *  2. Mirror the change into the auth context so the in-memory user (top-bar,
+ *     etc.) reflects it immediately instead of waiting for the next refresh.
+ *  3. `switchLocale` persists the choice and reloads so every module-load
+ *     `i18n.t(...)` label re-resolves in the new language.
+ *
+ * A failed PATCH leaves localStorage and the page untouched (no desync) and
+ * surfaces an error toast. A no-op when the language is already active.
+ *
+ * @returns an async `switchAdminLocale(code)` performing the full sequence
+ */
+export function useSwitchAdminLocale() {
+  const { t } = useTranslation()
+  const { updateUser } = useAuth()
+
+  return async (code: string): Promise<void> => {
+    if (code === i18n.language) return
+    try {
+      const { user } = await adminClient.me.update({ selected_locale: code })
+      updateUser(user)
+      switchLocale(code)
+    } catch {
+      toast.error(t('admin.account.language.update_failed'))
+    }
+  }
+}

--- a/packages/dashboard-core/src/hooks/use-switch-admin-locale.ts
+++ b/packages/dashboard-core/src/hooks/use-switch-admin-locale.ts
@@ -20,20 +20,28 @@ import { useAuth } from './use-auth'
  *     `i18n.t(...)` label re-resolves in the new language.
  *
  * A failed PATCH leaves localStorage and the page untouched (no desync) and
- * surfaces an error toast. A no-op when the language is already active.
+ * surfaces an error toast. Fully a no-op only when the account ALREADY records
+ * `code` and the UI is already displaying it — otherwise the account is brought
+ * in sync even if the UI happens to match (e.g. the language was applied via the
+ * store-default fallback, which writes localStorage but leaves the account
+ * `selected_locale` null), and the page reloads only when the displayed language
+ * actually changes.
  *
  * @returns an async `switchAdminLocale(code)` performing the full sequence
  */
 export function useSwitchAdminLocale() {
   const { t } = useTranslation()
-  const { updateUser } = useAuth()
+  const { user, updateUser } = useAuth()
 
   return async (code: string): Promise<void> => {
-    if (code === i18n.language) return
+    // Already adopted on the account AND on screen — nothing to do.
+    if (code === user?.selected_locale && code === i18n.language) return
     try {
-      const { user } = await adminClient.me.update({ selected_locale: code })
-      updateUser(user)
-      switchLocale(code)
+      const { user: updated } = await adminClient.me.update({ selected_locale: code })
+      updateUser(updated)
+      // Reload only if the displayed language is actually changing; persisting
+      // to the account above is enough when the UI already shows `code`.
+      if (code !== i18n.language) switchLocale(code)
     } catch {
       toast.error(t('admin.account.language.update_failed'))
     }

--- a/packages/dashboard-core/src/hooks/use-switch-admin-locale.ts
+++ b/packages/dashboard-core/src/hooks/use-switch-admin-locale.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { adminClient } from '../client'
-import { i18n, switchLocale } from '../lib/i18n'
+import { i18n, markGenuineLocaleChoice, switchLocale } from '../lib/i18n'
 import { useAuth } from './use-auth'
 
 /**
@@ -39,9 +39,15 @@ export function useSwitchAdminLocale() {
     try {
       const { user: updated } = await adminClient.me.update({ selected_locale: code })
       updateUser(updated)
-      // Reload only if the displayed language is actually changing; persisting
-      // to the account above is enough when the UI already shows `code`.
-      if (code !== i18n.language) switchLocale(code)
+      if (code !== i18n.language) {
+        // Displayed language changes — persist the genuine choice + reload.
+        switchLocale(code)
+      } else {
+        // Already on screen: no reload, but still record it as a GENUINE choice
+        // (clearing any store-default auto-marker) so a later store switch can't
+        // override what the admin explicitly picked.
+        markGenuineLocaleChoice(code)
+      }
     } catch {
       toast.error(t('admin.account.language.update_failed'))
     }

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -50,6 +50,7 @@ export * from './hooks/use-display-name'
 export * from './hooks/use-export'
 export * from './hooks/use-global-search'
 export * from './hooks/use-resource-mutation'
+export * from './hooks/use-switch-admin-locale'
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -66,8 +66,14 @@ export function coreLocaleCodes(): string[] {
 // a still-armed `beforeunload` dirty-guard would trigger the browser's
 // "unsaved changes" prompt.
 export function switchLocale(code: string): void {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem(ADMIN_LOCALE_STORAGE_KEY, code)
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(ADMIN_LOCALE_STORAGE_KEY, code)
+    }
+  } catch {
+    // Restricted-storage contexts (Safari private mode, sandboxed iframes) throw
+    // on write; the reload below still applies the language for this session via
+    // the booted `lng`, so a failed persist is non-fatal.
   }
   if (typeof window !== 'undefined') {
     setTimeout(() => window.location.reload(), 0)

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -9,9 +9,21 @@ import en from '../locales/en.json'
 // made anywhere is honored on the next paint.
 export const ADMIN_LOCALE_STORAGE_KEY = 'spree-admin-locale'
 
+// Read the stored locale, tolerating restricted-storage contexts (Safari
+// private mode, sandboxed iframes) where `localStorage` access throws. Returns
+// `null` when there is no stored choice (or storage is unavailable) so callers
+// can distinguish "no choice yet" from an explicit value.
+function storedLocale(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null
+    return localStorage.getItem(ADMIN_LOCALE_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
 function readStoredLocale(): string {
-  if (typeof localStorage === 'undefined') return 'en'
-  return localStorage.getItem(ADMIN_LOCALE_STORAGE_KEY) || 'en'
+  return storedLocale() || 'en'
 }
 
 /**
@@ -22,8 +34,7 @@ function readStoredLocale(): string {
  * `preferred_admin_locale` fallback may only apply when this is false.
  */
 export function hasStoredLocale(): boolean {
-  if (typeof localStorage === 'undefined') return false
-  return localStorage.getItem(ADMIN_LOCALE_STORAGE_KEY) != null
+  return storedLocale() != null
 }
 
 // All non-English core bundles, imported EAGERLY so the active language has its

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -14,6 +14,18 @@ function readStoredLocale(): string {
   return localStorage.getItem(ADMIN_LOCALE_STORAGE_KEY) || 'en'
 }
 
+/**
+ * Whether the admin has an explicitly stored UI-language choice (made via the
+ * top-bar switcher, the profile form, or a previously-synced account
+ * `selected_locale`). Distinguishes "no choice yet" (key absent) from
+ * "explicitly chose English" (key present === 'en') — the store-wide
+ * `preferred_admin_locale` fallback may only apply when this is false.
+ */
+export function hasStoredLocale(): boolean {
+  if (typeof localStorage === 'undefined') return false
+  return localStorage.getItem(ADMIN_LOCALE_STORAGE_KEY) != null
+}
+
 // All non-English core bundles, imported EAGERLY so the active language has its
 // resources synchronously available (registered just after init() below) —
 // no flash, no async race with module-load `i18n.t(...)` calls.
@@ -21,6 +33,14 @@ const coreLocales = import.meta.glob<{ default: Record<string, unknown> }>(
   ['../locales/*.json', '!../locales/en.json'],
   { eager: true },
 )
+
+/** Admin-UI locale codes the framework ships a bundle for (including `en`). */
+export function coreLocaleCodes(): string[] {
+  return [
+    'en',
+    ...Object.keys(coreLocales).map((p) => p.replace('../locales/', '').replace('.json', '')),
+  ]
+}
 
 // Switch the admin UI language. Persists the choice and reloads the page.
 //

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -136,14 +136,23 @@ export function coreLocaleCodes(): string[] {
   ]
 }
 
-// Switch the admin UI language from an explicit, genuine choice (top-bar
-// switcher, profile, login). Persists the choice, clears any store-default
-// marker, and reloads (see `reloadSoon`) so every module-load label re-resolves.
-export function switchLocale(code: string): void {
+/**
+ * Record an explicit, genuine UI-language choice (top-bar switcher, profile,
+ * login, settings-save) WITHOUT reloading. Persists the locale and clears any
+ * store-default marker, so the choice now outranks every store default and
+ * won't be superseded on store switches. Use this when the UI already displays
+ * `code` (no reload needed) but the choice must still be marked as genuine.
+ */
+export function markGenuineLocaleChoice(code: string): void {
   writeStorage(ADMIN_LOCALE_STORAGE_KEY, code)
-  // A genuine choice clears any auto-applied store-default marker, so it now
-  // outranks every store default and won't be superseded on store switches.
   clearStorage(ADMIN_LOCALE_AUTO_STORE_KEY)
+}
+
+// Switch the admin UI language from an explicit, genuine choice. Marks it as
+// genuine (see `markGenuineLocaleChoice`) and reloads (see `reloadSoon`) so
+// every module-load label re-resolves in the new language.
+export function switchLocale(code: string): void {
+  markGenuineLocaleChoice(code)
   reloadSoon()
 }
 

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -68,56 +68,51 @@ function readStoredLocale(): string {
 }
 
 /**
- * Whether the admin has an explicit, genuine UI-language choice stored (made via
- * the top-bar switcher, the profile form, or a previously-synced account
- * `selected_locale`) — as opposed to a value auto-applied from a store's
- * `preferred_admin_locale`. A genuine choice outranks any store default and must
- * win across every store; an auto-applied default is per-store and may be
- * superseded when the admin enters a store with a different default.
- */
-export function hasStoredLocale(): boolean {
-  return storedLocale() != null && readStorage(ADMIN_LOCALE_AUTO_STORE_KEY) == null
-}
-
-/**
- * Apply a store's `preferred_admin_locale` as an auto-applied default for an
- * admin with no genuine choice. Records `storeId` alongside the locale so a
- * later store boundary can re-apply that store's default. Persists, then reloads
- * only when the displayed language actually changes.
+ * Reconcile the admin UI language against a store's `preferred_admin_locale`
+ * fallback (legacy `base_controller` parity), for an admin with no genuine
+ * personal choice. Encodes the precedence:
+ *   account selected_locale > genuine stored choice > store preferred_admin_locale > 'en'
  *
- * @param code     the store's `preferred_admin_locale`
- * @param storeId  the store the default belongs to
- * @param supported  locale codes the dashboard ships a bundle for
+ * No-op when a higher tier owns the language (an account locale, or a genuine
+ * stored choice — locale key set without an auto-marker). Otherwise drives the
+ * stored language to this store's current default:
+ *   - a supported default → adopt it (auto-marked to this store);
+ *   - a blank/cleared/unsupported default → revert to 'en' IF the prior value was
+ *     auto-applied (a stale auto-default from this or another store is dropped);
+ *   - already matching → nothing changes.
+ * Reloads (via the boot path) only when the displayed language actually changes.
+ *
+ * @param code        the store's current `preferred_admin_locale`
+ * @param storeId     the store being entered
+ * @param accountLocale  the account's `selected_locale` (null when unset)
+ * @param supported   locale codes the dashboard ships a bundle for
  */
-export function applyStoreDefaultLocale(
+export function reconcileStoreDefaultLocale(
   code: string | null | undefined,
   storeId: string,
+  accountLocale: string | null,
   supported: string[],
 ): void {
-  if (!code || !supported.includes(code)) return
-  // Record the locale AND the owning store. Unlike `switchLocale` (a genuine
-  // choice), this keeps the auto-marker so a later store boundary can supersede
-  // it. Reload only when the displayed language actually changes.
-  writeStorage(ADMIN_LOCALE_STORAGE_KEY, code)
-  writeStorage(ADMIN_LOCALE_AUTO_STORE_KEY, storeId)
-  if (code === (i18n.resolvedLanguage ?? i18n.language)) return
-  reloadSoon()
-}
-
-/**
- * Whether the store-default fallback may run for `storeId`: only when the admin
- * has no account `selected_locale` and no GENUINE stored choice. An auto-applied
- * default from a *different* store does not block it (the new store's default
- * supersedes it); one already applied for *this* store does (nothing to do).
- */
-export function canApplyStoreDefaultLocale(accountLocale: string | null, storeId: string): boolean {
-  if (accountLocale) return false
+  if (accountLocale) return
   const auto = readStorage(ADMIN_LOCALE_AUTO_STORE_KEY)
-  // A genuine choice (locale key set, no auto-marker) always wins.
-  if (storedLocale() != null && auto == null) return false
-  // Already auto-applied for this exact store — no churn.
-  if (auto === storeId) return false
-  return true
+  const stored = storedLocale()
+  // A genuine choice (locale key set, no auto-marker) outranks any store default.
+  if (stored != null && auto == null) return
+
+  const target = code && supported.includes(code) ? code : null
+  const current = i18n.resolvedLanguage ?? i18n.language
+
+  if (target) {
+    writeStorage(ADMIN_LOCALE_STORAGE_KEY, target)
+    writeStorage(ADMIN_LOCALE_AUTO_STORE_KEY, storeId)
+    if (target !== current) reloadSoon()
+  } else if (auto != null) {
+    // Store has no usable default and the current language was auto-applied —
+    // drop it so the UI reverts to the app default ('en').
+    clearStorage(ADMIN_LOCALE_STORAGE_KEY)
+    clearStorage(ADMIN_LOCALE_AUTO_STORE_KEY)
+    if (current !== 'en') reloadSoon()
+  }
 }
 
 // All non-English core bundles, imported EAGERLY so the active language has its

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -9,17 +9,58 @@ import en from '../locales/en.json'
 // made anywhere is honored on the next paint.
 export const ADMIN_LOCALE_STORAGE_KEY = 'spree-admin-locale'
 
-// Read the stored locale, tolerating restricted-storage contexts (Safari
-// private mode, sandboxed iframes) where `localStorage` access throws. Returns
-// `null` when there is no stored choice (or storage is unavailable) so callers
-// can distinguish "no choice yet" from an explicit value.
-function storedLocale(): string | null {
+// Marks the locale key as auto-applied from a store's `preferred_admin_locale`
+// (vs an explicit choice). Holds the storeId whose default is currently in
+// effect, so crossing into a different store can re-apply that store's default
+// while a genuine choice (switcher/profile/login) still wins everywhere. Mirrors
+// legacy Rails: the `spree_admin_locale` cookie only ever held an explicit
+// login-screen pick; the store default was re-derived per request, never stored.
+const ADMIN_LOCALE_AUTO_STORE_KEY = 'spree-admin-locale-auto-store'
+
+function readStorage(key: string): string | null {
   try {
     if (typeof localStorage === 'undefined') return null
-    return localStorage.getItem(ADMIN_LOCALE_STORAGE_KEY)
+    return localStorage.getItem(key)
   } catch {
     return null
   }
+}
+
+function writeStorage(key: string, value: string): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(key, value)
+  } catch {
+    // Restricted-storage contexts (Safari private mode, sandboxed iframes) throw
+    // on write; the choice still applies for this session via the booted `lng`.
+  }
+}
+
+function clearStorage(key: string): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(key)
+  } catch {
+    // Ignore — see writeStorage.
+  }
+}
+
+// A full reload is deliberate for a language change: many labels (table columns,
+// nav, registry titles) are resolved with `i18n.t(...)` at module-load time and
+// don't react to a live `changeLanguage`. Reloading re-runs those at boot in the
+// new language (read from localStorage by `init`). Deferred to the next macrotask
+// so a pending React state flush (e.g. a just-saved form clearing its dirty
+// state) completes first — otherwise a still-armed `beforeunload` dirty-guard
+// would trigger the browser's "unsaved changes" prompt.
+function reloadSoon(): void {
+  if (typeof window !== 'undefined') {
+    setTimeout(() => window.location.reload(), 0)
+  }
+}
+
+// Read the stored locale, tolerating restricted-storage contexts where
+// `localStorage` access throws. Returns `null` when there is no stored choice
+// so callers can distinguish "no choice yet" from an explicit value.
+function storedLocale(): string | null {
+  return readStorage(ADMIN_LOCALE_STORAGE_KEY)
 }
 
 function readStoredLocale(): string {
@@ -27,14 +68,56 @@ function readStoredLocale(): string {
 }
 
 /**
- * Whether the admin has an explicitly stored UI-language choice (made via the
- * top-bar switcher, the profile form, or a previously-synced account
- * `selected_locale`). Distinguishes "no choice yet" (key absent) from
- * "explicitly chose English" (key present === 'en') — the store-wide
- * `preferred_admin_locale` fallback may only apply when this is false.
+ * Whether the admin has an explicit, genuine UI-language choice stored (made via
+ * the top-bar switcher, the profile form, or a previously-synced account
+ * `selected_locale`) — as opposed to a value auto-applied from a store's
+ * `preferred_admin_locale`. A genuine choice outranks any store default and must
+ * win across every store; an auto-applied default is per-store and may be
+ * superseded when the admin enters a store with a different default.
  */
 export function hasStoredLocale(): boolean {
-  return storedLocale() != null
+  return storedLocale() != null && readStorage(ADMIN_LOCALE_AUTO_STORE_KEY) == null
+}
+
+/**
+ * Apply a store's `preferred_admin_locale` as an auto-applied default for an
+ * admin with no genuine choice. Records `storeId` alongside the locale so a
+ * later store boundary can re-apply that store's default. Persists, then reloads
+ * only when the displayed language actually changes.
+ *
+ * @param code     the store's `preferred_admin_locale`
+ * @param storeId  the store the default belongs to
+ * @param supported  locale codes the dashboard ships a bundle for
+ */
+export function applyStoreDefaultLocale(
+  code: string | null | undefined,
+  storeId: string,
+  supported: string[],
+): void {
+  if (!code || !supported.includes(code)) return
+  // Record the locale AND the owning store. Unlike `switchLocale` (a genuine
+  // choice), this keeps the auto-marker so a later store boundary can supersede
+  // it. Reload only when the displayed language actually changes.
+  writeStorage(ADMIN_LOCALE_STORAGE_KEY, code)
+  writeStorage(ADMIN_LOCALE_AUTO_STORE_KEY, storeId)
+  if (code === (i18n.resolvedLanguage ?? i18n.language)) return
+  reloadSoon()
+}
+
+/**
+ * Whether the store-default fallback may run for `storeId`: only when the admin
+ * has no account `selected_locale` and no GENUINE stored choice. An auto-applied
+ * default from a *different* store does not block it (the new store's default
+ * supersedes it); one already applied for *this* store does (nothing to do).
+ */
+export function canApplyStoreDefaultLocale(accountLocale: string | null, storeId: string): boolean {
+  if (accountLocale) return false
+  const auto = readStorage(ADMIN_LOCALE_AUTO_STORE_KEY)
+  // A genuine choice (locale key set, no auto-marker) always wins.
+  if (storedLocale() != null && auto == null) return false
+  // Already auto-applied for this exact store — no churn.
+  if (auto === storeId) return false
+  return true
 }
 
 // All non-English core bundles, imported EAGERLY so the active language has its
@@ -53,31 +136,15 @@ export function coreLocaleCodes(): string[] {
   ]
 }
 
-// Switch the admin UI language. Persists the choice and reloads the page.
-//
-// A full reload is deliberate: many labels (table columns, nav, registry
-// titles) are resolved with `i18n.t(...)` at module-load time and don't react
-// to a live `changeLanguage`. Reloading re-runs those at boot in the new
-// language (read from localStorage by `init` below), so every string switches
-// — not just the components currently subscribed to i18next.
-//
-// The reload is deferred to the next macrotask so any pending React state flush
-// (e.g. a just-saved form resetting its dirty state) completes first — otherwise
-// a still-armed `beforeunload` dirty-guard would trigger the browser's
-// "unsaved changes" prompt.
+// Switch the admin UI language from an explicit, genuine choice (top-bar
+// switcher, profile, login). Persists the choice, clears any store-default
+// marker, and reloads (see `reloadSoon`) so every module-load label re-resolves.
 export function switchLocale(code: string): void {
-  try {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(ADMIN_LOCALE_STORAGE_KEY, code)
-    }
-  } catch {
-    // Restricted-storage contexts (Safari private mode, sandboxed iframes) throw
-    // on write; the reload below still applies the language for this session via
-    // the booted `lng`, so a failed persist is non-fatal.
-  }
-  if (typeof window !== 'undefined') {
-    setTimeout(() => window.location.reload(), 0)
-  }
+  writeStorage(ADMIN_LOCALE_STORAGE_KEY, code)
+  // A genuine choice clears any auto-applied store-default marker, so it now
+  // outranks every store default and won't be superseded on store switches.
+  clearStorage(ADMIN_LOCALE_AUTO_STORE_KEY)
+  reloadSoon()
 }
 
 // Bootstrap i18next with the framework's base translation namespace. Side-effect

--- a/packages/dashboard-core/src/providers/store-provider.tsx
+++ b/packages/dashboard-core/src/providers/store-provider.tsx
@@ -10,26 +10,7 @@ import {
 } from 'react'
 import { adminClient } from '../client'
 import { useAuth } from '../hooks/use-auth'
-import { coreLocaleCodes, hasStoredLocale, i18n, switchLocale } from '../lib/i18n'
-
-// Store-wide admin-language fallback (legacy base_controller parity). Sits BELOW
-// the personal choice in the precedence chain:
-//   account selected_locale > stored localStorage choice > preferred_admin_locale > 'en'.
-// We only act when the admin has made NO personal choice: neither an account
-// `selected_locale` nor a stored localStorage key (the latter distinguishes "no
-// choice yet" from an explicit 'en'). The account check is independent of
-// localStorage because the auth provider skips writing the key when the account
-// locale already matches the booted language. switchLocale writes the key +
-// reloads, so it's one-shot: a later settings-save refetch sees the key and bows out.
-function applyStoreDefaultLocale(
-  code: string | null | undefined,
-  accountLocale: string | null,
-): void {
-  if (!code || !coreLocaleCodes().includes(code)) return
-  if (accountLocale || hasStoredLocale()) return
-  if (code === (i18n.resolvedLanguage ?? i18n.language)) return
-  switchLocale(code)
-}
+import { applyStoreDefaultLocale, canApplyStoreDefaultLocale, coreLocaleCodes } from '../lib/i18n'
 
 interface StoreContextValue {
   store: Store | null
@@ -59,10 +40,10 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
   // Run the store-default fallback only on the FIRST store load. A later refetch
   // (e.g. after saving store settings) must not re-apply it: that path already
   // owns the locale via `switchAdminLocale`, and re-applying would race that
-  // PATCH and could reload before it lands.
+  // PATCH and could reload before it lands. Re-armed per store (effect below) so
+  // a multi-store admin still inherits each store's preferred_admin_locale.
   const localeFallbackDoneRef = useRef(false)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: adminClient resolves the store from the route's storeId, so we must refetch when it changes
   const fetchStore = useCallback(async () => {
     setIsLoading(true)
     let data: Store | null = null
@@ -75,15 +56,19 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
       setIsLoading(false)
     }
     // Outside the try: a thrown storage write in the locale fallback must not be
-    // mistaken for a failed fetch and null a store that loaded successfully.
+    // mistaken for a failed fetch and null a store that loaded successfully. The
+    // fallback inherits the store's admin language only when the admin has no
+    // account locale and no genuine personal choice (legacy base_controller
+    // parity); an auto-applied default from another store is superseded here.
     if (data && !localeFallbackDoneRef.current) {
       localeFallbackDoneRef.current = true
-      applyStoreDefaultLocale(data.preferred_admin_locale, accountLocaleRef.current)
+      if (canApplyStoreDefaultLocale(accountLocaleRef.current, storeId)) {
+        applyStoreDefaultLocale(data.preferred_admin_locale, storeId, coreLocaleCodes())
+      }
     }
   }, [storeId])
 
-  // Re-arm the one-shot fallback for each store the admin switches into, so a
-  // multi-store admin still inherits each store's preferred_admin_locale.
+  // Re-arm the one-shot fallback for each store the admin switches into.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-arm on store boundary only
   useEffect(() => {
     localeFallbackDoneRef.current = false

--- a/packages/dashboard-core/src/providers/store-provider.tsx
+++ b/packages/dashboard-core/src/providers/store-provider.tsx
@@ -9,7 +9,27 @@ import {
   useState,
 } from 'react'
 import { adminClient } from '../client'
+import { useAuth } from '../hooks/use-auth'
 import { coreLocaleCodes, hasStoredLocale, i18n, switchLocale } from '../lib/i18n'
+
+// Store-wide admin-language fallback (legacy base_controller parity). Sits BELOW
+// the personal choice in the precedence chain:
+//   account selected_locale > stored localStorage choice > preferred_admin_locale > 'en'.
+// We only act when the admin has made NO personal choice: neither an account
+// `selected_locale` nor a stored localStorage key (the latter distinguishes "no
+// choice yet" from an explicit 'en'). The account check is independent of
+// localStorage because the auth provider skips writing the key when the account
+// locale already matches the booted language. switchLocale writes the key +
+// reloads, so it's one-shot: a later settings-save refetch sees the key and bows out.
+function applyStoreDefaultLocale(
+  code: string | null | undefined,
+  accountLocale: string | null,
+): void {
+  if (!code || !coreLocaleCodes().includes(code)) return
+  if (accountLocale || hasStoredLocale()) return
+  if (code === (i18n.resolvedLanguage ?? i18n.language)) return
+  switchLocale(code)
+}
 
 interface StoreContextValue {
   store: Store | null
@@ -30,25 +50,12 @@ const StoreContext = createContext<StoreContextValue | null>(null)
 export function StoreProvider({ storeId, children }: { storeId: string; children: ReactNode }) {
   const [store, setStore] = useState<Store | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const localeAppliedRef = useRef(false)
+  const { user } = useAuth()
 
-  // Store-wide admin-language fallback (legacy base_controller parity). Sits
-  // BELOW the personal choice in the precedence chain:
-  //   user.selected_locale > stored localStorage choice > preferred_admin_locale > 'en'.
-  // The auth provider applies the account's selected_locale and the top-bar/
-  // profile persist explicit switches — both write the localStorage key — so we
-  // only act when NO such choice exists (key absent), which distinguishes "no
-  // choice yet" from an explicit 'en'. switchLocale writes the key + reloads, so
-  // this is one-shot per browser; the ref additionally stops a settings-save
-  // refetch from re-triggering it within the same page load.
-  const applyStoreDefaultLocale = useCallback((code: string | null | undefined) => {
-    if (localeAppliedRef.current) return
-    localeAppliedRef.current = true
-    if (!code || !coreLocaleCodes().includes(code)) return
-    if (hasStoredLocale()) return
-    if (code === (i18n.resolvedLanguage ?? i18n.language)) return
-    switchLocale(code)
-  }, [])
+  // Read the account locale through a ref so a `user` identity change (frequent —
+  // every auth update) doesn't re-key `fetchStore` and refetch the store.
+  const accountLocaleRef = useRef<string | null>(user?.selected_locale ?? null)
+  accountLocaleRef.current = user?.selected_locale ?? null
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: adminClient resolves the store from the route's storeId, so we must refetch when it changes
   const fetchStore = useCallback(async () => {
@@ -56,13 +63,13 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
     try {
       const data = await adminClient.store.get()
       setStore(data)
-      applyStoreDefaultLocale(data.preferred_admin_locale)
+      applyStoreDefaultLocale(data.preferred_admin_locale, accountLocaleRef.current)
     } catch {
       setStore(null)
     } finally {
       setIsLoading(false)
     }
-  }, [storeId, applyStoreDefaultLocale])
+  }, [storeId])
 
   useEffect(() => {
     fetchStore()

--- a/packages/dashboard-core/src/providers/store-provider.tsx
+++ b/packages/dashboard-core/src/providers/store-provider.tsx
@@ -1,6 +1,15 @@
 import type { Store } from '@spree/admin-sdk'
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react'
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { adminClient } from '../client'
+import { coreLocaleCodes, hasStoredLocale, i18n, switchLocale } from '../lib/i18n'
 
 interface StoreContextValue {
   store: Store | null
@@ -21,6 +30,25 @@ const StoreContext = createContext<StoreContextValue | null>(null)
 export function StoreProvider({ storeId, children }: { storeId: string; children: ReactNode }) {
   const [store, setStore] = useState<Store | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const localeAppliedRef = useRef(false)
+
+  // Store-wide admin-language fallback (legacy base_controller parity). Sits
+  // BELOW the personal choice in the precedence chain:
+  //   user.selected_locale > stored localStorage choice > preferred_admin_locale > 'en'.
+  // The auth provider applies the account's selected_locale and the top-bar/
+  // profile persist explicit switches — both write the localStorage key — so we
+  // only act when NO such choice exists (key absent), which distinguishes "no
+  // choice yet" from an explicit 'en'. switchLocale writes the key + reloads, so
+  // this is one-shot per browser; the ref additionally stops a settings-save
+  // refetch from re-triggering it within the same page load.
+  const applyStoreDefaultLocale = useCallback((code: string | null | undefined) => {
+    if (localeAppliedRef.current) return
+    localeAppliedRef.current = true
+    if (!code || !coreLocaleCodes().includes(code)) return
+    if (hasStoredLocale()) return
+    if (code === (i18n.resolvedLanguage ?? i18n.language)) return
+    switchLocale(code)
+  }, [])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: adminClient resolves the store from the route's storeId, so we must refetch when it changes
   const fetchStore = useCallback(async () => {
@@ -28,12 +56,13 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
     try {
       const data = await adminClient.store.get()
       setStore(data)
+      applyStoreDefaultLocale(data.preferred_admin_locale)
     } catch {
       setStore(null)
     } finally {
       setIsLoading(false)
     }
-  }, [storeId])
+  }, [storeId, applyStoreDefaultLocale])
 
   useEffect(() => {
     fetchStore()

--- a/packages/dashboard-core/src/providers/store-provider.tsx
+++ b/packages/dashboard-core/src/providers/store-provider.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react'
 import { adminClient } from '../client'
 import { useAuth } from '../hooks/use-auth'
-import { applyStoreDefaultLocale, canApplyStoreDefaultLocale, coreLocaleCodes } from '../lib/i18n'
+import { coreLocaleCodes, reconcileStoreDefaultLocale } from '../lib/i18n'
 
 interface StoreContextValue {
   store: Store | null
@@ -65,15 +65,18 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
       if (latestStoreIdRef.current === storeId) setIsLoading(false)
     }
     // Outside the try: a thrown storage write in the locale fallback must not be
-    // mistaken for a failed fetch and null a store that loaded successfully. The
-    // fallback inherits the store's admin language only when the admin has no
-    // account locale and no genuine personal choice (legacy base_controller
-    // parity); an auto-applied default from another store is superseded here.
+    // mistaken for a failed fetch and null a store that loaded successfully.
+    // Reconcile the admin language against this store's default — adopting it,
+    // or dropping a now-stale auto-applied default — only when no account locale
+    // or genuine personal choice owns it (legacy base_controller parity).
     if (data && !localeFallbackDoneRef.current) {
       localeFallbackDoneRef.current = true
-      if (canApplyStoreDefaultLocale(accountLocaleRef.current, storeId)) {
-        applyStoreDefaultLocale(data.preferred_admin_locale, storeId, coreLocaleCodes())
-      }
+      reconcileStoreDefaultLocale(
+        data.preferred_admin_locale,
+        storeId,
+        accountLocaleRef.current,
+        coreLocaleCodes(),
+      )
     }
   }, [storeId])
 

--- a/packages/dashboard-core/src/providers/store-provider.tsx
+++ b/packages/dashboard-core/src/providers/store-provider.tsx
@@ -56,19 +56,37 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
   // every auth update) doesn't re-key `fetchStore` and refetch the store.
   const accountLocaleRef = useRef<string | null>(user?.selected_locale ?? null)
   accountLocaleRef.current = user?.selected_locale ?? null
+  // Run the store-default fallback only on the FIRST store load. A later refetch
+  // (e.g. after saving store settings) must not re-apply it: that path already
+  // owns the locale via `switchAdminLocale`, and re-applying would race that
+  // PATCH and could reload before it lands.
+  const localeFallbackDoneRef = useRef(false)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: adminClient resolves the store from the route's storeId, so we must refetch when it changes
   const fetchStore = useCallback(async () => {
     setIsLoading(true)
+    let data: Store | null = null
     try {
-      const data = await adminClient.store.get()
+      data = await adminClient.store.get()
       setStore(data)
-      applyStoreDefaultLocale(data.preferred_admin_locale, accountLocaleRef.current)
     } catch {
       setStore(null)
     } finally {
       setIsLoading(false)
     }
+    // Outside the try: a thrown storage write in the locale fallback must not be
+    // mistaken for a failed fetch and null a store that loaded successfully.
+    if (data && !localeFallbackDoneRef.current) {
+      localeFallbackDoneRef.current = true
+      applyStoreDefaultLocale(data.preferred_admin_locale, accountLocaleRef.current)
+    }
+  }, [storeId])
+
+  // Re-arm the one-shot fallback for each store the admin switches into, so a
+  // multi-store admin still inherits each store's preferred_admin_locale.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-arm on store boundary only
+  useEffect(() => {
+    localeFallbackDoneRef.current = false
   }, [storeId])
 
   useEffect(() => {

--- a/packages/dashboard-core/src/providers/store-provider.tsx
+++ b/packages/dashboard-core/src/providers/store-provider.tsx
@@ -43,17 +43,26 @@ export function StoreProvider({ storeId, children }: { storeId: string; children
   // PATCH and could reload before it lands. Re-armed per store (effect below) so
   // a multi-store admin still inherits each store's preferred_admin_locale.
   const localeFallbackDoneRef = useRef(false)
+  // Latest requested storeId, so a slow in-flight fetch that resolves after the
+  // route already moved to another store is dropped instead of clobbering the
+  // current store's state and one-shot locale fallback.
+  const latestStoreIdRef = useRef(storeId)
+  latestStoreIdRef.current = storeId
 
   const fetchStore = useCallback(async () => {
     setIsLoading(true)
     let data: Store | null = null
     try {
-      data = await adminClient.store.get()
+      const result = await adminClient.store.get()
+      // Drop a stale response: the route moved on while this was in flight.
+      if (latestStoreIdRef.current !== storeId) return
+      data = result
       setStore(data)
     } catch {
+      if (latestStoreIdRef.current !== storeId) return
       setStore(null)
     } finally {
-      setIsLoading(false)
+      if (latestStoreIdRef.current === storeId) setIsLoading(false)
     }
     // Outside the try: a thrown storage write in the locale fallback must not be
     // mistaken for a failed fetch and null a store that loaded successfully. The

--- a/packages/dashboard/e2e/store-settings.spec.ts
+++ b/packages/dashboard/e2e/store-settings.spec.ts
@@ -43,6 +43,68 @@ test.describe('store settings — general', () => {
     await page.getByRole('button', { name: /^save$/i }).click()
     await expect(page.locator('#store-name')).toHaveValue(creds.store_name)
   })
+
+  test('setting the store admin language switches the dashboard UI', async ({ page }) => {
+    const creds = await login(page)
+
+    // Precondition: give the admin an explicit personal language that DIFFERS
+    // from the one we'll set via store settings. This persists `selected_locale`
+    // on the account, which the auth provider treats as the cross-device source
+    // of truth. Without a saved personal language the store-locale switch passes
+    // trivially on a fresh account (selected_locale = null → nothing to revert
+    // it) while still being broken for a real user who has one — the auth
+    // provider reverts a localStorage-only switch back to the saved language on
+    // the next session bootstrap. German here; the store switch to Polish below
+    // must win over it and survive a reload.
+    await page.goto(`/${creds.store_id}/settings/profile`)
+    await expect(page.locator('#profile-language')).toBeVisible({ timeout: 15_000 })
+    await page.locator('#profile-language').click()
+    await page.getByRole('option', { name: /^deutsch$/i }).click()
+    await page.getByRole('button', { name: /^save$/i }).click()
+    // Saving a new language reloads into it; the profile heading is now German.
+    await expect(page.getByText('Persönliche Daten', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    await page.goto(STORE_PATH(creds.store_id))
+    await expect(page.locator('#store-admin-locale')).toBeVisible({ timeout: 15_000 })
+
+    // Pick Polish (endonym shown in the picker) and save. The page is currently
+    // in German (the precondition above), so the Save button reads "Speichern".
+    // Saving persists preferred_admin_locale AND switches the dashboard into
+    // Polish, reloading so every module-load `i18n.t(...)` label re-resolves.
+    await page.locator('#store-admin-locale').click()
+    await page.getByRole('option', { name: /polski/i }).click()
+    await page.getByRole('button', { name: /^speichern$/i }).click()
+
+    // Whole UI re-renders in Polish: the "Standards and formats" card title →
+    // "Standardy i formaty", and the nav "Products" → "Produkty" (proves the
+    // switch drives boot-time labels across nav/tables, not just this form).
+    await expect(page.getByText('Standardy i formaty', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByRole('link', { name: /produkty/i })).toBeVisible()
+
+    // The crux: survives a reload. The switch must have been adopted as the
+    // admin's own `selected_locale` (PATCH /me), not just written to
+    // localStorage — otherwise the auth provider reverts to the previously
+    // saved German on the next session bootstrap and the UI bounces back.
+    await page.reload()
+    await expect(page.getByText('Standardy i formaty', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByRole('link', { name: /produkty/i })).toBeVisible()
+
+    // Reset to English so later tests/specs run against English chrome. The
+    // page is now in Polish: the field label is "Język panelu administracyjnego"
+    // and the save button is "Zapisz".
+    await page.locator('#store-admin-locale').click()
+    await page.getByRole('option', { name: /^english$/i }).click()
+    await page.getByRole('button', { name: /^zapisz$/i }).click()
+    await expect(page.getByText('Standards and formats', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+  })
 })
 
 test.describe('store settings — emails', () => {

--- a/packages/dashboard/e2e/store-settings.spec.ts
+++ b/packages/dashboard/e2e/store-settings.spec.ts
@@ -47,6 +47,22 @@ test.describe('store settings — general', () => {
   test('setting the store admin language switches the dashboard UI', async ({ page }) => {
     const creds = await login(page)
 
+    // Normalize the store's admin language to English while the UI is still
+    // English, so the Polish selection below is always a real change regardless
+    // of any value left by a prior run (the suite shares one seeded DB). A
+    // concrete language (not the blank "use default") is used because clearing
+    // the override sends `undefined`, which the backend treats as "unchanged".
+    // Save only when this actually dirties the form.
+    await page.goto(STORE_PATH(creds.store_id))
+    await expect(page.locator('#store-admin-locale')).toBeVisible({ timeout: 15_000 })
+    await page.locator('#store-admin-locale').click()
+    await page.getByRole('option', { name: /^english$/i }).click()
+    const saveEn = page.getByRole('button', { name: /^save$/i })
+    if (await saveEn.isEnabled()) {
+      await saveEn.click()
+      await expect(saveEn).toBeDisabled({ timeout: 15_000 })
+    }
+
     // Precondition: give the admin an explicit personal language that DIFFERS
     // from the one we'll set via store settings. This persists `selected_locale`
     // on the account, which the auth provider treats as the cross-device source
@@ -60,7 +76,10 @@ test.describe('store settings — general', () => {
     await expect(page.locator('#profile-language')).toBeVisible({ timeout: 15_000 })
     await page.locator('#profile-language').click()
     await page.getByRole('option', { name: /^deutsch$/i }).click()
-    await page.getByRole('button', { name: /^save$/i }).click()
+    // Save only if the selection dirtied the form — a prior run may have already
+    // left the account on German, in which case the button stays disabled.
+    const saveProfile = page.getByRole('button', { name: /^(save|speichern)$/i })
+    if (await saveProfile.isEnabled()) await saveProfile.click()
     // Saving a new language reloads into it; the profile heading is now German.
     await expect(page.getByText('Persönliche Daten', { exact: true })).toBeVisible({
       timeout: 15_000,
@@ -94,9 +113,19 @@ test.describe('store settings — general', () => {
       timeout: 15_000,
     })
 
-    // Reset to English so later tests/specs run against English chrome. The
-    // page is now in Polish: the field label is "Język panelu administracyjnego"
-    // and the save button is "Zapisz".
+    // Saving an UNRELATED field (the store name) must NOT touch the admin's UI
+    // language: only an actual change to the admin-locale field switches it.
+    // The UI stays Polish — no surprise reload back to a different language.
+    await page.locator('#store-name').fill(`${creds.store_name} ${Date.now()}`)
+    await page.getByRole('button', { name: /^zapisz$/i }).click()
+    await expect(page.getByText('Standardy i formaty', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Reset to English + restore the store name so later tests/specs run
+    // against clean English chrome. The page is now in Polish: the admin-locale
+    // field and the save button read "Zapisz".
+    await page.locator('#store-name').fill(creds.store_name)
     await page.locator('#store-admin-locale').click()
     await page.getByRole('option', { name: /^english$/i }).click()
     await page.getByRole('button', { name: /^zapisz$/i }).click()

--- a/packages/dashboard/e2e/store-settings.spec.ts
+++ b/packages/dashboard/e2e/store-settings.spec.ts
@@ -93,7 +93,6 @@ test.describe('store settings — general', () => {
     await expect(page.getByText('Standardy i formaty', { exact: true })).toBeVisible({
       timeout: 15_000,
     })
-    await expect(page.getByRole('link', { name: /produkty/i })).toBeVisible()
 
     // Reset to English so later tests/specs run against English chrome. The
     // page is now in Polish: the field label is "Język panelu administracyjnego"

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
@@ -1,6 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { SpreeError, type Store } from '@spree/admin-sdk'
-import { mapSpreeErrorsToForm, PageHeader, useSwitchAdminLocale } from '@spree/dashboard-core'
+import {
+  mapSpreeErrorsToForm,
+  PageHeader,
+  reconcileStoreDefaultLocale,
+  useAuth,
+  useStore,
+  useSwitchAdminLocale,
+} from '@spree/dashboard-core'
 import {
   Card,
   CardContent,
@@ -108,6 +115,8 @@ function StoreSettingsPage() {
 
 function StoreSettingsForm({ store }: { store: Store }) {
   const { t } = useTranslation()
+  const { user } = useAuth()
+  const { storeId } = useStore()
   const updateMutation = useUpdateStoreSettings()
   const switchAdminLocale = useSwitchAdminLocale()
 
@@ -148,11 +157,24 @@ function StoreSettingsForm({ store }: { store: Store }) {
       // switch below reloads the page while the `beforeunload` dirty-guard is
       // still armed, triggering the browser's "unsaved changes" prompt.
       form.reset(values)
-      // Only when the admin language was actually changed: adopt it as this
-      // admin's own UI language and switch the dashboard into it immediately
-      // (same as the profile picker / top-bar). A blank value ("use the
-      // default") is not an active choice, so it doesn't force a switch.
-      if (localeChanged && code) await switchAdminLocale(code)
+      // When the admin language was actually changed:
+      //  - a concrete value → adopt it as this admin's own UI language and switch
+      //    the dashboard into it immediately (same as the profile / top-bar);
+      //  - a blank value ("use the default") → reconcile, so an admin with no
+      //    personal choice who was on this store's auto-applied default reverts
+      //    to the app default instead of being stuck on the old language.
+      if (localeChanged) {
+        if (code) {
+          await switchAdminLocale(code)
+        } else {
+          reconcileStoreDefaultLocale(
+            null,
+            storeId,
+            user?.selected_locale ?? null,
+            getAvailableUiLocales().map((l) => l.code),
+          )
+        }
+      }
     } catch (err) {
       if (mapSpreeErrorsToForm(err, form.setError)) return
       if (err instanceof SpreeError) throw err

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
@@ -129,6 +129,12 @@ function StoreSettingsForm({ store }: { store: Store }) {
   }, [unitSystem, form])
 
   const onSubmit = async (values: StoreSettingsFormValues) => {
+    // Whether the admin language was changed in THIS save — compared against the
+    // store's currently-persisted value, not RHF's `dirtyFields` (which a Base UI
+    // Select via Controller doesn't reliably populate). Saving unrelated fields
+    // (name, timezone, units) must not touch the admin's UI language.
+    const code = values.preferred_admin_locale
+    const localeChanged = (code ?? '') !== (store.preferred_admin_locale ?? '')
     try {
       await updateMutation.mutateAsync({
         name: values.name,
@@ -142,12 +148,11 @@ function StoreSettingsForm({ store }: { store: Store }) {
       // switch below reloads the page while the `beforeunload` dirty-guard is
       // still armed, triggering the browser's "unsaved changes" prompt.
       form.reset(values)
-      // Setting the store's admin language adopts it as this admin's own UI
-      // language and switches the dashboard into it immediately (same as the
-      // profile picker / top-bar). A blank value ("use the default") is not an
-      // active choice, so it doesn't force a switch.
-      const code = values.preferred_admin_locale
-      if (code) await switchAdminLocale(code)
+      // Only when the admin language was actually changed: adopt it as this
+      // admin's own UI language and switch the dashboard into it immediately
+      // (same as the profile picker / top-bar). A blank value ("use the
+      // default") is not an active choice, so it doesn't force a switch.
+      if (localeChanged && code) await switchAdminLocale(code)
     } catch (err) {
       if (mapSpreeErrorsToForm(err, form.setError)) return
       if (err instanceof SpreeError) throw err

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
@@ -1,6 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { SpreeError, type Store } from '@spree/admin-sdk'
-import { mapSpreeErrorsToForm, PageHeader } from '@spree/dashboard-core'
+import {
+  i18n,
+  mapSpreeErrorsToForm,
+  PageHeader,
+  switchLocale,
+  useAuth,
+} from '@spree/dashboard-core'
 import {
   Card,
   CardContent,
@@ -33,9 +39,10 @@ import {
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { useUpdateProfile } from '@/hooks/use-profile'
 import { useStoreSettings, useUpdateStoreSettings } from '@/hooks/use-store-settings'
+import { getAvailableUiLocales } from '@/i18n-setup'
 import {
-  ADMIN_LOCALE_OPTIONS,
   type StoreSettingsFormValues,
   storeSettingsFormSchema,
   UNIT_SYSTEMS,
@@ -108,7 +115,9 @@ function StoreSettingsPage() {
 
 function StoreSettingsForm({ store }: { store: Store }) {
   const { t } = useTranslation()
+  const { updateUser } = useAuth()
   const updateMutation = useUpdateStoreSettings()
+  const updateProfileMutation = useUpdateProfile()
 
   const form = useForm<StoreSettingsFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,7 +146,31 @@ function StoreSettingsForm({ store }: { store: Store }) {
         preferred_weight_unit: values.preferred_weight_unit,
       })
       toast.success(t('admin.messages.store_settings_updated'))
+      // Reset FIRST so the form is no longer dirty — otherwise the language
+      // switch below reloads the page while the `beforeunload` dirty-guard is
+      // still armed, triggering the browser's "unsaved changes" prompt.
       form.reset(values)
+      // Setting the store's admin language switches the dashboard into it
+      // immediately (mirrors the profile picker). A blank value ("use the
+      // default") is not an active choice, so it doesn't force a switch.
+      const code = values.preferred_admin_locale
+      if (code && code !== i18n.language) {
+        // Persist the choice to the ACCOUNT (PATCH /me), not just localStorage:
+        // the auth provider treats the account's `selected_locale` as the
+        // source of truth and would revert a localStorage-only switch on the
+        // next session bootstrap. Adopt the store-wide language as this admin's
+        // own, then `switchLocale` reloads so every module-load `i18n.t(...)`
+        // label re-resolves in the new language. Only switch on success — a
+        // failed PATCH would desync localStorage from the server and bounce the
+        // locale back.
+        try {
+          const updated = await updateProfileMutation.mutateAsync({ selected_locale: code })
+          updateUser(updated.user)
+          switchLocale(code)
+        } catch {
+          toast.error(t('admin.account.language.update_failed'))
+        }
+      }
     } catch (err) {
       if (mapSpreeErrorsToForm(err, form.setError)) return
       if (err instanceof SpreeError) throw err
@@ -161,6 +194,18 @@ function StoreSettingsForm({ store }: { store: Store }) {
         label: t(`admin.store.weight_units.${value}`),
       })),
     [t, unitSystem],
+  )
+  // Admin-UI language options come from the dashboard's own shipped locale
+  // bundles (getAvailableUiLocales) — the SAME canonical source the profile
+  // picker and top-bar switcher use, so the lists never desync. The leading
+  // empty option clears the store-wide override (preferred_admin_locale is
+  // nullable → "no override, fall back to the app default").
+  const adminLocaleOptions = useMemo(
+    () => [
+      { value: '', label: t('admin.fields.store.preferred_admin_locale.placeholder') },
+      ...getAvailableUiLocales().map((l) => ({ value: l.code, label: l.name })),
+    ],
+    [t],
   )
 
   const { errors } = form.formState
@@ -215,7 +260,7 @@ function StoreSettingsForm({ store }: { store: Store }) {
                     placeholder={t('admin.fields.store.preferred_admin_locale.placeholder')}
                     name="preferred_admin_locale"
                     control={form.control}
-                    options={ADMIN_LOCALE_OPTIONS}
+                    options={adminLocaleOptions}
                   />
                   <SelectField
                     id="store-timezone"

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/store.tsx
@@ -1,12 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { SpreeError, type Store } from '@spree/admin-sdk'
-import {
-  i18n,
-  mapSpreeErrorsToForm,
-  PageHeader,
-  switchLocale,
-  useAuth,
-} from '@spree/dashboard-core'
+import { mapSpreeErrorsToForm, PageHeader, useSwitchAdminLocale } from '@spree/dashboard-core'
 import {
   Card,
   CardContent,
@@ -39,7 +33,6 @@ import {
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { useUpdateProfile } from '@/hooks/use-profile'
 import { useStoreSettings, useUpdateStoreSettings } from '@/hooks/use-store-settings'
 import { getAvailableUiLocales } from '@/i18n-setup'
 import {
@@ -115,9 +108,8 @@ function StoreSettingsPage() {
 
 function StoreSettingsForm({ store }: { store: Store }) {
   const { t } = useTranslation()
-  const { updateUser } = useAuth()
   const updateMutation = useUpdateStoreSettings()
-  const updateProfileMutation = useUpdateProfile()
+  const switchAdminLocale = useSwitchAdminLocale()
 
   const form = useForm<StoreSettingsFormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -150,27 +142,12 @@ function StoreSettingsForm({ store }: { store: Store }) {
       // switch below reloads the page while the `beforeunload` dirty-guard is
       // still armed, triggering the browser's "unsaved changes" prompt.
       form.reset(values)
-      // Setting the store's admin language switches the dashboard into it
-      // immediately (mirrors the profile picker). A blank value ("use the
-      // default") is not an active choice, so it doesn't force a switch.
+      // Setting the store's admin language adopts it as this admin's own UI
+      // language and switches the dashboard into it immediately (same as the
+      // profile picker / top-bar). A blank value ("use the default") is not an
+      // active choice, so it doesn't force a switch.
       const code = values.preferred_admin_locale
-      if (code && code !== i18n.language) {
-        // Persist the choice to the ACCOUNT (PATCH /me), not just localStorage:
-        // the auth provider treats the account's `selected_locale` as the
-        // source of truth and would revert a localStorage-only switch on the
-        // next session bootstrap. Adopt the store-wide language as this admin's
-        // own, then `switchLocale` reloads so every module-load `i18n.t(...)`
-        // label re-resolves in the new language. Only switch on success — a
-        // failed PATCH would desync localStorage from the server and bounce the
-        // locale back.
-        try {
-          const updated = await updateProfileMutation.mutateAsync({ selected_locale: code })
-          updateUser(updated.user)
-          switchLocale(code)
-        } catch {
-          toast.error(t('admin.account.language.update_failed'))
-        }
-      }
+      if (code) await switchAdminLocale(code)
     } catch (err) {
       if (mapSpreeErrorsToForm(err, form.setError)) return
       if (err instanceof SpreeError) throw err

--- a/packages/dashboard/src/schemas/store.ts
+++ b/packages/dashboard/src/schemas/store.ts
@@ -20,16 +20,3 @@ export const storeSettingsFormSchema = z.object({
 })
 
 export type StoreSettingsFormValues = z.infer<typeof storeSettingsFormSchema>
-
-export const ADMIN_LOCALE_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'en', label: 'English' },
-  { value: 'fr', label: 'Français' },
-  { value: 'de', label: 'Deutsch' },
-  { value: 'es', label: 'Español' },
-  { value: 'it', label: 'Italiano' },
-  { value: 'pt-BR', label: 'Português (Brasil)' },
-  { value: 'pl', label: 'Polski' },
-  { value: 'nl', label: 'Nederlands' },
-  { value: 'ja', label: '日本語' },
-  { value: 'zh-CN', label: '中文 (简体)' },
-]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes account locale persistence, i18n localStorage, and store-load reload behavior—user-facing session/bootstrap paths—but logic is centralized and covered by new E2E tests.
> 
> **Overview**
> Fixes **store admin language** in the React dashboard so changing `preferred_admin_locale` actually switches the UI, survives reload, and does not fire when saving unrelated store fields.
> 
> Introduces **`useSwitchAdminLocale`** so top-bar, profile, and store settings all **PATCH `/me` `selected_locale`**, update auth context, then reload or **`markGenuineLocaleChoice`**—fixing localStorage-only switches that auth reverts on bootstrap. **`reconcileStoreDefaultLocale`** and an auto-applied store marker implement precedence: account locale → explicit choice → store default → `en`, with legacy Rails-style behavior when entering a store.
> 
> **`StoreProvider`** runs a one-shot store-default reconcile on first load per store (not on refetch), with stale-fetch guards. Store settings builds locale options from **`getAvailableUiLocales`** (replacing a static list) and clears override via an empty option. E2E covers Polish UI, reload persistence over a conflicting account locale, and no language change on name-only save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1a3ce84eea7ec1ecefa67191ee5f893725a159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store-level admin language selection now persists across reloads and correctly falls back to a default when no stored choice exists.
  * The store-wide admin language override can be cleared to remove the override.

* **Improvements**
  * Switching store/account admin language updates the dashboard UI immediately and uses dynamically generated locale options.
  * The admin locale switch flow is centralized for consistent persistence and error handling.

* **Tests**
  * Added end-to-end coverage for changing the store admin language, verifying UI-wide updates, persistence after reload, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->