### PR TITLE
Handle race condition in find_or_create_from_oauth method

### DIFF
--- a/spree/core/app/models/spree/user_identity.rb
+++ b/spree/core/app/models/spree/user_identity.rb
@@ -45,28 +45,32 @@ module Spree
           user_class: user_class
         )
       end
+    rescue ActiveRecord::RecordNotUnique
+      find_by!(provider: provider, uid: uid, user_type: user_type).user
     end
 
     def self.create_user_from_oauth(provider:, uid:, info:, tokens: {}, user_class: nil)
       user_class ||= Spree.user_class
 
-      user = user_class.create!(
-        email: info[:email] || generate_temp_email(provider, uid),
-        password: SecureRandom.hex(32), # Random password for OAuth users
-        first_name: info[:first_name],
-        last_name: info[:last_name]
-      )
+      transaction do
+        user = user_class.create!(
+          email: info[:email] || generate_temp_email(provider, uid),
+          password: SecureRandom.hex(32), # Random password for OAuth users
+          first_name: info[:first_name],
+          last_name: info[:last_name]
+        )
 
-      user.identities.create!(
-        provider: provider,
-        uid: uid,
-        info: info,
-        access_token: tokens[:access_token],
-        refresh_token: tokens[:refresh_token],
-        expires_at: tokens[:expires_at]
-      )
+        user.identities.create!(
+          provider: provider,
+          uid: uid,
+          info: info,
+          access_token: tokens[:access_token],
+          refresh_token: tokens[:refresh_token],
+          expires_at: tokens[:expires_at]
+        )
 
-      user
+        user
+      end
     end
 
     def self.generate_temp_email(provider, uid)

--- a/spree/core/app/models/spree/user_identity.rb
+++ b/spree/core/app/models/spree/user_identity.rb
@@ -5,10 +5,10 @@ module Spree
     belongs_to :user, polymorphic: true, optional: false
 
     validates :provider, presence: true
-    validates :uid, presence: true, uniqueness: { scope: [:provider, :user_type] }
+    validates :uid, presence: true, uniqueness: { scope: %i[provider user_type] }
 
     validates :provider, inclusion: {
-      in: ->(_record) {
+      in: lambda { |_record|
         (Spree.store_authentication_strategies.keys + Spree.admin_authentication_strategies.keys).uniq.map(&:to_s)
       }
     }
@@ -27,14 +27,7 @@ module Spree
       identity = find_by(provider: provider, uid: uid, user_type: user_type)
 
       if identity
-        # Update existing identity with fresh tokens
-        identity.update(
-          info: info,
-          access_token: tokens[:access_token],
-          refresh_token: tokens[:refresh_token],
-          expires_at: tokens[:expires_at]
-        )
-        identity.user
+        refresh_identity(identity, info: info, tokens: tokens).user
       else
         # Create new user and identity
         create_user_from_oauth(
@@ -46,7 +39,21 @@ module Spree
         )
       end
     rescue ActiveRecord::RecordNotUnique
-      find_by!(provider: provider, uid: uid, user_type: user_type).user
+      refresh_identity(
+        find_by!(provider: provider, uid: uid, user_type: user_type),
+        info: info,
+        tokens: tokens
+      ).user
+    end
+
+    def self.refresh_identity(identity, info:, tokens: {})
+      identity.update(
+        info: info,
+        access_token: tokens[:access_token],
+        refresh_token: tokens[:refresh_token],
+        expires_at: tokens[:expires_at]
+      )
+      identity
     end
 
     def self.create_user_from_oauth(provider:, uid:, info:, tokens: {}, user_class: nil)

--- a/spree/core/spec/models/spree/user_identity_spec.rb
+++ b/spree/core/spec/models/spree/user_identity_spec.rb
@@ -40,8 +40,7 @@ describe Spree::UserIdentity, type: :model do
       it 'allows same uid for different user types' do
         stub_const('Spree::AdminUser', Class.new(Spree.user_class))
 
-        different_user_type = build(:user_identity, user_type: 'Spree::AdminUser', user_id: user.id, provider: 'email',
-                                                    uid: '12345')
+        different_user_type = build(:user_identity, user_type: 'Spree::AdminUser', user_id: user.id, provider: 'email', uid: '12345')
         expect(different_user_type).to be_valid
       end
     end

--- a/spree/core/spec/models/spree/user_identity_spec.rb
+++ b/spree/core/spec/models/spree/user_identity_spec.rb
@@ -40,7 +40,8 @@ describe Spree::UserIdentity, type: :model do
       it 'allows same uid for different user types' do
         stub_const('Spree::AdminUser', Class.new(Spree.user_class))
 
-        different_user_type = build(:user_identity, user_type: 'Spree::AdminUser', user_id: user.id, provider: 'email', uid: '12345')
+        different_user_type = build(:user_identity, user_type: 'Spree::AdminUser', user_id: user.id, provider: 'email',
+                                                    uid: '12345')
         expect(different_user_type).to be_valid
       end
     end
@@ -191,6 +192,36 @@ describe Spree::UserIdentity, type: :model do
         expect(identity.info).to include('email' => 'new@example.com', 'first_name' => 'Jane')
       end
     end
+
+    context 'when a concurrent request creates the identity during the race window' do
+      let!(:winner) { create(:user, email: 'winner@example.com') }
+      let!(:winning_identity) do
+        create(:user_identity, user: winner, provider: provider, uid: uid)
+      end
+
+      before do
+        allow(described_class).to receive(:find_by).and_call_original
+        allow(described_class).to receive(:find_by)
+          .with(provider: provider, uid: uid, user_type: Spree.user_class.name)
+          .and_return(nil)
+        allow(described_class).to receive(:create_user_from_oauth)
+          .and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it 'recovers by returning the winner instead of raising error' do
+        result = nil
+        expect do
+          result = described_class.find_or_create_from_oauth(
+            provider: provider,
+            uid: uid,
+            info: info,
+            tokens: tokens
+          )
+        end.not_to raise_error
+
+        expect(result).to eq(winner)
+      end
+    end
   end
 
   describe '.create_user_from_oauth' do
@@ -205,6 +236,28 @@ describe Spree::UserIdentity, type: :model do
       expect(user.persisted?).to be_truthy
       expect(user.valid?).to be_truthy
       expect(user.password).to be_present
+    end
+
+    context 'when the identity insert fails' do
+      subject do
+        described_class.create_user_from_oauth(
+          provider: 'email',
+          uid: 'dup',
+          info: { email: 'test@example.com' },
+          tokens: {}
+        )
+      end
+
+      before do
+        allow_any_instance_of(Spree.user_class).to receive(:identities)
+          .and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it 'rolls back the user' do
+        expect do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotUnique)
+        end.not_to change(Spree.user_class, :count)
+      end
     end
   end
 


### PR DESCRIPTION
https://vendo-connect.sentry.io/issues/7597758731/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OAuth account-creation path used by store/admin authentication strategies; behavior is narrowly defensive (retry + transaction) with new specs, but still touches identity uniqueness and user provisioning.
> 
> **Overview**
> Fixes concurrent OAuth sign-up failures when two requests try to create the same **provider/uid** identity after both miss on `find_by`.
> 
> **`find_or_create_from_oauth`** now rescues `ActiveRecord::RecordNotUnique`, reloads the existing identity with `find_by!`, and runs the same token/info refresh via a new **`refresh_identity`** helper instead of surfacing the DB error.
> 
> **`create_user_from_oauth`** wraps user + identity creation in a **transaction** and persists tokens on the identity in one place, so a failed identity insert rolls back the new user. Existing-identity updates also go through `refresh_identity`.
> 
> Specs add a simulated race (stale `find_by` + `RecordNotUnique` on create) and assert rollback when identity insert fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abad73c91daaf99d0e3aee5f48d68727581c80e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in/signup reliability when two requests try to create the same account at once.
  * Prevented duplicate identity errors from causing failures; the app now reuses the already-created account when available.
  * Kept user and identity creation consistent by rolling back incomplete account creation if identity setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->