### PR TITLE
Harden Store API Cart Associate endpoint

### DIFF
--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -2276,7 +2276,8 @@ paths:
         bearer_auth: []
       description: |
         Associates a guest cart with the currently authenticated user.
-        Requires JWT authentication. The cart must not belong to another user.
+        Requires JWT authentication and possession of the cart's token
+        (x-spree-token) — the token authorizes claiming the cart.
       x-codeSamples:
       - lang: javascript
         label: Spree SDK
@@ -2300,6 +2301,12 @@ paths:
       - name: Authorization
         in: header
         required: true
+        schema:
+          type: string
+      - name: x-spree-token
+        in: header
+        required: true
+        description: Cart token
         schema:
           type: string
       - name: id
@@ -2495,6 +2502,16 @@ paths:
                 error:
                   code: authentication_required
                   message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: forbidden - cart token missing or does not match
+          content:
+            application/json:
+              example:
+                error:
+                  code: access_denied
+                  message: You are not authorized to access this page.
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
   "/api/v3/store/carts/{id}/complete":

--- a/spree/api/app/controllers/spree/api/v3/store/carts_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts_controller.rb
@@ -83,10 +83,15 @@ module Spree
           end
 
           # PATCH /api/v3/store/carts/:id/associate
-          # Associates a guest cart with the currently authenticated user
-          # Requires: JWT authentication + cart ID in URL
+          # Associates a guest cart with the currently authenticated user.
+          # Requires: JWT authentication + cart ID in URL + possession of the
+          # cart's token (x-spree-token). The token is the credential that
+          # authorizes claiming the cart, so it is required even when the cart
+          # is already the caller's own.
           def associate
             @cart = find_cart_for_association
+            authorize!(:update, @cart, cart_token)
+            require_cart_token!
 
             result = Spree.cart_associate_service.call(guest_order: @cart, user: current_user, guest_only: true)
 
@@ -176,6 +181,14 @@ module Spree
           # Only finds guest carts (no user) or carts already owned by current user (idempotent).
           def find_cart_for_association
             current_store.carts.where(user: [nil, current_user]).find_by_prefix_id!(params[:id])
+          end
+
+          # Claiming a cart requires presenting its token, even when the caller
+          # already owns it — the token, not ownership, is the claim credential.
+          def require_cart_token!
+            valid = cart_token.present? && cart_token == @cart.token
+
+            raise CanCan::AccessDenied.new(nil, :update, @cart) unless valid
           end
         end
       end

--- a/spree/api/spec/controllers/spree/api/v3/store/carts_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts_controller_spec.rb
@@ -729,41 +729,71 @@ RSpec.describe Spree::Api::V3::Store::CartsController, type: :controller do
         request.headers['Authorization'] = "Bearer #{jwt_token}"
       end
 
-      it 'associates guest cart with current user' do
+      context 'with the guest cart token' do
+        before { request.headers['x-spree-token'] = guest_cart.token }
+
+        it 'associates guest cart with current user' do
+          patch :associate, params: { id: guest_cart.prefixed_id }
+
+          expect(response).to have_http_status(:ok)
+          expect(guest_cart.reload.user).to eq(user)
+          expect(json_response['number']).to eq(guest_cart.number)
+        end
+
+        it 'updates cart email to users email' do
+          patch :associate, params: { id: guest_cart.prefixed_id }
+
+          expect(response).to have_http_status(:ok)
+          expect(guest_cart.reload.email).to eq(user.email)
+        end
+
+        it 'sets user addresses on cart when user has addresses' do
+          bill = create(:address, firstname: 'Bill')
+          ship = create(:address, firstname: 'Ship')
+          user.update!(bill_address: bill, ship_address: ship)
+
+          patch :associate, params: { id: guest_cart.prefixed_id }
+
+          expect(response).to have_http_status(:ok)
+          guest_cart.reload
+          expect(guest_cart.bill_address).to be_present
+          expect(guest_cart.ship_address).to be_present
+        end
+      end
+
+      it 'allows re-associating a cart already owned by current user with its token' do
+        guest_cart.update!(user: user)
+        request.headers['x-spree-token'] = guest_cart.token
+
         patch :associate, params: { id: guest_cart.prefixed_id }
 
         expect(response).to have_http_status(:ok)
         expect(guest_cart.reload.user).to eq(user)
-        expect(json_response['number']).to eq(guest_cart.number)
       end
 
-      it 'updates cart email to users email' do
+      it 'forbids associating a cart without the cart token' do
         patch :associate, params: { id: guest_cart.prefixed_id }
 
-        expect(response).to have_http_status(:ok)
-        expect(guest_cart.reload.email).to eq(user.email)
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['error']['code']).to eq('access_denied')
+        expect(guest_cart.reload.user).to be_nil
       end
 
-      it 'sets user addresses on cart when user has addresses' do
-        bill = create(:address, firstname: 'Bill')
-        ship = create(:address, firstname: 'Ship')
-        user.update!(bill_address: bill, ship_address: ship)
-
-        patch :associate, params: { id: guest_cart.prefixed_id }
-
-        expect(response).to have_http_status(:ok)
-        guest_cart.reload
-        expect(guest_cart.bill_address).to be_present
-        expect(guest_cart.ship_address).to be_present
-      end
-
-      it 'allows re-associating cart already owned by current user' do
+      it 'forbids associating an own cart without the cart token' do
         guest_cart.update!(user: user)
 
         patch :associate, params: { id: guest_cart.prefixed_id }
 
-        expect(response).to have_http_status(:ok)
-        expect(guest_cart.reload.user).to eq(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'forbids associating a cart with the wrong cart token' do
+        request.headers['x-spree-token'] = 'not-the-real-token'
+
+        patch :associate, params: { id: guest_cart.prefixed_id }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(guest_cart.reload.user).to be_nil
       end
 
       it 'returns not found for invalid id' do
@@ -802,6 +832,8 @@ RSpec.describe Spree::Api::V3::Store::CartsController, type: :controller do
 
     context 'without JWT authentication' do
       it 'returns unauthorized' do
+        request.headers['x-spree-token'] = guest_cart.token
+
         patch :associate, params: { id: guest_cart.prefixed_id }
 
         expect(response).to have_http_status(:unauthorized)

--- a/spree/api/spec/integration/spree/api/v3/store/carts_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/carts_spec.rb
@@ -271,19 +271,22 @@ RSpec.describe 'Carts API', type: :request, swagger_doc: 'api-reference/store.ya
       security [api_key: [], bearer_auth: []]
       description <<~DESC
         Associates a guest cart with the currently authenticated user.
-        Requires JWT authentication. The cart must not belong to another user.
+        Requires JWT authentication and possession of the cart's token
+        (x-spree-token) — the token authorizes claiming the cart.
       DESC
 
       sdk_example 'carts/associate'
 
       parameter name: 'x-spree-api-key', in: :header, type: :string, required: true
       parameter name: 'Authorization', in: :header, type: :string, required: true
+      parameter name: 'x-spree-token', in: :header, type: :string, required: true, description: 'Cart token'
       parameter name: :id, in: :path, type: :string, required: true, description: 'Cart prefixed ID'
 
       response '200', 'cart associated successfully' do
         let(:guest_cart) { create(:order_with_line_items, store: store, user: nil) }
         let(:'x-spree-api-key') { api_key.token }
         let(:'Authorization') { "Bearer #{jwt_token}" }
+        let(:'x-spree-token') { guest_cart.token }
         let(:id) { guest_cart.prefixed_id }
 
         schema '$ref' => '#/components/schemas/Cart'
@@ -299,6 +302,19 @@ RSpec.describe 'Carts API', type: :request, swagger_doc: 'api-reference/store.ya
         let(:guest_cart) { create(:order_with_line_items, store: store, user: nil) }
         let(:'x-spree-api-key') { api_key.token }
         let(:'Authorization') { '' }
+        let(:'x-spree-token') { guest_cart.token }
+        let(:id) { guest_cart.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+
+      response '403', 'forbidden - cart token missing or does not match' do
+        let(:guest_cart) { create(:order_with_line_items, store: store, user: nil) }
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { "Bearer #{jwt_token}" }
+        let(:'x-spree-token') { 'does-not-match' }
         let(:id) { guest_cart.prefixed_id }
 
         schema '$ref' => '#/components/schemas/ErrorResponse'


### PR DESCRIPTION
always require the cart token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Guest carts now require both JWT authentication and the correct `x-spree-token` when associating them with an account.
  * Requests with a missing or mismatched cart token are denied with a clear forbidden response.

* **Documentation**
  * Updated API documentation to describe the required cart token header and related error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->