### PR TITLE
Preload Channels and Customer groups for combobox/pickers in Promo / …

### DIFF
--- a/packages/dashboard/src/components/spree/price-list-editors/rule-channel.tsx
+++ b/packages/dashboard/src/components/spree/price-list-editors/rule-channel.tsx
@@ -4,7 +4,7 @@ import { Field, FieldGroup, FieldLabel } from '@spree/dashboard-ui'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { EditorShell } from '@/components/spree/promotion-editors/editor-shell'
-import { channelAutocompleteProps } from '@/hooks/use-channels'
+import { channelAutocompleteProps, useChannels } from '@/hooks/use-channels'
 import type { PriceRuleEditorContext } from './types'
 
 /**
@@ -16,6 +16,9 @@ import type { PriceRuleEditorContext } from './types'
  */
 export function ChannelRuleEditor({ draft, onSave, onClose }: PriceRuleEditorContext) {
   const { t } = useTranslation()
+  // Preload the full channel list so the picker surfaces options on open
+  // without the merchant having to type — the list is small and cached.
+  const { data: channelsData } = useChannels()
   // Seed from `draft.channels` (the embed) — `preferences.channel_ids`
   // holds raw integer IDs server-side while the embed carries the prefixed
   // `ch_…` IDs the picker round-trips.
@@ -40,6 +43,7 @@ export function ChannelRuleEditor({ draft, onSave, onClose }: PriceRuleEditorCon
           <FieldLabel>{t('admin.fields.price_rule.channels.label')}</FieldLabel>
           <ResourceMultiAutocomplete
             {...channelAutocompleteProps('price-rule-channels')}
+            initialItems={channelsData?.data}
             value={channelIds}
             onChange={setChannelIds}
             onResolvedOptionsChange={setChannels}

--- a/packages/dashboard/src/components/spree/price-list-editors/rule-customer-group.tsx
+++ b/packages/dashboard/src/components/spree/price-list-editors/rule-customer-group.tsx
@@ -4,11 +4,14 @@ import { Field, FieldGroup, FieldLabel } from '@spree/dashboard-ui'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { EditorShell } from '@/components/spree/promotion-editors/editor-shell'
-import { customerGroupAutocompleteProps } from '@/hooks/use-customer-groups'
+import { customerGroupAutocompleteProps, useCustomerGroups } from '@/hooks/use-customer-groups'
 import type { PriceRuleEditorContext } from './types'
 
 export function CustomerGroupRuleEditor({ draft, onSave, onClose }: PriceRuleEditorContext) {
   const { t } = useTranslation()
+  // Preload the full customer-group list so the picker surfaces options on
+  // open without the merchant having to type — the list is small and cached.
+  const { data: customerGroupsData } = useCustomerGroups()
   // Seed from `draft.customer_groups` (the embed) — `preferences.customer_group_ids`
   // holds raw integer IDs server-side while the embed carries the prefixed `cg_…`
   // IDs the picker round-trips.
@@ -33,6 +36,7 @@ export function CustomerGroupRuleEditor({ draft, onSave, onClose }: PriceRuleEdi
           <FieldLabel>{t('admin.fields.price_rule.customer_groups.label')}</FieldLabel>
           <ResourceMultiAutocomplete
             {...customerGroupAutocompleteProps('price-rule-customer-groups')}
+            initialItems={customerGroupsData?.data}
             value={groupIds}
             onChange={setGroupIds}
             onResolvedOptionsChange={setCustomerGroups}

--- a/packages/dashboard/src/components/spree/promotion-editors/rule-channel.tsx
+++ b/packages/dashboard/src/components/spree/promotion-editors/rule-channel.tsx
@@ -2,7 +2,7 @@ import type { Channel } from '@spree/admin-sdk'
 import { ResourceMultiAutocomplete, useTranslation } from '@spree/dashboard-core'
 import { Field, FieldGroup, FieldLabel } from '@spree/dashboard-ui'
 import { useState } from 'react'
-import { channelAutocompleteProps } from '@/hooks/use-channels'
+import { channelAutocompleteProps, useChannels } from '@/hooks/use-channels'
 import { EditorShell } from './editor-shell'
 import type { PromotionRuleEditorContext } from './types'
 
@@ -15,6 +15,9 @@ import type { PromotionRuleEditorContext } from './types'
  */
 export function ChannelRuleEditor({ draft, onSave, onClose }: PromotionRuleEditorContext) {
   const { t } = useTranslation()
+  // Preload the full channel list so the picker surfaces options on open
+  // without the merchant having to type — the list is small and cached.
+  const { data: channelsData } = useChannels()
   const [channelIds, setChannelIds] = useState<string[]>(() =>
     (draft.channels ?? []).map((c) => c.id),
   )
@@ -36,6 +39,7 @@ export function ChannelRuleEditor({ draft, onSave, onClose }: PromotionRuleEdito
           <FieldLabel>{t('admin.promotions.rules.channel.label')}</FieldLabel>
           <ResourceMultiAutocomplete
             {...channelAutocompleteProps('promotion-rule-channels')}
+            initialItems={channelsData?.data}
             value={channelIds}
             onChange={setChannelIds}
             onResolvedOptionsChange={setChannels}

--- a/packages/dashboard/src/components/spree/promotion-editors/rule-customer-group.tsx
+++ b/packages/dashboard/src/components/spree/promotion-editors/rule-customer-group.tsx
@@ -2,12 +2,15 @@ import type { CustomerGroup } from '@spree/admin-sdk'
 import { ResourceMultiAutocomplete, useTranslation } from '@spree/dashboard-core'
 import { Field, FieldGroup, FieldLabel } from '@spree/dashboard-ui'
 import { useState } from 'react'
-import { customerGroupAutocompleteProps } from '@/hooks/use-customer-groups'
+import { customerGroupAutocompleteProps, useCustomerGroups } from '@/hooks/use-customer-groups'
 import { EditorShell } from './editor-shell'
 import type { PromotionRuleEditorContext } from './types'
 
 export function CustomerGroupRuleEditor({ draft, onSave, onClose }: PromotionRuleEditorContext) {
   const { t } = useTranslation()
+  // Preload the full customer-group list so the picker surfaces options on
+  // open without the merchant having to type — the list is small and cached.
+  const { data: customerGroupsData } = useCustomerGroups()
   const [groupIds, setGroupIds] = useState<string[]>(
     () => (draft.preferences?.customer_group_ids ?? []) as string[],
   )
@@ -29,6 +32,7 @@ export function CustomerGroupRuleEditor({ draft, onSave, onClose }: PromotionRul
           <FieldLabel>{t('admin.promotions.rules.customer_group.label')}</FieldLabel>
           <ResourceMultiAutocomplete
             {...customerGroupAutocompleteProps('promotion-rule-customer-groups')}
+            initialItems={customerGroupsData?.data}
             value={groupIds}
             onChange={setGroupIds}
             onResolvedOptionsChange={setCustomerGroups}


### PR DESCRIPTION
…Price List rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel and customer group pickers now load available options immediately when opened.
  * This improves the selection experience in both promotion and price list editors, making multi-select fields feel faster and more complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->