### PR TITLE
Relocate render.yaml to project root with rootDir: backend

### DIFF
--- a/packages/create-spree-app/.changeset/render-yaml-nested-backend.md
+++ b/packages/create-spree-app/.changeset/render-yaml-nested-backend.md
@@ -1,5 +1,0 @@
----
-"create-spree-app": patch
----
-
-Relocate the generated project's Render Blueprint (`render.yaml`) to the repository root and add `rootDir: backend` to every buildable service. In the wrapper layout the Rails app lives under `backend/`, so a Blueprint left in that subdirectory is invisible to Render and, without `rootDir`, its services build from the wrong directory — the deploy fails. The commented-out worker template is adjusted too, so uncommenting it still deploys correctly. Managed services (Redis, database) are left untouched.

--- a/packages/create-spree-app/.changeset/render-yaml-nested-backend.md
+++ b/packages/create-spree-app/.changeset/render-yaml-nested-backend.md
@@ -1,0 +1,5 @@
+---
+"create-spree-app": patch
+---
+
+Relocate the generated project's Render Blueprint (`render.yaml`) to the repository root and add `rootDir: backend` to every buildable service. In the wrapper layout the Rails app lives under `backend/`, so a Blueprint left in that subdirectory is invisible to Render and, without `rootDir`, its services build from the wrong directory — the deploy fails. The commented-out worker template is adjusted too, so uncommenting it still deploys correctly. Managed services (Redis, database) are left untouched.

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-spree-app
 
+## 1.0.8
+
+### Patch Changes
+
+- Relocate the generated project's Render Blueprint (`render.yaml`) to the repository root and add `rootDir: backend` to every buildable service. In the wrapper layout the Rails app lives under `backend/`, so a Blueprint left in that subdirectory is invisible to Render and, without `rootDir`, its services build from the wrong directory — the deploy fails. The commented-out worker template is adjusted too, so uncommenting it still deploys correctly. Managed services (Redis, database) are left untouched.
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/backend.ts
+++ b/packages/create-spree-app/src/backend.ts
@@ -27,8 +27,10 @@ export async function downloadBackend(projectDir: string): Promise<void> {
 
 /**
  * Tidy the freshly-cloned starter for the nested `backend/` layout: drop files
- * the wrapper project supplies itself, and relocate the CI workflow to the repo
- * root (where GitHub Actions runs it) adapted to run against backend/.
+ * the wrapper project supplies itself, relocate the CI workflow to the repo
+ * root (where GitHub Actions runs it) adapted to run against backend/, and
+ * relocate the Render Blueprint likewise (adapted so each service builds from
+ * backend/).
  */
 export function prepareBackendTemplate(projectDir: string): void {
   const backendDir = path.join(projectDir, 'backend')
@@ -52,6 +54,18 @@ export function prepareBackendTemplate(projectDir: string): void {
     // replaces with its own root .github/dependabot.yml (covering /, /backend,
     // and the storefront). Keeping it would leave a stale, duplicate config.
     fs.rmSync(path.join(backendDir, '.github'), { recursive: true, force: true })
+  }
+
+  // Render reads a single Blueprint from the repository root. The starter ships
+  // render.yaml authored for a repo where the Rails app *is* the root; left in
+  // backend/ it is invisible to Render, and even at the root its services would
+  // build from the wrong directory. Relocate it to the project root with
+  // `rootDir: backend` on every buildable service.
+  const srcRenderYaml = path.join(backendDir, 'render.yaml')
+  if (fs.existsSync(srcRenderYaml)) {
+    const content = fs.readFileSync(srcRenderYaml, 'utf-8')
+    fs.writeFileSync(path.join(projectDir, 'render.yaml'), adaptRenderYamlForNestedBackend(content))
+    fs.rmSync(srcRenderYaml, { force: true })
   }
 }
 
@@ -85,4 +99,24 @@ export function adaptWorkflowForNestedBackend(content: string): string {
   )
 
   return result
+}
+
+/**
+ * Rewrite the starter's Render Blueprint so each service that builds from source
+ * deploys the `backend/` subdirectory instead of the repo root. The starter
+ * authors render.yaml for a repo where the Rails app *is* the root; in the
+ * wrapper project the app lives under backend/, so without `rootDir: backend`
+ * Render runs `bundle install` at the root (no Gemfile) and the build fails.
+ *
+ * `rootDir` is added after every `runtime:` line — the marker of a
+ * build-from-source service (web, worker) — while managed services (redis,
+ * databases) have no runtime and are left untouched. The commented-out worker
+ * template is handled too: its `runtime:` line keeps its `#` prefix, so
+ * uncommenting the block yields a correctly-rooted worker.
+ */
+export function adaptRenderYamlForNestedBackend(content: string): string {
+  return content.replace(
+    /^([ \t]*(?:#[ \t]*)?)runtime:.*$/gm,
+    (line, prefix) => `${line}\n${prefix}rootDir: backend`,
+  )
 }

--- a/packages/create-spree-app/tests/backend.test.ts
+++ b/packages/create-spree-app/tests/backend.test.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { adaptWorkflowForNestedBackend, prepareBackendTemplate } from '../src/backend'
+import {
+  adaptRenderYamlForNestedBackend,
+  adaptWorkflowForNestedBackend,
+  prepareBackendTemplate,
+} from '../src/backend'
 
 // Mirrors spree-starter's .github/workflows/backend-ci.yml (the workflow that
 // create-spree-app relocates to the generated project root).
@@ -56,6 +60,39 @@ jobs:
           context: .
 `
 
+// Mirrors spree-starter's render.yaml (the Render Blueprint create-spree-app
+// relocates to the generated project root). Includes an active web service, the
+// commented-out worker template, a managed redis service, and a database — the
+// mix that exercises which services get `rootDir`.
+const RENDER_YAML = `services:
+  - type: web
+    name: spree
+    runtime: ruby
+    plan: free
+    buildCommand: bundle install && bundle exec rails db:prepare
+    startCommand: bundle exec puma -C config/puma.rb
+    healthCheckPath: /up
+
+  # uncomment to add background jobs, requires standard (paid) plan
+  # - type: worker
+  #   name: spree-worker
+  #   runtime: ruby
+  #   plan: standard
+  #   buildCommand: bundle install && bundle exec rails assets:precompile
+  #   startCommand: bundle exec sidekiq
+
+  - type: redis
+    name: spree-redis
+    plan: free
+    ipAllowList: []
+
+databases:
+  - name: spree-db
+    plan: free
+    databaseName: spree
+    ipAllowList: []
+`
+
 describe('adaptWorkflowForNestedBackend', () => {
   it('points ruby/setup-ruby at the backend/ subdirectory', () => {
     const result = adaptWorkflowForNestedBackend(BACKEND_CI)
@@ -94,6 +131,26 @@ describe('adaptWorkflowForNestedBackend', () => {
   })
 })
 
+describe('adaptRenderYamlForNestedBackend', () => {
+  it('adds rootDir: backend to the buildable web service', () => {
+    const result = adaptRenderYamlForNestedBackend(RENDER_YAML)
+    expect(result).toContain('    runtime: ruby\n    rootDir: backend\n')
+  })
+
+  it('adds a commented rootDir to the commented worker so uncommenting still deploys', () => {
+    const result = adaptRenderYamlForNestedBackend(RENDER_YAML)
+    expect(result).toContain('  #   runtime: ruby\n  #   rootDir: backend\n')
+  })
+
+  it('leaves managed services (redis, databases) untouched', () => {
+    const result = adaptRenderYamlForNestedBackend(RENDER_YAML)
+    // redis and the database have no runtime, so no rootDir is injected for them
+    expect(result.match(/rootDir: backend/g)).toHaveLength(2)
+    expect(result).toContain('  - type: redis\n    name: spree-redis\n    plan: free')
+    expect(result).toContain('databases:\n  - name: spree-db')
+  })
+})
+
 describe('prepareBackendTemplate', () => {
   const tempDirs: string[] = []
 
@@ -106,6 +163,7 @@ describe('prepareBackendTemplate', () => {
     fs.writeFileSync(path.join(workflows, 'backend-ci.yml'), BACKEND_CI)
     fs.writeFileSync(path.join(workflows, 'release.yml'), RELEASE)
     fs.writeFileSync(path.join(projectDir, 'backend', 'README.md'), '# Spree starter')
+    fs.writeFileSync(path.join(projectDir, 'backend', 'render.yaml'), RENDER_YAML)
 
     return projectDir
   }
@@ -137,5 +195,16 @@ describe('prepareBackendTemplate', () => {
     prepareBackendTemplate(projectDir)
 
     expect(fs.existsSync(path.join(projectDir, 'backend', 'README.md'))).toBe(false)
+  })
+
+  it('relocates render.yaml to the project root with rootDir: backend', () => {
+    const projectDir = seedClonedBackend()
+    prepareBackendTemplate(projectDir)
+
+    const moved = path.join(projectDir, 'render.yaml')
+    expect(fs.existsSync(moved)).toBe(true)
+    expect(fs.readFileSync(moved, 'utf-8')).toContain('    runtime: ruby\n    rootDir: backend\n')
+    // The original in backend/ is removed so Render never reads a stale copy.
+    expect(fs.existsSync(path.join(projectDir, 'backend', 'render.yaml'))).toBe(false)
   })
 })

--- a/packages/create-spree-app/tests/backend.test.ts
+++ b/packages/create-spree-app/tests/backend.test.ts
@@ -60,37 +60,21 @@ jobs:
           context: .
 `
 
-// Mirrors spree-starter's render.yaml (the Render Blueprint create-spree-app
-// relocates to the generated project root). Includes an active web service, the
-// commented-out worker template, a managed redis service, and a database — the
-// mix that exercises which services get `rootDir`.
+// A trimmed render.yaml covering the three shapes the transform distinguishes:
+// a buildable service (has `runtime:`), the commented-out worker template
+// (`runtime:` behind a `#`), and a managed service (no `runtime:`).
 const RENDER_YAML = `services:
   - type: web
-    name: spree
     runtime: ruby
     plan: free
-    buildCommand: bundle install && bundle exec rails db:prepare
-    startCommand: bundle exec puma -C config/puma.rb
-    healthCheckPath: /up
 
-  # uncomment to add background jobs, requires standard (paid) plan
   # - type: worker
-  #   name: spree-worker
   #   runtime: ruby
   #   plan: standard
-  #   buildCommand: bundle install && bundle exec rails assets:precompile
-  #   startCommand: bundle exec sidekiq
 
   - type: redis
     name: spree-redis
     plan: free
-    ipAllowList: []
-
-databases:
-  - name: spree-db
-    plan: free
-    databaseName: spree
-    ipAllowList: []
 `
 
 describe('adaptWorkflowForNestedBackend', () => {
@@ -142,12 +126,12 @@ describe('adaptRenderYamlForNestedBackend', () => {
     expect(result).toContain('  #   runtime: ruby\n  #   rootDir: backend\n')
   })
 
-  it('leaves managed services (redis, databases) untouched', () => {
+  it('leaves managed services (no runtime) untouched', () => {
     const result = adaptRenderYamlForNestedBackend(RENDER_YAML)
-    // redis and the database have no runtime, so no rootDir is injected for them
+    // Only web + the commented worker have a runtime, so exactly two rootDirs;
+    // redis has none and is left verbatim.
     expect(result.match(/rootDir: backend/g)).toHaveLength(2)
     expect(result).toContain('  - type: redis\n    name: spree-redis\n    plan: free')
-    expect(result).toContain('databases:\n  - name: spree-db')
   })
 })
 


### PR DESCRIPTION
## Summary

When `create-spree-app` generates a project with a nested `backend/` layout, the Render Blueprint (`render.yaml`) must be relocated from the backend subdirectory to the repository root and adapted so that buildable services (web, worker) deploy from the `backend/` directory.

## Problem

The starter's `render.yaml` is authored for a repository where the Rails app is at the root. In the wrapper project layout:
- A Blueprint left in `backend/` is invisible to Render (which reads from the repo root)
- Even if placed at the root, services would build from the wrong directory, causing deployment failures (e.g., `bundle install` fails when Gemfile is in `backend/`)

## Solution

- **New function `adaptRenderYamlForNestedBackend()`**: Rewrites the Blueprint by adding `rootDir: backend` after every `runtime:` line (marking buildable services like web and worker), while leaving managed services (Redis, databases) untouched
- **Updated `prepareBackendTemplate()`**: Relocates `render.yaml` from `backend/` to the project root with the adaptation applied, then removes the original to prevent Render from reading a stale copy
- **Commented worker handling**: The commented-out worker template is adjusted with `#   rootDir: backend`, so uncommenting the block yields a correctly-rooted worker

## Changes

- Added `adaptRenderYamlForNestedBackend()` export to `src/backend.ts` with regex-based transformation
- Updated `prepareBackendTemplate()` to handle `render.yaml` relocation and adaptation
- Added comprehensive test suite in `tests/backend.test.ts` covering:
  - Web service rootDir injection
  - Commented worker template handling
  - Managed service preservation (Redis left untouched)
  - End-to-end file relocation and cleanup
- Added changeset documenting the patch

https://claude.ai/code/session_01YHhWFx1oNUGtLiKZDjMbj6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to scaffold-time file generation and string transforms in create-spree-app; no runtime or auth changes.
> 
> **Overview**
> Fixes **Render deploys** for projects scaffolded with a nested `backend/` layout by moving the starter’s `render.yaml` to the **repo root** (where Render reads Blueprints) and injecting **`rootDir: backend`** on every build-from-source service (`runtime:` lines).
> 
> Adds **`adaptRenderYamlForNestedBackend()`** (same idea as the existing CI adapter) so web/worker builds run against `backend/`; **managed services** without `runtime:` stay unchanged. **Commented worker** blocks get a matching commented `rootDir`, so uncommenting still works. **`prepareBackendTemplate()`** writes the adapted file at the project root and deletes `backend/render.yaml` to avoid a stale copy.
> 
> Tests cover the transform and end-to-end relocation; version **1.0.8** and changelog updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835b36c08f99680034f26949f93e92b97cd0611f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated backend projects now place the deployment config at the project root and automatically point buildable services to the nested `backend/` app directory.
  * Commented service templates are updated so they still work correctly if later enabled.
* **Bug Fixes**
  * Removed the stale nested deployment config after setup to prevent deployment tools from reading the wrong file.
* **Chores**
  * Updated the project version and release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->