### PR TITLE
Make `ensure_store` a global for all store resources

### DIFF
--- a/spree/core/app/models/concerns/spree/single_store_resource.rb
+++ b/spree/core/app/models/concerns/spree/single_store_resource.rb
@@ -3,12 +3,17 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
+      before_validation :ensure_store, unless: :store_id?
       validate :ensure_store_association_is_not_changed
 
       scope :for_store, ->(store) { where(store_id: store.id) }
     end
 
     protected
+
+    def ensure_store
+      self.store ||= Spree::Current.store
+    end
 
     def ensure_store_association_is_not_changed
       if store_id_changed? && persisted?

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -224,7 +224,6 @@ module Spree
     accepts_nested_attributes_for :shipments
 
     # Needs to happen before save_permalink is called
-    before_validation :ensure_store_presence
     before_validation :ensure_market_presence
     before_validation :ensure_channel_presence
     before_validation :ensure_currency_presence

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -500,7 +500,8 @@ module Spree
     end
 
     def ensure_store_presence
-      self.store ||= Spree::Store.default
+      Spree::Deprecation.warn('Spree::Order#ensure_store_presence is deprecated and will be removed in Spree 6.0. ensure_store instead.')
+      ensure_store
     end
 
     def ensure_market_presence

--- a/spree/core/app/models/spree/role_user.rb
+++ b/spree/core/app/models/spree/role_user.rb
@@ -28,7 +28,7 @@ module Spree
     #
     # Callbacks
     #
-    before_validation :set_default_resource, :ensure_store
+    before_validation :set_default_resource
 
     private
 
@@ -36,10 +36,6 @@ module Spree
     # this will allow a graceful migration from the old roles system to the new one
     def set_default_resource
       self.resource ||= Spree::Store.current
-    end
-
-    def ensure_store
-      self.store ||= Spree::Current.store
     end
   end
 end

--- a/spree/core/app/models/spree/taxon.rb
+++ b/spree/core/app/models/spree/taxon.rb
@@ -506,7 +506,9 @@ module Spree
     # populated for new records. Guards on the raw +store_id+ column rather than
     # +#store+, whose reader masks an unset column with the taxonomy fallback.
     def ensure_store
-      self.store ||= taxonomy&.store || parent&.store || Spree::Store.current
+      return if store_id.present?
+
+      self.store = taxonomy&.store || parent&.store || Spree::Store.current
     end
 
     def regenerate_translations_pretty_name_and_permalink

--- a/spree/core/app/models/spree/taxon.rb
+++ b/spree/core/app/models/spree/taxon.rb
@@ -506,9 +506,7 @@ module Spree
     # populated for new records. Guards on the raw +store_id+ column rather than
     # +#store+, whose reader masks an unset column with the taxonomy fallback.
     def ensure_store
-      return if store_id.present?
-
-      self.store = taxonomy&.store || parent&.store || Spree::Store.current
+      self.store ||= taxonomy&.store || parent&.store || Spree::Store.current
     end
 
     def regenerate_translations_pretty_name_and_permalink

--- a/spree/core/app/models/spree/taxon.rb
+++ b/spree/core/app/models/spree/taxon.rb
@@ -83,7 +83,6 @@ module Spree
     #
     before_validation :set_permalink, if: :name
     before_validation :copy_taxonomy_from_parent
-    before_validation :set_store
     before_save :set_pretty_name
     after_save :touch_ancestors_and_taxonomy
     after_update :sync_taxonomy_name
@@ -497,11 +496,16 @@ module Spree
       self.taxonomy = parent.taxonomy if parent.present? && taxonomy.blank?
     end
 
+    def set_store
+      Spree::Deprecation.warn('Spree::Taxon#set_store is deprecated and will be removed in Spree 6.0. ensure_store instead.')
+      ensure_store
+    end
+
     # Every taxon is store-owned. Resolve the store from the taxonomy, then the
     # parent, finally the current store — so the direct column is always
     # populated for new records. Guards on the raw +store_id+ column rather than
     # +#store+, whose reader masks an unset column with the taxonomy fallback.
-    def set_store
+    def ensure_store
       return if store_id.present?
 
       self.store = taxonomy&.store || parent&.store || Spree::Store.current

--- a/spree/core/app/models/spree/taxon.rb
+++ b/spree/core/app/models/spree/taxon.rb
@@ -4,6 +4,8 @@ require 'stringex'
 
 module Spree
   class Taxon < Spree.base_class
+    include Spree::SingleStoreResource
+
     has_prefix_id :ctg
 
     RULES_MATCH_POLICIES = %w[all any].freeze

--- a/spree/core/spec/models/spree/allowed_origin_spec.rb
+++ b/spree/core/spec/models/spree/allowed_origin_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Spree::AllowedOrigin, type: :model do
   describe 'validations' do
     subject { build(:allowed_origin, store: store) }
 
-    it { is_expected.to validate_presence_of(:store) }
     it { is_expected.to validate_presence_of(:origin) }
 
     it 'validates uniqueness of origin scoped to store' do

--- a/spree/core/spec/models/spree/customer_group_spec.rb
+++ b/spree/core/spec/models/spree/customer_group_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Spree::CustomerGroup, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:store) }
 
     context 'uniqueness' do
       let!(:existing_group) { create(:customer_group, name: 'VIP', store: store) }

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Spree::Market, type: :model do
   describe 'validations' do
     subject { build(:market, store: store) }
 
-    it { is_expected.to validate_presence_of(:store) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:currency) }
     it { is_expected.to validate_presence_of(:default_locale) }

--- a/spree/core/spec/models/spree/wishlist_spec.rb
+++ b/spree/core/spec/models/spree/wishlist_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Spree::Wishlist, type: :model do
-  let!(:store) { @default_store }
-  let!(:other_store) { create(:store) }
-  let!(:user) { create(:user) }
-  let!(:other_user) { create(:user) }
+  let(:store) { @default_store }
+  let(:other_store) { create(:store) }
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
 
-  let!(:wishlist) { create(:wishlist, user: user, name: 'My Wishlist', store: store, is_default: true) }
-  let!(:wishlist_belonging_to_other_store) { create(:wishlist, user: user, name: 'My Wishlist', store: other_store, is_default: true) }
-  let!(:wishlist_belonging_to_other_user) { create(:wishlist, user: other_user, name: 'My Wishlist', store: store, is_default: true) }
+  let(:wishlist) { create(:wishlist, user: user, name: 'My Wishlist', store: store, is_default: true) }
+  let(:wishlist_belonging_to_other_store) { create(:wishlist, user: user, name: 'My Wishlist', store: other_store, is_default: true) }
+  let(:wishlist_belonging_to_other_user) { create(:wishlist, user: other_user, name: 'My Wishlist', store: store, is_default: true) }
 
   describe 'lifecycle events', events: true do
     describe 'wishlist.created' do
@@ -41,25 +41,14 @@ describe Spree::Wishlist, type: :model do
     end
   end
 
-  it 'has a valid factory' do
-    expect(wishlist).to be_valid
-  end
-
-  it 'validates presence of name' do
-    expect(described_class.new(name: nil, user: user, store: store)).not_to be_valid
-  end
-
-  it 'validates presence of store' do
-    expect(described_class.new(name: 'My Wishlist', user: user, store: nil)).not_to be_valid
-  end
-
-  it 'validates presence of user' do
-    expect(described_class.new(name: 'My Wishlist', user: nil, store: store)).not_to be_valid
-  end
-
   describe '.ensure_default_exists_and_is_unique' do
     context 'when user creates a new default store' do
-      let!(:new_wl) { create(:wishlist, name: 'My New WishList', user: user, store: store, is_default: true) }
+      let(:new_wl) { create(:wishlist, name: 'My New WishList', user: user, store: store, is_default: true) }
+
+      before do
+        wishlist
+        new_wl
+      end
 
       it 'preserves is_default: true for new wishlist' do
         expect(new_wl.is_default).to be true


### PR DESCRIPTION
This moves us closed to the future where all spree models will be tied natively with store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-store resources and taxonomies now automatically populate `store` during validation when no store is selected.
  * Taxonomy store resolution is consistent (taxonomy → parent → current store) and preserves any existing `store_id`; store associations remain locked after saving.
* **Chores**
  * Added deprecation warnings for legacy order and taxonomy store-presence/store-setting behavior ahead of a future major release.
* **Tests**
  * Updated wishlist specs for more reliable lazy setup.
  * Adjusted validation expectations in specs to match updated store requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->