### PR TITLE
Fixed rails admin tailwind watch inside docker container

### DIFF
--- a/spree/admin/lib/spree/admin/tailwind_helper.rb
+++ b/spree/admin/lib/spree/admin/tailwind_helper.rb
@@ -47,18 +47,40 @@ module Spree
           end
         end
 
+        # [relative dir, glob] pairs Tailwind scans for utility classes.
+        SOURCE_PATHS = [
+          ["app/views/spree/admin", "**/*.erb"],
+          ["app/helpers/spree/admin", "**/*.rb"],
+          ["app/javascript/spree/admin", "**/*.js"]
+        ].freeze
+
         def engine_sources(engine)
           root = engine.root.to_s
-          source_paths = [
-            ["app/views/spree/admin", "**/*.erb"],
-            ["app/helpers/spree/admin", "**/*.rb"],
-            ["app/javascript/spree/admin", "**/*.js"]
-          ]
 
-          source_paths.filter_map do |dir, pattern|
+          SOURCE_PATHS.filter_map do |dir, pattern|
             full_dir = File.join(root, dir)
             %(@source "#{full_dir}/#{pattern}";) if File.directory?(full_dir)
           end
+        end
+
+        # Every template/CSS glob that affects the compiled admin CSS, across all
+        # Spree engines plus the host app. Used by watch mode to poll for changes
+        # (OS file-system events don't cross a Docker bind mount from a macOS host).
+        #
+        # @return [Array<String>] absolute Dir.glob patterns
+        def source_globs
+          roots = spree_engines.map { |engine| engine.root.to_s }
+          roots << Rails.root.to_s
+
+          template_globs = roots.product(SOURCE_PATHS).map do |root, (dir, pattern)|
+            File.join(root, dir, pattern)
+          end
+
+          css_globs = [engine_css_path.to_s, input_path.dirname.to_s].map do |dir|
+            File.join(dir, "**", "*.css")
+          end
+
+          (template_globs + css_globs).uniq
         end
 
         def write_resolved_css

--- a/spree/admin/lib/tasks/tailwind.rake
+++ b/spree/admin/lib/tasks/tailwind.rake
@@ -41,6 +41,9 @@ namespace :spree do
         build = lambda do
           Spree::Admin::TailwindHelper.write_resolved_css
           system(Tailwindcss::Ruby.executable, "-i", resolved_path.to_s, "-o", output_path.to_s)
+          # system doesn't raise on a non-zero exit, so surface build failures
+          # (invalid CSS, missing binary) — otherwise a broken rebuild is silent.
+          warn "[tailwind watch] build failed (exit #{$?.exitstatus})" unless $?.success?
         end
 
         source_mtimes = lambda do

--- a/spree/admin/lib/tasks/tailwind.rake
+++ b/spree/admin/lib/tasks/tailwind.rake
@@ -29,54 +29,54 @@ namespace :spree do
       task watch: :environment do
         require "tailwindcss/ruby"
 
-        begin
-          require "listen"
-        rescue LoadError
-          puts "ERROR: The 'listen' gem is required for watch mode."
-          puts "Add it to your Gemfile in the development group:"
-          puts ""
-          puts "  group :development do"
-          puts "    gem 'listen', '>= 3.0'"
-          puts "  end"
-          puts ""
-          exit 1
-        end
-
         output_path = Spree::Admin::TailwindHelper.output_path
         FileUtils.mkdir_p(output_path.dirname)
 
-        # Initial write of resolved CSS
-        resolved_path = Spree::Admin::TailwindHelper.write_resolved_css
+        resolved_path = Spree::Admin::TailwindHelper.resolved_input_path
+
+        # One-shot Tailwind build. Polling drives recompilation instead of
+        # Tailwind's own --watch: its file watching (like the `listen` gem's)
+        # relies on OS file-system events, which don't cross a Docker bind mount
+        # from a macOS host, so a host-side template edit would never rebuild.
+        build = lambda do
+          Spree::Admin::TailwindHelper.write_resolved_css
+          system(Tailwindcss::Ruby.executable, "-i", resolved_path.to_s, "-o", output_path.to_s)
+        end
+
+        source_mtimes = lambda do
+          Spree::Admin::TailwindHelper.source_globs.each_with_object({}) do |glob, acc|
+            Dir.glob(glob).each do |file|
+              acc[file] = File.mtime(file) rescue next
+            end
+          end
+        end
+
         puts "Watching Spree Admin Tailwind CSS for changes..."
         puts "  Host input: #{Spree::Admin::TailwindHelper.input_path}"
         puts "  Engine CSS: #{Spree::Admin::TailwindHelper.engine_css_path}"
         puts "  Resolved: #{resolved_path}"
         puts "  Output: #{output_path}"
 
-        # Watch paths for CSS source changes
-        watch_paths = [
-          Spree::Admin::TailwindHelper.engine_css_path.to_s,  # Engine CSS files
-          Spree::Admin::TailwindHelper.input_path.dirname.to_s # Host app CSS files
-        ].select { |p| File.directory?(p) }
+        build.call
+        previous = source_mtimes.call
 
-        # Set up listener to regenerate resolved CSS when source files change
-        listener = Listen.to(*watch_paths, only: /\.css$/) do |modified, added, removed|
-          changed = (modified + added + removed).map { |f| File.basename(f) }.join(", ")
-          puts "\n[#{Time.now.strftime('%H:%M:%S')}] CSS changed: #{changed}"
-          puts "  Regenerating resolved CSS..."
-          Spree::Admin::TailwindHelper.write_resolved_css
+        loop do
+          sleep 1
+          begin
+            current = source_mtimes.call
+            next if current == previous
+
+            changed = (current.keys | previous.keys).select { |f| current[f] != previous[f] }
+                      .map { |f| File.basename(f) }.uniq.first(5).join(", ")
+            previous = current
+            puts "\n[#{Time.now.strftime('%H:%M:%S')}] Sources changed: #{changed} — rebuilding..."
+            build.call
+          rescue => e
+            # A transient read/build error (e.g. a source file caught mid-save)
+            # must not kill the watch loop — log and keep polling.
+            warn "[tailwind watch] rebuild failed: #{e.class}: #{e.message}"
+          end
         end
-        listener.start
-
-        # Run Tailwind in watch mode (this blocks)
-        command = [
-          Tailwindcss::Ruby.executable,
-          "-i", resolved_path.to_s,
-          "-o", output_path.to_s,
-          "--watch"
-        ]
-
-        system(*command)
       end
     end
   end

--- a/spree/admin/spec/lib/spree/admin/tailwind_helper_spec.rb
+++ b/spree/admin/spec/lib/spree/admin/tailwind_helper_spec.rb
@@ -75,6 +75,29 @@ RSpec.describe Spree::Admin::TailwindHelper do
     end
   end
 
+  describe '.source_globs' do
+    subject(:globs) { described_class.source_globs }
+
+    it 'returns absolute Dir.glob patterns' do
+      expect(globs).to all(start_with('/'))
+    end
+
+    it 'includes the admin engine template globs' do
+      admin_root = Spree::Admin::Engine.root.to_s
+
+      expect(globs).to include("#{admin_root}/app/views/spree/admin/**/*.erb")
+    end
+
+    it 'includes the host app and engine CSS globs' do
+      expect(globs).to include(File.join(described_class.engine_css_path.to_s, "**", "*.css"))
+      expect(globs).to include(File.join(described_class.input_path.dirname.to_s, "**", "*.css"))
+    end
+
+    it 'does not contain duplicates' do
+      expect(globs).to eq(globs.uniq)
+    end
+  end
+
   describe '.write_resolved_css' do
     after do
       FileUtils.rm_rf(Rails.root.join("tmp/tailwind"))


### PR DESCRIPTION
dropped `listen` dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin Tailwind styles now refresh automatically when relevant template or stylesheet files change.
  * Improved Tailwind source detection brings in additional admin/app template and CSS locations for more complete compiled admin styling.

* **Bug Fixes**
  * Increased watch/rebuild resilience by handling transient build/read issues without stopping updates.
  * Prevents duplicate source entries to avoid redundant compilation work and reduce inconsistent refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->