### PR TITLE
Add `store` association to `Spree::RoleUser` and use it for checking user permissions

### DIFF
--- a/spree/api/app/controllers/concerns/spree/api/v3/admin/role_grant_guard.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/admin/role_grant_guard.rb
@@ -78,13 +78,15 @@ module Spree
           end
 
           # The caller's store-scoped role names, fetched once per request.
+          # Scoped by store_id so the caller's own privileges are recognized even
+          # when their role is held on a non-store resource bound to this store.
           def caller_role_names
             return @caller_role_names if defined?(@caller_role_names)
 
             user = try_spree_current_user
             @caller_role_names =
               if user.respond_to?(:role_users)
-                user.role_users.where(resource: current_store).joins(:role).
+                user.role_users.where(store: current_store).joins(:role).
                   pluck("#{Spree::Role.table_name}.name")
               else
                 []

--- a/spree/api/app/controllers/concerns/spree/api/v3/admin_authentication.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/admin_authentication.rb
@@ -64,7 +64,7 @@ module Spree
         def current_user_member_of_store?
           return false unless current_user.respond_to?(:role_users)
 
-          current_user.role_users.exists?(resource: current_store)
+          current_user.role_users.exists?(store: current_store)
         end
 
         def set_no_store_cache

--- a/spree/api/spec/controllers/spree/api/v3/admin/base_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/base_controller_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Spree::Api::V3::Admin::BaseController, type: :controller do
       let(:other_store) { create(:store) }
       let(:foreign_admin) do
         create(:admin_user, :without_admin_role).tap do |u|
-          u.role_users.create!(role: Spree::Role.default_admin_role, resource: other_store)
+          u.role_users.create!(role: Spree::Role.default_admin_role, resource: other_store, store: other_store)
         end
       end
       let(:foreign_admin_jwt) do

--- a/spree/core/app/models/spree/ability.rb
+++ b/spree/core/app/models/spree/ability.rb
@@ -45,17 +45,18 @@ module Spree
     end
 
     # Determines the role names for the current user, scoped to the current
-    # store. A +Spree::RoleUser+ binds a role to a store via +resource+, so a
-    # role held on one store does not apply on another.
+    # store. A +Spree::RoleUser+ is bound to a store via its +store_id+ (set from
+    # the role's resource), so a role held on one store does not apply on another,
+    # independent of the polymorphic +resource+ the role is attached to.
     #
     # @return [Array<Symbol>] the role names
     def determine_role_names
       return [:default] unless @user.persisted?
 
       if @user.respond_to?(:role_users)
-        role_names = @user.role_users.where(resource: @store).
+        role_names = @user.role_users.where(store: @store).
                      joins(:role).
-                     pluck("#{Spree::Role.table_name}.name").map(&:to_sym)
+                     pluck("#{Spree::Role.table_name}.name").map(&:to_sym).uniq
         return role_names if role_names.any?
       end
 

--- a/spree/core/app/models/spree/role_user.rb
+++ b/spree/core/app/models/spree/role_user.rb
@@ -1,11 +1,14 @@
 module Spree
   class RoleUser < Spree.base_class
+    include Spree::SingleStoreResource
+
     #
     # Associations
     #
     belongs_to :role, class_name: 'Spree::Role', foreign_key: :role_id
     belongs_to :user, polymorphic: true
     belongs_to :resource, polymorphic: true
+    belongs_to :store, class_name: 'Spree::Store'
     belongs_to :invitation, class_name: 'Spree::Invitation', optional: true, inverse_of: :role_user
 
     #
@@ -14,6 +17,7 @@ module Spree
     validates :role, presence: true
     validates :user, presence: true
     validates :resource, presence: true
+    validates :store, presence: true
     validates :role_id, uniqueness: { scope: [:user_id, :resource_id, :user_type, :resource_type] }
 
     #
@@ -24,7 +28,7 @@ module Spree
     #
     # Callbacks
     #
-    before_validation :set_default_resource
+    before_validation :set_default_resource, :set_store
 
     private
 
@@ -32,6 +36,19 @@ module Spree
     # this will allow a graceful migration from the old roles system to the new one
     def set_default_resource
       self.resource ||= Spree::Store.current
+    end
+
+    def set_store
+      return if store.present?
+
+      self.store =
+        if resource.is_a?(Spree::Store)
+          resource
+        elsif resource.respond_to?(:store)
+          resource.store
+        else
+          Spree::Current.store
+        end
     end
   end
 end

--- a/spree/core/app/models/spree/role_user.rb
+++ b/spree/core/app/models/spree/role_user.rb
@@ -28,7 +28,7 @@ module Spree
     #
     # Callbacks
     #
-    before_validation :set_default_resource, :set_store
+    before_validation :set_default_resource, :ensure_store
 
     private
 
@@ -38,17 +38,8 @@ module Spree
       self.resource ||= Spree::Store.current
     end
 
-    def set_store
-      return if store.present?
-
-      self.store =
-        if resource.is_a?(Spree::Store)
-          resource
-        elsif resource.respond_to?(:store)
-          resource.store
-        else
-          Spree::Current.store
-        end
+    def ensure_store
+      self.store ||= Spree::Current.store
     end
   end
 end

--- a/spree/core/db/migrate/20260613000001_add_store_id_to_spree_role_users.rb
+++ b/spree/core/db/migrate/20260613000001_add_store_id_to_spree_role_users.rb
@@ -1,0 +1,10 @@
+class AddStoreIdToSpreeRoleUsers < ActiveRecord::Migration[7.2]
+  def change
+    # Denormalizes the store a role assignment applies within, so role
+    # resolution (Spree::Ability) can scope by store without depending on the
+    # polymorphic resource. Kept null: true here; existing rows are backfilled
+    # by `spree:role_users:backfill_store_ids` and presence is enforced
+    # on the model.
+    add_reference :spree_role_users, :store, null: true
+  end
+end

--- a/spree/core/lib/spree/upgrades/5_5_to_5_6/manifest.yml
+++ b/spree/core/lib/spree/upgrades/5_5_to_5_6/manifest.yml
@@ -1,0 +1,30 @@
+# Spree 5.5 → 5.6 upgrade manifest.
+#
+# Lists ONLY the version-specific rake tasks that perform data backfills.
+# Universal upgrade steps (bundle update, db:migrate, scheduling cron jobs,
+# reviewing breaking changes) are NOT in this file:
+#
+#   - `bundle update` + `db:migrate` are handled by your deploy pipeline
+#     (Heroku release phase, K8s init container, Render auto-migrate,
+#     Capistrano deploy hook, etc.) and by the @spree/cli's `spree upgrade`
+#     wrapper for local development.
+#   - Cron scheduling, optional tunings, and human-readable behavior changes
+#     live in the upgrade doc at docs/developer/upgrades/5.5-to-5.6.mdx.
+#
+# This manifest is the machine-runnable shape — what `bin/rake spree:upgrade`
+# (in production) and `spree upgrade` (in dev) execute. Every step must be a
+# rake task and must be idempotent. Re-running the full manifest is safe.
+---
+from: "5.5"
+to: "5.6"
+docs: "https://spreecommerce.org/docs/developer/upgrades/5.5-to-5.6"
+
+steps:
+  - id: role_user_store_ids
+    name: "Backfill store_id on role assignments"
+    task: "spree:role_users:backfill_store_ids"
+    notes: |
+      Sets spree_role_users.store_id from the store resource so Spree::Ability
+      resolves roles by store. Store-scoped assignments only; extensions (e.g.
+      spree_multi_vendor) backfill their own resource types. Store admins stay
+      authorized via the spree_admin? fallback until this runs.

--- a/spree/core/lib/tasks/role_users.rake
+++ b/spree/core/lib/tasks/role_users.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :spree do
+  namespace :role_users do
+    desc <<~DESC
+      Backfills +spree_role_users.store_id+ for store-scoped role assignments
+      (resource_type = 'Spree::Store') by copying +resource_id+. Idempotent —
+      only rows with a null +store_id+ are touched.
+
+      Role resolution (Spree::Ability) scopes by +store_id+, so run this after
+      adding the column. Until it does, the +spree_admin?+ fallback keeps store
+      admins authorized. Role assignments on non-store resources (e.g.
+      Spree::Vendor) are backfilled by the owning extension.
+    DESC
+    task backfill_store_ids: :environment do
+      count = Spree::RoleUser.where(resource_type: Spree::Store.name, store_id: nil)
+                             .update_all('store_id = resource_id')
+      puts "  Backfilled store_id on #{count} store-scoped role assignment(s)."
+    end
+  end
+end

--- a/spree/core/spec/lib/tasks/role_users_spec.rb
+++ b/spree/core/spec/lib/tasks/role_users_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'spree:role_users:backfill_store_ids' do
+  subject { Rake::Task[task_name] }
+
+  let(:task_name) { 'spree:role_users:backfill_store_ids' }
+
+  before(:all) do
+    Rake::Task.define_task(:environment)
+    load Spree::Core::Engine.root.join('lib', 'tasks', 'role_users.rake')
+  end
+
+  before { subject.reenable }
+
+  let!(:store) { Spree::Store.default || create(:store, default: true) }
+  let(:role) { create(:role, name: 'test_role') }
+  let(:user) { create(:user) }
+
+  # The set_store callback stamps store_id on create, so null it to reproduce a
+  # row created before the column existed.
+  def downgrade!(role_user)
+    role_user.update_columns(store_id: nil)
+    role_user
+  end
+
+  context 'store-scoped role assignment' do
+    let!(:role_user) { downgrade!(Spree::RoleUser.create!(role: role, user: user, resource: store)) }
+
+    it 'backfills store_id from the store resource' do
+      expect { subject.invoke }.to change { role_user.reload.store_id }.from(nil).to(store.id)
+    end
+
+    it 'is idempotent — a re-run changes nothing' do
+      subject.invoke
+      subject.reenable
+      expect { subject.invoke }.not_to change { role_user.reload.store_id }
+    end
+  end
+end

--- a/spree/core/spec/lib/tasks/role_users_spec.rb
+++ b/spree/core/spec/lib/tasks/role_users_spec.rb
@@ -17,7 +17,7 @@ describe 'spree:role_users:backfill_store_ids' do
   let(:role) { create(:role, name: 'test_role') }
   let(:user) { create(:user) }
 
-  # The set_store callback stamps store_id on create, so null it to reproduce a
+  # The ensure_store callback stamps store_id on create, so null it to reproduce a
   # row created before the column existed.
   def downgrade!(role_user)
     role_user.update_columns(store_id: nil)

--- a/spree/core/spec/models/spree/ability_spec.rb
+++ b/spree/core/spec/models/spree/ability_spec.rb
@@ -270,7 +270,7 @@ describe Spree::Ability, type: :model do
     end
   end
 
-  context 'role resolution is scoped to the current store' do
+  context 'role resolution uses the store of a role user' do
     let(:admin) { create(:admin_user, :without_admin_role) }
     let(:store_a) { @default_store }
     let(:store_b) { create(:store) }
@@ -279,12 +279,12 @@ describe Spree::Ability, type: :model do
       admin.role_users.create!(role: Spree::Role.default_admin_role, resource: store_a)
     end
 
-    it 'grants admin authority on the store where the role is held' do
+    it "grants authority on the role assignment's store" do
       ability = Spree::Ability.new(admin, store: store_a)
       expect(ability).to be_able_to :manage, Spree::Product.new
     end
 
-    it 'does not grant admin authority on a store where no role is held' do
+    it 'does not grant authority on a different store' do
       ability = Spree::Ability.new(admin, store: store_b)
       expect(ability).not_to be_able_to :manage, Spree::Product.new
     end

--- a/spree/core/spec/models/spree/role_user_spec.rb
+++ b/spree/core/spec/models/spree/role_user_spec.rb
@@ -36,29 +36,20 @@ describe Spree::RoleUser do
       end
     end
 
-    describe 'before_validation :set_store' do
-      let(:store) { create(:store) }
-
-      it 'sets the store from a store resource' do
-        role_user = described_class.new(role: role, user: spree_user, resource: store)
-        expect(role_user.valid?).to be_truthy
-
-        expect(role_user.store).to eq(store)
-      end
-
-      it 'derives the store from a resource that responds to #store' do
-        resource = create(:wishlist, store: store)
-        role_user = described_class.new(role: role, user: spree_user, resource: resource)
-        expect(role_user.valid?).to be_truthy
-
-        expect(role_user.store).to eq(store)
-      end
-
-      it 'defaults to the current store when no store can be derived' do
+    describe 'before_validation :ensure_store' do
+      it 'sets the store to the current store' do
         role_user = described_class.new(role: role, user: spree_user)
         expect(role_user.valid?).to be_truthy
 
-        expect(role_user.store).to eq(Spree::Store.current)
+        expect(role_user.store).to eq(Spree::Current.store)
+      end
+
+      it 'keeps an explicitly assigned store' do
+        store = create(:store)
+        role_user = described_class.new(role: role, user: spree_user, store: store)
+        expect(role_user.valid?).to be_truthy
+
+        expect(role_user.store).to eq(store)
       end
     end
   end

--- a/spree/core/spec/models/spree/role_user_spec.rb
+++ b/spree/core/spec/models/spree/role_user_spec.rb
@@ -35,6 +35,32 @@ describe Spree::RoleUser do
         expect(role_user.resource).to eq(Spree::Store.current)
       end
     end
+
+    describe 'before_validation :set_store' do
+      let(:store) { create(:store) }
+
+      it 'sets the store from a store resource' do
+        role_user = described_class.new(role: role, user: spree_user, resource: store)
+        expect(role_user.valid?).to be_truthy
+
+        expect(role_user.store).to eq(store)
+      end
+
+      it 'derives the store from a resource that responds to #store' do
+        resource = create(:wishlist, store: store)
+        role_user = described_class.new(role: role, user: spree_user, resource: resource)
+        expect(role_user.valid?).to be_truthy
+
+        expect(role_user.store).to eq(store)
+      end
+
+      it 'defaults to the current store when no store can be derived' do
+        role_user = described_class.new(role: role, user: spree_user)
+        expect(role_user.valid?).to be_truthy
+
+        expect(role_user.store).to eq(Spree::Store.current)
+      end
+    end
   end
 
   describe '#name' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added store-scoped role assignment support, ensuring role checks are correctly bound to the current store.
  * Introduced an automated backfill workflow (migration + upgrade task) to populate missing store links for existing role assignments.

* **Bug Fixes**
  * Fixed permission and admin authentication checks to evaluate roles using the intended store, preventing cross-store access issues.

* **Tests**
  * Updated and added coverage for store binding, backfill idempotency, and callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->