### PR TITLE
Add `spree shell` command for interactive container access

### DIFF
--- a/docs/developer/cli/quickstart.mdx
+++ b/docs/developer/cli/quickstart.mdx
@@ -141,6 +141,15 @@ Open a Rails console.
 spree console
 ```
 
+### `spree shell`
+
+Open an interactive bash shell inside the web container — the system-shell sibling of `spree console` (Rails) and `spree db:console` (psql). If the web container is down, it starts a one-off container against the same volumes instead. For one-off non-interactive commands, use `spree exec`.
+
+```bash
+spree shell
+spree bash    # alias
+```
+
 ### `spree open`
 
 Open the admin dashboard in the browser.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.3.9
+
+### Patch Changes
+
+- Add `spree shell` (alias: `spree bash`) — open an interactive bash shell inside the web container, the system-shell sibling of `spree console` (Rails) and `spree db:console` (psql). When the web container is down — a crash-looping stack is exactly when a shell is most useful — it falls back to a one-off container against the same volumes, with postgres cold-started and health-waited first.
+
 ## 2.3.8
 
 ### Patch Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,6 +88,15 @@ Open an interactive Rails console inside the running container.
 spree console
 ```
 
+### `spree shell`
+
+Open an interactive bash shell inside the web container. If the container is down, a one-off container is started against the same volumes instead.
+
+```bash
+spree shell
+spree bash    # alias
+```
+
 ### `spree rspec`
 
 Run the RSpec test suite inside the web container with `RAILS_ENV=test`. Everything after `rspec` is passed through to RSpec.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -1,0 +1,23 @@
+import type { Command } from 'commander'
+import { detectProject } from '../context.js'
+import { dockerComposeExecOrRun } from '../docker.js'
+
+// Open an interactive bash shell in the web container — the system-shell
+// sibling of `spree console` (Rails) and `spree db:console` (psql). One-off
+// non-interactive commands belong to `spree exec` instead.
+//
+// When web is down — a crash-looping container is exactly when a shell is
+// most useful — fall back to a one-off `compose run` shell against the same
+// volumes (its depends_on health-waits postgres).
+export function registerShellCommand(program: Command): void {
+  program
+    .command('shell')
+    .alias('bash')
+    .description('Open an interactive bash shell inside the web container')
+    .action(async () => {
+      const ctx = detectProject()
+      await dockerComposeExecOrRun(['bash'], ctx.projectDir, {
+        edgeHint: 'then open the shell',
+      })
+    })
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { registerRoutesCommand } from './commands/routes.js'
 import { registerRspecCommand } from './commands/rspec.js'
 import { registerSampleDataCommand } from './commands/sample-data.js'
 import { registerSeedCommand } from './commands/seed.js'
+import { registerShellCommand } from './commands/shell.js'
 import { registerStopCommand } from './commands/stop.js'
 import { registerTaskCommand } from './commands/task.js'
 import { registerUpdateCommand } from './commands/update.js'
@@ -83,6 +84,7 @@ registerRakeCommand(program)
 registerTaskCommand(program)
 registerRspecCommand(program)
 registerConsoleCommand(program)
+registerShellCommand(program)
 
 // Spree-specific helpers
 registerUserCommand(program)

--- a/packages/cli/tests/shell.test.ts
+++ b/packages/cli/tests/shell.test.ts
@@ -1,0 +1,46 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerShellCommand } from '../src/commands/shell'
+import { dockerComposeExecOrRun } from '../src/docker'
+
+let projectDir: string
+
+vi.mock('../src/context', () => ({
+  detectProject: () => ({ mode: 'docker', projectDir, port: 3000 }),
+}))
+
+vi.mock('../src/docker', () => ({
+  dockerComposeExecOrRun: vi.fn().mockResolvedValue(undefined),
+}))
+
+async function runShell(command: string): Promise<void> {
+  const program = new Command()
+  registerShellCommand(program)
+  await program.parseAsync([command], { from: 'user' })
+}
+
+describe('spree shell', () => {
+  beforeEach(() => {
+    projectDir = '/proj'
+    vi.clearAllMocks()
+  })
+
+  // Branching (exec vs one-off run vs monorepo-edge refusal) is covered by
+  // dockerComposeExecOrRun's own tests in docker.test.ts; here we only assert
+  // the command delegates with the right argv + edge hint.
+  it('delegates to dockerComposeExecOrRun with bash', async () => {
+    await runShell('shell')
+
+    expect(dockerComposeExecOrRun).toHaveBeenCalledWith(['bash'], '/proj', {
+      edgeHint: 'then open the shell',
+    })
+  })
+
+  it('is also invocable as `spree bash`', async () => {
+    await runShell('bash')
+
+    expect(dockerComposeExecOrRun).toHaveBeenCalledWith(['bash'], '/proj', {
+      edgeHint: 'then open the shell',
+    })
+  })
+})


### PR DESCRIPTION
Getting a system shell into the running stack required knowing about `spree exec bash`, which is neither discoverable from `spree --help` nor usable when the web container is down — exactly the state where a shell is most needed.

## What this adds

`spree shell` (alias: `spree bash`) — an interactive bash shell inside the web container, completing the interactive trio:

- `spree console` — Rails console
- `spree db:console` — psql
- `spree shell` — system shell

Like `console` and `bundle`, it uses the exec-or-run fallback: exec into the running web container when it's up; when it's down, fire a one-off `docker compose run --rm` container against the same volumes (postgres cold-started and health-waited via `depends_on`). Monorepo edge projects get the standard clean refusal. One-off non-interactive commands remain `spree exec …`'s job.

## Changes

- `packages/cli/src/commands/shell.ts` — the command (delegates to `dockerComposeExecOrRun`)
- `packages/cli/src/index.ts` — registration
- `packages/cli/tests/shell.test.ts` — delegation + alias coverage
- `packages/cli/README.md`, `docs/developer/cli/quickstart.mdx` — docs
- `packages/cli/CHANGELOG.md`, `packages/cli/package.json` — releases `@spree/cli` **2.3.9** (changeset consumed, patch)

## Testing

- `pnpm vitest run` — 134 passed (2 new)
- `pnpm typecheck`, `pnpm lint` — clean
- Built CLI verified: `spree shell|bash` appears in `--help` and both names resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSLtt2FfUL5ZuAL6Mf9kbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSLtt2FfUL5ZuAL6Mf9kbq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CLI command reuses established `dockerComposeExecOrRun` with no changes to Docker or Rails runtime; scope is documentation, version bump, and tests.
> 
> **Overview**
> Adds **`spree shell`** (alias **`spree bash`**) to `@spree/cli` so developers get a discoverable, help-listed way to open an interactive bash session in the web container—alongside `spree console` and `spree db:console`—instead of relying on `spree exec bash`.
> 
> The command is a thin wrapper around the existing **`dockerComposeExecOrRun`** helper (same exec-vs-one-off-`compose run` behavior as `console`, `bundle`, and `rspec` when web is down). Non-interactive one-offs stay on **`spree exec`**.
> 
> Ships as **`@spree/cli` 2.3.9** with CLI registration, vitest coverage for delegation and the alias, and README / quickstart docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef8fb142652f2192c8a4ab9f7ec197ae91550fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `spree shell` command for opening an interactive bash shell in the web container.
  * Added `spree bash` as an alias for the same command.
  * The CLI now falls back to a one-off container if the web container is unavailable.

* **Documentation**
  * Updated CLI docs and quickstart guidance with usage examples and clarified when to use `spree exec` for non-interactive commands.

* **Bug Fixes**
  * Improved the shell command experience when the stack is not already running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->