### PR TITLE
Fix `create-spree-app` generated `ci.yml`

### DIFF
--- a/packages/create-spree-app/.changeset/fix-nested-backend-ci-workflow.md
+++ b/packages/create-spree-app/.changeset/fix-nested-backend-ci-workflow.md
@@ -1,0 +1,5 @@
+---
+"create-spree-app": patch
+---
+
+Fix the generated project's CI workflow when the Rails app lives under `backend/`. The relocated `backend-ci.yml` now points `ruby/setup-ruby` and the `bin/rails`/`bundle` steps at the `backend/` subdirectory, so `ruby/setup-ruby` finds `.ruby-version` instead of failing with "input ruby-version needs to be specified".

--- a/packages/create-spree-app/.changeset/fix-nested-backend-ci-workflow.md
+++ b/packages/create-spree-app/.changeset/fix-nested-backend-ci-workflow.md
@@ -2,4 +2,4 @@
 "create-spree-app": patch
 ---
 
-Fix the generated project's CI workflow when the Rails app lives under `backend/`. The relocated `backend-ci.yml` now points `ruby/setup-ruby` and the `bin/rails`/`bundle` steps at the `backend/` subdirectory, so `ruby/setup-ruby` finds `.ruby-version` instead of failing with "input ruby-version needs to be specified".
+Fix and tidy the generated project's CI for the nested `backend/` layout. The relocated `backend-ci.yml` now points `ruby/setup-ruby` and the `bin/rails`/`bundle` steps at `backend/`, so `ruby/setup-ruby` finds `.ruby-version` instead of failing with "input ruby-version needs to be specified". The starter's `release.yml` (which publishes the official Spree image) and its standalone `README.md` are no longer carried into the generated project.

--- a/packages/create-spree-app/.changeset/fix-nested-backend-ci-workflow.md
+++ b/packages/create-spree-app/.changeset/fix-nested-backend-ci-workflow.md
@@ -1,5 +1,0 @@
----
-"create-spree-app": patch
----
-
-Fix and tidy the generated project's CI for the nested `backend/` layout. The relocated `backend-ci.yml` now points `ruby/setup-ruby` and the `bin/rails`/`bundle` steps at `backend/`, so `ruby/setup-ruby` finds `.ruby-version` instead of failing with "input ruby-version needs to be specified". The starter's `release.yml` (which publishes the official Spree image) and its standalone `README.md` are no longer carried into the generated project.

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-spree-app
 
+## 1.0.7
+
+### Patch Changes
+
+- Fix and tidy the generated project's CI for the nested `backend/` layout. The relocated `backend-ci.yml` now points `ruby/setup-ruby` and the `bin/rails`/`bundle` steps at `backend/`, so `ruby/setup-ruby` finds `.ruby-version` instead of failing with "input ruby-version needs to be specified". The starter's `release.yml` (which publishes the official Spree image) and its standalone `README.md` are no longer carried into the generated project.
+
 ## 1.0.6
 
 ### Patch Changes

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/backend.ts
+++ b/packages/create-spree-app/src/backend.ts
@@ -8,16 +8,52 @@ export async function downloadBackend(projectDir: string): Promise<void> {
   await execa('git', ['clone', '--depth', '1', BACKEND_REPO, backendDir], { stdio: 'ignore' })
   fs.rmSync(path.join(backendDir, '.git'), { recursive: true, force: true })
 
-  // Move backend CI workflow to project root
+  // Move backend CI workflow to project root.
+  // GitHub Actions only runs workflows from the repo root's .github/workflows,
+  // but the Rails app now lives under backend/, so adapt the workflow steps to
+  // run there (the starter's workflow assumes the app is the repo root).
   const srcWorkflows = path.join(backendDir, '.github', 'workflows')
   if (fs.existsSync(srcWorkflows)) {
     const destWorkflows = path.join(projectDir, '.github', 'workflows')
     fs.mkdirSync(destWorkflows, { recursive: true })
 
     for (const file of fs.readdirSync(srcWorkflows)) {
-      fs.renameSync(path.join(srcWorkflows, file), path.join(destWorkflows, file))
+      const content = fs.readFileSync(path.join(srcWorkflows, file), 'utf-8')
+      fs.writeFileSync(path.join(destWorkflows, file), adaptWorkflowForNestedBackend(content))
     }
 
     fs.rmSync(path.join(backendDir, '.github'), { recursive: true, force: true })
   }
+}
+
+/**
+ * Rewrite a Ruby/Rails CI workflow so its steps run against the `backend/`
+ * subdirectory instead of the repo root. The starter's workflow is authored for
+ * a repo where the Rails app *is* the root; once relocated to the wrapper
+ * project root it must point at backend/ or `ruby/setup-ruby` fails to find
+ * `.ruby-version`/`Gemfile` and the `bin/rails`/`bundle` steps run in the wrong
+ * place. Non-Ruby workflows are returned untouched.
+ */
+export function adaptWorkflowForNestedBackend(content: string): string {
+  if (!content.includes('ruby/setup-ruby')) return content
+
+  let result = content
+
+  // Run every `run:` step from backend/ via a job-level default. Anchored on the
+  // first `runs-on:` so the block is inserted at the job's indentation.
+  result = result.replace(
+    /^([ \t]*)runs-on:.*$/m,
+    (line, indent) =>
+      `${line}\n\n${indent}defaults:\n${indent}  run:\n${indent}    working-directory: backend`,
+  )
+
+  // `ruby/setup-ruby` is an action, not a `run:` step, so job defaults don't
+  // reach it — point it at backend/ explicitly so bundler-cache and the version
+  // file resolve there.
+  result = result.replace(
+    /^([ \t]*)- uses: ruby\/setup-ruby@[^\n]*\n([ \t]*)with:[ \t]*\n/m,
+    (match, _stepIndent, withIndent) => `${match}${withIndent}  working-directory: backend\n`,
+  )
+
+  return result
 }

--- a/packages/create-spree-app/src/backend.ts
+++ b/packages/create-spree-app/src/backend.ts
@@ -9,6 +9,15 @@ import { BACKEND_REPO } from './constants.js'
 const SKIP_BACKEND_FILES = ['README.md']
 const SKIP_BACKEND_WORKFLOWS = ['release.yml']
 
+/**
+ * Clone the spree-starter backend into `<projectDir>/backend` for the wrapper
+ * project's nested layout. Besides fetching the repo, this drops the clone's
+ * git metadata and delegates to {@link prepareBackendTemplate}, which relocates
+ * the CI workflow to the project root and removes starter-only files — callers
+ * get a ready-to-use `backend/`, not a verbatim checkout.
+ *
+ * @param projectDir absolute path to the wrapper project root
+ */
 export async function downloadBackend(projectDir: string): Promise<void> {
   const backendDir = path.join(projectDir, 'backend')
   await execa('git', ['clone', '--depth', '1', BACKEND_REPO, backendDir], { stdio: 'ignore' })
@@ -40,6 +49,10 @@ export function prepareBackendTemplate(projectDir: string): void {
       fs.writeFileSync(path.join(destWorkflows, file), adaptWorkflowForNestedBackend(content))
     }
 
+    // Drop the starter's whole .github — its only non-workflow file is a
+    // dependabot.yml scoped to the standalone starter repo, which the wrapper
+    // replaces with its own root .github/dependabot.yml (covering /, /backend,
+    // and the storefront). Keeping it would leave a stale, duplicate config.
     fs.rmSync(path.join(backendDir, '.github'), { recursive: true, force: true })
   }
 }

--- a/packages/create-spree-app/src/backend.ts
+++ b/packages/create-spree-app/src/backend.ts
@@ -3,21 +3,39 @@ import path from 'node:path'
 import { execa } from 'execa'
 import { BACKEND_REPO } from './constants.js'
 
+// Starter files that are redundant once the app is nested under backend/: the
+// wrapper project ships its own root README, and the release workflow publishes
+// the official Spree image and has no place in a generated project.
+const SKIP_BACKEND_FILES = ['README.md']
+const SKIP_BACKEND_WORKFLOWS = ['release.yml']
+
 export async function downloadBackend(projectDir: string): Promise<void> {
   const backendDir = path.join(projectDir, 'backend')
   await execa('git', ['clone', '--depth', '1', BACKEND_REPO, backendDir], { stdio: 'ignore' })
   fs.rmSync(path.join(backendDir, '.git'), { recursive: true, force: true })
 
-  // Move backend CI workflow to project root.
-  // GitHub Actions only runs workflows from the repo root's .github/workflows,
-  // but the Rails app now lives under backend/, so adapt the workflow steps to
-  // run there (the starter's workflow assumes the app is the repo root).
+  prepareBackendTemplate(projectDir)
+}
+
+/**
+ * Tidy the freshly-cloned starter for the nested `backend/` layout: drop files
+ * the wrapper project supplies itself, and relocate the CI workflow to the repo
+ * root (where GitHub Actions runs it) adapted to run against backend/.
+ */
+export function prepareBackendTemplate(projectDir: string): void {
+  const backendDir = path.join(projectDir, 'backend')
+
+  for (const file of SKIP_BACKEND_FILES) {
+    fs.rmSync(path.join(backendDir, file), { force: true })
+  }
+
   const srcWorkflows = path.join(backendDir, '.github', 'workflows')
   if (fs.existsSync(srcWorkflows)) {
     const destWorkflows = path.join(projectDir, '.github', 'workflows')
     fs.mkdirSync(destWorkflows, { recursive: true })
 
     for (const file of fs.readdirSync(srcWorkflows)) {
+      if (SKIP_BACKEND_WORKFLOWS.includes(file)) continue
       const content = fs.readFileSync(path.join(srcWorkflows, file), 'utf-8')
       fs.writeFileSync(path.join(destWorkflows, file), adaptWorkflowForNestedBackend(content))
     }

--- a/packages/create-spree-app/src/backend.ts
+++ b/packages/create-spree-app/src/backend.ts
@@ -3,11 +3,10 @@ import path from 'node:path'
 import { execa } from 'execa'
 import { BACKEND_REPO } from './constants.js'
 
-// Starter files that are redundant once the app is nested under backend/: the
-// wrapper project ships its own root README, and the release workflow publishes
-// the official Spree image and has no place in a generated project.
-const SKIP_BACKEND_FILES = ['README.md']
-const SKIP_BACKEND_WORKFLOWS = ['release.yml']
+// Starter paths (relative to backend/) that don't belong in a generated
+// project: the wrapper ships its own root README, and release.yml publishes the
+// official Spree image. Dropped before the CI workflow is relocated.
+const SKIP_BACKEND_PATHS = ['README.md', '.github/workflows/release.yml']
 
 /**
  * Clone the spree-starter backend into `<projectDir>/backend` for the wrapper
@@ -34,8 +33,8 @@ export async function downloadBackend(projectDir: string): Promise<void> {
 export function prepareBackendTemplate(projectDir: string): void {
   const backendDir = path.join(projectDir, 'backend')
 
-  for (const file of SKIP_BACKEND_FILES) {
-    fs.rmSync(path.join(backendDir, file), { force: true })
+  for (const relPath of SKIP_BACKEND_PATHS) {
+    fs.rmSync(path.join(backendDir, relPath), { recursive: true, force: true })
   }
 
   const srcWorkflows = path.join(backendDir, '.github', 'workflows')
@@ -44,7 +43,6 @@ export function prepareBackendTemplate(projectDir: string): void {
     fs.mkdirSync(destWorkflows, { recursive: true })
 
     for (const file of fs.readdirSync(srcWorkflows)) {
-      if (SKIP_BACKEND_WORKFLOWS.includes(file)) continue
       const content = fs.readFileSync(path.join(srcWorkflows, file), 'utf-8')
       fs.writeFileSync(path.join(destWorkflows, file), adaptWorkflowForNestedBackend(content))
     }

--- a/packages/create-spree-app/tests/backend.test.ts
+++ b/packages/create-spree-app/tests/backend.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { adaptWorkflowForNestedBackend } from '../src/backend'
+
+// Mirrors spree-starter's .github/workflows/backend-ci.yml (the workflow that
+// create-spree-app relocates to the generated project root).
+const BACKEND_CI = `name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:18
+
+    env:
+      RAILS_ENV: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:prepare
+
+      - name: Run tests
+        run: bundle exec rspec
+`
+
+// A non-Ruby workflow (e.g. release.yml) that must be left untouched.
+const RELEASE = `name: Release Docker Image
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+`
+
+describe('adaptWorkflowForNestedBackend', () => {
+  it('points ruby/setup-ruby at the backend/ subdirectory', () => {
+    const result = adaptWorkflowForNestedBackend(BACKEND_CI)
+    expect(result).toContain(
+      '      - uses: ruby/setup-ruby@v1\n' +
+        '        with:\n' +
+        '          working-directory: backend\n' +
+        '          bundler-cache: true',
+    )
+  })
+
+  it('runs job steps from backend/ via a job-level default', () => {
+    const result = adaptWorkflowForNestedBackend(BACKEND_CI)
+    expect(result).toContain(
+      '    runs-on: ubuntu-latest\n' +
+        '\n' +
+        '    defaults:\n' +
+        '      run:\n' +
+        '        working-directory: backend',
+    )
+  })
+
+  it('inserts the defaults block exactly once', () => {
+    const result = adaptWorkflowForNestedBackend(BACKEND_CI)
+    expect(result.match(/defaults:/g)).toHaveLength(1)
+  })
+
+  it('leaves the run-step commands unchanged', () => {
+    const result = adaptWorkflowForNestedBackend(BACKEND_CI)
+    expect(result).toContain('run: bin/rails db:prepare')
+    expect(result).toContain('run: bundle exec rspec')
+  })
+
+  it('leaves non-Ruby workflows untouched', () => {
+    expect(adaptWorkflowForNestedBackend(RELEASE)).toBe(RELEASE)
+  })
+})

--- a/packages/create-spree-app/tests/backend.test.ts
+++ b/packages/create-spree-app/tests/backend.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { adaptWorkflowForNestedBackend } from '../src/backend'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { adaptWorkflowForNestedBackend, prepareBackendTemplate } from '../src/backend'
 
 // Mirrors spree-starter's .github/workflows/backend-ci.yml (the workflow that
 // create-spree-app relocates to the generated project root).
@@ -88,5 +91,51 @@ describe('adaptWorkflowForNestedBackend', () => {
 
   it('leaves non-Ruby workflows untouched', () => {
     expect(adaptWorkflowForNestedBackend(RELEASE)).toBe(RELEASE)
+  })
+})
+
+describe('prepareBackendTemplate', () => {
+  const tempDirs: string[] = []
+
+  function seedClonedBackend(): string {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-spree-app-backend-'))
+    tempDirs.push(projectDir)
+
+    const workflows = path.join(projectDir, 'backend', '.github', 'workflows')
+    fs.mkdirSync(workflows, { recursive: true })
+    fs.writeFileSync(path.join(workflows, 'backend-ci.yml'), BACKEND_CI)
+    fs.writeFileSync(path.join(workflows, 'release.yml'), RELEASE)
+    fs.writeFileSync(path.join(projectDir, 'backend', 'README.md'), '# Spree starter')
+
+    return projectDir
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true })
+    tempDirs.length = 0
+  })
+
+  it('relocates the CI workflow to the project root, adapted for backend/', () => {
+    const projectDir = seedClonedBackend()
+    prepareBackendTemplate(projectDir)
+
+    const moved = path.join(projectDir, '.github', 'workflows', 'backend-ci.yml')
+    expect(fs.existsSync(moved)).toBe(true)
+    expect(fs.readFileSync(moved, 'utf-8')).toContain('working-directory: backend')
+  })
+
+  it('drops the release workflow instead of copying it', () => {
+    const projectDir = seedClonedBackend()
+    prepareBackendTemplate(projectDir)
+
+    expect(fs.existsSync(path.join(projectDir, '.github', 'workflows', 'release.yml'))).toBe(false)
+    expect(fs.existsSync(path.join(projectDir, 'backend', '.github'))).toBe(false)
+  })
+
+  it("drops the starter's README", () => {
+    const projectDir = seedClonedBackend()
+    prepareBackendTemplate(projectDir)
+
+    expect(fs.existsSync(path.join(projectDir, 'backend', 'README.md'))).toBe(false)
   })
 })


### PR DESCRIPTION
Fix and tidy the generated project's CI for the nested `backend/` layout. The relocated `backend-ci.yml` now points `ruby/setup-ruby` and the `bin/rails`/`bundle` steps at `backend/`, so `ruby/setup-ruby` finds `.ruby-version` instead of failing with "input ruby-version needs to be specified". The starter's `release.yml` (which publishes the official Spree image) and its standalone `README.md` are no longer carried into the generated project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated backend setup for nested project layouts by relocating backend GitHub Actions workflows to the project root.
  * Updated Ruby CI workflows so commands run from the `backend/` subdirectory (including Ruby setup configuration).
  * Removed redundant starter artifacts from the nested `backend/` directory, including starter README and release workflow content.
* **Tests**
  * Added automated tests covering workflow rewriting and backend template preparation for nested layouts.
* **Chores**
  * Bumped the create app package version to 1.0.7 and updated the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->