### PR TITLE
Set default from: address in BaseMailer so no need to calling it every time

### DIFF
--- a/spree/core/app/mailers/spree/admin_user_mailer.rb
+++ b/spree/core/app/mailers/spree/admin_user_mailer.rb
@@ -11,7 +11,6 @@ module Spree
       with_store_locale(store, preferred_locale(admin_user, store)) do
         mail(
           to: admin_user.email,
-          from: from_address,
           subject: "#{store.name} #{Spree.t('admin_user_mailer.password_reset_email.subject')}",
           store_url: store.formatted_url
         )
@@ -26,7 +25,6 @@ module Spree
       with_store_locale(store, preferred_locale(admin_user, store)) do
         mail(
           to: admin_user.email,
-          from: from_address,
           subject: "#{store.name} #{Spree.t('admin_user_mailer.confirmation_email.subject')}",
           store_url: store.formatted_url
         )

--- a/spree/core/app/mailers/spree/base_mailer.rb
+++ b/spree/core/app/mailers/spree/base_mailer.rb
@@ -2,7 +2,7 @@ module Spree
   class BaseMailer < ActionMailer::Base
     helper Spree::ImagesHelper
 
-    default reply_to: -> { reply_to_address }
+    default from: -> { from_address }, reply_to: -> { reply_to_address }
 
     def current_store
       @current_store ||= @order&.store.presence || Spree::Store.current || Spree::Store.default

--- a/spree/core/app/mailers/spree/export_mailer.rb
+++ b/spree/core/app/mailers/spree/export_mailer.rb
@@ -7,7 +7,6 @@ module Spree
         mail(
           to: @export.user.email,
           subject: Spree.t('export_mailer.export_done.subject', export_number: @export.number).to_s,
-          from: from_address,
           store_url: current_store.url
         )
       end

--- a/spree/core/app/mailers/spree/invitation_mailer.rb
+++ b/spree/core/app/mailers/spree/invitation_mailer.rb
@@ -9,7 +9,6 @@ module Spree
       @current_store = invitation.store
       with_store_locale(invitation.store) do
         mail(to: invitation.email,
-             from: from_address,
              subject: Spree.t('invitation_mailer.invitation_email.subject',
                               resource_name: invitation.resource&.name))
       end
@@ -21,7 +20,6 @@ module Spree
       @current_store = invitation.store
       with_store_locale(invitation.store) do
         mail(to: invitation.inviter.email,
-             from: from_address,
              subject: Spree.t('invitation_mailer.invitation_accepted.subject',
                               invitee_name: invitation.invitee&.name,
                               resource_name: invitation.resource&.name))

--- a/spree/core/app/mailers/spree/report_mailer.rb
+++ b/spree/core/app/mailers/spree/report_mailer.rb
@@ -6,8 +6,7 @@ module Spree
       with_store_locale(@report.store) do
         mail(
           to: @report.user.email,
-          subject: Spree.t('report_mailer.report_done.subject', report_name: @report.human_name).to_s,
-          from: from_address
+          subject: Spree.t('report_mailer.report_done.subject', report_name: @report.human_name).to_s
         )
       end
     end

--- a/spree/core/app/mailers/spree/webhook_mailer.rb
+++ b/spree/core/app/mailers/spree/webhook_mailer.rb
@@ -9,7 +9,6 @@ module Spree
       with_store_locale(webhook_endpoint.store) do
         mail(
           to: @current_store.new_order_notifications_email.presence || @current_store.mail_from_address,
-          from: from_address,
           subject: Spree.t('webhook_mailer.endpoint_disabled.subject', endpoint_name: @endpoint.name || @endpoint.url),
           store_url: @current_store.formatted_url
         )

--- a/spree/core/spec/mailers/spree/base_mailer_spec.rb
+++ b/spree/core/spec/mailers/spree/base_mailer_spec.rb
@@ -6,6 +6,12 @@ class ReplyToProbeMailer < Spree::BaseMailer
   end
 end
 
+class FromProbeMailer < Spree::BaseMailer
+  def sample
+    mail(to: 'probe@example.com', subject: 'probe', body: 'body')
+  end
+end
+
 describe Spree::BaseMailer, type: :mailer do
   let!(:store) { @default_store }
 
@@ -31,6 +37,18 @@ describe Spree::BaseMailer, type: :mailer do
     end
   end
 
+  describe '#from_address' do
+    subject(:mailer) { described_class.new }
+
+    before { allow(mailer).to receive(:current_store).and_return(store) }
+
+    let(:store) { create(:store, mail_from_address: 'no-reply@example.com') }
+
+    it 'returns the store mail from address' do
+      expect(mailer.from_address).to eq('no-reply@example.com')
+    end
+  end
+
   describe '#reply_to_address' do
     subject(:mailer) { described_class.new }
 
@@ -50,6 +68,14 @@ describe Spree::BaseMailer, type: :mailer do
       it 'falls back to the mail from address' do
         expect(mailer.reply_to_address).to eq('no-reply@example.com')
       end
+    end
+  end
+
+  describe 'default From header' do
+    let!(:store) { @default_store }
+
+    it 'is applied without the mailer passing from explicitly' do
+      expect(FromProbeMailer.sample.from).to eq([store.mail_from_address])
     end
   end
 

--- a/spree/emails/app/mailers/spree/customer_mailer.rb
+++ b/spree/emails/app/mailers/spree/customer_mailer.rb
@@ -12,7 +12,6 @@ module Spree
       with_store_locale(store) do
         mail(
           to: user.email,
-          from: from_address,
           subject: "#{store.name} #{Spree.t('customer_mailer.password_reset_email.subject')}",
           store_url: store.storefront_url
         )

--- a/spree/emails/app/mailers/spree/newsletter_mailer.rb
+++ b/spree/emails/app/mailers/spree/newsletter_mailer.rb
@@ -9,7 +9,7 @@ module Spree
       base_url = redirect_url.presence || store.storefront_url
       @confirm_email_url = append_token(base_url, @subscriber.verification_token)
       with_store_locale(store) do
-        mail(to: @subscriber.email, from: from_address, subject: Spree.t('newsletter_mailer.email_confirmation.subject'))
+        mail(to: @subscriber.email, subject: Spree.t('newsletter_mailer.email_confirmation.subject'))
       end
     end
 

--- a/spree/emails/app/mailers/spree/order_mailer.rb
+++ b/spree/emails/app/mailers/spree/order_mailer.rb
@@ -7,7 +7,7 @@ module Spree
       current_store = @order.store
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('order_mailer.confirm_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
+        mail(to: @order.email, subject: subject, store_url: current_store.storefront_url)
       end
     end
 
@@ -16,7 +16,7 @@ module Spree
       current_store = @order.store
       with_store_locale(current_store) do
         subject = Spree.t('order_mailer.store_owner_notification_email.subject', store_name: current_store.name)
-        mail(to: current_store.new_order_notifications_email, from: from_address, subject: subject, store_url: current_store.storefront_url)
+        mail(to: current_store.new_order_notifications_email, subject: subject, store_url: current_store.storefront_url)
       end
     end
 
@@ -25,7 +25,7 @@ module Spree
       current_store = @order.store
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('order_mailer.cancel_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
+        mail(to: @order.email, subject: subject, store_url: current_store.storefront_url)
       end
     end
 
@@ -35,7 +35,7 @@ module Spree
       @checkout_payment_url = spree.checkout_state_url(@order.token, :payment, host: @current_store.storefront_url)
 
       with_store_locale(@current_store, @order.locale) do
-        mail(to: @order.email, from: from_address, subject: Spree.t('order_mailer.payment_link_email.subject', number: @order.number),
+        mail(to: @order.email, subject: Spree.t('order_mailer.payment_link_email.subject', number: @order.number),
              store_url: @current_store.storefront_url)
       end
     end

--- a/spree/emails/app/mailers/spree/reimbursement_mailer.rb
+++ b/spree/emails/app/mailers/spree/reimbursement_mailer.rb
@@ -8,7 +8,7 @@ module Spree
       current_store = @reimbursement.store || Spree::Store.default
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('reimbursement_mailer.reimbursement_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
+        mail(to: @order.email, subject: subject, store_url: current_store.storefront_url)
       end
     end
   end

--- a/spree/emails/app/mailers/spree/shipment_mailer.rb
+++ b/spree/emails/app/mailers/spree/shipment_mailer.rb
@@ -9,7 +9,7 @@ module Spree
       current_store = @shipment.store
       with_store_locale(current_store, @order.locale) do
         subject = order_email_subject(current_store, Spree.t('shipment_mailer.shipped_email.subject'), @order.number, resend: resend)
-        mail(to: @order.email, from: from_address, subject: subject, store_url: current_store.storefront_url)
+        mail(to: @order.email, subject: subject, store_url: current_store.storefront_url)
       end
     end
   end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> All customer and admin transactional emails now rely on the BaseMailer default and `current_store` resolution for the From header; wrong store context would affect every mailer at once, though that matches the prior `from_address` behavior.
> 
> **Overview**
> Centralizes the **From** address on `Spree::BaseMailer` by adding `default from: -> { from_address }` next to the existing **Reply-To** default, so each mail action no longer passes `from: from_address`.
> 
> Removes that repeated `from:` option across core and emails mailers (admin auth, invitations, exports/reports, webhooks, orders, shipments, reimbursements, customer password reset, newsletter confirmation). Behavior stays tied to `current_store.mail_from_address` when subclasses set `@current_store` (or order/store context) before `mail`.
> 
> Adds `base_mailer_spec` coverage for `#from_address` and for the default **From** header when `mail` omits `from` explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f9d3882b8c1b11ea69a77719fed8510d02f495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Email notifications now consistently use the configured store sender address by default.
  - Updated password reset, confirmation, order, shipment, reimbursement, invitation, export, report, newsletter, and webhook emails to apply the standard sender configuration.

- **Tests**
  - Added coverage verifying that emails inherit the current store’s configured sender address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->