### PR TITLE
Handle immutable addresses correctly

### DIFF
--- a/spree/admin/app/controllers/spree/admin/addresses_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/addresses_controller.rb
@@ -50,10 +50,6 @@ module Spree
         []
       end
 
-      def location_after_save
-        spree.admin_user_url(@address.user)
-      end
-
       def collection_url
         if @address.user.present?
           spree.admin_user_url(@address.user)

--- a/spree/admin/app/controllers/spree/admin/addresses_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/addresses_controller.rb
@@ -20,12 +20,9 @@ module Spree
       end
 
       def update
-        order = address_user_current_order
-
         result = update_service.call(
           address: @address,
           address_params: permitted_resource_params,
-          order: order,
           address_changes_except: address_update_address_changes_except
         )
 
@@ -51,11 +48,6 @@ module Spree
 
       def address_update_address_changes_except
         []
-      end
-
-      def address_user_current_order
-        incomplete_orders = @address.user.orders.incomplete
-        incomplete_orders.where(ship_address: @address).or(incomplete_orders.where(bill_address: @address)).first
       end
 
       def location_after_save

--- a/spree/admin/spec/controllers/spree/admin/addresses_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/addresses_controller_spec.rb
@@ -130,4 +130,33 @@ RSpec.describe Spree::Admin::AddressesController, type: :controller do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    context 'when the address is not referenced by an order' do
+      let!(:address) { create(:address, user: user) }
+
+      it 'hard-deletes the address' do
+        expect { delete :destroy, params: { id: address.to_param } }.to change(Spree::Address, :count).by(-1)
+      end
+    end
+
+    context 'when the address is referenced by a completed order' do
+      let!(:address) { create(:address, user: user) }
+      let!(:order) { create(:completed_order_with_totals, user: user, ship_address: address, bill_address: address) }
+
+      it 'soft-deletes the address, keeping the row for the order' do
+        expect { delete :destroy, params: { id: address.to_param } }.not_to change(Spree::Address, :count)
+
+        expect(address.reload.deleted_at).to be_present
+      end
+    end
+
+    context 'when the address has no user' do
+      let!(:address) { create(:address, user: nil) }
+
+      it 'hard-deletes the address' do
+        expect { delete :destroy, params: { id: address.to_param } }.to change(Spree::Address, :count).by(-1)
+      end
+    end
+  end
 end

--- a/spree/api/app/controllers/spree/api/v3/admin/customers/addresses_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/customers/addresses_controller.rb
@@ -7,7 +7,7 @@ module Spree
 
             # POST /api/v3/admin/customers/:customer_id/addresses
             def create
-              authorize_resource!(@parent.addresses.new, :create)
+              authorize_resource!(Spree::Address.new(user_id: @parent.id), :create)
 
               result = Spree.address_create_service.call(
                 address_params: address_attrs,

--- a/spree/api/app/controllers/spree/api/v3/admin/customers/addresses_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/customers/addresses_controller.rb
@@ -7,17 +7,19 @@ module Spree
 
             # POST /api/v3/admin/customers/:customer_id/addresses
             def create
-              @resource = @parent.addresses.new(address_attrs)
-              authorize_resource!(@resource, :create)
+              authorize_resource!(@parent.addresses.new, :create)
 
-              ApplicationRecord.transaction do
-                if @resource.save
-                  apply_default_flags(@resource)
-                  render json: serialize_resource(@resource.reload), status: :created
-                else
-                  render_validation_error(@resource.errors)
-                  raise ActiveRecord::Rollback
-                end
+              result = Spree.address_create_service.call(
+                address_params: address_attrs,
+                user: @parent,
+                default_billing: default_billing_flag,
+                default_shipping: default_shipping_flag
+              )
+
+              if result.success?
+                render json: serialize_resource(result.value), status: :created
+              else
+                render_validation_error(result.value.errors)
               end
             end
 
@@ -25,14 +27,17 @@ module Spree
             def update
               authorize_resource!(@resource)
 
-              ApplicationRecord.transaction do
-                if @resource.update(address_attrs)
-                  apply_default_flags(@resource)
-                  render json: serialize_resource(@resource.reload)
-                else
-                  render_validation_error(@resource.errors)
-                  raise ActiveRecord::Rollback
-                end
+              result = Spree.address_update_service.call(
+                address: @resource,
+                address_params: address_attrs,
+                default_billing: default_billing_flag,
+                default_shipping: default_shipping_flag
+              )
+
+              if result.success?
+                render json: serialize_resource(result.value)
+              else
+                render_validation_error(result.value.errors)
               end
             end
 
@@ -69,11 +74,12 @@ module Spree
               )
             end
 
-            def apply_default_flags(address)
-              updates = {}
-              updates[:bill_address_id] = address.id if ActiveModel::Type::Boolean.new.cast(params[:is_default_billing])
-              updates[:ship_address_id] = address.id if ActiveModel::Type::Boolean.new.cast(params[:is_default_shipping])
-              @parent.update!(updates) if updates.any?
+            def default_billing_flag
+              ActiveModel::Type::Boolean.new.cast(params[:is_default_billing])
+            end
+
+            def default_shipping_flag
+              ActiveModel::Type::Boolean.new.cast(params[:is_default_shipping])
             end
           end
         end

--- a/spree/api/app/controllers/spree/api/v3/store/customer/addresses_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/customer/addresses_controller.rb
@@ -35,6 +35,14 @@ module Spree
               end
             end
 
+            # DELETE /api/v3/store/customers/me/addresses/:id
+            def destroy
+              @resource.destroy!
+              head :no_content
+            rescue ActiveRecord::RecordNotDestroyed => e
+              render_validation_error(e.record.errors.presence || e.message)
+            end
+
             protected
 
             def set_parent

--- a/spree/api/spec/controllers/spree/api/v3/admin/customers/addresses_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/customers/addresses_controller_spec.rb
@@ -105,6 +105,40 @@ RSpec.describe Spree::Api::V3::Admin::Customers::AddressesController, type: :con
       expect(response).to have_http_status(:ok)
       expect(customer.reload.bill_address_id).to eq(target_id)
     end
+
+    context 'when the address is referenced by a completed order' do
+      let!(:order) { create(:completed_order_with_totals, user: customer, ship_address: address) }
+
+      it 'edits a copy instead of mutating the historical order address in place' do
+        original_id = address.id
+        original_city = address.city
+
+        patch :update, params: {
+          customer_id: customer.prefixed_id,
+          id: address.prefixed_id,
+          firstname: address.firstname,
+          lastname: address.lastname,
+          address1: address.address1,
+          city: 'NewCity',
+          zipcode: address.zipcode,
+          phone: address.phone,
+          country_id: address.country_id,
+          state_id: address.state_id
+        }, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['city']).to eq('NewCity')
+
+        # a new address backs the edit; the original is soft-deleted but unchanged
+        expect(Spree::Address.find_by_prefix_id(json_response['id']).id).not_to eq(original_id)
+        expect(address.reload.city).to eq(original_city)
+        expect(address.deleted_at).to be_present
+
+        # the completed order still points at the original, historical address
+        expect(order.reload.ship_address_id).to eq(original_id)
+        expect(order.ship_address.city).to eq(original_city)
+      end
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spree/api/spec/controllers/spree/api/v3/admin/customers/addresses_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/customers/addresses_controller_spec.rb
@@ -114,5 +114,45 @@ RSpec.describe Spree::Api::V3::Admin::Customers::AddressesController, type: :con
       expect(response).to have_http_status(:no_content)
       expect(Spree::Address.where(id: address.id)).to be_empty
     end
+
+    context 'when the address is referenced by a shipment' do
+      let!(:shipment) { create(:shipment, address: address) }
+
+      it 'soft-deletes the address, keeping the shipment association intact' do
+        expect {
+          delete :destroy, params: { customer_id: customer.prefixed_id, id: address.prefixed_id }, as: :json
+        }.to change { customer.addresses.count }.by(-1)
+
+        expect(response).to have_http_status(:no_content)
+        expect(address.reload.deleted_at).to be_present
+        expect(shipment.reload.address).to eq(address)
+      end
+    end
+
+    context 'when the address is referenced by a completed order' do
+      shared_examples 'soft-deletes the referenced address' do |association|
+        it 'soft-deletes the address, keeping the order association intact' do
+          expect {
+            delete :destroy, params: { customer_id: customer.prefixed_id, id: address.prefixed_id }, as: :json
+          }.to change { customer.addresses.count }.by(-1)
+
+          expect(response).to have_http_status(:no_content)
+          expect(address.reload.deleted_at).to be_present
+          expect(order.reload.public_send(association)).to eq(address)
+        end
+      end
+
+      context 'as the ship address' do
+        let!(:order) { create(:completed_order_with_totals, user: customer, ship_address: address) }
+
+        it_behaves_like 'soft-deletes the referenced address', :ship_address
+      end
+
+      context 'as the bill address' do
+        let!(:order) { create(:completed_order_with_totals, user: customer, bill_address: address) }
+
+        it_behaves_like 'soft-deletes the referenced address', :bill_address
+      end
+    end
   end
 end

--- a/spree/api/spec/controllers/spree/api/v3/store/customer/addresses_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/customer/addresses_controller_spec.rb
@@ -289,6 +289,46 @@ RSpec.describe Spree::Api::V3::Store::Customer::AddressesController, type: :cont
       expect(response).to have_http_status(:no_content)
     end
 
+    context 'when the address is referenced by a shipment' do
+      let!(:shipment) { create(:shipment, address: address) }
+
+      it 'soft-deletes the address, keeping the shipment association intact' do
+        expect {
+          delete :destroy, params: { id: address.prefixed_id }
+        }.to change { user.addresses.count }.by(-1)
+
+        expect(response).to have_http_status(:no_content)
+        expect(address.reload.deleted_at).to be_present
+        expect(shipment.reload.address).to eq(address)
+      end
+    end
+
+    context 'when the address is referenced by a completed order' do
+      shared_examples 'soft-deletes the referenced address' do |association|
+        it 'soft-deletes the address, keeping the order association intact' do
+          expect {
+            delete :destroy, params: { id: address.prefixed_id }
+          }.to change { user.addresses.count }.by(-1)
+
+          expect(response).to have_http_status(:no_content)
+          expect(address.reload.deleted_at).to be_present
+          expect(order.reload.public_send(association)).to eq(address)
+        end
+      end
+
+      context 'as the ship address' do
+        let!(:order) { create(:completed_order_with_totals, user: user, ship_address: address) }
+
+        it_behaves_like 'soft-deletes the referenced address', :ship_address
+      end
+
+      context 'as the bill address' do
+        let!(:order) { create(:completed_order_with_totals, user: user, bill_address: address) }
+
+        it_behaves_like 'soft-deletes the referenced address', :bill_address
+      end
+    end
+
     context 'when address belongs to another user' do
       let!(:other_user) { create(:user) }
       let!(:other_address) { create(:address, user: other_user) }

--- a/spree/core/app/models/spree/address.rb
+++ b/spree/core/app/models/spree/address.rb
@@ -233,6 +233,7 @@ module Spree
       assign_new_default_address_to_user
 
       if can_be_deleted?
+        unassign_from_incomplete_orders
         super
       else
         update_column :deleted_at, Time.current
@@ -363,6 +364,19 @@ module Spree
 
     def assign_new_default_address_to_user_scope
       user.addresses.not_quick_checkout.reorder(created_at: :desc)
+    end
+
+    # Prevents dangling address references on active carts when the row is hard-deleted.
+    # can_be_deleted? only guards completed orders, so incomplete orders must be detached here.
+    def unassign_from_incomplete_orders
+      orders = Spree::Order.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: id)
+
+      orders.find_each do |order|
+        order.ship_address_id = nil if order.ship_address_id == id
+        order.bill_address_id = nil if order.bill_address_id == id
+        order.state = 'address'
+        order.save!
+      end
     end
   end
 end

--- a/spree/core/app/models/spree/address.rb
+++ b/spree/core/app/models/spree/address.rb
@@ -366,8 +366,6 @@ module Spree
       user.addresses.not_quick_checkout.reorder(created_at: :desc)
     end
 
-    # Prevents dangling address references on active carts when the row is hard-deleted.
-    # can_be_deleted? only guards completed orders, so incomplete orders must be detached here.
     def unassign_from_incomplete_orders
       orders = Spree::Order.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: id)
 

--- a/spree/core/app/models/spree/address.rb
+++ b/spree/core/app/models/spree/address.rb
@@ -367,8 +367,9 @@ module Spree
     end
 
     def unassign_from_incomplete_orders
-      Spree::Order.incomplete.where(ship_address_id: id).update_all(ship_address_id: nil, state: 'address', updated_at: Time.current)
-      Spree::Order.incomplete.where(bill_address_id: id).update_all(bill_address_id: nil, state: 'address', updated_at: Time.current)
+      orders = Spree::Order.incomplete.where(user_id: user_id)
+      orders.where(ship_address_id: id).update_all(ship_address_id: nil, state: 'address', updated_at: Time.current)
+      orders.where(bill_address_id: id).update_all(bill_address_id: nil, state: 'address', updated_at: Time.current)
     end
   end
 end

--- a/spree/core/app/models/spree/address.rb
+++ b/spree/core/app/models/spree/address.rb
@@ -367,14 +367,8 @@ module Spree
     end
 
     def unassign_from_incomplete_orders
-      orders = Spree::Order.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: id)
-
-      orders.find_each do |order|
-        order.ship_address_id = nil if order.ship_address_id == id
-        order.bill_address_id = nil if order.bill_address_id == id
-        order.state = 'address'
-        order.save!
-      end
+      Spree::Order.incomplete.where(ship_address_id: id).update_all(ship_address_id: nil, state: 'address', updated_at: Time.current)
+      Spree::Order.incomplete.where(bill_address_id: id).update_all(bill_address_id: nil, state: 'address', updated_at: Time.current)
     end
   end
 end

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -44,22 +44,20 @@ module Spree
         return success(address) unless address_changed
 
         if address.editable?
-          if address.update(address_params)
-            if address.user.present?
-              assign_to_user_as_default(
-                user: address.user,
-                address_id: address.id,
-                default_billing: default_billing,
-                default_shipping: default_shipping
-              )
+          address.update!(address_params)
 
-              reassign_incomplete_orders(address.user, address.id, address)
-            end
+          if address.user.present?
+            assign_to_user_as_default(
+              user: address.user,
+              address_id: address.id,
+              default_billing: default_billing,
+              default_shipping: default_shipping
+            )
 
-            success(address)
-          else
-            failure(address)
+            reassign_incomplete_orders(address.user, address.id, address)
           end
+
+          success(address)
         elsif new_address(address_params).valid?
           old_address_id = address.id
           address.destroy!

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -90,14 +90,9 @@ module Spree
       end
 
       def reassign_incomplete_orders(old_address_id, new_address)
-        orders = Spree::Order.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: old_address_id)
-
-        orders.find_each do |incomplete_order|
-          incomplete_order.ship_address = new_address if incomplete_order.ship_address_id == old_address_id
-          incomplete_order.bill_address = new_address if incomplete_order.bill_address_id == old_address_id
-          incomplete_order.state = 'address'
-          incomplete_order.save!
-        end
+        orders = Spree::Order.incomplete.where(user_id: new_address.user_id)
+        orders.where(ship_address_id: old_address_id).update_all(ship_address_id: new_address.id, state: 'address', updated_at: Time.current)
+        orders.where(bill_address_id: old_address_id).update_all(bill_address_id: new_address.id, state: 'address', updated_at: Time.current)
       end
 
       def defaults_changed?(address, default_billing, default_shipping)

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -10,7 +10,7 @@ module Spree
         ApplicationRecord.transaction do
           perform(address: address, address_params: address_params, **opts)
         end
-      rescue ActiveRecord::RecordInvalid => e
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotDestroyed => e
         failure(e.record)
       end
 
@@ -62,7 +62,7 @@ module Spree
           end
         elsif new_address(address_params).valid?
           old_address_id = address.id
-          address.destroy
+          address.destroy!
 
           if new_address.user.present?
             default_billing = address.user_default_billing? || default_billing

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -15,7 +15,6 @@ module Spree
       private
 
       def perform(address:, address_params:, **opts)
-        order = opts[:order]
         default_billing = address_params.key?(:is_default_billing) ? address_params.delete(:is_default_billing) : opts.fetch(:default_billing, false)
         default_shipping = address_params.key?(:is_default_shipping) ? address_params.delete(:is_default_shipping) : opts.fetch(:default_shipping, false)
         address_changes_except = opts.fetch(:address_changes_except, [])
@@ -51,15 +50,16 @@ module Spree
                 default_billing: default_billing,
                 default_shipping: default_shipping
               )
-            end
 
-            order.update(state: 'address') if order.present?
+              reassign_incomplete_orders(address.user, address.id, address)
+            end
 
             success(address)
           else
             failure(address)
           end
         elsif new_address(address_params).valid?
+          old_address_id = address.id
           address.destroy
 
           if new_address.user.present?
@@ -72,13 +72,8 @@ module Spree
               default_billing: default_billing,
               default_shipping: default_shipping
             )
-          end
 
-          if order.present?
-            order.ship_address = new_address if order.ship_address_id == address.id
-            order.bill_address = new_address if order.bill_address_id == address.id
-            order.state = 'address'
-            order.save
+            reassign_incomplete_orders(new_address.user, old_address_id, new_address)
           end
 
           success(new_address)
@@ -92,6 +87,17 @@ module Spree
         address_params[:country_id] ||= address.country_id
         address_params = fill_country_and_state_ids(address_params)
         address_params.transform_values!(&:presence)
+      end
+
+      def reassign_incomplete_orders(user, old_address_id, new_address)
+        orders = user.orders.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: old_address_id)
+
+        orders.find_each do |incomplete_order|
+          incomplete_order.ship_address = new_address if incomplete_order.ship_address_id == old_address_id
+          incomplete_order.bill_address = new_address if incomplete_order.bill_address_id == old_address_id
+          incomplete_order.state = 'address'
+          incomplete_order.save!
+        end
       end
 
       def defaults_changed?(address, default_billing, default_shipping)

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -7,6 +7,14 @@ module Spree
       attr_accessor :country
 
       def call(address:, address_params:, **opts)
+        ApplicationRecord.transaction do
+          perform(address: address, address_params: address_params, **opts)
+        end
+      end
+
+      private
+
+      def perform(address:, address_params:, **opts)
         order = opts[:order]
         default_billing = address_params.key?(:is_default_billing) ? address_params.delete(:is_default_billing) : opts.fetch(:default_billing, false)
         default_shipping = address_params.key?(:is_default_shipping) ? address_params.delete(:is_default_shipping) : opts.fetch(:default_shipping, false)
@@ -78,8 +86,6 @@ module Spree
           failure(new_address)
         end
       end
-
-      private
 
       def prepare_address_params!(address, address_params)
         address_params[:user_id] = address&.user_id

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -10,6 +10,8 @@ module Spree
         ApplicationRecord.transaction do
           perform(address: address, address_params: address_params, **opts)
         end
+      rescue ActiveRecord::RecordInvalid => e
+        failure(e.record)
       end
 
       private

--- a/spree/core/app/services/spree/addresses/update.rb
+++ b/spree/core/app/services/spree/addresses/update.rb
@@ -53,9 +53,9 @@ module Spree
               default_billing: default_billing,
               default_shipping: default_shipping
             )
-
-            reassign_incomplete_orders(address.user, address.id, address)
           end
+
+          reassign_incomplete_orders(address.id, address)
 
           success(address)
         elsif new_address(address_params).valid?
@@ -72,9 +72,9 @@ module Spree
               default_billing: default_billing,
               default_shipping: default_shipping
             )
-
-            reassign_incomplete_orders(new_address.user, old_address_id, new_address)
           end
+
+          reassign_incomplete_orders(old_address_id, new_address)
 
           success(new_address)
         else
@@ -89,8 +89,8 @@ module Spree
         address_params.transform_values!(&:presence)
       end
 
-      def reassign_incomplete_orders(user, old_address_id, new_address)
-        orders = user.orders.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: old_address_id)
+      def reassign_incomplete_orders(old_address_id, new_address)
+        orders = Spree::Order.incomplete.where('ship_address_id = :id OR bill_address_id = :id', id: old_address_id)
 
         orders.find_each do |incomplete_order|
           incomplete_order.ship_address = new_address if incomplete_order.ship_address_id == old_address_id

--- a/spree/core/spec/models/spree/address_spec.rb
+++ b/spree/core/spec/models/spree/address_spec.rb
@@ -583,6 +583,16 @@ describe Spree::Address, type: :model do
         expect(Spree::Address.where(id: address.id)).to be_empty
       end
 
+      it "leaves another user's order referencing the same address untouched" do
+        other_order = create(:order, user: create(:user), bill_address: address, ship_address: address, state: 'delivery')
+
+        address.destroy
+
+        expect(other_order.reload.ship_address_id).to eq(address.id)
+        expect(other_order.bill_address_id).to eq(address.id)
+        expect(other_order.state).to eq('delivery')
+      end
+
       context 'when the address is also used by a completed order' do
         let!(:completed_order) do
           create(:completed_order_with_totals, bill_address: address, ship_address: address)

--- a/spree/core/spec/models/spree/address_spec.rb
+++ b/spree/core/spec/models/spree/address_spec.rb
@@ -564,6 +564,41 @@ describe Spree::Address, type: :model do
       expect(Spree::Address.not_deleted.where(['id = (?)', address2.id])).to be_empty
     end
 
+    context 'when an incomplete order references the address' do
+      let!(:incomplete_order) do
+        create(:order, user: user, bill_address: address, ship_address: address, state: 'delivery')
+      end
+
+      it 'detaches the address from the order and resets it to the address step' do
+        address.destroy
+
+        incomplete_order.reload
+        expect(incomplete_order.bill_address_id).to be_nil
+        expect(incomplete_order.ship_address_id).to be_nil
+        expect(incomplete_order.state).to eq('address')
+      end
+
+      it 'still hard-deletes the address' do
+        address.destroy
+        expect(Spree::Address.where(id: address.id)).to be_empty
+      end
+
+      context 'when the address is also used by a completed order' do
+        let!(:completed_order) do
+          create(:completed_order_with_totals, bill_address: address, ship_address: address)
+        end
+
+        it 'soft-deletes the address and keeps it associated to all orders' do
+          address.destroy
+
+          expect(address.reload.deleted_at).to be_present
+          expect(incomplete_order.reload.bill_address_id).to eq(address.id)
+          expect(incomplete_order.ship_address_id).to eq(address.id)
+          expect(completed_order.reload.bill_address_id).to eq(address.id)
+        end
+      end
+    end
+
     context 'when saving user raises error' do
       before do
         user.update(ship_address: address2, bill_address: address2)

--- a/spree/core/spec/services/spree/addresses/update_spec.rb
+++ b/spree/core/spec/services/spree/addresses/update_spec.rb
@@ -241,6 +241,26 @@ RSpec.describe Spree::Addresses::Update do
           end
         end
 
+        context 'when a separate incomplete order shares the address' do
+          let!(:incomplete_order) { create(:order, user: user, ship_address: address, bill_address: address) }
+
+          it 'repoints the incomplete order to the new address and moves it to the address step' do
+            result
+
+            expect(incomplete_order.reload.ship_address_id).to eq(value.id)
+            expect(incomplete_order.bill_address_id).to eq(value.id)
+            expect(incomplete_order.state).to eq('address')
+          end
+
+          it 'keeps the completed order on the original, soft-deleted address' do
+            result
+
+            expect(completed_order.reload.ship_address_id).to eq(address.id)
+            expect(completed_order.bill_address_id).to eq(address.id)
+            expect(address.reload.deleted_at).to be_present
+          end
+        end
+
         it_behaves_like 'updating with same params'
       end
     end

--- a/spree/core/spec/services/spree/addresses/update_spec.rb
+++ b/spree/core/spec/services/spree/addresses/update_spec.rb
@@ -273,6 +273,18 @@ RSpec.describe Spree::Addresses::Update do
           end
         end
 
+        context 'when soft-deleting the previous address fails' do
+          before do
+            allow(address).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed.new('failed', address))
+          end
+
+          it 'rolls back the address replacement and returns a failure' do
+            expect { result }.not_to change(Spree::Address.unscoped, :count)
+            expect(result).to be_failure
+            expect(result.value).to eq(address)
+          end
+        end
+
         it_behaves_like 'updating with same params'
       end
     end

--- a/spree/core/spec/services/spree/addresses/update_spec.rb
+++ b/spree/core/spec/services/spree/addresses/update_spec.rb
@@ -287,6 +287,29 @@ RSpec.describe Spree::Addresses::Update do
 
         it_behaves_like 'updating with same params'
       end
+
+      context 'when a guest cart shares an immutable address' do
+        let(:address) { create(:address) }
+        let!(:completed_guest_order) do
+          create(:order, user: nil, email: 'guest-complete@example.com', completed_at: Time.current,
+                         ship_address: address, bill_address: address)
+        end
+        let!(:guest_cart) do
+          create(:order, user: nil, email: 'guest-cart@example.com', ship_address: address, bill_address: address)
+        end
+
+        it 'repoints the guest cart to the copy and keeps the completed order on the original' do
+          expect(result).to be_success
+          expect(value.id).not_to eq(address.id)
+          expect(address.reload.deleted_at).to be_present
+
+          expect(guest_cart.reload.ship_address_id).to eq(value.id)
+          expect(guest_cart.bill_address_id).to eq(value.id)
+          expect(guest_cart.state).to eq('address')
+
+          expect(completed_guest_order.reload.ship_address_id).to eq(address.id)
+        end
+      end
     end
 
     context 'with invalid params' do

--- a/spree/core/spec/services/spree/addresses/update_spec.rb
+++ b/spree/core/spec/services/spree/addresses/update_spec.rb
@@ -260,16 +260,14 @@ RSpec.describe Spree::Addresses::Update do
             expect(address.reload.deleted_at).to be_present
           end
 
-          context 'when repointing the incomplete order fails' do
-            before do
-              allow_any_instance_of(Spree::Order).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(incomplete_order))
-            end
+          it "does not repoint another user's order sharing the address" do
+            other_order = create(:order, user: create(:user), ship_address: address, bill_address: address, state: 'delivery')
 
-            it 'rolls back the address replacement and returns a failure' do
-              expect { result }.not_to change(Spree::Address.unscoped, :count)
-              expect(result).to be_failure
-              expect(address.reload.deleted_at).to be_nil
-            end
+            result
+
+            expect(other_order.reload.ship_address_id).to eq(address.id)
+            expect(other_order.bill_address_id).to eq(address.id)
+            expect(other_order.state).to eq('delivery')
           end
         end
 

--- a/spree/core/spec/services/spree/addresses/update_spec.rb
+++ b/spree/core/spec/services/spree/addresses/update_spec.rb
@@ -259,6 +259,18 @@ RSpec.describe Spree::Addresses::Update do
             expect(completed_order.bill_address_id).to eq(address.id)
             expect(address.reload.deleted_at).to be_present
           end
+
+          context 'when repointing the incomplete order fails' do
+            before do
+              allow_any_instance_of(Spree::Order).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(incomplete_order))
+            end
+
+            it 'rolls back the address replacement and returns a failure' do
+              expect { result }.not_to change(Spree::Address.unscoped, :count)
+              expect(result).to be_failure
+              expect(address.reload.deleted_at).to be_nil
+            end
+          end
         end
 
         it_behaves_like 'updating with same params'

--- a/spree/core/spec/services/spree/addresses/update_spec.rb
+++ b/spree/core/spec/services/spree/addresses/update_spec.rb
@@ -327,6 +327,16 @@ RSpec.describe Spree::Addresses::Update do
         messages = result.error.value.messages
         expect(messages).to eq( zipcode: ["can't be blank"])
       end
+
+      context 'when the address is uneditable' do
+        let!(:completed_order) { create(:completed_order_with_totals, user: user, ship_address: address, bill_address: address) }
+
+        it 'returns a failure and leaves the original address intact' do
+          expect { result }.not_to change(Spree::Address, :count)
+          expect(result).to be_failure
+          expect(address.reload.deleted_at).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes checkout order state and address identity for carts sharing historical addresses; incorrect repointing could affect in-flight checkouts, though behavior is heavily spec’d and transactional.
> 
> **Overview**
> **Immutable address handling** is centralized in `Spree::Addresses::Update`: updates run inside a DB transaction with rollback on validation/destroy failures. When an address is not **editable** (used on a completed order), edits **soft-delete the original** and return a **new** row so completed orders keep the historical snapshot; **incomplete** orders (including guest carts) that still point at the old id are **repointed** and reset to the `address` checkout step via `reassign_incomplete_orders`, replacing the old per-controller `order` argument.
> 
> **API and admin surfaces** align on shared services: admin customer address **create/update** use `address_create_service` / `address_update_service` with default billing/shipping flags instead of inline saves. **Store** customers get **DELETE** on saved addresses (`destroy!` with validation errors on failure). **Admin** address **update** drops local incomplete-order lookup; redirect after save defers to `collection_url`.
> 
> **Tests** cover soft vs hard delete, copy-on-update for completed orders, shipment/order associations after delete, guest carts, and transactional rollback when order repoint or soft-delete fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c576f58c866bc96892ce6c0af9eaacd0f7e39cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customers can now delete saved addresses via the store API endpoint.
  * Successful address deletion returns **204 No Content**.
* **Bug Fixes**
  * Updating an address used by completed orders now preserves the original historical address.
  * Deleting an address now **soft-deletes** it while keeping shipment and completed order associations intact.
  * Address updates now more reliably repoint affected **incomplete** orders, apply default billing/shipping, and normalize country/state details.
  * Validation errors are returned when create/update/delete operations fail.
* **Tests**
  * Expanded controller and service specs for shared address behavior, soft-deletion integrity, guest carts, and rollback on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->