### PR TITLE
Fix product status dropdown showing raw i18n key for Active

### DIFF
--- a/packages/dashboard/src/components/spree/products/product-form-cards.tsx
+++ b/packages/dashboard/src/components/spree/products/product-form-cards.tsx
@@ -596,6 +596,11 @@ export function SEOCard({ form, product }: FormCardProps & { product?: Product }
 
 export function StatusCard({ form }: FormCardProps) {
   const { t } = useTranslation()
+  const statusItems = [
+    { value: 'draft', label: t('admin.pages.products.status_options.draft') },
+    { value: 'active', label: t('admin.pages.products.status_options.active') },
+    { value: 'archived', label: t('admin.pages.products.status_options.archived') },
+  ]
   return (
     <Card>
       <CardHeader>
@@ -608,20 +613,20 @@ export function StatusCard({ form }: FormCardProps) {
             name="status"
             control={form.control}
             render={({ field }) => (
-              <Select value={field.value} onValueChange={field.onChange}>
+              <Select
+                items={statusItems as never}
+                value={field.value}
+                onValueChange={field.onChange}
+              >
                 <SelectTrigger className="w-full">
-                  <SelectValue>
-                    {(v) => t(`admin.pages.products.status_options.${v as string}`)}
-                  </SelectValue>
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="draft">
-                    {t('admin.pages.products.status_options.draft')}
-                  </SelectItem>
-                  <SelectItem value="active">{t('admin.fields.active.label')}</SelectItem>
-                  <SelectItem value="archived">
-                    {t('admin.pages.products.status_options.archived')}
-                  </SelectItem>
+                  {statusItems.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             )}

--- a/packages/dashboard/src/locales/ar.json
+++ b/packages/dashboard/src/locales/ar.json
@@ -1231,6 +1231,7 @@
         "variants_empty": "لا توجد متغيرات حتى الآن.",
         "status_options": {
           "draft": "مسودة",
+          "active": "نشط",
           "archived": "مؤرشف"
         },
         "inventory": {

--- a/packages/dashboard/src/locales/de.json
+++ b/packages/dashboard/src/locales/de.json
@@ -1183,6 +1183,7 @@
         "variants_empty": "Noch keine Varianten.",
         "status_options": {
           "draft": "Entwurf",
+          "active": "Aktiv",
           "archived": "Archiviert"
         },
         "inventory": {

--- a/packages/dashboard/src/locales/en.json
+++ b/packages/dashboard/src/locales/en.json
@@ -1231,6 +1231,7 @@
         "variants_empty": "No variants yet.",
         "status_options": {
           "draft": "Draft",
+          "active": "Active",
           "archived": "Archived"
         },
         "inventory": {

--- a/packages/dashboard/src/locales/fr.json
+++ b/packages/dashboard/src/locales/fr.json
@@ -1183,6 +1183,7 @@
         "variants_empty": "Aucune variante pour le moment.",
         "status_options": {
           "draft": "Brouillon",
+          "active": "Actif",
           "archived": "Archivé"
         },
         "inventory": {

--- a/packages/dashboard/src/locales/pl.json
+++ b/packages/dashboard/src/locales/pl.json
@@ -1183,6 +1183,7 @@
         "variants_empty": "Brak wariantów.",
         "status_options": {
           "draft": "Wersja robocza",
+          "active": "Aktywne",
           "archived": "Zarchiwizowany"
         },
         "inventory": {

--- a/packages/dashboard/src/locales/zh-CN.json
+++ b/packages/dashboard/src/locales/zh-CN.json
@@ -1231,6 +1231,7 @@
         "variants_empty": "暂无变体。",
         "status_options": {
           "draft": "草稿",
+          "active": "启用",
           "archived": "已归档"
         },
         "inventory": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the product status dropdown on the product edit page showing `admin.pages.products.status_options.active` instead of "Active" when a product is active.

## Root cause

Two issues combined:

1. `admin.pages.products.status_options.active` was missing from locale files (only `draft` and `archived` existed).
2. The `SelectValue` render-prop tried to translate `status_options.${value}` for all values, but Base UI's `Select` does not reliably resolve labels from `SelectItem` children without the `items` prop.

## Fix

- Add `active` to `admin.pages.products.status_options` in all dashboard locale files.
- Update `StatusCard` to use the `items` prop pattern (same as option-type kind select and other dropdowns), so the trigger label resolves correctly.

## Test plan

- [ ] Open an active product in the admin SPA (`/products/:id`).
- [ ] Confirm the status dropdown trigger shows "Active" (not a raw i18n key).
- [ ] Open the dropdown and confirm Draft / Active / Archived labels are correct.
- [ ] Switch status and save; confirm the selected label updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff3a7bc8-ce07-4695-9be8-4c654c09258d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff3a7bc8-ce07-4695-9be8-4c654c09258d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the missing “Active” status label for products in multiple languages, including English, German, French, Polish, Arabic, and Chinese.
  * Improved the product status selector so all status options display consistently in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->