### PR TITLE
Getting started - simplify tracking when storefront is connected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Backend: http://localhost:3000, admin at `/admin` (`spree@example.com` / `spree1
 - Commit message body: be precise, DON'T include implementation detail, focus on the "what" and "why", not the "how"
 - If n-commits are needed for a single logical change, use `git commit --fixup` for the follow-ups and `git rebase -i --autosquash` to combine into a single commit before merging
 - Documentation also needs to follow the same principles — focus on the "what" and "why", not the "how". Don't include implementation details in docs. Docs should explain the feature, its purpose, and how to use it, but not how it's implemented internally.
+- NEVER commit anything to main branch, always use feature/fix/chore branches for development
 
 ## Backend (Ruby)
 

--- a/spree/admin/app/controllers/spree/admin/storefront_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/storefront_controller.rb
@@ -20,15 +20,15 @@ module Spree
       # PATCH /admin/storefront
       #
       # Saves the storefront URL preference (used as the base for links in
-      # customer emails and as the "connected" signal for non-web storefronts),
-      # optionally adding it as an allowed origin for browser-based storefronts.
+      # customer emails and as the setup-task completion signal) and adds it
+      # as an allowed origin so browser-based storefronts can call the Store API.
       def update
         origin = normalize_origin(params[:storefront_url])
 
         if origin.nil?
           flash[:error] = Spree.t('admin.storefront_setup.invalid_origin')
         elsif current_store.update(preferred_storefront_url: origin)
-          current_store.allowed_origins.find_or_create_by(origin: origin) if params[:add_allowed_origin] == '1'
+          current_store.allowed_origins.find_or_create_by(origin: origin)
           flash[:success] = Spree.t('admin.storefront_setup.storefront_url_saved', url: origin)
         else
           flash[:error] = current_store.errors.full_messages.to_sentence

--- a/spree/admin/app/views/spree/admin/storefront/show.html.erb
+++ b/spree/admin/app/views/spree/admin/storefront/show.html.erb
@@ -121,12 +121,6 @@
                    placeholder="https://myshop.com" value="<%= current_store.preferred_storefront_url %>">
             <p class="text-gray-500 text-sm mt-1 mb-0"><%= Spree.t('admin.storefront_setup.storefront_url_help') %></p>
           </div>
-          <div class="form-checkbox">
-            <%= check_box_tag :add_allowed_origin, '1', true, class: 'custom-control-input' %>
-            <label class="custom-control-label" for="add_allowed_origin">
-              <%= Spree.t('admin.storefront_setup.add_allowed_origin_label') %>
-            </label>
-          </div>
           <div>
             <button type="submit" class="btn btn-primary"><%= Spree.t('actions.save') %></button>
           </div>

--- a/spree/admin/app/views/spree/admin/storefront/show.html.erb
+++ b/spree/admin/app/views/spree/admin/storefront/show.html.erb
@@ -76,6 +76,7 @@
             <% end %>
           <% end %>
         </div>
+        <p class="text-gray-500 text-sm mb-3"><%= Spree.t('admin.storefront_setup.deploy_finish_hint') %></p>
         <%= external_link_to Spree.t('admin.storefront_setup.local_installation_instructions'), 'https://spreecommerce.org/docs/developer/storefront/nextjs/quickstart' %>
       </div>
     </div>

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -555,7 +555,8 @@ en:
         connect_title: Connect your storefront
         connected_title: Connected storefronts
         deploy_button: Deploy to Vercel
-        deploy_copy: Don't have a storefront yet? The fastest way to launch is the official open-source Next.js storefront. Deploying clones it to your Git account and builds it on Vercel with your credentials prefilled — once it finishes, you'll be redirected back here to complete the setup.
+        deploy_copy: Don't have a storefront yet? The fastest way to launch is the official open-source Next.js storefront. Deploying clones it to your Git account and builds it on Vercel with your credentials prefilled.
+        deploy_finish_hint: Once the deployment finishes, copy your storefront's URL from Vercel into the Storefront URL field below and save it to finish the setup.
         deploy_title: 'Recommended: deploy the official Next.js storefront'
         deployed_copy: It's now live at
         deployed_title: Your storefront has been deployed!

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -548,7 +548,6 @@ en:
           setup: Setup Tax Rates
       storefront: Storefront
       storefront_setup:
-        add_allowed_origin_label: Also add this URL as an allowed origin — required for browser-based storefronts to call the Store API
         allow_origin_button: Allow this origin & finish setup
         api_url_label: Store API URL
         connect_copy: 'Use these credentials in any client that talks to the Store API — a web storefront, a mobile app, or anything else:'
@@ -571,7 +570,7 @@ en:
         origin_allowed: "%{origin} can now access your Store API."
         publishable_key_label: Publishable API key
         see_online_demo: See online demo
-        storefront_url_help: The URL customers use to reach your storefront. It becomes the base for links in customer emails — mobile-only setups can point it at their landing page.
+        storefront_url_help: The URL customers use to reach your storefront. It becomes the base for links in customer emails and is automatically added as an allowed origin so browser-based storefronts can call the Store API.
         storefront_url_label: Storefront URL
         storefront_url_saved: 'Storefront URL saved: %{url}'
         title: Setup Storefront

--- a/spree/admin/spec/controllers/spree/admin/storefront_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/storefront_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Spree::Admin::StorefrontController, type: :controller do
   describe 'PATCH #update' do
     subject(:update_storefront) { patch :update, params: params }
 
-    let(:params) { { storefront_url: 'myshop.com', add_allowed_origin: '1' } }
+    let(:params) { { storefront_url: 'myshop.com' } }
 
     it 'saves the normalized storefront url and allows the origin' do
       expect { update_storefront }.to change { store.allowed_origins.count }.by(1)
@@ -113,13 +113,13 @@ RSpec.describe Spree::Admin::StorefrontController, type: :controller do
       expect(response).to redirect_to(spree.admin_storefront_path)
     end
 
-    context 'without the add_allowed_origin flag' do
-      let(:params) { { storefront_url: 'https://app.myshop.com' } }
+    context 'when the origin is already allowed' do
+      before { create(:allowed_origin, store: store, origin: 'https://myshop.com') }
 
-      it 'only saves the preference' do
+      it 'does not duplicate it' do
         expect { update_storefront }.not_to change(Spree::AllowedOrigin, :count)
 
-        expect(store.reload.preferred_storefront_url).to eq('https://app.myshop.com')
+        expect(store.reload.preferred_storefront_url).to eq('https://myshop.com')
       end
     end
 

--- a/spree/core/app/models/concerns/spree/stores/setup.rb
+++ b/spree/core/app/models/concerns/spree/stores/setup.rb
@@ -51,15 +51,10 @@ module Spree
         payment_methods.active.where.not(type: Spree::PaymentMethod::StoreCredit.to_s).any?
       end
 
-      # A storefront counts as set up once an active publishable key has actually
-      # authenticated a Store API request and the merchant has saved the
-      # storefront URL (entered manually or backfilled by the Vercel callback).
+      # A storefront counts as set up once the merchant has saved the storefront
+      # URL (entered manually or backfilled by the Vercel callback).
       def storefront_setup?
-        storefront_publishable_key_used? && preferred_storefront_url.present?
-      end
-
-      def storefront_publishable_key_used?
-        api_keys.active.publishable.where.not(last_used_at: nil).exists?
+        preferred_storefront_url.present?
       end
     end
   end

--- a/spree/core/app/models/concerns/spree/stores/setup.rb
+++ b/spree/core/app/models/concerns/spree/stores/setup.rb
@@ -52,25 +52,14 @@ module Spree
       end
 
       # A storefront counts as set up once an active publishable key has actually
-      # authenticated a Store API request and a storefront is connected.
+      # authenticated a Store API request and the merchant has saved the
+      # storefront URL (entered manually or backfilled by the Vercel callback).
       def storefront_setup?
-        storefront_publishable_key_used? && storefront_connected?
+        storefront_publishable_key_used? && preferred_storefront_url.present?
       end
 
       def storefront_publishable_key_used?
         api_keys.active.publishable.where.not(last_used_at: nil).exists?
-      end
-
-      # A non-loopback allowed origin (web storefronts) or an explicit storefront
-      # URL (mobile apps and other clients that don't need CORS) both count as a
-      # connected storefront; the `http://localhost` origin seeded on install
-      # doesn't.
-      def storefront_connected?
-        storefront_origin_added? || preferred_storefront_url.present?
-      end
-
-      def storefront_origin_added?
-        allowed_origins.reject(&:loopback?).any?
       end
     end
   end

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -960,10 +960,10 @@ describe Spree::Store, type: :model, without_global_store: true do
     describe '#storefront_setup?' do
       subject { store.storefront_setup? }
 
-      context 'with a used publishable key and a non-loopback allowed origin' do
+      context 'with a used publishable key and a saved storefront URL' do
         before do
           create(:api_key, store: store, last_used_at: 1.hour.ago)
-          create(:allowed_origin, store: store, origin: 'https://shop.example.com')
+          store.update!(preferred_storefront_url: 'https://shop.example.com')
         end
 
         it { is_expected.to be true }
@@ -976,7 +976,7 @@ describe Spree::Store, type: :model, without_global_store: true do
       context 'when the publishable key has never been used' do
         before do
           create(:api_key, store: store)
-          create(:allowed_origin, store: store, origin: 'https://shop.example.com')
+          store.update!(preferred_storefront_url: 'https://shop.example.com')
         end
 
         it { is_expected.to be false }
@@ -985,28 +985,21 @@ describe Spree::Store, type: :model, without_global_store: true do
       context 'when the used publishable key is revoked' do
         before do
           create(:api_key, :revoked, store: store, last_used_at: 1.hour.ago)
+          store.update!(preferred_storefront_url: 'https://shop.example.com')
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context 'without a saved storefront URL' do
+        before do
+          create(:api_key, store: store, last_used_at: 1.hour.ago)
           create(:allowed_origin, store: store, origin: 'https://shop.example.com')
         end
 
-        it { is_expected.to be false }
-      end
-
-      context 'when only a loopback origin exists' do
-        before do
-          create(:api_key, store: store, last_used_at: 1.hour.ago)
-          create(:allowed_origin, store: store, origin: 'http://localhost')
+        it 'stays pending even when an allowed origin exists' do
+          expect(subject).to be false
         end
-
-        it { is_expected.to be false }
-      end
-
-      context 'when connected via the storefront_url preference only' do
-        before do
-          create(:api_key, store: store, last_used_at: 1.hour.ago)
-          store.update!(preferred_storefront_url: 'https://app.example.com')
-        end
-
-        it { is_expected.to be true }
       end
     end
   end

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -960,9 +960,8 @@ describe Spree::Store, type: :model, without_global_store: true do
     describe '#storefront_setup?' do
       subject { store.storefront_setup? }
 
-      context 'with a used publishable key and a saved storefront URL' do
+      context 'with a saved storefront URL' do
         before do
-          create(:api_key, store: store, last_used_at: 1.hour.ago)
           store.update!(preferred_storefront_url: 'https://shop.example.com')
         end
 
@@ -973,27 +972,8 @@ describe Spree::Store, type: :model, without_global_store: true do
         end
       end
 
-      context 'when the publishable key has never been used' do
-        before do
-          create(:api_key, store: store)
-          store.update!(preferred_storefront_url: 'https://shop.example.com')
-        end
-
-        it { is_expected.to be false }
-      end
-
-      context 'when the used publishable key is revoked' do
-        before do
-          create(:api_key, :revoked, store: store, last_used_at: 1.hour.ago)
-          store.update!(preferred_storefront_url: 'https://shop.example.com')
-        end
-
-        it { is_expected.to be false }
-      end
-
       context 'without a saved storefront URL' do
         before do
-          create(:api_key, store: store, last_used_at: 1.hour.ago)
           create(:allowed_origin, store: store, origin: 'https://shop.example.com')
         end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to admin onboarding UX, CORS origin creation on save, and setup-task gating; no auth or payment paths are touched.
> 
> **Overview**
> **Getting started** now treats the storefront setup step as complete only when **`preferred_storefront_url`** is saved—not when a publishable key has been used, a non-loopback allowed origin exists, or both.
> 
> Saving the storefront URL in admin **always** registers that URL as an allowed origin (the optional checkbox is removed). Copy and hints steer merchants to paste their Vercel URL after deploy and save to finish setup.
> 
> Specs and `CLAUDE.md` are updated to match (including a rule to never commit directly to `main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2abc6432b58c558db32f99ac593a4d90e7ed35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified storefront setup: saving a storefront URL now marks setup as complete.
  * The connected storefront origin is now added automatically during setup.
  * Added clearer guidance for finishing deployment and using the storefront URL.

* **Bug Fixes**
  * Removed the extra checkbox from the storefront connection form for a smoother setup experience.
  * Prevented duplicate allowed origins from being created when the storefront URL is already saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->