### PR TITLE
Add warning on shipping rates deletion

### DIFF
--- a/spree/api/spec/controllers/spree/api/v3/store/carts_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts_controller_spec.rb
@@ -486,6 +486,24 @@ RSpec.describe Spree::Api::V3::Store::CartsController, type: :controller do
         expect(json_response['fulfillments']).to be_present
       end
 
+      it 'surfaces a delivery_unavailable warning when the cart cannot be delivered' do
+        address = create(:address, user: user, country: country, state: us_state)
+        cart.update!(email: 'customer@example.com', ship_address: address)
+        cart.shipments.delete_all
+        cart.update_column(:state, 'address')
+
+        # Move the products into a shipping category no shipping method serves.
+        unserved_category = create(:shipping_category, name: 'Unserved')
+        cart.line_items.each { |line_item| line_item.variant.product.update!(shipping_category: unserved_category) }
+        cart.reload
+
+        get :show, params: { id: cart.prefixed_id }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['fulfillments']).to be_empty
+        expect(json_response['warnings'].map { |warning| warning['code'] }).to include('delivery_unavailable')
+      end
+
       it 'does not advance when no address is set' do
         cart.update!(ship_address: nil)
         cart.shipments.delete_all
@@ -519,6 +537,27 @@ RSpec.describe Spree::Api::V3::Store::CartsController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       expect(order.reload.ship_address_id).to eq(existing_address.id)
+    end
+
+    context 'when a line item cannot be delivered to the address' do
+      let(:address) { user.addresses.first || create(:address, user: user, country: country, state: us_state) }
+      let(:unserved_category) { create(:shipping_category, name: 'Unserved') }
+
+      before do
+        order.update!(email: 'customer@example.com')
+        order.line_items.each { |line_item| line_item.variant.product.update!(shipping_category: unserved_category) }
+      end
+
+      it 'returns ok with a delivery_unavailable warning, an unmet delivery requirement, and no fulfillments' do
+        patch :update, params: { id: order.prefixed_id, shipping_address_id: address.prefixed_id }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['fulfillments']).to be_empty
+        expect(json_response['warnings'].map { |warning| warning['code'] }).to include('delivery_unavailable')
+        expect(json_response['requirements']).to include(
+          a_hash_including('step' => 'delivery', 'field' => 'shipping_method')
+        )
+      end
     end
 
     context 'updating market' do

--- a/spree/api/spec/controllers/spree/api/v3/store/carts_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts_controller_spec.rb
@@ -502,6 +502,9 @@ RSpec.describe Spree::Api::V3::Store::CartsController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(json_response['fulfillments']).to be_empty
         expect(json_response['warnings'].map { |warning| warning['code'] }).to include('delivery_unavailable')
+        expect(json_response['requirements']).to include(
+          a_hash_including('step' => 'delivery', 'field' => 'shipping_method')
+        )
       end
 
       it 'does not advance when no address is set' do

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -62,17 +62,20 @@ module Spree
       [outstanding_balance - total_applied_store_credit, 0].max
     end
 
-    # Transient warnings populated by remove_out_of_stock_items!
+    # Transient warnings populated by remove_out_of_stock_items! and ensure_available_shipping_rates
     attribute :warnings, default: -> { [] }
 
     # Removes out-of-stock/discontinued items and populates warnings.
     # Returns self (reloaded if items were removed) with warnings set.
+    # Captured before the call because removing items reloads the order, which
+    # would drop warnings already recorded upstream.
     def remove_out_of_stock_items!
+      existing_warnings = warnings
       result = Spree::Cart::RemoveOutOfStockItems.call(order: self)
       return self unless result.success?
 
-      order, _messages, warnings = result.value
-      order.warnings = warnings || []
+      order, _messages, new_warnings = result.value
+      order.warnings = existing_warnings | (new_warnings || [])
       order
     end
 
@@ -1081,8 +1084,17 @@ module Spree
 
         if line_items_without_shipping_rates.present?
           errors.add(:base, Spree.t(:products_cannot_be_shipped, product_names: line_items_without_shipping_rates.map(&:name).to_sentence))
+          self.warnings |= line_items_without_shipping_rates.map do |line_item|
+            {
+              code: 'delivery_unavailable',
+              message: Spree.t('cart_line_item.delivery_unavailable', li_name: line_item.name),
+              line_item_id: line_item.prefixed_id,
+              variant_id: line_item.variant&.prefixed_id
+            }
+          end
         else
           errors.add(:base, Spree.t(:items_cannot_be_shipped))
+          self.warnings |= [{ code: 'delivery_unavailable', message: Spree.t(:items_cannot_be_shipped) }]
         end
 
         false

--- a/spree/core/app/services/spree/carts/update.rb
+++ b/spree/core/app/services/spree/carts/update.rb
@@ -144,11 +144,14 @@ module Spree
       rescue StandardError => e
         Rails.error.report(e, context: { order_id: cart.id, state: cart.state }, source: 'spree.checkout')
       ensure
+        # A halted transition records warnings on the cart, which reload would drop, so carry them across the reload.
+        warnings = cart.warnings
         begin
           cart.reload
         rescue StandardError # rubocop:disable Lint/SuppressedException
           # reload failure must not mask the original result
         end
+        cart.warnings |= warnings if warnings.present?
       end
     end
   end

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -728,6 +728,7 @@ en:
     cart: Cart
     cart_already_updated: The cart has already been updated.
     cart_line_item:
+      delivery_unavailable: "%{li_name} cannot be delivered to the selected address"
       discontinued: "%{li_name} was removed because it was discontinued"
       out_of_stock: "%{li_name} was removed because it was sold out"
     categories: Categories

--- a/spree/core/spec/services/spree/carts/update_spec.rb
+++ b/spree/core/spec/services/spree/carts/update_spec.rb
@@ -627,6 +627,32 @@ module Spree
         end
       end
 
+      describe 'when the cart cannot be delivered' do
+        let!(:order) { create(:order_with_line_items, user: user, store: store, state: 'address') }
+        let(:params) { { email: 'buyer@example.com' } }
+        let(:unserved_category) { create(:shipping_category, name: 'Unserved') }
+
+        before do
+          order.line_items.each { |line_item| line_item.variant.product.update!(shipping_category: unserved_category) }
+          order.reload
+        end
+
+        it 'keeps the cart on the address step with no fulfillments' do
+          expect(subject).to be_success
+          expect(order.reload.state).to eq('address')
+          expect(order.shipments).to be_empty
+        end
+
+        it 'surfaces a delivery_unavailable warning for each undeliverable line item' do
+          warnings = subject.value.warnings
+
+          expect(warnings).to be_present
+          expect(warnings).to all(include(code: 'delivery_unavailable'))
+          expect(warnings.map { |warning| warning[:line_item_id] })
+            .to match_array(order.line_items.map(&:prefixed_id))
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches checkout delivery validation and transient warning handling on the order model; behavior change is scoped but affects cart API responses during address/delivery transitions.
> 
> **Overview**
> When checkout cannot produce shipping rates (shipments cleared or line items with no rates), the cart now adds **`delivery_unavailable`** warnings on the order—per line item when specific products cannot ship, or a single generic warning otherwise—alongside existing validation errors.
> 
> **Warning persistence:** `remove_out_of_stock_items!` and `Spree::Carts::Update#try_advance` now **merge** warnings across reloads instead of losing them, so delivery warnings survive auto-advance and out-of-stock cleanup.
> 
> Storefront **v3 cart** `show`/`update` responses are covered by specs: empty fulfillments, `delivery_unavailable` in `warnings`, and an unmet **delivery / shipping_method** requirement. A new locale string supports per–line item messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa41abfd58ade7d945f16fcc363b2f38727f2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new delivery-unavailable warning message for undeliverable cart items to the selected address.
* **Bug Fixes**
  * Improved delivery-unavailable warning/requirement reporting when shipping methods aren’t available for selected items or addresses.
  * Cart/checkout update flows now preserve existing warnings across reloads and when advancing steps.
  * Out-of-stock item removal now merges with any pre-existing order warnings instead of overwriting them.
* **Tests**
  * Extended API and cart update specs to cover undeliverable delivery scenarios and emitted warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->