### PR TITLE
Fix `spree --version` reporting stale hardcoded version

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.3.6
+
+### Patch Changes
+
+- Fix `spree --version` reporting a stale hardcoded `2.0.0` instead of the installed CLI version. The version is now read from the package's `package.json` at runtime, so `spree -V` and `npx spree -V` always match the release you have installed.
+
 ## 2.3.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,11 +27,12 @@ import { registerTaskCommand } from './commands/task.js'
 import { registerUpdateCommand } from './commands/update.js'
 import { registerUpgradeCommand } from './commands/upgrade.js'
 import { registerUserCommand } from './commands/user.js'
+import { VERSION } from './version.js'
 
 const program = new Command()
   .name('spree')
   .description('CLI for managing Spree Commerce projects')
-  .version('2.0.0')
+  .version(VERSION)
   // Required by passThroughOptions on subcommands (exec/rails/bundle/rake/task)
   // so flags like `ls -la` or `bin/rails routes -g foo` reach the inner command
   // instead of being parsed as options of the spree subcommand.

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,10 @@
+import { createRequire } from 'node:module'
+
+// Resolve the CLI version from the package's own package.json at runtime rather
+// than hardcoding it, so `spree --version` always reports the installed release.
+// `../package.json` resolves the same whether this runs as the bundled
+// `dist/index.js` or as `src/` source (tests), and npm always ships
+// package.json in the published tarball.
+const requirePackage = createRequire(import.meta.url)
+
+export const VERSION: string = (requirePackage('../package.json') as { version: string }).version


### PR DESCRIPTION
## Summary

The CLI was reporting a hardcoded `2.0.0` version instead of the actual installed release. This change reads the version from `package.json` at runtime, ensuring `spree --version` and `npx spree -V` always match the installed CLI version.

## Changes

- **New file**: `packages/cli/src/version.ts` — Exports a `VERSION` constant that reads from the CLI package's `package.json` at runtime using `createRequire(import.meta.url)`. This approach works both when the CLI runs as bundled `dist/index.js` and as source code (in tests).
- **Updated**: `packages/cli/src/index.ts` — Replaced hardcoded `.version('2.0.0')` with `.version(VERSION)` imported from the new version module.
- **Bumped**: `packages/cli/package.json` — Version incremented from `2.3.5` to `2.3.6`.
- **Updated**: `packages/cli/CHANGELOG.md` — Added entry documenting the fix.

## Implementation Details

The version resolution uses `createRequire(import.meta.url)` to dynamically load the package's own `package.json` at runtime. The relative path `../package.json` resolves correctly whether the code runs as bundled output or source, and npm always includes `package.json` in published tarballs, making this approach reliable across all deployment scenarios.

https://claude.ai/code/session_01EWM7Z83Vn2RZV1NsQ2niZE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI version output so `spree --version`, `spree -V`, and `npx spree -V` now show the installed release version instead of an outdated value.
  * Version reporting now stays consistent across local development, built output, and test runs.

* **Chores**
  * Bumped the CLI release to `2.3.6`.
  * Updated the changelog with the latest patch release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->