### PR TITLE
Fix bulk product status dialog showing raw status value in trigger

### DIFF
--- a/packages/dashboard/e2e/products-bulk.spec.ts
+++ b/packages/dashboard/e2e/products-bulk.spec.ts
@@ -65,6 +65,12 @@ test.describe('products bulk operations', () => {
 
     await page.getByRole('combobox').click()
     await page.getByRole('option', { name: /^archived$/i }).click()
+
+    // Regression guard: the trigger must render the translated label ("Archived"),
+    // not the raw status value ("archived"). Base UI's <SelectValue> only resolves
+    // the label when the <Select> is given an `items` array.
+    await expect(page.getByRole('combobox')).toHaveText('Archived')
+
     await page
       .getByRole('dialog')
       .getByRole('button', { name: /^apply$/i })

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/index.tsx
@@ -364,7 +364,7 @@ function StatusPickerSheet({ onSubmit, onCancel }: BulkActionFormProps<StatusFor
       <Field>
         <FieldLabel>{t('admin.fields.status.label')}</FieldLabel>
         <Select
-          items={statusItems as never}
+          items={statusItems}
           value={status}
           onValueChange={(v) => setStatus(v as ProductStatus)}
         >

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/index.tsx
@@ -342,9 +342,16 @@ function ProductRowActions({ product, storeId }: { product: Product; storeId: st
   )
 }
 
+const PRODUCT_STATUSES: ProductStatus[] = ['draft', 'active', 'archived']
+
 function StatusPickerSheet({ onSubmit, onCancel }: BulkActionFormProps<StatusFormValues>) {
   const { t } = useTranslation()
   const [status, setStatus] = useState<ProductStatus>('active')
+
+  const statusItems = PRODUCT_STATUSES.map((value) => ({
+    value,
+    label: t(`admin.pages.products.status_options.${value}`),
+  }))
 
   return (
     <BulkDialog
@@ -356,16 +363,20 @@ function StatusPickerSheet({ onSubmit, onCancel }: BulkActionFormProps<StatusFor
     >
       <Field>
         <FieldLabel>{t('admin.fields.status.label')}</FieldLabel>
-        <Select value={status} onValueChange={(v) => setStatus(v as ProductStatus)}>
+        <Select
+          items={statusItems as never}
+          value={status}
+          onValueChange={(v) => setStatus(v as ProductStatus)}
+        >
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="draft">{t('admin.pages.products.status_options.draft')}</SelectItem>
-            <SelectItem value="active">{t('admin.fields.active.label')}</SelectItem>
-            <SelectItem value="archived">
-              {t('admin.pages.products.status_options.archived')}
-            </SelectItem>
+            {statusItems.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </Field>


### PR DESCRIPTION
https://claude.ai/code/session_01HjZpZKPVsgFQi3vDpAuscc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to bulk status picker labeling and a focused e2e assertion; no API or auth impact.
> 
> **Overview**
> Fixes the **Set status** bulk dialog so the status combobox shows translated labels (e.g. **Archived**) instead of raw enum values (e.g. `archived`) after a choice is made.
> 
> `StatusPickerSheet` now builds a shared `statusItems` list from `PRODUCT_STATUSES` and passes it to `Select` via the `items` prop so Base UI’s `SelectValue` can resolve the display label. Options are rendered from that same list instead of three hard-coded `SelectItem` nodes.
> 
> An e2e step asserts the combobox text is `Archived` after picking archived, guarding the regression called out in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcad25f3f638811f743ee992124d877577478474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product status labels now display correctly in the bulk action and status selector, showing translated names like “Archived” instead of raw values.
  * Improved consistency of product status options across the dashboard by using the same localized set of statuses everywhere.
* **Tests**
  * Enhanced the products bulk e2e coverage with a regression assertion to verify the status picker shows the translated “Archived” label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->