### PR TITLE
Use new `store=` setter in tests and remove the deprecated `stores=` …

### DIFF
--- a/spree/admin/spec/controllers/spree/admin/orders/order_promotions_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/orders/order_promotions_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Spree::Admin::Orders::OrderPromotionsController do
     end
 
     context 'with expired promotion' do
-      let(:promotion) { create(:promotion, :with_order_adjustment, code: 'EXPIRED', stores: [store], starts_at: 3.days.ago, expires_at: 1.day.ago) }
+      let(:promotion) { create(:promotion, :with_order_adjustment, code: 'EXPIRED', store: store, starts_at: 3.days.ago, expires_at: 1.day.ago) }
       let(:coupon_code) { promotion.code }
 
       it 'sets error flash message' do

--- a/spree/api/spec/controllers/spree/api/v3/admin/categories/products_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/categories/products_controller_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Spree::Api::V3::Admin::Categories::ProductsController, type: :con
   end
 
   describe 'GET #index' do
-    let!(:product_a) { create(:product, stores: [store]) }
-    let!(:product_b) { create(:product, stores: [store]) }
-    let!(:product_c) { create(:product, stores: [store]) }
-    let!(:other_category_product) { create(:product, stores: [store]) }
+    let!(:product_a) { create(:product, store: store) }
+    let!(:product_b) { create(:product, store: store) }
+    let!(:product_c) { create(:product, store: store) }
+    let!(:other_category_product) { create(:product, store: store) }
     let!(:other_category) { Spree::Category.create!(name: 'Other', store: store) }
 
     before do
@@ -49,7 +49,7 @@ RSpec.describe Spree::Api::V3::Admin::Categories::ProductsController, type: :con
   end
 
   describe 'POST #create' do
-    let!(:product) { create(:product, stores: [store]) }
+    let!(:product) { create(:product, store: store) }
 
     it 'adds the product to the category' do
       post :create, params: { category_id: category.prefixed_id, product_id: product.prefixed_id }, as: :json
@@ -67,7 +67,7 @@ RSpec.describe Spree::Api::V3::Admin::Categories::ProductsController, type: :con
   end
 
   describe 'DELETE #destroy' do
-    let!(:product) { create(:product, stores: [store]) }
+    let!(:product) { create(:product, store: store) }
 
     before { Spree::Classification.create!(taxon: category, product: product, position: 1) }
 
@@ -79,7 +79,7 @@ RSpec.describe Spree::Api::V3::Admin::Categories::ProductsController, type: :con
     end
 
     it '404s for a product not in the category' do
-      stray = create(:product, stores: [store])
+      stray = create(:product, store: store)
       delete :destroy, params: { category_id: category.prefixed_id, id: stray.prefixed_id }, as: :json
 
       expect(response).to have_http_status(:not_found)
@@ -87,9 +87,9 @@ RSpec.describe Spree::Api::V3::Admin::Categories::ProductsController, type: :con
   end
 
   describe 'PATCH #reposition' do
-    let!(:first)  { create(:product, stores: [store]) }
-    let!(:second) { create(:product, stores: [store]) }
-    let!(:third)  { create(:product, stores: [store]) }
+    let!(:first)  { create(:product, store: store) }
+    let!(:second) { create(:product, store: store) }
+    let!(:third)  { create(:product, store: store) }
 
     before do
       Spree::Classification.create!(taxon: category, product: first, position: 1)

--- a/spree/api/spec/controllers/spree/api/v3/admin/payment_methods_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/payment_methods_controller_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Spree::Api::V3::Admin::PaymentMethodsController, type: :controlle
 
     context 'when filtering by storefront_visible' do
       let!(:storefront_visible_method) do
-        create(:check_payment_method, stores: [store], display_on: 'both')
+        create(:check_payment_method, store: store, display_on: 'both')
       end
       let!(:admin_only_method) do
-        create(:check_payment_method, stores: [store], display_on: 'back_end')
+        create(:check_payment_method, store: store, display_on: 'back_end')
       end
 
       it 'returns only storefront-visible methods when q[storefront_visible_eq]=true' do

--- a/spree/api/spec/controllers/spree/api/v3/admin/promotion_actions_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/promotion_actions_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Spree::Api::V3::Admin::PromotionActionsController, type: :control
 
   include_context 'API v3 Admin authenticated'
 
-  let!(:promotion) { create(:promotion, stores: [store]) }
+  let!(:promotion) { create(:promotion, store: store) }
 
   before { request.headers.merge!(headers) }
 

--- a/spree/api/spec/controllers/spree/api/v3/admin/promotion_rules_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/promotion_rules_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Spree::Api::V3::Admin::PromotionRulesController, type: :controlle
 
   include_context 'API v3 Admin authenticated'
 
-  let!(:promotion) { create(:promotion, stores: [store]) }
+  let!(:promotion) { create(:promotion, store: store) }
 
   before { request.headers.merge!(headers) }
 

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/discount_codes_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/discount_codes_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Spree::Api::V3::Store::Carts::DiscountCodesController, type: :con
 
     context 'with expired promotion' do
       let!(:promotion) do
-        create(:promotion_with_item_adjustment, code: 'EXPIRED', stores: [store],
+        create(:promotion_with_item_adjustment, code: 'EXPIRED', store: store,
                starts_at: 1.month.ago, expires_at: 1.day.ago)
       end
 

--- a/spree/api/spec/integration/spree/api/v3/admin/categories_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/admin/categories_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe 'Admin Categories API', type: :request, swagger_doc: 'api-referen
       }
 
       response '201', 'product added' do
-        let!(:product) { create(:product, stores: [store]) }
+        let!(:product) { create(:product, store: store) }
         let(:'x-spree-api-key') { secret_api_key.plaintext_token }
         let(:category_id) { category.prefixed_id }
         let(:body) { { product_id: product.prefixed_id } }
@@ -293,7 +293,7 @@ RSpec.describe 'Admin Categories API', type: :request, swagger_doc: 'api-referen
       }
 
       response '204', 'product repositioned' do
-        let!(:product) { create(:product, stores: [store]) }
+        let!(:product) { create(:product, store: store) }
         let(:'x-spree-api-key') { secret_api_key.plaintext_token }
         let(:category_id) { category.prefixed_id }
         let(:id) { product.prefixed_id }

--- a/spree/core/spec/models/spree/category_spec.rb
+++ b/spree/core/spec/models/spree/category_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Spree::Category, type: :model do
     it 'decrements ancestors when a subcategory is destroyed' do
       parent = described_class.create!(name: 'Electronics', store: store)
       child = described_class.create!(name: 'Phones', parent: parent)
-      Spree::Classification.create!(taxon: child, product: create(:product, stores: [store]))
+      Spree::Classification.create!(taxon: child, product: create(:product, store: store))
       expect(parent.reload.products_count).to eq(1)
 
       child.destroy
@@ -36,8 +36,8 @@ RSpec.describe Spree::Category, type: :model do
       parent = described_class.create!(name: 'Electronics', store: store)
       phones = described_class.create!(name: 'Phones', parent: parent)
       laptops = described_class.create!(name: 'Laptops', parent: parent)
-      Spree::Classification.create!(taxon: phones, product: create(:product, stores: [store]))
-      Spree::Classification.create!(taxon: laptops, product: create(:product, stores: [store]))
+      Spree::Classification.create!(taxon: phones, product: create(:product, store: store))
+      Spree::Classification.create!(taxon: laptops, product: create(:product, store: store))
       expect(parent.reload.products_count).to eq(2)
 
       phones.destroy
@@ -49,7 +49,7 @@ RSpec.describe Spree::Category, type: :model do
       root = described_class.create!(name: 'Root', store: store)
       mid = described_class.create!(name: 'Mid', parent: root)
       leaf = described_class.create!(name: 'Leaf', parent: mid)
-      Spree::Classification.create!(taxon: leaf, product: create(:product, stores: [store]))
+      Spree::Classification.create!(taxon: leaf, product: create(:product, store: store))
       expect(root.reload.products_count).to eq(1)
 
       mid.destroy # removes the mid + leaf subtree
@@ -61,7 +61,7 @@ RSpec.describe Spree::Category, type: :model do
       root = described_class.create!(name: 'Root', store: store)
       a = described_class.create!(name: 'A', parent: root)
       b = described_class.create!(name: 'B', parent: root)
-      product = create(:product, stores: [store])
+      product = create(:product, store: store)
       Spree::Classification.create!(taxon: a, product: product)
       Spree::Classification.create!(taxon: b, product: product)
       expect(root.reload.products_count).to eq(1)
@@ -167,15 +167,15 @@ RSpec.describe Spree::Category, type: :model do
     end
 
     it 'counts a directly-assigned product on the category' do
-      add(create(:product, stores: [store]), phones)
+      add(create(:product, store: store), phones)
 
       expect(phones.reload.products_count).to eq(1)
       expect(phones.reload.classification_count).to eq(1)
     end
 
     it 'rolls subcategory products up to ancestors' do
-      add(create(:product, stores: [store]), phones)
-      add(create(:product, stores: [store]), laptops)
+      add(create(:product, store: store), phones)
+      add(create(:product, store: store), laptops)
 
       expect(electronics.reload.products_count).to eq(2) # inclusive
       expect(electronics.reload.classification_count).to eq(0) # nothing direct
@@ -184,7 +184,7 @@ RSpec.describe Spree::Category, type: :model do
     end
 
     it 'de-duplicates a product reachable through several nodes' do
-      product = create(:product, stores: [store])
+      product = create(:product, store: store)
       add(product, phones)
       add(product, electronics) # also directly on the ancestor
 
@@ -192,7 +192,7 @@ RSpec.describe Spree::Category, type: :model do
     end
 
     it 'decrements ancestors when a product is removed' do
-      product = create(:product, stores: [store])
+      product = create(:product, store: store)
       add(product, phones)
       expect(electronics.reload.products_count).to eq(1)
 
@@ -203,7 +203,7 @@ RSpec.describe Spree::Category, type: :model do
     end
 
     it 'maintains the count on a direct Classification create/destroy' do
-      product = create(:product, stores: [store])
+      product = create(:product, store: store)
       classification = Spree::Classification.create!(taxon: phones, product: product)
       expect(electronics.reload.products_count).to eq(1)
 
@@ -213,7 +213,7 @@ RSpec.describe Spree::Category, type: :model do
 
     it 'updates both ancestor chains when a subtree moves' do
       other_root = described_class.create!(name: 'Office', store: store)
-      add(create(:product, stores: [store]), phones)
+      add(create(:product, store: store), phones)
       expect(electronics.reload.products_count).to eq(1)
 
       phones.reload.move_to_child_of(other_root.reload)

--- a/spree/core/spec/models/spree/order_contents_spec.rb
+++ b/spree/core/spec/models/spree/order_contents_spec.rb
@@ -66,7 +66,7 @@ describe Spree::OrderContents, type: :model do
     end
 
     context 'running promotions' do
-      let(:promotion) { create(:promotion, kind: :automatic, stores: [store]) }
+      let(:promotion) { create(:promotion, kind: :automatic, store: store) }
       let(:calculator) { Spree::Calculator::FlatRate.new(preferred_amount: 10) }
 
       shared_context 'discount changes order total' do

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -862,8 +862,8 @@ describe Spree::Order, type: :model do
 
   # Regression test for #4199
   describe '#collect_frontend_payment_methods' do
-    let(:ok_method) { double :payment_method, available_for_order?: true, available_for_store?: true, stores: [store] }
-    let(:no_method) { double :payment_method, available_for_order?: false, available_for_store?: true, stores: [store] }
+    let(:ok_method) { double :payment_method, available_for_order?: true, available_for_store?: true, store: store }
+    let(:no_method) { double :payment_method, available_for_order?: false, available_for_store?: true, store: store }
     let(:methods) { [ok_method, no_method] }
     let(:store_2) { create(:store) }
     let(:order_from_different_store) { create(:order, user: user, store: store_2) }


### PR DESCRIPTION
…usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only changes with no runtime or production logic modified.
> 
> **Overview**
> Updates specs to use the **`store=`** association setter instead of the deprecated **`stores=`** API (which warns and delegates to the first store).
> 
> Factory calls for **products**, **promotions**, and **payment methods** now pass `store: store` rather than `stores: [store]` across admin, API v3, and core model specs. In **`#collect_frontend_payment_methods`**, test doubles stub **`store:`** instead of **`stores:`** to match how payment methods are scoped.
> 
> No production code changes; behavior under test is unchanged aside from avoiding deprecation noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e852df87bffbfcd70910a1c26ec2849448d2f43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to use single-store associations consistently across admin, API, cart, order, and category scenarios.
  * Added consistency checks for promotions, payment methods, product management, and discount code behavior.
  * Kept existing expectations unchanged while improving coverage around store-specific filtering and category product counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->