### PR TITLE
Fix nav item title and badge visibility in collapsed icon mode

### DIFF
--- a/packages/dashboard-core/src/components/nav-main.tsx
+++ b/packages/dashboard-core/src/components/nav-main.tsx
@@ -102,9 +102,12 @@ function NavItemContent({
     >
       <Link to={item.url}>
         <NavIcon icon={item.icon} isActive={itemIsActive} />
-        <span>{item.title}</span>
+        {/* Explicitly hide in collapsed icon mode: a trailing badge span would
+            otherwise steal the `span:last-child` position the base button style
+            relies on to hide the label, leaving the title visible. */}
+        <span className="group-data-[collapsible=icon]:hidden">{item.title}</span>
         {item.badge && (
-          <span className="ml-auto">
+          <span className="ml-auto group-data-[collapsible=icon]:hidden">
             <item.badge />
           </span>
         )}


### PR DESCRIPTION
## Summary
Fixes a layout issue in the navigation component where the title text and badge would remain visible when the navigation is in collapsed icon-only mode, breaking the intended compact appearance.

## Key Changes
- Added `group-data-[collapsible=icon]:hidden` class to the title `<span>` to explicitly hide it in collapsed mode
- Added the same class to the badge `<span>` to prevent it from stealing the `span:last-child` CSS selector position that the base button style relies on to hide the label
- Included explanatory comment documenting why both elements need the hidden class

## Implementation Details
The issue occurred because when a badge was present, it became the last child element instead of the title span. This caused the base button style's `span:last-child` selector to target the badge instead of the title, leaving the title visible in collapsed mode. By explicitly hiding both the title and badge in collapsed icon mode, we ensure the correct visual appearance regardless of element order.

https://claude.ai/code/session_016BGTdmYEHcSTE4FXHY6jYg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS/class change in nav presentation only; no auth, data, or API impact.
> 
> **Overview**
> Fixes **collapsed icon-only sidebar** nav items showing the label and optional badge when a `badge` is present.
> 
> Applies `group-data-[collapsible=icon]:hidden` to both the title and badge wrapper spans so they stay hidden in icon mode. Without this, the badge span becomes `span:last-child` and the base `SidebarMenuButton` styling no longer hides the title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60086e1bac20b88fbce635c8dfd349c7b5ebfa06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapsed navigation behavior by hiding menu labels and badges in icon-only mode.
  * Ensured navigation items remain aligned and display correctly when the sidebar is collapsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->