### PR TITLE
Make deleting variants in rails admin safer

### DIFF
--- a/spree/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
+++ b/spree/admin/app/javascript/spree/admin/controllers/variants_form_controller.js
@@ -72,6 +72,10 @@ export default class extends CheckboxSelectAll {
     }
 
     this.inventoryFormTarget = document.querySelector('.inventory-form');
+
+    // Drop stale removal inputs (e.g. restored from the Turbo cache) so a fresh
+    // session never re-submits removals the user didn't make in it.
+    this.syncRemovedVariantIdInputs()
   }
 
   toggleQuantityTracked() {
@@ -119,6 +123,37 @@ export default class extends CheckboxSelectAll {
     }
   }
 
+  // The set of persisted variant ids the user removed from the matrix. Submitted as
+  // `product[removed_variant_ids][]` — the server only ever destroys ids listed there,
+  // never variants that are merely missing from the re-submitted form.
+  get removedVariantIds() {
+    if (!this._removedVariantIds) this._removedVariantIds = new Set()
+
+    return this._removedVariantIds
+  }
+
+  markVariantRemoved(internalName) {
+    const variantId = this.variantIdsValue[internalName]
+    if (variantId) this.removedVariantIds.add(String(variantId))
+  }
+
+  markVariantKept(internalName) {
+    const variantId = this.variantIdsValue[internalName]
+    if (variantId) this.removedVariantIds.delete(String(variantId))
+  }
+
+  syncRemovedVariantIdInputs() {
+    this.element.querySelectorAll('input[name="product[removed_variant_ids][]"]').forEach((input) => input.remove())
+
+    this.removedVariantIds.forEach((variantId) => {
+      const input = document.createElement('input')
+      input.type = 'hidden'
+      input.name = 'product[removed_variant_ids][]'
+      input.value = variantId
+      this.element.appendChild(input)
+    })
+  }
+
   deleteSelected() {
     const newStockValue = this.stockValue
     const newPricesValue = this.pricesValue
@@ -126,6 +161,7 @@ export default class extends CheckboxSelectAll {
       const internalName = checkbox.value
 
       this.ignoredVariants.add(internalName)
+      this.markVariantRemoved(internalName)
       const variant = this.variantsContainerTarget.querySelector(`[data-variant-name="${internalName}"]`)
 
       const nestingLevel = internalName.split('/').length
@@ -157,7 +193,8 @@ export default class extends CheckboxSelectAll {
 
       delete newStockValue[internalName]
       delete newPricesValue[internalName]
-      variant.remove()
+      // the row may already be gone when deleting an option value re-rendered the matrix
+      variant?.remove()
     })
 
     this.stockValue = newStockValue
@@ -166,6 +203,7 @@ export default class extends CheckboxSelectAll {
     this.checkboxAllTarget.checked = false
     this.refresh()
     this.refreshParentInputs()
+    this.syncRemovedVariantIdInputs()
   }
 
   reorderOptions(event) {
@@ -498,6 +536,14 @@ export default class extends CheckboxSelectAll {
           }
           currentVariants.add(internalName)
 
+          // Reconcile the removal ledger with what this render keeps: leaf rows
+          // re-submit their variant id, parent (grouping) rows never do.
+          if (i === nestingLevel - 1) {
+            this.markVariantKept(internalName)
+          } else if (i === 0 && nestingLevel > 1) {
+            this.markVariantRemoved(internalName)
+          }
+
           const existingVariant = this.variantsContainerTarget.querySelector(`[data-variant-name="${internalName}"]`)
           if (existingVariant) {
             if (i === 0) {
@@ -599,6 +645,7 @@ export default class extends CheckboxSelectAll {
     this.variantsContainerTarget.querySelectorAll('[data-variants-form-target="variant"]').forEach((variant) => {
       const variantName = variant.dataset.variantName
       if (!currentVariants.has(variantName)) {
+        this.markVariantRemoved(variantName)
         variant.remove()
       }
     })
@@ -609,6 +656,7 @@ export default class extends CheckboxSelectAll {
     }
 
     this.refreshParentInputs()
+    this.syncRemovedVariantIdInputs()
   }
 
   refreshParentInputs() {

--- a/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/products_controller_spec.rb
@@ -1128,9 +1128,10 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         end
       end
 
-      context 'when variant is no longer present in the params' do
+      context 'when variant is explicitly removed' do
         before do
           product_params[:variants_attributes].delete('0')
+          product_params[:removed_variant_ids] = [variant1.id.to_s]
         end
 
         it 'removes the variant' do
@@ -1140,16 +1141,42 @@ RSpec.describe Spree::Admin::ProductsController, type: :controller do
         end
       end
 
-      context 'when all variants are removed' do
+      context 'when variant is no longer present in the params but not explicitly removed' do
         before do
-          product_params.delete(:variants_attributes)
+          product_params[:variants_attributes].delete('0')
         end
 
-        it 'removes the product variants' do
+        it 'keeps the variant' do
+          send_request
+
+          expect(product.reload.variant_ids).to match_array([variant1.id, variant2.id, variant3.id])
+        end
+      end
+
+      context 'when all variants are explicitly removed' do
+        before do
+          product_params.delete(:variants_attributes)
+          product_params[:removed_variant_ids] = [variant1.id.to_s, variant2.id.to_s, variant3.id.to_s]
+        end
+
+        it 'removes the product variants and option types' do
           send_request
 
           expect(product.reload.variant_ids).to be_empty
           expect(product.option_types).to be_empty
+        end
+      end
+
+      context 'when variants_attributes are missing without explicit removals' do
+        before do
+          product_params.delete(:variants_attributes)
+        end
+
+        it 'keeps the product variants and option types' do
+          send_request
+
+          expect(product.reload.variant_ids).to match_array([variant1.id, variant2.id, variant3.id])
+          expect(product.option_types).not_to be_empty
         end
       end
     end

--- a/spree/core/app/services/spree/products/prepare_nested_attributes.rb
+++ b/spree/core/app/services/spree/products/prepare_nested_attributes.rb
@@ -7,6 +7,12 @@ module Spree
     # from other stores are preserved. This prevents accidental data loss when a store
     # admin updates product categories in their store without affecting other stores.
     #
+    # Variant removal is opt-in: only variants explicitly listed in the
+    # `removed_variant_ids` param are marked for destruction (or collected for
+    # discontinuation when they have completed orders). Variants merely absent from
+    # `variants_attributes` are left untouched, so a partially rendered or broken
+    # form can never silently mass-delete variants.
+    #
     # @example
     #   service = Spree::Products::PrepareNestedAttributes.new(
     #     product,
@@ -28,10 +34,13 @@ module Spree
       end
 
       def call
+        extract_removed_variant_ids
+
         if params[:variants_attributes]
           params[:variants_attributes].each do |key, variant_params|
             existing_variant = variant_params[:id].presence && @product.variants.find_by(id: variant_params[:id])
-            variants_to_remove.delete(variant_params[:id]) if variant_params[:id].present?
+            # a re-submitted variant always wins over a removal request
+            variants_to_remove.delete(variant_params[:id].to_s) if variant_params[:id].present?
 
             variant_params.delete(:price) # remove legacy price param
 
@@ -72,17 +81,17 @@ module Spree
         # ensure the product is owned by a store
         params[:store_id] = store.id if params[:store_id].blank? && product.store_id.blank?
 
-        # Add empty list for option_type_ids and mark variants as removed if there are no variants and options
-        if params[:variants_attributes].blank? && variants_to_remove.any? && !params.key?(:option_type_ids)
-          params[:option_type_ids] = []
-          params[:variants_attributes] = {}
+        # The variants matrix was emptied: no variant rows re-submitted, removals sent instead.
+        # Option types are detached only when the removal list covers every variant, so a
+        # partial (possibly broken) submission never turns the product into a simple one.
+        if params[:variants_attributes].blank? && variants_to_remove.any?
+          attributes = removed_variants_attributes
 
-          populate_variants_to_discontinue
-          variant_ids_to_destroy.each_with_index do |variant_id, index|
-            params[:variants_attributes][index.to_s] = { id: variant_id, _destroy: '1' }
+          if attributes.any?
+            params[:option_type_ids] = [] if removing_all_variants? && !params.key?(:option_type_ids)
+            params[:variants_attributes] = attributes
+            params[:variants_attributes].permit!
           end
-
-          params[:variants_attributes].permit!
         end
 
         params
@@ -116,8 +125,24 @@ module Spree
         @product_option_types_to_remove ||= product.product_option_type_ids
       end
 
+      # Pulls `removed_variant_ids` out of the params so it never reaches Product#update.
+      # Must run before any `variants_to_remove` access.
+      def extract_removed_variant_ids
+        @removed_variant_ids = Array(params.delete(:removed_variant_ids)).map(&:to_s)
+      end
+
+      # Only variants the client explicitly asked to remove, and only ones that
+      # actually belong to this product.
       def variants_to_remove
-        @variants_to_remove ||= product.variant_ids.map(&:to_s)
+        @variants_to_remove ||= (@removed_variant_ids || []).uniq & all_variant_ids
+      end
+
+      def all_variant_ids
+        @all_variant_ids ||= product.variant_ids.map(&:to_s)
+      end
+
+      def removing_all_variants?
+        (all_variant_ids - variants_to_remove).empty?
       end
 
       def can_update_prices?
@@ -142,7 +167,7 @@ module Spree
         populate_variants_to_discontinue
 
         attributes = {}
-        last_index = params[:variants_attributes].keys.map(&:to_i).max
+        last_index = params[:variants_attributes].presence&.keys&.map(&:to_i)&.max || -1
         variant_ids_to_destroy.each_with_index do |variant_id, index|
           attributes[(last_index + 1 + index).to_s] = { id: variant_id, _destroy: '1' }
         end

--- a/spree/core/app/services/spree/products/prepare_nested_attributes.rb
+++ b/spree/core/app/services/spree/products/prepare_nested_attributes.rb
@@ -84,11 +84,14 @@ module Spree
         # The variants matrix was emptied: no variant rows re-submitted, removals sent instead.
         # Option types are detached only when the removal list covers every variant, so a
         # partial (possibly broken) submission never turns the product into a simple one.
-        if params[:variants_attributes].blank? && variants_to_remove.any?
+        # Variants kept alive by discontinuation still count as removed from the matrix,
+        # so the detachment can't hinge on any of them yielding a `_destroy` row.
+        if params[:variants_attributes].blank? && variants_to_remove.any? && can_remove_variants?
           attributes = removed_variants_attributes
 
+          params[:option_type_ids] = [] if removing_all_variants? && !params.key?(:option_type_ids)
+
           if attributes.any?
-            params[:option_type_ids] = [] if removing_all_variants? && !params.key?(:option_type_ids)
             params[:variants_attributes] = attributes
             params[:variants_attributes].permit!
           end

--- a/spree/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/spree/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -33,6 +33,7 @@ module Spree
 
         def permitted_product_attributes
           permitted_attributes.product_attributes + [
+            removed_variant_ids: [],
             variants_attributes: permitted_variant_attributes + ['id', :_destroy],
             master_attributes: permitted_variant_attributes + ['id']
           ]

--- a/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
+++ b/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
@@ -313,6 +313,10 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
           removed = prepared_params[:variants_attributes]&.values&.find { |v| v[:id] == variant.id.to_s }
           expect(removed).to be_nil
         end
+
+        it 'still clears the option types' do
+          expect(prepared_params[:option_type_ids]).to eq([])
+        end
       end
     end
 

--- a/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
+++ b/spree/core/spec/services/spree/products/prepare_nested_attributes_spec.rb
@@ -112,22 +112,86 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
 
   describe 'variant removal handling' do
     let(:option_type) { create(:option_type) }
-    let(:option_value) { create(:option_value, option_type: option_type) }
     let(:variant) { create(:variant, product: product) }
 
-    context 'when variant has completed orders' do
-      before do
-        create(:completed_order_with_totals, variants: [variant])
+    let(:new_option_value) { create(:option_value, option_type: option_type) }
+    let(:new_variant) { create(:variant, product: product) }
+    let(:variants_attributes) do
+      {
+        '0' => {
+          id: new_variant.id.to_s,
+          options: [
+            {
+              id: option_type.id,
+              name: option_type.name,
+              position: '0',
+              option_value_name: new_option_value.name,
+              option_value_presentation: new_option_value.presentation
+            }
+          ]
+        }
+      }
+    end
+
+    context 'when a variant is only omitted from variants_attributes' do
+      before { variant } # ensure variant exists before service runs
+
+      let(:raw_params) { { variants_attributes: variants_attributes } }
+
+      it 'does not mark the omitted variant for destruction' do
+        removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+        expect(removed).to be_nil
       end
 
-      context 'via variants_attributes' do
-        let(:new_option_value) { create(:option_value, option_type: option_type) }
-        let(:new_variant) { create(:variant, product: product) }
+      it 'does not collect the omitted variant for discontinuation' do
+        prepared_params
+        expect(service.variants_to_discontinue).to be_empty
+      end
+    end
+
+    context 'when no variants_attributes and no removals are submitted' do
+      before { variant } # ensure variant exists before service runs
+
+      let(:raw_params) { { name: 'Updated Product' } }
+
+      it 'leaves the variants untouched' do
+        expect(prepared_params[:variants_attributes]).to be_nil
+      end
+
+      it 'does not clear the option types' do
+        expect(prepared_params).not_to have_key(:option_type_ids)
+      end
+    end
+
+    context 'when a variant is explicitly removed' do
+      let(:raw_params) do
+        {
+          removed_variant_ids: [variant.id.to_s],
+          variants_attributes: variants_attributes
+        }
+      end
+
+      it 'marks the variant for destruction' do
+        removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+        expect(removed[:_destroy]).to eq('1')
+      end
+
+      it 'does not collect the variant for discontinuation' do
+        prepared_params
+        expect(service.variants_to_discontinue).not_to include(variant)
+      end
+
+      it 'consumes the removed_variant_ids param' do
+        expect(prepared_params).not_to have_key(:removed_variant_ids)
+      end
+
+      context 'when the variant is also re-submitted in variants_attributes' do
         let(:raw_params) do
           {
-            variants_attributes: {
-              '0' => {
-                id: new_variant.id.to_s,
+            removed_variant_ids: [variant.id.to_s],
+            variants_attributes: variants_attributes.merge(
+              '1' => {
+                id: variant.id.to_s,
                 options: [
                   {
                     id: option_type.id,
@@ -138,7 +202,91 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
                   }
                 ]
               }
-            }
+            )
+          }
+        end
+
+        it 'keeps the variant' do
+          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s && v[:_destroy].present? }
+          expect(removed).to be_nil
+        end
+      end
+
+      context 'when the user cannot destroy variants' do
+        before do
+          ability.cannot :destroy, Spree::Variant
+        end
+
+        it 'ignores the removals' do
+          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+          expect(removed).to be_nil
+        end
+      end
+    end
+
+    context 'when a removed variant belongs to another product' do
+      let(:other_variant) { create(:variant) }
+      let(:raw_params) do
+        {
+          removed_variant_ids: [other_variant.id.to_s],
+          variants_attributes: variants_attributes
+        }
+      end
+
+      it 'ignores the foreign variant id' do
+        removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == other_variant.id.to_s }
+        expect(removed).to be_nil
+      end
+    end
+
+    context 'when all variants are removed without variants_attributes' do
+      let(:raw_params) { { name: 'Updated Product', removed_variant_ids: [variant.id.to_s] } }
+
+      it 'marks the variant for destruction' do
+        removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
+        expect(removed[:_destroy]).to eq('1')
+      end
+
+      it 'clears the option types' do
+        expect(prepared_params[:option_type_ids]).to eq([])
+      end
+
+      context 'when the user cannot destroy variants' do
+        before do
+          ability.cannot :destroy, Spree::Variant
+        end
+
+        it 'ignores the removals and keeps the option types' do
+          expect(prepared_params[:variants_attributes]).to be_nil
+          expect(prepared_params).not_to have_key(:option_type_ids)
+        end
+      end
+    end
+
+    context 'when only some variants are removed without variants_attributes' do
+      before { new_variant } # ensure the second variant exists before service runs
+
+      let(:raw_params) { { name: 'Updated Product', removed_variant_ids: [variant.id.to_s] } }
+
+      it 'marks only the removed variant for destruction' do
+        expect(prepared_params[:variants_attributes].values.map { |v| v[:id] }).to eq([variant.id.to_s])
+      end
+
+      it 'does not clear the option types' do
+        expect(prepared_params).not_to have_key(:option_type_ids)
+      end
+    end
+
+    context 'when a removed variant has completed orders' do
+      before do
+        create(:completed_order_with_totals, variants: [variant])
+      end
+
+      context 'via variants_attributes' do
+        let(:raw_params) do
+          {
+            removed_variant_ids: [variant.id.to_s],
+            variants_attributes: variants_attributes
           }
         end
 
@@ -153,8 +301,8 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
         end
       end
 
-      context 'via fallback removal (no variants_attributes)' do
-        let(:raw_params) { { name: 'Updated Product' } }
+      context 'without variants_attributes' do
+        let(:raw_params) { { name: 'Updated Product', removed_variant_ids: [variant.id.to_s] } }
 
         it 'collects the variant for discontinuation' do
           prepared_params
@@ -168,62 +316,20 @@ RSpec.describe Spree::Products::PrepareNestedAttributes do
       end
     end
 
-    context 'when variant has no completed orders' do
-      before { variant } # ensure variant exists before service runs
-
-      context 'via variants_attributes' do
-        let(:new_option_value) { create(:option_value, option_type: option_type) }
-        let(:new_variant) { create(:variant, product: product) }
-        let(:raw_params) do
-          {
-            variants_attributes: {
-              '0' => {
-                id: new_variant.id.to_s,
-                options: [
-                  {
-                    id: option_type.id,
-                    name: option_type.name,
-                    position: '0',
-                    option_value_name: new_option_value.name,
-                    option_value_presentation: new_option_value.presentation
-                  }
-                ]
-              }
-            }
-          }
-        end
-
-        it 'marks the variant for destruction' do
-          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
-          expect(removed[:_destroy]).to eq('1')
-        end
-
-        it 'does not collect the variant for discontinuation' do
-          prepared_params
-          expect(service.variants_to_discontinue).not_to include(variant)
-        end
-      end
-
-      context 'via fallback removal (no variants_attributes)' do
-        let(:raw_params) { { name: 'Updated Product' } }
-
-        it 'marks the variant for destruction' do
-          removed = prepared_params[:variants_attributes].values.find { |v| v[:id] == variant.id.to_s }
-          expect(removed[:_destroy]).to eq('1')
-        end
-      end
-    end
-
-    context 'when product has mix of variants with and without completed orders' do
+    context 'when removing a mix of variants with and without completed orders' do
       let(:variant_with_order) { create(:variant, product: product) }
       let(:variant_without_order) { create(:variant, product: product) }
 
       before do
-        variant_without_order # ensure variant exists before service runs
         create(:completed_order_with_totals, variants: [variant_with_order])
       end
 
-      let(:raw_params) { { name: 'Updated Product' } }
+      let(:raw_params) do
+        {
+          name: 'Updated Product',
+          removed_variant_ids: [variant_with_order.id.to_s, variant_without_order.id.to_s]
+        }
+      end
 
       it 'collects the variant with completed orders for discontinuation' do
         prepared_params


### PR DESCRIPTION
Only delete variants which IDs are explicitely passed in params

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the product update contract for variant destruction—incorrect client or param handling could leave orphans or fail to remove intended variants—but the change reduces silent mass-deletion risk from broken or partial forms.
> 
> **Overview**
> Product variant deletion in the Rails admin is now **opt-in** via `product[removed_variant_ids][]` instead of inferring removals from missing `variants_attributes` rows.
> 
> **Backend:** `PrepareNestedAttributes` only marks variants for `_destroy` (or discontinuation when they have completed orders) when their id is in `removed_variant_ids` and belongs to the product; re-submitted variant rows override a removal request. Option types are cleared only when **all** variants are explicitly removed, not when the matrix is empty or partial. The param is stripped before `Product#update` and whitelisted in strong parameters.
> 
> **Admin UI:** The variants form Stimulus controller maintains a removal ledger, emits hidden `removed_variant_ids` inputs on delete/matrix refresh, reconciles parent vs leaf rows, and clears stale removal inputs on connect (e.g. Turbo cache) so accidental resubmits cannot delete variants the user did not remove in the current session.
> 
> Specs cover explicit vs omitted variants, authorization, foreign ids, partial/full removal, and completed-order discontinuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72cca39522b84f629c420ca3452843ca5020c673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product variant removal so only explicitly selected variants (via `removed_variant_ids`) are removed.
  * Prevented variants from being deleted when they’re merely omitted from submitted form data.
  * Preserved variants that are re-submitted during editing, including correct option-type clearing rules.
  * Improved handling of variants with completed orders by discontinuing them instead of deleting them.
  * Prevented unauthorized and unrelated variant removals from affecting products, including more reliable front-end removal input syncing.

* **Tests**
  * Expanded coverage for partial vs complete removals, missing `variants_attributes`, authorization, cross-product cases, and mixed discontinuation/destruction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->