### PR TITLE
Add dashboard component to Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -39,6 +39,10 @@ flags:
     paths:
       - spree/emails/
     carryforward: true
+  dashboard:
+    paths:
+      - spree/dashboard/
+    carryforward: true
 
 component_management:
   individual_components:
@@ -62,6 +66,11 @@ component_management:
       paths:
         - spree/emails/app/**
         - spree/emails/lib/**
+    - component_id: dashboard
+      name: Dashboard
+      paths:
+        - spree/dashboard/app/**
+        - spree/dashboard/lib/**
 
 ignore:
   - "docs/**"


### PR DESCRIPTION
## Summary
Adds the dashboard component to the Codecov configuration file to enable coverage tracking for the new dashboard module.

## Changes
- Added `dashboard` flag under `flags` section with paths pointing to `spree/dashboard/` and carryforward enabled
- Added `dashboard` component under `component_management.individual_components` with paths for `spree/dashboard/app/**` and `spree/dashboard/lib/**`

## Details
This change aligns with the `5.6-project-layout-and-dashboard.md` plan to introduce the React Dashboard as a first-class component in the Spree monorepo. The configuration enables Codecov to track coverage metrics separately for the dashboard module, consistent with how other components (e.g., emails) are configured.

https://claude.ai/code/session_01DtKxNMbwGECCpw247XfDKM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dashboard-specific coverage tracking.
  * Dashboard code is now separately represented in coverage reporting for clearer quality insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->