### PR TITLE
Permit admin_name on stock location strong params

### DIFF
--- a/spree/admin/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Spree::Admin::StockLocationsController, type: :controller do
     let(:stock_location_params) do
       {
         name: 'Main Warehouse',
+        admin_name: 'Internal Warehouse',
         address1: '123 Main St',
         city: 'Portland',
         zipcode: '97210',
@@ -48,6 +49,7 @@ RSpec.describe Spree::Admin::StockLocationsController, type: :controller do
 
       expect(stock_location).to be_persisted
       expect(stock_location.name).to eq('Main Warehouse')
+      expect(stock_location.admin_name).to eq('Internal Warehouse')
       expect(stock_location.address1).to eq('123 Main St')
       expect(stock_location.city).to eq('Portland')
     end
@@ -68,10 +70,11 @@ RSpec.describe Spree::Admin::StockLocationsController, type: :controller do
     let!(:stock_location) { create(:stock_location, name: 'Main Warehouse') }
 
     it 'updates the stock location' do
-      put :update, params: { id: stock_location.to_param, stock_location: { name: 'New Warehouse' } }
+      put :update, params: { id: stock_location.to_param, stock_location: { name: 'New Warehouse', admin_name: 'Internal Warehouse' } }
 
       expect(response).to redirect_to(spree.edit_admin_stock_location_path(stock_location))
       expect(stock_location.reload.name).to eq('New Warehouse')
+      expect(stock_location.admin_name).to eq('Internal Warehouse')
     end
   end
 

--- a/spree/core/lib/spree/permitted_attributes.rb
+++ b/spree/core/lib/spree/permitted_attributes.rb
@@ -257,7 +257,7 @@ module Spree
     @@stock_item_attributes = [:variant_id, :stock_location_id, :backorderable, :count_on_hand, { metadata: {} }]
 
     @@stock_location_attributes = [
-      :name, :active, :address1, :address2, :city, :zipcode, :company,
+      :name, :admin_name, :active, :address1, :address2, :city, :zipcode, :company,
       :backorderable_default, :state_name, :state_id, :country_id, :phone,
       :propagate_all_variants
     ]


### PR DESCRIPTION
The admin stock location form renders the admin_name field, but it was missing from the permitted attributes, so it was silently dropped and never persisted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows a strong-params gap for an existing admin-only field; no auth or storefront behavior changes.
> 
> **Overview**
> Fixes a bug where the admin stock location **internal name** (`admin_name`) field was shown on the form but never saved because it was omitted from strong parameters.
> 
> Adds `:admin_name` to `@@stock_location_attributes` in `permitted_attributes.rb`, and extends the stock locations controller specs so create/update assert `admin_name` is persisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d084c1b5ca2a74c94e1812b2845c54b79cf8b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stock locations now support an administrative name field, allowing users to assign custom identifiers for improved organization and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->