### PR TITLE
Fix displaying product images in order emails

### DIFF
--- a/spree/emails/app/helpers/spree/mail_helper.rb
+++ b/spree/emails/app/helpers/spree/mail_helper.rb
@@ -4,7 +4,9 @@ module Spree
     include Spree::ImagesHelper
 
     def variant_image_url(variant)
-      image = variant.primary_media
+      Spree::Deprecation.warn(
+        'Spree::MailHelper#variant_image_url is deprecated. Use spree_image_url instead. Will be removed in Spree 6.0.'
+      )
       image.present? && image.attached? ? spree_image_url(image, variant: :mini) : image_url('noimage/small.png')
     end
 

--- a/spree/emails/app/helpers/spree/mail_helper.rb
+++ b/spree/emails/app/helpers/spree/mail_helper.rb
@@ -7,6 +7,8 @@ module Spree
       Spree::Deprecation.warn(
         'Spree::MailHelper#variant_image_url is deprecated. Use spree_image_url instead. Will be removed in Spree 6.0.'
       )
+
+      image = variant.primary_media
       image.present? && image.attached? ? spree_image_url(image, variant: :mini) : image_url('noimage/small.png')
     end
 

--- a/spree/emails/app/views/spree/reimbursement_mailer/reimbursement_email.html.erb
+++ b/spree/emails/app/views/spree/reimbursement_mailer/reimbursement_email.html.erb
@@ -19,7 +19,12 @@
     <% @reimbursement.return_items.exchange_requested.each do |return_item| %>
       <tr>
         <td class="purchase_image">
-          <%= link_to(image_tag(variant_image_url(return_item.variant)), spree_storefront_resource_url(return_item.variant.product)) %>
+          <% image = return_item.variant.primary_media || return_item.variant.product.primary_media %>
+          <% if image.present? && image.attached? %>
+            <%= link_to(spree_image_tag(image, variant: :mini, alt: return_item.variant.name), spree_storefront_resource_url(return_item.variant.product)) %>
+          <% else %>
+            <%= link_to(image_tag('noimage/small.png', alt: return_item.variant.name), spree_storefront_resource_url(return_item.variant.product)) %>
+          <% end %>
         </td>
         <td class="purchase_item">
           <strong>

--- a/spree/emails/app/views/spree/shared/purchased_items_table/_line_item.html.erb
+++ b/spree/emails/app/views/spree/shared/purchased_items_table/_line_item.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="purchase_image">
-    <% image = line_item.variant.default_image %>
+    <% image = line_item.variant.primary_media || line_item.product.primary_media %>
     <% if image.present? && image.attached? %>
       <%= link_to(spree_image_tag(image, variant: :mini, alt: line_item.name), spree_storefront_resource_url(line_item.product)) %>
     <% else %>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Email template and helper changes only; no auth, payments, or order processing logic.
> 
> **Overview**
> Fixes broken or missing product thumbnails in **purchase** and **reimbursement** emails by resolving images through `primary_media` on the variant, then the product, instead of `default_image` or the deprecated `variant_image_url` helper.
> 
> Reimbursement exchange rows now use the same inline pattern as the shared line-item partial: `spree_image_tag` with a `noimage/small.png` fallback and product links. **`Spree::MailHelper#variant_image_url`** is kept but emits a deprecation warning directing callers to `spree_image_url` before removal in Spree 6.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95cb5b101e034c4b2cb735de147c7cbfe2aa2bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product image rendering in purchase and reimbursement emails, with smarter fallbacks when variant media is missing.
  * Reimbursement emails now display a linked thumbnail from available media, or a placeholder image when none is attached.
* **Chores**
  * Added a deprecation notice for an older image URL helper, advising switching to the newer image URL approach (scheduled for removal in a future major release).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->