### PR TITLE
Add allow list for optional attributes in google merchant center

### DIFF
--- a/spree/core/app/presenters/spree/data_feeds/google_presenter.rb
+++ b/spree/core/app/presenters/spree/data_feeds/google_presenter.rb
@@ -8,7 +8,7 @@ module Spree
       OPTIONAL_ATTRIBUTES = %w[
         brand gtin mpn identifier_exists condition adult multipack is_bundle
         age_group color gender material pattern size size_type size_system
-        item_group_id product_length product_width product_height product_weight
+        product_length product_width product_height product_weight
         google_product_category product_type sale_price sale_price_effective_date
         cost_of_goods_sold unit_pricing_measure unit_pricing_base_measure
         shipping shipping_label shipping_weight shipping_length shipping_width

--- a/spree/core/app/presenters/spree/data_feeds/google_presenter.rb
+++ b/spree/core/app/presenters/spree/data_feeds/google_presenter.rb
@@ -3,6 +3,22 @@ require 'nokogiri'
 module Spree
   module DataFeeds
     class GooglePresenter < BasePresenter
+      # Optional Google Merchant Center product attributes sourced from
+      # metafields. See https://support.google.com/merchants/answer/7052112
+      OPTIONAL_ATTRIBUTES = %w[
+        brand gtin mpn identifier_exists condition adult multipack is_bundle
+        age_group color gender material pattern size size_type size_system
+        item_group_id product_length product_width product_height product_weight
+        google_product_category product_type sale_price sale_price_effective_date
+        cost_of_goods_sold unit_pricing_measure unit_pricing_base_measure
+        shipping shipping_label shipping_weight shipping_length shipping_width
+        shipping_height ships_from_country transit_time_label max_handling_time
+        min_handling_time tax tax_category energy_efficiency_class
+        min_energy_efficiency_class max_energy_efficiency_class
+        gtin_source expiration_date custom_label_0 custom_label_1 custom_label_2
+        custom_label_3 custom_label_4 mobile_link additional_image_link
+      ].freeze
+
       # @return [String] RSS XML feed for Google Merchant Center
       def call
         builder = Nokogiri::XML::Builder.new do |xml|
@@ -59,8 +75,19 @@ module Spree
 
       def build_optional_attributes(xml, product)
         product.public_metafields.each do |metafield|
-          xml['g'].send(metafield.metafield_definition.key.parameterize.underscore, metafield.value)
+          key = metafield.metafield_definition.key.parameterize.underscore
+          next unless OPTIONAL_ATTRIBUTES.include?(key)
+
+          append_g_element(xml, key, metafield.value)
         end
+      end
+
+      def append_g_element(xml, name, value)
+        parent = xml.parent
+        node = Nokogiri::XML::Node.new(name, parent.document)
+        node.namespace = parent.namespace_scopes.find { |ns| ns.prefix == 'g' }
+        node.content = value
+        parent << node
       end
 
       def format_title(product, variant)

--- a/spree/core/spec/presenters/spree/data_feeds/google_presenter_spec.rb
+++ b/spree/core/spec/presenters/spree/data_feeds/google_presenter_spec.rb
@@ -114,6 +114,31 @@ RSpec.describe Spree::DataFeeds::GooglePresenter do
       end
     end
 
+    context 'metafield with a key that is not a known Google attribute' do
+      let(:product) { create(:product) }
+      let(:metafield_definition) { create(:metafield_definition, name: 'Internal', key: 'internal_note') }
+      let!(:metafield) { create(:metafield, resource: product, metafield_definition: metafield_definition, value: 'secret') }
+
+      it 'omits the metafield from the feed' do
+        expect(xml).not_to include('internal_note')
+        expect(xml).not_to include('secret')
+      end
+    end
+
+    context 'metafield whose key collides with a Ruby method name' do
+      let(:product) { create(:product) }
+      let(:metafield_definition) do
+        create(:metafield_definition, name: 'System', key: 'brand').tap do |definition|
+          definition.update_column(:key, 'system')
+        end
+      end
+      let!(:metafield) { create(:metafield, resource: product, metafield_definition: metafield_definition, value: 'id') }
+
+      it 'does not dispatch the key as a method and omits it from the feed' do
+        expect(xml).not_to include('<g:system>')
+      end
+    end
+
     context 'title generation does not mutate product name' do
       it 'generates independent titles for multiple variants' do
         option_type = create(:option_type)

--- a/spree/core/spec/presenters/spree/data_feeds/google_presenter_spec.rb
+++ b/spree/core/spec/presenters/spree/data_feeds/google_presenter_spec.rb
@@ -139,6 +139,17 @@ RSpec.describe Spree::DataFeeds::GooglePresenter do
       end
     end
 
+    context 'metafield whose key matches a required attribute' do
+      let(:product) { create(:product) }
+      let(:metafield_definition) { create(:metafield_definition, name: 'Item Group', key: 'item_group_id') }
+      let!(:metafield) { create(:metafield, resource: product, metafield_definition: metafield_definition, value: 'injected') }
+
+      it 'does not emit the metafield value, only the required item_group_id' do
+        expect(xml).to include("<g:item_group_id>#{product.id}</g:item_group_id>")
+        expect(xml).not_to include('<g:item_group_id>injected</g:item_group_id>')
+      end
+    end
+
     context 'title generation does not mutate product name' do
       it 'generates independent titles for multiple variants' do
         option_type = create(:option_type)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to Google feed XML generation; behavior change is stricter filtering of metafields with tests, no auth or payment impact.
> 
> **Overview**
> **Google Merchant Center** optional product fields from metafields are now gated by an explicit **`OPTIONAL_ATTRIBUTES`** allowlist aligned with Google’s supported attributes, instead of emitting every public metafield key.
> 
> Unknown metafield keys are skipped, and optional tags are written via **`append_g_element`** (manual `g` namespace nodes) rather than **`xml['g'].send(key, …)`**, so keys that match Ruby methods (e.g. `system`) are not mis-dispatched. Keys that correspond to required feed fields such as **`item_group_id`** are not on the allowlist, so metafields cannot override values already set in **`build_required_attributes`**.
> 
> Specs cover omitted internal keys, method-name collisions, and blocked overrides of required attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9c65fdb6521e31a55188c46f31fef4d97a98ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Merchant Center feeds now include only supported optional attributes.
  * Metafields with unknown or conflicting keys are omitted to prevent incorrect XML output.
  * Optional Google feed elements are generated with consistent namespace formatting.
* **Tests**
  * Added coverage to verify omitted metafields and attribute preservation behavior in generated XML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->