### PR TITLE
Fix rich text description round-tripping in product forms

### DIFF
--- a/packages/dashboard/.changeset/product-description-formatting.md
+++ b/packages/dashboard/.changeset/product-description-formatting.md
@@ -1,0 +1,5 @@
+---
+"@spree/dashboard": patch
+---
+
+Fix the product edit form collapsing multi-paragraph descriptions on reload. The description editor now hydrates from the API's `description_html` field instead of the tag-stripped plain-text `description`, so paragraphs, line breaks, and inline formatting survive save and reload cycles.

--- a/packages/dashboard/.changeset/product-description-formatting.md
+++ b/packages/dashboard/.changeset/product-description-formatting.md
@@ -1,5 +1,0 @@
----
-"@spree/dashboard": patch
----
-
-Fix the product edit form collapsing multi-paragraph descriptions on reload. The description editor now hydrates from the API's `description_html` field instead of the tag-stripped plain-text `description`, so paragraphs, line breaks, and inline formatting survive save and reload cycles.

--- a/packages/dashboard/CHANGELOG.md
+++ b/packages/dashboard/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @spree/dashboard
+
+## 0.10.2
+
+### Patch Changes
+
+- Fix the product edit form collapsing multi-paragraph descriptions on reload. The description editor now hydrates from the API's `description_html` field instead of the tag-stripped plain-text `description`, so paragraphs, line breaks, and inline formatting survive save and reload cycles.

--- a/packages/dashboard/e2e/products-edit.spec.ts
+++ b/packages/dashboard/e2e/products-edit.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { FIXTURE_BULK_CHANNEL_NAME, login } from './helpers'
-import { createProduct, publishingCard } from './products-helpers'
+import { createProduct, publishingCard, typeDescription } from './products-helpers'
 
 test.describe('product edit', () => {
   test('creates a product and lands on the edit page', async ({ page }) => {
@@ -11,6 +11,32 @@ test.describe('product edit', () => {
 
     // The Name input on the edit page mirrors the saved name.
     await expect(page.getByLabel(/^name$/i)).toHaveValue(name)
+  })
+
+  test('preserves multi-paragraph description formatting across reload', async ({ page }) => {
+    const creds = await login(page)
+    const name = `E2E Product Rich Text ${Date.now()}`
+
+    await createProduct(page, creds.store_id, name)
+
+    // Type two paragraphs on the edit page so the save goes through the
+    // update path (the reported bug scenario), not create.
+    await typeDescription(page, 'First paragraph\nSecond paragraph')
+
+    await page.getByRole('button', { name: /save product/i }).click()
+    await expect(page.getByRole('button', { name: /save product/i })).toBeDisabled({
+      timeout: 15_000,
+    })
+
+    await page.reload()
+
+    // The saved HTML must round-trip as two separate paragraphs. Before the
+    // fix the form hydrated from the tag-stripped, whitespace-squished
+    // plain-text `description`, collapsing both lines into a single block.
+    const description = page.locator('#product-description')
+    await expect(description.locator('p')).toHaveCount(2)
+    await expect(description.locator('p').first()).toHaveText('First paragraph')
+    await expect(description.locator('p').nth(1)).toHaveText('Second paragraph')
   })
 
   test('updates name on an existing product', async ({ page }) => {

--- a/packages/dashboard/e2e/products-helpers.ts
+++ b/packages/dashboard/e2e/products-helpers.ts
@@ -6,11 +6,20 @@ export const PRODUCTS_PATH = (storeId: string) => `/${storeId}/products`
 export const OPTIONS_PATH = (storeId: string) => `/${storeId}/products/options`
 
 /**
+ * Focus the product form's description field and type `text`. The field is a
+ * tiptap `RichTextEditor` (contenteditable), not a textarea, so `.fill()` is
+ * wrong; we click to focus and `keyboard.type` instead, which presses Enter
+ * for each `\n` — splitting the text into separate paragraphs.
+ */
+export async function typeDescription(page: Page, text: string): Promise<void> {
+  await page.getByLabel(/^description$/i).click()
+  await page.keyboard.type(text)
+}
+
+/**
  * Drive the New Product form and land on the edit page. The minimum input the
  * form accepts is a name — pass a `description` when the spec specifically
- * verifies how rich-text data round-trips. The description field is a tiptap
- * `RichTextEditor` (contenteditable), not a textarea, so `.fill()` is wrong;
- * we click to focus and `keyboard.type` instead.
+ * verifies how rich-text data round-trips.
  */
 export async function createProduct(
   page: Page,
@@ -22,11 +31,7 @@ export async function createProduct(
   await page.getByRole('button', { name: /add product/i }).click()
   await expect(page.getByRole('heading', { name: /^new product$/i })).toBeVisible()
   await page.getByLabel(/^name$/i).fill(name)
-  if (description) {
-    const editor = page.getByLabel(/^description$/i)
-    await editor.click()
-    await page.keyboard.type(description)
-  }
+  if (description) await typeDescription(page, description)
   await page.getByRole('button', { name: /^create product$/i }).click()
   // Lands on `/$storeId/products/$productId` (not `/new`).
   await expect(page).toHaveURL(new RegExp(`/${storeId}/products/prod_[^/]+$`), { timeout: 15_000 })

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spree/dashboard",
   "license": "MIT",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Spree Dashboard app shell \u2014 the next-gen React admin for Spree Commerce. Routes, resource hooks, schemas, locales, and the <Dashboard /> component. Source-only package; hosts compile it via @spree/dashboard/vite. Developer Preview.",
   "author": "Vendo Connect Inc.",
   "homepage": "https://spreecommerce.org",

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/$productId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/$productId.tsx
@@ -132,7 +132,11 @@ function productToFormValues(
 
   return {
     name: product.name,
-    description: product.description ?? '',
+    // Hydrate the Tiptap editor from the HTML field, not `description` — the
+    // serializer squishes that one to tag-stripped plain text, which would
+    // collapse paragraphs/line breaks on every reload. Write still goes back
+    // through the `description` param (the API accepts HTML there).
+    description: product.description_html ?? '',
     status: (product.status as ProductFormValues['status']) ?? 'draft',
     category_ids: product.categories?.map((t) => t.id) ?? [],
     tags: product.tags ?? [],

--- a/spree/api/app/serializers/spree/api/v3/product_serializer.rb
+++ b/spree/api/app/serializers/spree/api/v3/product_serializer.rb
@@ -48,7 +48,7 @@ module Spree
         attribute :description do |product|
           next if product.description.blank?
 
-          Nokogiri::HTML.fragment(product.description).text.squish
+          Spree::RichTextHelper.to_plain_text(product.description)
         end
 
         attribute :description_html do |product|

--- a/spree/core/app/helpers/spree/rich_text_helper.rb
+++ b/spree/core/app/helpers/spree/rich_text_helper.rb
@@ -1,0 +1,37 @@
+module Spree
+  # Converts stored rich text HTML (Tiptap output persisted in plain text
+  # columns, e.g. +Spree::Product#description+) into a faithful plain-text
+  # rendering for API +description+/+body+ fields.
+  #
+  # Tiptap serializes blocks with no whitespace between them
+  # (+<p>a</p><p>b</p>+), so a naive tag strip glues adjacent blocks into a
+  # single run ("ab") and loses every paragraph and line break. This maps
+  # block boundaries and +<br>+ to newlines before stripping tags, keeping the
+  # text readable for storefronts, feeds, search indexing, and meta tags.
+  #
+  # Newlines already present in the markup (pretty-printed source from the
+  # legacy admin's TinyMCE code view, imports, seeds) render as a single space
+  # in a browser and are treated the same way here — only +<br>+ and block
+  # boundaries produce line breaks.
+  module RichTextHelper
+    # Closing block tags whose boundaries become line breaks.
+    BLOCK_BOUNDARY = %r{</(?:p|div|li|h[1-6]|blockquote|tr|ul|ol|table|section|article|header|footer|pre)>}i
+
+    # Hard line breaks.
+    LINE_BREAK = %r{<br\s*/?>}i
+
+    # @param html [String, nil] rich text HTML
+    # @return [String] plain text with paragraph and line breaks preserved
+    def self.to_plain_text(html)
+      return '' if html.blank?
+
+      with_breaks = html.gsub(/\s+/, ' ').gsub(LINE_BREAK, "\n").gsub(BLOCK_BOUNDARY, "\\0\n")
+
+      Nokogiri::HTML.fragment(with_breaks).text
+                    .gsub(/[^\S\n]+/, ' ') # collapse runs of non-newline whitespace
+                    .gsub(/ *\n */, "\n")  # trim spaces hugging newlines
+                    .gsub(/\n{3,}/, "\n\n") # cap consecutive blank lines
+                    .strip
+    end
+  end
+end

--- a/spree/core/spec/helpers/spree/rich_text_helper_spec.rb
+++ b/spree/core/spec/helpers/spree/rich_text_helper_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Spree::RichTextHelper do
+  describe '.to_plain_text' do
+    subject { described_class.to_plain_text(html) }
+
+    context 'when blank' do
+      let(:html) { nil }
+
+      it { is_expected.to eq('') }
+    end
+
+    context 'with a single paragraph' do
+      let(:html) { '<p>A <strong>comfortable</strong> cotton t-shirt.</p>' }
+
+      it 'strips tags without trailing whitespace' do
+        is_expected.to eq('A comfortable cotton t-shirt.')
+      end
+    end
+
+    context 'with multiple blocks' do
+      let(:html) { '<p>Need to install the following packages:</p><p>create-spree-app@1.1.2</p>' }
+
+      it 'separates adjacent blocks with a newline instead of gluing them' do
+        is_expected.to eq("Need to install the following packages:\ncreate-spree-app@1.1.2")
+      end
+    end
+
+    context 'with hard line breaks and lists' do
+      let(:html) { '<p>First<br>Second</p><ul><li>One</li><li>Two</li></ul>' }
+
+      it 'preserves line breaks and list item boundaries' do
+        is_expected.to eq("First\nSecond\nOne\nTwo")
+      end
+    end
+
+    context 'with pretty-printed source HTML (legacy TinyMCE, imports)' do
+      let(:html) { "<p>Hello\n  world</p>\n<p>Second</p>" }
+
+      it 'renders source newlines as spaces, like a browser' do
+        is_expected.to eq("Hello world\nSecond")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a bug where multi-paragraph product descriptions were collapsed into a single paragraph when reloading the product edit form. The issue occurred because the form was hydrated from the API's `description` field (tag-stripped plain text) instead of the `description_html` field (original HTML), losing paragraph boundaries.

## Changes

- **New `Spree::RichTextHelper.to_plain_text` method** — Converts stored Tiptap HTML to faithful plain text by:
  - Mapping block boundaries (`</p>`, `</div>`, `</li>`, etc.) and `<br>` tags to newlines before stripping tags
  - Collapsing runs of whitespace (except newlines) to single spaces, matching browser rendering
  - Normalizing consecutive blank lines to at most two newlines
  - Preserving paragraph and line break structure for storefronts, feeds, search indexing, and meta tags

- **Updated `ProductSerializer#description` attribute** — Now uses `RichTextHelper.to_plain_text` instead of naive `Nokogiri::HTML.fragment.text.squish`, which was losing all formatting

- **Fixed product form hydration** — Changed `productToFormValues` to hydrate the Tiptap editor from `description_html` (original HTML) instead of `description` (plain text), preserving formatting across reloads

- **Added comprehensive test coverage** — `RichTextHelper` spec covers blank input, single paragraphs, multiple blocks, hard line breaks, lists, and legacy pretty-printed HTML

- **Added E2E test** — Verifies multi-paragraph descriptions round-trip correctly through save and reload cycles

- **Refactored E2E helpers** — Extracted `typeDescription` helper for reusable rich text input across tests

## Implementation Details

The `to_plain_text` method handles the impedance mismatch between Tiptap's serialization (no whitespace between blocks) and naive tag stripping (which glues blocks together). It also normalizes source HTML newlines (from legacy TinyMCE code view, imports, seeds) to spaces, matching browser rendering behavior.

The form now writes through the `description` param (API accepts HTML there) but reads from `description_html`, ensuring the editor always has the original structured content rather than the lossy plain-text serialization.

https://claude.ai/code/session_012DbwAYp1pmFM1xZCt7XLEU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product descriptions now preserve paragraph breaks and rich-text formatting after saving and reloading.
  * Product editing correctly restores formatted descriptions instead of collapsing content into plain text.
  * Plain-text descriptions retain meaningful line breaks when generated from rich-text content.

* **Documentation**
  * Updated the dashboard changelog for version 0.10.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->