### PR TITLE
Fix taxon store_id backfill rake task for PostgreSQL

### DIFF
--- a/spree/core/lib/tasks/taxons.rake
+++ b/spree/core/lib/tasks/taxons.rake
@@ -4,20 +4,37 @@ namespace :spree do
     task backfill_store_id: :environment do |_t, _args|
       puts 'Backfilling taxon store_id from taxonomy...'
 
-      Spree::Taxon.unscoped.where(store_id: nil).in_batches(of: 1000) do |batch|
-        batch.joins(:taxonomy).update_all('store_id = spree_taxonomies.store_id')
+      # Resolve per-taxonomy and update by id — never reference a joined table in
+      # an update_all SET clause. It is not portable: on some adapter / Rails
+      # version combinations (e.g. Rails 7.2 on PostgreSQL) update_all-with-join
+      # is rewritten to `... WHERE id IN (subquery)`, leaving the joined alias out
+      # of scope in the SET and raising PG::UndefinedTable ("missing FROM-clause
+      # entry"). It fails at parse time, even when no rows need changing.
+      Spree::Taxonomy.where.not(store_id: nil).find_each do |taxonomy|
+        Spree::Taxon.unscoped.where(store_id: nil, taxonomy_id: taxonomy.id).
+          in_batches(of: 1000).update_all(store_id: taxonomy.store_id)
         print '.'
       end
 
-      # Mirror Spree::Taxon#set_store: taxonomy-less rows inherit their parent's
-      # store. Loop so a chain of unbackfilled ancestors resolves top-down.
-      taxons = Spree::Taxon.arel_table
-      parents = Spree::Taxon.arel_table.alias('parents')
+      puts "\nResolving taxonomy-less taxons through the parent chain..."
+
+      # Mirror Spree::Taxon#ensure_store: taxonomy-less rows inherit their parent's
+      # store. Loop so a chain of unbackfilled ancestors resolves top-down — each
+      # pass pushes an already-resolved parent's store onto its children.
       loop do
-        updated = Spree::Taxon.unscoped.where(store_id: nil).where.not(parent_id: nil).
-                  joins("INNER JOIN #{taxons.name} #{parents.name} ON #{parents.name}.id = #{taxons.name}.parent_id").
-                  where.not(parents[:store_id].eq(nil)).
-                  update_all("store_id = #{parents.name}.store_id")
+        updated = 0
+
+        # Resolved parents that still have children missing a store form the
+        # frontier; push each store down in one UPDATE per (store, id batch).
+        frontier = Spree::Taxon.unscoped.where.not(store_id: nil).
+                   where(id: Spree::Taxon.unscoped.where(store_id: nil).select(:parent_id))
+        frontier.pluck(:id, :store_id).group_by(&:last).each do |store_id, rows|
+          rows.map(&:first).each_slice(1000) do |parent_ids|
+            updated += Spree::Taxon.unscoped.where(store_id: nil, parent_id: parent_ids).
+                       update_all(store_id: store_id)
+          end
+        end
+
         print '.'
         break if updated.zero?
       end

--- a/spree/core/spec/lib/tasks/taxons_spec.rb
+++ b/spree/core/spec/lib/tasks/taxons_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'spree:taxons:backfill_store_id' do
+  subject { Rake::Task[task_name] }
+
+  let(:task_name) { 'spree:taxons:backfill_store_id' }
+
+  before(:all) do
+    Rake::Task.define_task(:environment)
+    load Spree::Core::Engine.root.join('lib', 'tasks', 'taxons.rake')
+  end
+
+  before { subject.reenable }
+
+  let!(:store) { Spree::Store.default || create(:store, default: true) }
+
+  # ensure_store stamps store_id on create, so null it to reproduce a row
+  # created before the column existed.
+  def downgrade!(taxon)
+    taxon.update_columns(store_id: nil)
+    taxon
+  end
+
+  context 'taxonomy-backed taxon' do
+    let(:taxonomy) { create(:taxonomy, store: store) }
+    let!(:taxon) { downgrade!(create(:taxon, taxonomy: taxonomy)) }
+
+    it 'backfills store_id from the taxonomy' do
+      expect { subject.invoke }.to change { taxon.reload.store_id }.from(nil).to(store.id)
+    end
+  end
+
+  context 'taxonomy-less taxons in a parent chain' do
+    # Root keeps its store (resolved via the taxonomy pass or pre-existing);
+    # descendants must inherit it down the chain.
+    let!(:root) { Spree::Category.create!(name: 'Root', store: store) }
+    let!(:mid) { downgrade!(Spree::Category.create!(name: 'Mid', parent: root)) }
+    let!(:leaf) { downgrade!(Spree::Category.create!(name: 'Leaf', parent: mid)) }
+
+    it 'resolves every level from the nearest resolved ancestor' do
+      subject.invoke
+
+      expect(mid.reload.store_id).to eq(store.id)
+      expect(leaf.reload.store_id).to eq(store.id)
+    end
+
+    it 'is idempotent — a re-run changes nothing' do
+      subject.invoke
+      subject.reenable
+      expect { subject.invoke }.not_to change { [mid.reload.store_id, leaf.reload.store_id] }
+    end
+  end
+
+  context 'when nothing needs backfilling' do
+    # Every taxon already has a store_id — the task must still run cleanly.
+    # The buggy join-update raised at SQL-parse time even with zero matching rows.
+    let!(:taxon) { create(:taxon, taxonomy: create(:taxonomy, store: store)) }
+
+    it 'is a safe no-op' do
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+  context 'taxonomy-less root with no resolvable ancestor' do
+    # No taxonomy and no parent to inherit from — the backfill has no store to
+    # resolve it against, so the row is intentionally left untouched rather than
+    # defaulted (ensure_store's current-store fallback needs request context the
+    # task doesn't have).
+    let!(:orphan) { downgrade!(Spree::Category.create!(name: 'Orphan', store: store)) }
+
+    it 'leaves store_id nil' do
+      expect { subject.invoke }.not_to change { orphan.reload.store_id }.from(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a critical bug in the `spree:taxons:backfill_store_id` rake task that caused SQL parse errors on PostgreSQL (and potentially other adapters) when attempting to update taxon `store_id` values from their associated taxonomies.

## Problem

The original implementation used `update_all` with a JOIN clause in the SET expression:
```ruby
batch.joins(:taxonomy).update_all('store_id = spree_taxonomies.store_id')
```

On Rails 7.2+ with PostgreSQL, this is rewritten to use a subquery in the WHERE clause, which leaves the joined table alias out of scope in the SET clause, causing `PG::UndefinedTable` errors at parse time—even when no rows need updating.

## Solution

Refactored the backfill logic to avoid joined table references in UPDATE statements:

- **Taxonomy-backed taxons**: Iterate through each taxonomy and update its taxons by ID, passing the store_id as a literal value rather than a column reference
- **Taxonomy-less taxons**: Resolve store_id through the parent chain iteratively, using a frontier-based approach that groups updates by store_id to minimize queries
- Added comprehensive test coverage including edge cases (idempotency, no-op when nothing needs backfilling)

## Key Changes

- Replaced single `joins().update_all()` call with per-taxonomy updates using literal values
- Rewrote parent-chain resolution loop to avoid JOIN in UPDATE; now uses `pluck` + grouping to build a frontier of resolved parents
- Added detailed comments explaining the portability issue and the solution
- Added full test suite (`spree/core/spec/lib/tasks/taxons_spec.rb`) covering taxonomy-backed taxons, parent chain resolution, idempotency, and safe no-op behavior

## Implementation Details

The new approach:
1. Processes each taxonomy once, updating all its null-store_id taxons in batches
2. Iteratively resolves taxonomy-less taxons by finding parents with a store_id and pushing that store down to their children
3. Groups children by store_id to minimize UPDATE statements
4. Batches large parent lists (1000 at a time) to avoid query size limits
5. Continues looping until no rows are updated (idempotent)

This is portable across all database adapters and Rails versions, and handles the edge case where all taxons already have a store_id (safe no-op).

https://claude.ai/code/session_01GxnwpfNCaWpSQNUDjNLWTU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the store backfill task to reliably update taxonomy-linked and taxonomy-less taxons, avoiding query-related errors.
  * Taxonomy-less categories now inherit store information from the nearest resolved ancestor in their parent chain.
  * The task is now safe to rerun and behaves as a clean no-op when no updates are needed.
* **Tests**
  * Added RSpec coverage for taxonomy-based backfills, parent-chain inheritance, safe no-op behavior, and handling orphan roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->