### PR TITLE
Bump dashboard packages to 0.10.0

### DIFF
--- a/docs/developer/dashboard/plugins/publishing.mdx
+++ b/docs/developer/dashboard/plugins/publishing.mdx
@@ -15,8 +15,8 @@ Your plugin imports React, the dashboard, Tailwind, i18next, etc., but **you don
   "peerDependencies": {
     "react": "^19",
     "react-dom": "^19",
-    "@spree/dashboard-core": "^0.1.0",
-    "@spree/dashboard-ui": "^0.1.0",
+    "@spree/dashboard-core": "^0.10.0",
+    "@spree/dashboard-ui": "^0.10.0",
     "@spree/admin-sdk": "^0.5.0",
     "i18next": "^26",
     "react-i18next": "^17",
@@ -27,7 +27,7 @@ Your plugin imports React, the dashboard, Tailwind, i18next, etc., but **you don
 }
 ```
 
-Use ranges, not exact versions — pin too tightly and consumers can't upgrade the dashboard without you cutting a release. One Developer Preview caveat: for `0.x` versions, `^` only allows patch-level drift (`^0.1.0` matches `0.1.x`, not `0.2.0`), so expect to bump your `@spree/dashboard-*` peers alongside dashboard releases until 1.0. `spree plugin new` scaffolds these ranges for you, matched to the current release.
+Use ranges, not exact versions — pin too tightly and consumers can't upgrade the dashboard without you cutting a release. One Developer Preview caveat: for `0.x` versions, `^` only allows patch-level drift (`^0.10.0` matches `0.10.x`, not `0.11.0`), so expect to bump your `@spree/dashboard-*` peers alongside dashboard releases until 1.0. `spree plugin new` scaffolds these ranges for you, matched to the current release.
 
 `dependencies` is for things your plugin *uses* that the host *doesn't* — small utilities (e.g., `clsx`, `date-fns` if you need a specific version, your own helper packages). When in doubt, peer-dep it. The trade-off is "user has to install one more thing" vs. "user has two copies of React" — always pay the first cost.
 

--- a/packages/cli/templates/plugin/packages/dashboard/package.json.tt
+++ b/packages/cli/templates/plugin/packages/dashboard/package.json.tt
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@spree/admin-sdk": "^0.5.0",
-    "@spree/dashboard-core": "^0.1.0",
-    "@spree/dashboard-ui": "^0.1.0",
+    "@spree/dashboard-core": "^0.10.0",
+    "@spree/dashboard-ui": "^0.10.0",
     "@tanstack/react-query": "^5",
     "@tanstack/react-router": "^1",
     "i18next": "^26",

--- a/packages/dashboard-core/package.json
+++ b/packages/dashboard-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spree/dashboard-core",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "description": "Spree Dashboard framework — registries (table, nav, slot, settings-nav), providers (auth, permission, store), admin SDK client, generic infra hooks, and the defineDashboardPlugin extension API. Developer Preview.",
   "author": "Vendo Connect Inc.",
   "homepage": "https://spreecommerce.org",

--- a/packages/dashboard-ui/package.json
+++ b/packages/dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spree/dashboard-ui",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "description": "Spree Dashboard design system — shadcn primitives, headless composed components, and design tokens. Source-only package; consumers compile via their own Vite/Tailwind setup. Developer Preview.",
   "author": "Vendo Connect Inc.",
   "homepage": "https://spreecommerce.org",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spree/dashboard",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "description": "Spree Dashboard app shell — the next-gen React admin for Spree Commerce. Routes, resource hooks, schemas, locales, and the <Dashboard /> component. Source-only package; hosts compile it via @spree/dashboard/vite. Developer Preview.",
   "author": "Vendo Connect Inc.",
   "homepage": "https://spreecommerce.org",


### PR DESCRIPTION
@spree/dashboard 0.1.0 and 0.2.x were published years ago, and npm never allows reusing a version — so the Developer Preview starts at **0.10.0**, all three packages (`dashboard`, `dashboard-core`, `dashboard-ui`) in lockstep.

Also updates the plugin scaffold's peer ranges and the publishing docs; the CLI's embedded starter template picks the new pins up automatically at build time (verified: embedded template pins `^0.10.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DzwNXZwhBsLqcJzwZwAmD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and documentation/template updates with no application or runtime code changes.
> 
> **Overview**
> Sets the Developer Preview npm line to **0.10.0** for `@spree/dashboard`, `@spree/dashboard-core`, and `@spree/dashboard-ui` (all three stay in lockstep), avoiding reuse of older `0.1.0` / `0.2.x` versions already on npm.
> 
> Plugin authors get aligned defaults: the `spree plugin new` dashboard `package.json` template now peers on `^0.10.0` for dashboard-core/ui, and the publishing docs example and semver caveat text use `0.10.x` instead of `0.1.x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107df0ae1fe8c7dadfa65f1d089ad54d63a40e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin publishing guidance with the latest compatible dashboard package versions.
  - Clarified version compatibility behavior for dashboard plugin peer dependencies.

- **Chores**
  - Released the dashboard, dashboard UI, and dashboard core packages as version 0.10.0.
  - Updated new plugin templates to reference the compatible 0.10.x dashboard packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->