### PR TITLE
Fix Import group performance issues

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,15 @@
       "Bash(rm -rf server/.git server/.gitignore)",
       "Skill(update-config)",
       "Skill(simplify)",
-      "mcp__claude_ai_Claude_Code_Remote__list_triggers"
+      "mcp__claude_ai_Claude_Code_Remote__list_triggers",
+      "mcp__scout-apm__list_apps",
+      "mcp__scout-apm__get_app_jobs",
+      "mcp__scout-apm__get_app_job_traces",
+      "mcp__scout-apm__get_job_metrics",
+      "mcp__scout-apm__get_app_trace",
+      "mcp__scout-apm__get_app_insights",
+      "mcp__scout-apm__get_app_error_groups",
+      "mcp__scout-apm__get_app_anomaly_events"
     ],
     "deny": [
       "Bash(sudo *)",

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -1,6 +1,10 @@
 module Spree
   module Imports
     class ProcessGroupJob < Spree::Imports::BaseJob
+      # Rows are loaded in slices so a large group never holds every ImportRow
+      # (and its raw CSV data) in memory for the whole job.
+      ROWS_BATCH_SIZE = 100
+
       def perform(import_id, row_ids)
         import = Spree::Import.find(import_id)
         Spree::Current.store = import.store
@@ -8,16 +12,23 @@ module Spree
         mappings = import.mappings.mapped.to_a
         schema_fields = import.schema_fields
         large = import.large_import?
-        # Skip rows already completed on a prior attempt so retries don't double-process them.
-        rows = import.rows.where(id: row_ids).pending_and_failed.order(:row_number)
 
-        if large
-          Spree::Events.disable do
-            rows.each { |row| row.bulk_process!(mappings: mappings, schema_fields: schema_fields) }
-          end
-        else
-          rows.each do |row|
-            row.process!(mappings: mappings, schema_fields: schema_fields)
+        row_ids.each_slice(ROWS_BATCH_SIZE) do |ids|
+          # Skip rows already completed on a prior attempt so retries don't double-process them.
+          rows = import.rows.where(id: ids).pending_and_failed.order(:row_number).to_a
+          # Share the already-loaded import across rows: each row's processor reads
+          # `row.import` (store, ability, lookup cache), and without this every row
+          # lazily loads its own Import instance and rebuilds all of that per row.
+          rows.each { |row| row.association(:import).target = import }
+
+          if large
+            Spree::Events.disable do
+              rows.each { |row| row.bulk_process!(mappings: mappings, schema_fields: schema_fields) }
+            end
+          else
+            rows.each do |row|
+              row.process!(mappings: mappings, schema_fields: schema_fields)
+            end
           end
         end
 

--- a/spree/core/app/jobs/spree/imports/process_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_rows_job.rb
@@ -2,6 +2,7 @@ module Spree
   module Imports
     class ProcessRowsJob < Spree::Imports::BaseJob
       BATCH_SIZE = 100
+      UNGROUPED_KEY = '__ungrouped__'.freeze
 
       def perform(import_id)
         import = Spree::Import.find(import_id)
@@ -27,20 +28,27 @@ module Spree
 
         import.rows.pending_and_failed.order(:row_number).pluck(:id, :data).each do |id, data|
           parsed = JSON.parse(data)
-          key = parsed[file_column].to_s.strip.downcase.presence || '__ungrouped__'
+          key = parsed[file_column].to_s.strip.downcase.presence || UNGROUPED_KEY
           groups[key] << id
         rescue JSON::ParserError
-          groups['__ungrouped__'] << id
+          groups[UNGROUPED_KEY] << id
         end
+
+        # Rows without a group value don't depend on each other, so they don't have
+        # to share a single job — split them into bounded batches. Real groups stay
+        # intact: their rows must run sequentially (product row before variant rows).
+        ungrouped = groups.delete(UNGROUPED_KEY)
+        batches = groups.values
+        ungrouped&.each_slice(BATCH_SIZE) { |row_ids| batches << row_ids }
 
         # Set count before enqueuing so workers can't complete prematurely
         import.update_columns(
-          processing_groups_count: groups.size,
+          processing_groups_count: batches.size,
           completed_groups_count: 0,
           updated_at: Time.current
         )
 
-        groups.each_value { |row_ids| ProcessGroupJob.perform_later(import.id, row_ids) }
+        batches.each { |row_ids| ProcessGroupJob.perform_later(import.id, row_ids) }
       end
 
       def dispatch_batched(import)

--- a/spree/core/app/models/spree/import.rb
+++ b/spree/core/app/models/spree/import.rb
@@ -245,6 +245,15 @@ module Spree
       @current_ability ||= Spree.ability_class.new(user, { store: store })
     end
 
+    # Per-instance cache shared by row processors within a single processing job.
+    # Group jobs funnel every row through the same Import instance, so lookups of
+    # shared records (tax/shipping categories, option types, metafield definitions)
+    # resolve once per job instead of once per row.
+    # @return [Hash]
+    def row_lookup_cache
+      @row_lookup_cache ||= {}
+    end
+
     def event_serializer_class
       'Spree::Api::V3::ImportSerializer'.safe_constantize
     end

--- a/spree/core/app/services/spree/imports/row_processors/base.rb
+++ b/spree/core/app/services/spree/imports/row_processors/base.rb
@@ -20,6 +20,15 @@ module Spree
 
         private
 
+        # Memoizes a shared-record lookup (including nil misses) in the import's
+        # per-job cache so repeated rows don't re-run the same query.
+        def cached_lookup(*key)
+          cache = import.row_lookup_cache
+          return cache[key] if cache.key?(key)
+
+          cache[key] = yield
+        end
+
         def build_schema_hash(row, mappings, schema_fields)
           attributes = {}
           schema_fields.each do |field|

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -123,12 +123,16 @@ module Spree
 
         def prepare_shipping_category
           shipping_category_name = attributes['shipping_category'].strip
-          Spree::ShippingCategory.find_by(name: shipping_category_name)
+          cached_lookup(:shipping_category, shipping_category_name) do
+            Spree::ShippingCategory.find_by(name: shipping_category_name)
+          end
         end
 
         def prepare_tax_category
           tax_category_name = attributes['tax_category'].strip
-          Spree::TaxCategory.find_by(name: tax_category_name)
+          cached_lookup(:tax_category, tax_category_name) do
+            Spree::TaxCategory.find_by(name: tax_category_name)
+          end
         end
 
         def prepare_option_value_variants
@@ -171,27 +175,39 @@ module Spree
         # surfaces via the DB unique index (RecordNotUnique) or the AR uniqueness
         # validator (RecordInvalid with a :taken error on the relevant attribute).
         def find_or_create_option_type!(presentation)
-          Spree::OptionType.search_by_name(presentation).first || Spree::OptionType.create!(presentation: presentation)
-        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-          raise unless uniqueness_conflict?(e, :name)
+          cached_lookup(:option_type, presentation) do
+            begin
+              Spree::OptionType.search_by_name(presentation).first || Spree::OptionType.create!(presentation: presentation)
+            rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+              raise unless uniqueness_conflict?(e, :name)
 
-          Spree::OptionType.search_by_name(presentation).first!
+              Spree::OptionType.search_by_name(presentation).first!
+            end
+          end
         end
 
         def find_or_create_option_value!(option_type, presentation)
-          option_type.option_values.search_by_name(presentation).first || option_type.option_values.create!(presentation: presentation)
-        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-          raise unless uniqueness_conflict?(e, :name)
+          cached_lookup(:option_value, option_type.id, presentation) do
+            begin
+              option_type.option_values.search_by_name(presentation).first || option_type.option_values.create!(presentation: presentation)
+            rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+              raise unless uniqueness_conflict?(e, :name)
 
-          option_type.option_values.search_by_name(presentation).first!
+              option_type.option_values.search_by_name(presentation).first!
+            end
+          end
         end
 
         def find_or_create_product_option_type!(option_type)
-          Spree::ProductOptionType.find_or_create_by!(product: product, option_type: option_type)
-        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-          raise unless uniqueness_conflict?(e, :product_id)
+          cached_lookup(:product_option_type, product.id, option_type.id) do
+            begin
+              Spree::ProductOptionType.find_or_create_by!(product: product, option_type: option_type)
+            rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+              raise unless uniqueness_conflict?(e, :product_id)
 
-          Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
+              Spree::ProductOptionType.find_by!(product: product, option_type: option_type)
+            end
+          end
         end
 
         # RecordNotUnique is always a uniqueness conflict; RecordInvalid only when the
@@ -245,11 +261,13 @@ module Spree
             namespace, key = product.extract_namespace_and_key(full_key)
 
             # Find or initialize metafield definition
-            metafield_definition = Spree::MetafieldDefinition.find_by(
-              namespace: namespace,
-              key: key,
-              resource_type: product.class.name
-            )
+            metafield_definition = cached_lookup(:metafield_definition, namespace, key, product.class.name) do
+              Spree::MetafieldDefinition.find_by(
+                namespace: namespace,
+                key: key,
+                resource_type: product.class.name
+              )
+            end
 
             next unless metafield_definition
 

--- a/spree/core/spec/jobs/spree/imports/process_rows_job_spec.rb
+++ b/spree/core/spec/jobs/spree/imports/process_rows_job_spec.rb
@@ -66,6 +66,32 @@ RSpec.describe Spree::Imports::ProcessRowsJob, type: :job do
         described_class.perform_now(import.id)
       end
     end
+
+    context 'with rows missing the group value' do
+      before { stub_const('Spree::Imports::ProcessRowsJob::BATCH_SIZE', 2) }
+
+      let!(:ungrouped_rows) do
+        3.times.map do |i|
+          create(:import_row, import: import, row_number: 4 + i, status: :pending,
+                 data: { 'sku' => "LONE#{i}", 'name' => "Lone #{i}", 'price' => '5.00' }.to_json)
+        end
+      end
+
+      it 'splits ungrouped rows into bounded batches instead of one unbounded job' do
+        expect(Spree::Imports::ProcessGroupJob).to receive(:perform_later)
+          .with(import.id, [product_row.id, variant_row.id])
+        expect(Spree::Imports::ProcessGroupJob).to receive(:perform_later)
+          .with(import.id, [other_product_row.id])
+        expect(Spree::Imports::ProcessGroupJob).to receive(:perform_later)
+          .with(import.id, ungrouped_rows.first(2).map(&:id))
+        expect(Spree::Imports::ProcessGroupJob).to receive(:perform_later)
+          .with(import.id, [ungrouped_rows.last.id])
+
+        described_class.perform_now(import.id)
+
+        expect(import.reload.processing_groups_count).to eq(4)
+      end
+    end
   end
 
   describe 'batched import (Customers — no group_column)' do


### PR DESCRIPTION
- process_group_job.rb — rows now load in slices of 100 instead of the whole group at once, and every row shares the job's already-loaded Import instance via association(:import).target. That last bit was a hidden per-row cascade: each row was lazily loading its own Import, its polymorphic owner, and rebuilding the CanCanCan ability from scratch — all gone now, one per job.
- process_rows_job.rb — the __ungrouped__ bucket (rows with a blank/unparseable group value) is now split into BATCH_SIZE chunks instead of becoming one unbounded job. Real slug groups stay intact since their rows must run in order (product row before variant rows).
- import.rb + row processors — new per-job row_lookup_cache on Spree::Import with a cached_lookup helper in the processor base (caches nil misses too). ProductVariant now caches shipping/tax categories, option types, option values, product option types, and metafield definitions — previously re-queried for every row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core import job orchestration and shared-record find-or-create caching; ordering for real groups is preserved but concurrent imports could behave differently around cached option/metafield resolution.
> 
> **Overview**
> Improves **import group processing** so large jobs use less memory and fewer redundant DB loads, without changing the rule that real slug groups still run in one ordered job.
> 
> **`ProcessGroupJob`** now loads rows in slices of **100** instead of the full `row_ids` set, and pins each row’s `import` association to the job’s already-loaded `Spree::Import` so processors don’t reload import, owner, and CanCan ability per row.
> 
> **`ProcessRowsJob`** keeps true product groups intact but **splits the ungrouped bucket** (blank or bad JSON group values) into `BATCH_SIZE` chunks, updating `processing_groups_count` to match the new batch list. A spec covers this behavior.
> 
> **`Spree::Import#row_lookup_cache`** plus **`cached_lookup`** on the row processor base feed **`ProductVariant`** lookups (shipping/tax categories, option types/values, product option types, metafield definitions), including cached nil misses.
> 
> Also adds Scout APM MCP tool permissions in **`.claude/settings.local.json`** (dev tooling only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e412580b75c31051e78eed4224d40f48f8f80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import jobs now process large row sets in smaller batches, improving stability and throughput.
  * Ungrouped import rows are now split into manageable batches instead of being handled as one large task.

* **Bug Fixes**
  * Reduced repeated record lookups during product variant imports, which should improve performance and lower the chance of import slowdowns.
  * Improved handling of shared import data so rows in the same job reuse loaded information more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->