### PR TITLE
Fix admin auth refresh cookie never being set over plain-http product…

### DIFF
--- a/docs/plans/5.5-admin-auth-cookie-refresh.md
+++ b/docs/plans/5.5-admin-auth-cookie-refresh.md
@@ -16,14 +16,14 @@ The design follows Saleor's storefront Auth SDK pattern — access token in memo
 ## Key Decisions (do not deviate without discussion)
 
 - **Refresh token delivery:** `Set-Cookie` on `/auth/login` and `/auth/refresh`. Never returned in the JSON response body.
-- **Cookie attributes:** `HttpOnly; SameSite=Lax; Path=/api/v3/admin/auth` in dev, `HttpOnly; Secure; SameSite=None; Path=/api/v3/admin/auth` in production. Cookie is **signed** via Rails `cookies.signed` for tamper-evidence.
+- **Cookie attributes:** `HttpOnly; SameSite=Lax; Path=/api/v3/admin/auth` on plain-http requests, `HttpOnly; Secure; SameSite=None; Path=/api/v3/admin/auth` on https requests (keyed off `request.ssl?`, not the Rails env — Rails silently drops Secure cookies on non-SSL requests, which broke production images served over http://localhost). Cookie is **signed** via Rails `cookies.signed` for tamper-evidence.
 - **Cookie name:** `spree_admin_refresh_token`.
 - **Access token storage:** React state only. No `localStorage`, no `sessionStorage`.
 - **CSRF protection:** Provided by the combination of (a) `SameSite=Lax`/`SameSite=None` cookie attributes and (b) `Spree::AllowedOrigin` enforced via `Rack::Cors` with `credentials: true`. **No separate CSRF token is issued or verified.** Reasoning: a cross-origin attacker cannot pass the CORS preflight (Origin not on the allowlist), and `SameSite` blocks cross-site form/POST autosubmits independently. A double-submit token would only add value if the AllowedOrigin allowlist were misconfigured (`*`) or if XSS happened on a different allowlisted origin — both scenarios where deeper problems outweigh the CSRF mitigation, and where an in-memory CSRF token has the same XSS exposure as the access token anyway.
 - **Cookie scope:** `Path=/api/v3/admin/auth` so the refresh cookie is only sent to login/refresh/logout, never on `/products`, `/orders`, etc.
 - **Logout:** new `POST /api/v3/admin/auth/logout` endpoint clears the cookie via `Set-Cookie` with `Max-Age=0` and destroys the `Spree::RefreshToken` row server-side (matching the hard-delete pattern in `RefreshToken#rotate!`). Idempotent — succeeds even when no session exists.
 - **No special-casing for secret-key clients:** secret-key flows never hit `/auth/login` (they use the key directly). The backend sets cookies unconditionally on login responses; non-browser clients ignore `Set-Cookie`.
-- **Local development:** uses Vite proxy (`/api/*` → `:3000`) so the SPA is same-origin with the API. Cookie attributes are environment-conditional: `SameSite=Lax` without `Secure` in dev, `SameSite=None; Secure` in production.
+- **Local development:** uses Vite proxy (`/api/*` → `:3000`) so the SPA is same-origin with the API. Cookie attributes are scheme-conditional: `SameSite=Lax` without `Secure` over http, `SameSite=None; Secure` over https.
 - **Bootstrap:** SPA calls `/auth/refresh` on cold load before rendering authenticated routes. Success → in-memory access token, render. Failure → render `/login`.
 - **No backwards compatibility window:** `@spree/admin-sdk` is unreleased (Developer Preview, `next` dist-tag) so we don't need a transition period. The 5.5 release ships the cookie-only contract directly: refresh token only via cookie, no `refresh_token` field in response bodies, no `params[:refresh_token]` body fallback.
 - **Admin JWT TTL is 5 minutes (separate from storefront).** A new `Spree::Api::Config[:admin_jwt_expiration]` (default 300s) is consumed only by `Spree::Api::V3::Admin::AuthController#jwt_expiration`. The general `Spree::Api::Config[:jwt_expiration]` (default 3600s) continues to govern Store API tokens — customer JWTs have lower blast radius and don't justify the refresh chatter. SPA's background refresh schedule is `4m30s` (30s before expiry); 401-driven refresh handles the rest.
@@ -33,7 +33,7 @@ The design follows Saleor's storefront Auth SDK pattern — access token in memo
 
 ### Cookie contract
 
-| Cookie | Attributes (production) | Attributes (development) | Set on | Cleared on |
+| Cookie | Attributes (https) | Attributes (http) | Set on | Cleared on |
 |---|---|---|---|---|
 | `spree_admin_refresh_token` | `HttpOnly; Secure; SameSite=None; Path=/api/v3/admin/auth` (signed) | `HttpOnly; SameSite=Lax; Path=/api/v3/admin/auth` (signed) | `/auth/login`, `/auth/refresh` (rotation) | `/auth/logout`, refresh failure |
 
@@ -43,8 +43,8 @@ Cookie expiry: `Max-Age` matches the refresh token's natural lifetime (`Spree::R
 
 Classic CSRF assumes the attacker can trigger an authenticated request from a different origin and only needs the cookie to be auto-attached. Three independent defenses already block this for our setup:
 
-1. **`SameSite=Lax`** (dev) blocks cross-site POSTs entirely. The cookie won't be attached.
-2. **`SameSite=None; Secure`** (prod) is the only mode that allows cross-site cookie attachment, and it is constrained by:
+1. **`SameSite=Lax`** (http) blocks cross-site POSTs entirely. The cookie won't be attached.
+2. **`SameSite=None; Secure`** (https) is the only mode that allows cross-site cookie attachment, and it is constrained by:
 3. **CORS preflight + `Spree::AllowedOrigin`** — for any cross-origin authenticated POST, the browser sends an `OPTIONS` preflight. `Rack::Cors` echoes `Access-Control-Allow-Origin` only for origins on `Spree::AllowedOrigin`. An attacker's origin (`evil.com`) is not on the allowlist, the preflight fails, and the browser blocks the actual POST. The cookie is never sent.
 
 A double-submit CSRF token would only add value in two narrow scenarios:
@@ -68,8 +68,8 @@ Response body:
 ```
 
 `Set-Cookie` header:
-- `spree_admin_refresh_token=<signed_value>; HttpOnly; Secure; SameSite=None; Path=/api/v3/admin/auth; Max-Age=2592000` (production)
-- `spree_admin_refresh_token=<signed_value>; HttpOnly; SameSite=Lax; Path=/api/v3/admin/auth; Max-Age=2592000` (development)
+- `spree_admin_refresh_token=<signed_value>; HttpOnly; Secure; SameSite=None; Path=/api/v3/admin/auth; Max-Age=2592000` (https)
+- `spree_admin_refresh_token=<signed_value>; HttpOnly; SameSite=Lax; Path=/api/v3/admin/auth; Max-Age=2592000` (http)
 
 #### `POST /api/v3/admin/auth/refresh`
 

--- a/spree/api/app/controllers/concerns/spree/api/v3/admin/auth_cookies.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/admin/auth_cookies.rb
@@ -10,7 +10,7 @@ module Spree
         # CSRF protection:
         #   We deliberately do NOT use a CSRF token here. The threat model is fully
         #   covered by the combination of:
-        #     - SameSite=Lax (dev) / SameSite=None; Secure (prod) on the refresh cookie
+        #     - SameSite=Lax (http) / SameSite=None; Secure (https) on the refresh cookie
         #     - Spree::AllowedOrigin allowlist enforced via Rack::Cors with credentials: true
         #     - CORS preflight blocking cross-origin requests from non-allowlisted Origins
         #   A double-submit CSRF token would only add value if the AllowedOrigin allowlist
@@ -48,8 +48,14 @@ module Spree
             cookies.signed[REFRESH_COOKIE_NAME].presence
           end
 
+          # Keyed off the request scheme, not the Rails env: Rails silently refuses to
+          # write a Secure cookie on a non-SSL request, so a production app served over
+          # plain http (local Docker image, http-only intranet) would never get the
+          # refresh cookie at all. SameSite=None requires Secure, so http falls back to
+          # Lax — fine for same-site setups (ports don't factor into site identity);
+          # cross-site dashboards need https anyway.
           def base_cookie_attributes
-            if Rails.env.production?
+            if request.ssl?
               { secure: true, same_site: :none }
             else
               { secure: false, same_site: :lax }

--- a/spree/api/spec/controllers/spree/api/v3/admin/auth_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/auth_controller_spec.rb
@@ -46,9 +46,19 @@ RSpec.describe Spree::Api::V3::Admin::AuthController, type: :controller do
         expect(line).to be_present
         expect(line).to include('httponly')
         expect(line).to include('path=/api/v3/admin/auth')
-        # In dev/test env (non-production), SameSite=Lax and no Secure flag
+        # Over plain http, SameSite=Lax and no Secure flag
         expect(line).to include('samesite=lax')
         expect(line).not_to match(/;\s*secure/i)
+      end
+
+      it 'sets a Secure SameSite=None refresh cookie on https requests' do
+        request.env['HTTPS'] = 'on'
+        post :create, params: { email: existing_admin.email, password: 'password123' }
+
+        line = set_cookie_for('spree_admin_refresh_token')
+        expect(line).to be_present
+        expect(line).to include('samesite=none')
+        expect(line).to match(/;\s*secure/i)
       end
 
       it 'creates a RefreshToken row matching the signed cookie value' do


### PR DESCRIPTION
…ion deployments

In production, Rails silently refuses to write a Secure cookie on a non-SSL request, so a production app served over plain http (e.g. the prebuilt Docker image on http://localhost:3000) never received the refresh cookie on login. Every /api/v3/admin/auth/refresh then failed with 401 "Refresh token cookie missing", signing admins out of the dashboard as soon as the short-lived access token expired.

Cookie attributes were keyed off the Rails env, conflating "production" with "served over https". They now follow the request scheme: https requests keep Secure; SameSite=None (required for cross-site dashboard deployments), while http requests fall back to SameSite=Lax — safe because same-site covers both the baked-in /dashboard and local Vite dev, and any cross-site setup requires https anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin refresh-token cookies now automatically use secure cookie settings based on whether the request uses HTTPS, rather than the application environment.
  * HTTP requests receive `SameSite=Lax` cookies without the `Secure` flag, while HTTPS requests receive `SameSite=None` cookies with `Secure` enabled.

* **Documentation**
  * Updated cookie security guidance and examples to clearly distinguish HTTP and HTTPS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->