### PR TITLE
Fixed: move remaining hardcoded admin UI elements to translations

### DIFF
--- a/spree/admin/app/helpers/spree/admin/orders_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/orders_helper.rb
@@ -82,44 +82,19 @@ module Spree
       end
 
       def avs_response_code
-        {
-          'A' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
-          'B' => 'Street address matches, but postal code not verified.',
-          'C' => 'Street address and postal code do not match.',
-          'D' => 'Street address and postal code match. ',
-          'E' => 'AVS data is invalid or AVS is not allowed for this card type.',
-          'F' => "Card member's name does not match, but billing postal code matches.",
-          'G' => 'Non-U.S. issuing bank does not support AVS.',
-          'H' => "Card member's name does not match. Street address and postal code match.",
-          'I' => 'Address not verified.',
-          'J' => "Card member's name, billing address, and postal code match.",
-          'K' => "Card member's name matches but billing address and billing postal code do not match.",
-          'L' => "Card member's name and billing postal code match, but billing address does not match.",
-          'M' => 'Street address and postal code match. ',
-          'N' => 'Street address and postal code do not match.',
-          'O' => "Card member's name and billing address match, but billing postal code does not match.",
-          'P' => 'Postal code matches, but street address not verified.',
-          'Q' => "Card member's name, billing address, and postal code match.",
-          'R' => 'System unavailable.',
-          'S' => 'Bank does not support AVS.',
-          'T' => "Card member's name does not match, but street address matches.",
-          'U' => 'Address information unavailable. Returned if the U.S. bank does not support non-U.S. AVS or if the AVS in a U.S. bank is not functioning properly.',
-          'V' => "Card member's name, billing address, and billing postal code match.",
-          'W' => 'Street address does not match, but 9-digit postal code matches.',
-          'X' => 'Street address and 9-digit postal code match.',
-          'Y' => 'Street address and 5-digit postal code match.',
-          'Z' => 'Street address does not match, but 5-digit postal code matches.'
-        }
+        ('A'..'Z').each_with_object({}) do |code, codes|
+          codes[code] = Spree.t("admin.orders.avs_responses.#{code.downcase}")
+        end
       end
 
       def cvv_response_code
         {
-          'M' => 'CVV2 Match',
-          'N' => 'CVV2 No Match',
-          'P' => 'Not Processed',
-          'S' => 'Issuer indicates that CVV2 data should be present on the card, but the merchant has indicated data is not present on the card',
-          'U' => 'Issuer has not certified for CVV2 or Issuer has not provided Visa with the CVV2 encryption keys',
-          '' => 'Transaction failed because wrong CVV2 number was entered or no CVV2 number was entered'
+          'M' => Spree.t('admin.orders.cvv_responses.m'),
+          'N' => Spree.t('admin.orders.cvv_responses.n'),
+          'P' => Spree.t('admin.orders.cvv_responses.p'),
+          'S' => Spree.t('admin.orders.cvv_responses.s'),
+          'U' => Spree.t('admin.orders.cvv_responses.u'),
+          '' => Spree.t('admin.orders.cvv_responses.blank')
         }
       end
     end

--- a/spree/admin/app/helpers/spree/admin/products_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/products_helper.rb
@@ -29,7 +29,7 @@ module Spree
 
       def product_status(product)
         if product.deleted?
-          content_tag(:span, 'Deleted', class: 'badge  badge-danger')
+          content_tag(:span, Spree.t('admin.products.deleted'), class: 'badge  badge-danger')
         else
           content_tag(:span, class: "badge  badge-#{product.status}") do
             if product.active?

--- a/spree/admin/app/helpers/spree/admin/shipment_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/shipment_helper.rb
@@ -12,7 +12,7 @@ module Spree::Admin
         where(spree_stock_items: { variant_id: variant.id }).
         group(:id).
         pluck(:name, "sum(spree_stock_items.count_on_hand)", :id).
-        map { |name, count, id| ["#{name.capitalize} (#{count} on hand)", "stock-location_#{id}"] }
+        map { |name, count, id| [Spree.t('admin.shipments.stock_location_option', name: name.capitalize, count: count), "stock-location_#{id}"] }
     end
 
     def shipments_for_transfer(current_shipment)

--- a/spree/admin/app/helpers/spree/admin/shipment_helper.rb
+++ b/spree/admin/app/helpers/spree/admin/shipment_helper.rb
@@ -12,7 +12,7 @@ module Spree::Admin
         where(spree_stock_items: { variant_id: variant.id }).
         group(:id).
         pluck(:name, "sum(spree_stock_items.count_on_hand)", :id).
-        map { |name, count, id| [Spree.t('admin.shipments.stock_location_option', name: name.capitalize, count: count), "stock-location_#{id}"] }
+        map { |name, count, id| [Spree.t('admin.shipments.stock_location_option', name: name, count: count), "stock-location_#{id}"] }
     end
 
     def shipments_for_transfer(current_shipment)

--- a/spree/admin/app/javascript/spree/admin/controllers/query_builder_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/query_builder_controller.js
@@ -226,22 +226,10 @@ export default class extends Controller {
     const operatorSelect = filterRow.querySelector("[data-operator-select]")
     operatorSelect.innerHTML = ""
 
-    const operatorLabels = {
-      eq: "equals",
-      not_eq: "does not equal",
-      cont: "contains",
-      not_cont: "does not contain",
-      start: "starts with",
-      end: "ends with",
-      gt: "greater than",
-      gteq: "greater than or equal",
-      lt: "less than",
-      lteq: "less than or equal",
-      in: "is any of",
-      not_in: "is none of",
-      null: "is empty",
-      not_null: "is not empty"
-    }
+    // Labels come from the server already translated (see Filter.operators_for_select).
+    const operatorLabels = Object.fromEntries(
+      this.operatorsValue.map(op => [op.value, op.label])
+    )
 
     operators.forEach(op => {
       const option = document.createElement("option")

--- a/spree/admin/app/models/spree/admin/table/filter.rb
+++ b/spree/admin/app/models/spree/admin/table/filter.rb
@@ -3,20 +3,20 @@ module Spree
     class Table
       class Filter
         OPERATORS = {
-          eq: { label: 'equals', predicate: '_eq' },
-          not_eq: { label: 'does not equal', predicate: '_not_eq' },
-          cont: { label: 'contains', predicate: '_cont' },
-          not_cont: { label: 'does not contain', predicate: '_not_cont' },
-          start: { label: 'starts with', predicate: '_start' },
-          end: { label: 'ends with', predicate: '_end' },
-          gt: { label: 'greater than', predicate: '_gt' },
-          gteq: { label: 'greater than or equal to', predicate: '_gteq' },
-          lt: { label: 'less than', predicate: '_lt' },
-          lteq: { label: 'less than or equal to', predicate: '_lteq' },
-          in: { label: 'is any of', predicate: '_in' },
-          not_in: { label: 'is none of', predicate: '_not_in' },
-          null: { label: 'is empty', predicate: '_null', no_value: true },
-          not_null: { label: 'is not empty', predicate: '_not_null', no_value: true }
+          eq: { predicate: '_eq' },
+          not_eq: { predicate: '_not_eq' },
+          cont: { predicate: '_cont' },
+          not_cont: { predicate: '_not_cont' },
+          start: { predicate: '_start' },
+          end: { predicate: '_end' },
+          gt: { predicate: '_gt' },
+          gteq: { predicate: '_gteq' },
+          lt: { predicate: '_lt' },
+          lteq: { predicate: '_lteq' },
+          in: { predicate: '_in' },
+          not_in: { predicate: '_not_in' },
+          null: { predicate: '_null', no_value: true },
+          not_null: { predicate: '_not_null', no_value: true }
         }.freeze
 
         attr_accessor :field, :operator, :value, :id
@@ -73,7 +73,7 @@ module Spree
         # Get human-readable operator label
         # @return [String]
         def operator_label
-          OPERATORS.dig(@operator, :label) || @operator.to_s.humanize
+          self.class.translate_operator(@operator)
         end
 
         # Check if this operator requires a value
@@ -107,8 +107,15 @@ module Spree
         # @return [Array<Hash>]
         def self.operators_for_select
           OPERATORS.map do |key, config|
-            { value: key.to_s, label: config[:label], no_value: config[:no_value] || false }
+            { value: key.to_s, label: translate_operator(key), no_value: config[:no_value] || false }
           end
+        end
+
+        # Translate an operator key to its human-readable label
+        # @param operator [Symbol]
+        # @return [String]
+        def self.translate_operator(operator)
+          Spree.t("admin.table.operators.#{operator}", default: operator.to_s.humanize)
         end
       end
     end

--- a/spree/admin/app/models/spree/admin/table/query_builder.rb
+++ b/spree/admin/app/models/spree/admin/table/query_builder.rb
@@ -108,11 +108,19 @@ module Spree
 
           resolved_options.map do |opt|
             if opt.is_a?(Hash)
-              { value: opt[:value] || opt['value'], label: opt[:label] || opt['label'] }
+              { value: opt[:value] || opt['value'], label: resolve_option_label(opt[:label] || opt['label']) }
             else
               { value: opt.to_s, label: opt.to_s.humanize }
             end
           end
+        end
+
+        # Translate a value-option label when it is given as an i18n key (a dotted
+        # string like 'admin.products.draft'); plain strings are returned as-is.
+        def resolve_option_label(label)
+          return label unless label.is_a?(String) && label.include?('.')
+
+          I18n.t(label, default: label.split('.').last.humanize)
         end
       end
     end

--- a/spree/admin/app/views/spree/admin/admin_users/_audit_log.html.erb
+++ b/spree/admin/app/views/spree/admin/admin_users/_audit_log.html.erb
@@ -1,5 +1,5 @@
 <div class="text-gray-600 py-12 gap-4 flex flex-col items-center justify-center">
-  <p>Audit log is part of the Spree Enterprise offering.</p>
+  <p><%= Spree.t('admin.admin_users.audit_log_enterprise_notice') %></p>
 
-  <%= external_link_to 'Upgrade to Spree Enterprise', 'https://spreecommerce.org/pricing', class: 'btn btn-primary' %>
+  <%= external_link_to Spree.t('admin.admin_users.upgrade_to_enterprise'), 'https://spreecommerce.org/pricing', class: 'btn btn-primary' %>
 </div>

--- a/spree/admin/app/views/spree/admin/admin_users/new.html.erb
+++ b/spree/admin/app/views/spree/admin/admin_users/new.html.erb
@@ -3,7 +3,7 @@
 
       <div class="rounded-md border p-6 mb-6 flex items-center gap-2">
         <%= render_avatar(@invitation.inviter, height: 32, width: 32) %>
-        <%= @invitation.inviter.name %> has invited you to join <strong><%= @invitation.resource.name %></strong>
+        <%= raw(Spree.t('admin.invitations.invited_you_to_join_html', inviter: tag.strong(@invitation.inviter.name), resource: tag.strong(@invitation.resource.name))) %>
       </div>
 
       <%= render 'form', f: f %>

--- a/spree/admin/app/views/spree/admin/admin_users/new.html.erb
+++ b/spree/admin/app/views/spree/admin/admin_users/new.html.erb
@@ -3,7 +3,7 @@
 
       <div class="rounded-md border p-6 mb-6 flex items-center gap-2">
         <%= render_avatar(@invitation.inviter, height: 32, width: 32) %>
-        <%= raw(Spree.t('admin.invitations.invited_you_to_join_html', inviter: tag.strong(@invitation.inviter.name), resource: tag.strong(@invitation.resource.name))) %>
+        <%= Spree.t('admin.invitations.invited_you_to_join_html', inviter: tag.strong(@invitation.inviter.name), resource: tag.strong(@invitation.resource.name)) %>
       </div>
 
       <%= render 'form', f: f %>

--- a/spree/admin/app/views/spree/admin/dashboard/_updater.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/_updater.html.erb
@@ -3,13 +3,13 @@
     <%= image_tag 'favicon_256x256.png', alt: 'Spree', width: 32, height: 32 %>
     <div class="flex flex-col">
       <p class="mb-1">
-        <strong>Spree <%= spree_updater.latest_release['name'] %></strong> is available.
-        <br />Your current version is <strong>Spree <%= spree_updater.current_release %></strong>. 
+        <%= raw(Spree.t('admin.dashboard.updater.available_html', version: tag.strong("Spree #{spree_updater.latest_release['name']}"))) %>
+        <br /><%= raw(Spree.t('admin.dashboard.updater.current_version_html', version: tag.strong("Spree #{spree_updater.current_release}"))) %>
       </p>
 
       <% if spree_updater.latest_release['url'] %>
         <div>
-          <%= external_link_to "View release notes", spree_updater.latest_release['url'], target: '_blank', class: 'btn btn-sm btn-secondary' %>
+          <%= external_link_to Spree.t('admin.dashboard.updater.view_release_notes'), spree_updater.latest_release['url'], target: '_blank', class: 'btn btn-sm btn-secondary' %>
         </div>
       <% end %>
     </div>

--- a/spree/admin/app/views/spree/admin/dashboard/_updater.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/_updater.html.erb
@@ -3,8 +3,8 @@
     <%= image_tag 'favicon_256x256.png', alt: 'Spree', width: 32, height: 32 %>
     <div class="flex flex-col">
       <p class="mb-1">
-        <%= raw(Spree.t('admin.dashboard.updater.available_html', version: tag.strong("Spree #{spree_updater.latest_release['name']}"))) %>
-        <br /><%= raw(Spree.t('admin.dashboard.updater.current_version_html', version: tag.strong("Spree #{spree_updater.current_release}"))) %>
+        <%= Spree.t('admin.dashboard.updater.available_html', version: tag.strong("Spree #{spree_updater.latest_release['name']}")) %>
+        <br /><%= Spree.t('admin.dashboard.updater.current_version_html', version: tag.strong("Spree #{spree_updater.current_release}")) %>
       </p>
 
       <% if spree_updater.latest_release['url'] %>

--- a/spree/admin/app/views/spree/admin/dashboard/_visits.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/_visits.html.erb
@@ -3,7 +3,7 @@
     <div class="card h-full">
       <div class="card-header">
         <h5 class="card-title">
-          Where are visitors coming from?
+          <%= Spree.t('admin.dashboard.visits.referrers_title') %>
         </h5>
       </div>
       <% if @top_referrers.any? %>
@@ -19,9 +19,9 @@
         <p class="m-12 text-center text-gray-600">
           <%= icon 'share', height: 50, class: 'mb-4', style: 'opacity: 0.5' %>
           <br />
-          <strong>No data</strong>
+          <strong><%= Spree.t('admin.dashboard.visits.no_data') %></strong>
           <br />
-          No data available for this period.
+          <%= Spree.t('admin.dashboard.visits.no_data_for_period') %>
         </p>
       <% end %>
     </div>
@@ -30,7 +30,7 @@
     <div class="card h-full">
       <div class="card-header">
         <h5 class="card-title">
-          Top landing pages
+          <%= Spree.t('admin.dashboard.visits.landing_pages_title') %>
         </h5>
       </div>
       <% if @top_landing_pages.any? %>
@@ -46,9 +46,9 @@
         <p class="m-12 text-center text-gray-600">
           <%= icon 'pointer', height: 50, class: 'mb-4', style: 'opacity: 0.5' %>
           <br />
-          <strong>No data</strong>
+          <strong><%= Spree.t('admin.dashboard.visits.no_data') %></strong>
           <br />
-          No data available for this period.
+          <%= Spree.t('admin.dashboard.visits.no_data_for_period') %>
         </p>
       <% end %>
     </div>
@@ -57,7 +57,7 @@
     <div class="card h-full">
       <div class="card-header">
         <h5 class="card-title">
-          Visitor location
+          <%= Spree.t('admin.dashboard.visits.locations_title') %>
         </h5>
       </div>
       <% if @top_locations.any? %>
@@ -80,9 +80,9 @@
         <p class="m-12 text-center text-gray-600">
           <%= icon 'world', height: 50, class: 'mb-4', style: 'opacity: 0.5' %>
           <br />
-          <strong>No data</strong>
+          <strong><%= Spree.t('admin.dashboard.visits.no_data') %></strong>
           <br />
-          No data available for this period.
+          <%= Spree.t('admin.dashboard.visits.no_data_for_period') %>
         </p>
       <% end %>
     </div>
@@ -91,7 +91,7 @@
     <div class="card">
       <div class="card-header">
         <h5 class="card-title">
-          Visitor devices
+          <%= Spree.t('admin.dashboard.visits.devices_title') %>
         </h5>
       </div>
       <% if @top_devices.count > 0 %>
@@ -102,9 +102,9 @@
         <p class="m-12 text-center text-gray-600">
           <%= icon 'device-mobile', height: 50, class: 'mb-4', style: 'opacity: 0.5' %>
           <br />
-          <strong>No data</strong>
+          <strong><%= Spree.t('admin.dashboard.visits.no_data') %></strong>
           <br />
-          No data available for this period.
+          <%= Spree.t('admin.dashboard.visits.no_data_for_period') %>
         </p>
       <% end %>
     </div>

--- a/spree/admin/app/views/spree/admin/dashboard/analytics.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/analytics.html.erb
@@ -11,7 +11,7 @@
         <div class="col-span-6 lg:col-span-4 gap-2">
           <div class="analytics-card-tab active" data-tabs-target="tab" data-action="click->tabs#select">
             <div class="flex justify-center flex-col mb-6 lg:mb-0">
-              <span class="text-sm text-gray-500">Total Sales</span>
+              <span class="text-sm text-gray-500"><%= Spree.t(:total_sales) %></span>
               <span class="text-lg text-gray-900 font-bold mt-1">
                 <%= @sales_total %>
               </span>
@@ -25,7 +25,7 @@
         <div class="col-span-6 lg:col-span-2">
           <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#select">
             <div class="flex justify-center flex-col mb-6 lg:mb-0">
-              <span class="text-sm text-gray-500">Avg. Order Value</span>
+              <span class="text-sm text-gray-500"><%= Spree.t('admin.avg_order_value') %></span>
               <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @orders_average %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @orders_average_growth_rate %>
@@ -37,7 +37,7 @@
         <div class="col-span-6 lg:col-span-2">
           <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#select">
             <div class="flex justify-center flex-col mb-6 lg:mb-0">
-              <span class="text-sm text-gray-500">Total Orders</span>
+              <span class="text-sm text-gray-500"><%= Spree.t('admin.total_orders') %></span>
               <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @orders_total  %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @orders_growth_rate %>
@@ -49,7 +49,7 @@
           <div class="col-span-6 lg:col-span-2">
             <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#select">
               <div class="flex justify-center flex-col">
-                <span class="text-sm text-gray-500">Visits</span>
+                <span class="text-sm text-gray-500"><%= Spree.t(:visits) %></span>
                 <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @visits_total %></span>
                 <div>
                   <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @visits_growth_rate %>
@@ -63,7 +63,7 @@
           <div class="col-span-6 lg:col-span-2">
             <div class="analytics-card-tab" data-tabs-target="tab" data-action="click->tabs#select">
               <div class="flex justify-center flex-col">
-                <span class="text-sm text-gray-500">Sign-ups</span>
+                <span class="text-sm text-gray-500"><%= Spree.t('admin.sign_ups') %></span>
                 <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @audience_total %></span>
                 <div>
                   <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: @audience_growth_rate %>

--- a/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_add_products.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_add_products.html.erb
@@ -1,16 +1,16 @@
 <% if done %>
   <p>
-    Good job, you've added products to your store!
+    <%= Spree.t('admin.store_setup_tasks.add_products_task.done_title') %>
   </p>
   <p>
-    Remember you can always add more!
+    <%= Spree.t('admin.store_setup_tasks.add_products_task.done_subtitle') %>
   </p>
 <% else %>
   <p>
-    Add products to your store, either your own or invite 3rd party vendors to sell together.
+    <%= Spree.t('admin.store_setup_tasks.add_products_task.copy') %>
   </p>
   <p>
-    You can also import products in bulk from a CSV or Excel file.
+    <%= Spree.t('admin.store_setup_tasks.add_products_task.import_hint') %>
   </p>
 <% end %>
 

--- a/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
@@ -5,7 +5,7 @@
 
   <% if done %>
     <p class="mb-3">
-      <%= raw(Spree.t('admin.store_setup_tasks.customer_support_email_task.current_html', email: tag.strong("#{current_store.customer_support_email}."))) %>
+      <%= Spree.t('admin.store_setup_tasks.customer_support_email_task.current_html', email: tag.strong("#{current_store.customer_support_email}.")) %>
     </p>
     <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_emails_admin_store_path, class: 'btn btn-light' %>
   <% else %>

--- a/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
@@ -5,7 +5,7 @@
 
   <% if done %>
     <p class="mb-3">
-      <%= Spree.t('admin.store_setup_tasks.customer_support_email_task.current_html', email: tag.strong("#{current_store.customer_support_email}.")) %>
+      <%= Spree.t('admin.store_setup_tasks.customer_support_email_task.current_html', email: tag.strong(current_store.customer_support_email)) %>
     </p>
     <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_emails_admin_store_path, class: 'btn btn-light' %>
   <% else %>

--- a/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
+++ b/spree/admin/app/views/spree/admin/dashboard/setup_tasks/_set_customer_support_email.html.erb
@@ -1,18 +1,17 @@
 <%= turbo_frame_tag :set_customer_support_email, class: 'w-full' do %>
   <div class="alert alert-info">
-    We need your customer support email to display on your storefront.
-    This email will work as a contact point for your customers to reach out to you for any queries or support.
+    <%= Spree.t('admin.store_setup_tasks.customer_support_email_task.copy') %>
   </div>
 
   <% if done %>
     <p class="mb-3">
-      Your customer support email is <strong><%= current_store.customer_support_email %>.</strong>
+      <%= raw(Spree.t('admin.store_setup_tasks.customer_support_email_task.current_html', email: tag.strong("#{current_store.customer_support_email}."))) %>
     </p>
     <%= link_to_with_icon 'edit', Spree.t(:edit), spree.edit_emails_admin_store_path, class: 'btn btn-light' %>
   <% else %>
     <%= form_for current_store, url: spree.admin_store_path, as: :store do |f| %>
       <div class="form-group">
-        <%= f.label :customer_support_email, 'Customer support email' %>
+        <%= f.label :customer_support_email, Spree.t('admin.store_setup_tasks.customer_support_email_task.label') %>
         <%= f.email_field :customer_support_email, class: 'form-input', required: true %>
       </div>
       <%= turbo_save_button_tag %>

--- a/spree/admin/app/views/spree/admin/gift_card_batches/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/gift_card_batches/_form.html.erb
@@ -10,6 +10,6 @@
     <%= f.spree_money_field :amount, currency: f.object.currency, required: true, disabled: f.object.persisted? %>
     <%= f.spree_select :currency, options_for_select(supported_currency_options, f.object.currency), { label: Spree.t(:currency), autocomplete: true } %>
     <%= f.spree_number_field :codes_count, required: true, min: 1, max: Spree::Config[:gift_card_batch_limit], label: Spree.t('admin.gift_card_batches.codes_count') %>
-    <%= f.spree_date_field :expires_at, disabled: f.object.persisted?, help: 'Gift cards will expire after this date.' %>
+    <%= f.spree_date_field :expires_at, disabled: f.object.persisted?, help: Spree.t('admin.gift_card_batches.expires_at_help') %>
   </div>
 </div>

--- a/spree/admin/app/views/spree/admin/import_rows/show.html.erb
+++ b/spree/admin/app/views/spree/admin/import_rows/show.html.erb
@@ -4,10 +4,10 @@
   <div class="drawer-body" data-controller="highlight tabs">
     <ul class="nav nav-pills mb-6">
       <li class="nav-item">
-        <a class="nav-link active" data-tabs-target="tab" data-action="click->tabs#select">JSON</a>
+        <a class="nav-link active" data-tabs-target="tab" data-action="click->tabs#select"><%= Spree.t('admin.imports.json') %></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select">Schema</a>
+        <a class="nav-link" data-tabs-target="tab" data-action="click->tabs#select"><%= Spree.t('admin.imports.schema') %></a>
       </li>
     </ul>
 

--- a/spree/admin/app/views/spree/admin/imports/_footer.html.erb
+++ b/spree/admin/app/views/spree/admin/imports/_footer.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div>
-      <%= import.rows.processed.count %> / <%= import.rows_count %> rows processed
+      <%= Spree.t('admin.imports.rows_processed', processed: import.rows.processed.count, total: import.rows_count) %>
     </div>
   <% elsif import.status != 'failed' %>
     <div>

--- a/spree/admin/app/views/spree/admin/imports/_mapping_form.html.erb
+++ b/spree/admin/app/views/spree/admin/imports/_mapping_form.html.erb
@@ -6,6 +6,6 @@
     <% if mapping.file_column.present? %>
       <% select_options.prepend([mapping.file_column, mapping.file_column]) %>
     <% end %>
-    <%= f.select :file_column, options_for_select(select_options, mapping.file_column), { include_blank: 'Please select a column' }, { data: { action: 'auto-submit#submit', controller: 'autocomplete-select' }, id: "import_mapping_file_column_#{mapping.id}" } %>
+    <%= f.select :file_column, options_for_select(select_options, mapping.file_column), { include_blank: Spree.t('admin.imports.please_select_a_column') }, { data: { action: 'auto-submit#submit', controller: 'autocomplete-select' }, id: "import_mapping_file_column_#{mapping.id}" } %>
   <% end %>
 <% end %>

--- a/spree/admin/app/views/spree/admin/imports/show.html.erb
+++ b/spree/admin/app/views/spree/admin/imports/show.html.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% content_for :steps do %>
-  <li class="border-r grow h-full flex items-center justify-center <% if @import.mapping? %>bg-gray-100 font-bold<% end %>">1. Map fields</li>
-  <li class="border-r grow h-full flex items-center justify-center <% if @import.processing? %>bg-gray-100 font-bold<% end %>">2. Process rows</li>
-  <li class="grow h-full flex items-center justify-center <% if @import.complete? %>bg-gray-100 font-bold<% end %>">3. Complete</li>
+  <li class="border-r grow h-full flex items-center justify-center <% if @import.mapping? %>bg-gray-100 font-bold<% end %>"><%= Spree.t('admin.imports.steps.map_fields') %></li>
+  <li class="border-r grow h-full flex items-center justify-center <% if @import.processing? %>bg-gray-100 font-bold<% end %>"><%= Spree.t('admin.imports.steps.process_rows') %></li>
+  <li class="grow h-full flex items-center justify-center <% if @import.complete? %>bg-gray-100 font-bold<% end %>"><%= Spree.t('admin.imports.steps.complete') %></li>
 <% end %>
 
 <% if @import.status == 'mapping' %>

--- a/spree/admin/app/views/spree/admin/integrations/index.html.erb
+++ b/spree/admin/app/views/spree/admin/integrations/index.html.erb
@@ -28,13 +28,11 @@
       <% end %>
 
       <p class="text-gray-600 text-center my-12">
-        <%= Spree.t('admin.integrations.find_more') %> <%= external_link_to Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
+        <%= Spree.t('admin.integrations.find_more_html', integrations_link: external_link_to(Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank')) %>
       </p>
     <% else %>
       <p class="text-gray-600 text-center my-12">
-        <%= Spree.t('admin.integrations.none_installed') %>
-
-        <%= external_link_to Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
+        <%= Spree.t('admin.integrations.none_installed_html', integrations_link: external_link_to(Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank')) %>
       </p>
     <% end %>
   </div>

--- a/spree/admin/app/views/spree/admin/integrations/index.html.erb
+++ b/spree/admin/app/views/spree/admin/integrations/index.html.erb
@@ -28,13 +28,13 @@
       <% end %>
 
       <p class="text-gray-600 text-center my-12">
-        Find more integrations in <%= external_link_to 'Integrations Directory', 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
+        <%= Spree.t('admin.integrations.find_more') %> <%= external_link_to Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
       </p>
     <% else %>
       <p class="text-gray-600 text-center my-12">
-        No integrations installed yet. Find integrations in 
+        <%= Spree.t('admin.integrations.none_installed') %>
 
-        <%= external_link_to 'Integrations Directory', 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
+        <%= external_link_to Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
       </p>
     <% end %>
   </div>

--- a/spree/admin/app/views/spree/admin/invitations/_invitation.html.erb
+++ b/spree/admin/app/views/spree/admin/invitations/_invitation.html.erb
@@ -21,7 +21,7 @@
       <span class="badge badge-warning"><%= Spree.t(:expired) %></span>
     <% else %>
       <span class="badge badge-light"><%= Spree.t(:pending) %></span>
-      <p class="text-gray-600 text-sm mb-0 mt-2 pl-1">Expires at: <%= spree_time(invitation.expires_at) %></p>
+      <p class="text-gray-600 text-sm mb-0 mt-2 pl-1"><%= Spree.t('admin.invitations.expires_at') %>: <%= spree_time(invitation.expires_at) %></p>
     <% end %>
   </td>
   <td class="w-10">

--- a/spree/admin/app/views/spree/admin/invitations/new.html.erb
+++ b/spree/admin/app/views/spree/admin/invitations/new.html.erb
@@ -5,7 +5,7 @@
     <%= dialog_header Spree.t('actions.send_invitation') %>
     <div class="dialog-body">
       <%= render 'spree/admin/shared/error_messages', target: @invitation %>
-      <%= f.spree_email_field :email, required: true, data: { 'enable-button-target': 'input' }, placeholder: 'eg. steve@apple.com', autofocus: true %>
+      <%= f.spree_email_field :email, required: true, data: { 'enable-button-target': 'input' }, placeholder: Spree.t('admin.invitations.email_placeholder'), autofocus: true %>
       <% if @roles.any? %>
         <%= f.spree_select :role_id, @roles.map { |role| [role.name, role.id] }, { label: Spree.t(:role_id), autocomplete: true, required: true }, { data: { 'enable-button-target': 'input' } } %>
       <% end %>

--- a/spree/admin/app/views/spree/admin/invitations/show.html.erb
+++ b/spree/admin/app/views/spree/admin/invitations/show.html.erb
@@ -3,7 +3,7 @@
     <%= render_avatar(@invitation.inviter, height: 32, width: 32) %>
   </div>
   <div>
-    <strong><%= @invitation.inviter.name %></strong> has invited you to join <strong><%= @invitation.resource.name %></strong>
+    <%= raw(Spree.t('admin.invitations.invited_you_to_join_html', inviter: tag.strong(@invitation.inviter.name), resource: tag.strong(@invitation.resource.name))) %>
   </div>
 </div>
 <%= link_to Spree.t(:accept), spree.accept_admin_invitation_path(@invitation), class: 'btn btn-primary mx-auto px-12', data: { turbo_method: :put } %>

--- a/spree/admin/app/views/spree/admin/invitations/show.html.erb
+++ b/spree/admin/app/views/spree/admin/invitations/show.html.erb
@@ -3,7 +3,7 @@
     <%= render_avatar(@invitation.inviter, height: 32, width: 32) %>
   </div>
   <div>
-    <%= raw(Spree.t('admin.invitations.invited_you_to_join_html', inviter: tag.strong(@invitation.inviter.name), resource: tag.strong(@invitation.resource.name))) %>
+    <%= Spree.t('admin.invitations.invited_you_to_join_html', inviter: tag.strong(@invitation.inviter.name), resource: tag.strong(@invitation.resource.name)) %>
   </div>
 </div>
 <%= link_to Spree.t(:accept), spree.accept_admin_invitation_path(@invitation), class: 'btn btn-primary mx-auto px-12', data: { turbo_method: :put } %>

--- a/spree/admin/app/views/spree/admin/metafields/edit.html.erb
+++ b/spree/admin/app/views/spree/admin/metafields/edit.html.erb
@@ -35,7 +35,7 @@
     <div class="drawer-body">
       <div class="text-gray-600 p-12 flex items-center w-full justify-center flex-col gap-4">
         <%= icon 'map-search', class: 'text-4xl' %>
-        <p>No metafield definitions configured for <%= model_class.name.demodulize.titleize.pluralize %>.</p>
+        <p><%= Spree.t('admin.metafields.none_configured_for', resource: model_class.name.demodulize.titleize.pluralize) %></p>
         <%= link_to_with_icon 'plus', Spree.t(:add_one), spree.new_admin_metafield_definition_path(resource_type: model_class.to_s), class: 'btn btn-primary', data: { 'turbo-frame': '_top' } if can?(:create, Spree::MetafieldDefinition) %>
       </div>
     </div>

--- a/spree/admin/app/views/spree/admin/metafields/edit.html.erb
+++ b/spree/admin/app/views/spree/admin/metafields/edit.html.erb
@@ -35,7 +35,7 @@
     <div class="drawer-body">
       <div class="text-gray-600 p-12 flex items-center w-full justify-center flex-col gap-4">
         <%= icon 'map-search', class: 'text-4xl' %>
-        <p><%= Spree.t('admin.metafields.none_configured_for', resource: model_class.name.demodulize.titleize.pluralize) %></p>
+        <p><%= Spree.t('admin.metafields.none_configured_for', resource: model_class.model_name.human(count: 2)) %></p>
         <%= link_to_with_icon 'plus', Spree.t(:add_one), spree.new_admin_metafield_definition_path(resource_type: model_class.to_s), class: 'btn btn-primary', data: { 'turbo-frame': '_top' } if can?(:create, Spree::MetafieldDefinition) %>
       </div>
     </div>

--- a/spree/admin/app/views/spree/admin/option_types/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/option_types/_form.html.erb
@@ -5,11 +5,11 @@
     <div class="card-body" data-controller="slug-form">
       <div class="grid grid-cols-12 gap-6 mb-6">
         <div class="col-span-12 md:col-span-6">
-          <%= f.spree_text_field :presentation, required: true, autofocus: f.object.new_record?, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName' }, help_text: "This is used to display the option type on the storefront." %>
+          <%= f.spree_text_field :presentation, required: true, autofocus: f.object.new_record?, data: { slug_form_target: :name, action: 'slug-form#updateUrlFromName' }, help_text: Spree.t('admin.option_types.presentation_help') %>
         </div>
 
         <div class="col-span-12 md:col-span-6">
-          <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, help_text: raw("This is used internally to identify the option type. <strong>It must be unique.</strong>") %>
+          <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, help_text: raw(Spree.t('admin.option_types.name_help_html')) %>
         </div>
       </div>
       <div class="grid grid-cols-12 gap-6 mb-6">
@@ -38,7 +38,7 @@
       <h5 class="card-title"><%= Spree.t(:option_values) %></h5>
       <% if @option_values_total > 0 %>
         <span class="text-sm text-gray-500">
-          <%= @option_values_total %> <%= 'value'.pluralize(@option_values_total) %>
+          <%= Spree.t('admin.option_types.value_count', count: @option_values_total) %>
         </span>
       <% end %>
     </div>
@@ -77,14 +77,17 @@
         <div class="flex items-center justify-between p-3 border-t">
           <span class="text-sm text-gray-500">
             <% per_page = Spree::Admin::RuntimeConfig.admin_option_values_per_page %>
-            Showing <%= (@option_values_page - 1) * per_page + 1 %>-<%= [@option_values_page * per_page, @option_values_total].min %> of <%= @option_values_total %>
+            <%= Spree.t('admin.option_types.showing_pagination',
+                  from: (@option_values_page - 1) * per_page + 1,
+                  to: [@option_values_page * per_page, @option_values_total].min,
+                  total: @option_values_total) %>
           </span>
           <div class="flex gap-1.5">
             <% if @option_values_page > 1 %>
               <%= link_to icon('chevron-left', class: 'text-gray-900 mr-0'),
                   spree.edit_admin_option_type_path(@option_type, option_values_page: @option_values_page - 1),
                   class: "btn btn-light p-2",
-                  'aria-label': 'Previous page' %>
+                  'aria-label': Spree.t('admin.previous_page') %>
             <% else %>
               <button class="btn btn-light p-2 cursor-not-allowed opacity-50" disabled>
                 <%= icon('chevron-left', class: 'text-gray-900 mr-0') %>
@@ -95,7 +98,7 @@
               <%= link_to icon('chevron-right', class: 'text-gray-900 mr-0'),
                   spree.edit_admin_option_type_path(@option_type, option_values_page: @option_values_page + 1),
                   class: "btn btn-light p-2",
-                  'aria-label': 'Next page' %>
+                  'aria-label': Spree.t('admin.next_page') %>
             <% else %>
               <button class="btn btn-light p-2 cursor-not-allowed opacity-50" disabled>
                 <%= icon('chevron-right', class: 'text-gray-900 mr-0') %>

--- a/spree/admin/app/views/spree/admin/option_types/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/option_types/_form.html.erb
@@ -9,7 +9,7 @@
         </div>
 
         <div class="col-span-12 md:col-span-6">
-          <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, help_text: raw(Spree.t('admin.option_types.name_help_html')) %>
+          <%= f.spree_text_field :name, label: Spree.t(:internal_name), data: { slug_form_target: :url }, help_text: Spree.t('admin.option_types.name_help_html') %>
         </div>
       </div>
       <div class="grid grid-cols-12 gap-6 mb-6">

--- a/spree/admin/app/views/spree/admin/option_types/index.html.erb
+++ b/spree/admin/app/views/spree/admin/option_types/index.html.erb
@@ -9,8 +9,7 @@
 
 <%= content_for(:page_alerts) do %>
   <div class="alert alert-info">
-    Options are used to group certain attributes. For example, you can create an option named "shirt size" and then
-    create an option value named "small" and "medium" for this option.
+    <%= Spree.t('admin.option_types.intro_help') %>
   </div>
 <% end %>
 
@@ -19,5 +18,5 @@
 <%= render_table @collection, :option_types, sortable: true %>
 
 <p class="documentation-link-container">
-  <%= external_link_to "Learn more about options", "https://spreecommerce.org/docs/user/manage-products/product-options" %>
+  <%= external_link_to Spree.t('admin.option_types.learn_more'), "https://spreecommerce.org/docs/user/manage-products/product-options" %>
 </p>

--- a/spree/admin/app/views/spree/admin/orders/_customer_summary.html.erb
+++ b/spree/admin/app/views/spree/admin/orders/_customer_summary.html.erb
@@ -11,7 +11,7 @@
     <span class="text-gray-600">
       <%= order.full_name %>
     </span>
-    <%= help_bubble('This order was placed by a guest customer') %>
+    <%= help_bubble(Spree.t('admin.orders.placed_by_guest')) %>
   <% else %>
     <span class="text-gray-600">
       <%= Spree.t(:not_available) %>

--- a/spree/admin/app/views/spree/admin/orders/_user_overview.html.erb
+++ b/spree/admin/app/views/spree/admin/orders/_user_overview.html.erb
@@ -2,12 +2,14 @@
   <div class="alert alert-info mt-2 mb-0">
     <div>
       <h5 class="font-bold">
-        <%= icon('magic') %> Assistant
+        <%= icon('magic') %> <%= Spree.t('admin.assistant') %>
       </h5>
-      This is a repeat customer that has spent a total of
-      <strong><%= Spree::Money.new(@order.user.orders.complete.sum(:total)) %></strong> across
-      <strong><%= @order.user.orders.complete.count %> orders</strong>, averaging
-      <strong><%= Spree::Money.new(@order.user.orders.complete.average(:total)) %></strong> per order.
+      <%= Spree.t(
+            'admin.orders.repeat_customer_summary_html',
+            amount: tag.strong(Spree::Money.new(@order.user.orders.complete.sum(:total))),
+            count: tag.strong(Spree.t('admin.orders.orders_count', count: @order.user.orders.complete.count)),
+            average: tag.strong(Spree::Money.new(@order.user.orders.complete.average(:total)))
+          ) %>
     </div>
   </div>
 <% end %>

--- a/spree/admin/app/views/spree/admin/orders/_user_overview.html.erb
+++ b/spree/admin/app/views/spree/admin/orders/_user_overview.html.erb
@@ -1,4 +1,5 @@
-<% if @order.user.orders.complete.any? %>
+<% completed_orders = current_store.orders.where(user: @order.user).complete %>
+<% if completed_orders.any? %>
   <div class="alert alert-info mt-2 mb-0">
     <div>
       <h5 class="font-bold">
@@ -6,9 +7,9 @@
       </h5>
       <%= Spree.t(
             'admin.orders.repeat_customer_summary_html',
-            amount: tag.strong(Spree::Money.new(@order.user.orders.complete.sum(:total))),
-            count: tag.strong(Spree.t('admin.orders.orders_count', count: @order.user.orders.complete.count)),
-            average: tag.strong(Spree::Money.new(@order.user.orders.complete.average(:total)))
+            amount: tag.strong(Spree::Money.new(completed_orders.sum(:total))),
+            count: tag.strong(Spree.t('admin.orders.orders_count', count: completed_orders.count)),
+            average: tag.strong(Spree::Money.new(completed_orders.average(:total)))
           ) %>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/payment_methods/_form.html.erb
@@ -22,7 +22,7 @@
     <h5 class="card-title"><%= Spree.t(:display_settings) %></h5>
   </div>
   <div class="card-body">
-    <%= f.spree_text_field :name, help: 'This name will be used to identify the payment method on the storefront' %>
+    <%= f.spree_text_field :name, help: Spree.t('admin.payment_methods.name_help') %>
 
     <%= f.spree_select :display_on, display_on_options, { label: Spree.t(:display) } %>
     <%= f.spree_select :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes).to_s, true], [Spree.t(:say_no).to_s, false]], { label: Spree.t(:auto_capture) } %>

--- a/spree/admin/app/views/spree/admin/payment_methods/index.html.erb
+++ b/spree/admin/app/views/spree/admin/payment_methods/index.html.erb
@@ -26,7 +26,7 @@
 </div>
 
 <% if available_payment_methods.present? && can?(:create, Spree::PaymentMethod) %>
-  <h6 class="pb-2 pt-6">Available Payment Methods</h6>
+  <h6 class="pb-2 pt-6"><%= Spree.t('admin.payment_methods.available_payment_methods') %></h6>
   <div class="card-lg">
     <div class="table-responsive">
       <table class="table">
@@ -46,5 +46,5 @@
 <% end %>
 
 <p class="text-gray-600 text-center my-12">
-  Find more payment methods in <%= external_link_to 'Integrations Directory', 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
+  <%= Spree.t('admin.payment_methods.find_more_payment_methods') %> <%= external_link_to Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
 </p>

--- a/spree/admin/app/views/spree/admin/payment_methods/index.html.erb
+++ b/spree/admin/app/views/spree/admin/payment_methods/index.html.erb
@@ -46,5 +46,5 @@
 <% end %>
 
 <p class="text-gray-600 text-center my-12">
-  <%= Spree.t('admin.payment_methods.find_more_payment_methods') %> <%= external_link_to Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank' %>
+  <%= Spree.t('admin.payment_methods.find_more_payment_methods_html', integrations_link: external_link_to(Spree.t('admin.integrations_directory'), 'https://spreecommerce.org/docs/integrations/integrations', target: '_blank')) %>
 </p>

--- a/spree/admin/app/views/spree/admin/price_lists/index.html.erb
+++ b/spree/admin/app/views/spree/admin/price_lists/index.html.erb
@@ -9,7 +9,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Price lists are a powerful tool for managing pricing strategies based on customer groups, products, or other criteria.
+    <%= Spree.t('admin.price_lists.page_info') %>
   </div>
 <% end %>
 
@@ -18,5 +18,5 @@
 <%= render_table @collection, :price_lists, sortable: true %>
 
 <p class="documentation-link-container">
-  <%= external_link_to "Learn more about price lists", "https://spreecommerce.org/docs/user/manage-products/price-lists" %>
+  <%= external_link_to Spree.t('admin.price_lists.learn_more'), "https://spreecommerce.org/docs/user/manage-products/price-lists" %>
 </p>

--- a/spree/admin/app/views/spree/admin/products/index.html.erb
+++ b/spree/admin/app/views/spree/admin/products/index.html.erb
@@ -14,6 +14,5 @@
 <%= render_table @collection, :products, bulk_operations: true, export_type: Spree::Exports::Products %>
 
 <p class="documentation-link-container">
-  Learn more about
-  <%= external_link_to 'managing products', 'https://spreecommerce.org/docs/user/manage-products' %>
+  <%= external_link_to Spree.t('admin.products.learn_more'), 'https://spreecommerce.org/docs/user/manage-products' %>
 </p>

--- a/spree/admin/app/views/spree/admin/promotion_rules/forms/_item_total.html.erb
+++ b/spree/admin/app/views/spree/admin/promotion_rules/forms/_item_total.html.erb
@@ -20,7 +20,7 @@
     <%= f.number_field :preferred_amount_max, class: 'form-input' %>
 
     <span class="form-text mt-2">
-      Leave this field blank to not limit the maximum amount.
+      <%= Spree.t('item_total_rule.max_amount_help') %>
     </span>
   </div>
 </div>

--- a/spree/admin/app/views/spree/admin/promotions/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/_form.html.erb
@@ -5,7 +5,7 @@
     </h5>
   </div>
   <div class="card-body">
-    <%= f.spree_text_field :name, required: true, autofocus: true, help: 'Customers will see this in their cart and at checkout.' %>
+    <%= f.spree_text_field :name, required: true, autofocus: true, help: Spree.t('admin.promotions.name_help') %>
   </div>
 </div>
 
@@ -32,5 +32,5 @@
 </div>
 
 <p class="alert alert-info text-center">
-  In the next step you will be able to add actions and rules to your promotion
+  <%= Spree.t('admin.promotions.next_step_info') %>
 </p>

--- a/spree/admin/app/views/spree/admin/promotions/_sidebar.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/_sidebar.html.erb
@@ -18,7 +18,7 @@
           <%= Spree.t(:used) %>: <%= used_coupon_codes_count %> / <%= coupon_codes_count %>
         </span>
         <span class="badge badge-light">
-          Remaining: <%= coupon_codes_count - used_coupon_codes_count %>
+          <%= Spree.t(:remaining) %>: <%= coupon_codes_count - used_coupon_codes_count %>
         </span>
       </div>
     </div>

--- a/spree/admin/app/views/spree/admin/promotions/edit.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/edit.html.erb
@@ -15,14 +15,14 @@
           <%= f.text_field :name, class: 'form-input', required: true, autofocus: true %>
           <%= f.error_message_on :name %>
           <span class="form-text mt-2">
-            Customers will see this in their cart and at checkout.
+            <%= Spree.t('admin.promotions.name_help') %>
           </span>
         </div>
 
         <% if @promotion.coupon_code? && !@promotion.multi_codes? %>
           <div class="form-group">   
             <%= f.label :code %>
-            <%= f.text_field :code, class: 'form-input uppercase', placeholder: 'Your coupon code' %>
+            <%= f.text_field :code, class: 'form-input uppercase', placeholder: Spree.t('admin.promotions.coupon_code_placeholder') %>
           </div>
         <% end %>
       </div>

--- a/spree/admin/app/views/spree/admin/promotions/form/_kind.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/form/_kind.html.erb
@@ -31,7 +31,7 @@
           <div>
             <%= f.text_field :code_prefix, class: 'form-input uppercase', placeholder: Spree.t('admin.promotions.code_prefix_placeholder') %>
             <span class="form-text mt-1">
-              <%= raw(Spree.t('admin.promotions.code_prefix_example_html', example: tag.strong('ABC'))) %>
+              <%= Spree.t('admin.promotions.code_prefix_example_html', example: tag.strong('ABC')) %>
             </span>
           </div>
           <div>

--- a/spree/admin/app/views/spree/admin/promotions/form/_kind.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/form/_kind.html.erb
@@ -8,40 +8,40 @@
         <div class="custom-control custom-radio">
           <%= f.radio_button :multi_codes, false, data: { action: 'change->reveal#toggle' }, class: 'custom-control-input' %>
           <%= f.label :multi_codes_false, class: 'custom-control-label flex-col items-start' do %>
-            One code for all customers
+            <%= Spree.t('admin.promotions.kind.one_code_label') %>
             <span class="form-text font-normal">
-              You can limit the number of times this code can be used.
+              <%= Spree.t('admin.promotions.kind.one_code_help') %>
             </span>
           <% end %>
         </div>
         <div data-reveal-target="item" class="mt-2 ml-6 <% if @promotion.multi_codes? %>hidden<% end %>">
-          <%= f.text_field :code, class: 'form-input uppercase', placeholder: 'Your coupon code' %>
+          <%= f.text_field :code, class: 'form-input uppercase', placeholder: Spree.t('admin.promotions.coupon_code_placeholder') %>
         </div>
 
         <div class="mt-6 custom-control custom-radio">
           <%= f.radio_button :multi_codes, true, data: { action: 'change->reveal#toggle' }, class: 'custom-control-input' %>
           <%= f.label :multi_codes_true, class: 'custom-control-label flex-col items-start' do %>
-            Generate unique codes
+            <%= Spree.t('admin.promotions.kind.multi_codes_label') %>
             <span class="form-text font-normal">
-              These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
+              <%= Spree.t('admin.promotions.kind.multi_codes_help') %>
             </span>
           <% end %>
         </div>
         <div data-reveal-target="item" class="ml-6 mt-2 grid gap-3 <% unless @promotion.multi_codes? %>hidden<% end %>">
           <div>
-            <%= f.text_field :code_prefix, class: 'form-input uppercase', placeholder: 'Coupon Prefix (optional)' %>
+            <%= f.text_field :code_prefix, class: 'form-input uppercase', placeholder: Spree.t('admin.promotions.code_prefix_placeholder') %>
             <span class="form-text mt-1">
-              eg. <strong>ABC</strong>
+              <%= raw(Spree.t('admin.promotions.code_prefix_example_html', example: tag.strong('ABC'))) %>
             </span>
           </div>
           <div>
             <% minimum_number_of_codes = @promotion.persisted? && @promotion.coupon_codes.count.positive? ? @promotion.coupon_codes.count : 1 %>
             <% maximum_number_of_codes = ENV.fetch('PROMOTION_MAX_NUMBER_OF_CODES', 5000) %>
-            <%= f.number_field :number_of_codes, class: 'form-input', placeholder: 'Number of codes', min: minimum_number_of_codes, max: maximum_number_of_codes, step: 1 %>
+            <%= f.number_field :number_of_codes, class: 'form-input', placeholder: Spree.t('admin.promotions.number_of_codes_placeholder'), min: minimum_number_of_codes, max: maximum_number_of_codes, step: 1 %>
             <span class="form-text mt-1">
-              How many codes you want to generate.
+              <%= Spree.t('admin.promotions.number_of_codes_help') %>
               <% if @promotion.persisted? %>
-                To add more codes just increase this number
+                <%= Spree.t('admin.promotions.add_more_codes_help') %>
               <% end %>
             </span>
           </div>
@@ -55,7 +55,7 @@
     <%= f.label :kind_automatic, Spree.t(:automatic_promotion), class: 'custom-control-label flex-col items-start' do %>
       <%= Spree.t(:automatic_promotion) %>
       <span class="form-text font-normal">
-        This promotion will be automatically applied to all eligible orders.
+        <%= Spree.t('admin.promotions.kind.automatic_help') %>
       </span>
     <% end %>
 

--- a/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
@@ -15,4 +15,4 @@
 
 <%= f.spree_datetime_field :expires_at,
       value: expires_at_local,
-      help: "#{Spree.t('admin.promotions.expires_at_help')} #{tz_help}" %>
+      help: Spree.t('admin.promotions.expires_at_help', zone: store_timezone.name) %>

--- a/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
+++ b/spree/admin/app/views/spree/admin/promotions/form/_settings.html.erb
@@ -1,5 +1,5 @@
 <% unless @promotion.multi_codes? %>
-  <%= f.spree_number_field :usage_limit, min: 0, step: 1, help: 'Leave this field blank for unlimited usage.' %>
+  <%= f.spree_number_field :usage_limit, min: 0, step: 1, help: Spree.t('admin.promotions.usage_limit_help') %>
 <% end %>
 
 <%# datetime-local inputs have no timezone; render values in the store's timezone so admins see and submit values in the store's local time. %>
@@ -15,4 +15,4 @@
 
 <%= f.spree_datetime_field :expires_at,
       value: expires_at_local,
-      help: "Leave this field blank for no expiration. #{tz_help}" %>
+      help: "#{Spree.t('admin.promotions.expires_at_help')} #{tz_help}" %>

--- a/spree/admin/app/views/spree/admin/shared/_analytics_loader_skeleton.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_analytics_loader_skeleton.html.erb
@@ -4,7 +4,7 @@
         <div class="col-span-6 lg:col-span-4 gap-2">
           <div class="analytics-card-tab active" style="min-height: 82px;">
             <div class="flex justify-center flex-col mb-6 lg:mb-0">
-              <span class="text-sm text-gray-600">Total Sales</span>
+              <span class="text-sm text-gray-600"><%= Spree.t(:total_sales) %></span>
               <span class="text-lg text-gray-900 font-bold mt-1">
                 <%= @sales_total %>
               </span>
@@ -18,7 +18,7 @@
         <div class="col-span-6 lg:col-span-2">
           <div class="analytics-card-tab" >
             <div class="flex justify-center flex-col mb-6 lg:mb-0">
-              <span class="text-sm text-gray-600">Avg. Order Value</span>
+              <span class="text-sm text-gray-600"><%= Spree.t('admin.avg_order_value') %></span>
               <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @orders_average %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: 0 %>
@@ -30,7 +30,7 @@
         <div class="col-span-6 lg:col-span-2">
           <div class="analytics-card-tab" >
             <div class="flex justify-center flex-col mb-6 lg:mb-0">
-              <span class="text-sm text-gray-600">Total Orders</span>
+              <span class="text-sm text-gray-600"><%= Spree.t('admin.total_orders') %></span>
               <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @orders_total  %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: 0 %>
@@ -42,7 +42,7 @@
           <div class="col-span-6 lg:col-span-2">
             <div class="analytics-card-tab" >
               <div class="flex justify-center flex-col">
-                <span class="text-sm text-gray-600">Visits</span>
+                <span class="text-sm text-gray-600"><%= Spree.t(:visits) %></span>
                 <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @visits_total %></span>
                 <div>
                   <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: 0 %>
@@ -55,7 +55,7 @@
         <div class="col-span-6 lg:col-span-2">
           <div class="analytics-card-tab" >
             <div class="flex justify-center flex-col">
-              <span class="text-sm text-gray-600">Sign-ups</span>
+              <span class="text-sm text-gray-600"><%= Spree.t('admin.sign_ups') %></span>
               <span class="text-lg text-gray-900 font-bold mt-1 mr-3"><%= @audience_total %></span>
               <div>
                 <%= render 'spree/admin/shared/growth_rate_badge', growth_rate: 0 %>

--- a/spree/admin/app/views/spree/admin/shared/_content_header.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_content_header.html.erb
@@ -47,7 +47,7 @@
                   <%= hidden_field_tag :record_number, record.number, data: { clipboard_target: 'source' } %>
                   <button data-action="clipboard#copy" class="text-left dropdown-item" data-clipboard-target="button">
                     <%= icon 'copy' %>
-                    <%= 'Copy number' %>
+                    <%= Spree.t(:copy_number) %>
                   </button>
                 </div>
               <% end %>

--- a/spree/admin/app/views/spree/admin/shared/_growth_rate_badge.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_growth_rate_badge.html.erb
@@ -2,7 +2,7 @@
 
 <div class="flex">
   <% if growth_rate == 0 %>
-    <svg viewBox="0 0 11 16" height="16" width="11" role="img" class="_SVG_1ou8g_150" tabindex="-1"><title>No change</title><path d="M0.519531 1.79395H12.0039V0.249023H0.519531V1.79395Z" fill="var(--p-icon-subdued, #8c9196)" transform="translate(0, 7)"></path></svg>
+    <svg viewBox="0 0 11 16" height="16" width="11" role="img" class="_SVG_1ou8g_150" tabindex="-1"><title><%= Spree.t('admin.no_change') %></title><path d="M0.519531 1.79395H12.0039V0.249023H0.519531V1.79395Z" fill="var(--p-icon-subdued, #8c9196)" transform="translate(0, 7)"></path></svg>
   <% elsif growth_rate > 0 %>
     <span class="text-green-700">
       <%= icon 'arrow-up', class: 'mr-1 text-base' %>

--- a/spree/admin/app/views/spree/admin/shared/_index_table_options.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_index_table_options.html.erb
@@ -12,7 +12,7 @@
           <%= link_to icon('chevron-left', class: 'text-gray-900 mr-0'),
               url_for(request.query_parameters.merge(page: @pagy.previous)),
               class: "btn btn-light p-2",
-              'aria-label': 'Previous page' %>
+              'aria-label': Spree.t('admin.previous_page') %>
         <% else %>
           <button class="btn btn-light p-2 cursor-not-allowed opacity-50" disabled>
             <%= icon('chevron-left', class: 'text-gray-900 mr-0') %>
@@ -23,7 +23,7 @@
           <%= link_to icon('chevron-right', class: 'text-gray-900 mr-0'),
               url_for(request.query_parameters.merge(page: @pagy.next)),
               class: "btn btn-light p-2",
-              'aria-label': 'Next page' %>
+              'aria-label': Spree.t('admin.next_page') %>
         <% else %>
           <button class="btn btn-light p-2 cursor-not-allowed opacity-50" disabled>
             <%= icon('chevron-right', class: 'text-gray-900 mr-0') %>

--- a/spree/admin/app/views/spree/admin/shared/_seo.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_seo.html.erb
@@ -1,7 +1,7 @@
 <div class="card mb-6 seo-form">
   <div class="card-header flex justify-between">
     <h5 class="card-title"><%= Spree.t(:search_engine_listing) %></h5>
-    <button class="btn btn-light btn-sm ms-auto" data-action="click->seo-form#toggleInputs" type="button">Edit</button>
+    <button class="btn btn-light btn-sm ms-auto" data-action="click->seo-form#toggleInputs" type="button"><%= Spree.t('actions.edit') %></button>
   </div>
   <div class="card-body flex flex-col">
     <div class="seo__preview <% if title.blank? && description.blank? %>hidden<% else %>flex flex-col<% end %>" data-seo-form-target="preview">

--- a/spree/admin/app/views/spree/admin/shared/sidebar/_enterprise_edition_notice.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/sidebar/_enterprise_edition_notice.html.erb
@@ -3,9 +3,9 @@
     <section class="hidden lg:block">
       <div id="enterprise-edition-notice">
         <%= link_to '', spree.admin_dismiss_enterprise_edition_notice_path, data: { turbo_method: :patch }, class: 'btn-close' %>
-        <p>Thank you for using Spree Community Edition! Please consider upgrading to Enterprise Edition for access to all features and support.</p>
+        <p><%= Spree.t('admin.enterprise_edition_notice.body') %></p>
 
-        <%= external_link_to 'Upgrade', 'https://spreecommerce.org/pricing', target: '_blank', class: 'btn btn-secondary btn-sm shadow-xs' %>
+        <%= external_link_to Spree.t('admin.enterprise_edition_notice.upgrade'), 'https://spreecommerce.org/pricing', target: '_blank', class: 'btn btn-secondary btn-sm shadow-xs' %>
       </div>
     </section>
   <% end %>

--- a/spree/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
+++ b/spree/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
@@ -1,9 +1,9 @@
 <div class="card mb-6">
   <div class="card-body pb-0">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3">
-      <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record?, help: 'This will be displayed to customers'  %>
+      <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record?, help: Spree.t('admin.shipping_methods.name_help')  %>
       <%= f.spree_select :display_on, display_on_options, { label: Spree.t(:display_on) }, { required: true } %>
-      <%= f.spree_text_field :admin_name, label: Spree.t(:internal_name), help: 'This will be displayed to admins' %>
+      <%= f.spree_text_field :admin_name, label: Spree.t(:internal_name), help: Spree.t('admin.shipping_methods.admin_name_help') %>
       <%= f.spree_text_field :code, label: Spree.t(:code)%>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/shipping_methods/form/_estimated_transit_business_days.html.erb
+++ b/spree/admin/app/views/spree/admin/shipping_methods/form/_estimated_transit_business_days.html.erb
@@ -6,8 +6,7 @@
   </div>
   <div class="card-body">
     <div class="alert alert-info">
-      This is the estimated number of business days it will take for the package to arrive at the customer's address.
-      It will be displayed on the checkout page.
+      <%= Spree.t('admin.shipping_methods.estimated_transit_business_days_help') %>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <%= f.spree_number_field :estimated_transit_business_days_min, size: 2, placeholder: Spree.t(:min), min: 1, label: Spree.t(:min) %>

--- a/spree/admin/app/views/spree/admin/shipping_methods/form/_tracking_url.html.erb
+++ b/spree/admin/app/views/spree/admin/shipping_methods/form/_tracking_url.html.erb
@@ -12,7 +12,7 @@
 
     <p class="form-text small mt-2">
       <code>:tracking</code>
-      <span>will be replaced with the tracking number.</span>
+      <span><%= Spree.t('admin.shipping_methods.tracking_url_token_help') %></span>
     </p>
   </div>
 </div>

--- a/spree/admin/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/spree/admin/app/views/spree/admin/shipping_methods/index.html.erb
@@ -11,7 +11,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Shipping methods are options that the customer sees when they reach the checkout, they are the carriers and services used to send your products.
+    <%= Spree.t('admin.shipping_methods.checkout_info') %>
   </div>
 <% end %>
 

--- a/spree/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/spree/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -24,7 +24,7 @@
   <div class="card-body">
     <div class="alert alert-info w-full mb-0">
       <span>
-        <%= raw(Spree.t('admin.store_form.currencies_managed_by_markets_html', markets_link: link_to(Spree.t('admin.markets.list'), spree.admin_markets_path))) %>
+        <%= Spree.t('admin.store_form.currencies_managed_by_markets_html', markets_link: link_to(Spree.t('admin.markets.list'), spree.admin_markets_path)) %>
       </span>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/stores/form/_basic.html.erb
+++ b/spree/admin/app/views/spree/admin/stores/form/_basic.html.erb
@@ -13,7 +13,7 @@
     </p>
     <%= f.spree_text_field :name, required: true, autofocus: f.object.new_record? %>
 
-    <%= f.spree_file_field :logo, width: 240, height: 240, crop: true, help_bubble: "Used in the admin dashboard" %>
+    <%= f.spree_file_field :logo, width: 240, height: 240, crop: true, help_bubble: Spree.t('admin.store_form.logo_help') %>
   </div>
 </div>
 
@@ -24,7 +24,7 @@
   <div class="card-body">
     <div class="alert alert-info w-full mb-0">
       <span>
-        Currencies and locales are now managed by <%= link_to 'Markets', spree.admin_markets_path %>.
+        <%= raw(Spree.t('admin.store_form.currencies_managed_by_markets_html', markets_link: link_to(Spree.t('admin.markets.list'), spree.admin_markets_path))) %>
       </span>
     </div>
   </div>

--- a/spree/admin/app/views/spree/admin/stores/form/_emails.html.erb
+++ b/spree/admin/app/views/spree/admin/stores/form/_emails.html.erb
@@ -14,11 +14,11 @@
 
 <div class="card mb-6">
   <div class="card-header">
-    <h5 class="card-title">Email addresses</h5>
+    <h5 class="card-title"><%= Spree.t('admin.store_form.email_addresses') %></h5>
   </div>
   <div class="card-body">
     <p class="text-gray-600">
-      Please provide the email address that will be used as the sender of all emails sent from your store.
+      <%= Spree.t('admin.store_form.mail_from_address_help') %>
     </p>
 
     <%= f.spree_email_field :mail_from_address, required: true %>
@@ -32,12 +32,10 @@
     <h5 class="card-title"><%= Spree.t(:logo) %></h5>
   </div>
   <div class="card-body">
-    <p class="text-gray-600">This logo is included in all email notifications such as order confirmation</p>
+    <p class="text-gray-600"><%= Spree.t('admin.store_form.mailer_logo_help') %></p>
     <%= f.spree_file_field :mailer_logo, width: 204, height: 104 %>
     <p class="form-text mb-0 mt-2">
-      We recommend images with a transparent background.
-      <br />
-      Only JPEG and PNG formats are supported.
+      <%= Spree.t('admin.store_form.mailer_logo_format_hint') %>
     </p>
   </div>
 </div>

--- a/spree/admin/app/views/spree/admin/taxons/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/taxons/_form.html.erb
@@ -85,7 +85,7 @@
         <%= f.spree_file_field :image, width: 1920, height: 1080 %>
       </div>
       <div class="card-body">
-        <%= f.spree_file_field :square_image, width: 400, height: 400, crop: true, help: "Used for the featured image on the homepage." %>
+        <%= f.spree_file_field :square_image, width: 400, height: 400, crop: true, help: Spree.t('admin.taxons.square_image_help') %>
       </div>
     </div>
 
@@ -113,6 +113,6 @@
           slug_attribute_name: :permalink_part,
           slug: @permalink_part,
           slug_path: ['t', @parent_permalink.presence].compact.join('/'),
-          placeholder: 'Add a title and description to see how this taxon might appear in a search engine listing' %>
+          placeholder: Spree.t('admin.taxons.seo.placeholder') %>
   </div>
 </div>

--- a/spree/admin/app/views/spree/admin/user_sessions/new.html.erb
+++ b/spree/admin/app/views/spree/admin/user_sessions/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:title, Spree.t(:login)) %>
 
-<h1 class="mb-4 font-light">Welcome back</h1>
+<h1 class="mb-4 font-light"><%= Spree.t('admin.user_sessions.welcome_back') %></h1>
 <%= form_for resource, as: resource_name, url: session_path(resource_name), data: { controller: 'enable-button', turbo: false } do |f| %>
   <div class="form-group mb-4">
     <%= f.label :email, Spree.t(:email), required: true, class: 'form-label' %>
-    <%= f.email_field :email, required: true, class: 'form-input form-input-lg', placeholder: 'steve@getvendo.com', data: { enable_button_target: :input }, autocomplete: :email, autofocus: true %>
+    <%= f.email_field :email, required: true, class: 'form-input form-input-lg', placeholder: Spree.t('admin.user_sessions.email_placeholder'), data: { enable_button_target: :input }, autocomplete: :email, autofocus: true %>
   </div>
   <div class="form-group mb-4">
     <%= f.label :password, Spree.t(:password), required: true, class: 'form-label' %>

--- a/spree/admin/app/views/spree/admin/users/_tabs.html.erb
+++ b/spree/admin/app/views/spree/admin/users/_tabs.html.erb
@@ -2,7 +2,7 @@
   <ul class="nav nav-pills mb-4" role="tablist">
     <% if spree.respond_to?(:admin_user_visits_path) %>
       <li class="nav-item" role="presentation">
-        <a class="nav-link active" id="pills-overview-tab" data-tabs-target="tab" data-action="click->tabs#select" role="tab" aria-controls="pills-overview" aria-selected="true">Timeline</a>
+        <a class="nav-link active" id="pills-overview-tab" data-tabs-target="tab" data-action="click->tabs#select" role="tab" aria-controls="pills-overview" aria-selected="true"><%= Spree.t('admin.users.timeline') %></a>
       </li>
     <% end %>
 

--- a/spree/admin/app/views/spree/admin/variants/_search_result.html.erb
+++ b/spree/admin/app/views/spree/admin/variants/_search_result.html.erb
@@ -17,7 +17,7 @@
     <div class="w-20">
       <% if params[:stock_location_id].present? %>
         <% stock_item = variant.stock_items.find { |si| si.stock_location_id == params[:stock_location_id] } %>
-        <span><%= stock_item&.count_on_hand || 0 %> at location</span>
+        <span><%= Spree.t('admin.variants.count_at_location', count: stock_item&.count_on_hand || 0) %></span>
         <% if stock_item&.backorderable? %> <span class="text-gray-600"><%= Spree.t(:backorderable) %></span><% end %>
       <% else %>
         <%= display_inventory(variant) %>

--- a/spree/admin/app/views/spree/admin/webhook_endpoints/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/webhook_endpoints/_form.html.erb
@@ -3,7 +3,7 @@
     <h5 class="card-title"><%= Spree.t('admin.webhook_endpoints.endpoint_settings') %></h5>
   </div>
   <div class="card-body">
-    <%= f.spree_text_field :name, placeholder: 'e.g. Storefront emails, Fulfillment service' %>
+    <%= f.spree_text_field :name, placeholder: Spree.t('admin.webhook_endpoints.name_placeholder') %>
     <%= f.spree_text_field :url, required: true, autofocus: f.object.new_record?, placeholder: 'https://example.com/webhooks' %>
     <%= f.spree_check_box :active %>
   </div>

--- a/spree/admin/app/views/spree/admin/webhook_endpoints/_form.html.erb
+++ b/spree/admin/app/views/spree/admin/webhook_endpoints/_form.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="card-body">
     <%= f.spree_text_field :name, placeholder: Spree.t('admin.webhook_endpoints.name_placeholder') %>
-    <%= f.spree_text_field :url, required: true, autofocus: f.object.new_record?, placeholder: 'https://example.com/webhooks' %>
+    <%= f.spree_text_field :url, required: true, autofocus: f.object.new_record?, placeholder: Spree.t('admin.webhook_endpoints.url_placeholder') %>
     <%= f.spree_check_box :active %>
   </div>
 </div>

--- a/spree/admin/app/views/spree/admin/zones/index.html.erb
+++ b/spree/admin/app/views/spree/admin/zones/index.html.erb
@@ -9,7 +9,7 @@
 
 <% content_for :page_alerts do %>
   <div class="alert alert-info">
-    Zones are geographical groupings, they represent collections of either states or countries.
+    <%= Spree.t('admin.zones.info') %>
   </div>
 <% end %>
 

--- a/spree/admin/config/i18n-tasks.yml
+++ b/spree/admin/config/i18n-tasks.yml
@@ -156,6 +156,8 @@ ignore_unused:
   - 'spree.admin.bulk_ops.users.title.*'
   - 'spree.admin.display_on_options.*'
   - 'spree.admin.order.events.*'
+  - 'spree.admin.orders.avs_responses.*'
+  - 'spree.admin.orders.cvv_responses.*'
   - 'spree.admin.orders.no_email_present'
   - 'spree.admin.orders.payment_link_sent'
   - 'spree.admin.store_setup_tasks.*'

--- a/spree/admin/config/i18n-tasks.yml
+++ b/spree/admin/config/i18n-tasks.yml
@@ -161,6 +161,7 @@ ignore_unused:
   - 'spree.admin.orders.no_email_present'
   - 'spree.admin.orders.payment_link_sent'
   - 'spree.admin.store_setup_tasks.*'
+  - 'spree.admin.table.operators.*'
   - 'spree.admin.taxon_rules.*'
   - 'spree.admin.webhooks_subscribers.*'
 

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -35,9 +35,9 @@ Rails.application.config.after_initialize do
                                         position: 20,
                                         partial: 'spree/admin/tables/columns/product_status',
                                         value_options: [
-                                          { value: 'draft', label: 'Draft' },
-                                          { value: 'active', label: 'Active' },
-                                          { value: 'archived', label: 'Archived' }
+                                          { value: 'draft', label: 'admin.products.draft' },
+                                          { value: 'active', label: 'admin.products.active' },
+                                          { value: 'archived', label: 'admin.products.archived' }
                                         ]
 
   # Inventory display (custom partial)
@@ -90,7 +90,7 @@ Rails.application.config.after_initialize do
 
   # Stock filter (filter-only, not displayed as column)
   Spree.admin.tables.products.add :in_stock,
-                                        label: 'In Stock',
+                                        label: 'admin.products.in_stock',
                                         type: :boolean,
                                         filter_type: :boolean,
                                         sortable: false,
@@ -293,7 +293,7 @@ Rails.application.config.after_initialize do
                                       default: false,
                                       position: 90,
                                       operators: %i[eq not_eq in not_in],
-                                      value_options: -> { Spree::Order.state_machine(:state).states.map { |s| { value: s.name.to_s, label: s.name.to_s.humanize } } }
+                                      value_options: -> { Spree::Order.state_machine(:state).states.map { |s| { value: s.name.to_s, label: Spree.t("state_machine_states.#{s.name}", default: s.name.to_s.humanize) } } }
 
   Spree.admin.tables.orders.add :email,
                                       label: :email,
@@ -414,7 +414,7 @@ Rails.application.config.after_initialize do
                                         default: true,
                                         position: 40,
                                         operators: %i[eq not_eq in not_in],
-                                        value_options: -> { Spree::Order.state_machine(:state).states.map { |s| { value: s.name.to_s, label: s.name.to_s.humanize } } }
+                                        value_options: -> { Spree::Order.state_machine(:state).states.map { |s| { value: s.name.to_s, label: Spree.t("state_machine_states.#{s.name}", default: s.name.to_s.humanize) } } }
 
   Spree.admin.tables.checkouts.add :item_count,
                                         label: :item_count,
@@ -1296,8 +1296,8 @@ Rails.application.config.after_initialize do
                                                  position: 20,
                                                  filter_type: :select,
                                                  value_options: [
-                                                   { value: 'true', label: 'Active' },
-                                                   { value: 'false', label: 'Inactive' }
+                                                   { value: 'true', label: 'price_list_statuses.active' },
+                                                   { value: 'false', label: 'price_list_statuses.inactive' }
                                                  ]
 
   Spree.admin.tables.webhook_endpoints.add :health,
@@ -1440,8 +1440,8 @@ Rails.application.config.after_initialize do
                                         partial: 'spree/admin/tables/columns/api_key_type',
                                         filter_type: :select,
                                         value_options: [
-                                          { value: 'publishable', label: 'Publishable' },
-                                          { value: 'secret', label: 'Secret' }
+                                          { value: 'publishable', label: 'admin.api_keys.key_types.publishable' },
+                                          { value: 'secret', label: 'admin.api_keys.key_types.secret' }
                                         ]
 
   Spree.admin.tables.api_keys.add :status,
@@ -1500,10 +1500,10 @@ Rails.application.config.after_initialize do
                                            position: 20,
                                            partial: 'spree/admin/tables/columns/price_list_status',
                                            value_options: [
-                                             { value: 'draft', label: 'Draft' },
-                                             { value: 'active', label: 'Active' },
-                                             { value: 'scheduled', label: 'Scheduled' },
-                                             { value: 'inactive', label: 'Inactive' }
+                                             { value: 'draft', label: 'price_list_statuses.draft' },
+                                             { value: 'active', label: 'price_list_statuses.active' },
+                                             { value: 'scheduled', label: 'price_list_statuses.scheduled' },
+                                             { value: 'inactive', label: 'price_list_statuses.inactive' }
                                            ]
 
   Spree.admin.tables.price_lists.add :starts_at,
@@ -1562,7 +1562,7 @@ Rails.application.config.after_initialize do
                                                    position: 20,
                                                    partial: 'spree/admin/tables/columns/product_status',
                                                    ransack_attribute: 'status',
-                                                   value_options: -> { Spree::Product::STATUSES.map { |s| { value: s, label: s.humanize } } }
+                                                   value_options: -> { Spree::Product::STATUSES.map { |s| { value: s, label: Spree.t("admin.products.#{s}", default: s.humanize) } } }
 
   Spree.admin.tables.price_list_products.add :inventory,
                                                    label: :inventory,
@@ -1747,8 +1747,8 @@ Rails.application.config.after_initialize do
                                             default: true,
                                             position: 20,
                                             value_options: [
-                                              { value: 'unused', label: 'Unused' },
-                                              { value: 'used', label: 'Used' }
+                                              { value: 'unused', label: 'admin.coupon_codes.unused' },
+                                              { value: 'used', label: 'admin.coupon_codes.used' }
                                             ]
 
   Spree.admin.tables.coupon_codes.add :created_at,

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -156,7 +156,7 @@ en:
         visits:
           devices_title: Visitor devices
           landing_pages_title: Top landing pages
-          locations_title: Visitor location
+          locations_title: Visitor locations
           no_data: No data
           no_data_for_period: No data available for this period.
           referrers_title: Where are visitors coming from?
@@ -216,9 +216,9 @@ en:
           process_rows: 2. Process rows
         waiting_for_file_to_be_processed: Waiting for file to be processed...
       integrations:
-        find_more: Find more integrations in
+        find_more_html: Find more integrations in %{integrations_link}
         invalid_integration_type: This integration is not allowed
-        none_installed: No integrations installed yet. Find integrations in
+        none_installed_html: No integrations installed yet. Find integrations in %{integrations_link}
         page_subtitle: Connect your store to third-party services to enhance customer experience.
       integrations_directory: Integrations Directory
       invitations:
@@ -369,7 +369,7 @@ en:
         youtube_video_url: Youtube video URL
       payment_methods:
         available_payment_methods: Available Payment Methods
-        find_more_payment_methods: Find more payment methods in
+        find_more_payment_methods_html: Find more payment methods in %{integrations_link}
         name_help: This name will be used to identify the payment method on the storefront
       personal_details: Personal Details
       previous_page: Previous page
@@ -432,7 +432,7 @@ en:
         code_prefix_example_html: eg. %{example}
         code_prefix_placeholder: Coupon Prefix (optional)
         coupon_code_placeholder: Your coupon code
-        expires_at_help: Leave this field blank for no expiration.
+        expires_at_help: 'Leave this field blank for no expiration. Time zone: %{zone}'
         kind:
           automatic_help: This promotion will be automatically applied to all eligible orders.
           multi_codes_help: These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
@@ -510,7 +510,7 @@ en:
           import_hint: You can also import products in bulk from a CSV or Excel file.
         customer_support_email_task:
           copy: We need your customer support email to display on your storefront. This email will work as a contact point for your customers to reach out to you for any queries or support.
-          current_html: Your customer support email is %{email}
+          current_html: Your customer support email is %{email}.
           label: Customer support email
         payment_methods:
           copy: In order to collect payments, please setup at least one online payment provider.
@@ -671,6 +671,7 @@ en:
         successful_deliveries: Successful Deliveries
         test_failed: Failed to send test webhook. Please check the endpoint configuration.
         test_sent: Test webhook sent. Check deliveries for the result.
+        url_placeholder: https://example.com/webhooks
       webhooks_subscribers:
         all_events: All Events
         new_webhooks_subscriber: New Webhooks Subscriber

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -38,6 +38,9 @@ en:
     adjustment_closed_description: The adjustment is closed, and will not be recalculated.
     adjustment_open_description: The adjustment is open, and will be recalculated.
     admin:
+      admin_users:
+        audit_log_enterprise_notice: Audit log is part of the Spree Enterprise offering.
+        upgrade_to_enterprise: Upgrade to Spree Enterprise
       allowed_origins:
         origin_help: Enter the full origin URL of your storefront (e.g. https://myshop.com). Do not include paths or query strings.
         origin_settings: Origin Settings
@@ -71,6 +74,7 @@ en:
         usage_instructions:
           publishable: Use this key for client-side requests. It can be safely included in your frontend code.
           secret: Use this key for server-side requests only. Keep it confidential and never expose it in client-side code.
+      assistant: Assistant
       audit_log: Audit Log
       avg_order_value: Avg. Order Value
       back_to_dashboard: Back to dashboard
@@ -144,7 +148,18 @@ en:
           steps_done_html: "<strong>%{done}</strong> of %{total} steps done"
           title: Your overall setup progress
         top_products: Top products
+        updater:
+          available_html: "%{version} is available."
+          current_version_html: Your current version is %{version}.
+          view_release_notes: View release notes
         view_report: View report
+        visits:
+          devices_title: Visitor devices
+          landing_pages_title: Top landing pages
+          locations_title: Visitor location
+          no_data: No data
+          no_data_for_period: No data available for this period.
+          referrers_title: Where are visitors coming from?
         whats_happening_on_html: Here's what's happening on <strong>%{store_name}</strong> today.
       datetime_field_timezone_help: 'Time zone: %{zone}'
       digital_shipment_fulfillment_note: This shipment will be marked as fulfilled once the user downloads the digital product
@@ -158,6 +173,9 @@ en:
       edit_profile: Edit Profile
       edit_shipping_address: Edit shipping address
       edit_theme: Edit theme
+      enterprise_edition_notice:
+        body: Thank you for using Spree Community Edition! Please consider upgrading to Enterprise Edition for access to all features and support.
+        upgrade: Upgrade
       errors: Errors
       execution_time: Execution Time
       expand_sidebar: Expand sidebar
@@ -170,6 +188,7 @@ en:
       getting_started: Getting started
       gift_card_batches:
         codes_count: Codes count
+        expires_at_help: Gift cards will expire after this date.
         new_gift_card_batch: New Gift Card Batch
         prefix: Prefix
       gift_cards:
@@ -182,15 +201,30 @@ en:
         all_required_columns_mapped: Good job, all required columns are mapped!
         field_required: Field required
         import_done: All done!
+        json: JSON
         large_import_background_note: You can close this page — the import will continue in the background.
         large_import_message: This import contains %{count} rows and is too large to display individually.
         large_import_summary: "%{completed} completed, %{failed} failed"
         mapping_required: This field is required
         please_map_all_required_fields: Please map all the required fields to continue.
+        please_select_a_column: Please select a column
+        rows_processed: "%{processed} / %{total} rows processed"
+        schema: Schema
+        steps:
+          complete: 3. Complete
+          map_fields: 1. Map fields
+          process_rows: 2. Process rows
         waiting_for_file_to_be_processed: Waiting for file to be processed...
       integrations:
+        find_more: Find more integrations in
         invalid_integration_type: This integration is not allowed
+        none_installed: No integrations installed yet. Find integrations in
         page_subtitle: Connect your store to third-party services to enhance customer experience.
+      integrations_directory: Integrations Directory
+      invitations:
+        email_placeholder: eg. steve@apple.com
+        expires_at: Expires at
+        invited_you_to_join_html: "%{inviter} has invited you to join %{resource}"
       json_preview:
         no_api_response: No API response found for this resource
       manage_markets: Manage Markets
@@ -206,6 +240,8 @@ en:
       metafield_definitions:
         edit_warning: You can't change the resource type or metafield type after the definition has been used.
         used_in: Used in
+      metafields:
+        none_configured_for: No metafield definitions configured for %{resource}.
       name: Name
       navigation:
         nested_under: Nested under
@@ -213,6 +249,8 @@ en:
         all: All
         unverified: Unverified
         verified: Verified
+      next_page: Next page
+      no_change: No change
       not_tracking_inventory: Not tracking inventory
       notifications: Notifications
       num_orders: No. of Orders
@@ -226,6 +264,15 @@ en:
         read_and_write: Read & Write
         read_only: Read Only
         scopes: Scopes
+      option_types:
+        intro_help: Options are used to group certain attributes. For example, you can create an option named "shirt size" and then create an option value named "small" and "medium" for this option.
+        learn_more: Learn more about options
+        name_help_html: This is used internally to identify the option type. <strong>It must be unique.</strong>
+        presentation_help: This is used to display the option type on the storefront.
+        showing_pagination: Showing %{from}-%{to} of %{total}
+        value_count:
+          one: "%{count} value"
+          other: "%{count} values"
       order:
         events:
           approve: Approve
@@ -235,15 +282,54 @@ en:
       orders:
         add_user_to_this_order: Add customer to this order
         all_orders: All Orders
+        avs_responses:
+          a: Street address matches, but 5-digit and 9-digit postal code do not match.
+          b: Street address matches, but postal code not verified.
+          c: Street address and postal code do not match.
+          d: Street address and postal code match.
+          e: AVS data is invalid or AVS is not allowed for this card type.
+          f: Card member's name does not match, but billing postal code matches.
+          g: Non-U.S. issuing bank does not support AVS.
+          h: Card member's name does not match. Street address and postal code match.
+          i: Address not verified.
+          j: Card member's name, billing address, and postal code match.
+          k: Card member's name matches but billing address and billing postal code do not match.
+          l: Card member's name and billing postal code match, but billing address does not match.
+          m: Street address and postal code match.
+          "n": Street address and postal code do not match.
+          o: Card member's name and billing address match, but billing postal code does not match.
+          p: Postal code matches, but street address not verified.
+          q: Card member's name, billing address, and postal code match.
+          r: System unavailable.
+          s: Bank does not support AVS.
+          t: Card member's name does not match, but street address matches.
+          u: Address information unavailable. Returned if the U.S. bank does not support non-U.S. AVS or if the AVS in a U.S. bank is not functioning properly.
+          v: Card member's name, billing address, and billing postal code match.
+          w: Street address does not match, but 9-digit postal code matches.
+          x: Street address and 9-digit postal code match.
+          "y": Street address and 5-digit postal code match.
+          z: Street address does not match, but 5-digit postal code matches.
         canceled: Canceled
+        cvv_responses:
+          blank: Transaction failed because wrong CVV2 number was entered or no CVV2 number was entered
+          m: CVV2 Match
+          "n": CVV2 No Match
+          p: Not Processed
+          s: Issuer indicates that CVV2 data should be present on the card, but the merchant has indicated data is not present on the card
+          u: Issuer has not certified for CVV2 or Issuer has not provided Visa with the CVV2 encryption keys
         fulfilled: Fulfilled
         no_email_present: Please add an email address to send the payment link
+        orders_count:
+          one: "%{count} order"
+          other: "%{count} orders"
         orders_to_fulfill: Orders to fulfill
         partially_refunded: Partially Refunded
         payment_link_sent: Payment link was sent to the customer
+        placed_by_guest: This order was placed by a guest customer
         provide_email: Provide an email address
         refunded: Refunded
         remove_user_from_this_order: Remove customer from this order
+        repeat_customer_summary_html: This is a repeat customer that has spent a total of %{amount} across %{count}, averaging %{average} per order.
         unfulfilled: Unfulfilled
       page_builder:
         background_color: Background color
@@ -281,7 +367,12 @@ en:
         use_description_from_admin: Use description from admin
         vertical_alignment: Vertical alignment
         youtube_video_url: Youtube video URL
+      payment_methods:
+        available_payment_methods: Available Payment Methods
+        find_more_payment_methods: Find more payment methods in
+        name_help: This name will be used to identify the payment method on the storefront
       personal_details: Personal Details
+      previous_page: Previous page
       price_lists:
         activate: Activate
         activated: Price list has been activated
@@ -291,6 +382,8 @@ en:
         confirm_unschedule: Are you sure you want to unschedule this price list?
         deactivate: Deactivate
         deactivated: Price list has been deactivated
+        learn_more: Learn more about price lists
+        page_info: Price lists are a powerful tool for managing pricing strategies based on customer groups, products, or other criteria.
         schedule: Schedule
         scheduled: Price list has been scheduled
         unschedule: Unschedule
@@ -317,6 +410,7 @@ en:
         inventory:
           barcode: Barcode (ISBN, UPC, GTIN, etc.)
           sku: SKU (Stock Keeping Unit)
+        learn_more: Learn more about managing products
         out_of_stock: Out of Stock
         paused: Paused
         search_results:
@@ -333,6 +427,23 @@ en:
           choose_stores: Choose which stores this product should be available in
         variants:
           option_types_link: To add more option types please go to <a href="%{link}">Option Types</a>
+      promotions:
+        add_more_codes_help: To add more codes just increase this number
+        code_prefix_example_html: eg. %{example}
+        code_prefix_placeholder: Coupon Prefix (optional)
+        coupon_code_placeholder: Your coupon code
+        expires_at_help: Leave this field blank for no expiration.
+        kind:
+          automatic_help: This promotion will be automatically applied to all eligible orders.
+          multi_codes_help: These codes are generated automatically and can be downloaded as a CSV file. Codes are unique and can only be used once.
+          multi_codes_label: Generate unique codes
+          one_code_help: You can limit the number of times this code can be used.
+          one_code_label: One code for all customers
+        name_help: Customers will see this in their cart and at checkout.
+        next_step_info: In the next step you will be able to add actions and rules to your promotion
+        number_of_codes_help: How many codes you want to generate.
+        number_of_codes_placeholder: Number of codes
+        usage_limit_help: Leave this field blank for unlimited usage.
       publishing:
         caption_hidden_after: Comes down %{date}
         caption_live: Visible to customers now
@@ -362,7 +473,16 @@ en:
         please_provide_tracking_details: Before marking shipment as shipped please provide tracking details
       shipment_transfer:
         wrong_destination: Wrong destination
+      shipments:
+        stock_location_option: "%{name} (%{count} on hand)"
+      shipping_methods:
+        admin_name_help: This will be displayed to admins
+        checkout_info: Shipping methods are options that the customer sees when they reach the checkout, they are the carriers and services used to send your products.
+        estimated_transit_business_days_help: This is the estimated number of business days it will take for the package to arrive at the customer's address. It will be displayed on the checkout page.
+        name_help: This will be displayed to customers
+        tracking_url_token_help: will be replaced with the tracking number.
       show_json: Show JSON
+      sign_ups: Sign-ups
       stock_transfers:
         add_products_tip: You need to select a destination location first
       store_credit:
@@ -371,12 +491,27 @@ en:
         company_field:
           description: It shows the company field on the address form in the My Account section and on the checkout address step.
           label: Display the company address field
+        currencies_managed_by_markets_html: Currencies and locales are now managed by %{markets_link}.
         customer_support_email_help: This email is visible to your Store visitors in the Footer section
+        email_addresses: Email addresses
+        logo_help: Used in the admin dashboard
+        mail_from_address_help: Please provide the email address that will be used as the sender of all emails sent from your store.
+        mailer_logo_format_hint: We recommend images with a transparent background. Only JPEG and PNG formats are supported.
+        mailer_logo_help: This logo is included in all email notifications such as order confirmation
         new_order_notifications_email_help: If you want to receive an email notification every time someone places an Order please provide an email address for that notification to be sent to
         send_consumer_transactional_emails_help: When unchecked, transactional emails like order confirmations and shipment notifications will not be sent to customers
       store_setup_tasks:
         add_billing_address: Add billing address
         add_products: Add products
+        add_products_task:
+          copy: Add products to your store, either your own or invite 3rd party vendors to sell together.
+          done_subtitle: Remember you can always add more!
+          done_title: Good job, you've added products to your store!
+          import_hint: You can also import products in bulk from a CSV or Excel file.
+        customer_support_email_task:
+          copy: We need your customer support email to display on your storefront. This email will work as a contact point for your customers to reach out to you for any queries or support.
+          current_html: Your customer support email is %{email}
+          label: Customer support email
         payment_methods:
           copy: In order to collect payments, please setup at least one online payment provider.
           done: You're all set! You can always manage your Payment Methods on <a href="%{link}" data-turbo-frame="_top">this</a> page.
@@ -443,18 +578,30 @@ en:
         automatic_info: Automatically add products to this category if they match the rules you set.
         manual: Manual
         manual_info: Curate products manually. You can add or remove them in bulk.
+      taxons:
+        seo:
+          placeholder: Add a title and description to see how this taxon might appear in a search engine listing
+        square_image_help: Used for the featured image on the homepage.
+      total_orders: Total Orders
       translations:
         no_translations_configured: No translations configured. Please setup Markets to use translations.
       upload_new_asset: Upload new media
       user:
         last_order_placed: Last order placed
         no_store_credit: Customer has no Store Credit available
+      user_sessions:
+        email_placeholder: steve@getvendo.com
+        welcome_back: Welcome back
       users:
         filters:
           search_placeholder: Search customers by email or name
+        timeline: Timeline
       utilities:
         preview: Preview
       variants:
+        count_at_location:
+          one: "%{count} at location"
+          other: "%{count} at location"
         search_results:
           no_variants: We couldn't find any variants matching your search :(
       variants_form:
@@ -498,6 +645,7 @@ en:
           healthy: "%{percentage}% success"
           no_deliveries: No data
         health_label: Health
+        name_placeholder: e.g. Storefront emails, Fulfillment service
         new: New Webhook Endpoint
         re_enable: Re-enable
         secret_key: Secret Key
@@ -516,6 +664,8 @@ en:
         subscriptions: Subscriptions
         time_of_last_event: Time of Last Event
         webhooks_events: Webhooks Events
+      zones:
+        info: Zones are geographical groupings, they represent collections of either states or countries.
     admin_language_help: The language your admin dashboard is displayed in. Only affects what you see, not the store or other staff.
     admin_locale_help: The language used for the admin dashboard. If not set, defaults to the application locale.
     all_items_have_been_returned: All items have been returned
@@ -548,6 +698,7 @@ en:
     continue_selling_when_out_of_stock: Continue selling when out of stock
     copied: Copied!
     copy_id: Copy ID
+    copy_number: Copy number
     country_based: Country Based
     create_a_new_account: Create a new account
     custom_domains: Custom domains
@@ -601,6 +752,7 @@ en:
     invitation_resent: Invitation resent!
     issued_on: Issued On
     item_total_rule:
+      max_amount_help: Leave this field blank to not limit the maximum amount.
       operators:
         gt: greater than
         gte: greater than or equal to
@@ -758,6 +910,7 @@ en:
     purchased_quantity: Purchased Quantity
     refund_reasons: Refund Reasons
     reimbursement_type_override: Reimbursement Type Override
+    remaining: Remaining
     remove_condition: Remove condition
     return_authorization_reasons: Return Authorization Reasons
     return_authorization_states:

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -526,6 +526,22 @@ en:
       storefront: Storefront
       successful: Successful
       successfully_reset_digital_links_limit: Download limits have been reset
+      table:
+        operators:
+          cont: contains
+          end: ends with
+          eq: equals
+          gt: greater than
+          gteq: greater than or equal to
+          in: is any of
+          lt: less than
+          lteq: less than or equal to
+          not_cont: does not contain
+          not_eq: does not equal
+          not_in: is none of
+          not_null: is not empty
+          'null': is empty
+          start: starts with
       tables:
         add_filter: Add filter
         add_or_group: Add OR group


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded localized, translation-driven UI text across many admin screens (dashboard, orders, products, promotions, shipping, imports, invitations, stores, settings), including help, placeholders, empty states, and links.

* **Bug Fixes**
  * Improved multi-language consistency by replacing hardcoded labels with localized versions, including deleted product badges, stock-count/options text, AVS/CVV explanations, table/filter operator labels, query-builder option labels, and pagination/accessibility messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->