### PR TITLE
Fix retry failed rows race condition with refetch

### DIFF
--- a/packages/dashboard/e2e/imports.spec.ts
+++ b/packages/dashboard/e2e/imports.spec.ts
@@ -31,10 +31,9 @@ test.describe('csv import', () => {
     await openImportSheet(page, creds.store_id)
 
     // Rows without name/price are guaranteed row-level failures that feed the
-    // failed-rows report without failing the whole import. Thirty of them keep
-    // the retry pass long enough to observe its transient copy (a single row
-    // re-processes faster than the post-mutation refetch) and paginate the
-    // failure report (25 per page).
+    // failed-rows report without failing the whole import. Thirty of them
+    // paginate the failure report (25 per page) so the "next page" control has
+    // something to page through.
     const badRows = Array.from({ length: 30 }, (_, i) => {
       const n = String(i + 1).padStart(2, '0')
       return `e2e-import-bad-${n}-${suffix},E2E-IMP-BAD-${n}-${suffix},,`

--- a/packages/dashboard/src/hooks/use-imports.ts
+++ b/packages/dashboard/src/hooks/use-imports.ts
@@ -62,7 +62,14 @@ export function useRetryFailedRows(id: string) {
     mutationFn: () => adminClient.imports.retryFailedRows(id),
     onSuccess: (imp) => {
       queryClient.setQueryData<Import>(buildKey('imports', id), imp)
-      queryClient.invalidateQueries({ queryKey: buildKey('imports') })
+      // `refetchType: 'none'` refreshes the history list on its next mount
+      // without refetching the active wizard detail query: the retry response
+      // already carried the fresh `processing` status we just cached, and an
+      // immediate refetch would race the (fast) background retry job — often
+      // returning `completed` before the "Retrying failed rows" state is ever
+      // rendered. Marking stale keeps the poll as the single source of the
+      // completion transition.
+      queryClient.invalidateQueries({ queryKey: buildKey('imports'), refetchType: 'none' })
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : String(err))


### PR DESCRIPTION
## Summary
Prevents a race condition in the import retry flow where an immediate refetch of the imports query could return a `completed` status before the "Retrying failed rows" UI state is rendered to the user.

## Changes
- **use-imports.ts**: Added `refetchType: 'none'` to the `invalidateQueries` call in `useRetryFailedRows`
  - The retry response already contains the fresh `processing` status, which is cached immediately
  - Marking the query as stale (without refetching) allows the history list to refresh on next mount
  - The background polling mechanism becomes the single source of truth for the completion transition, avoiding the race where a fast refetch returns `completed` before the transient "Retrying" state is visible
  
- **imports.spec.ts**: Updated test comment to reflect the actual purpose of the 30 bad rows
  - Clarified that the rows are used to paginate the failure report (25 per page), not to observe the transient retry state
  - Removed outdated explanation about observing the retry pass duration

## Implementation Details
The fix leverages TanStack Query's `refetchType: 'none'` option to invalidate the query without immediately refetching it. This allows:
1. The cached retry response (with `processing` status) to be served immediately
2. The history list to refresh when it next mounts
3. The polling mechanism to handle the eventual `completed` transition, ensuring the UI renders the intermediate state

https://claude.ai/code/session_011q6J7AZTh2ZETcsvWCkgcH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TanStack Query cache behavior in the import retry mutation; no auth, API, or data-model changes.
> 
> **Overview**
> Fixes a **race in the CSV import “retry failed rows” flow** where the wizard could skip the transient **“Retrying failed rows”** state.
> 
> After a successful retry mutation, `useRetryFailedRows` still **writes the mutation response** (`processing`) into the detail cache, but **`invalidateQueries` for the imports list now uses `refetchType: 'none'`** so it only marks the list stale instead of triggering an immediate refetch. That avoids a fast refetch returning **`completed`** before the UI can show the retry-in-progress copy; **polling on the active import** remains the path for the completion transition. The imports history list still refreshes the next time it mounts.
> 
> The **imports E2E comment** is updated to say the 30 bad rows exist to **exercise failure-report pagination**, not to stretch the retry pass for UI timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132f7c24743efe728cb70f4230277151680d3ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for failed import rows by preventing unnecessary immediate refreshes while background processing is underway.
  * Maintained access to paginated failed-row reports without causing the overall import to fail when individual rows contain errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->