### PR TITLE
Simplify Store seeding logic with early return

### DIFF
--- a/spree/core/app/services/spree/seeds/stores.rb
+++ b/spree/core/app/services/spree/seeds/stores.rb
@@ -4,20 +4,18 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call
-        default_store = Spree::Store.default
+        return if Spree::Store.where(default: true).exists?
 
-        unless default_store.persisted?
-          Spree::Store.new do |s|
-            s.name                         = 'Shop'
-            s.code                         = 'shop'
-            s.url                          = Rails.application.routes.default_url_options[:host] || 'localhost:3000'
-            s.mail_from_address            = 'no-reply@example.com'
-            s.customer_support_email       = 'support@example.com'
-            s.default_currency             = 'USD'
-            s.default_country_iso          = 'US'
-            s.default_locale               = I18n.locale
-          end.save!
-        end
+        Spree::Store.new do |s|
+          s.name                         = 'Shop'
+          s.code                         = 'shop'
+          s.url                          = Rails.application.routes.default_url_options[:host] || 'localhost:3000'
+          s.mail_from_address            = 'no-reply@example.com'
+          s.customer_support_email       = 'support@example.com'
+          s.default_currency             = 'USD'
+          s.default_country_iso          = 'US'
+          s.default_locale               = I18n.locale
+        end.save!
       end
     end
   end


### PR DESCRIPTION
## Summary
Refactors the `Spree::Seeds::Stores` service to use an early return pattern, improving code clarity and reducing nesting.

## Changes
- Replace `Spree::Store.default` lookup with a direct database existence check (`where(default: true).exists?`)
- Use early return to exit if a default store already exists, eliminating the `unless` guard clause
- Simplify the store creation logic by removing one level of indentation and the intermediate variable assignment

## Implementation Details
The refactored approach is more efficient as it:
- Avoids instantiating a Store object just to check persistence
- Uses a direct database query (`exists?`) which is faster than loading the full record
- Improves readability with the early-return pattern, making the "happy path" the main flow
- Maintains identical behavior: only creates a default store if one doesn't already exist

https://claude.ai/code/session_01DvUBuk3HpDHZxPjWd9FHdu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default store setup to avoid creating duplicate default stores during setup or seeding.
  * Existing default store settings remain unchanged when a default store is already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->