### PR TITLE
Invalidate import-touched caches on import completion

### DIFF
--- a/packages/dashboard/e2e/imports.spec.ts
+++ b/packages/dashboard/e2e/imports.spec.ts
@@ -83,8 +83,11 @@ test.describe('csv import', () => {
       timeout: 15_000,
     })
 
-    // The good row became a real product.
-    await page.goto(PRODUCTS_PATH(creds.store_id))
+    // The good row became a real product, visible through in-app navigation:
+    // completion invalidates the products cache, so the list mounted under
+    // the wizard is already fresh. (A full-page goto would reset the query
+    // cache and mask a stale list.)
+    await page.getByRole('button', { name: /view products/i }).click()
     await expect(page.getByText(goodName)).toBeVisible({ timeout: 15_000 })
   })
 

--- a/packages/dashboard/src/hooks/use-imports.ts
+++ b/packages/dashboard/src/hooks/use-imports.ts
@@ -1,6 +1,7 @@
 import type { Import, ImportCompleteMappingParams } from '@spree/admin-sdk'
 import { adminClient, useResourceKey, useResourceKeyBuilder } from '@spree/dashboard-core'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { isImportActive } from '../lib/import-types'
 
@@ -9,19 +10,48 @@ export { isImportActive }
 const IMPORT_POLL_INTERVAL_MS = 2000
 const ROWS_POLL_INTERVAL_MS = 5000
 
+// Caches any import may have written to, plus `imports` itself (history table
+// status column). Deliberately not per-type — imports are rare, so a few
+// extra refetches beat maintaining a type → resource map (product rows alone
+// fan out to option types/values and categories created on the fly).
+const IMPORT_TOUCHED_RESOURCES = ['products', 'option-types', 'categories', 'customers', 'imports']
+
 /**
  * Single import, polled every 2s while the pipeline is running. `mapping`
  * (user-driven) and terminal statuses don't poll — a mapping-state refetch
  * would re-read the attached CSV server-side on every tick.
+ *
+ * A finished import (completed, or failed — earlier rows may still have been
+ * written) invalidates every cache imports can touch: the pipeline writes
+ * records server-side, outside any tracked mutation, so nothing else ever
+ * marks those lists stale and "View products" would keep serving the
+ * pre-import cache.
  */
 export function useImport(id: string) {
-  return useQuery({
+  const queryClient = useQueryClient()
+  const buildKey = useResourceKeyBuilder()
+
+  const query = useQuery({
     queryKey: useResourceKey('imports', id),
     queryFn: () => adminClient.imports.get(id),
     enabled: !!id,
     refetchInterval: (query) =>
       isImportActive(query.state.data?.status) ? IMPORT_POLL_INTERVAL_MS : false,
   })
+
+  // Fires when the poll lands on a finished status — including again after
+  // each retry pass (`finished` flips false → true anew). Reopening an
+  // already-finished import refires it; harmless, invalidation is idempotent.
+  const status = query.data?.status
+  const finished = status === 'completed' || status === 'failed'
+  useEffect(() => {
+    if (!finished) return
+    for (const resource of IMPORT_TOUCHED_RESOURCES) {
+      queryClient.invalidateQueries({ queryKey: buildKey(resource) })
+    }
+  }, [finished, queryClient, buildKey])
+
+  return query
 }
 
 /** Rows of an import (the failure report), optionally polled while processing. */

--- a/spree/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/spree/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -75,6 +75,7 @@ development:
 test:
   adapter: sqlite3
   database: db/spree_test<%%= ENV['TEST_ENV_NUMBER'] %>.sqlite3
+  timeout: 10000
 production:
   adapter: sqlite3
   database: db/spree_production.sqlite3


### PR DESCRIPTION
## Summary

When a CSV import completes (successfully or with failures), the admin dashboard now invalidates all resource caches that the import pipeline may have written to. This ensures that subsequent navigation (e.g., "View products") displays fresh data rather than stale pre-import cache entries.

## Changes

- **useImport hook**: Added cache invalidation logic that fires when an import reaches a terminal status (`completed` or `failed`). The hook now invalidates queries for all resources imports can touch: products, option-types, categories, customers, and imports itself.
  - Introduced `IMPORT_TOUCHED_RESOURCES` constant documenting which caches are affected
  - Added `useEffect` hook to detect status transitions to terminal states and trigger invalidation
  - Updated JSDoc to explain the cache invalidation strategy

- **E2E test**: Changed the import completion test to navigate via the in-app "View products" button instead of a full-page `goto`. This validates that the cache invalidation works correctly—the products list mounted under the wizard should already be fresh without requiring a page reload.

- **Test database config**: Added `timeout: 10000` to SQLite test database configuration to prevent timeout issues during parallel test execution.

## Implementation Details

The invalidation uses `queryClient.invalidateQueries()` with the resource key builder to mark all queries for affected resources as stale. This approach is deliberately broad (not per-type) since imports are rare operations, making a few extra refetches acceptable compared to maintaining a type-to-resource mapping. The effect re-fires on each retry pass when the status remains in a terminal state, but invalidation is idempotent so this is harmless.

https://claude.ai/code/session_013NKETijfLwd96LxMRVZ3pM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product and related data now refresh automatically after CSV imports complete or fail.
  * Improved navigation from the import results screen to the product list.
  * Increased SQLite test database timeout to improve reliability during automated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->