### PR TITLE
Fixed race condition during spree eject with bundler cache

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,8 @@
       "Bash(git clone *)",
       "Bash(rm -rf server/.git server/.gitignore)",
       "Skill(update-config)",
-      "Skill(simplify)"
+      "Skill(simplify)",
+      "mcp__claude_ai_Claude_Code_Remote__list_triggers"
     ],
     "deny": [
       "Bash(sudo *)",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.3.3
+
+### Patch Changes
+
+- Fix an intermittent `failed to mkdir … file exists` error on the first `spree eject` / `spree dev` / `spree init` / `spree update` of a fresh project. On a cold `bundle_cache` volume the `web` and `worker` containers raced to populate it; the CLI now brings `web` up alone first so it seeds the volume uncontended before the rest of the stack starts.
+
 ## 2.3.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -3,7 +3,7 @@ import type { Command } from 'commander'
 import pc from 'picocolors'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject, hasMonorepoSpreePath } from '../context.js'
-import { dockerCompose } from '../docker.js'
+import { dockerCompose, primeBundleVolume } from '../docker.js'
 
 export function registerDevCommand(program: Command): void {
   program
@@ -52,6 +52,14 @@ export function registerDevCommand(program: Command): void {
       process.on('SIGINT', ignoreSigint)
       let result: { exitCode?: number }
       try {
+        // Prime the shared bundle_cache volume with web alone first so the
+        // foreground `up web worker` below doesn't race the cold-volume
+        // copy-up. web is left running and re-attached (its logs still stream);
+        // only worker is newly started by the foreground up. Run INSIDE the
+        // SIGINT-ignore guard so a Ctrl+C during the brief priming window can't
+        // leave the volume half-populated (a partial copy-up would make the
+        // next run's emptiness gate lie). On a warm volume this is a ~1s no-op.
+        await primeBundleVolume(ctx.projectDir)
         result = await dockerCompose(['up', 'web', 'worker'], ctx.projectDir, {
           stdio: 'inherit',
           reject: false,

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import pc from 'picocolors'
 import { detectProject } from '../context.js'
-import { dockerCompose, dockerComposeExec } from '../docker.js'
+import { dockerCompose, dockerComposeExec, primeBundleVolume } from '../docker.js'
 
 // Switch the project from the prebuilt-image compose to the bind-mounted
 // dev compose. Source under ./backend becomes live in the container —
@@ -47,6 +47,9 @@ export function registerEjectCommand(program: Command) {
       fs.writeFileSync(path.join(ctx.projectDir, 'docker-compose.yml'), composeContent)
 
       console.log(`\n${pc.bold('Switching to dev compose (bind-mounts ./backend)...')}\n`)
+      // Prime the shared bundle_cache volume with web alone so the parallel up
+      // below doesn't race the cold-volume copy-up (web + worker → "file exists").
+      await primeBundleVolume(ctx.projectDir)
       await dockerCompose(['up', '-d'], ctx.projectDir, { stdio: 'inherit' })
 
       // The dev image bypasses bin/docker-entrypoint (which runs db:prepare

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,7 @@ import pc from 'picocolors'
 import { mintProjectCredentials } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject } from '../context.js'
-import { dockerCompose, rakeTask, streamLogs } from '../docker.js'
+import { dockerCompose, primeBundleVolume, rakeTask, streamLogs } from '../docker.js'
 
 const HEALTH_CHECK_INTERVAL_MS = 3000
 const HEALTH_CHECK_TIMEOUT_MS = 120_000
@@ -27,6 +27,10 @@ export function registerInitCommand(program: Command): void {
 
       const s = p.spinner()
       s.start('Starting Docker services...')
+      // Prime the shared bundle_cache volume with web alone so the up below
+      // doesn't race the cold-volume copy-up. stdio: 'ignore' keeps the spinner
+      // clean — the inherited `pull` above already showed image progress.
+      await primeBundleVolume(ctx.projectDir, { stdio: 'ignore' })
       await dockerCompose(['up', '-d'], ctx.projectDir)
       s.stop('Docker services started.')
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import { detectProject } from '../context.js'
-import { dockerCompose } from '../docker.js'
+import { dockerCompose, primeBundleVolume } from '../docker.js'
 
 export function registerUpdateCommand(program: Command): void {
   program
@@ -15,6 +15,9 @@ export function registerUpdateCommand(program: Command): void {
 
       const s = p.spinner()
       s.start('Recreating containers...')
+      // Prime the shared bundle_cache volume with web alone first so the up
+      // below doesn't race the copy-up if this follows a `down -v` (cold volume).
+      await primeBundleVolume(ctx.projectDir, { stdio: 'ignore' })
       await dockerCompose(['up', '-d'], ctx.projectDir)
       s.stop('Containers recreated.')
 

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -7,6 +7,36 @@ export async function dockerCompose(args: string[], projectDir: string, options?
   })
 }
 
+// web and worker share one bundle_cache named volume and, in the dev compose,
+// start concurrently. On a COLD volume Docker copies the image's populated
+// /usr/local/bundle into it ("copy-up") the first time a container mounts it —
+// per container, with no cross-container lock. Two concurrent copy-ups race on
+// mkdir of the same nested gem-extension dirs and one loses with "file exists"
+// (nondeterministic, first-boot only).
+//
+// Fix: bring `web` up alone first and wait for it. That single container wins
+// the copy-up uncontended; by the time the rest of the stack starts the volume
+// is non-empty, Docker's emptiness gate is false, and no further copy-up (hence
+// no race) happens. `up -d` blocks until the container is started, which is
+// when the copy-up runs (during mount setup, before the entrypoint), so the
+// volume is populated once this resolves. On a warm volume it's a ~1s no-op.
+//
+// Best-effort: a failed prime (image not built yet, daemon hiccup) is swallowed
+// so the caller's real `up` builds/pulls and surfaces the genuine error — we
+// remove a race, we never mask a failure.
+export async function primeBundleVolume(
+  projectDir: string,
+  options?: { stdio?: ExecaOptions['stdio'] },
+): Promise<void> {
+  try {
+    await dockerCompose(['up', '-d', '--no-deps', 'web'], projectDir, {
+      stdio: options?.stdio ?? 'inherit',
+    })
+  } catch {
+    // fall through to the caller's `up`, which reports any real failure
+  }
+}
+
 export async function rakeTask(
   task: string,
   projectDir: string,

--- a/packages/cli/tests/eject.test.ts
+++ b/packages/cli/tests/eject.test.ts
@@ -2,9 +2,9 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { Command } from 'commander'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { registerEjectCommand } from '../src/commands/eject'
-import { dockerCompose, dockerComposeExec } from '../src/docker'
+import { dockerCompose, dockerComposeExec, primeBundleVolume } from '../src/docker'
 
 const COMPOSE_DEV_STALE = `x-app: &app
   build:
@@ -33,6 +33,7 @@ vi.mock('../src/context', () => ({
 vi.mock('../src/docker', () => ({
   dockerCompose: vi.fn().mockResolvedValue(undefined),
   dockerComposeExec: vi.fn().mockResolvedValue(undefined),
+  primeBundleVolume: vi.fn().mockResolvedValue(undefined),
 }))
 
 function makeProject(devComposeContent: string): string {
@@ -96,5 +97,21 @@ describe('spree eject', () => {
     expect(dockerComposeExec).toHaveBeenCalledWith(['bin/rails', 'db:prepare'], projectDir, {
       tty: false,
     })
+  })
+
+  it('primes the bundle volume with web before the parallel up', async () => {
+    projectDir = makeProject(COMPOSE_DEV_STALE)
+
+    await runEject()
+
+    expect(primeBundleVolume).toHaveBeenCalledWith(projectDir)
+    // The primer must run before the parallel `up -d` so web wins the
+    // cold-volume copy-up uncontended (no web/worker "file exists" race).
+    const primeOrder = (primeBundleVolume as Mock).mock.invocationCallOrder[0]
+    const upCall = (dockerCompose as Mock).mock.calls.findIndex(
+      ([args]) => Array.isArray(args) && args.join(' ') === 'up -d',
+    )
+    expect(upCall).toBeGreaterThanOrEqual(0)
+    expect(primeOrder).toBeLessThan((dockerCompose as Mock).mock.invocationCallOrder[upCall])
   })
 })


### PR DESCRIPTION
Root cause (confirmed by a diagnose→design→verify workflow): npx spree eject runs docker compose up -d, which starts web and worker concurrently. Both share one bundle_cache named volume. On a cold volume, Docker copies the image's populated /usr/local/bundle into it ("copy-up") per container, with no cross-container lock — so both containers walk the same tree and race on mkdir of the same gem-extension dir (json-2.20.0), and one loses with file exists. It's first-boot-only (warm volume skips copy-up) and nondeterministic; aarch64 is incidental (just the platform string in the path).

Fix (CLI-side, so it reaches already-scaffolded projects on npm i -g @spree/cli — a compose-only fix would only help re-scaffolded projects): a new primeBundleVolume() helper brings web up alone first (up -d --no-deps web), so it wins the copy-up uncontended; by the time the full stack starts, the volume is non-empty and no further copy-up happens. On a warm volume it's a ~1s no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability across CLI commands by seeding the shared `bundle_cache` volume first to avoid intermittent startup races.
  * `init`, `update`, `dev`, and `eject` now prime using the `web` container before bringing up the rest of the stack, especially after removing local Docker volumes.
* **Tests**
  * Added/updated CLI test coverage to verify the volume priming step occurs before the main parallel container startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->