### PR TITLE
Bump version to 5.6.0.rc1

### DIFF
--- a/spree/core/lib/spree/core/version.rb
+++ b/spree/core/lib/spree/core/version.rb
@@ -1,5 +1,5 @@
 module Spree
-  VERSION = '5.5.0'.freeze
+  VERSION = '5.6.0.rc1'.freeze
 
   def self.version
     VERSION


### PR DESCRIPTION
Version bump for the 5.6 RC1 release — the first release carrying the React Dashboard Developer Preview (`spree_dashboard` host gem publishes alongside the existing gems; it's already in `SPREE_OPTIONAL_GEMS`, so `rake gem:release` covers it).

After merging: `git tag v5.6.0.rc1 && git push origin v5.6.0.rc1` — note the pending trusted publisher for `spree_dashboard` on rubygems.org expires ~12h after creation, so tag within the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DzwNXZwhBsLqcJzwZwAmD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no runtime logic or dependency updates in the diff.
> 
> **Overview**
> Bumps the canonical Spree gem version constant from **`5.5.0`** to **`5.6.0.rc1`** in `spree/core/lib/spree/core/version.rb`, marking the first release candidate for the 5.6 line (including the React Dashboard developer preview per release notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88563815aaccedb4bdf34affda281a9319583b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the reported Spree version to 5.6.0 release candidate 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->