### PR TITLE
Fix: rails admin shouldnt change mobility locale when admin_locale is…

### DIFF
--- a/spree/admin/app/controllers/concerns/spree/admin/locale_concern.rb
+++ b/spree/admin/app/controllers/concerns/spree/admin/locale_concern.rb
@@ -22,10 +22,27 @@ module Spree
 
       private
 
+      # The store's content locale — the language record content (product names,
+      # etc.) is authored in — independent of the chosen admin UI language.
+      def content_locale
+        (defined?(current_store) && current_store&.default_locale.presence) || I18n.default_locale
+      end
+
       # Read all record content in the store's content locale, independent of
       # the chosen UI language.
       def pin_content_locale!
-        Mobility.locale = (defined?(current_store) && current_store&.default_locale.presence) || I18n.default_locale
+        Mobility.locale = content_locale
+      end
+
+      # Keep `I18n.default_locale` on the store's content locale so it matches
+      # `Mobility.locale` (set by `pin_content_locale!`). The admin overrides
+      # `default_locale` to return the UI language, which the inherited
+      # `set_locale` leaks into the process-global `I18n.default_locale`. When it
+      # diverges from `Mobility.locale`, Mobility's `column_fallback` JOINs the
+      # translations table instead of reading the base column, breaking the
+      # admin's ordered + `DISTINCT` listings.
+      def align_i18n_default_locale_to_content!
+        I18n.default_locale = content_locale
       end
 
       def admin_user_selected_locale

--- a/spree/admin/app/controllers/spree/admin/base_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/base_controller.rb
@@ -86,10 +86,17 @@ module Spree
         @default_locale ||= current_store&.preferred_admin_locale.presence || super
       end
 
-      # Set the UI language (`I18n.locale`, via super) while pinning content
-      # reads to the store's locale — see Spree::Admin::LocaleConcern.
+      # Set the UI language (`I18n.locale`, via super) while keeping content
+      # reads on the store's locale — see Spree::Admin::LocaleConcern.
+      #
+      # `super` derives `I18n.default_locale` from the overridden `default_locale`
+      # (the admin UI language), but `I18n.default_locale` must track the store's
+      # *content* locale so it matches `Mobility.locale`; otherwise Mobility JOINs
+      # the translations table instead of the base column and ordered + `DISTINCT`
+      # listings raise. Re-align it immediately after `super`.
       def set_locale
         super
+        align_i18n_default_locale_to_content!
         pin_content_locale!
       end
 

--- a/spree/admin/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/base_controller_spec.rb
@@ -35,9 +35,17 @@ describe Spree::Admin::BaseController, type: :controller do
     context 'when preferred_admin_locale is set' do
       before { allow(store).to receive(:preferred_admin_locale).and_return('de') }
 
-      it 'uses the admin locale' do
+      it 'uses the admin locale for the UI chrome' do
         get :index
-        expect(I18n.default_locale).to eq(:de)
+        expect(I18n.locale).to eq(:de)
+      end
+
+      it 'keeps I18n.default_locale on the content locale, not the admin UI locale' do
+        # `I18n.default_locale` must track the store content locale so it matches
+        # `Mobility.locale`; binding it to the admin UI language desyncs Mobility
+        # and breaks ordered + DISTINCT listings.
+        get :index
+        expect(I18n.default_locale.to_s).to eq(store.default_locale)
       end
     end
 
@@ -56,9 +64,14 @@ describe Spree::Admin::BaseController, type: :controller do
         allow(store).to receive(:default_locale).and_return('fr')
       end
 
-      it 'uses admin locale instead of market locale' do
+      it 'uses the admin locale for the UI chrome' do
         get :index
-        expect(I18n.default_locale).to eq(:en)
+        expect(I18n.locale).to eq(:en)
+      end
+
+      it 'keeps I18n.default_locale on the market/content locale' do
+        get :index
+        expect(I18n.default_locale).to eq(:fr)
       end
     end
   end
@@ -128,18 +141,20 @@ describe Spree::Admin::BaseController, type: :controller do
 
     around do |example|
       original_i18n = I18n.locale
+      original_default = I18n.default_locale
       original_mobility = Mobility.locale
       example.run
     ensure
       I18n.locale = original_i18n
+      I18n.default_locale = original_default
       Mobility.locale = original_mobility
     end
 
     before do
       allow(controller).to receive(:current_store).and_return(store)
       # Store content locale (fr) is deliberately distinct from both the chosen
-      # UI locale (de) and the app default (en), so only the explicit Mobility
-      # pin can produce it — guarding against a coincidental pass.
+      # UI locale (de) and the app default (en), so each assertion pins down a
+      # specific locale rather than passing by coincidence.
       allow(store).to receive_messages(preferred_admin_locale: 'en', default_locale: 'fr')
       allow(Spree).to receive(:available_locales).and_return(%i[en de fr])
       allow(controller).to receive(:admin_user_selected_locale).and_return('de')
@@ -153,6 +168,15 @@ describe Spree::Admin::BaseController, type: :controller do
     it "pins the content locale (Mobility) to the store's content locale, not the UI locale" do
       get :index
       expect(Mobility.locale).to eq(:fr)
+    end
+
+    it 'keeps I18n.default_locale aligned with Mobility (the content locale)' do
+      # Mobility's column_fallback reads the base column only when the locale
+      # equals I18n.default_locale; if they diverge, translated listings JOIN the
+      # translations table and ordered + DISTINCT queries raise.
+      get :index
+      expect(I18n.default_locale).to eq(:fr)
+      expect(I18n.default_locale).to eq(Mobility.locale)
     end
   end
 

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -110,13 +110,11 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         Mobility.locale = original_mobility
       end
 
-      let!(:translated_product) do
-        create(:product, name: 'English Name').tap do |product|
-          product.translations.create!(locale: 'de', name: 'Deutscher Name')
-        end
-      end
+      let!(:translated_product) { create(:product, name: 'English Name') }
 
       before do
+        create(:product_translation, translated_model: translated_product, locale: 'de', name: 'Deutscher Name')
+
         allow(controller).to receive(:current_store).and_return(store)
         allow(store).to receive_messages(preferred_admin_locale: 'de', default_locale: 'en')
         allow(Spree).to receive(:available_locales).and_return(%i[en de])

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -88,6 +88,52 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
       end
     end
 
+    # Regression: a store whose admin UI language (`preferred_admin_locale`)
+    # differs from its content locale. The admin keeps the UI chrome on
+    # `I18n.locale` but must keep `I18n.default_locale` aligned with the content
+    # locale (and `Mobility.locale`). If `I18n.default_locale` is left on the UI
+    # language, Mobility's `column_fallback` JOINs the translations table for the
+    # ordered `name` column, and the listing's `SELECT DISTINCT` raises
+    # PG::InvalidColumnReference ("ORDER BY expressions must appear in select
+    # list"). Mirrors production: content locale `en`, admin UI locale German.
+    context 'when the store admin UI locale differs from the content locale' do
+      render_views
+
+      around do |example|
+        original_default = I18n.default_locale
+        original_locale = I18n.locale
+        original_mobility = Mobility.locale
+        example.run
+      ensure
+        I18n.default_locale = original_default
+        I18n.locale = original_locale
+        Mobility.locale = original_mobility
+      end
+
+      let!(:translated_product) do
+        create(:product, name: 'English Name').tap do |product|
+          product.translations.create!(locale: 'de', name: 'Deutscher Name')
+        end
+      end
+
+      before do
+        allow(controller).to receive(:current_store).and_return(store)
+        allow(store).to receive_messages(preferred_admin_locale: 'de', default_locale: 'en')
+        allow(Spree).to receive(:available_locales).and_return(%i[en de])
+      end
+
+      it 'renders the ordered, distinct products listing without a SQL error' do
+        expect { get :index }.not_to raise_error
+        expect(response).to be_successful
+        expect(assigns[:collection]).to include(translated_product)
+        # UI chrome follows the admin language; content default + Mobility stay on
+        # the store content locale and aligned, so reads use the column path.
+        expect(I18n.locale).to eq(:de)
+        expect(I18n.default_locale).to eq(:en)
+        expect(Mobility.locale).to eq(:en)
+      end
+    end
+
     describe 'sorting by price' do
       let!(:product_cheap) { create(:product, name: 'Cheap Product') }
       let!(:product_expensive) { create(:product, name: 'Expensive Product') }


### PR DESCRIPTION
… set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global I18n.default_locale on every admin request; behavior is intentional but could affect code that assumed default_locale tracked the admin UI language.
> 
> **Overview**
> Fixes admin breakage when **preferred admin UI language** differs from the store **content locale** (e.g. German chrome, English catalog).
> 
> After `set_locale` runs, inherited logic was setting process-global `I18n.default_locale` from the admin-overridden `default_locale` (UI language) while `Mobility.locale` stayed on the store content locale. That mismatch made Mobility `column_fallback` JOIN translations for ordered fields, which broke **ordered + `DISTINCT`** listings (notably admin products index) with `PG::InvalidColumnReference`.
> 
> The PR introduces `content_locale` / `align_i18n_default_locale_to_content!`, calls realignment right after `super` in `set_locale`, and refines specs plus a products index regression when UI locale is `de` and content locale is `en`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a81e02689a7cf19d528edd91942c075e7367db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin pages now correctly separate the UI interface language from the store content language, preventing locale mismatches in listings.
  * Fixed admin product index behavior when the admin UI locale differs from the store’s content locale, avoiding translation-related errors.
  * `I18n.default_locale` is kept aligned with the store content locale to match translation behavior reliably across admin actions.
* **Tests**
  * Added/updated controller coverage to prevent regressions for mixed UI vs content locale scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->