### PR TITLE
Fix i18n lookup for select options with namespace separators

### DIFF
--- a/packages/dashboard/e2e/channels-settings.spec.ts
+++ b/packages/dashboard/e2e/channels-settings.spec.ts
@@ -79,6 +79,12 @@ test.describe('settings / channels', () => {
     await expect(page.getByRole('heading', { name: original })).toBeVisible({ timeout: 15_000 })
 
     await page.getByLabel(/^name$/i).fill(updated)
+
+    // Pick the routing strategy by its human label — the dropdown must surface
+    // readable option labels, never the raw strategy class name.
+    await page.locator('#preferred_order_routing_strategy').click()
+    await page.getByRole('option', { name: /^rules \(ordered\)$/i }).click()
+
     await page.getByRole('button', { name: /^save$/i }).click()
 
     await expect(rowButton(page, updated)).toBeVisible({ timeout: 15_000 })

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/channels.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/channels.tsx
@@ -331,7 +331,16 @@ function InheritableSelectField({
   const error = form.formState.errors[name]
   const options = values.map((value) => ({
     value,
-    label: value === '' ? t(`${scope}.inherit`) : t(`${scope}.options.${value}`),
+    // `nsSeparator: false` because option values can contain `::` (e.g. strategy
+    // class names), which i18next would otherwise parse as a namespace separator
+    // and miss the lookup.
+    label:
+      value === ''
+        ? t(`${scope}.inherit`)
+        : t(`${scope}.options.${value}`, {
+            nsSeparator: false,
+            defaultValue: value.replace(/^Spree::/, ''),
+          }),
   }))
   return (
     <Field>


### PR DESCRIPTION
## Summary
Fixed i18n translation lookup for inheritable select field options that contain namespace separator characters (`::`), which are commonly found in strategy class names like `Spree::SomeStrategy`.

## Changes
- Updated `InheritableSelectField` in the channels settings to pass `nsSeparator: false` to i18next when looking up option labels
- Added a `defaultValue` fallback that strips the `Spree::` prefix from the option value, providing a sensible display label when translation keys are not found
- Added explanatory comment documenting why the namespace separator must be disabled

## Implementation Details
The issue occurred because i18next by default treats `::` as a namespace separator. When an option value like `Spree::SomeStrategy` was used as part of a translation key (e.g., `scope.options.Spree::SomeStrategy`), i18next would incorrectly parse it as a namespace lookup and fail to find the translation.

By setting `nsSeparator: false`, the full string is treated as a single key. The `defaultValue` provides a user-friendly fallback by removing the `Spree::` prefix, so users see "SomeStrategy" if no translation exists rather than the raw option value.

https://claude.ai/code/session_019XUs68h4kiJ7sZQ2dqEH4x