### PR TITLE
Add fingerprint-based deduplication to Spree::CreditCard

### DIFF
--- a/spree/core/app/models/spree/credit_card.rb
+++ b/spree/core/app/models/spree/credit_card.rb
@@ -37,6 +37,11 @@ module Spree
       validates :name, presence: true
     end
 
+    # Prevents saving the same physical card (same gateway fingerprint + expiry)
+    # twice for a user and payment method. Skipped when the gateway does not
+    # provide a fingerprint.
+    validate :fingerprint_not_duplicated, if: -> { fingerprint.present? }
+
     scope :with_payment_profile, -> { where.not(gateway_customer_profile_id: nil) }
     scope :capturable, -> { where.not(gateway_customer_profile_id: nil).or(where.not(gateway_payment_profile_id: nil)) }
     scope :default, -> { where(default: true) }
@@ -46,6 +51,19 @@ module Spree
            where('CAST(spree_credit_cards.month AS DECIMAL) >= ?', Time.current.month))
     }
     scope :not_removed, -> { where(deleted_at: nil) }
+
+    # Matches saved cards by the gateway's stable card fingerprint plus expiry,
+    # used to reuse an existing card instead of saving a duplicate when a gateway
+    # issues a fresh payment method id for the same physical card.
+    #
+    # @param fingerprint [String] gateway card fingerprint
+    # @param month [Integer, String] expiry month
+    # @param year [Integer, String] expiry year
+    scope :by_fingerprint, ->(fingerprint, month, year) {
+      where(fingerprint: fingerprint).
+        where("CAST(#{table_name}.month AS DECIMAL) = ?", month).
+        where("CAST(#{table_name}.year AS DECIMAL) = ?", year)
+    }
 
     alias_attribute :brand, :cc_type
     alias_attribute :last4, :last_digits
@@ -164,6 +182,17 @@ module Spree
     end
 
     private
+
+    # month/year are varchar columns exposed as integer attributes, so the
+    # match must go through #by_fingerprint's decimal cast rather than a plain
+    # equality (which Postgres rejects as `character varying = integer`).
+    def fingerprint_not_duplicated
+      duplicates = self.class.where(user_id: user_id, payment_method_id: payment_method_id).
+                   by_fingerprint(fingerprint, month, year)
+      duplicates = duplicates.where.not(id: id) if persisted?
+
+      errors.add(:fingerprint, :taken) if duplicates.exists?
+    end
 
     def require_card_numbers?
       !encrypted_data.present? && !has_payment_profile?

--- a/spree/core/db/migrate/20260707000001_add_fingerprint_to_spree_credit_cards.rb
+++ b/spree/core/db/migrate/20260707000001_add_fingerprint_to_spree_credit_cards.rb
@@ -1,0 +1,39 @@
+class AddFingerprintToSpreeCreditCards < ActiveRecord::Migration[7.2]
+  INDEX_NAME = 'index_spree_credit_cards_unique_fingerprint'.freeze
+
+  def up
+    add_column :spree_credit_cards, :fingerprint, :string
+
+    # Prevent duplicate saved cards (same gateway fingerprint + expiry) per user
+    # and payment method at the database level, backing the application-level
+    # check against concurrent writes. Only active, fingerprinted cards are
+    # constrained, so legacy/non-gateway cards (NULL fingerprint) and
+    # soft-deleted rows are left untouched.
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      # MySQL has no partial indexes, but treats NULL as distinct in unique
+      # indexes, so NULL fingerprints are naturally allowed. COALESCE on
+      # deleted_at keeps soft-deleted rows from colliding with active ones.
+      execute <<-SQL
+        CREATE UNIQUE INDEX #{INDEX_NAME}
+        ON spree_credit_cards(
+          user_id,
+          payment_method_id,
+          fingerprint,
+          month,
+          year,
+          (COALESCE(deleted_at, CAST('1970-01-01' AS DATETIME)))
+        )
+      SQL
+    else
+      add_index :spree_credit_cards, [:user_id, :payment_method_id, :fingerprint, :month, :year],
+                unique: true,
+                where: 'fingerprint IS NOT NULL AND deleted_at IS NULL',
+                name: INDEX_NAME
+    end
+  end
+
+  def down
+    remove_index :spree_credit_cards, name: INDEX_NAME
+    remove_column :spree_credit_cards, :fingerprint
+  end
+end

--- a/spree/core/spec/models/spree/credit_card_spec.rb
+++ b/spree/core/spec/models/spree/credit_card_spec.rb
@@ -146,6 +146,46 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
+  describe 'fingerprint uniqueness' do
+    let(:user) { create(:user) }
+    let(:payment_method) { create(:credit_card_payment_method) }
+    let!(:existing_card) do
+      create(:credit_card, user: user, payment_method: payment_method,
+                           fingerprint: 'FZqjhq46SWprIY8i', month: 11, year: 2030)
+    end
+
+    def build_duplicate(attributes = {})
+      build(
+        :credit_card,
+        { user: user, payment_method: payment_method, fingerprint: 'FZqjhq46SWprIY8i', month: 11, year: 2030 }.merge(attributes)
+      )
+    end
+
+    it 'rejects the same physical card for the same user, payment method and expiry' do
+      card = build_duplicate
+      expect(card).not_to be_valid
+      expect(card.errors[:fingerprint]).to be_present
+    end
+
+    it 'allows the same fingerprint with a different expiry' do
+      expect(build_duplicate(year: 2031)).to be_valid
+    end
+
+    it 'allows the same fingerprint under a different payment method' do
+      expect(build_duplicate(payment_method: create(:credit_card_payment_method))).to be_valid
+    end
+
+    it 'does not enforce uniqueness when the fingerprint is missing' do
+      create(:credit_card, user: user, payment_method: payment_method, fingerprint: nil, month: 11, year: 2030)
+      expect(build_duplicate(fingerprint: nil)).to be_valid
+    end
+
+    it 'ignores soft-deleted cards' do
+      existing_card.destroy
+      expect(build_duplicate).to be_valid
+    end
+  end
+
   describe '#save' do
     before do
       credit_card.attributes = valid_credit_card_attributes
@@ -394,6 +434,24 @@ describe Spree::CreditCard, type: :model do
 
       it 'does not include credit cards without profile or payment id' do
         expect(described_class.capturable).not_to include(credit_card_without_profile_or_payment_id)
+      end
+    end
+
+    describe '#by_fingerprint' do
+      let!(:match) { create(:credit_card, fingerprint: 'FZqjhq46SWprIY8i', month: 2, year: 2030) }
+      let!(:other_fingerprint) { create(:credit_card, fingerprint: 'differentFingerprint', month: 2, year: 2030) }
+      let!(:other_expiry) { create(:credit_card, fingerprint: 'FZqjhq46SWprIY8i', month: 12, year: 2031) }
+
+      it 'returns cards matching the fingerprint and expiry' do
+        expect(described_class.by_fingerprint('FZqjhq46SWprIY8i', 2, 2030)).to contain_exactly(match)
+      end
+
+      it 'matches when month and year are passed as strings' do
+        expect(described_class.by_fingerprint('FZqjhq46SWprIY8i', '2', '2030')).to contain_exactly(match)
+      end
+
+      it 'returns nothing when the expiry differs' do
+        expect(described_class.by_fingerprint('FZqjhq46SWprIY8i', 1, 2030)).to be_empty
       end
     end
   end


### PR DESCRIPTION
Prevents saving the same physical card twice for a user and payment method when a gateway issues a fresh payment method id for it. Adds a fingerprint column, a by_fingerprint scope, a uniqueness validation, and a partial unique index. Cards without a fingerprint and soft-deleted records are not constrained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment card persistence with a new uniqueness constraint; incorrect fingerprint or expiry handling could block legitimate saves or allow duplicates, though NULL fingerprints and soft-deleted cards are excluded.
> 
> **Overview**
> Adds **gateway fingerprint–based deduplication** on `Spree::CreditCard` so the same physical card is not stored twice for a user and payment method when the gateway returns a new payment method id.
> 
> A new **`fingerprint`** column is introduced with a **`by_fingerprint`** scope (fingerprint plus month/year, with decimal casts for varchar expiry columns). An application **`fingerprint_not_duplicated`** validation runs only when a fingerprint is present; duplicates are scoped by user, payment method, fingerprint, and expiry, and **soft-deleted** rows are ignored.
> 
> A **partial unique index** (Postgres) or **MySQL equivalent with `COALESCE` on `deleted_at`** enforces the same rule at the DB layer for concurrent writes. Cards with **NULL fingerprint** remain unconstrained.
> 
> Specs cover uniqueness edge cases and the **`by_fingerprint`** scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37eec1599a1094f84a55374e0edc17feaf69b10d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger duplicate-card prevention when saving payment cards with the same saved card details.

* **Bug Fixes**
  * Improved card matching so saved cards are recognized reliably even when expiry values are stored in different formats.
  * Soft-deleted cards no longer block adding a new card with the same saved details.
  * Duplicate card checks now respect card expiry, payment method, and customer account, reducing false conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->