### PR TITLE
Parallelize dashboard E2E tests across sharded CI jobs

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -98,8 +98,16 @@ jobs:
         run: pnpm test:integration
 
   dashboard-e2e:
-    name: "Dashboard - E2E"
+    name: "Dashboard - E2E (${{ matrix.shard }}/4)"
     runs-on: ubuntu-latest
+    # Each shard is a full isolated stack (own Rails + SQLite + Vite), so
+    # shards can't interfere through shared server state the way parallel
+    # workers against one backend would. Playwright distributes spec files
+    # across shards; within a shard the suite stays serial (workers: 1).
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       RAILS_ENV: test
       DB: sqlite3
@@ -119,14 +127,25 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Same Turbo cache as the check job — unchanged packages restore their
+      # build outputs instead of rebuilding per shard.
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
 
-      # The admin SPA imports built dist from the SDKs (per the workspace
-      # convention), and its vite.config resolves dashboard-core's compiled
-      # Vite entry (dist/vite) — build them first so Vite resolves the
-      # workspace deps.
-      - name: Build SDK dependencies
-        run: pnpm turbo build --filter=@spree/sdk-core --filter=@spree/admin-sdk --filter=@spree/dashboard-core
+      # Build the dashboard and its workspace deps (sdk-core, admin-sdk,
+      # dashboard-core/-ui via ^build). The E2E suite runs against the built
+      # SPA (`vite preview`, E2E_PREVIEW below): fresh browser contexts have
+      # empty caches, so the dev server would re-serve hundreds of on-demand
+      # modules on every page load in every test.
+      - name: Build dashboard packages
+        run: pnpm turbo build --filter=@spree/dashboard --cache-dir=.turbo
 
       - name: Setup dummy Rails app
         working-directory: spree/api
@@ -161,17 +180,35 @@ jobs:
 
       - name: Run dashboard E2E tests
         working-directory: packages/dashboard
-        run: pnpm test:e2e
+        env:
+          E2E_PREVIEW: "1"
+        run: pnpm test:e2e --shard=${{ matrix.shard }}/4
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: |
             packages/dashboard/playwright-report/
             packages/dashboard/test-results/
           retention-days: 14
+
+  # Stable single-status roll-up of the shard matrix, keeping the check name
+  # branch-protection rules and status badges can pin against.
+  dashboard-e2e-result:
+    name: "Dashboard - E2E"
+    needs: dashboard-e2e
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check shard results
+        run: |
+          if [ "${{ needs.dashboard-e2e.result }}" != "success" ]; then
+            echo "One or more E2E shards did not succeed: ${{ needs.dashboard-e2e.result }}"
+            exit 1
+          fi
+          echo "All E2E shards passed."
 
   release-sdk:
     name: "SDK - Release"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -638,12 +638,14 @@ cd packages/sdk && pnpm test       # SDK tests (uses MSW for HTTP mocking)
 
 ### Admin SPA E2E (Playwright)
 
-End-to-end tests for `packages/dashboard` live in `packages/dashboard/e2e/`. The global setup boots a real Rails test server (port 3010) + Vite dev (port 5174) once and seeds the DB; specs then exercise the SPA through a browser against that stack.
+End-to-end tests for `packages/dashboard` live in `packages/dashboard/e2e/`. The global setup boots a real Rails test server (port 3010) + Vite (port 5174) once and seeds the DB; specs then exercise the SPA through a browser against that stack. Locally Vite runs in dev mode; CI builds first and serves the bundle (`E2E_PREVIEW=1` → `vite preview`) because every test's fresh browser context re-downloads all dev-mode modules. CI also splits the suite across shard jobs (`--shard=n/m`), each with its own isolated Rails + SQLite + Vite stack — specs must stay self-contained (seed via global-setup fixtures or create your own records) and must not depend on records another spec file leaves behind.
 
 ```bash
 cd packages/dashboard && pnpm test:e2e          # full suite
 cd packages/dashboard && pnpm test:e2e:ui       # Playwright UI mode (debug)
 ```
+
+The `login(page)` helper authenticates through the API (one POST plants the refresh cookie; the SPA's boot-time silent refresh does the rest) — only `auth.spec.ts` drives the login form itself.
 
 **Write UI-only assertions, like Capybara.** Drive the test through user-visible actions (fill labels, click buttons, find by role) and assert on visible UI. **Do not** reach for `page.waitForResponse(/api/...)` to wait for backend completion — it leaks API shape into tests and makes refactors painful. Playwright's `await expect(...).toBeVisible()` auto-polls until the condition is met (same as Capybara's `default_max_wait_time`), which covers virtually all cases.
 

--- a/packages/dashboard/e2e/helpers.ts
+++ b/packages/dashboard/e2e/helpers.ts
@@ -62,19 +62,36 @@ export function getCredentials(): E2ECredentials {
 }
 
 /**
- * Drive the admin login flow as a precondition for any spec that needs an
- * authenticated session. Returns the credentials so callers can immediately
+ * Establish an authenticated admin session as a precondition for any spec
+ * that needs one. Returns the credentials so callers can immediately
  * navigate into a specific store (e.g. `/${creds.store_id}/products/options`).
  *
- * Not used by `auth.spec.ts` — that spec exercises the login flow itself.
+ * Logs in through the API rather than the login form: the POST plants the
+ * refresh-token cookie in this context's cookie jar (`page.request` shares
+ * it), and the SPA's boot-time silent refresh turns that into a session on
+ * the next navigation. This skips a full SPA boot + form roundtrip per test.
+ * A shared Playwright `storageState` can't do this cheaper — refresh tokens
+ * are single-use (rotated on every refresh), so each context needs its own.
+ *
+ * Not used by `auth.spec.ts` — that spec exercises the login form itself.
  */
 export async function login(page: Page): Promise<E2ECredentials> {
   const creds = getCredentials()
-  await page.goto('/login')
-  await page.getByLabel(/email/i).fill(creds.admin_email)
-  await page.getByLabel(/password/i).fill(creds.admin_password)
-  await page.getByRole('button', { name: /^sign in$/i }).click()
-  await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 })
+  const res = await page.request.post('/api/v3/admin/auth/login', {
+    data: { email: creds.admin_email, password: creds.admin_password },
+  })
+  if (!res.ok()) {
+    throw new Error(`API login failed with ${res.status()}: ${await res.text()}`)
+  }
+  await page.goto('/')
+  // Wait for the authenticated redirect to the store-scoped home — not just
+  // "left /login", which is trivially true at `/` while the boot refresh is
+  // still in flight. Returning early lets the spec's next `page.goto` boot a
+  // second SPA instance that refreshes with the same single-use cookie; the
+  // loser of that race gets a 401 that clears the cookie and bounces the
+  // page to /login. The redirect only fires after auth init settles, so it
+  // doubles as the refresh-complete barrier.
+  await expect(page).toHaveURL(new RegExp(`/${creds.store_id}`), { timeout: 15_000 })
   return creds
 }
 

--- a/packages/dashboard/playwright.config.ts
+++ b/packages/dashboard/playwright.config.ts
@@ -5,14 +5,29 @@ import { defineConfig, devices } from '@playwright/test'
 const RAILS_PORT = process.env.E2E_RAILS_PORT || '3010'
 const VITE_PORT = process.env.E2E_VITE_PORT || '5174'
 
+// `E2E_PREVIEW=1` serves the built SPA (`vite preview`) instead of the dev
+// server. Every test gets a fresh browser context with an empty HTTP cache,
+// so dev mode re-serves hundreds of on-demand-transformed modules on every
+// `page.goto` — the production bundle is a handful of files. CI builds first
+// and sets this; local runs default to `vite dev` (no build step needed).
+const PREVIEW = process.env.E2E_PREVIEW === '1'
+
 export default defineConfig({
   testDir: './e2e',
-  // Sequential — the global Rails server + SQLite test DB are shared, and the
-  // suite mutates server state (creating invitations, accepting them).
+  // Sequential per machine — the global Rails server + SQLite test DB are
+  // shared across specs, and the suite mutates server state (store settings,
+  // the admin profile, creating + accepting invitations), so concurrent
+  // workers against one backend would interfere. CI still parallelizes by
+  // sharding (`--shard=n/m`): each shard is a separate machine with its own
+  // Rails + DB + Vite stack, and specs are self-contained (fixtures come from
+  // global-setup; dynamic records use `Date.now()` suffixes).
   fullyParallel: false,
   workers: 1,
 
-  reporter: process.env.CI ? 'github' : 'list',
+  // `github` gives inline PR annotations; `html` is what the failure-artifact
+  // upload ships (with the plain `github` reporter alone, playwright-report/
+  // stays empty and the artifact is useless).
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
   retries: process.env.CI ? 2 : 0,
   timeout: 30_000,
   expect: { timeout: 10_000 },
@@ -27,16 +42,19 @@ export default defineConfig({
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 
   // Boots Rails + the seed pipeline once before the suite starts, then Vite
-  // dev pointed at that Rails. Playwright handles process lifecycle and waits
+  // pointed at that Rails. Playwright handles process lifecycle and waits
   // for both to respond to a probe before any spec runs.
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',
 
   webServer: [
     {
-      // Vite dev — proxies `/api/*` to the test Rails per `vite.config.ts`,
+      // Vite — proxies `/api/*` to the test Rails per `vite.config.ts`,
       // aimed at the test Rails port via `VITE_API_PROXY_TARGET` below.
-      command: `pnpm dev --port ${VITE_PORT}`,
+      // Preview mode serves `dist/` and applies the same proxy config.
+      command: PREVIEW
+        ? `pnpm preview --port ${VITE_PORT} --strictPort`
+        : `pnpm dev --port ${VITE_PORT} --strictPort`,
       url: `http://localhost:${VITE_PORT}`,
       reuseExistingServer: false,
       timeout: 60_000,

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -62,5 +62,14 @@ export default defineConfig(({ mode }) => {
         '/rails': { target: proxyTarget, changeOrigin: true },
       },
     },
+    // `vite preview` inherits `server.proxy` by default, and the E2E suite
+    // depends on that when it serves the built SPA on CI — pin the proxy
+    // explicitly so a future `preview` block can't silently drop it.
+    preview: {
+      proxy: {
+        '/api': { target: proxyTarget, changeOrigin: true },
+        '/rails': { target: proxyTarget, changeOrigin: true },
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary

Restructure the dashboard E2E test pipeline to run in parallel across 4 isolated CI jobs (shards), each with its own Rails server, SQLite database, and Vite instance. This reduces total CI time while maintaining test isolation and reliability.

## Key Changes

- **CI workflow sharding** (`packages.yml`):
  - Split `dashboard-e2e` job into a 4-shard matrix (`shard: [1, 2, 3, 4]`)
  - Each shard runs `pnpm test:e2e --shard=n/4` with its own isolated backend stack
  - Added Turbo cache sharing across shards to avoid rebuilding unchanged packages
  - Simplified build step to `pnpm turbo build --filter=@spree/dashboard` (dependencies resolved transitively)
  - Added `dashboard-e2e-result` rollup job to provide a stable single status for branch protection rules
  - Playwright now runs in preview mode (`E2E_PREVIEW=1` → `vite preview`) on CI to serve the built SPA instead of dev-mode modules (faster, matches production)

- **E2E test infrastructure** (`playwright.config.ts`):
  - Added `E2E_PREVIEW` environment variable support to toggle between `vite dev` (local) and `vite preview` (CI)
  - Updated reporter config to emit both GitHub annotations and HTML reports (artifact upload now has content)
  - Clarified comments on sequential execution per machine (workers: 1) vs. CI-level parallelization via sharding

- **Login helper optimization** (`helpers.ts`):
  - Replaced form-based login with API-driven authentication (`POST /api/v3/admin/auth/login`)
  - Refresh token is planted in the request context's cookie jar; SPA's boot-time silent refresh converts it to a session
  - Eliminates full SPA boot + form roundtrip per test, reducing per-test overhead
  - Only `auth.spec.ts` exercises the login form itself

- **Vite config** (`vite.config.ts`):
  - Explicitly pinned proxy config in `preview` block to ensure `vite preview` inherits API/Rails proxies (prevents silent breakage if preview config is added later)

- **Documentation** (`CLAUDE.md`):
  - Updated E2E section to explain sharding, preview mode, and self-contained spec requirements
  - Documented the API-based login helper and its performance benefits

## Implementation Details

- **Shard isolation**: Each shard is a completely independent stack (separate Rails process, SQLite DB, Vite server), so specs cannot interfere through shared server state. Playwright distributes spec files across shards; within a shard, tests run serially (workers: 1).
- **Turbo cache**: Shared across shards via `key: turbo-${{ runner.os }}-${{ github.sha }}` to restore built packages instead of rebuilding per shard.
- **API login**: Avoids the overhead of rendering the login form and navigating through it; the refresh token cookie is single-use and rotated on each refresh, so each context needs its own (can't use shared `storageState`).
- **Preview mode**: CI builds the SPA once and serves it via `vite preview`; local development continues to use `vite dev` (no build step required). Fresh browser contexts in E2E tests have empty HTTP caches, so dev mode would re-serve hundreds of on-demand modules per test.

https://claude.ai/code/session_01P1e1boeUjru43c9gL27jg1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CI and E2E harness only; production app code is untouched aside from explicit Vite preview proxies.
> 
> **Overview**
> **CI** splits dashboard E2E into a **4-shard matrix** (`--shard=n/4`), each with its own Rails + SQLite + Vite stack. Shards share a **Turbo cache**, build via `@spree/dashboard`, run with **`E2E_PREVIEW=1`** (`vite preview` instead of dev), upload **per-shard Playwright artifacts**, and roll up to a stable **`Dashboard - E2E`** job for branch protection.
> 
> **Playwright** toggles dev vs preview from `E2E_PREVIEW`, adds **HTML + GitHub reporters** on CI, and documents shard vs serial workers.
> 
> **`login()`** now **POSTs admin auth** and waits for store-scoped redirect (avoids refresh-token races); **`vite.config`** pins **`preview` proxy** for `/api` and `/rails`. **CLAUDE.md** documents sharding, preview mode, and API login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3bdad6806ffc2ae7e04c7d0956c7455c174c599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard end-to-end test reliability by running tests across multiple parallel shards.
  * Preserved API and Rails connectivity when using the production preview build.
  * Streamlined test authentication while maintaining store-specific redirects.

* **Tests**
  * Added per-shard test reporting and artifact collection.
  * Enabled HTML test reports for CI runs.
  * Updated test guidance for preview-mode execution and isolated test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->