### PR TITLE
Fixed condition to render the new store link

### DIFF
--- a/spree/admin/app/views/spree/admin/shared/_new_item_dropdown.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_new_item_dropdown.html.erb
@@ -21,7 +21,7 @@
 
     <%= invite_vendor_button(class: 'dropdown-item') if defined?(invite_vendor_button) %>
 
-    <% if can?(:create, Spree::Store) && Spree.root_domain.present? %>
+    <% if can?(:create, Spree::Store) && Spree.root_domain.present? && spree.respond_to?(:new_admin_store_path) %>
       <div class="dropdown-divider"></div>
 
       <%= link_to_with_icon 'building-store', Spree.t(:new_store), spree.new_admin_store_path, class: 'dropdown-item' %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “New store” option in the admin dropdown now appears only when the user has permission, a root domain is configured, and the store creation link is available.
  * This prevents showing an option that may not work in all setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->