### PR TITLE
Move MultiSearchable alias to separate file for Zeitwerk

### DIFF
--- a/spree/core/app/models/concerns/spree/multi_searchable.rb
+++ b/spree/core/app/models/concerns/spree/multi_searchable.rb
@@ -1,0 +1,10 @@
+module Spree
+  # Constant alias for Spree::Searchable — remove in Spree 6.0.
+  #
+  # Lets legacy code and extensions reference the concern by its former name
+  # after the Searchable rename. The concern itself lives in Spree::Searchable;
+  # keeping the alias in its own file lets Zeitwerk manage (and reload) it,
+  # avoiding the "already initialized constant" warning that a second constant
+  # defined inside searchable.rb would raise.
+  MultiSearchable = Searchable
+end

--- a/spree/core/app/models/concerns/spree/searchable.rb
+++ b/spree/core/app/models/concerns/spree/searchable.rb
@@ -31,7 +31,4 @@ module Spree
       def self.multi_search_condition(model_class, attribute, query) = search_condition(model_class, attribute, query)
     end
   end
-
-  # Backward compatibility alias — remove in Spree 6.0
-  MultiSearchable = Searchable
 end


### PR DESCRIPTION
## Summary
Moves the `MultiSearchable` backward compatibility alias from `searchable.rb` to its own dedicated file (`multi_searchable.rb`). This allows Zeitwerk to properly manage and reload the constant without triggering "already initialized constant" warnings.

## Changes
- **New file**: `spree/core/app/models/concerns/spree/multi_searchable.rb`
  - Defines `MultiSearchable = Searchable` as a constant alias
  - Includes documentation explaining this is a backward compatibility shim for the Spree 5.x → 6.0 rename
  
- **Modified**: `spree/core/app/models/concerns/spree/searchable.rb`
  - Removes the inline `MultiSearchable` constant definition
  - Keeps all functional code in `Searchable` unchanged

## Implementation Details
Separating the alias into its own file leverages Zeitwerk's autoloading to manage the constant lifecycle independently. This prevents the "already initialized constant" warning that would occur if the same constant were defined in multiple places during development reloads, while maintaining full backward compatibility for legacy code and extensions that reference `Spree::MultiSearchable`.

The alias will be removed in Spree 6.0 as part of the broader cleanup of deprecated naming conventions.

https://claude.ai/code/session_01TXm7Y989wq9V5QbWNoLojj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward compatibility for search-related functionality, helping older integrations continue to work without changes.
  * Kept existing search behavior intact while reducing the chance of reload-related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->