### PR TITLE
Ensure TinyMCE Propshaft integration loads correctly

### DIFF
--- a/spree/admin/lib/spree/admin.rb
+++ b/spree/admin/lib/spree/admin.rb
@@ -19,6 +19,15 @@ require 'spree/admin/engine'
 require 'spree/core/partials'
 
 require 'oembed'
+# tinymce-rails only registers its Propshaft integration when Propshaft is
+# already loaded at require time. Host apps commonly list `gem 'propshaft'`
+# after the Spree gems, so load it first — otherwise TinyMCE's lazily-loaded
+# plugins/themes/icons (requested without a digest) 404 in development.
+begin
+  require 'propshaft'
+rescue LoadError
+  # Propshaft is not in the host app's bundle (e.g. Sprockets is used instead)
+end
 require 'tinymce-rails'
 require 'pagy'
 


### PR DESCRIPTION
## Summary
Fixes an issue where TinyMCE's Propshaft integration fails to register when the host application lists `gem 'propshaft'` after Spree gems in the Gemfile. This causes TinyMCE's lazily-loaded plugins, themes, and icons to 404 in development.

## Key Changes
- Added explicit `require 'propshaft'` before `require 'tinymce-rails'` in the admin initialization
- Wrapped the Propshaft require in a begin/rescue block to gracefully handle cases where Propshaft is not in the host app's bundle (e.g., when using Sprockets instead)
- Added explanatory comments documenting why this ordering is necessary

## Implementation Details
The tinymce-rails gem only registers its Propshaft integration at require time. Since host applications commonly list `gem 'propshaft'` after the Spree gems in their Gemfile, Propshaft may not be loaded when tinymce-rails is required. By explicitly requiring Propshaft first (with a fallback for apps not using it), we ensure TinyMCE's asset pipeline integration is properly registered before the gem initializes.

https://claude.ai/code/session_01QVsEbvZcmY12H1TH6qVe9i

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small initialization-order change with a safe LoadError fallback; no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes TinyMCE plugin/theme/icon 404s in development when host apps list `propshaft` after Spree in the Gemfile.
> 
> **`spree/admin/lib/spree/admin.rb`** now **`require`s `propshaft` inside a `begin/rescue LoadError` block** immediately before **`require 'tinymce-rails'`**, so `tinymce-rails` can register its Propshaft hook at load time. Apps on Sprockets (no Propshaft gem) skip the require without failing boot. Comments document the Gemfile ordering issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27618802759ea1d81736493cbf23a74cc626aa37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TinyMCE plugin and theme loading during development.
  * Prevented missing asset errors in applications that use Propshaft or do not include it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->