### PR TITLE
Distinguish reply-to mail header + DRY

### DIFF
--- a/spree/core/app/mailers/spree/admin_user_mailer.rb
+++ b/spree/core/app/mailers/spree/admin_user_mailer.rb
@@ -12,7 +12,6 @@ module Spree
         mail(
           to: admin_user.email,
           from: from_address,
-          reply_to: reply_to_address,
           subject: "#{store.name} #{Spree.t('admin_user_mailer.password_reset_email.subject')}",
           store_url: store.formatted_url
         )
@@ -28,7 +27,6 @@ module Spree
         mail(
           to: admin_user.email,
           from: from_address,
-          reply_to: reply_to_address,
           subject: "#{store.name} #{Spree.t('admin_user_mailer.confirmation_email.subject')}",
           store_url: store.formatted_url
         )

--- a/spree/core/app/mailers/spree/base_mailer.rb
+++ b/spree/core/app/mailers/spree/base_mailer.rb
@@ -2,9 +2,6 @@ module Spree
   class BaseMailer < ActionMailer::Base
     helper Spree::ImagesHelper
 
-    # Apply Reply-To to every mailer so subclasses don't need to pass
-    # `reply_to: reply_to_address` on each `mail` call. Passing `reply_to:`
-    # explicitly still overrides this default.
     default reply_to: -> { reply_to_address }
 
     def current_store

--- a/spree/core/app/mailers/spree/base_mailer.rb
+++ b/spree/core/app/mailers/spree/base_mailer.rb
@@ -2,6 +2,11 @@ module Spree
   class BaseMailer < ActionMailer::Base
     helper Spree::ImagesHelper
 
+    # Apply Reply-To to every mailer so subclasses don't need to pass
+    # `reply_to: reply_to_address` on each `mail` call. Passing `reply_to:`
+    # explicitly still overrides this default.
+    default reply_to: -> { reply_to_address }
+
     def current_store
       @current_store ||= @order&.store.presence || Spree::Store.current || Spree::Store.default
     end
@@ -39,7 +44,7 @@ module Spree
     end
 
     def reply_to_address
-      current_store.mail_from_address
+      current_store.customer_support_email.presence || current_store.mail_from_address
     end
 
     def money(amount, currency = nil)

--- a/spree/core/app/mailers/spree/export_mailer.rb
+++ b/spree/core/app/mailers/spree/export_mailer.rb
@@ -8,7 +8,6 @@ module Spree
           to: @export.user.email,
           subject: Spree.t('export_mailer.export_done.subject', export_number: @export.number).to_s,
           from: from_address,
-          reply_to: reply_to_address,
           store_url: current_store.url
         )
       end

--- a/spree/core/app/mailers/spree/invitation_mailer.rb
+++ b/spree/core/app/mailers/spree/invitation_mailer.rb
@@ -10,7 +10,6 @@ module Spree
       with_store_locale(invitation.store) do
         mail(to: invitation.email,
              from: from_address,
-             reply_to: reply_to_address,
              subject: Spree.t('invitation_mailer.invitation_email.subject',
                               resource_name: invitation.resource&.name))
       end
@@ -23,7 +22,6 @@ module Spree
       with_store_locale(invitation.store) do
         mail(to: invitation.inviter.email,
              from: from_address,
-             reply_to: reply_to_address,
              subject: Spree.t('invitation_mailer.invitation_accepted.subject',
                               invitee_name: invitation.invitee&.name,
                               resource_name: invitation.resource&.name))

--- a/spree/core/app/mailers/spree/report_mailer.rb
+++ b/spree/core/app/mailers/spree/report_mailer.rb
@@ -7,8 +7,7 @@ module Spree
         mail(
           to: @report.user.email,
           subject: Spree.t('report_mailer.report_done.subject', report_name: @report.human_name).to_s,
-          from: from_address,
-          reply_to: reply_to_address
+          from: from_address
         )
       end
     end

--- a/spree/core/app/models/spree/store.rb
+++ b/spree/core/app/models/spree/store.rb
@@ -142,6 +142,7 @@ module Spree
     validates :preferred_stock_reservation_ttl_minutes, numericality: { only_integer: true, greater_than: 0 }
     validates :preferred_storefront_access, inclusion: { in: Spree::Channel::Gating::STOREFRONT_ACCESS }
     validates :mail_from_address, email: { allow_blank: false }
+    validates :customer_support_email, email: { allow_blank: true }
     # FIXME: we should remove this condition in v5
     if !ENV['SPREE_DISABLE_DB_CONNECTION'] &&
        connected? &&

--- a/spree/core/spec/mailers/spree/base_mailer_spec.rb
+++ b/spree/core/spec/mailers/spree/base_mailer_spec.rb
@@ -1,5 +1,11 @@
 require 'spec_helper'
 
+class ReplyToProbeMailer < Spree::BaseMailer
+  def sample
+    mail(to: 'probe@example.com', from: 'from@example.com', subject: 'probe', body: 'body')
+  end
+end
+
 describe Spree::BaseMailer, type: :mailer do
   let!(:store) { @default_store }
 
@@ -22,6 +28,36 @@ describe Spree::BaseMailer, type: :mailer do
       I18n.locale = :en
       mailer.set_email_locale
       expect(I18n.locale).to eq(:de)
+    end
+  end
+
+  describe '#reply_to_address' do
+    subject(:mailer) { described_class.new }
+
+    before { allow(mailer).to receive(:current_store).and_return(store) }
+
+    context 'when the store has a customer support email' do
+      let(:store) { create(:store, customer_support_email: 'support@example.com', mail_from_address: 'no-reply@example.com') }
+
+      it 'returns the customer support email' do
+        expect(mailer.reply_to_address).to eq('support@example.com')
+      end
+    end
+
+    context 'when the customer support email is blank' do
+      let(:store) { create(:store, customer_support_email: '', mail_from_address: 'no-reply@example.com') }
+
+      it 'falls back to the mail from address' do
+        expect(mailer.reply_to_address).to eq('no-reply@example.com')
+      end
+    end
+  end
+
+  describe 'default Reply-To header' do
+    let!(:store) { @default_store }
+
+    it 'is applied without the mailer passing reply_to explicitly' do
+      expect(ReplyToProbeMailer.sample.reply_to).to eq([store.customer_support_email])
     end
   end
 

--- a/spree/core/spec/mailers/spree/invitation_mailer_spec.rb
+++ b/spree/core/spec/mailers/spree/invitation_mailer_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Spree::InvitationMailer, type: :mailer do
       expect(mail.from).to eq([store.mail_from_address])
     end
 
-    it 'sets reply-to as the store mail from address' do
-      expect(mail.reply_to).to eq([store.mail_from_address])
+    it 'sets reply-to as the store customer support email' do
+      expect(mail.reply_to).to eq([store.customer_support_email])
     end
 
     # The link target depends on whether the legacy `spree_admin` Rails gem
@@ -131,8 +131,8 @@ RSpec.describe Spree::InvitationMailer, type: :mailer do
       expect(mail.from).to eq([store.mail_from_address])
     end
 
-    it 'sets reply-to as the store mail from address' do
-      expect(mail.reply_to).to eq([store.mail_from_address])
+    it 'sets reply-to as the store customer support email' do
+      expect(mail.reply_to).to eq([store.customer_support_email])
     end
   end
 end

--- a/spree/core/spec/mailers/spree/report_mailer_spec.rb
+++ b/spree/core/spec/mailers/spree/report_mailer_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Spree::ReportMailer, type: :mailer do
       expect(mail.from).to eq([store.mail_from_address])
     end
 
-    it 'sets reply-to as the store mail from address' do
-      expect(mail.reply_to).to eq([store.mail_from_address])
+    it 'sets reply-to as the store customer support email' do
+      expect(mail.reply_to).to eq([store.customer_support_email])
     end
 
     it 'includes download link in the body' do

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -266,6 +266,24 @@ describe Spree::Store, type: :model, without_global_store: true do
         expect(store.code).to eq('default')
       end
     end
+
+    describe '#customer_support_email' do
+      it 'is valid when blank' do
+        store = build(:store, customer_support_email: '')
+        expect(store).to be_valid
+      end
+
+      it 'is valid with a properly formatted email' do
+        store = build(:store, customer_support_email: 'support@example.com')
+        expect(store).to be_valid
+      end
+
+      it 'is invalid with a malformed email' do
+        store = build(:store, customer_support_email: 'not-an-email')
+        expect(store).not_to be_valid
+        expect(store.errors[:customer_support_email]).to be_present
+      end
+    end
   end
 
   context 'Translations' do

--- a/spree/emails/app/mailers/spree/customer_mailer.rb
+++ b/spree/emails/app/mailers/spree/customer_mailer.rb
@@ -13,7 +13,6 @@ module Spree
         mail(
           to: user.email,
           from: from_address,
-          reply_to: reply_to_address,
           subject: "#{store.name} #{Spree.t('customer_mailer.password_reset_email.subject')}",
           store_url: store.storefront_url
         )

--- a/spree/emails/app/mailers/spree/order_mailer.rb
+++ b/spree/emails/app/mailers/spree/order_mailer.rb
@@ -7,7 +7,7 @@ module Spree
       current_store = @order.store
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('order_mailer.confirm_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
+        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
       end
     end
 
@@ -16,7 +16,7 @@ module Spree
       current_store = @order.store
       with_store_locale(current_store) do
         subject = Spree.t('order_mailer.store_owner_notification_email.subject', store_name: current_store.name)
-        mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
+        mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.storefront_url)
       end
     end
 
@@ -25,7 +25,7 @@ module Spree
       current_store = @order.store
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('order_mailer.cancel_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
+        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
       end
     end
 
@@ -36,7 +36,7 @@ module Spree
 
       with_store_locale(@current_store, @order.locale) do
         mail(to: @order.email, from: from_address, subject: Spree.t('order_mailer.payment_link_email.subject', number: @order.number),
-             store_url: @current_store.storefront_url, reply_to: reply_to_address)
+             store_url: @current_store.storefront_url)
       end
     end
   end

--- a/spree/emails/app/mailers/spree/reimbursement_mailer.rb
+++ b/spree/emails/app/mailers/spree/reimbursement_mailer.rb
@@ -8,7 +8,7 @@ module Spree
       current_store = @reimbursement.store || Spree::Store.default
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('reimbursement_mailer.reimbursement_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
+        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
       end
     end
   end

--- a/spree/emails/app/mailers/spree/shipment_mailer.rb
+++ b/spree/emails/app/mailers/spree/shipment_mailer.rb
@@ -9,7 +9,7 @@ module Spree
       current_store = @shipment.store
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('shipment_mailer.shipped_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url, reply_to: reply_to_address)
+        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
       end
     end
   end

--- a/spree/emails/spec/mailers/spree/order_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/order_mailer_spec.rb
@@ -41,11 +41,11 @@ describe Spree::OrderMailer, type: :mailer do
   end
 
   context ':reply_to not set explicitly' do
-    it 'uses store mail from address' do
+    it 'uses store customer support email' do
       message = described_class.confirm_email(order)
-      expect(message.reply_to).to eq([store.mail_from_address])
+      expect(message.reply_to).to eq([store.customer_support_email])
       message = described_class.cancel_email(order)
-      expect(message.reply_to).to eq([store.mail_from_address])
+      expect(message.reply_to).to eq([store.customer_support_email])
     end
   end
 

--- a/spree/emails/spec/mailers/spree/reimbursement_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/reimbursement_mailer_spec.rb
@@ -15,9 +15,9 @@ describe Spree::ReimbursementMailer, type: :mailer do
   end
 
   context ':reply_to not set explicitly' do
-    it 'uses store mail from address' do
+    it 'uses store customer support email' do
       message = Spree::ReimbursementMailer.reimbursement_email(reimbursement)
-      expect(message.reply_to).to eq [@default_store.mail_from_address]
+      expect(message.reply_to).to eq [@default_store.customer_support_email]
     end
   end
 

--- a/spree/emails/spec/mailers/spree/shipment_mailer_spec.rb
+++ b/spree/emails/spec/mailers/spree/shipment_mailer_spec.rb
@@ -22,9 +22,9 @@ describe Spree::ShipmentMailer, type: :mailer do
   end
 
   context ':reply_to not set explicitly' do
-    it 'falls back to store mail from address' do
+    it 'uses store customer support email' do
       message = described_class.shipped_email(shipment)
-      expect(message.reply_to).to eq([store.mail_from_address])
+      expect(message.reply_to).to eq([store.customer_support_email])
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Transactional email header change only; From is unchanged and blank support email still falls back to mail_from_address.
> 
> **Overview**
> **Reply-To** on Spree mail now prefers the store’s **`customer_support_email`**, falling back to **`mail_from_address`** when support email is blank. **`Spree::BaseMailer`** sets `default reply_to: -> { reply_to_address }`, so individual mailers no longer pass `reply_to:` on each `mail()` call.
> 
> **`Spree::Store`** validates **`customer_support_email`** as an optional email format. Specs cover `reply_to_address`, the default header, and mailer expectations updated from mail-from to customer-support for Reply-To.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c738104c4c74cc04f6fa04b5de764d36b5dca6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated outgoing emails to set the **Reply-To** to the store’s **customer support email** by default.
  * If customer support email is blank, **Reply-To** falls back to the store’s **From** address.
  * Standardized reply handling across account, order, invitation, export, report, reimbursement, and shipment emails.
  * Allowed `customer_support_email` to be blank while still validating format when provided.
* **Tests**
  * Added and updated specs to verify the default Reply-To behavior and fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->