### PR TITLE
docs(plans): reconcile 6.0 status for master-variant + taxons→categories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Active plans (6.0 target, work pending):
 - `6.0-admin-api.md` — Admin REST API conventions, auth, endpoint list (~300 endpoints)
 - `6.0-admin-spa.md` — React admin architecture, extension points, table registry, i18n + server-error mapping
 - `6.0-product-types.md` — Prototype → ProductType rename, MetafieldDefinition schema enforcement
-- `6.0-remove-master-variant.md` — Eliminate is_master, add default_variant_id FK on Product
+- `6.0-remove-master-variant.md` — Eliminate is_master, add default_variant_id FK on Product. **Shipped to 6-0-dev (PR #14265):** is_master removed from all models, default_variant_id + `spree:remove_master_variant` data-migration rake landed; only the physical is_master column drop remains (6.1 cleanup).
 - `6.0-split-adjustments.md` — Replace polymorphic Adjustment with TaxLine, Discount, Fee
 - `6.0-typed-stock-movements.md` — Replace generic StockMovement with typed kinds + concrete FKs
 - `6.0-normalize-state-to-status.md` — Rename state → status on Payment, Shipment, InventoryUnit, ReturnAuthorization, GiftCard
@@ -28,7 +28,7 @@ Active plans (6.0 target, work pending):
 - `6.0-delivery-rate-provider.md` — Per-DeliveryMethod DeliveryRateProvider, replaces Estimator + Calculator, DeliveryZone with postal code support
 - `6.0-rich-text-descriptions.md` — Drop ActionText storage, store HTML in text columns, sanitize on write, serve `description` + `description_html` in API (description_html serializer field shipped in 5.4)
 - `6.0-inventory-operations.md` — StockTransfer lifecycle (draft → ready_to_ship → in_transit → received with partial receive), new `Spree::PurchaseOrder` + `Spree::Supplier` (renamed from Vendor — `Spree::Vendor` is the marketplace seller, see decisions.md 2026-07-14) replacing today's "external receive" hack, variant + stock-location stock history panels. Consumes the typed-movement primitives from `6.0-typed-stock-movements.md`.
-- `6.0-replace-taxons-with-categories.md` — Split Taxon into Category (hierarchy) + Collection (flat/rule-based). Category surface shipped (5.5–5.6): `Spree::Category < Spree::Taxon` scoped subclass, direct `store_id` ownership + backfill, full Admin Categories API, counter caches (`products_count`), dashboard UI. Pending 6.0: table rename + inheritance flip, the `Collection` stack, model-level removal of automatic/rules from Category, and dropping `Taxonomy`. No brand feature in 6.0 — brands are modeled as a Category/Collection; `brand_taxon`/`brand_name` removed with `Taxonomy`.
+- `6.0-replace-taxons-with-categories.md` — Split Taxon into Category (hierarchy) + Collection (flat/rule-based). **Shipped to 6-0-dev (PR #14302):** the Category surface (5.5–5.6) plus the 6.0 core — `spree_taxons`→`spree_categories` table rename + inheritance flip (`Spree::Category < Spree.base_class`, `Spree::Taxon` alias kept), the full `Collection` stack (model + rules + DB/Meilisearch manual sort + API), the taxon→category/collection data migration, and de-ruling Category. Pending (all 6.1): channel-aware `CollectionRules::AvailableOn` (ships interim now, rides with channels) + dropping `spree_taxon_rules`/`Taxonomy`. No brand feature in 6.0 — brands are modeled as a Category/Collection; `brand_taxon`/`brand_name` removed with `Taxonomy`.
 
 Multi-version plans (some phases shipped, some pending):
 - `5.4-store-api-naming-standardization.md` — Standardize API naming against industry (address fields, discounts, customer_note, label, brand/last4, etc.). 5.4 model/API aliases shipped; 6.0 column/table renames pending.

--- a/docs/plans/6.0-remove-master-variant.md
+++ b/docs/plans/6.0-remove-master-variant.md
@@ -1,10 +1,10 @@
 # Remove Master Variant
 
-**Status:** Design finalized. Phase 4 (API) partially shipped — public serializer/controller surface migrated to `default_variant`; internal API-layer cleanup + backend Phases 1–3 + data migration pending.
+**Status:** Shipped to `6-0-dev` (PR #14265, merged 2026-07-10). Phases 1–4 complete — `is_master` removed from all models, `default_variant_id` FK + `ensure_default_variant`/`set_default_variant`/`auto_promote_default_variant` wired on Product, and the `spree:remove_master_variant` data-migration rake task landed. **Remaining:** Phase 5 cleanup only — dropping the physical `is_master` column and the deprecated `master`/`variants_including_master` aliases (scoped to 6.1).
 **Target:** Spree 6.0
 **Depends on:** None (standalone, but coordinate with Cart/Order split)
 **Author:** Damian + Claude
-**Last updated:** 2026-06-30
+**Last updated:** 2026-07-20
 
 ## Summary
 

--- a/docs/plans/6.0-replace-taxons-with-categories.md
+++ b/docs/plans/6.0-replace-taxons-with-categories.md
@@ -1,10 +1,10 @@
 # Replace Taxons with Categories & Add Collections
 
-**Status:** Category read/write surface shipped (5.5–5.6): `Spree::Category < Spree::Taxon` scoped subclass, direct `store_id` ownership + backfill, full Admin Categories API (CRUD + `reposition` + nested products/custom_fields/translations), and counter caches (`products_count`). **Remaining for 6.0:** table rename, the `Collection` stack (model + join + rules + API), model-level removal of automatic/rules from Category, and dropping `Taxonomy`.
+**Status:** Shipped to `6-0-dev` (PR #14302, merged 2026-07-19). The Category read/write surface landed earlier (5.5–5.6); PR #14302 completed the 6.0 core: the `spree_taxons` → `spree_categories` table rename + inheritance flip (`Spree::Category < Spree.base_class`, `Spree::Taxon` retained as a deprecation alias), the full `Collection` stack (model + join + rules + DB/Meilisearch manual sort + API), the taxon→category/collection data-migration task, and de-ruling Category. **Remaining (all 6.1):** the channel-aware reimplementation of `CollectionRules::AvailableOn` — Phase 5, which ships now with an interim legacy-`available_on` `apply` and rides with `6.1-channels-catalogs-b2b.md`; and dropping `spree_taxon_rules` + `Spree::TaxonRule`/`TaxonRules::*` + the `Taxonomy` model (Phase 6). Nothing 6.0-blocking is left.
 **Target:** Spree 6.0 (Category surface landed in 5.5–5.6; 6.0 renames the table, splits out `Collection`, and drops `Taxonomy`)
 **Depends on:** API v3 conventions, ProductType plan (6.0-product-types.md), Rich Text Descriptions plan (6.0-rich-text-descriptions.md), Admin SPA plan (6.0-admin-spa.md — dashboard UI), Channels/Publications plan (6.0-channels-catalogs-b2b.md — the `CollectionRules::AvailableOn` rule's channel-aware implementation depends on its `available_on` → `ProductPublication#published_at` migration; see Migration Phase 5)
 **Author:** Damian + Claude
-**Last updated:** 2026-07-16
+**Last updated:** 2026-07-20
 
 ## Summary
 


### PR DESCRIPTION
## What

Update the `Status` headers of two 6.0 plans and their matching CLAUDE.md active-plan blurbs to reflect what is actually merged on `6-0-dev`.

Both headers were last edited *before* their feature PRs merged, so they still described completed work as pending — a trap for anyone (or any agent) sequencing 6.0 work off `docs/plans/`.

## Why

Verified against the `6-0-dev` branch (models + migrations) and the merged PRs:

- **Remove Master Variant** (PR #14265, merged 2026-07-10) — `is_master` removed from all models, `default_variant_id` FK + `spree:remove_master_variant` data-migration rake landed. Phases 1–4 (the whole 6.0 scope) are done. Only the Phase 5 `is_master` column drop + deprecated aliases remain — explicitly 6.1.
- **Replace Taxons with Categories** (PR #14302, merged 2026-07-19) — `spree_taxons`→`spree_categories` rename + inheritance flip, the full `Collection` stack, data migration, and de-ruling all shipped; `Product` has `primary_category`/`categories`/`collections`/`collections_count`. Remaining items are both 6.1: the channel-aware `CollectionRules::AvailableOn` reimplementation (ships interim now, rides with the deferred channels plan) and dropping `spree_taxon_rules`/`Taxonomy`.

The other seven 6.0 plans were spot-checked against the branch and their headers are accurate — no changes needed.

## Scope

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or API behavior changes.
> 
> **Overview**
> **Docs-only** update so plan status matches what is already on `6-0-dev` after PR #14265 and PR #14302.
> 
> **Remove master variant** (`6.0-remove-master-variant.md` + `CLAUDE.md`): status now says Phases 1–4 are **shipped** (`is_master` gone from models, `default_variant_id`, data-migration rake). Leftover work is called out as **6.1** (drop `is_master` column / deprecated aliases). `Last updated` → 2026-07-20.
> 
> **Taxons → categories** (`6.0-replace-taxons-with-categories.md` + `CLAUDE.md`): status now says the **6.0 core is shipped** (table rename, inheritance flip, full `Collection` stack, data migration, de-ruled Category). Remaining items are **6.1** (channel-aware `CollectionRules::AvailableOn`, drop `Taxonomy` / `spree_taxon_rules`). `Last updated` → 2026-07-20.
> 
> No application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c2c8553f208c34920c1ccd17b875c345aa9187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->