### PR TITLE
Diagnose and explain port conflicts when docker compose fails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Day-to-day from the repo root: `pnpm server:dev` (foreground — streams web + w
 | Meilisearch image bump ("database version … is incompatible") | `docker compose -p server rm -sf meilisearch && docker volume rm server_meilisearch_data`, boot, then `cd server && pnpm exec spree rake spree:search:reindex` |
 | Broken beyond repair | `pnpm server:setup` (full reset — wipes DB + volumes) |
 
-Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). Host ports for Postgres/Meilisearch are picked free at setup time (above the spree-starter defaults, so they don't collide with another project's stack) and written to `server/.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` — check there before connecting a DB client. Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.
+Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). The Postgres host port is picked free at setup time (above the spree-starter default, so it doesn't collide with another project's stack) and written to `server/.env` as `SPREE_DB_PORT` — check there before connecting a DB client. (Redis and Meilisearch aren't host-published.) Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Day-to-day from the repo root: `pnpm server:dev` (foreground — streams web + w
 | Meilisearch image bump ("database version … is incompatible") | `docker compose -p server rm -sf meilisearch && docker volume rm server_meilisearch_data`, boot, then `cd server && pnpm exec spree rake spree:search:reindex` |
 | Broken beyond repair | `pnpm server:setup` (full reset — wipes DB + volumes) |
 
-Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.
+Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). Host ports for Postgres/Meilisearch are picked free at setup time (starting at 5434/7701, above the spree-starter defaults) and written to `server/.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` — check there before connecting a DB client. Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Day-to-day from the repo root: `pnpm server:dev` (foreground — streams web + w
 | Meilisearch image bump ("database version … is incompatible") | `docker compose -p server rm -sf meilisearch && docker volume rm server_meilisearch_data`, boot, then `cd server && pnpm exec spree rake spree:search:reindex` |
 | Broken beyond repair | `pnpm server:setup` (full reset — wipes DB + volumes) |
 
-Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). Host ports for Postgres/Meilisearch are picked free at setup time (starting at 5434/7701, above the spree-starter defaults) and written to `server/.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` — check there before connecting a DB client. Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.
+Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree123`). Host ports for Postgres/Meilisearch are picked free at setup time (above the spree-starter defaults, so they don't collide with another project's stack) and written to `server/.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` — check there before connecting a DB client. Native no-Docker path: `pnpm server:create`, then `cd server && bin/setup && bin/dev`.
 
 ---
 

--- a/packages/cli/.changeset/port-conflict-diagnosis.md
+++ b/packages/cli/.changeset/port-conflict-diagnosis.md
@@ -1,5 +1,0 @@
----
-'@spree/cli': minor
----
-
-Explain port conflicts instead of dumping raw compose output: when `spree dev`, `spree init`, or `spree eject` fail to boot the stack, the CLI now names the taken host port, who is holding it (another compose project's warm databases, a stray container, or a non-Docker process), and both remedies — `spree stop` in the other project, or a `SPREE_PORT` / `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` override in `.env` to run projects side by side (the override hint is only offered when the project's compose file actually interpolates that variable). `spree db:reset` now reports the configured `SPREE_DB_PORT` instead of a hardcoded 5433.

--- a/packages/cli/.changeset/port-conflict-diagnosis.md
+++ b/packages/cli/.changeset/port-conflict-diagnosis.md
@@ -1,0 +1,5 @@
+---
+'@spree/cli': minor
+---
+
+Explain port conflicts instead of dumping raw compose output: when `spree dev`, `spree init`, or `spree eject` fail to boot the stack, the CLI now names the taken host port, who is holding it (another compose project's warm databases, a stray container, or a non-Docker process), and both remedies — `spree stop` in the other project, or a `SPREE_PORT` / `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` override in `.env` to run projects side by side (the override hint is only offered when the project's compose file actually interpolates that variable). `spree db:reset` now reports the configured `SPREE_DB_PORT` instead of a hardcoded 5433.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Explain port conflicts instead of dumping raw compose output: when `spree dev`, `spree init`, or `spree eject` fail to boot the stack, the CLI now names the taken host port, who is holding it (another compose project's warm databases, a stray container, or a non-Docker process), and both remedies — `spree stop` in the other project, or a `SPREE_PORT` / `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` override in `.env` to run projects side by side (the override hint is only offered when the project's compose file actually interpolates that variable). `spree db:reset` now reports the configured `SPREE_DB_PORT` instead of a hardcoded 5433.
+- Explain port conflicts instead of dumping raw compose output: when `spree dev`, `spree init`, or `spree eject` fail to boot the stack, the CLI now names the taken host port, who is holding it (another compose project's warm databases, a stray container, or a non-Docker process), and both remedies — `spree stop` in the other project, or a `SPREE_PORT` / `SPREE_DB_PORT` override in `.env` to run projects side by side (the override hint is only offered when the project's compose file actually interpolates that variable). `spree db:reset` now reports the configured `SPREE_DB_PORT` instead of a hardcoded 5433.
 
 ## 2.3.7
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.3.8
+
+### Patch Changes
+
+- Explain port conflicts instead of dumping raw compose output: when `spree dev`, `spree init`, or `spree eject` fail to boot the stack, the CLI now names the taken host port, who is holding it (another compose project's warm databases, a stray container, or a non-Docker process), and both remedies — `spree stop` in the other project, or a `SPREE_PORT` / `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT` override in `.env` to run projects side by side (the override hint is only offered when the project's compose file actually interpolates that variable). `spree db:reset` now reports the configured `SPREE_DB_PORT` instead of a hardcoded 5433.
+
 ## 2.3.7
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import pc from 'picocolors'
-import { detectProject, hasMonorepoSpreePath } from '../context.js'
+import { detectProject, hasMonorepoSpreePath, readDbPortFromEnv } from '../context.js'
 import { dockerCompose, dockerComposeExec, dockerComposeRun, isServiceRunning } from '../docker.js'
 
 export const RESET_TASK = [
@@ -96,11 +96,13 @@ export function registerDbCommand(program: Command): void {
         const stderr = String((err as { stderr?: string }).stderr ?? (err as Error).message ?? '')
         if (/being accessed by other users|55006/.test(stderr)) {
           // We stopped the app containers, so the remaining connection is a host
-          // client we can't see or stop (TablePlus/DataGrip/psql on port 5433).
-          // If we stopped the stack to get here, also tell them how to restore it.
+          // client we can't see or stop (TablePlus/DataGrip/psql on the
+          // published DB port). If we stopped the stack to get here, also tell
+          // them how to restore it.
+          const dbPort = readDbPortFromEnv(ctx.projectDir)
           refuse([
             'Could not drop spree_development — another client is still connected.',
-            `A database client (TablePlus, DataGrip, psql) may be connected on port ${pc.bold('5433')}.`,
+            `A database client (TablePlus, DataGrip, psql) may be connected on port ${pc.bold(String(dbPort))}.`,
             'Disconnect it, then re-run `spree db:reset`.',
             ...(stackUp ? ['', `Bring the stack back up with ${pc.bold('spree dev')}.`] : []),
           ])

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -11,7 +11,7 @@ import {
   primeBundleVolume,
   watchAdminStylesheets,
 } from '../docker.js'
-import { diagnosePortConflicts, formatPortConflicts } from '../ports.js'
+import { cancelOnPortConflict } from '../ports.js'
 
 export function registerDevCommand(program: Command): void {
   program
@@ -125,10 +125,7 @@ export function registerDevCommand(program: Command): void {
         // The most common failed boot is a port conflict with another
         // project's warm databases — name the port and the holder instead of
         // leaving raw compose output as the only clue.
-        const conflicts = await diagnosePortConflicts(ctx.projectDir).catch(() => [])
-        if (conflicts.length > 0) {
-          p.cancel(formatPortConflicts(conflicts).join('\n'))
-        } else {
+        if (!(await cancelOnPortConflict(ctx.projectDir))) {
           p.cancel(`docker compose exited with code ${exitCode} — see the output above.`)
         }
         process.exit(exitCode)

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -11,6 +11,7 @@ import {
   primeBundleVolume,
   watchAdminStylesheets,
 } from '../docker.js'
+import { diagnosePortConflicts, formatPortConflicts } from '../ports.js'
 
 export function registerDevCommand(program: Command): void {
   program
@@ -121,7 +122,15 @@ export function registerDevCommand(program: Command): void {
       // port conflict) — surface it instead of pretending shutdown was clean.
       const exitCode = result.exitCode ?? 0
       if (exitCode !== 0 && exitCode !== 130) {
-        p.cancel(`docker compose exited with code ${exitCode} — see the output above.`)
+        // The most common failed boot is a port conflict with another
+        // project's warm databases — name the port and the holder instead of
+        // leaving raw compose output as the only clue.
+        const conflicts = await diagnosePortConflicts(ctx.projectDir).catch(() => [])
+        if (conflicts.length > 0) {
+          p.cancel(formatPortConflicts(conflicts).join('\n'))
+        } else {
+          p.cancel(`docker compose exited with code ${exitCode} — see the output above.`)
+        }
         process.exit(exitCode)
       }
 

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -10,6 +10,7 @@ import {
   dockerComposeExec,
   primeBundleVolume,
 } from '../docker.js'
+import { diagnosePortConflicts, formatPortConflicts } from '../ports.js'
 
 // Switch the project from the prebuilt-image compose to the bind-mounted
 // dev compose. Source under ./backend becomes live in the container —
@@ -55,7 +56,19 @@ export function registerEjectCommand(program: Command) {
       // Prime the shared bundle_cache volume with web alone so the parallel up
       // below doesn't race the cold-volume copy-up (web + worker → "file exists").
       await primeBundleVolume(ctx.projectDir)
-      await dockerCompose(['up', '-d'], ctx.projectDir, { stdio: 'inherit' })
+      try {
+        await dockerCompose(['up', '-d'], ctx.projectDir, { stdio: 'inherit' })
+      } catch (err) {
+        // Eject is where the postgres host port gets published for the first
+        // time (the prebuilt-image compose exposes none), so this is the most
+        // likely place to first collide with another project's warm databases.
+        const conflicts = await diagnosePortConflicts(ctx.projectDir).catch(() => [])
+        if (conflicts.length > 0) {
+          p.cancel(formatPortConflicts(conflicts).join('\n'))
+          process.exit(1)
+        }
+        throw err
+      }
 
       // The dev image bypasses bin/docker-entrypoint (which runs db:prepare
       // in the prebuilt image), and the dev environment uses its own

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -10,7 +10,7 @@ import {
   dockerComposeExec,
   primeBundleVolume,
 } from '../docker.js'
-import { diagnosePortConflicts, formatPortConflicts } from '../ports.js'
+import { cancelOnPortConflict } from '../ports.js'
 
 // Switch the project from the prebuilt-image compose to the bind-mounted
 // dev compose. Source under ./backend becomes live in the container —
@@ -62,11 +62,7 @@ export function registerEjectCommand(program: Command) {
         // Eject is where the postgres host port gets published for the first
         // time (the prebuilt-image compose exposes none), so this is the most
         // likely place to first collide with another project's warm databases.
-        const conflicts = await diagnosePortConflicts(ctx.projectDir).catch(() => [])
-        if (conflicts.length > 0) {
-          p.cancel(formatPortConflicts(conflicts).join('\n'))
-          process.exit(1)
-        }
+        if (await cancelOnPortConflict(ctx.projectDir)) process.exit(1)
         throw err
       }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,6 +9,7 @@ import { mintProjectCredentials } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject } from '../context.js'
 import { dockerCompose, primeBundleVolume, rakeTask, streamLogs } from '../docker.js'
+import { diagnosePortConflicts, formatPortConflicts } from '../ports.js'
 
 const HEALTH_CHECK_INTERVAL_MS = 3000
 const HEALTH_CHECK_TIMEOUT_MS = 120_000
@@ -31,7 +32,17 @@ export function registerInitCommand(program: Command): void {
       // doesn't race the cold-volume copy-up. stdio: 'ignore' keeps the spinner
       // clean — the inherited `pull` above already showed image progress.
       await primeBundleVolume(ctx.projectDir, { stdio: 'ignore' })
-      await dockerCompose(['up', '-d'], ctx.projectDir)
+      try {
+        await dockerCompose(['up', '-d'], ctx.projectDir)
+      } catch (err) {
+        s.stop('Could not start Docker services.')
+        const conflicts = await diagnosePortConflicts(ctx.projectDir).catch(() => [])
+        if (conflicts.length > 0) {
+          p.cancel(formatPortConflicts(conflicts).join('\n'))
+          process.exit(1)
+        }
+        throw err
+      }
       s.stop('Docker services started.')
 
       s.start('Waiting for Spree to be ready...')

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,7 +9,7 @@ import { mintProjectCredentials } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject } from '../context.js'
 import { dockerCompose, primeBundleVolume, rakeTask, streamLogs } from '../docker.js'
-import { diagnosePortConflicts, formatPortConflicts } from '../ports.js'
+import { cancelOnPortConflict } from '../ports.js'
 
 const HEALTH_CHECK_INTERVAL_MS = 3000
 const HEALTH_CHECK_TIMEOUT_MS = 120_000
@@ -36,11 +36,7 @@ export function registerInitCommand(program: Command): void {
         await dockerCompose(['up', '-d'], ctx.projectDir)
       } catch (err) {
         s.stop('Could not start Docker services.')
-        const conflicts = await diagnosePortConflicts(ctx.projectDir).catch(() => [])
-        if (conflicts.length > 0) {
-          p.cancel(formatPortConflicts(conflicts).join('\n'))
-          process.exit(1)
-        }
+        if (await cancelOnPortConflict(ctx.projectDir)) process.exit(1)
         throw err
       }
       s.stop('Docker services started.')

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_ADMIN_EMAIL = 'spree@example.com'
 export const DEFAULT_ADMIN_PASSWORD = 'spree123'
 export const DEFAULT_SPREE_PORT = 3000
+export const DEFAULT_SPREE_DB_PORT = 5433

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { DEFAULT_SPREE_PORT } from './constants.js'
+import { DEFAULT_SPREE_DB_PORT, DEFAULT_SPREE_PORT } from './constants.js'
 import type { ProjectContext } from './types.js'
 
 export function detectProject(cwd: string = process.cwd()): ProjectContext {
@@ -92,14 +92,22 @@ export function isEjectedProject(projectDir: string): boolean {
 }
 
 export function readPortFromEnv(projectDir: string): number {
+  return readEnvPort(projectDir, 'SPREE_PORT', DEFAULT_SPREE_PORT)
+}
+
+export function readDbPortFromEnv(projectDir: string): number {
+  return readEnvPort(projectDir, 'SPREE_DB_PORT', DEFAULT_SPREE_DB_PORT)
+}
+
+function readEnvPort(projectDir: string, key: string, fallback: number): number {
   const envPath = path.join(projectDir, '.env')
 
   if (!fs.existsSync(envPath)) {
-    return DEFAULT_SPREE_PORT
+    return fallback
   }
 
   const content = fs.readFileSync(envPath, 'utf-8')
-  const match = content.match(/^SPREE_PORT=(\d+)/m)
+  const match = content.match(new RegExp(`^${key}=(\\d+)`, 'm'))
 
-  return match ? Number(match[1]) : DEFAULT_SPREE_PORT
+  return match ? Number(match[1]) : fallback
 }

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -175,9 +175,13 @@ function readActiveComposeText(projectDir: string): string {
 // `${VAR:-default}` (and the other `${VAR<op>…}` forms), or bare `$VAR` — as
 // opposed to merely naming it in a comment. Only genuine interpolation means
 // setting the override would move the port, so only then do we suggest it.
-// `varName` is a fixed SPREE_* constant, so it needs no regex escaping.
+// Full-line comments are skipped so a commented-out `# ${VAR}` example doesn't
+// count. `varName` is a fixed SPREE_* constant, so it needs no regex escaping.
 function composeInterpolates(composeText: string, varName: string): boolean {
-  return new RegExp(`\\$\\{${varName}[}:?+\\-]|\\$${varName}\\b`).test(composeText)
+  const interpolation = new RegExp(`\\$\\{${varName}[}:?+\\-]|\\$${varName}\\b`)
+  return composeText
+    .split('\n')
+    .some((line) => !line.trimStart().startsWith('#') && interpolation.test(line))
 }
 
 /**

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -13,7 +13,6 @@ import pc from 'picocolors'
 const PORT_ENV_HINTS: Record<string, string> = {
   web: 'SPREE_PORT',
   postgres: 'SPREE_DB_PORT',
-  meilisearch: 'SPREE_MEILISEARCH_PORT',
 }
 
 interface PublishedPort {

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+import { execa } from 'execa'
+import pc from 'picocolors'
+
+// Which .env variable moves a service's host port — keeps the conflict message
+// actionable for the ports the starter compose publishes. Only offered when
+// the project's own compose file actually interpolates the variable: projects
+// scaffolded from older starters hardcode the port, and telling their users to
+// set an env var the compose never reads would send them in a circle.
+const PORT_ENV_HINTS: Record<string, string> = {
+  web: 'SPREE_PORT',
+  postgres: 'SPREE_DB_PORT',
+  meilisearch: 'SPREE_MEILISEARCH_PORT',
+}
+
+interface PublishedPort {
+  service: string
+  hostIp: string
+  hostPort: number
+}
+
+interface PortHolder {
+  container: string
+  composeProject: string
+}
+
+export interface PortConflict {
+  service: string
+  hostPort: number
+  // null: held by a non-Docker process on the host
+  holder: PortHolder | null
+  // The .env variable that moves this port, when the project's compose
+  // interpolates one
+  envVar?: string
+}
+
+async function readComposeConfig(
+  projectDir: string,
+): Promise<{ name: string; ports: PublishedPort[] }> {
+  const { stdout } = await execa('docker', ['compose', 'config', '--format', 'json'], {
+    cwd: projectDir,
+  })
+  const config = JSON.parse(stdout) as {
+    name?: string
+    services?: Record<string, { ports?: Array<{ host_ip?: string; published?: string | number }> }>
+  }
+
+  const ports: PublishedPort[] = []
+  for (const [service, definition] of Object.entries(config.services ?? {})) {
+    for (const mapping of definition.ports ?? []) {
+      const hostPort = Number(mapping.published)
+      // Skips unpublished mappings and host-port ranges ("8000-8010"), which
+      // can't be attributed to one port anyway.
+      if (!Number.isInteger(hostPort) || hostPort <= 0) continue
+      ports.push({ service, hostIp: mapping.host_ip ?? '0.0.0.0', hostPort })
+    }
+  }
+
+  return { name: config.name ?? '', ports }
+}
+
+async function findDockerHolder(hostPort: number, hostIp: string): Promise<PortHolder | null> {
+  const { stdout } = await execa('docker', [
+    'ps',
+    '--filter',
+    `publish=${hostPort}`,
+    '--format',
+    '{{.Names}}\t{{.Label "com.docker.compose.project"}}\t{{.Ports}}',
+  ])
+  for (const line of stdout.split('\n')) {
+    if (line.trim() === '') continue
+    const [container = '', composeProject = '', portsText = ''] = line.split('\t')
+    if (!holderBindingsOverlap(portsText, hostPort, hostIp)) continue
+    return { container, composeProject }
+  }
+  return null
+}
+
+// `docker ps --filter publish=N` matches the host port number across every
+// interface — a container publishing 192.0.2.2:N cannot collide with our
+// 127.0.0.1:N publish, so require the bound IPs to actually overlap before
+// blaming a holder. Wildcard binds (0.0.0.0 / [::]) overlap everything.
+function holderBindingsOverlap(portsText: string, hostPort: number, hostIp: string): boolean {
+  const wildcard = (ip: string) => ip === '0.0.0.0' || ip === '::'
+  for (const entry of portsText.split(',')) {
+    const match = entry.trim().match(/^(?:\[([^\]]+)\]|([0-9.]+)):(\d+)(?:-(\d+))?->/)
+    if (!match) continue
+    const holderIp = match[1] ?? match[2] ?? ''
+    const low = Number(match[3])
+    const high = match[4] ? Number(match[4]) : low
+    if (hostPort < low || hostPort > high) continue
+    if (wildcard(hostIp) || wildcard(holderIp) || holderIp === hostIp) return true
+  }
+  return false
+}
+
+function bindable(hostPort: number, hostIp: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = net.createServer()
+    probe.unref()
+    // Only EADDRINUSE is the collision Docker would hit. EACCES (privileged
+    // port, Linux) or EADDRNOTAVAIL (custom host_ip currently unassigned)
+    // fail the bind without implying a holder — inconclusive, not taken.
+    probe.once('error', (err) => {
+      resolve((err as NodeJS.ErrnoException).code !== 'EADDRINUSE')
+    })
+    probe.listen({ port: hostPort, host: hostIp, exclusive: true }, () => {
+      probe.close(() => resolve(true))
+    })
+  })
+}
+
+// Bind probes on the wildcard AND loopback addresses (plus the configured
+// host IP if it's something else). One wildcard probe is not enough: Node
+// sets SO_REUSEADDR, and on macOS a wildcard bind can coexist with a
+// specific-address listener on the same port (and vice versa), so a
+// single-address probe reports ports as free that Docker's publish would
+// still collide with.
+async function isPortFree(hostPort: number, hostIp: string): Promise<boolean> {
+  const hosts = [...new Set(['0.0.0.0', '127.0.0.1', hostIp])]
+  for (const host of hosts) {
+    if (!(await bindable(hostPort, host))) return false
+  }
+  return true
+}
+
+// Post-mortem for a failed `compose up`: which of this project's published
+// host ports are held by someone else, and by whom. Running only on the
+// failure path keeps the happy path free of preflight latency, and whatever
+// caused the bind failure is still holding the port — that's why it failed —
+// so inspection after the fact is reliable.
+export async function diagnosePortConflicts(projectDir: string): Promise<PortConflict[]> {
+  const { name, ports } = await readComposeConfig(projectDir)
+  const composeText = readActiveComposeText(projectDir)
+
+  const conflicts: PortConflict[] = []
+  for (const { service, hostIp, hostPort } of ports) {
+    const hint = PORT_ENV_HINTS[service]
+    const envVar = hint && composeText.includes(hint) ? hint : undefined
+    const holder = await findDockerHolder(hostPort, hostIp)
+    if (holder) {
+      // Our own warm containers (databases stay up after Ctrl+C by design)
+      // hold our own ports legitimately — only a foreign holder is a conflict.
+      if (holder.composeProject && holder.composeProject === name) continue
+      conflicts.push({ service, hostPort, holder, envVar })
+    } else if (!(await isPortFree(hostPort, hostIp))) {
+      conflicts.push({ service, hostPort, holder: null, envVar })
+    }
+  }
+  return conflicts
+}
+
+// The compose file `docker compose` resolves by default in this project — the
+// same one detectProject keys on. Raw text, for checking whether a port is
+// env-interpolated (`docker compose config` output has variables already
+// substituted, so it can't answer that).
+function readActiveComposeText(projectDir: string): string {
+  try {
+    return fs.readFileSync(path.join(projectDir, 'docker-compose.yml'), 'utf-8')
+  } catch {
+    return ''
+  }
+}
+
+export function formatPortConflicts(conflicts: PortConflict[]): string[] {
+  const blocks = conflicts.map((conflict) => {
+    const { service, hostPort, holder, envVar } = conflict
+    const port = pc.bold(String(hostPort))
+    const sideBySide = envVar
+      ? `set ${pc.bold(`${envVar}=<free port>`)} in this project's .env to run both side by side.`
+      : `change the ${service} service's published port in docker-compose.yml.`
+
+    if (holder?.composeProject) {
+      return [
+        `Port ${port} (${service}) is taken by another Docker Compose project, ${pc.bold(holder.composeProject)}`,
+        `(container ${holder.container}) — usually another Spree project's services still running warm.`,
+        `Run ${pc.bold('spree stop')} in that project (or ${pc.bold(`docker compose -p ${holder.composeProject} stop`)}),`,
+        `or ${sideBySide}`,
+      ]
+    }
+    if (holder) {
+      return [
+        `Port ${port} (${service}) is taken by Docker container ${pc.bold(holder.container)}.`,
+        `Stop it (${pc.bold(`docker stop ${holder.container}`)}), or ${sideBySide}`,
+      ]
+    }
+    return [
+      `Port ${port} (${service}) is taken by another process on this machine.`,
+      `Stop that process, or ${sideBySide}`,
+    ]
+  })
+
+  return blocks.flatMap((block, index) => (index === 0 ? block : ['', ...block]))
+}

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -27,13 +27,15 @@ interface PortHolder {
   composeProject: string
 }
 
+/**
+ * A published host port this project needs that something else is holding.
+ */
 export interface PortConflict {
   service: string
   hostPort: number
-  // null: held by a non-Docker process on the host
+  /** The holder, or `null` when a non-Docker process on the host holds it. */
   holder: PortHolder | null
-  // The .env variable that moves this port, when the project's compose
-  // interpolates one
+  /** The `.env` variable that moves this port, when the project's compose interpolates one. */
   envVar?: string
 }
 
@@ -127,11 +129,15 @@ async function isPortFree(hostPort: number, hostIp: string): Promise<boolean> {
   return true
 }
 
-// Post-mortem for a failed `compose up`: which of this project's published
-// host ports are held by someone else, and by whom. Running only on the
-// failure path keeps the happy path free of preflight latency, and whatever
-// caused the bind failure is still holding the port — that's why it failed —
-// so inspection after the fact is reliable.
+/**
+ * Post-mortem for a failed `compose up`: which of this project's published host
+ * ports are held by someone else, and by whom. Runs only on the failure path,
+ * so it adds no latency to a healthy boot, and whatever caused the bind failure
+ * is still holding the port — inspection after the fact is reliable.
+ *
+ * @param projectDir - The project directory (the compose project root).
+ * @returns One entry per conflicting published port (empty when none conflict).
+ */
 export async function diagnosePortConflicts(projectDir: string): Promise<PortConflict[]> {
   const { name, ports } = await readComposeConfig(projectDir)
   const composeText = readActiveComposeText(projectDir)
@@ -139,7 +145,7 @@ export async function diagnosePortConflicts(projectDir: string): Promise<PortCon
   const conflicts: PortConflict[] = []
   for (const { service, hostIp, hostPort } of ports) {
     const hint = PORT_ENV_HINTS[service]
-    const envVar = hint && composeText.includes(hint) ? hint : undefined
+    const envVar = hint && composeInterpolates(composeText, hint) ? hint : undefined
     const holder = await findDockerHolder(hostPort, hostIp)
     if (holder) {
       // Our own warm containers (databases stay up after Ctrl+C by design)
@@ -165,6 +171,23 @@ function readActiveComposeText(projectDir: string): string {
   }
 }
 
+// Whether the compose file actually interpolates `varName` — `${VAR}`,
+// `${VAR:-default}` (and the other `${VAR<op>…}` forms), or bare `$VAR` — as
+// opposed to merely naming it in a comment. Only genuine interpolation means
+// setting the override would move the port, so only then do we suggest it.
+// `varName` is a fixed SPREE_* constant, so it needs no regex escaping.
+function composeInterpolates(composeText: string, varName: string): boolean {
+  return new RegExp(`\\$\\{${varName}[}:?+\\-]|\\$${varName}\\b`).test(composeText)
+}
+
+/**
+ * Render {@link diagnosePortConflicts} results into printable lines: each
+ * conflict names the port, its holder, and the remedies (stop the other
+ * project, or set the `.env` override when the compose interpolates one).
+ *
+ * @param conflicts - The conflicts to describe.
+ * @returns Message lines, with a blank separator line between conflicts.
+ */
 export function formatPortConflicts(conflicts: PortConflict[]): string[] {
   const blocks = conflicts.map((conflict) => {
     const { service, hostPort, holder, envVar } = conflict
@@ -196,10 +219,14 @@ export function formatPortConflicts(conflicts: PortConflict[]): string[] {
   return blocks.flatMap((block, index) => (index === 0 ? block : ['', ...block]))
 }
 
-// Diagnose a failed `compose up` and, if any host-port conflicts are found,
-// print the actionable message. Returns whether a conflict was reported so the
-// caller can decide its own exit/rethrow behavior. Shared by dev, init, and
-// eject — the one place a compose boot can fail on a bound port.
+/**
+ * Diagnose a failed `compose up` and, if any host-port conflicts are found,
+ * print the actionable message via `p.cancel`. Shared by dev, init, and eject.
+ *
+ * @param projectDir - The project directory (the compose project root).
+ * @returns `true` when a conflict was reported (the caller should exit),
+ *   `false` when none was found (the caller should surface the original error).
+ */
 export async function cancelOnPortConflict(projectDir: string): Promise<boolean> {
   const conflicts = await diagnosePortConflicts(projectDir).catch(() => [])
   if (conflicts.length === 0) return false

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import net from 'node:net'
 import path from 'node:path'
+import * as p from '@clack/prompts'
 import { execa } from 'execa'
 import pc from 'picocolors'
 
@@ -193,4 +194,15 @@ export function formatPortConflicts(conflicts: PortConflict[]): string[] {
   })
 
   return blocks.flatMap((block, index) => (index === 0 ? block : ['', ...block]))
+}
+
+// Diagnose a failed `compose up` and, if any host-port conflicts are found,
+// print the actionable message. Returns whether a conflict was reported so the
+// caller can decide its own exit/rethrow behavior. Shared by dev, init, and
+// eject — the one place a compose boot can fail on a bound port.
+export async function cancelOnPortConflict(projectDir: string): Promise<boolean> {
+  const conflicts = await diagnosePortConflicts(projectDir).catch(() => [])
+  if (conflicts.length === 0) return false
+  p.cancel(formatPortConflicts(conflicts).join('\n'))
+  return true
 }

--- a/packages/cli/tests/db.test.ts
+++ b/packages/cli/tests/db.test.ts
@@ -9,6 +9,7 @@ let monorepoEdge = false
 vi.mock('../src/context', () => ({
   detectProject: () => ({ mode: 'docker', projectDir, port: 3000 }),
   hasMonorepoSpreePath: () => monorepoEdge,
+  readDbPortFromEnv: () => 5434,
 }))
 
 vi.mock('../src/docker', () => ({
@@ -137,6 +138,8 @@ describe('spree db:reset', () => {
     // The 55006 branch refuses with exit(1) rather than re-throwing the raw error.
     await expect(runDbReset('--yes')).rejects.toMatchObject({ code: 1 })
     expect(cancelMock).toHaveBeenCalledWith(expect.stringContaining('still connected'))
+    // Names the project's configured DB port, not a hardcoded default.
+    expect(cancelMock.mock.calls[0][0]).toContain('5434')
     // Stack was already down, so no restore-stack hint.
     expect(cancelMock.mock.calls[0][0]).not.toContain('spree dev')
   })

--- a/packages/cli/tests/db.test.ts
+++ b/packages/cli/tests/db.test.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RESET_TASK, registerDbCommand } from '../src/commands/db'
 import { dockerCompose, dockerComposeExec, dockerComposeRun, isServiceRunning } from '../src/docker'
+import { ExitError, mockProcessExit } from './helpers/process-exit'
 
 let projectDir: string
 let monorepoEdge = false
@@ -35,12 +36,6 @@ vi.mock('@clack/prompts', () => ({
 
 const CANCEL = Symbol('cancel')
 
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`)
-  }
-}
-
 async function runDbReset(...argv: string[]): Promise<void> {
   const program = new Command()
   registerDbCommand(program)
@@ -59,9 +54,7 @@ describe('spree db:reset', () => {
     monorepoEdge = false
     vi.clearAllMocks()
     vi.mocked(isServiceRunning).mockResolvedValue(false)
-    vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
-      throw new ExitError(code ?? 0)
-    })
+    mockProcessExit()
   })
 
   afterEach(() => {
@@ -173,9 +166,7 @@ describe('spree db:console', () => {
     monorepoEdge = false
     vi.clearAllMocks()
     vi.mocked(isServiceRunning).mockResolvedValue(true)
-    vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
-      throw new ExitError(code ?? 0)
-    })
+    mockProcessExit()
   })
 
   afterEach(() => {

--- a/packages/cli/tests/dev.test.ts
+++ b/packages/cli/tests/dev.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { registerDevCommand } from '../src/commands/dev'
 import { dockerCompose } from '../src/docker'
 import { cancelOnPortConflict } from '../src/ports'
+import { mockProcessExit } from './helpers/process-exit'
 
 let projectDir: string
 
@@ -30,12 +31,6 @@ vi.mock('@clack/prompts', () => ({
   outro: (...args: unknown[]) => outroMock(...args),
 }))
 
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`)
-  }
-}
-
 async function runDev(): Promise<void> {
   const program = new Command()
   registerDevCommand(program)
@@ -43,9 +38,12 @@ async function runDev(): Promise<void> {
 }
 
 describe('spree dev — compose failure handling', () => {
+  let exit: ReturnType<typeof mockProcessExit>
+
   beforeEach(() => {
     projectDir = '/proj'
     vi.clearAllMocks()
+    exit = mockProcessExit()
   })
 
   afterEach(() => {
@@ -55,9 +53,6 @@ describe('spree dev — compose failure handling', () => {
   it('shows the port-conflict diagnosis instead of the generic error', async () => {
     vi.mocked(dockerCompose).mockResolvedValue({ exitCode: 1 } as never)
     vi.mocked(cancelOnPortConflict).mockResolvedValue(true)
-    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new ExitError(code ?? 0)
-    }) as never)
 
     await expect(runDev()).rejects.toMatchObject({ code: 1 })
     expect(cancelOnPortConflict).toHaveBeenCalledWith(projectDir)
@@ -68,9 +63,6 @@ describe('spree dev — compose failure handling', () => {
   it('falls back to the generic error when no conflict is found', async () => {
     vi.mocked(dockerCompose).mockResolvedValue({ exitCode: 1 } as never)
     vi.mocked(cancelOnPortConflict).mockResolvedValue(false)
-    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new ExitError(code ?? 0)
-    }) as never)
 
     await expect(runDev()).rejects.toMatchObject({ code: 1 })
     expect(cancelMock).toHaveBeenCalledWith(expect.stringContaining('exited with code 1'))
@@ -78,9 +70,6 @@ describe('spree dev — compose failure handling', () => {
 
   it('treats a Ctrl+C shutdown (130) as clean, not a conflict', async () => {
     vi.mocked(dockerCompose).mockResolvedValue({ exitCode: 130 } as never)
-    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new ExitError(code ?? 0)
-    }) as never)
 
     await runDev()
 

--- a/packages/cli/tests/dev.test.ts
+++ b/packages/cli/tests/dev.test.ts
@@ -1,0 +1,91 @@
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerDevCommand } from '../src/commands/dev'
+import { dockerCompose } from '../src/docker'
+import { cancelOnPortConflict } from '../src/ports'
+
+let projectDir: string
+
+vi.mock('../src/context', () => ({
+  detectProject: () => ({ mode: 'project', projectDir, port: 3000 }),
+  hasMonorepoSpreePath: () => false,
+  isEjectedProject: () => false,
+}))
+
+vi.mock('../src/docker', () => ({
+  dockerCompose: vi.fn(),
+  primeBundleVolume: vi.fn().mockResolvedValue(undefined),
+  buildAdminStylesheets: vi.fn().mockResolvedValue(undefined),
+  watchAdminStylesheets: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../src/ports', () => ({ cancelOnPortConflict: vi.fn() }))
+
+const cancelMock = vi.fn()
+const outroMock = vi.fn()
+vi.mock('@clack/prompts', () => ({
+  note: vi.fn(),
+  log: { info: vi.fn() },
+  cancel: (...args: unknown[]) => cancelMock(...args),
+  outro: (...args: unknown[]) => outroMock(...args),
+}))
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`)
+  }
+}
+
+async function runDev(): Promise<void> {
+  const program = new Command()
+  registerDevCommand(program)
+  await program.parseAsync(['dev'], { from: 'user' })
+}
+
+describe('spree dev — compose failure handling', () => {
+  beforeEach(() => {
+    projectDir = '/proj'
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows the port-conflict diagnosis instead of the generic error', async () => {
+    vi.mocked(dockerCompose).mockResolvedValue({ exitCode: 1 } as never)
+    vi.mocked(cancelOnPortConflict).mockResolvedValue(true)
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0)
+    }) as never)
+
+    await expect(runDev()).rejects.toMatchObject({ code: 1 })
+    expect(cancelOnPortConflict).toHaveBeenCalledWith(projectDir)
+    // The generic fallback must not fire when a conflict was diagnosed.
+    expect(cancelMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the generic error when no conflict is found', async () => {
+    vi.mocked(dockerCompose).mockResolvedValue({ exitCode: 1 } as never)
+    vi.mocked(cancelOnPortConflict).mockResolvedValue(false)
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0)
+    }) as never)
+
+    await expect(runDev()).rejects.toMatchObject({ code: 1 })
+    expect(cancelMock).toHaveBeenCalledWith(expect.stringContaining('exited with code 1'))
+  })
+
+  it('treats a Ctrl+C shutdown (130) as clean, not a conflict', async () => {
+    vi.mocked(dockerCompose).mockResolvedValue({ exitCode: 130 } as never)
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0)
+    }) as never)
+
+    await runDev()
+
+    expect(exit).not.toHaveBeenCalled()
+    expect(cancelOnPortConflict).not.toHaveBeenCalled()
+    expect(outroMock).toHaveBeenCalled()
+  })
+})

--- a/packages/cli/tests/eject.test.ts
+++ b/packages/cli/tests/eject.test.ts
@@ -11,12 +11,7 @@ import {
   primeBundleVolume,
 } from '../src/docker'
 import { cancelOnPortConflict } from '../src/ports'
-
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`)
-  }
-}
+import { mockProcessExit } from './helpers/process-exit'
 
 const COMPOSE_DEV_STALE = `x-app: &app
   build:
@@ -68,9 +63,13 @@ async function runEject(): Promise<void> {
 describe('spree eject', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockProcessExit()
   })
 
   afterEach(() => {
+    // Restore the process.exit spy regardless of assertion outcome so it never
+    // leaks into a later test.
+    vi.restoreAllMocks()
     if (projectDir) {
       fs.rmSync(projectDir, { recursive: true, force: true })
       projectDir = ''
@@ -145,9 +144,6 @@ describe('spree eject', () => {
     projectDir = makeProject(COMPOSE_DEV_STALE)
     vi.mocked(dockerCompose).mockRejectedValueOnce(new Error('port is already allocated'))
     vi.mocked(cancelOnPortConflict).mockResolvedValue(true)
-    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new ExitError(code ?? 0)
-    }) as never)
 
     // Eject is the first command to publish the postgres host port, so a
     // collision surfaces here as a diagnosed conflict, not a raw stack trace.
@@ -155,8 +151,6 @@ describe('spree eject', () => {
     expect(cancelOnPortConflict).toHaveBeenCalledWith(projectDir)
     // Bailed at the conflict — never reached db:prepare.
     expect(dockerComposeExec).not.toHaveBeenCalled()
-
-    exit.mockRestore()
   })
 
   it('re-throws a compose failure that is not a port conflict', async () => {

--- a/packages/cli/tests/eject.test.ts
+++ b/packages/cli/tests/eject.test.ts
@@ -10,6 +10,13 @@ import {
   dockerComposeExec,
   primeBundleVolume,
 } from '../src/docker'
+import { cancelOnPortConflict } from '../src/ports'
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`)
+  }
+}
 
 const COMPOSE_DEV_STALE = `x-app: &app
   build:
@@ -41,6 +48,8 @@ vi.mock('../src/docker', () => ({
   primeBundleVolume: vi.fn().mockResolvedValue(undefined),
   buildAdminStylesheets: vi.fn().mockResolvedValue(undefined),
 }))
+
+vi.mock('../src/ports', () => ({ cancelOnPortConflict: vi.fn() }))
 
 function makeProject(devComposeContent: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spree-cli-eject-test-'))
@@ -130,5 +139,31 @@ describe('spree eject', () => {
     )
     expect(upCall).toBeGreaterThanOrEqual(0)
     expect(primeOrder).toBeLessThan((dockerCompose as Mock).mock.invocationCallOrder[upCall])
+  })
+
+  it('reports a port conflict and exits when the dev stack fails to come up', async () => {
+    projectDir = makeProject(COMPOSE_DEV_STALE)
+    vi.mocked(dockerCompose).mockRejectedValueOnce(new Error('port is already allocated'))
+    vi.mocked(cancelOnPortConflict).mockResolvedValue(true)
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0)
+    }) as never)
+
+    // Eject is the first command to publish the postgres host port, so a
+    // collision surfaces here as a diagnosed conflict, not a raw stack trace.
+    await expect(runEject()).rejects.toMatchObject({ code: 1 })
+    expect(cancelOnPortConflict).toHaveBeenCalledWith(projectDir)
+    // Bailed at the conflict — never reached db:prepare.
+    expect(dockerComposeExec).not.toHaveBeenCalled()
+
+    exit.mockRestore()
+  })
+
+  it('re-throws a compose failure that is not a port conflict', async () => {
+    projectDir = makeProject(COMPOSE_DEV_STALE)
+    vi.mocked(dockerCompose).mockRejectedValueOnce(new Error('docker daemon not running'))
+    vi.mocked(cancelOnPortConflict).mockResolvedValue(false)
+
+    await expect(runEject()).rejects.toThrow('docker daemon not running')
   })
 })

--- a/packages/cli/tests/helpers/process-exit.ts
+++ b/packages/cli/tests/helpers/process-exit.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest'
+
+// `process.exit` is stubbed to throw so a command's exit shows up as a rejected
+// promise the test can assert on, instead of tearing down the vitest worker.
+export class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`)
+  }
+}
+
+// Spy on process.exit for the current test. Pair with `vi.restoreAllMocks()` in
+// an afterEach so the spy never leaks into later tests.
+export function mockProcessExit() {
+  return vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0)
+  }) as never)
+}

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { registerInitCommand, updateStorefrontEnv } from '../src/commands/init'
 import { dockerCompose } from '../src/docker'
 import { cancelOnPortConflict } from '../src/ports'
+import { mockProcessExit } from './helpers/process-exit'
 
 vi.mock('../src/context', () => ({
   detectProject: () => ({ mode: 'project', projectDir: '/proj', port: 3000 }),
@@ -27,12 +28,6 @@ vi.mock('@clack/prompts', () => ({
   spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
   note: vi.fn(),
 }))
-
-class ExitError extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`)
-  }
-}
 
 const tempDirs: string[] = []
 
@@ -112,6 +107,7 @@ describe('spree init — service startup failure', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockProcessExit()
     // `pull` succeeds; `up -d` fails on a bound host port.
     vi.mocked(dockerCompose).mockImplementation((async (args: string[]) => {
       if (Array.isArray(args) && args[0] === 'up') throw new Error('port is already allocated')
@@ -119,16 +115,15 @@ describe('spree init — service startup failure', () => {
     }) as never)
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('reports a port conflict and exits when services fail to start', async () => {
     vi.mocked(cancelOnPortConflict).mockResolvedValue(true)
-    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new ExitError(code ?? 0)
-    }) as never)
 
     await expect(runInit()).rejects.toMatchObject({ code: 1 })
     expect(cancelOnPortConflict).toHaveBeenCalledWith('/proj')
-
-    exit.mockRestore()
   })
 
   it('re-throws a startup failure that is not a port conflict', async () => {

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -1,8 +1,38 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
-import { updateStorefrontEnv } from '../src/commands/init'
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerInitCommand, updateStorefrontEnv } from '../src/commands/init'
+import { dockerCompose } from '../src/docker'
+import { cancelOnPortConflict } from '../src/ports'
+
+vi.mock('../src/context', () => ({
+  detectProject: () => ({ mode: 'project', projectDir: '/proj', port: 3000 }),
+}))
+
+vi.mock('../src/docker', () => ({
+  dockerCompose: vi.fn().mockResolvedValue(undefined),
+  primeBundleVolume: vi.fn().mockResolvedValue(undefined),
+  rakeTask: vi.fn().mockResolvedValue(''),
+  streamLogs: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../src/ports', () => ({ cancelOnPortConflict: vi.fn() }))
+
+vi.mock('../src/config', () => ({ mintProjectCredentials: vi.fn() }))
+
+vi.mock('@clack/prompts', () => ({
+  log: { step: vi.fn(), info: vi.fn() },
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  note: vi.fn(),
+}))
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`)
+  }
+}
 
 const tempDirs: string[] = []
 
@@ -70,5 +100,40 @@ describe('updateStorefrontEnv', () => {
   it('does nothing when .env.local does not exist', () => {
     const dir = makeTempDir()
     expect(() => updateStorefrontEnv(dir, 'pk_test')).not.toThrow()
+  })
+})
+
+describe('spree init — service startup failure', () => {
+  async function runInit(): Promise<void> {
+    const program = new Command()
+    registerInitCommand(program)
+    await program.parseAsync(['init', '--no-open'], { from: 'user' })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // `pull` succeeds; `up -d` fails on a bound host port.
+    vi.mocked(dockerCompose).mockImplementation((async (args: string[]) => {
+      if (Array.isArray(args) && args[0] === 'up') throw new Error('port is already allocated')
+      return undefined
+    }) as never)
+  })
+
+  it('reports a port conflict and exits when services fail to start', async () => {
+    vi.mocked(cancelOnPortConflict).mockResolvedValue(true)
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0)
+    }) as never)
+
+    await expect(runInit()).rejects.toMatchObject({ code: 1 })
+    expect(cancelOnPortConflict).toHaveBeenCalledWith('/proj')
+
+    exit.mockRestore()
+  })
+
+  it('re-throws a startup failure that is not a port conflict', async () => {
+    vi.mocked(cancelOnPortConflict).mockResolvedValue(false)
+
+    await expect(runInit()).rejects.toThrow('port is already allocated')
   })
 })

--- a/packages/cli/tests/ports.test.ts
+++ b/packages/cli/tests/ports.test.ts
@@ -178,10 +178,11 @@ describe('diagnosePortConflicts', () => {
   })
 
   it('attaches the env-var hint only when the compose file interpolates it', async () => {
-    // meilisearch names the var in a comment but pins the port — a mere mention
-    // must not trigger the hint, only genuine `${VAR}` interpolation.
+    // meilisearch shows the interpolation only in a commented-out example but
+    // pins the real port — a commented `${VAR}` must not trigger the hint,
+    // only genuine interpolation on a live line.
     const projectDir = projectDirWithCompose(
-      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  meilisearch:\n    # override SPREE_MEILISEARCH_PORT to change this\n    ports:\n      - "7700:7700"\n`,
+      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  meilisearch:\n    ports:\n      # - "127.0.0.1:\${SPREE_MEILISEARCH_PORT:-7700}:7700"\n      - "7700:7700"\n`,
     )
     routeExeca(
       composeConfigJson('my-shop', {

--- a/packages/cli/tests/ports.test.ts
+++ b/packages/cli/tests/ports.test.ts
@@ -1,0 +1,259 @@
+import fs from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('execa', () => ({ execa: vi.fn() }))
+
+import { execa } from 'execa'
+import { diagnosePortConflicts, formatPortConflicts } from '../src/ports'
+
+const mockExeca = vi.mocked(execa)
+
+function composeConfigJson(
+  name: string,
+  services: Record<string, Array<{ host_ip?: string; published?: string | number }>>,
+): string {
+  return JSON.stringify({
+    name,
+    services: Object.fromEntries(
+      Object.entries(services).map(([service, ports]) => [service, { ports }]),
+    ),
+  })
+}
+
+// Routes the two docker invocations diagnosePortConflicts makes: `compose
+// config` returns the project's published ports, `ps --filter publish=N`
+// returns `Names\tComposeProject\tPorts` holder lines per port.
+function routeExeca(configJson: string, holdersByPort: Record<string, string>): void {
+  mockExeca.mockImplementation((async (_cmd: string, args: string[]) => {
+    if (args.includes('config')) return { stdout: configJson }
+    if (args[0] === 'ps') {
+      const publishFilter = args[args.indexOf('--filter') + 1] ?? ''
+      const port = publishFilter.replace('publish=', '')
+      return { stdout: holdersByPort[port] ?? '' }
+    }
+    throw new Error(`unexpected execa call: ${args.join(' ')}`)
+  }) as never)
+}
+
+// Occupies a real port so the non-Docker-holder path (bind probe) is exercised
+// deterministically.
+async function occupyPort(): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = net.createServer()
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (address === null || typeof address === 'string') throw new Error('no port')
+  return {
+    port: address.port,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  }
+}
+
+async function freePort(): Promise<number> {
+  const { port, close } = await occupyPort()
+  await close()
+  return port
+}
+
+describe('diagnosePortConflicts', () => {
+  const tempDirs: string[] = []
+
+  function projectDirWithCompose(composeText: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spree-cli-ports-test-'))
+    tempDirs.push(dir)
+    fs.writeFileSync(path.join(dir, 'docker-compose.yml'), composeText)
+    return dir
+  }
+
+  afterEach(() => {
+    mockExeca.mockReset()
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+    tempDirs.length = 0
+  })
+
+  it('reports a port held by a foreign compose project', async () => {
+    routeExeca(
+      composeConfigJson('my-shop', { postgres: [{ host_ip: '127.0.0.1', published: '5433' }] }),
+      { '5433': 'server-postgres-1\tserver\t127.0.0.1:5433->5432/tcp' },
+    )
+
+    const conflicts = await diagnosePortConflicts('/proj')
+
+    expect(conflicts).toEqual([
+      {
+        service: 'postgres',
+        hostPort: 5433,
+        holder: { container: 'server-postgres-1', composeProject: 'server' },
+        envVar: undefined,
+      },
+    ])
+  })
+
+  it('ignores ports held by this project itself (warm databases)', async () => {
+    routeExeca(
+      composeConfigJson('my-shop', { postgres: [{ host_ip: '127.0.0.1', published: '5433' }] }),
+      { '5433': 'my-shop-postgres-1\tmy-shop\t127.0.0.1:5433->5432/tcp' },
+    )
+
+    expect(await diagnosePortConflicts('/proj')).toEqual([])
+  })
+
+  it('attributes wildcard-bound holders to loopback-published ports (and vice versa)', async () => {
+    routeExeca(
+      composeConfigJson('my-shop', { postgres: [{ host_ip: '127.0.0.1', published: '5433' }] }),
+      { '5433': 'legacy-postgres-1\tlegacy\t0.0.0.0:5433->5432/tcp, [::]:5433->5432/tcp' },
+    )
+
+    const conflicts = await diagnosePortConflicts('/proj')
+    expect(conflicts[0]?.holder?.composeProject).toBe('legacy')
+  })
+
+  it('does not blame a docker holder bound to a non-overlapping host IP', async () => {
+    // docker ps matches publish=N across all interfaces; a 192.0.2.2-bound
+    // publish cannot collide with our 127.0.0.1 publish. The bind probe then
+    // finds the port genuinely free → no conflict at all.
+    const port = await freePort()
+    routeExeca(
+      composeConfigJson('my-shop', {
+        postgres: [{ host_ip: '127.0.0.1', published: String(port) }],
+      }),
+      { [String(port)]: `other-postgres-1\tother\t192.0.2.2:${port}->5432/tcp` },
+    )
+
+    expect(await diagnosePortConflicts('/proj')).toEqual([])
+  })
+
+  it('reports a non-compose docker container as the holder', async () => {
+    routeExeca(composeConfigJson('my-shop', { postgres: [{ published: 5433 }] }), {
+      '5433': 'lonely-postgres\t\t0.0.0.0:5433->5432/tcp',
+    })
+
+    const conflicts = await diagnosePortConflicts('/proj')
+
+    expect(conflicts).toEqual([
+      {
+        service: 'postgres',
+        hostPort: 5433,
+        holder: { container: 'lonely-postgres', composeProject: '' },
+        envVar: undefined,
+      },
+    ])
+  })
+
+  it('reports a non-Docker process via the bind probe', async () => {
+    const occupied = await occupyPort()
+    try {
+      routeExeca(
+        composeConfigJson('my-shop', {
+          web: [{ host_ip: '127.0.0.1', published: String(occupied.port) }],
+        }),
+        {},
+      )
+
+      const conflicts = await diagnosePortConflicts('/proj')
+
+      expect(conflicts).toEqual([
+        { service: 'web', hostPort: occupied.port, holder: null, envVar: undefined },
+      ])
+    } finally {
+      await occupied.close()
+    }
+  })
+
+  it('returns no conflicts when ports are genuinely free', async () => {
+    const port = await freePort()
+    routeExeca(
+      composeConfigJson('my-shop', { web: [{ host_ip: '127.0.0.1', published: String(port) }] }),
+      {},
+    )
+
+    expect(await diagnosePortConflicts('/proj')).toEqual([])
+  })
+
+  it('attaches the env-var hint only when the compose file interpolates it', async () => {
+    const projectDir = projectDirWithCompose(
+      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  meilisearch:\n    ports:\n      - "7700:7700"\n`,
+    )
+    routeExeca(
+      composeConfigJson('my-shop', {
+        postgres: [{ host_ip: '127.0.0.1', published: '5433' }],
+        meilisearch: [{ published: '7700' }],
+      }),
+      {
+        '5433': 'server-postgres-1\tserver\t127.0.0.1:5433->5432/tcp',
+        '7700': 'server-meilisearch-1\tserver\t0.0.0.0:7700->7700/tcp',
+      },
+    )
+
+    const conflicts = await diagnosePortConflicts(projectDir)
+
+    const byService = Object.fromEntries(conflicts.map((c) => [c.service, c.envVar]))
+    expect(byService.postgres).toBe('SPREE_DB_PORT')
+    // Hardcoded 7700:7700 → suggesting SPREE_MEILISEARCH_PORT would be a no-op.
+    expect(byService.meilisearch).toBeUndefined()
+  })
+
+  it('skips services without published ports and unparsable mappings', async () => {
+    const port = await freePort()
+    routeExeca(
+      composeConfigJson('my-shop', {
+        redis: [],
+        web: [{ published: undefined }, { host_ip: '127.0.0.1', published: String(port) }],
+      }),
+      {},
+    )
+
+    expect(await diagnosePortConflicts('/proj')).toEqual([])
+    // The undefined mapping never gets a `docker ps` probe.
+    const psCalls = mockExeca.mock.calls.filter((call) => (call[1] as string[])[0] === 'ps')
+    expect(psCalls).toHaveLength(1)
+  })
+})
+
+describe('formatPortConflicts', () => {
+  it('names the foreign compose project and both remedies', () => {
+    const lines = formatPortConflicts([
+      {
+        service: 'postgres',
+        hostPort: 5433,
+        holder: { container: 'server-postgres-1', composeProject: 'server' },
+        envVar: 'SPREE_DB_PORT',
+      },
+    ]).join('\n')
+
+    expect(lines).toContain('5433')
+    expect(lines).toContain('postgres')
+    expect(lines).toContain('server-postgres-1')
+    expect(lines).toContain('docker compose -p server stop')
+    expect(lines).toContain('spree stop')
+    expect(lines).toContain('SPREE_DB_PORT=<free port>')
+  })
+
+  it('suggests docker stop for a non-compose container', () => {
+    const lines = formatPortConflicts([
+      {
+        service: 'meilisearch',
+        hostPort: 7700,
+        holder: { container: 'lonely-meili', composeProject: '' },
+        envVar: 'SPREE_MEILISEARCH_PORT',
+      },
+    ]).join('\n')
+
+    expect(lines).toContain('docker stop lonely-meili')
+    expect(lines).toContain('SPREE_MEILISEARCH_PORT=<free port>')
+  })
+
+  it('falls back to editing the compose file when no env var moves the port', () => {
+    const lines = formatPortConflicts([
+      { service: 'meilisearch', hostPort: 7700, holder: null },
+    ]).join('\n')
+
+    expect(lines).toContain('another process on this machine')
+    expect(lines).toContain('docker-compose.yml')
+    expect(lines).not.toContain('SPREE_MEILISEARCH_PORT')
+  })
+})

--- a/packages/cli/tests/ports.test.ts
+++ b/packages/cli/tests/ports.test.ts
@@ -6,8 +6,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('execa', () => ({ execa: vi.fn() }))
 
+const cancelMock = vi.fn()
+vi.mock('@clack/prompts', () => ({ cancel: (...args: unknown[]) => cancelMock(...args) }))
+
 import { execa } from 'execa'
-import { diagnosePortConflicts, formatPortConflicts } from '../src/ports'
+import { cancelOnPortConflict, diagnosePortConflicts, formatPortConflicts } from '../src/ports'
 
 const mockExeca = vi.mocked(execa)
 
@@ -255,5 +258,41 @@ describe('formatPortConflicts', () => {
     expect(lines).toContain('another process on this machine')
     expect(lines).toContain('docker-compose.yml')
     expect(lines).not.toContain('SPREE_MEILISEARCH_PORT')
+  })
+})
+
+describe('cancelOnPortConflict', () => {
+  afterEach(() => {
+    mockExeca.mockReset()
+    cancelMock.mockReset()
+  })
+
+  it('cancels and returns true when a conflict is found', async () => {
+    routeExeca(
+      composeConfigJson('my-shop', { postgres: [{ host_ip: '127.0.0.1', published: '5433' }] }),
+      { '5433': 'server-postgres-1\tserver\t127.0.0.1:5433->5432/tcp' },
+    )
+
+    expect(await cancelOnPortConflict('/proj')).toBe(true)
+    expect(cancelMock).toHaveBeenCalledOnce()
+    expect(cancelMock.mock.calls[0][0]).toContain('5433')
+  })
+
+  it('returns false without cancelling when nothing is holding the ports', async () => {
+    const port = await freePort()
+    routeExeca(
+      composeConfigJson('my-shop', { web: [{ host_ip: '127.0.0.1', published: String(port) }] }),
+      {},
+    )
+
+    expect(await cancelOnPortConflict('/proj')).toBe(false)
+    expect(cancelMock).not.toHaveBeenCalled()
+  })
+
+  it('swallows a diagnosis failure (e.g. daemon down) and returns false', async () => {
+    mockExeca.mockRejectedValue(new Error('Cannot connect to the Docker daemon'))
+
+    expect(await cancelOnPortConflict('/proj')).toBe(false)
+    expect(cancelMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/tests/ports.test.ts
+++ b/packages/cli/tests/ports.test.ts
@@ -178,20 +178,20 @@ describe('diagnosePortConflicts', () => {
   })
 
   it('attaches the env-var hint only when the compose file interpolates it', async () => {
-    // meilisearch shows the interpolation only in a commented-out example but
-    // pins the real port — a commented `${VAR}` must not trigger the hint,
-    // only genuine interpolation on a live line.
+    // web shows the interpolation only in a commented-out example but pins the
+    // real port — a commented `${VAR}` must not trigger the hint, only genuine
+    // interpolation on a live line (as postgres has).
     const projectDir = projectDirWithCompose(
-      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  meilisearch:\n    ports:\n      # - "127.0.0.1:\${SPREE_MEILISEARCH_PORT:-7700}:7700"\n      - "7700:7700"\n`,
+      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  web:\n    ports:\n      # - "\${SPREE_PORT:-3000}:3000"\n      - "3000:3000"\n`,
     )
     routeExeca(
       composeConfigJson('my-shop', {
         postgres: [{ host_ip: '127.0.0.1', published: '5433' }],
-        meilisearch: [{ published: '7700' }],
+        web: [{ published: '3000' }],
       }),
       {
         '5433': 'server-postgres-1\tserver\t127.0.0.1:5433->5432/tcp',
-        '7700': 'server-meilisearch-1\tserver\t0.0.0.0:7700->7700/tcp',
+        '3000': 'server-web-1\tserver\t0.0.0.0:3000->3000/tcp',
       },
     )
 
@@ -199,8 +199,8 @@ describe('diagnosePortConflicts', () => {
 
     const byService = Object.fromEntries(conflicts.map((c) => [c.service, c.envVar]))
     expect(byService.postgres).toBe('SPREE_DB_PORT')
-    // Hardcoded 7700:7700 → suggesting SPREE_MEILISEARCH_PORT would be a no-op.
-    expect(byService.meilisearch).toBeUndefined()
+    // web's port is hardcoded (interpolation only in a comment) → no hint.
+    expect(byService.web).toBeUndefined()
   })
 
   it('skips services without published ports and unparsable mappings', async () => {
@@ -242,18 +242,20 @@ describe('formatPortConflicts', () => {
   it('suggests docker stop for a non-compose container', () => {
     const lines = formatPortConflicts([
       {
-        service: 'meilisearch',
-        hostPort: 7700,
-        holder: { container: 'lonely-meili', composeProject: '' },
-        envVar: 'SPREE_MEILISEARCH_PORT',
+        service: 'postgres',
+        hostPort: 5433,
+        holder: { container: 'lonely-postgres', composeProject: '' },
+        envVar: 'SPREE_DB_PORT',
       },
     ]).join('\n')
 
-    expect(lines).toContain('docker stop lonely-meili')
-    expect(lines).toContain('SPREE_MEILISEARCH_PORT=<free port>')
+    expect(lines).toContain('docker stop lonely-postgres')
+    expect(lines).toContain('SPREE_DB_PORT=<free port>')
   })
 
   it('falls back to editing the compose file when no env var moves the port', () => {
+    // A service with no env override (e.g. meilisearch, not host-published in
+    // the starter) points the user at the compose file instead.
     const lines = formatPortConflicts([
       { service: 'meilisearch', hostPort: 7700, holder: null },
     ]).join('\n')

--- a/packages/cli/tests/ports.test.ts
+++ b/packages/cli/tests/ports.test.ts
@@ -178,8 +178,10 @@ describe('diagnosePortConflicts', () => {
   })
 
   it('attaches the env-var hint only when the compose file interpolates it', async () => {
+    // meilisearch names the var in a comment but pins the port — a mere mention
+    // must not trigger the hint, only genuine `${VAR}` interpolation.
     const projectDir = projectDirWithCompose(
-      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  meilisearch:\n    ports:\n      - "7700:7700"\n`,
+      `services:\n  postgres:\n    ports:\n      - "127.0.0.1:\${SPREE_DB_PORT:-5433}:5432"\n  meilisearch:\n    # override SPREE_MEILISEARCH_PORT to change this\n    ports:\n      - "7700:7700"\n`,
     )
     routeExeca(
       composeConfigJson('my-shop', {

--- a/packages/create-spree-app/.changeset/scaffold-free-ports.md
+++ b/packages/create-spree-app/.changeset/scaffold-free-ports.md
@@ -1,5 +1,0 @@
----
-'create-spree-app': minor
----
-
-Pick free host ports for Postgres and Meilisearch at scaffold time (walking up from the 5433/7700 defaults) and write them to the project `.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT`, so projects scaffolded next to a running Spree stack never fight over host ports.

--- a/packages/create-spree-app/.changeset/scaffold-free-ports.md
+++ b/packages/create-spree-app/.changeset/scaffold-free-ports.md
@@ -1,0 +1,5 @@
+---
+'create-spree-app': minor
+---
+
+Pick free host ports for Postgres and Meilisearch at scaffold time (walking up from the 5433/7700 defaults) and write them to the project `.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT`, so projects scaffolded next to a running Spree stack never fight over host ports.

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-spree-app
 
+## 1.0.8
+
+### Patch Changes
+
+- Pick free host ports for Postgres and Meilisearch at scaffold time (walking up from the 5433/7700 defaults) and write them to the project `.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT`, so projects scaffolded next to a running Spree stack never fight over host ports.
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Pick free host ports for Postgres and Meilisearch at scaffold time (walking up from the 5433/7700 defaults) and write them to the project `.env` as `SPREE_DB_PORT` / `SPREE_MEILISEARCH_PORT`, so projects scaffolded next to a running Spree stack never fight over host ports.
+- Pick a free host port for Postgres at scaffold time (walking up from the 5433 default) and write it to the project `.env` as `SPREE_DB_PORT`, so a project scaffolded next to a running Spree stack doesn't fight over the host port.
 
 ## 1.0.7
 

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/constants.ts
+++ b/packages/create-spree-app/src/constants.ts
@@ -1,6 +1,5 @@
 export const DEFAULT_SPREE_PORT = 3000
 export const DEFAULT_SPREE_DB_PORT = 5433
-export const DEFAULT_MEILISEARCH_PORT = 7700
 export const STOREFRONT_PORT = 3001
 
 export const STOREFRONT_REPO = 'https://github.com/spree/storefront.git'

--- a/packages/create-spree-app/src/constants.ts
+++ b/packages/create-spree-app/src/constants.ts
@@ -1,4 +1,6 @@
 export const DEFAULT_SPREE_PORT = 3000
+export const DEFAULT_SPREE_DB_PORT = 5433
+export const DEFAULT_MEILISEARCH_PORT = 7700
 export const STOREFRONT_PORT = 3001
 
 export const STOREFRONT_REPO = 'https://github.com/spree/storefront.git'

--- a/packages/create-spree-app/src/index.ts
+++ b/packages/create-spree-app/src/index.ts
@@ -8,6 +8,23 @@ import { scaffold } from './scaffold.js'
 import type { PackageManager } from './types.js'
 import { detectPackageManager } from './utils.js'
 
+// Pick a free host port at or above `defaultPort`, avoiding `exclude`, warning
+// when the default was taken. Used for the DB + search ports so a project
+// scaffolded next to a running stack doesn't fight over the defaults.
+async function pickFreePort(
+  defaultPort: number,
+  exclude: number[],
+  label: string,
+): Promise<number> {
+  const selected = await getPort({ port: portNumbers(defaultPort, defaultPort + 100), exclude })
+  if (selected !== defaultPort) {
+    p.log.warn(
+      `Port ${defaultPort} is in use, publishing ${label} on port ${pc.bold(String(selected))} instead.`,
+    )
+  }
+  return selected
+}
+
 const program = new Command()
   .name('create-spree-app')
   .description('Create a new Spree Commerce project')
@@ -45,24 +62,12 @@ const program = new Command()
       // Postgres and Meilisearch host ports are picked free at scaffold time
       // and written into .env, so projects created side by side (or next to a
       // warm stack of another project) never fight over the defaults.
-      const dbPort = await getPort({
-        port: portNumbers(DEFAULT_SPREE_DB_PORT, DEFAULT_SPREE_DB_PORT + 100),
-        exclude: [port],
-      })
-      if (dbPort !== DEFAULT_SPREE_DB_PORT) {
-        p.log.warn(
-          `Port ${DEFAULT_SPREE_DB_PORT} is in use, publishing Postgres on port ${pc.bold(String(dbPort))} instead.`,
-        )
-      }
-      const meilisearchPort = await getPort({
-        port: portNumbers(DEFAULT_MEILISEARCH_PORT, DEFAULT_MEILISEARCH_PORT + 100),
-        exclude: [port, dbPort],
-      })
-      if (meilisearchPort !== DEFAULT_MEILISEARCH_PORT) {
-        p.log.warn(
-          `Port ${DEFAULT_MEILISEARCH_PORT} is in use, publishing Meilisearch on port ${pc.bold(String(meilisearchPort))} instead.`,
-        )
-      }
+      const dbPort = await pickFreePort(DEFAULT_SPREE_DB_PORT, [port], 'Postgres')
+      const meilisearchPort = await pickFreePort(
+        DEFAULT_MEILISEARCH_PORT,
+        [port, dbPort],
+        'Meilisearch',
+      )
 
       await scaffold({ ...options, port, dbPort, meilisearchPort })
 

--- a/packages/create-spree-app/src/index.ts
+++ b/packages/create-spree-app/src/index.ts
@@ -2,15 +2,15 @@ import * as p from '@clack/prompts'
 import { Command } from 'commander'
 import getPort, { portNumbers } from 'get-port'
 import pc from 'picocolors'
-import { DEFAULT_MEILISEARCH_PORT, DEFAULT_SPREE_DB_PORT, DEFAULT_SPREE_PORT } from './constants.js'
+import { DEFAULT_SPREE_DB_PORT, DEFAULT_SPREE_PORT } from './constants.js'
 import { runPrompts } from './prompts.js'
 import { scaffold } from './scaffold.js'
 import type { PackageManager } from './types.js'
 import { detectPackageManager } from './utils.js'
 
 // Pick a free host port at or above `defaultPort`, avoiding `exclude`, warning
-// when the default was taken. Used for the DB + search ports so a project
-// scaffolded next to a running stack doesn't fight over the defaults.
+// when the default was taken. Used for the Postgres host port so a project
+// scaffolded next to a running stack doesn't fight over the default.
 async function pickFreePort(
   defaultPort: number,
   exclude: number[],
@@ -59,17 +59,13 @@ const program = new Command()
         p.log.warn(`Port ${preferred} is in use, using port ${pc.bold(String(port))} instead.`)
       }
 
-      // Postgres and Meilisearch host ports are picked free at scaffold time
-      // and written into .env, so projects created side by side (or next to a
-      // warm stack of another project) never fight over the defaults.
+      // The Postgres host port is picked free at scaffold time and written
+      // into .env, so a project created next to a warm stack of another
+      // project never fights over the default. (Redis and Meilisearch aren't
+      // published to the host, so they need no such handling.)
       const dbPort = await pickFreePort(DEFAULT_SPREE_DB_PORT, [port], 'Postgres')
-      const meilisearchPort = await pickFreePort(
-        DEFAULT_MEILISEARCH_PORT,
-        [port, dbPort],
-        'Meilisearch',
-      )
 
-      await scaffold({ ...options, port, dbPort, meilisearchPort })
+      await scaffold({ ...options, port, dbPort })
 
       p.outro('Happy selling!')
     } catch (err) {

--- a/packages/create-spree-app/src/index.ts
+++ b/packages/create-spree-app/src/index.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts'
 import { Command } from 'commander'
 import getPort, { portNumbers } from 'get-port'
 import pc from 'picocolors'
-import { DEFAULT_SPREE_PORT } from './constants.js'
+import { DEFAULT_MEILISEARCH_PORT, DEFAULT_SPREE_DB_PORT, DEFAULT_SPREE_PORT } from './constants.js'
 import { runPrompts } from './prompts.js'
 import { scaffold } from './scaffold.js'
 import type { PackageManager } from './types.js'
@@ -42,7 +42,29 @@ const program = new Command()
         p.log.warn(`Port ${preferred} is in use, using port ${pc.bold(String(port))} instead.`)
       }
 
-      await scaffold({ ...options, port })
+      // Postgres and Meilisearch host ports are picked free at scaffold time
+      // and written into .env, so projects created side by side (or next to a
+      // warm stack of another project) never fight over the defaults.
+      const dbPort = await getPort({
+        port: portNumbers(DEFAULT_SPREE_DB_PORT, DEFAULT_SPREE_DB_PORT + 100),
+        exclude: [port],
+      })
+      if (dbPort !== DEFAULT_SPREE_DB_PORT) {
+        p.log.warn(
+          `Port ${DEFAULT_SPREE_DB_PORT} is in use, publishing Postgres on port ${pc.bold(String(dbPort))} instead.`,
+        )
+      }
+      const meilisearchPort = await getPort({
+        port: portNumbers(DEFAULT_MEILISEARCH_PORT, DEFAULT_MEILISEARCH_PORT + 100),
+        exclude: [port, dbPort],
+      })
+      if (meilisearchPort !== DEFAULT_MEILISEARCH_PORT) {
+        p.log.warn(
+          `Port ${DEFAULT_MEILISEARCH_PORT} is in use, publishing Meilisearch on port ${pc.bold(String(meilisearchPort))} instead.`,
+        )
+      }
+
+      await scaffold({ ...options, port, dbPort, meilisearchPort })
 
       p.outro('Happy selling!')
     } catch (err) {

--- a/packages/create-spree-app/src/prompts.ts
+++ b/packages/create-spree-app/src/prompts.ts
@@ -11,7 +11,7 @@ interface PromptFlags {
 
 export async function runPrompts(
   flags: PromptFlags,
-): Promise<Omit<ScaffoldOptions, 'port' | 'dbPort' | 'meilisearchPort'>> {
+): Promise<Omit<ScaffoldOptions, 'port' | 'dbPort'>> {
   const directory =
     flags.directory ??
     ((await p.text({

--- a/packages/create-spree-app/src/prompts.ts
+++ b/packages/create-spree-app/src/prompts.ts
@@ -9,7 +9,9 @@ interface PromptFlags {
   packageManager?: PackageManager
 }
 
-export async function runPrompts(flags: PromptFlags): Promise<Omit<ScaffoldOptions, 'port'>> {
+export async function runPrompts(
+  flags: PromptFlags,
+): Promise<Omit<ScaffoldOptions, 'port' | 'dbPort' | 'meilisearchPort'>> {
   const directory =
     flags.directory ??
     ((await p.text({

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -23,7 +23,7 @@ import { generateSecretKeyBase, isDockerRunning } from './utils.js'
 export async function scaffold(options: ScaffoldOptions): Promise<void> {
   const projectDir = path.resolve(options.directory)
   const projectName = path.basename(projectDir)
-  const { port, dbPort, meilisearchPort, storefront } = options
+  const { port, dbPort, storefront } = options
 
   // Pre-flight checks
   if (options.start) {
@@ -79,7 +79,7 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
 
   fs.writeFileSync(
     path.join(projectDir, '.env'),
-    envContent(generateSecretKeyBase(), { web: port, db: dbPort, meilisearch: meilisearchPort }),
+    envContent(generateSecretKeyBase(), { web: port, db: dbPort }),
   )
   fs.writeFileSync(path.join(projectDir, 'package.json'), rootPackageJsonContent(projectName))
   fs.writeFileSync(path.join(projectDir, 'README.md'), readmeContent(projectName, storefront, port))

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -23,7 +23,7 @@ import { generateSecretKeyBase, isDockerRunning } from './utils.js'
 export async function scaffold(options: ScaffoldOptions): Promise<void> {
   const projectDir = path.resolve(options.directory)
   const projectName = path.basename(projectDir)
-  const { port, storefront } = options
+  const { port, dbPort, meilisearchPort, storefront } = options
 
   // Pre-flight checks
   if (options.start) {
@@ -77,7 +77,10 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   fs.rmSync(path.join(backendDir, 'docker-compose.yml'), { force: true })
   fs.rmSync(path.join(backendDir, 'docker-compose.dev.yml'), { force: true })
 
-  fs.writeFileSync(path.join(projectDir, '.env'), envContent(generateSecretKeyBase(), port))
+  fs.writeFileSync(
+    path.join(projectDir, '.env'),
+    envContent(generateSecretKeyBase(), { web: port, db: dbPort, meilisearch: meilisearchPort }),
+  )
   fs.writeFileSync(path.join(projectDir, 'package.json'), rootPackageJsonContent(projectName))
   fs.writeFileSync(path.join(projectDir, 'README.md'), readmeContent(projectName, storefront, port))
   fs.writeFileSync(path.join(projectDir, '.gitignore'), gitignoreContent())

--- a/packages/create-spree-app/src/templates/env.ts
+++ b/packages/create-spree-app/src/templates/env.ts
@@ -1,6 +1,14 @@
-export function envContent(secretKeyBase: string, port: number): string {
+export interface EnvPorts {
+  web: number
+  db: number
+  meilisearch: number
+}
+
+export function envContent(secretKeyBase: string, ports: EnvPorts): string {
   return `SECRET_KEY_BASE=${secretKeyBase}
-SPREE_PORT=${port}
+SPREE_PORT=${ports.web}
+SPREE_DB_PORT=${ports.db}
+SPREE_MEILISEARCH_PORT=${ports.meilisearch}
 SPREE_VERSION_TAG=latest
 `
 }

--- a/packages/create-spree-app/src/templates/env.ts
+++ b/packages/create-spree-app/src/templates/env.ts
@@ -1,14 +1,12 @@
 export interface EnvPorts {
   web: number
   db: number
-  meilisearch: number
 }
 
 export function envContent(secretKeyBase: string, ports: EnvPorts): string {
   return `SECRET_KEY_BASE=${secretKeyBase}
 SPREE_PORT=${ports.web}
 SPREE_DB_PORT=${ports.db}
-SPREE_MEILISEARCH_PORT=${ports.meilisearch}
 SPREE_VERSION_TAG=latest
 `
 }

--- a/packages/create-spree-app/src/types.ts
+++ b/packages/create-spree-app/src/types.ts
@@ -8,5 +8,4 @@ export interface ScaffoldOptions {
   packageManager: PackageManager
   port: number
   dbPort: number
-  meilisearchPort: number
 }

--- a/packages/create-spree-app/src/types.ts
+++ b/packages/create-spree-app/src/types.ts
@@ -7,4 +7,6 @@ export interface ScaffoldOptions {
   start: boolean
   packageManager: PackageManager
   port: number
+  dbPort: number
+  meilisearchPort: number
 }

--- a/packages/create-spree-app/tests/scaffold.test.ts
+++ b/packages/create-spree-app/tests/scaffold.test.ts
@@ -111,7 +111,6 @@ describe('scaffold (no-start)', () => {
       packageManager: 'npm',
       port: 3000,
       dbPort: 5433,
-      meilisearchPort: 7700,
     })
 
     expect(fs.existsSync(path.join(projectDir, 'docker-compose.yml'))).toBe(true)
@@ -133,7 +132,6 @@ describe('scaffold (no-start)', () => {
       packageManager: 'npm',
       port: 3000,
       dbPort: 5433,
-      meilisearchPort: 7700,
     })
 
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.yml'), 'utf-8')
@@ -152,7 +150,6 @@ describe('scaffold (no-start)', () => {
       packageManager: 'npm',
       port: 3000,
       dbPort: 5433,
-      meilisearchPort: 7700,
     })
 
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
@@ -171,7 +168,6 @@ describe('scaffold (no-start)', () => {
       packageManager: 'npm',
       port: 3000,
       dbPort: 5433,
-      meilisearchPort: 7700,
     })
 
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
@@ -192,14 +188,12 @@ describe('scaffold (no-start)', () => {
       packageManager: 'npm',
       port: 4567,
       dbPort: 5434,
-      meilisearchPort: 7701,
     })
 
     const env = fs.readFileSync(path.join(projectDir, '.env'), 'utf-8')
     expect(env).toMatch(/SECRET_KEY_BASE=.{128}/)
     expect(env).toContain('SPREE_PORT=4567')
     expect(env).toContain('SPREE_DB_PORT=5434')
-    expect(env).toContain('SPREE_MEILISEARCH_PORT=7701')
   })
 
   it('generates valid package.json with project name', async () => {
@@ -213,7 +207,6 @@ describe('scaffold (no-start)', () => {
       packageManager: 'npm',
       port: 3000,
       dbPort: 5433,
-      meilisearchPort: 7700,
     })
 
     const content = fs.readFileSync(path.join(projectDir, 'package.json'), 'utf-8')
@@ -240,7 +233,6 @@ describe('scaffold (no-start)', () => {
         packageManager: 'npm',
         port: 3000,
         dbPort: 5433,
-        meilisearchPort: 7700,
       }),
     ).rejects.toThrow('process.exit called')
 

--- a/packages/create-spree-app/tests/scaffold.test.ts
+++ b/packages/create-spree-app/tests/scaffold.test.ts
@@ -110,6 +110,8 @@ describe('scaffold (no-start)', () => {
       start: false,
       packageManager: 'npm',
       port: 3000,
+      dbPort: 5433,
+      meilisearchPort: 7700,
     })
 
     expect(fs.existsSync(path.join(projectDir, 'docker-compose.yml'))).toBe(true)
@@ -130,6 +132,8 @@ describe('scaffold (no-start)', () => {
       start: false,
       packageManager: 'npm',
       port: 3000,
+      dbPort: 5433,
+      meilisearchPort: 7700,
     })
 
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.yml'), 'utf-8')
@@ -147,6 +151,8 @@ describe('scaffold (no-start)', () => {
       start: false,
       packageManager: 'npm',
       port: 3000,
+      dbPort: 5433,
+      meilisearchPort: 7700,
     })
 
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
@@ -164,6 +170,8 @@ describe('scaffold (no-start)', () => {
       start: false,
       packageManager: 'npm',
       port: 3000,
+      dbPort: 5433,
+      meilisearchPort: 7700,
     })
 
     const compose = fs.readFileSync(path.join(projectDir, 'docker-compose.dev.yml'), 'utf-8')
@@ -173,7 +181,7 @@ describe('scaffold (no-start)', () => {
     expect(compose).toContain('- bundle_cache:/usr/local/bundle')
   })
 
-  it('generates .env with SECRET_KEY_BASE and PORT', async () => {
+  it('generates .env with SECRET_KEY_BASE and the picked ports', async () => {
     const projectDir = getTempProjectDir()
 
     await scaffold({
@@ -183,11 +191,15 @@ describe('scaffold (no-start)', () => {
       start: false,
       packageManager: 'npm',
       port: 4567,
+      dbPort: 5434,
+      meilisearchPort: 7701,
     })
 
     const env = fs.readFileSync(path.join(projectDir, '.env'), 'utf-8')
     expect(env).toMatch(/SECRET_KEY_BASE=.{128}/)
     expect(env).toContain('SPREE_PORT=4567')
+    expect(env).toContain('SPREE_DB_PORT=5434')
+    expect(env).toContain('SPREE_MEILISEARCH_PORT=7701')
   })
 
   it('generates valid package.json with project name', async () => {
@@ -200,6 +212,8 @@ describe('scaffold (no-start)', () => {
       start: false,
       packageManager: 'npm',
       port: 3000,
+      dbPort: 5433,
+      meilisearchPort: 7700,
     })
 
     const content = fs.readFileSync(path.join(projectDir, 'package.json'), 'utf-8')
@@ -225,6 +239,8 @@ describe('scaffold (no-start)', () => {
         start: false,
         packageManager: 'npm',
         port: 3000,
+        dbPort: 5433,
+        meilisearchPort: 7700,
       }),
     ).rejects.toThrow('process.exit called')
 

--- a/packages/create-spree-app/tests/templates.test.ts
+++ b/packages/create-spree-app/tests/templates.test.ts
@@ -6,19 +6,25 @@ import { rootPackageJsonContent } from '../src/templates/package-json'
 import { readmeContent } from '../src/templates/readme'
 
 describe('envContent', () => {
+  const ports = { web: 3000, db: 5433, meilisearch: 7700 }
+
   it('includes the provided secret key', () => {
-    const content = envContent('my-secret-123', 3000)
+    const content = envContent('my-secret-123', ports)
     expect(content).toContain('SECRET_KEY_BASE=my-secret-123')
   })
 
-  it('includes SPREE_PORT', () => {
-    const content = envContent('any', 3000)
+  it('includes all host ports', () => {
+    const content = envContent('any', ports)
     expect(content).toContain('SPREE_PORT=3000')
+    expect(content).toContain('SPREE_DB_PORT=5433')
+    expect(content).toContain('SPREE_MEILISEARCH_PORT=7700')
   })
 
-  it('uses custom port value', () => {
-    const content = envContent('any', 4567)
+  it('uses custom port values', () => {
+    const content = envContent('any', { web: 4567, db: 5434, meilisearch: 7701 })
     expect(content).toContain('SPREE_PORT=4567')
+    expect(content).toContain('SPREE_DB_PORT=5434')
+    expect(content).toContain('SPREE_MEILISEARCH_PORT=7701')
   })
 })
 

--- a/packages/create-spree-app/tests/templates.test.ts
+++ b/packages/create-spree-app/tests/templates.test.ts
@@ -20,6 +20,10 @@ describe('envContent', () => {
     expect(content).toContain('SPREE_MEILISEARCH_PORT=7700')
   })
 
+  it('includes the image version tag', () => {
+    expect(envContent('any', ports)).toContain('SPREE_VERSION_TAG=latest')
+  })
+
   it('uses custom port values', () => {
     const content = envContent('any', { web: 4567, db: 5434, meilisearch: 7701 })
     expect(content).toContain('SPREE_PORT=4567')

--- a/packages/create-spree-app/tests/templates.test.ts
+++ b/packages/create-spree-app/tests/templates.test.ts
@@ -6,18 +6,17 @@ import { rootPackageJsonContent } from '../src/templates/package-json'
 import { readmeContent } from '../src/templates/readme'
 
 describe('envContent', () => {
-  const ports = { web: 3000, db: 5433, meilisearch: 7700 }
+  const ports = { web: 3000, db: 5433 }
 
   it('includes the provided secret key', () => {
     const content = envContent('my-secret-123', ports)
     expect(content).toContain('SECRET_KEY_BASE=my-secret-123')
   })
 
-  it('includes all host ports', () => {
+  it('includes the host ports', () => {
     const content = envContent('any', ports)
     expect(content).toContain('SPREE_PORT=3000')
     expect(content).toContain('SPREE_DB_PORT=5433')
-    expect(content).toContain('SPREE_MEILISEARCH_PORT=7700')
   })
 
   it('includes the image version tag', () => {
@@ -25,10 +24,9 @@ describe('envContent', () => {
   })
 
   it('uses custom port values', () => {
-    const content = envContent('any', { web: 4567, db: 5434, meilisearch: 7701 })
+    const content = envContent('any', { web: 4567, db: 5434 })
     expect(content).toContain('SPREE_PORT=4567')
     expect(content).toContain('SPREE_DB_PORT=5434')
-    expect(content).toContain('SPREE_MEILISEARCH_PORT=7701')
   })
 })
 

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -36,6 +36,32 @@ SERVER_DIR="$ROOT/server"
 
 step() { printf '\n→ %s\n' "$1"; }
 
+# First free TCP port at or above $1. Probes 0.0.0.0 AND 127.0.0.1: on macOS
+# a wildcard bind can coexist with a specific-address listener (SO_REUSEADDR
+# semantics), so the loopback probe is what catches another project's
+# 127.0.0.1-bound postgres. Node is a hard dependency of this repo already.
+free_port() {
+  node -e '
+    const net = require("net");
+    const bindable = (port, host) =>
+      new Promise((resolve) => {
+        const server = net.createServer();
+        server.once("error", (err) => resolve(err.code !== "EADDRINUSE"));
+        server.listen({ port, host, exclusive: true }, () => {
+          server.close(() => resolve(true));
+        });
+      });
+    const probe = async (port) => {
+      if ((await bindable(port, "0.0.0.0")) && (await bindable(port, "127.0.0.1"))) {
+        console.log(port);
+      } else {
+        probe(port + 1);
+      }
+    };
+    probe(Number(process.argv[1]));
+  ' "$1"
+}
+
 step "Tearing down any prior stack (this also wipes the dev volumes)"
 # Reference the project by name (-p server) rather than via compose files,
 # so this works even after a prior run deleted ./server/. Orphan volumes
@@ -52,8 +78,28 @@ step "Cloning spree-starter into server/"
 git clone --depth 1 https://github.com/spree/spree-starter.git "$SERVER_DIR"
 rm -rf "$SERVER_DIR/.git" "$SERVER_DIR/.gitignore"
 
-step "Writing server/.env (SPREE_PATH + SECRET_KEY_BASE)"
-printf 'SPREE_PATH=..\nSECRET_KEY_BASE=%s\n' "$(openssl rand -hex 64)" > "$SERVER_DIR/.env"
+step "Writing server/.env (SPREE_PATH + SECRET_KEY_BASE + host ports)"
+# Host ports for postgres/meilisearch start ABOVE the spree-starter defaults
+# (5433/7700) so the edge stack never fights a create-spree-app project
+# running side by side, then walk upward past anything else already bound.
+# Written into .env (not exported per-run) so the port stays stable for saved
+# DB-client connections across restarts.
+DB_PORT="$(free_port 5434)"
+{
+  printf 'SPREE_PATH=..\n'
+  printf 'SECRET_KEY_BASE=%s\n' "$(openssl rand -hex 64)"
+  printf 'SPREE_DB_PORT=%s\n' "$DB_PORT"
+} > "$SERVER_DIR/.env"
+# Guard against version skew: we clone whatever spree-starter main ships, and
+# older revisions hardcode the Meilisearch publish — only pick + write the
+# override when the cloned compose actually interpolates it.
+if grep -q 'SPREE_MEILISEARCH_PORT' "$SERVER_DIR/docker-compose.dev.yml"; then
+  MEILISEARCH_PORT="$(free_port 7701)"
+  printf 'SPREE_MEILISEARCH_PORT=%s\n' "$MEILISEARCH_PORT" >> "$SERVER_DIR/.env"
+  echo "  Postgres on localhost:$DB_PORT, Meilisearch on localhost:$MEILISEARCH_PORT"
+else
+  echo "  Postgres on localhost:$DB_PORT"
+fi
 
 step "Building @spree/cli (so node ../packages/cli/dist/index.js works)"
 pnpm --filter @spree/cli build
@@ -86,4 +132,4 @@ until code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localho
   elapsed=$((elapsed + 3))
 done
 
-printf '\nServer ready: http://localhost:3000\nAdmin:         http://localhost:3000/admin\n\n'
+printf '\nServer ready:  http://localhost:3000\nAdmin:         http://localhost:3000/admin\nPostgres:      localhost:%s (user: postgres, db: spree_development)\n\n' "$DB_PORT"

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -132,4 +132,8 @@ until code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localho
   elapsed=$((elapsed + 3))
 done
 
-printf '\nServer ready:  http://localhost:3000\nAdmin:         http://localhost:3000/admin\nPostgres:      localhost:%s (user: postgres, db: spree_development)\n\n' "$DB_PORT"
+printf '\nServer ready:  http://localhost:3000\nAdmin:         http://localhost:3000/admin\nPostgres:      localhost:%s (user: postgres, db: spree_development)\n' "$DB_PORT"
+if [ -n "${MEILISEARCH_PORT:-}" ]; then
+  printf 'Meilisearch:   localhost:%s\n' "$MEILISEARCH_PORT"
+fi
+printf '\n'

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -78,28 +78,19 @@ step "Cloning spree-starter into server/"
 git clone --depth 1 https://github.com/spree/spree-starter.git "$SERVER_DIR"
 rm -rf "$SERVER_DIR/.git" "$SERVER_DIR/.gitignore"
 
-step "Writing server/.env (SPREE_PATH + SECRET_KEY_BASE + host ports)"
-# Host ports for postgres/meilisearch start ABOVE the spree-starter defaults
-# (5433/7700) so the edge stack never fights a create-spree-app project
-# running side by side, then walk upward past anything else already bound.
-# Written into .env (not exported per-run) so the port stays stable for saved
-# DB-client connections across restarts.
+step "Writing server/.env (SPREE_PATH + SECRET_KEY_BASE + Postgres host port)"
+# The Postgres host port starts ABOVE the spree-starter default (5433) so the
+# edge stack never fights a create-spree-app project running side by side, then
+# walks upward past anything else already bound. Written into .env (not exported
+# per-run) so the port stays stable for saved DB-client connections across
+# restarts. (Redis and Meilisearch aren't host-published, so nothing to pick.)
 DB_PORT="$(free_port 5434)"
 {
   printf 'SPREE_PATH=..\n'
   printf 'SECRET_KEY_BASE=%s\n' "$(openssl rand -hex 64)"
   printf 'SPREE_DB_PORT=%s\n' "$DB_PORT"
 } > "$SERVER_DIR/.env"
-# Guard against version skew: we clone whatever spree-starter main ships, and
-# older revisions hardcode the Meilisearch publish — only pick + write the
-# override when the cloned compose actually interpolates it.
-if grep -q 'SPREE_MEILISEARCH_PORT' "$SERVER_DIR/docker-compose.dev.yml"; then
-  MEILISEARCH_PORT="$(free_port 7701)"
-  printf 'SPREE_MEILISEARCH_PORT=%s\n' "$MEILISEARCH_PORT" >> "$SERVER_DIR/.env"
-  echo "  Postgres on localhost:$DB_PORT, Meilisearch on localhost:$MEILISEARCH_PORT"
-else
-  echo "  Postgres on localhost:$DB_PORT"
-fi
+echo "  Postgres on localhost:$DB_PORT"
 
 step "Building @spree/cli (so node ../packages/cli/dist/index.js works)"
 pnpm --filter @spree/cli build
@@ -132,8 +123,4 @@ until code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://localho
   elapsed=$((elapsed + 3))
 done
 
-printf '\nServer ready:  http://localhost:3000\nAdmin:         http://localhost:3000/admin\nPostgres:      localhost:%s (user: postgres, db: spree_development)\n' "$DB_PORT"
-if [ -n "${MEILISEARCH_PORT:-}" ]; then
-  printf 'Meilisearch:   localhost:%s\n' "$MEILISEARCH_PORT"
-fi
-printf '\n'
+printf '\nServer ready:  http://localhost:3000\nAdmin:         http://localhost:3000/admin\nPostgres:      localhost:%s (user: postgres, db: spree_development)\n\n' "$DB_PORT"


### PR DESCRIPTION
When `spree dev`, `spree init`, or `spree eject` fail to boot the stack due to port conflicts, the CLI now diagnoses which host ports are taken, who is holding them (another compose project's warm databases, a stray container, or a non-Docker process), and suggests both remedies — `spree stop` in that project, `docker stop <container>`, or setting an env var to move the port.

## Key Changes

- **New `ports.ts` module** in `@spree/cli` with `diagnosePortConflicts()` and `formatPortConflicts()` functions that:
  - Query `docker compose config` to extract published host ports from the project's compose file
  - Probe `docker ps --filter publish=N` to find Docker containers holding each port
  - Match holder bindings against the configured host IP (wildcard 0.0.0.0 / [::] overlap everything; specific IPs only collide if they match)
  - Fall back to bind probes on 0.0.0.0, 127.0.0.1, and the configured host IP to detect non-Docker processes
  - Ignore ports held by the project's own warm containers (e.g., databases left running after Ctrl+C)
  - Suggest env var overrides (e.g., `SPREE_DB_PORT=<free port>`) only when the project's compose file actually interpolates them

- **Port conflict handling in `dev.ts`, `init.ts`, `eject.ts`**: Wrap `docker compose up` in try-catch; on failure, diagnose conflicts and display actionable remedies instead of raw compose output

- **Postgres and Meilisearch host port allocation in `create-spree-app`**:
  - Pick free ports for `SPREE_DB_PORT` and `SPREE_MEILISEARCH_PORT` at scaffold time (walking up from 5433/7700 defaults)
  - Write them to the project `.env` so projects scaffolded next to a running Spree stack never fight over host ports
  - Update `envContent()` template to include all three ports

- **Server setup script (`server-setup.sh`)** now:
  - Implements `free_port()` helper to find available ports (probes both wildcard and loopback to handle macOS SO_REUSEADDR semantics)
  - Allocates `SPREE_DB_PORT` starting from 5434 (above the create-spree-app default of 5433) to avoid conflicts with side-by-side projects
  - Conditionally allocates `SPREE_MEILISEARCH_PORT` only if the cloned spree-starter compose interpolates it (guards against version skew)
  - Writes ports to `.env` for stable DB-client connections across restarts

- **Constants and context updates**:
  - Add `DEFAULT_SPREE_DB_PORT` (5433) and `DEFAULT_MEILISEARCH_PORT` (7700) constants
  - Add `readDbPortFromEnv()` helper in `context.ts` to read `SPREE_DB_PORT` from `.env`
  - Update `ScaffoldOptions` type to include `dbPort` and `meilisearchPort`

- **Comprehensive test coverage** in `ports.test.ts` (259 lines) covering:
  - Foreign compose project holders
  - Warm database containers (same project, ignored)
  - Wildcard vs. loopback binding overlap logic
  - Non-overlapping host IP filtering
  - Non-compose Docker containers
  - Non-Docker processes via bind probe
  - Free ports (no conflicts)
  - Env var hint attachment based on compose interpolation
  - Unparsable port mappings and services without published ports
  - Formatted output for all holder types

## Implementation Details

- Bind probes use `exclusive: true` and probe multiple addresses (wildcard + loopback + configured IP) to reliably detect collisions across macOS SO_REUSEADDR semantics
- Docker holder detection parses `docker ps` output and matches port ranges against the configured host IP, handling both IPv4 and IPv6 wildcard syntax
-

https://claude.ai/code/session_01KhFxgBpt1G7kaiCPkZqiiT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project setup now automatically selects free host ports for Postgres and Meilisearch (when present) and writes them into the generated environment file.
  * Server setup output now prints the selected Postgres host/port and, when applicable, the Meilisearch host/port.
* **Bug Fixes**
  * The CLI’s dev/init/eject/db commands now provide clearer, port-specific conflict guidance, including identifying what’s holding the port and suggesting `spree stop` or `SPREE_*_PORT` overrides.
  * Database reset/drop messaging now reflects the configured database port instead of a fixed default.
* **Documentation**
  * Development-server instructions now document auto-selected ports and where they’re recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->