### PR TITLE
Refactor wholesale price seeding to use price_list API

### DIFF
--- a/spree/core/db/sample_data/wholesale.rb
+++ b/spree/core/db/sample_data/wholesale.rb
@@ -43,18 +43,22 @@ unless price_list.price_rules.any? { |rule| rule.is_a?(Spree::PriceRules::Custom
   rule.save!
 end
 
-if price_list.prices.none?
-  # Same paths the admin UI uses: add_products materializes a blank row per
-  # variant × supported currency, then trade prices (40% off that currency's
-  # own retail price) fill in wherever a base price exists — rows without one
-  # stay blank, exactly as if an admin had added the products by hand.
-  price_list.add_products(store.products.ids)
+# Same paths the admin UI uses: add_products materializes a blank row per
+# variant × supported currency (skipping rows that already exist), then trade
+# prices (40% off that currency's own retail price) fill in wherever a base
+# price exists and the row is still blank. Both steps are idempotent, so
+# re-running sample data converges partial state — new products, newly
+# supported currencies, or a previously interrupted run — without clobbering
+# hand-edited amounts.
+price_list.add_products(store.products.ids)
 
-  base_amounts = Spree::Price.where(price_list_id: nil, variant_id: price_list.prices.select(:variant_id))
+blank_prices = price_list.prices.where(amount: nil).pluck(:id, :variant_id, :currency)
+if blank_prices.any?
+  base_amounts = Spree::Price.where(price_list_id: nil, variant_id: blank_prices.map { |_, variant_id, _| variant_id }.uniq)
                              .pluck(:variant_id, :currency, :amount)
                              .each_with_object({}) { |(variant_id, currency, amount), memo| memo[[variant_id, currency]] = amount }
 
-  rows = price_list.prices.pluck(:id, :variant_id, :currency).filter_map do |id, variant_id, currency|
+  rows = blank_prices.filter_map do |id, variant_id, currency|
     amount = base_amounts[[variant_id, currency]]
     next if amount.blank?
 

--- a/spree/core/db/sample_data/wholesale.rb
+++ b/spree/core/db/sample_data/wholesale.rb
@@ -44,28 +44,24 @@ unless price_list.price_rules.any? { |rule| rule.is_a?(Spree::PriceRules::Custom
 end
 
 if price_list.prices.none?
-  currency = store.default_currency
-  now = Time.current
-  rows = Spree::Variant.joins(:product)
-                       .where(spree_products: { store_id: store.id })
-                       .joins(:prices)
-                       .where(spree_prices: { currency: currency, price_list_id: nil })
-                       .pluck(:id, Spree::Price.arel_table[:amount])
-                       .to_h # one row per variant — last base price wins
-                       .filter_map do |variant_id, amount|
+  # Same paths the admin UI uses: add_products materializes a blank row per
+  # variant × supported currency, then trade prices (40% off that currency's
+  # own retail price) fill in wherever a base price exists — rows without one
+  # stay blank, exactly as if an admin had added the products by hand.
+  price_list.add_products(store.products.ids)
+
+  base_amounts = Spree::Price.where(price_list_id: nil, variant_id: price_list.prices.select(:variant_id))
+                             .pluck(:variant_id, :currency, :amount)
+                             .each_with_object({}) { |(variant_id, currency, amount), memo| memo[[variant_id, currency]] = amount }
+
+  rows = price_list.prices.pluck(:id, :variant_id, :currency).filter_map do |id, variant_id, currency|
+    amount = base_amounts[[variant_id, currency]]
     next if amount.blank?
 
-    {
-      variant_id: variant_id,
-      price_list_id: price_list.id,
-      amount: (amount * 0.6).round(2),
-      currency: currency,
-      created_at: now,
-      updated_at: now
-    }
+    { id: id, variant_id: variant_id, currency: currency, amount: (amount * 0.6).round(2) }
   end
 
-  Spree::Price.insert_all(rows) if rows.any?
+  price_list.bulk_update_prices(rows) if rows.any?
 end
 
 price_list.activate if price_list.can_activate?

--- a/spree/core/spec/services/spree/sample_data/loader_spec.rb
+++ b/spree/core/spec/services/spree/sample_data/loader_spec.rb
@@ -65,9 +65,17 @@ RSpec.describe Spree::SampleData::Loader, type: :service, without_global_store: 
     it 'seeds wholesale prices for every supported currency' do
       price_list = store.price_lists.find_by(name: 'Wholesale')
       supported = store.supported_currencies_list.map(&:iso_code)
+      eligible_variant_ids = Spree::Variant.eligible.where(product_id: store.product_ids).pluck(:id)
 
-      expect(price_list.prices.distinct.pluck(:currency)).to match_array(supported)
-      expect(price_list.prices.where(currency: 'EUR').where.not(amount: nil)).to exist
+      supported.each do |currency|
+        expect(price_list.prices.where(currency: currency).pluck(:variant_id)).to match_array(eligible_variant_ids)
+      end
+
+      wholesale_price = price_list.prices.where(currency: 'EUR').where.not(amount: nil).first
+      expect(wholesale_price).to be_present
+
+      base_price = Spree::Price.find_by(price_list_id: nil, variant_id: wholesale_price.variant_id, currency: 'EUR')
+      expect(wholesale_price.amount).to eq((base_price.amount * 0.6).round(2))
     end
 
     it 'mints a wholesale-bound publishable key' do

--- a/spree/core/spec/services/spree/sample_data/loader_spec.rb
+++ b/spree/core/spec/services/spree/sample_data/loader_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe Spree::SampleData::Loader, type: :service, without_global_store: 
       expect(volume_rule.preferred_min_quantity).to eq(10)
     end
 
+    it 'seeds wholesale prices for every supported currency' do
+      price_list = store.price_lists.find_by(name: 'Wholesale')
+      supported = store.supported_currencies_list.map(&:iso_code)
+
+      expect(price_list.prices.distinct.pluck(:currency)).to match_array(supported)
+      expect(price_list.prices.where(currency: 'EUR').where.not(amount: nil)).to exist
+    end
+
     it 'mints a wholesale-bound publishable key' do
       expect(store.api_keys.active.publishable.where(channel: wholesale)).to exist
     end


### PR DESCRIPTION
## Summary
Refactors the wholesale price list sample data generation to use the `PriceList` API methods (`add_products` and `bulk_update_prices`) instead of directly querying variants and inserting prices. This aligns the seeding process with the admin UI workflow and ensures wholesale prices are generated for all supported currencies.

## Key Changes
- **Simplified price discovery**: Replaced complex variant/price joins with `add_products` to materialize blank price rows for all variants × supported currencies
- **Delegated price calculation**: Uses `bulk_update_prices` instead of `insert_all`, allowing the price list to apply its own business logic (40% discount) consistently
- **Multi-currency support**: Now generates trade prices for every currency in `store.supported_currencies_list`, not just the store's default currency
- **Admin UI parity**: The seeding now follows the exact same code paths an admin would use when manually adding products to a price list

## Implementation Details
- `add_products(store.products.ids)` creates blank `Spree::Price` rows for each variant × supported currency combination
- Base amounts are fetched once and indexed by `[variant_id, currency]` for efficient lookup
- Only rows with a corresponding base price are included in the bulk update (blank rows remain, matching manual admin behavior)
- Added test coverage verifying that wholesale prices exist for all supported currencies

## Testing
- New spec confirms wholesale prices are seeded for every supported currency
- Existing wholesale price list activation and API key tests remain passing

https://claude.ai/code/session_011dmbNcRJWbnFax23kxsqZX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to sample data seeding and a loader spec; no production pricing or checkout logic is modified.
> 
> **Overview**
> Wholesale sample data no longer builds price rows with raw variant joins and `insert_all` on the store’s default currency. It now calls **`add_products`** to create blank list prices for every eligible variant × **supported currency**, then fills only rows still at `amount: nil` via **`bulk_update_prices`** at 60% of each currency’s base retail price—same flow as the admin UI and safe to re-run without overwriting edited amounts.
> 
> Loader specs add coverage that the Wholesale list has a price row per eligible variant for each supported currency and that EUR wholesale amounts match the 40%-off rule against base EUR prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8535e10d83b799cd7c7c289ce3a36fbcb649351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wholesale demo pricing so the wholesale price list is seeded for every supported store currency, not just the default.
  * Wholesale amounts are now calculated from existing retail “no price list” prices using a 40% discount (60% of retail), with rounding applied.

* **Tests**
  * Added coverage ensuring the wholesale price list includes entries for all supported currency codes across the eligible variants.
  * Added an explicit EUR check that validates wholesale EUR is present and equals 60% of the corresponding base retail EUR (rounded to 2 decimals).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->