### PR TITLE
Document new RAILS_HOST and CDN_HOST env vars

### DIFF
--- a/docs/developer/deployment/cdn.mdx
+++ b/docs/developer/deployment/cdn.mdx
@@ -37,3 +37,13 @@ Now scroll down and set the settings as below:
 ![Cloudflare Cache Rule Settings](/images/developer/deployment/cloudflare_cache_rule_2.png)
 
 Finally, click on "Deploy" and you are done!
+
+## Dedicated CDN Host
+
+The setup above caches on your primary domain and needs no extra configuration. If you instead serve assets and images from a separate CDN hostname (e.g. a CloudFront or Fastly distribution at `cdn.example.com` with your app as the origin), set the `CDN_HOST` environment variable:
+
+```bash
+CDN_HOST=cdn.example.com
+```
+
+Static asset URLs and image/attachment URLs (including those in API responses) will then use this host instead of [`RAILS_HOST`](/developer/deployment/environment_variables#urls-and-hosts). Host only, no protocol — URLs keep the scheme of your primary host.

--- a/docs/developer/deployment/docker.mdx
+++ b/docs/developer/deployment/docker.mdx
@@ -62,6 +62,9 @@ services:
       SECRET_KEY_BASE: change-me-to-a-real-secret
       RAILS_FORCE_SSL: "false"
       RAILS_ASSUME_SSL: "false"
+      # Public host used in generated URLs (images/attachments in API
+      # responses, email links) — set to your domain or IP in production.
+      RAILS_HOST: localhost:3000
     ports:
       - "3000:3000"
     healthcheck:
@@ -80,6 +83,7 @@ services:
       DATABASE_URL: postgres://postgres@postgres:5432/spree_production
       REDIS_URL: redis://redis:6379/0
       SECRET_KEY_BASE: change-me-to-a-real-secret
+      RAILS_HOST: localhost:3000
     command: bundle exec sidekiq
 
 volumes:
@@ -106,6 +110,7 @@ Use [create-spree-app](/developer/create-spree-app/quickstart) for a fully scaff
 | `DATABASE_URL` | PostgreSQL connection URL | `postgres://user:pass@host:5432/spree` |
 | `REDIS_URL` | Redis URL for jobs, caching, and Action Cable | `redis://redis:6379/0` |
 | `SECRET_KEY_BASE` | Secret key for session encryption | Generate with `bin/rails secret` |
+| `RAILS_HOST` | Public host used in generated URLs — image/attachment URLs in API responses, email links. Without it they fall back to the store's URL setting (`localhost` on a fresh install) | `store.example.com` |
 
 See [Environment Variables](/developer/deployment/environment_variables) for the full list.
 

--- a/docs/developer/deployment/emails.mdx
+++ b/docs/developer/deployment/emails.mdx
@@ -80,7 +80,7 @@ Set the following environment variables on the **Spree backend** to enable syste
 | `SMTP_USERNAME` | — | SMTP auth username |
 | `SMTP_PASSWORD` | — | SMTP auth password |
 | `SMTP_FROM_ADDRESS` | — | Default "from" email address (e.g., `admin@mystore.com`) |
-| `RAILS_HOST` | `example.com` | Public host used in email links (and all other [generated URLs](/developer/deployment/environment_variables#urls-and-hosts)) |
+| `RAILS_HOST` | `example.com` | Public host used in email links and other [generated URLs](/developer/deployment/environment_variables#urls-and-hosts) — image/attachment URLs use `CDN_HOST` instead when set |
 
 When `SMTP_HOST` is not set, emails are printed to the Rails log instead of being sent.
 

--- a/docs/developer/deployment/emails.mdx
+++ b/docs/developer/deployment/emails.mdx
@@ -80,7 +80,7 @@ Set the following environment variables on the **Spree backend** to enable syste
 | `SMTP_USERNAME` | — | SMTP auth username |
 | `SMTP_PASSWORD` | — | SMTP auth password |
 | `SMTP_FROM_ADDRESS` | — | Default "from" email address (e.g., `admin@mystore.com`) |
-| `RAILS_HOST` | `example.com` | Host used in email URLs |
+| `RAILS_HOST` | `example.com` | Public host used in email links (and all other [generated URLs](/developer/deployment/environment_variables#urls-and-hosts)) |
 
 When `SMTP_HOST` is not set, emails are printed to the Rails log instead of being sent.
 

--- a/docs/developer/deployment/environment_variables.mdx
+++ b/docs/developer/deployment/environment_variables.mdx
@@ -18,10 +18,10 @@ These variables are required to run Spree in production.
 
 ## URLs and Hosts
 
-`RAILS_HOST` is the canonical public host of your deployment. It is used for every URL Spree generates outside of a request context — image and attachment URLs in API responses, links in emails, and webhook payloads.
+`RAILS_HOST` is the canonical public host of your deployment. URLs Spree generates outside a request context use it — links in emails, webhook payloads, and image/attachment URLs in API responses (for the latter, `CDN_HOST` takes precedence when set).
 
 <Warning>
-Without `RAILS_HOST`, generated URLs fall back to the store's URL setting, which is `localhost` on a fresh install — API responses will contain `https://localhost/...` attachment URLs.
+When neither `RAILS_HOST` nor `CDN_HOST` is configured, image and attachment URLs fall back to the store's URL setting, which is `localhost` on a fresh install — API responses will contain `https://localhost/...` URLs.
 </Warning>
 
 | Variable | Default | Description |

--- a/docs/developer/deployment/environment_variables.mdx
+++ b/docs/developer/deployment/environment_variables.mdx
@@ -16,6 +16,21 @@ These variables are required to run Spree in production.
 | `REDIS_CACHE_URL` | Redis URL for caching (optional — falls back to `REDIS_URL`) | `redis://localhost:6380/0` |
 | `SECRET_KEY_BASE` | Secret key for session encryption. Generate with `bin/rails secret` | `2fad5c0b79d25e4765d3018d8c740f8c3a665f0e5c...` |
 
+## URLs and Hosts
+
+`RAILS_HOST` is the canonical public host of your deployment. It is used for every URL Spree generates outside of a request context — image and attachment URLs in API responses, links in emails, and webhook payloads.
+
+<Warning>
+Without `RAILS_HOST`, generated URLs fall back to the store's URL setting, which is `localhost` on a fresh install — API responses will contain `https://localhost/...` attachment URLs.
+</Warning>
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RAILS_HOST` | — | Public host, optionally with a port — e.g. `store.example.com` or `203.0.113.7:8080`. Host only, no protocol. On [Render](/developer/deployment/render), falls back to the platform-provided `RENDER_EXTERNAL_HOSTNAME`. |
+| `CDN_HOST` | — | Optional host for serving static assets and images, e.g. a CDN distribution in front of your app. Host only, no protocol. Falls back to `RAILS_HOST`. |
+
+Generated URLs use `https` unless both `RAILS_FORCE_SSL` and `RAILS_ASSUME_SSL` are set to `false` (see [SSL](#ssl)).
+
 ## Email (SMTP)
 
 <Tip>
@@ -31,7 +46,8 @@ Spree works with any SMTP provider (Resend, Postmark, Mailgun, SendGrid, Amazon 
 | `SMTP_USERNAME` | — | SMTP auth username |
 | `SMTP_PASSWORD` | — | SMTP auth password |
 | `SMTP_FROM_ADDRESS` | — | Default "from" email address |
-| `RAILS_HOST` | `example.com` | Host used in email URLs |
+
+Links in emails use the host configured via [`RAILS_HOST`](#urls-and-hosts).
 
 ## Web Server
 

--- a/docs/developer/deployment/render.mdx
+++ b/docs/developer/deployment/render.mdx
@@ -57,6 +57,8 @@ Default credentials are created during `db:seed`. Change them immediately after 
 
 Render sets `DATABASE_URL`, `REDIS_URL`, and `SECRET_KEY_BASE` automatically from the blueprint. For additional configuration (SMTP, file storage, Sentry, etc.), see [Environment Variables](/developer/deployment/environment_variables).
 
+Generated URLs (images and attachments in API responses, email links) automatically use Render's `RENDER_EXTERNAL_HOSTNAME` (`<your-app-name>.onrender.com`). When you attach a custom domain, set [`RAILS_HOST`](/developer/deployment/environment_variables#urls-and-hosts) to it — it takes precedence.
+
 ## Production Sizing
 
 The free/starter plans work for trying Spree. For production workloads, we recommend:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or configuration code modified.
> 
> **Overview**
> Documents **`RAILS_HOST`** and **`CDN_HOST`** across deployment guides so operators know how generated URLs (API attachments, emails, webhooks) are built.
> 
> Adds a dedicated **URLs and Hosts** section in `environment_variables.mdx` with defaults, the `localhost` fallback warning, Render’s `RENDER_EXTERNAL_HOSTNAME` behavior, and how HTTPS follows SSL env vars. **`CDN_HOST`** is explained in `cdn.mdx` for separate CDN hostnames vs same-domain Cloudflare caching.
> 
> **Docker** and **Render** guides now call out setting `RAILS_HOST` (compose examples include it on web/worker). **Emails** SMTP table points `RAILS_HOST` at the shared URLs section instead of treating it as email-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043ab4031a8a0faa0669c1d8e71fdf55f17f98f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented `RAILS_HOST` as the canonical public host for generated URLs, including API image/attachment URLs, webhook payloads, and email links.
  * Added guidance for using a dedicated CDN hostname via `CDN_HOST`, including host-only (no protocol) formatting and how it affects generated asset URLs.
  * Updated Docker setup and environment variable references to include `RAILS_HOST`.
  * Clarified HTTPS URL generation rules and warnings when public host configuration is missing.
  * Refreshed Render deployment guidance for hostname fallback and precedence when using custom domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->