### PR TITLE
Expose pre-order fields on the product-level inventory form

### DIFF
--- a/spree/admin/app/controllers/spree/admin/products_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/products_controller.rb
@@ -311,6 +311,7 @@ module Spree
                     params.require(:product).permit(permitted_product_attributes)
                   end
           parse_datetime_in_store_timezone(attrs, :available_on, :discontinue_on, :make_active_at)
+          parse_datetime_in_store_timezone(attrs[:master_attributes], :preorder_ships_at) if attrs[:master_attributes].present?
           attrs
         end
       end

--- a/spree/admin/app/views/spree/admin/products/form/_inventory.html.erb
+++ b/spree/admin/app/views/spree/admin/products/form/_inventory.html.erb
@@ -17,6 +17,25 @@
           %>
       <%= f.label :track_inventory, Spree.t(:track_quantity), class: 'custom-control-label' %>
     </div>
+    <%= f.fields_for :master, @product.master do |vf| %>
+      <div class="mb-2">
+        <%= vf.spree_check_box :preorderable, label: Spree.t('admin.variants_form.preorderable_label') %>
+        <small class="text-muted text-xs d-block"><%= Spree.t('admin.variants_form.preorderable_hint') %></small>
+      </div>
+      <div class="mb-2">
+        <%# datetime-local inputs have no timezone; render in the store's timezone so admins see and submit store-local times (parsed back in ProductsController#permitted_resource_params). %>
+        <% preorder_ships_at_local = vf.object.preorder_ships_at&.in_time_zone(current_timezone)&.strftime('%Y-%m-%dT%H:%M') %>
+        <%= vf.spree_datetime_field :preorder_ships_at,
+              value: preorder_ships_at_local,
+              label: Spree.t('admin.variants_form.preorder_ships_at_label'),
+              help: "#{Spree.t('admin.variants_form.preorder_ships_at_hint')} #{Spree.t('admin.datetime_field_timezone_help', zone: current_timezone.name)}" %>
+      </div>
+      <div class="mb-6">
+        <%= vf.spree_number_field :backorder_limit, min: 0,
+              label: Spree.t('admin.variants_form.backorder_limit_label'),
+              help: Spree.t('admin.variants_form.backorder_limit_hint') %>
+      </div>
+    <% end %>
     <div
       class="master-variant-quantity-form <%= @product.has_variants? || !@product.track_inventory ? 'hidden' : '' %>"
       data-product-form-target="<%= @product.has_variants? ? '' : 'quantityForm' %>"

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -638,6 +638,8 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
     end
 
     describe 'master variant pre-order' do
+      before { store.update!(preferred_timezone: 'Asia/Tokyo') }
+
       let(:product_params) do
         {
           master_attributes: {
@@ -655,7 +657,9 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         product.master.reload
         expect(product.master).to be_preorderable
         expect(product.master.backorder_limit).to eq(25)
-        expect(product.master.preorder_ships_at).to be_present
+        # The datetime-local value carries no zone, so it must be parsed in the
+        # store timezone: 12:00 in Tokyo (UTC+9) is stored as 03:00 UTC.
+        expect(product.master.preorder_ships_at).to eq(ActiveSupport::TimeZone['Asia/Tokyo'].parse('2026-05-01T12:00'))
       end
     end
 

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -637,6 +637,28 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
       end
     end
 
+    describe 'master variant pre-order' do
+      let(:product_params) do
+        {
+          master_attributes: {
+            id: product.master_id,
+            preorderable: '1',
+            preorder_ships_at: '2026-05-01T12:00',
+            backorder_limit: '25'
+          }
+        }
+      end
+
+      it 'updates the pre-order settings of the master variant' do
+        send_request
+
+        product.master.reload
+        expect(product.master).to be_preorderable
+        expect(product.master.backorder_limit).to eq(25)
+        expect(product.master.preorder_ships_at).to be_present
+      end
+    end
+
     describe 'master variant prices' do
       let(:product_params) do
         {
@@ -1181,7 +1203,11 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
           status: 'draft',
           make_active_at: '2026-04-10T09:00',
           available_on: '2026-04-11T10:30',
-          discontinue_on: '2026-04-20T18:45'
+          discontinue_on: '2026-04-20T18:45',
+          master_attributes: {
+            id: product.master_id,
+            preorder_ships_at: '2026-04-15T14:00'
+          }
         }
       end
 
@@ -1193,6 +1219,7 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         expect(product.make_active_at).to eq(tokyo.parse('2026-04-10T09:00'))
         expect(product.available_on).to eq(tokyo.parse('2026-04-11T10:30'))
         expect(product.discontinue_on).to eq(tokyo.parse('2026-04-20T18:45'))
+        expect(product.master.preorder_ships_at).to eq(tokyo.parse('2026-04-15T14:00'))
         # Tokyo is UTC+9, so 09:00 local is 00:00 UTC.
         expect(product.make_active_at.utc.strftime('%Y-%m-%dT%H:%M')).to eq('2026-04-10T00:00')
       end


### PR DESCRIPTION
## What & why

Pre-order settings — **Available for pre-order**, the **Ships by** date, and the **Backorder limit** — could only be set from the per-variant form. That left two gaps in the classic Rails admin:

- **Adding a new product** — no way to enable pre-orders.
- **Editing a product without variants** (single/master variant) — no way to enable pre-orders.

It only worked for multi-variant products, where the fields live in the per-variant editor. This follow-up to #14249 surfaces the same fields on the product-level inventory form, which edits the master variant.

## Changes

- **`products/form/_inventory.html.erb`** — Add the three pre-order fields inside an `f.fields_for :master` block, mirroring the per-variant form: same form-builder helpers, same locale keys, same store-timezone rendering for the `datetime-local` input. Placed after the *Track quantity* checkbox so they show for variant-less products regardless of the inventory-tracking toggle. The partial already renders only for products without variants, so no extra visibility logic is needed.
- **`products_controller.rb`** — Parse the master's `preorder_ships_at` in the store timezone in `permitted_resource_params`, mirroring the existing top-level datetime handling. The fields were already permitted (`master_attributes` resolves through `permitted_variant_attributes`), so no permit changes were required.
- **`products_controller_spec.rb`** — Add a spec covering persistence of all three fields via `master_attributes`, and extend the store-timezone datetime spec to assert the master's `preorder_ships_at` is parsed store-local → UTC.

## Testing

`products_controller_spec.rb` passes (83 examples, 0 failures), including the `render_views` tests that render the full product form with the new partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gx5sjUJ5DJ5Lnr6L2gQXf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added master-variant pre-order controls to the admin product inventory form, including preorderable, shipment “ships at” date/time, and backorder limit.
  * Admin “ships at” input now supports correct store-local entry for master-variant pre-orders.

* **Bug Fixes**
  * Improved saving of master-variant pre-order shipment dates so they’re parsed using the store timezone and persisted consistently (converted to UTC as needed).

* **Tests**
  * Added/extended controller specs to cover master-variant pre-order persistence and timezone parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->