### PR TITLE
Update Marketplace use case docs

### DIFF
--- a/docs/use-case/marketplace/admin-dashboard.mdx
+++ b/docs/use-case/marketplace/admin-dashboard.mdx
@@ -3,7 +3,7 @@ title: "Marketplace Admin Panel"
 description: "Learn about the Spree multi-vendor marketplace admin UX."
 ---
 
-![](/docs/images/use-cases/multi-vendor/admin.png)
+![A graphic depicting the Spree Commerce admin dashboard](/docs/images/use-cases/multi-vendor/admin.png)
 
 Spree Commerce Enterprise Edition provides comprehensive [<u>multi-vendor marketplace</u>](https://spreecommerce.org/marketplace-ecommerce/) management tools designed specifically with a robust Admin dashboard. 
 
@@ -22,9 +22,11 @@ With robust vendor onboarding, intuitive integration options (Shopify and WooCom
 
 Spree Enterprise allows full oversight of vendor relationships. Admins can invite vendors, approve or reject vendor signups, suspend accounts, and monitor vendor performance metrics.
 
-- **Vendor Invites and Approval**: Initiate onboarding via direct invites or self-service applications with approval workflows.
+- **Vendor Invites and Approval**: Initiate onboarding via direct invites with approval workflows.
 - **Permission Controls**: Temporarily reject or suspend vendors to restrict access without deleting their data.
-- **Commission Management**: Set percentage-based commissions on a globally, per vendor, or per product
+- **Commission Management**: Set percentage-based commissions globally, per vendor, or per product
+
+See [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management) for a full walkthrough of the vendor list, vendor profiles, and per-vendor configuration. See [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates) for how commission levels work and how to override them.
 
 ### Shopify Vendor Integration
 
@@ -35,6 +37,8 @@ Admins can streamline operations for Shopify vendors using a white-labelled Shop
 - **Shipment Sync & Notifications**: Customer shipment status updates flow automatically based on Shopify fulfillment.
 - **Cancellations, Refunds & Notifications**: Full/partial cancellations and refunds sync from Shopify and notify the customer automatically.
 
+See [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify) for step-by-step setup instructions for both the admin and the vendor.
+
 ### WooCommerce Vendor Integration
 
 Admins can also streamline onboarding for WooCommerce vendors using a direct API integration:
@@ -44,6 +48,8 @@ Admins can also streamline onboarding for WooCommerce vendors using a direct API
 - **Shipment Sync & Notifications**: Customer shipment status updates flow automatically based on WooCommerce fulfillment.
 - **Cancellations, Refunds & Notifications**: Full/partial cancellations and refunds sync from WooCommerce and notify the customer automatically.
 
+See [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce) for step-by-step setup instructions for both the admin and the vendor.
+
 ### Manual or CSV Vendor Onboarding
 
 Admins can manually onboard vendors without an online store or using unsupported platforms via direct account setup in the vendor dashboard:
@@ -51,6 +57,8 @@ Admins can manually onboard vendors without an online store or using unsupported
 - **Product Upload**: Add products manually or CSV import
 - **Order Management**: Can review and process orders in the vendor dashboard
 - **Cancellations & Refunds**: Access tools to manage returns and exceptions.
+
+See [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual) for the full invitation and onboarding flow.
 
 ### Marketplace Merchandising
 
@@ -61,6 +69,14 @@ Ensure product consistency and branding integrity across all vendors.
 - **Product Categorization, Collections, Tags**: Organize products automatically or manually for storefront clarity.
 - **Product Properties**: Define and filter by reusable attributes.
 
+### Markets, Price Lists & Sales Channels
+
+Spree provides three OOTB features that are particularly powerful for marketplace operators managing multi-region or multi-channel operations:
+
+- **Markets**: Define distinct shopping experiences for different regions — each with its own currency, language, and tax settings. Customers can switch between markets on the storefront to see prices and content tailored to their location. See [Markets](https://spreecommerce.org/docs/user/settings/markets) for setup.
+- **Price Lists**: Apply custom pricing to specific customer segments based on conditions like customer group, market, volume, or geographic zone — with no code required. Ideal for B2B, wholesale, or regional pricing strategies. See [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists) for setup.
+- **Sales Channels**: Run multiple storefronts or selling contexts from a single Spree instance — for example, a public marketplace, a wholesale portal, a mobile app, or a seasonal microsite — each with its own product catalog, order attribution, and fulfillment routing. See [Sales Channels](https://spreecommerce.org/docs/user/settings/sales-channels) for setup.
+
 ### Promotions & Marketing Automations
 
 Built-in campaign tools for engagement and retention:
@@ -69,11 +85,9 @@ Built-in campaign tools for engagement and retention:
 - **Gift Cards**: Issue and redeem digital gift balances.
 - **Email Automations**: Abandoned cart and upsell flows triggered based on user activity.
 
-### Storefront & Content Management
+### Storefront
 
-- **Drag & Drop Builder**: Customize homepage and category layouts with blocks.
-- **Modular Pages**: Create landing pages without dev effort.
-- **Blog CMS & Newsletter Subscriptions**: Enhance SEO and brand engagement.
+Spree's [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront/storefront) is the production-ready frontend for marketplace deployments. It supports multi-vendor checkout out of the box and connects to Spree's full Storefront API for headless customization. Because it's built on React and Next.js, development teams can extend and restyle it freely without touching the Spree backend.
 
 ### Checkout & Payments
 
@@ -81,6 +95,8 @@ Built-in campaign tools for engagement and retention:
 - **Quick Checkout Options**: Apple Pay, Google Pay, and BNPL methods.
 - **Tax Calculation**: Real-time tax logic per shipping region.
 - **Stripe Connect Integration**: Handles vendor onboarding, order-level payment splits, and payout automation.
+
+See [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout) for how the unified cart, per-vendor shipping selection, and order splitting works from the customer's perspective. See [Marketplace Configuration](https://spreecommerce.org/docs/user/settings/marketplace) for default commission and payout settings.
 
 ### Order Management
 
@@ -93,16 +109,13 @@ Built-in campaign tools for engagement and retention:
 - **Automatic & Manual Options**: Spree handles payouts via Stripe Connect or manual exports.
 - **KYC Flow & Analytics**: Vendors onboard themselves through Stripe and access dashboards with reports.
 
+See [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts) for how to configure the default payout schedule and override it per vendor.
+
 ### Analytics & Reporting
 
 - **KPIs Dashboard**: Track sales, AOV, top selling products, and more in the dashboard
 - **Native Google Analytics Integration**: Unified view of traffic and conversions.
 - **Data Exports**: Download product or order data in CSV format.
-
-### Customer Service
-
-- **Chat & AI Bots**: Optional integrations for 24/7 help.
-- **Ticketing & Store Credits**: Manage support cases and compensation.
 
 ### APIs
 
@@ -112,10 +125,14 @@ Built-in campaign tools for engagement and retention:
 
 - [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
 - [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [<u>Developer Docs</u>](https://spreecommerce.org/docs/developer/getting-started/quickstart)
-- [<u>User Docs</u>](https://spreecommerce.org/docs/user/what-is-spree-commerce)
-- [<u>Ecommerce API docs</u>](https://spreecommerce.org/docs/api-reference/introduction)
-- [<u>Integrations</u>](https://spreecommerce.org/docs/integrations/integrations)
+- [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management)
+- [Markets](https://spreecommerce.org/docs/user/settings/markets)
+- [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists)
+- [Sales Channels](https://spreecommerce.org/docs/user/settings/sales-channels)
+- [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify)
+- [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce)
+- [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual)
+
 
 ### Get Started
 

--- a/docs/use-case/marketplace/admin-dashboard.mdx
+++ b/docs/use-case/marketplace/admin-dashboard.mdx
@@ -26,7 +26,7 @@ Spree Enterprise allows full oversight of vendor relationships. Admins can invit
 - **Permission Controls**: Temporarily reject or suspend vendors to restrict access without deleting their data.
 - **Commission Management**: Set percentage-based commissions globally, per vendor, or per product
 
-See [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management) for a full walkthrough of the vendor list, vendor profiles, and per-vendor configuration. See [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates) for how commission levels work and how to override them.
+See [Vendor Management](/user/vendors/vendor-management) for a full walkthrough of the vendor list, vendor profiles, and per-vendor configuration. See [Commission Rates](/user/vendors/commission-rates) for how commission levels work and how to override them.
 
 ### Shopify Vendor Integration
 
@@ -37,7 +37,7 @@ Admins can streamline operations for Shopify vendors using a white-labelled Shop
 - **Shipment Sync & Notifications**: Customer shipment status updates flow automatically based on Shopify fulfillment.
 - **Cancellations, Refunds & Notifications**: Full/partial cancellations and refunds sync from Shopify and notify the customer automatically.
 
-See [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify) for step-by-step setup instructions for both the admin and the vendor.
+See [Shopify Vendor Onboarding](/user/vendors/vendor-onboarding-shopify) for step-by-step setup instructions for both the admin and the vendor.
 
 ### WooCommerce Vendor Integration
 
@@ -48,7 +48,7 @@ Admins can also streamline onboarding for WooCommerce vendors using a direct API
 - **Shipment Sync & Notifications**: Customer shipment status updates flow automatically based on WooCommerce fulfillment.
 - **Cancellations, Refunds & Notifications**: Full/partial cancellations and refunds sync from WooCommerce and notify the customer automatically.
 
-See [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce) for step-by-step setup instructions for both the admin and the vendor.
+See [WooCommerce Vendor Onboarding](/user/vendors/vendor-onboarding-woocommerce) for step-by-step setup instructions for both the admin and the vendor.
 
 ### Manual or CSV Vendor Onboarding
 
@@ -58,7 +58,7 @@ Admins can manually onboard vendors without an online store or using unsupported
 - **Order Management**: Can review and process orders in the vendor dashboard
 - **Cancellations & Refunds**: Access tools to manage returns and exceptions.
 
-See [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual) for the full invitation and onboarding flow.
+See [Manual/CSV Vendor Onboarding](/user/vendors/vendor-onboarding-manual) for the full invitation and onboarding flow.
 
 ### Marketplace Merchandising
 
@@ -73,9 +73,9 @@ Ensure product consistency and branding integrity across all vendors.
 
 Spree provides three OOTB features that are particularly powerful for marketplace operators managing multi-region or multi-channel operations:
 
-- **Markets**: Define distinct shopping experiences for different regions — each with its own currency, language, and tax settings. Customers can switch between markets on the storefront to see prices and content tailored to their location. See [Markets](https://spreecommerce.org/docs/user/settings/markets) for setup.
-- **Price Lists**: Apply custom pricing to specific customer segments based on conditions like customer group, market, volume, or geographic zone — with no code required. Ideal for B2B, wholesale, or regional pricing strategies. See [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists) for setup.
-- **Sales Channels**: Run multiple storefronts or selling contexts from a single Spree instance — for example, a public marketplace, a wholesale portal, a mobile app, or a seasonal microsite — each with its own product catalog, order attribution, and fulfillment routing. See [Sales Channels](https://spreecommerce.org/docs/user/settings/sales-channels) for setup.
+- **Markets**: Define distinct shopping experiences for different regions — each with its own currency, language, and tax settings. Customers can switch between markets on the storefront to see prices and content tailored to their location. See [Markets](/user/settings/markets) for setup.
+- **Price Lists**: Apply custom pricing to specific customer segments based on conditions like customer group, market, volume, or geographic zone — with no code required. Ideal for B2B, wholesale, or regional pricing strategies. See [Price Lists](/user/manage-products/price-lists) for setup.
+- **Sales Channels**: Run multiple storefronts or selling contexts from a single Spree instance — for example, a public marketplace, a wholesale portal, a mobile app, or a seasonal microsite — each with its own product catalog, order attribution, and fulfillment routing. See [Sales Channels](/user/settings/sales-channels) for setup.
 
 ### Promotions & Marketing Automations
 
@@ -87,7 +87,7 @@ Built-in campaign tools for engagement and retention:
 
 ### Storefront
 
-Spree's [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront/storefront) is the production-ready frontend for marketplace deployments. It supports multi-vendor checkout out of the box and connects to Spree's full Storefront API for headless customization. Because it's built on React and Next.js, development teams can extend and restyle it freely without touching the Spree backend.
+Spree's [Next.js Storefront](/developer/storefront/storefront) is the production-ready frontend for marketplace deployments. It supports multi-vendor checkout out of the box and connects to Spree's full Storefront API for headless customization. Because it's built on React and Next.js, development teams can extend and restyle it freely without touching the Spree backend.
 
 ### Checkout & Payments
 
@@ -96,7 +96,7 @@ Spree's [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront
 - **Tax Calculation**: Real-time tax logic per shipping region.
 - **Stripe Connect Integration**: Handles vendor onboarding, order-level payment splits, and payout automation.
 
-See [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout) for how the unified cart, per-vendor shipping selection, and order splitting works from the customer's perspective. See [Marketplace Configuration](https://spreecommerce.org/docs/user/settings/marketplace) for default commission and payout settings.
+See [Multi-Vendor Checkout](/user/vendors/multi-vendor-checkout) for how the unified cart, per-vendor shipping selection, and order splitting works from the customer's perspective. See [Marketplace Configuration](/user/settings/marketplace) for default commission and payout settings.
 
 ### Order Management
 
@@ -109,7 +109,7 @@ See [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-ve
 - **Automatic & Manual Options**: Spree handles payouts via Stripe Connect or manual exports.
 - **KYC Flow & Analytics**: Vendors onboard themselves through Stripe and access dashboards with reports.
 
-See [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts) for how to configure the default payout schedule and override it per vendor.
+See [Vendor Payouts](/user/vendors/vendor-payouts) for how to configure the default payout schedule and override it per vendor.
 
 ### Analytics & Reporting
 
@@ -123,15 +123,15 @@ See [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
 
 ### Further Reading
 
-- [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
-- [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management)
-- [Markets](https://spreecommerce.org/docs/user/settings/markets)
-- [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists)
-- [Sales Channels](https://spreecommerce.org/docs/user/settings/sales-channels)
-- [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify)
-- [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce)
-- [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual)
+- [Multi-Vendor Marketplace Model](/use-case/marketplace/model)
+- [Multi-vendor Marketplace Capabilities](/use-case/marketplace/capabilities)
+- [Vendor Management](/user/vendors/vendor-management)
+- [Markets](/user/settings/markets)
+- [Price Lists](/user/manage-products/price-lists)
+- [Sales Channels](/user/settings/sales-channels)
+- [Shopify Vendor Onboarding](/user/vendors/vendor-onboarding-shopify)
+- [WooCommerce Vendor Onboarding](/user/vendors/vendor-onboarding-woocommerce)
+- [Manual/CSV Vendor Onboarding](/user/vendors/vendor-onboarding-manual)
 
 
 ### Get Started

--- a/docs/use-case/marketplace/capabilities.mdx
+++ b/docs/use-case/marketplace/capabilities.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Marketplace Capabilities"
-description: "Build a multi-vendor marketplace with Spree Enterprise: vendor onboarding, Shopify and WooCommerce integrations, Stripe Connect payouts, and order splitting."
+description: "Learn how Spree supports multi-vendor marketplaces."
 ---
 
 Spree Commerce Enterprise Edition provides a robust out-of-the-box foundation for building a [<u>multi-vendor marketplace</u>](https://spreecommerce.org/marketplace-ecommerce/), while remaining flexible enough to support advanced customization. 
@@ -17,15 +17,18 @@ Here’s an overview of each user perspective:
 - **Manual or CSV Vendor Onboarding** - manually onboard vendors without an online store or using unsupported platforms via direct account setup in the vendor dashboard
 - **Marketplace Merchandising** - ensure product consistency and branding integrity across all vendors
 - **Promotions & Marketing Automations** - leverage marketing campaign tools for engagement and retention
-- **Storefront & Content Management** - drag-and-drop layouts, modular pages, blog CMS, and newsletter tools.
+- **Storefront** - the [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront/storefront) provides a production-ready, multi-vendor-aware frontend that supports multi-vendor checkout out of the box, with full API coverage for headless customization.
 - **Checkout & Payments** - support multi-vendor order splitting, quick checkout methods, tax calculation, and automated payouts via Stripe Connect.
 - **Order Management** - order filtering, actions like cancellations or refunds, and tracking fulfillment per vendor.
 - **Vendor Payouts** - automated or manual payouts with Stripe Connect, including KYC onboarding and vendor-accessible analytics.
+- **Markets** - define distinct shopping experiences for different regions, each with its own currency, language, and tax settings. Used as a rule condition in Price Lists for region-specific pricing without duplicating products.
+- **Price Lists** - configure custom pricing strategies by customer group, market, volume tier, or geographic zone — directly in the admin, no development required. Essential for B2B, wholesale, and localized marketplace scenarios.
+- **Sales Channels** - run multiple storefronts or selling contexts (e.g., main storefront, wholesale portal, mobile app) from a single Spree instance, with per-channel product catalogs, order attribution, and fulfillment routing.
 - **Analytics & Reporting** - built-in KPIs, Google Analytics integration, and CSV exports for products and orders.
 - **Customer Service** - optional chat and AI bots, ticketing, and store credits for efficient customer support.
 - **APIs for headless projects and programmatic operations** - full coverage for storefront, platform, and checkout to enable custom functionality and integrations.
 
-See [Marketplace Admin Panel](https://spreecommerce.org/docs/use-case/marketplace/admin-dashboard) for a more detailed breakdown.
+See [Marketplace Admin Panel](https://spreecommerce.org/docs/use-case/marketplace/admin-dashboard) for a more detailed breakdown. For step-by-step user guides, see [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management), [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates), [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts), and [Marketplace Configuration](https://spreecommerce.org/docs/user/settings/marketplace).
 
 ### Vendor Capabilities
 
@@ -38,7 +41,7 @@ See [Marketplace Admin Panel](https://spreecommerce.org/docs/use-case/marketplac
 - **Automated WooCommerce Onboarding & Operations** - syncs products, orders, shipments, cancellations, and refunds automatically between WooCommerce and the marketplace.
 - **Vendor Payouts & Reporting** - automated or manual payouts, Stripe KYC onboarding, financial dashboards, and optional accounting integrations.
 
-See [Marketplace Vendor Panel](https://spreecommerce.org/docs/use-case/marketplace/vendor-dashboard) for a more detailed breakdown.
+See [Marketplace Vendor Panel](https://spreecommerce.org/docs/use-case/marketplace/vendor-dashboard) for a more detailed breakdown. For onboarding guides, see [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify), [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce), and [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual).
 
 ### Customer Experience
 
@@ -51,16 +54,16 @@ See [Marketplace Vendor Panel](https://spreecommerce.org/docs/use-case/marketpla
 - **Express Checkout & Payment Options** - including Apple Pay, Google Pay, installment plans
 - **Notifications & Shipment Tracking** - send per-vendor email updates and provides a unified order view in the customer dashboard.
 
-See [Marketplace Customer Experience](https://spreecommerce.org/docs/use-case/marketplace/customer-ux) for a more detailed breakdown.
+See [Marketplace Customer Experience](https://spreecommerce.org/docs/use-case/marketplace/customer-ux) for a more detailed breakdown. For how the unified cart and checkout works in practice, see [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout).
 
 ## Marketplace Scenarios
 
 Spree’s modular architecture supports a variety of advanced marketplace models beyond the standard vendor-customer setup, enabling tailored experiences for specific business needs:
 
-- **B2B Marketplaces** - layer on custom pricing tiers, MOQs, tax exemptions, and quote workflows.
+- **B2B Marketplaces** - layer on custom pricing tiers, MOQs, tax exemptions, and quote workflows. Use [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists) to configure wholesale or account-based pricing by customer group or volume.
 - **Subscription Marketplace Hybrid** - vendors offer recurring purchases, managed through Spree’s subscriptions engine.
-- **Multi-region/Localized Marketplaces** - vendors can be grouped by country or region with localized catalogs, taxes, and shipping zones.
-- **Headless Marketplace Frontend** - use Spree’s API to deliver a marketplace within a mobile app or a custom storefront built in Next.js, Vue, while leveraging the Spree marketplace backend functionality.
+- **Multi-region/Localized Marketplaces** - vendors can be grouped by country or region with localized catalogs, taxes, and shipping zones. Use [Markets](https://spreecommerce.org/docs/user/settings/markets) to define per-region currency, language, and tax settings, and combine with Price Lists for region-specific pricing.
+- **Headless Marketplace Frontend** - use Spree’s API to deliver a marketplace within a mobile app or a custom storefront built in Next.js, Vue, or any framework, while leveraging the Spree marketplace backend functionality. Use [Sales Channels](https://spreecommerce.org/docs/user/settings/sales-channels) to separate order attribution, catalog availability, and fulfillment routing across each frontend.
 
 ## Marketplaces Running on Spree
 
@@ -70,17 +73,25 @@ Spree’s modular architecture supports a variety of advanced marketplace models
 
 ## Flexible, Customizable Architecture
 
-While many marketplace features are available out-of-the-box in Spree Enterprise, the open-source foundation means you can extend and tailor the platform to your exact business model - whether that means custom commission logic, ERP integrations, or unique checkout flows.
+While many marketplace features are available out-of-the-box in Spree Enterprise, the open-source foundation means you can extend and tailor the platform to your exact business model — whether that means custom commission logic, ERP integrations, bespoke checkout flows, or automating back-office operations with AI agents.
 
-Spree Enterprise offers flexibility across all layers of the platform, from code-level customization to no-code configuration.
+- **Backend (Ruby on Rails)**
+  - Extend business logic, workflows, and integrations via Spree's modular, open-source architecture. Build custom commission engines, vendor approval flows, fulfillment rules, or any other platform-specific behavior directly in Ruby on Rails. See: [<u>Spree Developer Quickstart</u>](https://spreecommerce.org/docs/developer/getting-started/quickstart)
+- **Store API**
+  - Full REST API coverage for building any frontend experience — power the Next.js Storefront, a mobile app, a custom checkout, or any headless frontend in any framework. The Storefront API handles catalog browsing, multi-vendor cart and checkout, customer accounts, order tracking, and more. See: [<u>Store API Reference</u>](https://spreecommerce.org/docs/api-reference/storefront)
+- **Admin API**
+  - Programmatic access to all back-office operations: products, orders, vendors, payouts, promotions, customers, and more. Built for data migrations, ERP or CRM integrations, custom reporting pipelines, and any automation that would otherwise require manual admin work. See: [<u>Admin API Reference</u>](https://spreecommerce.org/docs/api-reference/admin-api)
+- **Admin CLI & Agentic Operations**
+  - The `spree api` CLI turns the Admin API into a first-class terminal client — generic HTTP verbs against any endpoint, offline schema introspection, and credentials that resolve automatically from local dev to production. Designed to be driven by both humans and AI coding agents. See: [<u>Admin CLI</u>](https://spreecommerce.org/docs/developer/cli/admin-api)
+- **Next.js Storefront**
+  - **Multi-Vendor Ready** - the [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront/storefront) supports multi-vendor checkout out of the box with no additional configuration.
+  - **Fully Customizable** - built on React and Next.js, the storefront can be extended and restyled to match any brand or UX requirement.
+  - **API-Driven** - connects to Spree's Storefront API, giving developers full control over the frontend without touching the backend.
 
 ## Full Ownership And Control
 
 With Spree Enterprise, you’re not locked into a black-box SaaS model. You retain complete control over your infrastructure, data, and roadmap, enabling long-term flexibility, scalability, and compliance.
 
-- **API-Driven Extensibility**
-  - **Full API Coverage** - extend the platform via REST or GraphQL APIs for storefronts, checkout, vendor dashboards, or 3rd-party integrations. See: [<u>API Reference</u>](https://spreecommerce.org/docs/api-reference/introduction)
-  - **Custom Integrations** - seamlessly connect with ERPs, CRMs, payment providers, POS systems, or headless frontends.
 - **Deployment Flexibility**
   - **Self-Hosting Options** - deploy Spree anywhere; your cloud provider, on-premise, or in specific geographic regions. See: [<u>Deployment Guide</u>](https://spreecommerce.org/docs/developer/deployment/render)
   - **Provider Agnostic** - run on AWS, GCP, Azure, or Render. Tailor infrastructure to budget, compliance, and performance needs.
@@ -98,10 +109,14 @@ With Spree Enterprise, you’re not locked into a black-box SaaS model. You reta
 ## Further Reading
 
 - [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
-- [<u>Developer Docs</u>](https://spreecommerce.org/docs/developer/getting-started/quickstart)
-- [<u>User Docs</u>](https://spreecommerce.org/docs/user/what-is-spree-commerce)
-- [<u>Ecommerce API docs</u>](https://spreecommerce.org/docs/api-reference/introduction)
-- [<u>Integrations</u>](https://spreecommerce.org/docs/integrations/integrations)
+- [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management)
+- [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates)
+- [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
+- [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout)
+- [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify)
+- [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce)
+- [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual)
+
 
 ## Get Started
 

--- a/docs/use-case/marketplace/capabilities.mdx
+++ b/docs/use-case/marketplace/capabilities.mdx
@@ -9,7 +9,7 @@ Here’s an overview of each user perspective:
 
 ### Admin Capabilities
 
-![](/docs/images/use-cases/multi-vendor/admin.png)
+![A graphic showing the Spree marketplace owner dashboard](/docs/images/use-cases/multi-vendor/admin.png)
 
 - **Marketplace Management** - invite vendors, approve or reject vendor signups, suspend accounts, and monitor vendor performance metrics.
 - **Shopify Vendor Integration** - automate onboarding and operations for Shopify vendors using a white-labelled Shopify sales channel app
@@ -17,7 +17,7 @@ Here’s an overview of each user perspective:
 - **Manual or CSV Vendor Onboarding** - manually onboard vendors without an online store or using unsupported platforms via direct account setup in the vendor dashboard
 - **Marketplace Merchandising** - ensure product consistency and branding integrity across all vendors
 - **Promotions & Marketing Automations** - leverage marketing campaign tools for engagement and retention
-- **Storefront** - the [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront/storefront) provides a production-ready, multi-vendor-aware frontend that supports multi-vendor checkout out of the box, with full API coverage for headless customization.
+- **Storefront** - the [Next.js Storefront](/developer/storefront/storefront) provides a production-ready, multi-vendor-aware frontend that supports multi-vendor checkout out of the box, with full API coverage for headless customization.
 - **Checkout & Payments** - support multi-vendor order splitting, quick checkout methods, tax calculation, and automated payouts via Stripe Connect.
 - **Order Management** - order filtering, actions like cancellations or refunds, and tracking fulfillment per vendor.
 - **Vendor Payouts** - automated or manual payouts with Stripe Connect, including KYC onboarding and vendor-accessible analytics.
@@ -28,7 +28,7 @@ Here’s an overview of each user perspective:
 - **Customer Service** - optional chat and AI bots, ticketing, and store credits for efficient customer support.
 - **APIs for headless projects and programmatic operations** - full coverage for storefront, platform, and checkout to enable custom functionality and integrations.
 
-See [Marketplace Admin Panel](https://spreecommerce.org/docs/use-case/marketplace/admin-dashboard) for a more detailed breakdown. For step-by-step user guides, see [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management), [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates), [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts), and [Marketplace Configuration](https://spreecommerce.org/docs/user/settings/marketplace).
+See [Marketplace Admin Panel](/use-case/marketplace/admin-dashboard) for a more detailed breakdown. For step-by-step user guides, see [Vendor Management](/user/vendors/vendor-management), [Commission Rates](/user/vendors/commission-rates), [Vendor Payouts](/user/vendors/vendor-payouts), and [Marketplace Configuration](/user/settings/marketplace).
 
 ### Vendor Capabilities
 
@@ -41,7 +41,7 @@ See [Marketplace Admin Panel](https://spreecommerce.org/docs/use-case/marketplac
 - **Automated WooCommerce Onboarding & Operations** - syncs products, orders, shipments, cancellations, and refunds automatically between WooCommerce and the marketplace.
 - **Vendor Payouts & Reporting** - automated or manual payouts, Stripe KYC onboarding, financial dashboards, and optional accounting integrations.
 
-See [Marketplace Vendor Panel](https://spreecommerce.org/docs/use-case/marketplace/vendor-dashboard) for a more detailed breakdown. For onboarding guides, see [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify), [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce), and [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual).
+See [Marketplace Vendor Panel](/use-case/marketplace/vendor-dashboard) for a more detailed breakdown. For onboarding guides, see [Shopify Vendor Onboarding](/user/vendors/vendor-onboarding-shopify), [WooCommerce Vendor Onboarding](/user/vendors/vendor-onboarding-woocommerce), and [Manual/CSV Vendor Onboarding](/user/vendors/vendor-onboarding-manual).
 
 ### Customer Experience
 
@@ -54,16 +54,16 @@ See [Marketplace Vendor Panel](https://spreecommerce.org/docs/use-case/marketpla
 - **Express Checkout & Payment Options** - including Apple Pay, Google Pay, installment plans
 - **Notifications & Shipment Tracking** - send per-vendor email updates and provides a unified order view in the customer dashboard.
 
-See [Marketplace Customer Experience](https://spreecommerce.org/docs/use-case/marketplace/customer-ux) for a more detailed breakdown. For how the unified cart and checkout works in practice, see [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout).
+See [Marketplace Customer Experience](/use-case/marketplace/customer-ux) for a more detailed breakdown. For how the unified cart and checkout works in practice, see [Multi-Vendor Checkout](/user/vendors/multi-vendor-checkout).
 
 ## Marketplace Scenarios
 
 Spree’s modular architecture supports a variety of advanced marketplace models beyond the standard vendor-customer setup, enabling tailored experiences for specific business needs:
 
-- **B2B Marketplaces** - layer on custom pricing tiers, MOQs, tax exemptions, and quote workflows. Use [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists) to configure wholesale or account-based pricing by customer group or volume.
+- **B2B Marketplaces** - layer on custom pricing tiers, MOQs, tax exemptions, and quote workflows. Use [Price Lists](/user/manage-products/price-lists) to configure wholesale or account-based pricing by customer group or volume.
 - **Subscription Marketplace Hybrid** - vendors offer recurring purchases, managed through Spree’s subscriptions engine.
-- **Multi-region/Localized Marketplaces** - vendors can be grouped by country or region with localized catalogs, taxes, and shipping zones. Use [Markets](https://spreecommerce.org/docs/user/settings/markets) to define per-region currency, language, and tax settings, and combine with Price Lists for region-specific pricing.
-- **Headless Marketplace Frontend** - use Spree’s API to deliver a marketplace within a mobile app or a custom storefront built in Next.js, Vue, or any framework, while leveraging the Spree marketplace backend functionality. Use [Sales Channels](https://spreecommerce.org/docs/user/settings/sales-channels) to separate order attribution, catalog availability, and fulfillment routing across each frontend.
+- **Multi-region/Localized Marketplaces** - vendors can be grouped by country or region with localized catalogs, taxes, and shipping zones. Use [Markets](/user/settings/markets) to define per-region currency, language, and tax settings, and combine with Price Lists for region-specific pricing.
+- **Headless Marketplace Frontend** - use Spree’s API to deliver a marketplace within a mobile app or a custom storefront built in Next.js, Vue, or any framework, while leveraging the Spree marketplace backend functionality. Use [Sales Channels](/user/settings/sales-channels) to separate order attribution, catalog availability, and fulfillment routing across each frontend.
 
 ## Marketplaces Running on Spree
 
@@ -76,15 +76,15 @@ Spree’s modular architecture supports a variety of advanced marketplace models
 While many marketplace features are available out-of-the-box in Spree Enterprise, the open-source foundation means you can extend and tailor the platform to your exact business model — whether that means custom commission logic, ERP integrations, bespoke checkout flows, or automating back-office operations with AI agents.
 
 - **Backend (Ruby on Rails)**
-  - Extend business logic, workflows, and integrations via Spree's modular, open-source architecture. Build custom commission engines, vendor approval flows, fulfillment rules, or any other platform-specific behavior directly in Ruby on Rails. See: [<u>Spree Developer Quickstart</u>](https://spreecommerce.org/docs/developer/getting-started/quickstart)
+  - Extend business logic, workflows, and integrations via Spree's modular, open-source architecture. Build custom commission engines, vendor approval flows, fulfillment rules, or any other platform-specific behavior directly in Ruby on Rails. See: [<u>Spree Developer Quickstart</u>](/developer/getting-started/quickstart)
 - **Store API**
-  - Full REST API coverage for building any frontend experience — power the Next.js Storefront, a mobile app, a custom checkout, or any headless frontend in any framework. The Storefront API handles catalog browsing, multi-vendor cart and checkout, customer accounts, order tracking, and more. See: [<u>Store API Reference</u>](https://spreecommerce.org/docs/api-reference/storefront)
+  - Full REST API coverage for building any frontend experience — power the Next.js Storefront, a mobile app, a custom checkout, or any headless frontend in any framework. The Storefront API handles catalog browsing, multi-vendor cart and checkout, customer accounts, order tracking, and more. See: [<u>Store API Reference</u>](/api-reference/storefront)
 - **Admin API**
-  - Programmatic access to all back-office operations: products, orders, vendors, payouts, promotions, customers, and more. Built for data migrations, ERP or CRM integrations, custom reporting pipelines, and any automation that would otherwise require manual admin work. See: [<u>Admin API Reference</u>](https://spreecommerce.org/docs/api-reference/admin-api)
+  - Programmatic access to all back-office operations: products, orders, vendors, payouts, promotions, customers, and more. Built for data migrations, ERP or CRM integrations, custom reporting pipelines, and any automation that would otherwise require manual admin work. See: [<u>Admin API Reference</u>](/api-reference/admin-api)
 - **Admin CLI & Agentic Operations**
-  - The `spree api` CLI turns the Admin API into a first-class terminal client — generic HTTP verbs against any endpoint, offline schema introspection, and credentials that resolve automatically from local dev to production. Designed to be driven by both humans and AI coding agents. See: [<u>Admin CLI</u>](https://spreecommerce.org/docs/developer/cli/admin-api)
+  - The `spree api` CLI turns the Admin API into a first-class terminal client — generic HTTP verbs against any endpoint, offline schema introspection, and credentials that resolve automatically from local dev to production. Designed to be driven by both humans and AI coding agents. See: [<u>Admin CLI</u>](/developer/cli/admin-api)
 - **Next.js Storefront**
-  - **Multi-Vendor Ready** - the [Next.js Storefront](https://spreecommerce.org/docs/developer/storefront/storefront) supports multi-vendor checkout out of the box with no additional configuration.
+  - **Multi-Vendor Ready** - the [Next.js Storefront](/developer/storefront/storefront) supports multi-vendor checkout out of the box with no additional configuration.
   - **Fully Customizable** - built on React and Next.js, the storefront can be extended and restyled to match any brand or UX requirement.
   - **API-Driven** - connects to Spree's Storefront API, giving developers full control over the frontend without touching the backend.
 
@@ -93,7 +93,7 @@ While many marketplace features are available out-of-the-box in Spree Enterprise
 With Spree Enterprise, you’re not locked into a black-box SaaS model. You retain complete control over your infrastructure, data, and roadmap, enabling long-term flexibility, scalability, and compliance.
 
 - **Deployment Flexibility**
-  - **Self-Hosting Options** - deploy Spree anywhere; your cloud provider, on-premise, or in specific geographic regions. See: [<u>Deployment Guide</u>](https://spreecommerce.org/docs/developer/deployment/render)
+  - **Self-Hosting Options** - deploy Spree anywhere; your cloud provider, on-premise, or in specific geographic regions. See: [<u>Deployment Guide</u>](/developer/deployment/render)
   - **Provider Agnostic** - run on AWS, GCP, Azure, or Render. Tailor infrastructure to budget, compliance, and performance needs.
 - **Scalability & Performance**
   - **Built for Scale** - Spree supports advanced architectures using load balancers, Redis caching, CDN layers (e.g., Cloudflare or Fastly).
@@ -108,14 +108,14 @@ With Spree Enterprise, you’re not locked into a black-box SaaS model. You reta
 
 ## Further Reading
 
-- [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
-- [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management)
-- [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates)
-- [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
-- [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout)
-- [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify)
-- [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce)
-- [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual)
+- [Multi-Vendor Marketplace Model](/use-case/marketplace/model)
+- [Vendor Management](/user/vendors/vendor-management)
+- [Commission Rates](/user/vendors/commission-rates)
+- [Vendor Payouts](/user/vendors/vendor-payouts)
+- [Multi-Vendor Checkout](/user/vendors/multi-vendor-checkout)
+- [Shopify Vendor Onboarding](/user/vendors/vendor-onboarding-shopify)
+- [WooCommerce Vendor Onboarding](/user/vendors/vendor-onboarding-woocommerce)
+- [Manual/CSV Vendor Onboarding](/user/vendors/vendor-onboarding-manual)
 
 
 ## Get Started

--- a/docs/use-case/marketplace/customer-ux.mdx
+++ b/docs/use-case/marketplace/customer-ux.mdx
@@ -29,7 +29,7 @@ Behind the scenes, Spree splits the order into per-vendor suborders and routes e
 - Single payment covering all vendor totals in one transaction.
 - Order automatically splits post-checkout for per-vendor fulfillment, with no customer action required.
 
-See [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout) for a full breakdown of how the cart, checkout, and fulfillment flow works.
+See [Multi-Vendor Checkout](/user/vendors/multi-vendor-checkout) for a full breakdown of how the cart, checkout, and fulfillment flow works.
 
 ### Customer Account & Order Management
 
@@ -58,7 +58,7 @@ Spree supports country-specific shopping experiences out of the box, ensuring cu
 - Currency conversion applied consistently across the catalog and at checkout — no surprises at the payment step.
 - VAT-inclusive pricing supported for markets where tax is expected to be shown in the listed price (e.g., EU).
 
-Marketplace owners can configure per-region currency, language, and tax settings using [Markets](https://spreecommerce.org/docs/user/settings/markets), and combine them with [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists) to apply region-specific pricing without duplicating products.
+Marketplace owners can configure per-region currency, language, and tax settings using [Markets](/user/settings/markets), and combine them with [Price Lists](/user/manage-products/price-lists) to apply region-specific pricing without duplicating products.
 
 ### Express Checkout & Payment Options
 
@@ -84,9 +84,9 @@ The Spree Next.js Storefront is fully optimized for mobile, tablet, and desktop,
 
 ### Further Reading
 
-- [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
-- [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout)
+- [Multi-Vendor Marketplace Model](/use-case/marketplace/model)
+- [Multi-vendor Marketplace Capabilities](/use-case/marketplace/capabilities)
+- [Multi-Vendor Checkout](/user/vendors/multi-vendor-checkout)
 
 ### Get Started
 

--- a/docs/use-case/marketplace/customer-ux.mdx
+++ b/docs/use-case/marketplace/customer-ux.mdx
@@ -3,7 +3,7 @@ title: "Marketplace Customer Experience"
 description: "Learn about the Spree multi-vendor marketplace customer UX."
 ---
 
-![](/docs/images/use-cases/multi-vendor/customer.png)
+![A graphic showing an ecommerce storefront connected to Spree via API](/docs/images/use-cases/multi-vendor/customer.png)
 
 Spree Commerce Enterprise Edition ensures an exceptional end-customer experience in [<u>multi-vendor marketplaces</u>](https://spreecommerce.org/marketplace-ecommerce/), providing seamless shopping journeys across diverse vendors and products. 
 
@@ -20,42 +20,73 @@ Customers enjoy the convenience of a unified cart, transparent shipping details,
 
 ### Seamless Multi-Vendor Experience
 
-- Unified shopping cart across vendors.
-- Transparent shipping per vendor at checkout.
-- All vendor products appear under a consistent storefront design.
+One of the biggest friction points in multi-vendor shopping is fragmented checkout — forcing customers to pay separately for each vendor's items. Spree eliminates this entirely. Customers can browse across any number of vendors, add products to a single shared cart, select shipping options per vendor at checkout, and complete the entire purchase with a single payment.
 
-### Localization
+Behind the scenes, Spree splits the order into per-vendor suborders and routes each to the right fulfillment environment — whether that's a vendor's Shopify dashboard, WooCommerce admin, or Spree vendor panel. From the customer's perspective, it's simply one order with one payment confirmation.
 
-- Language and currency selector.
-- Currency conversion at catalog and checkout level.
+- Unified cart across all vendors, with a consistent storefront design throughout.
+- Per-vendor shipping method selection at checkout — customers choose how each vendor ships their portion of the order.
+- Single payment covering all vendor totals in one transaction.
+- Order automatically splits post-checkout for per-vendor fulfillment, with no customer action required.
+
+See [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout) for a full breakdown of how the cart, checkout, and fulfillment flow works.
+
+### Customer Account & Order Management
+
+Customers have a dedicated account dashboard that gives them a complete, unified view of their marketplace activity — regardless of how many vendors they've ordered from.
+
+- **Order History** — a full list of past orders with status, vendor breakdown, item details, and totals, all in one place.
+- **Per-Vendor Shipment Tracking** — within a single order, each vendor's shipment is tracked independently. Customers can see exactly which items have shipped, which are still being prepared, and track each package with its own carrier link.
+- **Saved Addresses** — customers can store multiple shipping addresses for faster checkout on repeat visits.
+- **Saved Payment Methods** — card details are securely stored for quick checkout, alongside express options like Apple Pay and Google Pay.
+- **Account Settings** — manage email, password, and notification preferences from a single profile page.
 
 ### Product Discovery
 
-- Browse by brand or vendor.
-- Discover admin-curated collections and categories.
+The marketplace storefront is built to surface the right products to the right shopper — whether they arrive knowing exactly what they want or are browsing for inspiration.
 
-### Express Checkout Options
+- **Full Catalog Search** — search across the entire marketplace catalog, spanning all vendor listings simultaneously.
+- **Filtering & Sorting** — filter results by price range, attributes, category, or vendor; sort by relevance, price, or newest.
+- **Browse by Vendor or Brand** — dedicated vendor pages let shoppers explore a specific vendor's full product range, shipping information, and policies.
+- **Curated Collections & Categories** — admins can build and maintain collections that group products across vendors by theme, season, or campaign, creating editorial-style discovery experiences.
 
-- Apple Pay, Google Pay, and saved card options.
-- Installment plans with Klarna, Afterpay, Affirm.
+### Localization
 
-### Notifications & Tracking
+Spree supports country-specific shopping experiences out of the box, ensuring customers always see prices and content in a format that feels native to them.
 
-- Confirmation, shipping, and delivery emails per vendor.
-- Unified view of all orders in customer dashboard.
+- Language and currency selector on the storefront, configurable per market.
+- Currency conversion applied consistently across the catalog and at checkout — no surprises at the payment step.
+- VAT-inclusive pricing supported for markets where tax is expected to be shown in the listed price (e.g., EU).
 
-### Storefront Responsive UX
+Marketplace owners can configure per-region currency, language, and tax settings using [Markets](https://spreecommerce.org/docs/user/settings/markets), and combine them with [Price Lists](https://spreecommerce.org/docs/user/manage-products/price-lists) to apply region-specific pricing without duplicating products.
 
-- Optimized storefront for mobile, tablet, and desktop.
+### Express Checkout & Payment Options
+
+Reducing checkout friction directly impacts conversion — particularly on mobile. Spree supports a range of fast checkout and payment methods out of the box.
+
+- **Express Checkout** — Apple Pay and Google Pay allow customers to complete the full checkout in two taps, using payment details stored on their device.
+- **Saved Cards** — returning customers can pay with a previously saved card without re-entering details.
+- **Buy Now, Pay Later** — installment plans via Klarna, Afterpay, and Affirm give customers flexible payment options at checkout, which can increase average order value.
+
+### Notifications & Shipment Tracking
+
+Customers receive automated email notifications at every key moment in their order lifecycle — with each notification scoped to the relevant vendor's shipment rather than the order as a whole.
+
+- **Order Confirmation** — sent immediately after checkout, summarising all items, vendors, and totals in the order.
+- **Per-Vendor Shipping Notifications** — as each vendor marks their portion of the order as fulfilled, the customer receives a shipping confirmation with carrier and tracking information for that specific package.
+- **Delivery Confirmation** — customers are notified when each package is delivered, independently of other vendors' shipments in the same order.
+
+A customer who ordered from three vendors will receive three independent shipping and delivery notifications — each clearly tied to the right items — without any confusion between shipments.
+
+### Responsive Storefront
+
+The Spree Next.js Storefront is fully optimized for mobile, tablet, and desktop, ensuring a consistent and high-quality experience regardless of how customers arrive at the marketplace.
 
 ### Further Reading
 
 - [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
 - [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [<u>Developer Docs</u>](https://spreecommerce.org/docs/developer/getting-started/quickstart)
-- [<u>User Docs</u>](https://spreecommerce.org/docs/user/what-is-spree-commerce)
-- [<u>Ecommerce API docs</u>](https://spreecommerce.org/docs/api-reference/introduction)
-- [<u>Integrations</u>](https://spreecommerce.org/docs/integrations/integrations)
+- [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout)
 
 ### Get Started
 

--- a/docs/use-case/marketplace/model.mdx
+++ b/docs/use-case/marketplace/model.mdx
@@ -59,3 +59,7 @@ Launching a successful marketplace requires careful attention to:
 - [Admin UX](https://spreecommerce.org/docs/use-case/marketplace/admin-dashboard)
 - [Vendor UX](https://spreecommerce.org/docs/use-case/marketplace/vendor-dashboard)
 - [Customer UX](https://spreecommerce.org/docs/use-case/marketplace/customer-ux)
+- [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management)
+- [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates)
+- [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
+- [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout)

--- a/docs/use-case/marketplace/model.mdx
+++ b/docs/use-case/marketplace/model.mdx
@@ -55,11 +55,11 @@ Launching a successful marketplace requires careful attention to:
 </Columns>
 
 ## Further Reading
-- [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [Admin UX](https://spreecommerce.org/docs/use-case/marketplace/admin-dashboard)
-- [Vendor UX](https://spreecommerce.org/docs/use-case/marketplace/vendor-dashboard)
-- [Customer UX](https://spreecommerce.org/docs/use-case/marketplace/customer-ux)
-- [Vendor Management](https://spreecommerce.org/docs/user/vendors/vendor-management)
-- [Commission Rates](https://spreecommerce.org/docs/user/vendors/commission-rates)
-- [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
-- [Multi-Vendor Checkout](https://spreecommerce.org/docs/user/vendors/multi-vendor-checkout)
+- [Multi-vendor Marketplace Capabilities](/use-case/marketplace/capabilities)
+- [Admin UX](/use-case/marketplace/admin-dashboard)
+- [Vendor UX](/use-case/marketplace/vendor-dashboard)
+- [Customer UX](/use-case/marketplace/customer-ux)
+- [Vendor Management](/user/vendors/vendor-management)
+- [Commission Rates](/user/vendors/commission-rates)
+- [Vendor Payouts](/user/vendors/vendor-payouts)
+- [Multi-Vendor Checkout](/user/vendors/multi-vendor-checkout)

--- a/docs/use-case/marketplace/vendor-dashboard.mdx
+++ b/docs/use-case/marketplace/vendor-dashboard.mdx
@@ -27,9 +27,9 @@ With automated integrations with popular platforms like Shopify and WooCommerce,
 
 ### Vendor Onboarding Options
 
-- **Shopify**: Sales channel app that syncs products, orders, and shipments. See [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify) for the full setup flow.
-- **WooCommerce**: Direct API integration that syncs products, orders, and shipments. See [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce) for the full setup flow.
-- **Manual or CSV Import**: For vendors not using ecommerce platforms. See [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual) for the full setup flow.
+- **Shopify**: Sales channel app that syncs products, orders, and shipments. See [Shopify Vendor Onboarding](/user/vendors/vendor-onboarding-shopify) for the full setup flow.
+- **WooCommerce**: Direct API integration that syncs products, orders, and shipments. See [WooCommerce Vendor Onboarding](/user/vendors/vendor-onboarding-woocommerce) for the full setup flow.
+- **Manual or CSV Import**: For vendors not using ecommerce platforms. See [Manual/CSV Vendor Onboarding](/user/vendors/vendor-onboarding-manual) for the full setup flow.
 
 ### Vendor Profile & Settings
 
@@ -64,16 +64,16 @@ With automated integrations with popular platforms like Shopify and WooCommerce,
 - **Stripe KYC Flow**: Vendors complete verification during onboarding.
 - **Stripe Dashboard Access**: View transactions, disputes, and payout history.
 
-See [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts) for how payout schedules are configured at the marketplace and vendor level.
+See [Vendor Payouts](/user/vendors/vendor-payouts) for how payout schedules are configured at the marketplace and vendor level.
 
 ### Further Reading
 
-- [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
-- [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify)
-- [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce)
-- [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual)
-- [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
+- [Multi-Vendor Marketplace Model](/use-case/marketplace/model)
+- [Multi-vendor Marketplace Capabilities](/use-case/marketplace/capabilities)
+- [Shopify Vendor Onboarding](/user/vendors/vendor-onboarding-shopify)
+- [WooCommerce Vendor Onboarding](/user/vendors/vendor-onboarding-woocommerce)
+- [Manual/CSV Vendor Onboarding](/user/vendors/vendor-onboarding-manual)
+- [Vendor Payouts](/user/vendors/vendor-payouts)
 
 
 ### Get Started

--- a/docs/use-case/marketplace/vendor-dashboard.mdx
+++ b/docs/use-case/marketplace/vendor-dashboard.mdx
@@ -3,7 +3,7 @@ title: "Marketplace Vendor Panel"
 description: "Learn about the Spree multi-vendor marketplace vendor UX."
 ---
 
-![](/docs/images/use-cases/multi-vendor/vendor.png)
+![A graphic showing the Spree Commerce vendor dashboard](/docs/images/use-cases/multi-vendor/vendor.png)
 
 Spree Commerce Enterprise Edition offers vendors a streamlined and intuitive dashboard designed specifically for [<u>multi-vendor marketplace</u>](https://spreecommerce.org/marketplace-ecommerce/) operations. 
 
@@ -20,22 +20,22 @@ With automated integrations with popular platforms like Shopify and WooCommerce,
 
 ### Vendor Dashboard UX
 
-1. **Products**: Upload and manage inventory, categories, and pricing.
+1. **Products**: Upload and manage inventory, content, and pricing.
 2. **Orders**: Process new orders, add shipment tracking, view status.
 3. **Analytics**: Review sales, refunds, and fulfillment metrics.
 4. **Settings**: Configure shipping methods, policies, billing info.
 
 ### Vendor Onboarding Options
 
-- **Shopify**: Sales channel app that syncs products, orders, and shipments.
-- **WooCommerce**: Direct API integratio that sync products, orders, and shipments.
-- **Manual or CSV Import**: For vendors not using ecommerce platforms.
+- **Shopify**: Sales channel app that syncs products, orders, and shipments. See [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify) for the full setup flow.
+- **WooCommerce**: Direct API integration that syncs products, orders, and shipments. See [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce) for the full setup flow.
+- **Manual or CSV Import**: For vendors not using ecommerce platforms. See [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual) for the full setup flow.
 
 ### Vendor Profile & Settings
 
 - **Shipping Setup**: Define rates and methods per location.
 - **Multi-Language & Currency Support**: Vendors can localize their store presence.
-- **Holiday Mode**: Pause shop temporarily.
+- **Invite Members**: Vendors can share dashboard access with their team members.
 
 ### Shopify Vendor Operations
 
@@ -63,16 +63,18 @@ With automated integrations with popular platforms like Shopify and WooCommerce,
 - **Automatic or Manual Payouts**: Payout frequency controlled by admin policy.
 - **Stripe KYC Flow**: Vendors complete verification during onboarding.
 - **Stripe Dashboard Access**: View transactions, disputes, and payout history.
-- **Accounting Tools**: Optional integrations with QuickBooks, Xero, etc.
+
+See [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts) for how payout schedules are configured at the marketplace and vendor level.
 
 ### Further Reading
 
 - [Multi-Vendor Marketplace Model](https://spreecommerce.org/docs/use-case/marketplace/model)
 - [Multi-vendor Marketplace Capabilities](https://spreecommerce.org/docs/use-case/marketplace/capabilities)
-- [<u>Developer Docs</u>](https://spreecommerce.org/docs/developer/getting-started/quickstart)
-- [<u>User Docs</u>](https://spreecommerce.org/docs/user/what-is-spree-commerce)
-- [<u>Ecommerce API docs</u>](https://spreecommerce.org/docs/api-reference/introduction)
-- [<u>Integrations</u>](https://spreecommerce.org/docs/integrations/integrations)
+- [Shopify Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-shopify)
+- [WooCommerce Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-woocommerce)
+- [Manual/CSV Vendor Onboarding](https://spreecommerce.org/docs/user/vendors/vendor-onboarding-manual)
+- [Vendor Payouts](https://spreecommerce.org/docs/user/vendors/vendor-payouts)
+
 
 ### Get Started
 


### PR DESCRIPTION
Updated the marketplace use case docs:
- Enhanced descriptions of Spree's multi-vendor capabilities 
- Added references to the latest big features such as Price Lists, Markets, and Sales Channels
- Replaced references to the old built-in storefront with the new Next.js storefront
- Added cross links to the low-level marketplace user docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Marketplace Admin Panel, Vendor Dashboard, Marketplace Capabilities, Customer UX, and Marketplace Model pages with clearer multi-vendor framing.
  * Added/expanded “Markets, Price Lists & Sales Channels” guidance and improved storefront, checkout/payment, analytics/reporting, and further reading references.
  * Strengthened onboarding links for vendor setup (Shopify, WooCommerce, Manual/CSV) plus added documentation links for multi-vendor checkout, marketplace configuration, commission rates, and vendor payouts.
  * Refreshed visuals/formatting, updated image alt text, revised vendor UX/admin bullet content, and corrected “Get Started” section layout markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->