### PR TITLE
Improve multi tenant documentation

### DIFF
--- a/docs/developer/admin/extending-ui.mdx
+++ b/docs/developer/admin/extending-ui.mdx
@@ -553,32 +553,6 @@ Here's a list of all places you can inject your custom code:
   </Accordion>
 </AccordionGroup>
 
-### Custom Domains
-
-<AccordionGroup>
-  <Accordion title="Custom Domains Actions">
-    `custom_domains_actions`
-
-    Injects code into the page actions area for the custom domains list page.
-
-    ```erb
-    <%= link_to "Verify All Domains", verify_all_domains_path, class: "btn btn-secondary" %>
-    ```
-  </Accordion>
-
-  <Accordion title="Custom Domains Header">
-    `custom_domains_header`
-
-    Injects code between the page header and the main content area for the custom domains list page.
-
-    ```erb
-    <div class="alert alert-info">
-      <strong>SSL:</strong> SSL certificates are automatically managed.
-    </div>
-    ```
-  </Accordion>
-</AccordionGroup>
-
 ### Customer Returns
 
 <AccordionGroup>

--- a/docs/developer/core-concepts/stores.mdx
+++ b/docs/developer/core-concepts/stores.mdx
@@ -5,9 +5,7 @@ description: Understand Spree Stores — the top-level tenant boundary that scop
 
 ## Overview
 
-The Store is the top-level tenant in Spree. Every resource — products, orders, channels, markets, taxonomies — belongs to exactly one store. A store owns its branding (logo, custom domain, mail-from address), its [channels](/developer/core-concepts/channels) (online, POS, wholesale, …), its [markets](/developer/core-concepts/markets) (region/currency/locale), and its catalog.
-
-## Store Attributes
+The StThe Store is the top-level tenant in Spree. Every resource — products, orders, channels, markets, taxonomies — belongs to exactly one store. A store owns its [channels](/developer/core-concepts/channels) (online, POS, wholesale, …), its [markets](/developer/core-concepts/markets) (region/currency/locale), and its [product catalog](/developer/core-concepts/products).tore Attributes
 
 | Attribute | Description |
 |-----------|-------------|

--- a/docs/developer/multi-tenant/configuration.mdx
+++ b/docs/developer/multi-tenant/configuration.mdx
@@ -5,16 +5,6 @@ sidebarTitle: Configuration
 
 Multi-tenant applications include additional configuration options. All configuration should be placed in `config/initializers/spree_multi_tenant.rb` file.
 
-### Root domain
-
-To make multi-tenant, you need a root/wildcard domain, eg. `*.example.com`. Tenant stores are usually accessed via subdomains, eg. `store1.example.com`, `store2.example.com`, etc.
-
-```bash
-Spree.root_domain = 'example.com'
-```
-
-Still your tenants will be able to add custom domains, eg. `myflowerstore.com` via the Spree admin panel. Tenant subdomains are used only for admin panel access.
-
 ### App subdomain
 
 Application subdomains is used to access the application, eg. `app.example.com`. By default for existing tenants it will redirect them to their tenant subdomain, eg. `store1.example.com`. If you want, you can also use this as a tenant signup/store setup page, this is available under `app.example.com/tenants/new`.

--- a/docs/developer/multi-tenant/quickstart.mdx
+++ b/docs/developer/multi-tenant/quickstart.mdx
@@ -1,88 +1,36 @@
 ---
-title: Spree Multi Tenant Installation
-sidebarTitle: Installation
-description: Install and configure Spree Multi-Tenant to run a SaaS ecommerce platform, including prerequisites, gem setup, license keys, and tenant provisioning.
+title: Create a multi-tenant / SaaS platform on top of Spree
+sidebarTitle: Quickstart
+description: Configure Spree to run a SaaS ecommerce platform, including prerequisites, gem setup, license keys, and tenant provisioning.
 ---
 
-<Warning>
-  This installation instructions assume you have a clean Spree Starter installation and you've purchased the [Spree Enterprise Edition license](https://spreecommerce.org/pricing).
-  
-  For migrating existing application from single-tenant to multi-tenant, please contact us at [support@spreecommerce.org](mailto:support@spreecommerce.org).
-</Warning>
+<Info>
+  Multi-tenancy requires [Spree Enterprise Edition license](https://spreecommerce.org/pricing).
+</Info>
+
+Spree can be configured to run a multi-tenant / SaaS platform. This guide will walk you through the steps to set up your Spree application to support multiple tenants (stores). 
+Each tenant (store) can have it's own isolated data and configuration, including:
+
+* customer accounts
+* staff accounts (admin users), staff can manage multiple tenants (it's the standard invitation flow)
+* products, categories, and other catalog data
+* orders and order history
+* shipping and payment methods
+* tax rates and zones
+* store settings (name, logo, etc.)
+* etc.
 
 ## Prerequisites
 
-* You need to be on Spree 5.1+, we recommend using [spree_starter](https://github.com/spree/spree_starter) as a base for your application
-* You need to have 2 environment variables set:
+* You need to be on Spree 5.1+, we recommend using [CLI](/developer/getting-started) to setup your Spree application.
+* You need to set 2 environment variables in your `backend` directory:
   * `KEYGEN_ACCOUNT_ID`
   * `KEYGEN_LICENSE_KEY`
-* We support both PostgreSQL and MySQL databases
+* Both PostgreSQL and MySQL are supported
 
 <Info>
-  Environment variables will be provided to you after purchasing the [Spree Enterprise Edition license](https://spreecommerce.org/pricing).
+  You will need to add these environment variables to your CI/CD pipeline and staging/production environments.
 </Info>
-
-<Warning>
-  You will need to add these environment variables to your CI/CD pipeline and production environments.
-</Warning>
-
-## Customer User Class
-
-Please follow [Authentication](/developer/customization/authentication) documentation to create a new user class.
-
-Now we will need to make slight adjustments to the generated user class so it can work in a multi-tenant environment.
-
-If you're using Devise, you will need to remove `:validatable` module. This module is responsible for validating the user's email uniqueness. We need to change it to validate it in the scope of the tenant.
-
-Spree Multi-Tenant gem injects `SpreeMultiTenant::CustomerUserConcern` that handles that instead.
-
-## Admin User Class
-
-For our multi-tenant setup we will need a separate Admin user class. Our standard User class will be only used for customer accounts which will be isolated by tenant. 
-Admin user classes will be shared across tenants allowing them to manage multiple tenants from a single admin panel.
-
-Let's create a new model with Devise (unless you already have one):
-
-<CodeGroup>
-
-```bash Spree CLI (Docker)
-spree rails g devise Spree::AdminUser
-```
-
-```bash Without Spree CLI
-bin/rails g devise Spree::AdminUser
-```
-
-</CodeGroup>
-
-Replace the generated Devise code with the following:
-
-```ruby
-class Spree::AdminUser < Spree::Base
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-        :recoverable, :rememberable, :validatable
-
-  # Spree modules
-  include Spree::UserMethods
-end
-```
-
-If you already have a custom Admin user class, you can add the following code to it:
-
-```ruby
-  # Spree modules
-  include Spree::UserMethods
-```
-
-This will make sure that the Admin user class works well with Spree ecosystem.
-
-Register new model in `config/initializers/spree.rb`:
-
-```ruby
-Spree.admin_user_class = "Spree::AdminUser"
-```
 
 ## Installing gems
 
@@ -126,3 +74,37 @@ Spree.admin_user_class = "Spree::AdminUser"
     <Info>
       This will copy and run migrations for `spree_enterprise` and `spree_multi_tenant` gems.
     </Info>
+
+
+## Setting root domain
+
+Usuaully multi-tenant applications are configured to use subdomains for each tenant. For example, if your root domain is `example.com`, you can have tenants like `tenant1.example.com`, `tenant2.example.com`, etc.
+To make it work you need to set the `Spree.root_domain` in your `config/initializers/spree.rb` file, eg.
+
+```ruby
+Spree.root_domain = 'example.com'
+```
+
+or use environment variable:
+
+```ruby
+Spree.root_domain = ENV.fetch('SPREE_ROOT_DOMAIN', 'localhost')
+```
+
+This way you can also test it locally using `localhost` as root domain, and use `tenant1.localhost`, `tenant2.localhost`, etc. for tenants.
+
+## Customer User Class adjustment
+
+We need to make slight adjustments to the user class so it can work in a multi-tenant environment.
+
+You need to remove `:validatable` module. This module is responsible for validating the user's email uniqueness. We need to change it to validate it in the scope of the tenant.
+
+```ruby backend/app/models/spree/user.rb
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable, :validatable # [!code --]
+  devise :database_authenticatable, :registerable, # [!code ++]
+         :recoverable, :rememberable, :trackable, :confirmable
+
+  include SpreeMultiTenant::CustomerUserConcern # [!code ++]
+end
+```

--- a/docs/developer/multi-tenant/quickstart.mdx
+++ b/docs/developer/multi-tenant/quickstart.mdx
@@ -9,7 +9,7 @@ description: Configure Spree to run a SaaS ecommerce platform, including prerequ
 </Info>
 
 Spree can be configured to run a multi-tenant / SaaS platform. This guide will walk you through the steps to set up your Spree application to support multiple tenants (stores). 
-Each tenant (store) can have it's own isolated data and configuration, including:
+Each tenant (store) can have its own isolated data and configuration, including:
 
 * customer accounts
 * staff accounts (admin users), staff can manage multiple tenants (it's the standard invitation flow)
@@ -19,6 +19,12 @@ Each tenant (store) can have it's own isolated data and configuration, including
 * tax rates and zones
 * store settings (name, logo, etc.)
 * etc.
+
+All data is fully isolated besided the staff users, which can manage multiple tenants. This allows you to create a SaaS platform where each tenant can have its own store with its own branding and configuration. Isolation works across admin dashboard and API.
+
+<Info>
+  If you need individual seller/supplier/vendor accounts but shared product listings under one site you should use [multi vendor recipe](/developer/multi-vendor) instead.
+</Info>
 
 ## Prerequisites
 
@@ -78,7 +84,7 @@ Each tenant (store) can have it's own isolated data and configuration, including
 
 ## Setting root domain
 
-Usuaully multi-tenant applications are configured to use subdomains for each tenant. For example, if your root domain is `example.com`, you can have tenants like `tenant1.example.com`, `tenant2.example.com`, etc.
+Usually multi-tenant applications are configured to use subdomains for each tenant. For example, if your root domain is `example.com`, you can have tenants like `tenant1.example.com`, `tenant2.example.com`, etc.
 To make it work you need to set the `Spree.root_domain` in your `config/initializers/spree.rb` file, eg.
 
 ```ruby

--- a/docs/user/settings/metafields.mdx
+++ b/docs/user/settings/metafields.mdx
@@ -40,7 +40,6 @@ You can define metafields for nearly any data object in Spree:
 - **Address** - e.g., delivery instructions
 - **Asset** - e.g., alt text or copyright
 - **Credit Card** - e.g., vault token
-- **Custom Domain** - e.g., domain verification token
 - **Customer Return** - e.g., return reason detail
 - **Gift Card** - e.g., personal message
 - **Image** - e.g., display priority or alt tag


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to MDX documentation with no runtime or security impact; the only caveat is the accidental typo in `stores.mdx` that could confuse readers.
> 
> **Overview**
> **Documentation-only** updates to align multi-tenant guidance and remove outdated custom-domain material from several pages.
> 
> The **multi-tenant quickstart** is reframed as a SaaS quickstart: clearer tenant isolation overview, a link to multi-vendor when that pattern fits better, slimmer prerequisites (env vars in `backend`, CLI link), and **new sections** for `Spree.root_domain` (including local `tenant1.localhost` testing) plus tenant-scoped customer Devise setup via `SpreeMultiTenant::CustomerUserConcern` (with a before/after snippet). The long **Admin user class** setup block is **removed** from this page.
> 
> **Multi-tenant configuration** drops the standalone **Root domain** section (that content moves to the quickstart); the emails `<Info>` block is fixed so it closes properly.
> 
> **Stores** overview copy is tightened: branding/custom-domain wording is removed in favor of links to channels, markets, and the product catalog—but the edit **corrupts** the overview line (merged “Store Attributes” heading text; worth fixing before merge).
> 
> **Admin extending UI** loses the **Custom Domains** injection-point accordion; **metafields** no longer lists **Custom Domain** as a supported resource.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40de305d7735718df0e33390a193879c90bcc2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined multi-tenant configuration and quickstart content by removing outdated “root domain” guidance and tightening email-related notes.
  * Reworked the multi-tenant quickstart to emphasize required environment variables and CI/CD-ready setup.
  * Added a “Setting root domain” section and updated tenant-scoped customer email validation example.
  * Refreshed store core-concepts wording and improved terminology links.
  * Removed outdated “custom domain” references from admin injection points and metafield supported resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->