### PR TITLE
Use default flag instead of code to resolve store's default channel

### DIFF
--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -186,8 +186,13 @@ module Spree
       Spree::Store.default&.supported_locales_list || []
     end
 
+    # Resolves the store's default channel via the +default+ boolean column
+    # so promoting another channel in the admin takes effect immediately.
+    # Falls back to the first active channel only for malformed data with no
+    # flagged default.
+    # @return [Spree::Channel, nil]
     def default_channel
-      channels.find_by(code: Spree::Channel::DEFAULT_CODE) || channels.active.first
+      channels.default.first || channels.active.first
     end
 
     # @deprecated Use Markets instead. Will be removed in Spree 5.5.

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -201,9 +201,20 @@ describe Spree::Store, type: :model, without_global_store: true do
           expect(store.default_channel.code).to eq('online')
         end
 
-        it 'falls back to first active channel when no online channel exists' do
+        it 'follows the default flag, not the code, when another channel is promoted' do
+          pos = store.channels.create!(name: 'POS', code: 'pos', default: true)
+          expect(store.default_channel).to eq(pos)
+          expect(store.channels.find_by(code: 'online')).not_to be_default
+        end
+
+        it 'still resolves the default channel after the online channel is renamed' do
           store.channels.find_by(code: 'online').update!(code: 'web')
           expect(store.default_channel.code).to eq('web')
+        end
+
+        it 'falls back to the first active channel when no channel is flagged default' do
+          store.channels.update_all(default: false)
+          expect(store.default_channel).to eq(store.channels.active.first)
         end
       end
     end

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -202,7 +202,7 @@ describe Spree::Store, type: :model, without_global_store: true do
         end
 
         it 'follows the default flag, not the code, when another channel is promoted' do
-          pos = store.channels.create!(name: 'POS', code: 'pos', default: true)
+          pos = create(:channel, store: store, name: 'POS', code: 'pos', default: true)
           expect(store.default_channel).to eq(pos)
           expect(store.channels.find_by(code: 'online')).not_to be_default
         end


### PR DESCRIPTION
## Summary
Changes the `Store#default_channel` method to resolve the default channel via the `default` boolean column on channels instead of hardcoding a lookup by the 'online' code. This allows promoting a different channel as default in the admin UI to take effect immediately, while maintaining backward compatibility by falling back to the first active channel when no channel is explicitly flagged as default.

## Key Changes
- **Updated `Store#default_channel` logic**: Changed from `channels.find_by(code: Spree::Channel::DEFAULT_CODE)` to `channels.default.first`, which queries the `default` boolean column instead of the hardcoded 'online' code
- **Added fallback behavior**: Preserves the fallback to `channels.active.first` for data integrity when no channel is flagged as default
- **Improved documentation**: Added comprehensive docstring explaining the resolution strategy and fallback behavior
- **Enhanced test coverage**: 
  - Renamed existing test to clarify it tests channel renaming behavior
  - Added test verifying that promoting a different channel (via the `default` flag) becomes the new default
  - Added test ensuring fallback to first active channel when no default is flagged

## Implementation Details
The change aligns with the `6.0-channels-catalogs-b2b.md` plan which shipped the `Channel#default` boolean in 5.5. This implementation ensures the admin UI's ability to promote channels is reflected immediately in the application logic, rather than being overridden by a hardcoded code-based lookup.

https://claude.ai/code/session_01Nc5LDBGDTpjKqcxmBqK1oV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in channel selection with explicit fallback and expanded model specs; no auth or payment paths touched.
> 
> **Overview**
> **`Store#default_channel`** no longer looks up the hardcoded `online` channel code. It now returns the channel marked with **`default: true`**, so admin promotion of another channel applies immediately.
> 
> If no channel is flagged default, behavior is unchanged: it still falls back to the **first active** channel. Doc comments describe that resolution order.
> 
> Specs now cover promotion via the default flag, renamed online channel codes, and the no-default fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ba29333e512b8a38182736b05ad5f49582167d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated store default channel selection to use the channel marked as default (with fallback to the first active channel).
  * Improved resilience when channel codes change, preventing reliance on a fixed channel code.
  * Ensured consistent fallback behavior when no channel is flagged as default.
* **Tests**
  * Refreshed model specs to reflect the new default channel resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->