### PR TITLE
Return 304 on fresh cache

### DIFF
--- a/spree/api/app/controllers/concerns/spree/api/v3/http_caching.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/http_caching.rb
@@ -48,7 +48,12 @@ module Spree
           response.headers['ETag'] = %("#{Digest::MD5.hexdigest(cache_key)}")
 
           # Return false if client has fresh cache (304 Not Modified)
-          !request.fresh?(response)
+          if request.fresh?(response)
+            head :not_modified
+            false
+          else
+            true
+          end
         end
 
         # Apply HTTP caching for a single resource (show actions)

--- a/spree/api/spec/controllers/concerns/spree/api/v3/http_caching_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/http_caching_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
           expect(response).to have_http_status(:ok)
         end
 
+        it 'returns 304 Not Modified when the collection has not changed' do
+          get :index
+          etag = response.headers['ETag']
+
+          request.headers['If-None-Match'] = etag
+          get :index
+
+          expect(response).to have_http_status(:not_modified)
+        end
+
         it 'changes ETag when a product is updated' do
           get :index
           original_etag = response.headers['ETag']


### PR DESCRIPTION
The problem is that controllers do: `return unless cache_collection(@collection)`,
so we do not set template, thus rails fall back to `204 No Content`:

```
[9f946815-5e39-467b-bce5-5e483f1a9ddf] Processing by Spree::Api::V3::Store::ProductsController#index as JSON
[9f946815-5e39-467b-bce5-5e483f1a9ddf]   Parameters: {"q"=>{"vendor_id_eq"=>"ven_uw2YK1rnl0"}, "page"=>"1"}
[9f946815-5e39-467b-bce5-5e483f1a9ddf] No template found for Spree::Api::V3::Store::ProductsController#index, rendering head :no_content
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in guest HTTP caching for collection index actions; aligns status with existing ETag logic and adds coverage.
> 
> **Overview**
> Guest API v3 index actions that use `return unless cache_collection(@collection)` were responding with **204 No Content** when the client sent a matching `If-None-Match` ETag, because the concern only returned `false` without setting a response body or status.
> 
> **`cache_collection`** now calls **`head :not_modified`** when `request.fresh?(response)` before returning `false`, so conditional GETs get a proper **304** instead of Rails’ default empty response. A controller spec asserts the two-request ETag flow returns `:not_modified` for unchanged collections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f762cb128ed8bec8c91eec93b6f140a25bc176a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API caching behavior so repeat requests with a matching `ETag` now correctly return **304 Not Modified**.
  * Added coverage to verify collection responses remain unchanged when the client reuses a valid cache validator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->