### PR TITLE
Fixed some misc admin translations

### DIFF
--- a/spree/admin/app/controllers/spree/admin/base_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/base_controller.rb
@@ -99,6 +99,14 @@ module Spree
         super
         align_i18n_default_locale_to_content!
         pin_content_locale!
+        sync_pagy_locale!
+      end
+
+      # Pagy ships its own i18n dictionaries and resolves them through `Pagy::I18n`
+      # (a thread-local that defaults to `:en`), not Rails `I18n`. Align it to the
+      # admin UI locale so pagination strings (e.g. "Displaying N items") localize.
+      def sync_pagy_locale!
+        Pagy::I18n.locale = I18n.locale if defined?(Pagy::I18n)
       end
 
       # Resolve the admin UI locale for the current request. Unlike the

--- a/spree/admin/app/javascript/spree/admin/controllers/calendar_range_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/calendar_range_controller.js
@@ -5,6 +5,12 @@ import { PresetPlugin } from '@easepick/preset-plugin';
 
 export default class extends Controller {
   static targets = [ "picker", "dateFrom", "dateTo", "label" ]
+  static values = {
+    presetLabels: {
+      type: Array,
+      default: ['Today', 'Yesterday', 'Last 7 Days', 'Last 30 Days', 'This Month', 'Last Month']
+    }
+  }
 
   connect() {
     this.picker = new easepick.create({
@@ -23,9 +29,7 @@ export default class extends Controller {
         endDate: this.dateToTarget.value,
       },
       PresetPlugin: {
-        customLabels: ['Today', 'Yesterday',
-        'Last 7 Days', 'Last 30 Days',
-        'This Month', 'Last Month'],
+        customLabels: this.presetLabelsValue,
         position: 'left'
       },
       lang: Spree.locale

--- a/spree/admin/app/models/spree/admin/table/column.rb
+++ b/spree/admin/app/models/spree/admin/table/column.rb
@@ -74,7 +74,16 @@ module Spree
 
         # Resolve label (handles i18n keys)
         def resolve_label
-          return I18n.t(label, default: label.split('.').last.humanize) if label.is_a?(String) && label.include?('.')
+          if label.is_a?(String) && label.include?('.')
+            # Dotted keys may live under the `spree` namespace (e.g. `admin.num_orders`,
+            # `price_list_statuses.active`) or at the I18n root (e.g. `activerecord.attributes.*`).
+            # Prefer the `spree`-scoped lookup, then fall back to the root lookup.
+            scoped = Spree.t(label, default: '')
+            return scoped if scoped.present?
+
+            return I18n.t(label, default: label.split('.').last.humanize)
+          end
+
           return label if label.is_a?(String) && label.present?
 
           key_to_translate = label || key

--- a/spree/admin/app/views/spree/admin/shared/_calendar_range_picker.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_calendar_range_picker.html.erb
@@ -7,7 +7,17 @@
 
 <% dropdown_direction ||= 'left' %>
 
-<%= dropdown direction: dropdown_direction, data: { controller: 'dropdown calendar-range', action: 'click->calendar-range#open' }, class: 'h-full', portal: false do %>
+<%# Labels MUST match the order of presets in the easepick preset-plugin (today, yesterday, last 7, last 30, this month, last month) %>
+<% preset_labels = [
+     Spree.t('date_range_presets.today'),
+     Spree.t('date_range_presets.yesterday'),
+     Spree.t('date_range_presets.last_7_days'),
+     Spree.t('date_range_presets.last_30_days'),
+     Spree.t('date_range_presets.this_month'),
+     Spree.t('date_range_presets.last_month')
+   ] %>
+
+<%= dropdown direction: dropdown_direction, data: { controller: 'dropdown calendar-range', action: 'click->calendar-range#open', 'calendar-range-preset-labels-value': preset_labels.to_json }, class: 'h-full', portal: false do %>
   <%= dropdown_toggle class: css_classes do %>
     <%= icon('calendar') %>
     <div data-calendar-range-target="label">

--- a/spree/admin/app/views/spree/admin/tables/_table.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/_table.html.erb
@@ -3,7 +3,8 @@
 <% columns = table.visible_columns(selected_columns, self) %>
 <% current_sort = params.dig(:q, :s) %>
 <% search_param = table.respond_to?(:search_param) ? table.search_param : :name_cont %>
-<% search_placeholder = (table.respond_to?(:search_placeholder) && table.search_placeholder) || [Spree.t(:search), controller_name.humanize.downcase].join(' ') %>
+<% resource_name = table.model_class ? table.model_class.model_name.human(count: 2).downcase : controller_name.humanize.downcase %>
+<% search_placeholder = (table.respond_to?(:search_placeholder) && table.search_placeholder) || [Spree.t(:search), resource_name].join(' ') %>
 <% date_range_param = table.date_range_param %>
 
 <%= turbo_frame_tag frame_name, data: { turbo_action: 'advance' } do %>

--- a/spree/admin/app/views/spree/admin/tables/_table.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/_table.html.erb
@@ -3,8 +3,8 @@
 <% columns = table.visible_columns(selected_columns, self) %>
 <% current_sort = params.dig(:q, :s) %>
 <% search_param = table.respond_to?(:search_param) ? table.search_param : :name_cont %>
-<% resource_name = table.model_class ? table.model_class.model_name.human(count: 2).downcase : controller_name.humanize.downcase %>
-<% search_placeholder = (table.respond_to?(:search_placeholder) && table.search_placeholder) || [Spree.t(:search), resource_name].join(' ') %>
+<% resource_name = table.model_class ? table.model_class.model_name.human(count: 2) : controller_name.humanize %>
+<% search_placeholder = (table.respond_to?(:search_placeholder) && table.search_placeholder) || Spree.t('admin.search_placeholder', resource: resource_name) %>
 <% date_range_param = table.date_range_param %>
 
 <%= turbo_frame_tag frame_name, data: { turbo_action: 'advance' } do %>

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -729,6 +729,13 @@ en:
     customers_removed_from_group:
       one: "%{count} customer removed from group"
       other: "%{count} customers removed from group"
+    date_range_presets:
+      today: Today
+      yesterday: Yesterday
+      last_7_days: Last 7 Days
+      last_30_days: Last 30 Days
+      this_month: This Month
+      last_month: Last Month
     days_ago: Days ago
     delete_selected: Delete selected
     digital_assets_help: Digital assets are files that can be downloaded by customers after purchase.

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -467,6 +467,7 @@ en:
       report_created: Your report is being generated. You will receive an email with a download link when it is ready!
       reset_digital_link_download_limits: Reset download limits
       response_code: Response Code
+      search_placeholder: Search %{resource}
       selected: selected
       send_payment_link: Send Payment Link
       shipment:
@@ -730,12 +731,12 @@ en:
       one: "%{count} customer removed from group"
       other: "%{count} customers removed from group"
     date_range_presets:
+      last_30_days: Last 30 Days
+      last_7_days: Last 7 Days
+      last_month: Last Month
+      this_month: This Month
       today: Today
       yesterday: Yesterday
-      last_7_days: Last 7 Days
-      last_30_days: Last 30 Days
-      this_month: This Month
-      last_month: Last Month
     days_ago: Days ago
     delete_selected: Delete selected
     digital_assets_help: Digital assets are files that can be downloaded by customers after purchase.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar range picker presets now display fully translated labels for common ranges (e.g., Today, Yesterday, Last 7 Days, Last 30 Days, This Month, Last Month).

* **Bug Fixes**
  * Admin pagination text now stays in sync with the active admin locale.
  * Table column label translation for dotted keys is resolved more reliably.
  * Table search placeholder text now uses a more accurate, translated resource name for clearer prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->