### PR TITLE
create-spree-app always yields a working app; spree dev completes first-run setup automatically

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,14 +10,17 @@ configure API keys) instead of a bare `docker compose up`. A bare `up` never
 pulls, so a mutable tag (`latest`) cached weeks ago by another project
 silently booted an old Spree whenever the first boot happened through
 `spree dev` — a `--no-start` scaffold, an interrupted create-spree-app run,
-or a fresh clone. The sample-data choice create-spree-app persists in `.env`
+or a fresh clone. A setup that was itself interrupted partway (e.g. Ctrl+C
+during the first image pull) is also detected and completed on the next
+`spree dev`, for projects scaffolded by create-spree-app 1.1.1+. The
+sample-data choice create-spree-app persists in `.env`
 (`SPREE_SAMPLE_DATA`) is honored, so a deferred first run keeps the answer
 given at scaffold time. Setup also installs `apps/storefront` and
 `apps/dashboard` dependencies when they're missing (a fresh clone, or a
 scaffold whose install step failed) — mirroring create-spree-app's per-app
-install steps — so every app is runnable with `pnpm dev` right after. Already-initialized projects are untouched: later
-boots never pull, dev stays offline-friendly, and upgrades stay explicit via
-`spree update`.
+install steps — so every app is runnable with `pnpm dev` right after.
+Already-initialized projects are untouched: later boots never pull, dev
+stays offline-friendly, and upgrades stay explicit via `spree update`.
 
 ## 2.4.1
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @spree/cli
 
+## 2.4.2
+
+### Patch Changes
+
+- `spree dev` on a project that was never set up now runs the full first-run
+flow automatically (pull fresh images, start services, seed the database,
+configure API keys) instead of a bare `docker compose up`. A bare `up` never
+pulls, so a mutable tag (`latest`) cached weeks ago by another project
+silently booted an old Spree whenever the first boot happened through
+`spree dev` — a `--no-start` scaffold, an interrupted create-spree-app run,
+or a fresh clone. Already-initialized projects are untouched: later boots
+never pull, dev stays offline-friendly, and upgrades stay explicit via
+`spree update`.
+
 ## 2.4.1
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,7 +12,10 @@ silently booted an old Spree whenever the first boot happened through
 `spree dev` — a `--no-start` scaffold, an interrupted create-spree-app run,
 or a fresh clone. The sample-data choice create-spree-app persists in `.env`
 (`SPREE_SAMPLE_DATA`) is honored, so a deferred first run keeps the answer
-given at scaffold time. Already-initialized projects are untouched: later
+given at scaffold time. Setup also installs `apps/storefront` and
+`apps/dashboard` dependencies when they're missing (a fresh clone, or a
+scaffold whose install step failed) — mirroring create-spree-app's per-app
+install steps — so every app is runnable with `pnpm dev` right after. Already-initialized projects are untouched: later
 boots never pull, dev stays offline-friendly, and upgrades stay explicit via
 `spree update`.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,8 +10,10 @@ configure API keys) instead of a bare `docker compose up`. A bare `up` never
 pulls, so a mutable tag (`latest`) cached weeks ago by another project
 silently booted an old Spree whenever the first boot happened through
 `spree dev` — a `--no-start` scaffold, an interrupted create-spree-app run,
-or a fresh clone. Already-initialized projects are untouched: later boots
-never pull, dev stays offline-friendly, and upgrades stay explicit via
+or a fresh clone. The sample-data choice create-spree-app persists in `.env`
+(`SPREE_SAMPLE_DATA`) is honored, so a deferred first run keeps the answer
+given at scaffold time. Already-initialized projects are untouched: later
+boots never pull, dev stays offline-friendly, and upgrades stay explicit via
 `spree update`.
 
 ## 2.4.1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -252,7 +252,7 @@ function writeDashboardEnv(envPath: string, port: number): void {
 }
 
 /** Prefer the project's own package manager (by lockfile); default to pnpm. */
-function detectPackageManager(projectDir: string, dashboardDir: string): string {
+export function detectPackageManager(projectDir: string, dashboardDir: string): string {
   for (const dir of [dashboardDir, projectDir]) {
     if (fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))) return 'pnpm'
     if (fs.existsSync(path.join(dir, 'yarn.lock'))) return 'yarn'

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -3,14 +3,17 @@ import path from 'node:path'
 import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import pc from 'picocolors'
+import { projectCredentialsPath } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject, hasMonorepoSpreePath, isEjectedProject } from '../context.js'
 import {
   buildAdminStylesheets,
   dockerCompose,
+  hasProjectContainers,
   primeBundleVolume,
   watchAdminStylesheets,
 } from '../docker.js'
+import { runFirstRunSetup } from './init.js'
 
 export function registerDevCommand(program: Command): void {
   program
@@ -28,6 +31,33 @@ export function registerDevCommand(program: Command): void {
           ].join('\n'),
         )
         process.exit(1)
+      }
+
+      // A project that was never set up gets the full first-run flow instead
+      // of a bare `up`: pull a fresh image (a mutable tag cached weeks ago by
+      // another project would otherwise boot an old Spree), seed the database,
+      // mint API keys. This keeps create-spree-app's contract — the app just
+      // works — on every path to a first boot (--no-start, an interrupted
+      // scaffold, a fresh clone) without requiring anyone to run `spree init`.
+      // "Never set up" = init never minted credentials AND compose never
+      // created a container, so a torn-down (`docker compose down`) but
+      // initialized project boots normally. Ejected projects build the image
+      // locally and manage their own lifecycle.
+      if (
+        !isEjectedProject(ctx.projectDir) &&
+        !fs.existsSync(projectCredentialsPath(ctx.projectDir))
+      ) {
+        let neverBooted = false
+        try {
+          neverBooted = !(await hasProjectContainers(ctx.projectDir))
+        } catch {
+          // Daemon trouble surfaces with compose's own error on the up below.
+        }
+        if (neverBooted) {
+          p.log.info('First run detected — completing setup automatically.')
+          await runFirstRunSetup({ sampleData: true, open: true })
+          return
+        }
       }
 
       p.note(

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -5,7 +5,12 @@ import type { Command } from 'commander'
 import pc from 'picocolors'
 import { projectCredentialsPath } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
-import { detectProject, hasMonorepoSpreePath, isEjectedProject } from '../context.js'
+import {
+  detectProject,
+  hasMonorepoSpreePath,
+  isEjectedProject,
+  readSampleDataFromEnv,
+} from '../context.js'
 import {
   buildAdminStylesheets,
   dockerCompose,
@@ -39,21 +44,28 @@ export function registerDevCommand(program: Command): void {
       // mint API keys. This keeps create-spree-app's contract — the app just
       // works — on every path to a first boot (--no-start, an interrupted
       // scaffold, a fresh clone) without requiring anyone to run `spree init`.
-      // "Never set up" = init never minted credentials AND compose never
-      // created a container, so a torn-down (`docker compose down`) but
-      // initialized project boots normally. Ejected projects build the image
+      // Setup is complete once init minted credentials. When they're missing:
+      // a project whose .env declares SPREE_SAMPLE_DATA was scaffolded by a
+      // create-spree-app that persists setup state, so missing credentials
+      // alone means setup never finished — even if an interrupted init already
+      // created containers. For older projects the only safe signal is
+      // "compose never created a container": an initialized
+      // pre-credentials-era project must not be re-set-up (that would load
+      // sample data into a real store). Ejected projects build the image
       // locally and manage their own lifecycle.
       if (
         !isEjectedProject(ctx.projectDir) &&
         !fs.existsSync(projectCredentialsPath(ctx.projectDir))
       ) {
-        let neverBooted = false
-        try {
-          neverBooted = !(await hasProjectContainers(ctx.projectDir))
-        } catch {
-          // Daemon trouble surfaces with compose's own error on the up below.
+        let neverSetUp = readSampleDataFromEnv(ctx.projectDir) !== undefined
+        if (!neverSetUp) {
+          try {
+            neverSetUp = !(await hasProjectContainers(ctx.projectDir))
+          } catch {
+            // Daemon trouble surfaces with compose's own error on the up below.
+          }
         }
-        if (neverBooted) {
+        if (neverSetUp) {
           p.log.info('First run detected — completing setup automatically.')
           await runFirstRunSetup({ sampleData: true, open: true })
           return

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import pc from 'picocolors'
-import { projectCredentialsPath } from '../config.js'
+import { projectCredentialsPath, projectSetupMarkerPath } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import {
   detectProject,
@@ -44,17 +44,21 @@ export function registerDevCommand(program: Command): void {
       // mint API keys. This keeps create-spree-app's contract — the app just
       // works — on every path to a first boot (--no-start, an interrupted
       // scaffold, a fresh clone) without requiring anyone to run `spree init`.
-      // Setup is complete once init minted credentials. When they're missing:
-      // a project whose .env declares SPREE_SAMPLE_DATA was scaffolded by a
-      // create-spree-app that persists setup state, so missing credentials
-      // alone means setup never finished — even if an interrupted init already
-      // created containers. For older projects the only safe signal is
-      // "compose never created a container": an initialized
+      // Completed setup writes a marker (separate from credentials.json,
+      // which `spree auth logout` deletes — losing auth must not look like a
+      // fresh project). Credentials still count as "set up" for projects
+      // initialized by older CLIs that minted them without a marker. When
+      // both are missing: a project whose .env declares SPREE_SAMPLE_DATA was
+      // scaffolded by a create-spree-app that persists setup state, so that
+      // alone means setup never finished — even if an interrupted init
+      // already created containers. For older projects the only safe signal
+      // is "compose never created a container": an initialized
       // pre-credentials-era project must not be re-set-up (that would load
       // sample data into a real store). Ejected projects build the image
       // locally and manage their own lifecycle.
       if (
         !isEjectedProject(ctx.projectDir) &&
+        !fs.existsSync(projectSetupMarkerPath(ctx.projectDir)) &&
         !fs.existsSync(projectCredentialsPath(ctx.projectDir))
       ) {
         let neverSetUp = readSampleDataFromEnv(ctx.projectDir) !== undefined

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,7 +5,7 @@ import * as p from '@clack/prompts'
 import type { Command } from 'commander'
 import { execa, execaCommand } from 'execa'
 import pc from 'picocolors'
-import { mintProjectCredentials } from '../config.js'
+import { mintProjectCredentials, writeProjectSetupMarker } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject, readSampleDataFromEnv } from '../context.js'
 import { dockerCompose, primeBundleVolume, rakeTask, streamLogs } from '../docker.js'
@@ -87,6 +87,11 @@ export async function runFirstRunSetup(flags: {
   await rakeTask('spree:search:reindex', ctx.projectDir)
   s.stop('Search index ready.')
 
+  writeProjectSetupMarker(ctx.projectDir)
+
+  const dashboardDir = path.join(ctx.projectDir, 'apps', 'dashboard')
+  const dashboardPm = detectPackageManager(ctx.projectDir, dashboardDir)
+
   p.note(
     [
       '',
@@ -104,10 +109,10 @@ export async function runFirstRunSetup(flags: {
       `  Secret key:      ${pc.cyan(secretKey)}`,
       `  ${pc.dim('Saved to .spree/credentials.json')}`,
       '',
-      ...(fs.existsSync(path.join(ctx.projectDir, 'apps', 'dashboard', 'package.json'))
+      ...(fs.existsSync(path.join(dashboardDir, 'package.json'))
         ? [
             pc.bold('React Dashboard (Developer Preview)'),
-            `  ${pc.cyan('cd apps/dashboard && pnpm dev')}`,
+            `  ${pc.cyan(`cd apps/dashboard && ${dashboardPm} run dev`)}`,
             '',
           ]
         : []),

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -20,76 +20,88 @@ export function registerInitCommand(program: Command): void {
     .option('--no-sample-data', 'skip loading sample data')
     .option('--no-open', 'skip opening browser')
     .action(async (flags: { sampleData: boolean; open: boolean }) => {
-      const ctx = detectProject()
-
-      p.log.step('Pulling latest images...')
-      await dockerCompose(['pull'], ctx.projectDir, { stdio: 'inherit' })
-
-      const s = p.spinner()
-      s.start('Starting Docker services...')
-      // Prime the shared bundle_cache volume with web alone so the up below
-      // doesn't race the cold-volume copy-up. stdio: 'ignore' keeps the spinner
-      // clean — the inherited `pull` above already showed image progress.
-      await primeBundleVolume(ctx.projectDir, { stdio: 'ignore' })
-      await dockerCompose(['up', '-d'], ctx.projectDir)
-      s.stop('Docker services started.')
-
-      s.start('Waiting for Spree to be ready...')
-      await waitForHealthy(ctx.port)
-      s.stop('Spree is ready.')
-
-      s.start('Seeding database...')
-      await rakeTask('db:seed', ctx.projectDir)
-      s.stop('Database seeded.')
-
-      s.start('Configuring API keys...')
-      // Sequential, not Promise.all: finish the publishable key (and its
-      // storefront env write) before minting the secret, so a failure on the
-      // first step never leaves a freshly minted secret stranded on disk while
-      // init aborts.
-      const publishableKey = await fetchApiKey(ctx.projectDir)
-      updateStorefrontEnv(ctx.projectDir, publishableKey)
-      const secretKey = await mintCliCredentials(ctx.projectDir, ctx.port)
-      s.stop('API keys configured.')
-
-      if (flags.sampleData) {
-        s.start('Loading sample data...')
-        await rakeTask('spree:load_sample_data', ctx.projectDir)
-        s.stop('Sample data loaded.')
-      }
-
-      s.start('Indexing products for search...')
-      await rakeTask('spree:search:reindex', ctx.projectDir)
-      s.stop('Search index ready.')
-
-      p.note(
-        [
-          '',
-          pc.bold('Admin Dashboard'),
-          `  ${pc.cyan(`http://localhost:${ctx.port}/admin`)}`,
-          `  Email:    ${DEFAULT_ADMIN_EMAIL}`,
-          `  Password: ${DEFAULT_ADMIN_PASSWORD}`,
-          '',
-          pc.bold('Store API'),
-          `  ${pc.cyan(`http://localhost:${ctx.port}/api/v3/store`)}`,
-          `  Publishable key: ${pc.cyan(publishableKey)}`,
-          '',
-          pc.bold('Admin API'),
-          `  ${pc.cyan(`http://localhost:${ctx.port}/api/v3/admin`)}`,
-          `  Secret key:      ${pc.cyan(secretKey)}`,
-          `  ${pc.dim('Saved to .spree/credentials.json')}`,
-          '',
-        ].join('\n'),
-        'Your Spree store is ready!',
-      )
-
-      if (flags.open) {
-        await openBrowser(`http://localhost:${ctx.port}/admin`)
-      }
-
-      p.log.info('Streaming logs (Ctrl+C to stop)...\n')
-      await streamLogs('web', ctx.projectDir)
+      await runFirstRunSetup(flags)
     })
+}
+
+// The whole first-run flow, callable outside the `init` command: `spree dev`
+// delegates here when it detects a project that has never been set up, so
+// create-spree-app's contract — the app just works — holds on every path
+// (--no-start, an interrupted scaffold, a fresh clone) without anyone having
+// to know `spree init` exists.
+export async function runFirstRunSetup(flags: {
+  sampleData: boolean
+  open: boolean
+}): Promise<void> {
+  const ctx = detectProject()
+
+  p.log.step('Pulling latest images...')
+  await dockerCompose(['pull'], ctx.projectDir, { stdio: 'inherit' })
+
+  const s = p.spinner()
+  s.start('Starting Docker services...')
+  // Prime the shared bundle_cache volume with web alone so the up below
+  // doesn't race the cold-volume copy-up. stdio: 'ignore' keeps the spinner
+  // clean — the inherited `pull` above already showed image progress.
+  await primeBundleVolume(ctx.projectDir, { stdio: 'ignore' })
+  await dockerCompose(['up', '-d'], ctx.projectDir)
+  s.stop('Docker services started.')
+
+  s.start('Waiting for Spree to be ready...')
+  await waitForHealthy(ctx.port)
+  s.stop('Spree is ready.')
+
+  s.start('Seeding database...')
+  await rakeTask('db:seed', ctx.projectDir)
+  s.stop('Database seeded.')
+
+  s.start('Configuring API keys...')
+  // Sequential, not Promise.all: finish the publishable key (and its
+  // storefront env write) before minting the secret, so a failure on the
+  // first step never leaves a freshly minted secret stranded on disk while
+  // init aborts.
+  const publishableKey = await fetchApiKey(ctx.projectDir)
+  updateStorefrontEnv(ctx.projectDir, publishableKey)
+  const secretKey = await mintCliCredentials(ctx.projectDir, ctx.port)
+  s.stop('API keys configured.')
+
+  if (flags.sampleData) {
+    s.start('Loading sample data...')
+    await rakeTask('spree:load_sample_data', ctx.projectDir)
+    s.stop('Sample data loaded.')
+  }
+
+  s.start('Indexing products for search...')
+  await rakeTask('spree:search:reindex', ctx.projectDir)
+  s.stop('Search index ready.')
+
+  p.note(
+    [
+      '',
+      pc.bold('Admin Dashboard'),
+      `  ${pc.cyan(`http://localhost:${ctx.port}/admin`)}`,
+      `  Email:    ${DEFAULT_ADMIN_EMAIL}`,
+      `  Password: ${DEFAULT_ADMIN_PASSWORD}`,
+      '',
+      pc.bold('Store API'),
+      `  ${pc.cyan(`http://localhost:${ctx.port}/api/v3/store`)}`,
+      `  Publishable key: ${pc.cyan(publishableKey)}`,
+      '',
+      pc.bold('Admin API'),
+      `  ${pc.cyan(`http://localhost:${ctx.port}/api/v3/admin`)}`,
+      `  Secret key:      ${pc.cyan(secretKey)}`,
+      `  ${pc.dim('Saved to .spree/credentials.json')}`,
+      '',
+    ].join('\n'),
+    'Your Spree store is ready!',
+  )
+
+  if (flags.open) {
+    await openBrowser(`http://localhost:${ctx.port}/admin`)
+  }
+
+  p.log.info('Streaming logs (Ctrl+C to stop)...\n')
+  await streamLogs('web', ctx.projectDir)
 }
 
 async function waitForHealthy(port: number): Promise<void> {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,11 +25,13 @@ export function registerInitCommand(program: Command): void {
     })
 }
 
-// The whole first-run flow, callable outside the `init` command: `spree dev`
-// delegates here when it detects a project that has never been set up, so
-// create-spree-app's contract — the app just works — holds on every path
-// (--no-start, an interrupted scaffold, a fresh clone) without anyone having
-// to know `spree init` exists.
+/**
+ * The whole first-run flow, callable outside the `init` command: `spree dev`
+ * delegates here when it detects a project that has never been set up, so
+ * create-spree-app's contract — the app just works — holds on every path
+ * (--no-start, an interrupted scaffold, a fresh clone) without anyone having
+ * to know `spree init` exists.
+ */
 export async function runFirstRunSetup(flags: {
   sampleData: boolean
   open: boolean
@@ -40,7 +42,7 @@ export async function runFirstRunSetup(flags: {
   // persisted in .env decides, so a deferred first run keeps the answer the
   // operator gave at scaffold time. Load sample data later any time with
   // `spree sample-data`.
-  const sampleData = flags.sampleData && readSampleDataFromEnv(ctx.projectDir)
+  const sampleData = flags.sampleData && (readSampleDataFromEnv(ctx.projectDir) ?? true)
 
   p.log.step('Pulling latest images...')
   await dockerCompose(['pull'], ctx.projectDir, { stdio: 'inherit' })

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,12 +3,13 @@ import { platform } from 'node:os'
 import path from 'node:path'
 import * as p from '@clack/prompts'
 import type { Command } from 'commander'
-import { execaCommand } from 'execa'
+import { execa, execaCommand } from 'execa'
 import pc from 'picocolors'
 import { mintProjectCredentials } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
 import { detectProject, readSampleDataFromEnv } from '../context.js'
 import { dockerCompose, primeBundleVolume, rakeTask, streamLogs } from '../docker.js'
+import { detectPackageManager } from './add.js'
 
 const HEALTH_CHECK_INTERVAL_MS = 3000
 const HEALTH_CHECK_TIMEOUT_MS = 120_000
@@ -71,6 +72,9 @@ export async function runFirstRunSetup(flags: {
   const secretKey = await mintCliCredentials(ctx.projectDir, ctx.port)
   s.stop('API keys configured.')
 
+  await installAppDeps(ctx.projectDir, 'storefront')
+  await installAppDeps(ctx.projectDir, 'dashboard')
+
   if (sampleData) {
     s.start('Loading sample data...')
     await rakeTask('spree:load_sample_data', ctx.projectDir)
@@ -98,6 +102,13 @@ export async function runFirstRunSetup(flags: {
       `  Secret key:      ${pc.cyan(secretKey)}`,
       `  ${pc.dim('Saved to .spree/credentials.json')}`,
       '',
+      ...(fs.existsSync(path.join(ctx.projectDir, 'apps', 'dashboard', 'package.json'))
+        ? [
+            pc.bold('React Dashboard (Developer Preview)'),
+            `  ${pc.cyan('cd apps/dashboard && pnpm dev')}`,
+            '',
+          ]
+        : []),
     ].join('\n'),
     'Your Spree store is ready!',
   )
@@ -108,6 +119,28 @@ export async function runFirstRunSetup(flags: {
 
   p.log.info('Streaming logs (Ctrl+C to stop)...\n')
   await streamLogs('web', ctx.projectDir)
+}
+
+// Install an optional app's dependencies when they're missing — a fresh
+// clone, or a scaffold whose install step failed — mirroring
+// create-spree-app's per-app install steps, so first-run setup leaves every
+// app runnable with `pnpm dev`. Best-effort: a registry hiccup shouldn't
+// fail backend setup.
+async function installAppDeps(projectDir: string, app: 'storefront' | 'dashboard'): Promise<void> {
+  const appDir = path.join(projectDir, 'apps', app)
+  if (!fs.existsSync(path.join(appDir, 'package.json'))) return
+  if (fs.existsSync(path.join(appDir, 'node_modules'))) return
+
+  const pm = detectPackageManager(projectDir, appDir)
+  const s = p.spinner()
+  s.start(`Installing ${app} dependencies with ${pm}...`)
+  try {
+    await execa(pm, ['install'], { cwd: appDir })
+    s.stop(`${app === 'dashboard' ? 'Dashboard' : 'Storefront'} dependencies installed.`)
+  } catch (err) {
+    s.stop(pc.yellow(`${pm} install failed — run it manually in apps/${app}/.`))
+    p.log.warn(err instanceof Error ? err.message : String(err))
+  }
 }
 
 async function waitForHealthy(port: number): Promise<void> {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,7 +7,7 @@ import { execaCommand } from 'execa'
 import pc from 'picocolors'
 import { mintProjectCredentials } from '../config.js'
 import { DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
-import { detectProject } from '../context.js'
+import { detectProject, readSampleDataFromEnv } from '../context.js'
 import { dockerCompose, primeBundleVolume, rakeTask, streamLogs } from '../docker.js'
 
 const HEALTH_CHECK_INTERVAL_MS = 3000
@@ -34,6 +34,12 @@ export async function runFirstRunSetup(flags: {
   open: boolean
 }): Promise<void> {
   const ctx = detectProject()
+
+  // `--no-sample-data` always wins; otherwise the choice create-spree-app
+  // persisted in .env decides, so a deferred first run keeps the answer the
+  // operator gave at scaffold time. Load sample data later any time with
+  // `spree sample-data`.
+  const sampleData = flags.sampleData && readSampleDataFromEnv(ctx.projectDir)
 
   p.log.step('Pulling latest images...')
   await dockerCompose(['pull'], ctx.projectDir, { stdio: 'inherit' })
@@ -65,7 +71,7 @@ export async function runFirstRunSetup(flags: {
   const secretKey = await mintCliCredentials(ctx.projectDir, ctx.port)
   s.stop('API keys configured.')
 
-  if (flags.sampleData) {
+  if (sampleData) {
     s.start('Loading sample data...')
     await rakeTask('spree:load_sample_data', ctx.projectDir)
     s.stop('Sample data loaded.')

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -131,6 +131,25 @@ export function projectCredentialsPath(projectDir: string): string {
   return path.join(projectDir, '.spree', 'credentials.json')
 }
 
+/**
+ * Marker written when first-run setup completes on this machine. Kept
+ * separate from credentials.json, which `spree auth logout` removes — losing
+ * auth must not make `spree dev` mistake an initialized project for a fresh
+ * one and re-run setup against its database. Lives in the fully gitignored
+ * `.spree/`, so a teammate's clone correctly reads as not-set-up.
+ */
+export function projectSetupMarkerPath(projectDir: string): string {
+  return path.join(projectDir, '.spree', 'setup-complete')
+}
+
+/** Records completed first-run setup — see {@link projectSetupMarkerPath}. */
+export function writeProjectSetupMarker(projectDir: string): void {
+  const file = projectSetupMarkerPath(projectDir)
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+  ensureGitignoreCatchAll(path.join(path.dirname(file), '.gitignore'))
+  fs.writeFileSync(file, `${new Date().toISOString()}\n`)
+}
+
 export function readProjectCredentials(projectDir: string): ProjectCredentials | null {
   let raw: string
   try {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -91,16 +91,22 @@ export function isEjectedProject(projectDir: string): boolean {
   }
 }
 
-// Whether first-run setup should load sample data. create-spree-app persists
-// the operator's choice in .env so a deferred first run (through `spree dev`)
-// still honors it. Absent (older projects, hand-rolled .env) defaults to
-// true, matching `spree init`.
-export function readSampleDataFromEnv(projectDir: string): boolean {
-  const envPath = path.join(projectDir, '.env')
-  if (!fs.existsSync(envPath)) return true
-
-  const content = fs.readFileSync(envPath, 'utf-8')
-  return !/^SPREE_SAMPLE_DATA=false\b/m.test(content)
+/**
+ * The sample-data choice create-spree-app persists in `.env`, so a deferred
+ * first run (through `spree dev`) honors the answer given at scaffold time.
+ * Returns `undefined` when `.env` doesn't declare one (older projects,
+ * hand-rolled `.env`) — callers decide the default. A declared value also
+ * fingerprints the project as scaffolded by a create-spree-app that persists
+ * setup state, which `spree dev` uses to detect unfinished setup.
+ */
+export function readSampleDataFromEnv(projectDir: string): boolean | undefined {
+  try {
+    const content = fs.readFileSync(path.join(projectDir, '.env'), 'utf-8')
+    const match = content.match(/^SPREE_SAMPLE_DATA=(true|false)\b/m)
+    return match ? match[1] === 'true' : undefined
+  } catch {
+    return undefined
+  }
 }
 
 export function readPortFromEnv(projectDir: string): number {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -91,6 +91,18 @@ export function isEjectedProject(projectDir: string): boolean {
   }
 }
 
+// Whether first-run setup should load sample data. create-spree-app persists
+// the operator's choice in .env so a deferred first run (through `spree dev`)
+// still honors it. Absent (older projects, hand-rolled .env) defaults to
+// true, matching `spree init`.
+export function readSampleDataFromEnv(projectDir: string): boolean {
+  const envPath = path.join(projectDir, '.env')
+  if (!fs.existsSync(envPath)) return true
+
+  const content = fs.readFileSync(envPath, 'utf-8')
+  return !/^SPREE_SAMPLE_DATA=false\b/m.test(content)
+}
+
 export function readPortFromEnv(projectDir: string): number {
   const envPath = path.join(projectDir, '.env')
 

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -65,8 +65,10 @@ export async function rakeTask(
     .trim()
 }
 
-// Whether compose has ever created a container (any state, including exited)
-// for this project.
+/**
+ * Whether compose has ever created a container (any state, including exited)
+ * for this project.
+ */
 export async function hasProjectContainers(projectDir: string): Promise<boolean> {
   const { stdout } = await execa('docker', ['compose', 'ps', '-a', '-q'], { cwd: projectDir })
   return stdout.trim().length > 0

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -65,6 +65,13 @@ export async function rakeTask(
     .trim()
 }
 
+// Whether compose has ever created a container (any state, including exited)
+// for this project.
+export async function hasProjectContainers(projectDir: string): Promise<boolean> {
+  const { stdout } = await execa('docker', ['compose', 'ps', '-a', '-q'], { cwd: projectDir })
+  return stdout.trim().length > 0
+}
+
 // Whether a compose service has a running container — used by commands that
 // can fall back to `compose run` when the stack is down. A defined service
 // with no containers exits 0 with empty output (the legitimate false case);

--- a/packages/cli/tests/env.test.ts
+++ b/packages/cli/tests/env.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { readPortFromEnv } from '../src/context'
+import { readPortFromEnv, readSampleDataFromEnv } from '../src/context'
 
 describe('readPortFromEnv', () => {
   const tempDirs: string[] = []
@@ -41,5 +41,44 @@ describe('readPortFromEnv', () => {
     const dir = makeTempDir()
     fs.writeFileSync(path.join(dir, '.env'), 'SECRET_KEY_BASE=abc\n')
     expect(readPortFromEnv(dir)).toBe(3000)
+  })
+})
+
+describe('readSampleDataFromEnv', () => {
+  const tempDirs: string[] = []
+
+  function makeTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spree-cli-env-test-'))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+    tempDirs.length = 0
+  })
+
+  it('defaults to true when .env is missing', () => {
+    expect(readSampleDataFromEnv(makeTempDir())).toBe(true)
+  })
+
+  it('defaults to true when the flag is absent', () => {
+    const dir = makeTempDir()
+    fs.writeFileSync(path.join(dir, '.env'), 'SPREE_PORT=3000\n')
+    expect(readSampleDataFromEnv(dir)).toBe(true)
+  })
+
+  it('honors an opt-out persisted by create-spree-app', () => {
+    const dir = makeTempDir()
+    fs.writeFileSync(path.join(dir, '.env'), 'SPREE_PORT=3000\nSPREE_SAMPLE_DATA=false\n')
+    expect(readSampleDataFromEnv(dir)).toBe(false)
+  })
+
+  it('treats an explicit true as true', () => {
+    const dir = makeTempDir()
+    fs.writeFileSync(path.join(dir, '.env'), 'SPREE_SAMPLE_DATA=true\n')
+    expect(readSampleDataFromEnv(dir)).toBe(true)
   })
 })

--- a/packages/cli/tests/env.test.ts
+++ b/packages/cli/tests/env.test.ts
@@ -60,14 +60,14 @@ describe('readSampleDataFromEnv', () => {
     tempDirs.length = 0
   })
 
-  it('defaults to true when .env is missing', () => {
-    expect(readSampleDataFromEnv(makeTempDir())).toBe(true)
+  it('returns undefined when .env is missing', () => {
+    expect(readSampleDataFromEnv(makeTempDir())).toBeUndefined()
   })
 
-  it('defaults to true when the flag is absent', () => {
+  it('returns undefined when the flag is absent', () => {
     const dir = makeTempDir()
     fs.writeFileSync(path.join(dir, '.env'), 'SPREE_PORT=3000\n')
-    expect(readSampleDataFromEnv(dir)).toBe(true)
+    expect(readSampleDataFromEnv(dir)).toBeUndefined()
   })
 
   it('honors an opt-out persisted by create-spree-app', () => {

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,20 @@
 # create-spree-app
 
+## 1.1.1
+
+### Patch Changes
+
+- A finished `create-spree-app` run now always means a working app. The
+optional storefront and React Dashboard phases used to abort the whole
+scaffold on failure — before the final setup phase (`spree init`: fresh
+image pull, seeded database, API keys) ever ran — leaving a project whose
+first boot silently started a stale, locally cached Spree image. Those
+phases now warn and continue with a recovery command, so setup always runs.
+When services can't start during scaffolding (`--no-start`, Docker off), the
+first `spree dev` completes setup automatically (requires `@spree/cli`
+2.4.2), and the printed next steps plus the generated README reflect that —
+nobody has to know `spree init` exists.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -12,8 +12,9 @@ first boot silently started a stale, locally cached Spree image. Those
 phases now warn and continue with a recovery command, so setup always runs.
 When services can't start during scaffolding (`--no-start`, Docker off), the
 first `spree dev` completes setup automatically (requires `@spree/cli`
-2.4.2), and the printed next steps plus the generated README reflect that —
-nobody has to know `spree init` exists.
+2.4.2), honoring the sample-data choice now persisted in `.env`
+(`SPREE_SAMPLE_DATA`), and the printed next steps plus the generated README
+reflect that — nobody has to know `spree init` exists.
 
 ## 1.1.0
 

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -9,12 +9,16 @@ optional storefront and React Dashboard phases used to abort the whole
 scaffold on failure — before the final setup phase (`spree init`: fresh
 image pull, seeded database, API keys) ever ran — leaving a project whose
 first boot silently started a stale, locally cached Spree image. Those
-phases now warn and continue with a recovery command, so setup always runs.
-When services can't start during scaffolding (`--no-start`, Docker off), the
-first `spree dev` completes setup automatically (requires `@spree/cli`
-2.4.2), honoring the sample-data choice now persisted in `.env`
-(`SPREE_SAMPLE_DATA`), and the printed next steps plus the generated README
-reflect that — nobody has to know `spree init` exists.
+phases now warn and continue with a recovery command, cleaning up their
+partial `apps/` directory so the recovery command actually works, and setup
+always runs. Project docs (README.md, CLAUDE.md, dependabot.yml) are
+generated after those phases from their actual outcomes, so they never
+document an app whose setup failed. When services can't start during
+scaffolding (`--no-start`, Docker off), the first `spree dev` completes
+setup automatically (requires `@spree/cli` 2.4.2), honoring the sample-data
+choice now persisted in `.env` (`SPREE_SAMPLE_DATA`), and the printed next
+steps plus the generated README reflect that — nobody has to know
+`spree init` exists.
 
 ## 1.1.0
 

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -4,7 +4,12 @@ import * as p from '@clack/prompts'
 import { execa } from 'execa'
 import pc from 'picocolors'
 import { downloadBackend } from './backend.js'
-import { DASHBOARD_PORT, DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from './constants.js'
+import {
+  DASHBOARD_PORT,
+  DEFAULT_ADMIN_EMAIL,
+  DEFAULT_ADMIN_PASSWORD,
+  STOREFRONT_REPO,
+} from './constants.js'
 import { scaffoldDashboard } from './dashboard.js'
 import {
   downloadStorefront,
@@ -108,25 +113,47 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   await installRootDeps(projectDir, options.packageManager)
   s.stop('Dependencies installed.')
 
+  // Phases 3/3b are optional apps — their failures warn and continue. They
+  // must never abort the scaffold before Phase 4: `spree init` is what
+  // guarantees a fresh Spree image (skipping it leaves a stale local `latest`
+  // to boot) and a seeded, credentialed backend.
+
   // Phase 3: Storefront (optional)
+  let storefrontReady = storefront
   if (storefront) {
-    s.start('Downloading storefront template...')
-    await downloadStorefront(projectDir)
-    s.stop('Storefront template downloaded.')
+    try {
+      s.start('Downloading storefront template...')
+      await downloadStorefront(projectDir)
+      s.stop('Storefront template downloaded.')
 
-    writeStorefrontEnv(projectDir, port)
+      writeStorefrontEnv(projectDir, port)
 
-    s.start('Installing storefront dependencies...')
-    await installStorefrontDeps(projectDir, options.packageManager)
-    s.stop('Storefront dependencies installed.')
+      s.start('Installing storefront dependencies...')
+      await installStorefrontDeps(projectDir, options.packageManager)
+      s.stop('Storefront dependencies installed.')
+    } catch (err) {
+      storefrontReady = false
+      s.stop('Storefront setup failed.')
+      p.log.warn(
+        `Continuing without the storefront — add it later by cloning ${STOREFRONT_REPO} into apps/storefront.\n${errorMessage(err)}`,
+      )
+    }
   }
 
   // Phase 3b: React Dashboard (optional, Developer Preview). Delegates to the
   // project-local `npx spree add dashboard` — @spree/cli is already installed
   // (root deps, above) and bundles the dashboard-starter template. It reads
   // the port from the project's .env and prints its own progress.
+  let dashboardReady = dashboard
   if (dashboard) {
-    await scaffoldDashboard(projectDir, { install: true, packageManager: options.packageManager })
+    try {
+      await scaffoldDashboard(projectDir, { install: true, packageManager: options.packageManager })
+    } catch (err) {
+      dashboardReady = false
+      p.log.warn(
+        `Continuing without the React Dashboard — add it later with ${pc.bold(`${runCommand(options.packageManager)} spree add dashboard`)}.\n${errorMessage(err)}`,
+      )
+    }
   }
 
   // Phase 4: Initialize and start services
@@ -134,23 +161,37 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
     const initArgs = ['spree', 'init']
     if (!options.sampleData) initArgs.push('--no-sample-data')
 
-    await execa(runCommand(options.packageManager), initArgs, {
-      cwd: projectDir,
-      stdio: 'inherit',
-    })
+    try {
+      await execa(runCommand(options.packageManager), initArgs, {
+        cwd: projectDir,
+        stdio: 'inherit',
+      })
+    } catch {
+      // init streams its own output, so the underlying failure is already on
+      // screen — what the operator needs from us is the recovery command.
+      throw new Error(
+        `Setup did not finish. Start your app with: cd ${projectName} && ${options.packageManager} run dev — the first run completes setup automatically.`,
+      )
+    }
 
-    if (storefront) {
+    if (storefrontReady) {
       p.log.info(
         `${pc.bold('Storefront')}: ${pc.cyan(`cd ${projectName}/apps/storefront && ${options.packageManager} run dev`)}`,
       )
     }
-    if (dashboard) {
+    if (dashboardReady) {
       p.log.info(
         `${pc.bold('React Dashboard')}: ${pc.cyan(`cd ${projectName}/apps/dashboard && ${options.packageManager} run dev`)} → http://localhost:${DASHBOARD_PORT}`,
       )
     }
   } else {
-    printSuccessWithoutDocker(projectName, storefront, dashboard, port, options.packageManager)
+    printSuccessWithoutDocker(
+      projectName,
+      storefrontReady,
+      dashboardReady,
+      port,
+      options.packageManager,
+    )
   }
 }
 
@@ -167,6 +208,7 @@ function printSuccessWithoutDocker(
     `${pc.bold('Next steps:')}`,
     `  cd ${projectName}`,
     `  ${run} spree dev`,
+    `  ${pc.dim('# First run completes setup automatically — pulls the latest image, seeds data, configures API keys.')}`,
   ]
 
   if (hasStorefront) {
@@ -213,4 +255,8 @@ function printSuccessWithoutDocker(
   )
 
   p.note(lines.join('\n'), 'Project created!')
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -94,20 +94,8 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
     envContent(generateSecretKeyBase(), port, options.sampleData),
   )
   fs.writeFileSync(path.join(projectDir, 'package.json'), rootPackageJsonContent(projectName))
-  fs.writeFileSync(
-    path.join(projectDir, 'README.md'),
-    readmeContent(projectName, storefront, port, dashboard, options.packageManager),
-  )
   fs.writeFileSync(path.join(projectDir, '.gitignore'), gitignoreContent())
-  fs.writeFileSync(
-    path.join(projectDir, 'CLAUDE.md'),
-    rootClaudeMdContent(storefront, dashboard, options.packageManager),
-  )
   fs.writeFileSync(path.join(projectDir, 'AGENTS.md'), agentsMdContent())
-
-  const githubDir = path.join(projectDir, '.github')
-  fs.mkdirSync(githubDir, { recursive: true })
-  fs.writeFileSync(path.join(githubDir, 'dependabot.yml'), dependabotContent(storefront, dashboard))
 
   s.stop('Project structure created.')
 
@@ -137,6 +125,9 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
     } catch (err) {
       storefrontReady = false
       s.stop('Storefront setup failed.')
+      // Remove the partial checkout so the recovery command (a fresh clone)
+      // actually works instead of failing on a non-empty directory.
+      fs.rmSync(path.join(projectDir, 'apps', 'storefront'), { recursive: true, force: true })
       p.log.warn(
         `Continuing without the storefront — add it later by cloning ${STOREFRONT_REPO} into apps/storefront.\n${errorMessage(err)}`,
       )
@@ -153,11 +144,32 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
       await scaffoldDashboard(projectDir, { install: true, packageManager: options.packageManager })
     } catch (err) {
       dashboardReady = false
+      // Remove the partial scaffold so the recovery command (`spree add
+      // dashboard`, which expects the directory to be absent) actually works.
+      fs.rmSync(path.join(projectDir, 'apps', 'dashboard'), { recursive: true, force: true })
       p.log.warn(
         `Continuing without the React Dashboard — add it later with ${pc.bold(`${runCommand(options.packageManager)} spree add dashboard`)}.\n${errorMessage(err)}`,
       )
     }
   }
+
+  // Project docs are generated only now, from the phases' actual outcomes —
+  // a README written up front from the requested flags would document apps
+  // whose setup failed.
+  fs.writeFileSync(
+    path.join(projectDir, 'README.md'),
+    readmeContent(projectName, storefrontReady, port, dashboardReady, options.packageManager),
+  )
+  fs.writeFileSync(
+    path.join(projectDir, 'CLAUDE.md'),
+    rootClaudeMdContent(storefrontReady, dashboardReady, options.packageManager),
+  )
+  const githubDir = path.join(projectDir, '.github')
+  fs.mkdirSync(githubDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(githubDir, 'dependabot.yml'),
+    dependabotContent(storefrontReady, dashboardReady),
+  )
 
   // Phase 4: Initialize and start services
   if (options.start) {

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -89,7 +89,10 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
   fs.rmSync(path.join(backendDir, 'docker-compose.yml'), { force: true })
   fs.rmSync(path.join(backendDir, 'docker-compose.dev.yml'), { force: true })
 
-  fs.writeFileSync(path.join(projectDir, '.env'), envContent(generateSecretKeyBase(), port))
+  fs.writeFileSync(
+    path.join(projectDir, '.env'),
+    envContent(generateSecretKeyBase(), port, options.sampleData),
+  )
   fs.writeFileSync(path.join(projectDir, 'package.json'), rootPackageJsonContent(projectName))
   fs.writeFileSync(
     path.join(projectDir, 'README.md'),

--- a/packages/create-spree-app/src/templates/env.ts
+++ b/packages/create-spree-app/src/templates/env.ts
@@ -1,3 +1,8 @@
+/**
+ * The project root `.env`: Rails secret, backend port, image tag, and the
+ * persisted sample-data choice (`SPREE_SAMPLE_DATA`) that first-run setup
+ * reads back when it runs deferred (through `spree dev`).
+ */
 export function envContent(secretKeyBase: string, port: number, sampleData: boolean): string {
   return `SECRET_KEY_BASE=${secretKeyBase}
 SPREE_PORT=${port}

--- a/packages/create-spree-app/src/templates/env.ts
+++ b/packages/create-spree-app/src/templates/env.ts
@@ -1,7 +1,9 @@
-export function envContent(secretKeyBase: string, port: number): string {
+export function envContent(secretKeyBase: string, port: number, sampleData: boolean): string {
   return `SECRET_KEY_BASE=${secretKeyBase}
 SPREE_PORT=${port}
 SPREE_VERSION_TAG=latest
+# Whether first-run setup loads demo products and orders.
+SPREE_SAMPLE_DATA=${sampleData}
 `
 }
 

--- a/packages/create-spree-app/src/templates/readme.ts
+++ b/packages/create-spree-app/src/templates/readme.ts
@@ -32,6 +32,9 @@ cd ${name}
 ${run} spree dev
 \`\`\`
 
+The first run completes setup automatically — it pulls the latest Spree image,
+seeds the database, and configures API keys.
+
 Wait for the services to be healthy, then open:
 
 - **Admin Dashboard:** http://localhost:${port}/admin
@@ -101,7 +104,7 @@ This project uses [\`@spree/cli\`](https://spreecommerce.org/docs/developer/cli/
 
 | Command | Description |
 |---------|-------------|
-| \`spree dev\` | Run the backend in the foreground — streams logs, Ctrl+C stops it |
+| \`spree dev\` | Run the backend in the foreground — streams logs, Ctrl+C stops it. First run completes setup automatically |
 | \`spree stop\` | Stop backend services |
 | \`spree update\` | Pull latest Spree image and restart (runs migrations automatically) |
 | \`spree eject\` | Switch from prebuilt image to building from \`backend/\` |

--- a/packages/create-spree-app/tests/templates.test.ts
+++ b/packages/create-spree-app/tests/templates.test.ts
@@ -8,18 +8,23 @@ import { readmeContent } from '../src/templates/readme'
 
 describe('envContent', () => {
   it('includes the provided secret key', () => {
-    const content = envContent('my-secret-123', 3000)
+    const content = envContent('my-secret-123', 3000, true)
     expect(content).toContain('SECRET_KEY_BASE=my-secret-123')
   })
 
   it('includes SPREE_PORT', () => {
-    const content = envContent('any', 3000)
+    const content = envContent('any', 3000, true)
     expect(content).toContain('SPREE_PORT=3000')
   })
 
   it('uses custom port value', () => {
-    const content = envContent('any', 4567)
+    const content = envContent('any', 4567, true)
     expect(content).toContain('SPREE_PORT=4567')
+  })
+
+  it('persists the sample-data choice', () => {
+    expect(envContent('any', 3000, true)).toContain('SPREE_SAMPLE_DATA=true')
+    expect(envContent('any', 3000, false)).toContain('SPREE_SAMPLE_DATA=false')
   })
 })
 


### PR DESCRIPTION
Fixes the "new app boots an old Spree" failure mode from today's RC testing. Design goal per review: **running create-spree-app gives you a fully working app — no path ever requires the user to run `spree init` themselves.**

## What happened

create-spree-app runs `spree init` (which pulls fresh images, seeds, mints API keys) as its **last** phase. When an optional phase threw (as the dashboard phase did during the window before `@spree/admin-sdk` 0.6.0 / `@spree/dashboard` 0.10.1 were published), the whole scaffold aborted before init ever ran. The natural next move — `pnpm dev` → `spree dev` → `docker compose up` — never pulls, so a `latest` image cached weeks earlier by another project silently booted an old Spree (observed: v5.5.0 from June 18 while remote `latest` was current).

## The fix

**create-spree-app (1.1.1):**
- Storefront and dashboard phases warn and continue on failure, each printing its recovery command — the setup phase now runs no matter what.
- If setup itself fails, the message says to run `pnpm run dev` (whose first run self-completes, below) instead of exposing `spree init`.
- `--no-start` next steps and the generated README say `spree dev` with a "first run completes setup automatically" note.
- The sample-data choice is persisted in `.env` (`SPREE_SAMPLE_DATA`) so a deferred first run honors it.

**@spree/cli (2.4.2):**
- `spree dev` detects a never-initialized project (no minted credentials **and** no containers ever created) and delegates to the full init flow — pull fresh images, start services, seed, configure API keys — then continues as normal. Covers `--no-start` scaffolds, interrupted create-spree-app runs, and fresh clones.
- First-run setup honors the persisted `SPREE_SAMPLE_DATA` choice (`--no-sample-data` on `spree init` still always wins; `spree sample-data` loads it on demand).
- First-run setup installs `apps/storefront` / `apps/dashboard` dependencies when they're missing (fresh clone, failed scaffold install), mirroring create-spree-app's per-app install steps — package manager detected from the lockfile, best-effort. The setup summary lists the dashboard dev command when `apps/dashboard` exists.
- Initialized projects are untouched: later boots never pull, dev stays offline-friendly, upgrades stay explicit via `spree update`. Ejected projects (local image builds) are skipped.
- The init flow is extracted to `runFirstRunSetup()`; the `init` command remains as a thin wrapper for explicit re-runs.

Smoke-tested: a never-booted project through `spree dev` prints "First run detected — completing setup automatically" and enters the pull/boot/seed flow; an initialized project boots normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DzwNXZwhBsLqcJzwZwAmD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optional storefront and React Dashboard scaffolding is now best-effort (warns and continues instead of failing the whole scaffold).
  * First-run failures provide clearer recovery guidance, and printed next steps now match actual setup readiness.
* **New Features**
  * `spree dev` now auto-completes the full first-run initialization for never-before-initialized projects, honoring the persisted `SPREE_SAMPLE_DATA` choice.
* **Documentation**
  * Generated README and service descriptions now reflect that first-run setup completes automatically.
* **Chores**
  * Version bumps: `create-spree-app` **1.1.1** and `spree/cli` **2.4.2**; generated `.env` now includes `SPREE_SAMPLE_DATA`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> First-run auto-setup can pull images, seed DB, and load sample data when detection misfires; logic tries to avoid re-init on real stores (credentials, containers, ejected projects).
> 
> **Overview**
> Fixes new projects booting a **stale cached `latest` Spree image** when setup never ran (optional scaffold phases aborted before `spree init`, `--no-start`, or `spree dev` doing a bare `compose up` without pull).
> 
> **`@spree/cli` 2.4.2:** `spree dev` detects unfinished first-run setup (`.spree/setup-complete` or legacy credentials absent, with guards for ejected stacks and older projects) and runs the full init path—**pull**, up, seed, API keys, optional sample data from **`SPREE_SAMPLE_DATA`**, best-effort **`apps/storefront` / `apps/dashboard` installs**—then streams logs. Init logic lives in shared **`runFirstRunSetup()`**; already-initialized projects keep normal dev behavior (no pull on every boot).
> 
> **`create-spree-app` 1.1.1:** Storefront and dashboard phases **warn and continue** on failure (partial `apps/` cleaned up); README/CLAUDE/dependabot are written **after** those phases reflect reality. Root `.env` now persists **`SPREE_SAMPLE_DATA`**; docs and next steps say first **`spree dev`** finishes setup instead of requiring **`spree init`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85374a0f831cc24c0d10bbf68c018e4ed6d26d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->