### PR TITLE
Fixed: legacy multi store method mapping should return an AR relation so

### DIFF
--- a/spree/core/app/models/concerns/spree/legacy_multi_store_support.rb
+++ b/spree/core/app/models/concerns/spree/legacy_multi_store_support.rb
@@ -9,12 +9,15 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
+      # Legacy accessors for the many-to-many store relationship. These are deprecated
+      # and will be removed in Spree 6.0 once the models finish migrating to single-store ownership.
+      # @return [ActiveRecord::Relation<Spree::Store>] the single store wrapped in a relation, or an empty relation if no store is set
       def stores
         Spree::Deprecation.warn(
           "#{self.class.base_class}#stores is deprecated. Please use #{self.class.base_class}#store instead. " \
           'If you want to continue using multiple stores please install spree_multi_store gem'
         )
-        store ? [store] : []
+        store ? Spree::Stores.where(id: store.id) : Spree::Store.none
       end
 
       def store_ids

--- a/spree/core/app/models/concerns/spree/legacy_multi_store_support.rb
+++ b/spree/core/app/models/concerns/spree/legacy_multi_store_support.rb
@@ -17,7 +17,7 @@ module Spree
           "#{self.class.base_class}#stores is deprecated. Please use #{self.class.base_class}#store instead. " \
           'If you want to continue using multiple stores please install spree_multi_store gem'
         )
-        store ? Spree::Stores.where(id: store.id) : Spree::Store.none
+        store ? Spree::Store.where(id: store.id) : Spree::Store.none
       end
 
       def store_ids


### PR DESCRIPTION
`stores.ids` still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the deprecated `stores` accessor to return a database-backed, queryable result instead of an in-memory array.
  * When a store is available, it now returns a relation scoped to that store; otherwise it returns an empty relation.
  * Kept the existing deprecation warning message unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->