### PR TITLE
Add channel column to admin checkouts and orders tables

### DIFF
--- a/spree/admin/app/controllers/spree/admin/checkouts_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/checkouts_controller.rb
@@ -25,7 +25,7 @@ module Spree
       end
 
       def collection_includes
-        { user: [] }
+        { user: [], channel: [] }
       end
 
       def edit_object_url(object, options = {})

--- a/spree/admin/app/controllers/spree/admin/orders_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/orders_controller.rb
@@ -97,7 +97,7 @@ module Spree
       end
 
       def collection_includes
-        { user: [], payments: [], refunds: [], shipments: :stock_location }
+        { user: [], channel: [], payments: [], refunds: [], shipments: :stock_location }
       end
 
       def order_params

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -405,6 +405,19 @@ Rails.application.config.after_initialize do
                                         partial: 'spree/admin/orders/customer_summary',
                                         partial_locals: ->(record) { { order: record } }
 
+  Spree.admin.tables.checkouts.add :channel,
+                                        label: :channel,
+                                        type: :association,
+                                        filter_type: :select,
+                                        sortable: true,
+                                        filterable: true,
+                                        default: true,
+                                        position: 35,
+                                        ransack_attribute: 'channel_id',
+                                        operators: %i[eq not_eq in not_in],
+                                        value_options: -> { Spree::Current.store&.channels&.order(:name)&.pluck(:name, :id)&.map { |name, id| { value: id, label: name } } || [] },
+                                        method: ->(order) { order.channel&.name }
+
   Spree.admin.tables.checkouts.add :state,
                                         label: :state,
                                         type: :status,

--- a/spree/admin/config/locales/en.yml
+++ b/spree/admin/config/locales/en.yml
@@ -937,7 +937,7 @@ en:
     order_email_resent_error: Order confirmation mail can only be sent for completed orders
     order_line_items: Order Line Items
     overview: Overview
-    package_from: package from
+    package_from: Package from
     page_not_found: Sorry! Page you are looking can’t be found.
     page_not_found_message: This page just doesn't exist.
     paste: Paste


### PR DESCRIPTION
## Summary
Adds channel visibility and filtering to the admin checkouts and orders tables, enabling merchants to view and filter orders by their associated sales channel.

## Key Changes
- **Admin Tables Configuration**: Added a new `channel` column to the checkouts table with:
  - Association-type column displaying the channel name
  - Select-based filtering with operators (eq, not_eq, in, not_in)
  - Dynamic value options populated from the current store's channels
  - Sortable and filterable by default at position 35
  
- **Controller Eager Loading**: Updated both `CheckoutsController` and `OrdersController` to include the `channel` association in `collection_includes` to prevent N+1 queries

- **Localization**: Fixed capitalization of "Package from" label in English locale (minor cleanup)

## Implementation Details
- The channel column uses a lambda to dynamically fetch available channels from `Spree::Current.store`, ensuring the filter options reflect the current store context
- The `ransack_attribute` is set to `channel_id` for proper filtering against the foreign key
- The display method extracts the channel name from the order's channel association
- Eager loading prevents performance degradation when rendering the channel column for multiple orders

https://claude.ai/code/session_01TnrG7yrxRkoHu6tSnfEGFo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only table configuration and query includes; no auth, payment, or order lifecycle logic changes.
> 
> **Overview**
> Merchants can **see and filter orders by sales channel** on the admin **draft checkouts** list. A default **channel** column (name display, sort, and `channel_id` filters with store channel options) is registered on the checkouts table, mirroring the existing orders table setup.
> 
> **Checkouts** and **orders** index queries now **eager-load `channel`** alongside existing associations so listing the new column does not trigger N+1 queries.
> 
> English copy for the **package from** column label is capitalized (`Package from`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404b7b02fa3775c5381f234011290b246fb5f00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Channel column to the admin Checkouts table.
  * Channels can now be filtered and sorted, with selectable channel names.

* **Bug Fixes**
  * Improved admin checkout and order listing performance when displaying channel information.
  * Updated the “Package from” label for consistent capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->