### PR TITLE
Fix: disable Turbo for sign-out to allow following different hosts fo…

### DIFF
--- a/spree/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
+++ b/spree/admin/app/views/spree/admin/shared/_user_dropdown.html.erb
@@ -44,8 +44,11 @@
 
       <div class="dropdown-divider"></div>
 
-        <%= button_to spree_admin_logout_path, class: 'dropdown-item text-danger hover:bg-red-100 mb-0', method: :delete do %>
-          <%= icon('logout', class: "icon icon-logout")  %>
+        <%# Turbo is disabled so the browser follows the sign-out redirect
+            natively — apps may redirect to a different host (e.g. multi-tenant
+            setups), which Turbo's fetch cannot follow cross-origin. %>
+        <%= button_to spree_admin_logout_path, class: 'dropdown-item text-danger hover:bg-red-100 mb-0', method: :delete, form: { data: { turbo: false } } do %>
+          <%= icon('logout', class: "icon icon-logout") %>
           <%= Spree.t(:logout) %>
         <% end if defined?(spree_admin_logout_path) %>
       <% end %>


### PR DESCRIPTION
…r multi tenant setups

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-view change to logout form behavior; improves redirect handling with no new auth logic.
> 
> **Overview**
> The admin user dropdown **logout** action now submits with **`data-turbo="false"`** on the form so the browser performs a full navigation after sign-out instead of a Turbo fetch.
> 
> This fixes broken logout flows in **multi-tenant** setups where the session destroy response redirects to a **different host**, which Turbo cannot follow cross-origin. A short ERB comment documents the rationale next to the `button_to`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afcef1db62eb7494846e524dac3f5c8ff6bcf012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the sign-out flow so logout redirects work reliably in the admin area.
  * Improved the logout button behavior to ensure the browser handles the redirect correctly after signing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->