### PR TITLE
Add user page sidebar injection point for admin UI extensions

### DIFF
--- a/docs/developer/admin/extending-ui.mdx
+++ b/docs/developer/admin/extending-ui.mdx
@@ -425,6 +425,29 @@ Here's a list of all places you can inject your custom code:
     * Include `data: { filters_target: :input }` for proper integration with the Stimulus Filters controller
     </Tip>
   </Accordion>
+
+  <Accordion title="Customer Page Sidebar">
+    `user_page_sidebar`
+
+    #### Variables
+
+    <ParamField path="user" type="Spree.user_class">
+      The customer displayed on the page.
+    </ParamField>
+
+    Injects a section into the customer detail page sidebar. This partial has access to the `user` variable.
+
+    ```erb
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title">Account review</h5>
+      </div>
+      <div class="card-body">
+        <%= user.email %>
+      </div>
+    </div>
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ### Stock Items

--- a/spree/admin/app/views/spree/admin/users/show.html.erb
+++ b/spree/admin/app/views/spree/admin/users/show.html.erb
@@ -29,6 +29,7 @@
     <%= render 'spree/admin/users/shipping' %>
     <%= render 'spree/admin/users/billing' %>
     <%= render 'spree/admin/shared/internal_note', notable: @user, form_url: spree.admin_user_path(@user) %>
+    <%= render_admin_partials(:user_page_sidebar_partials, user: @user) %>
   </div>
 </div>
 

--- a/spree/admin/lib/spree/admin/engine.rb
+++ b/spree/admin/lib/spree/admin/engine.rb
@@ -125,6 +125,7 @@ module Spree
         :themes_actions_partials,
         :themes_header_partials,
         :user_dropdown_partials,
+        :user_page_sidebar_partials,
         :users_actions_partials,
         :users_filters_partials,
         :users_header_partials,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying additional, configurable sidebar content on the admin user details page.
  * Introduced a new extension injection point for a user page sidebar, with access to the relevant user data for custom partials.
* **Documentation**
  * Updated the admin UI extending guide with the new “Customer Page Sidebar” injection point details and an example snippet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->