### PR TITLE
Fix importing products with store whose default locale differs from app default

### DIFF
--- a/spree/core/app/jobs/spree/imports/base_job.rb
+++ b/spree/core/app/jobs/spree/imports/base_job.rb
@@ -17,8 +17,11 @@ module Spree
         locale = store&.default_locale
         return yield if locale.blank?
 
+        previous_content_locale = Spree::Current.content_locale
         Spree::Current.content_locale = locale
         I18n.with_locale(locale, &block)
+      ensure
+        Spree::Current.content_locale = previous_content_locale unless locale.blank?
       end
     end
   end

--- a/spree/core/app/jobs/spree/imports/base_job.rb
+++ b/spree/core/app/jobs/spree/imports/base_job.rb
@@ -10,6 +10,16 @@ module Spree
     # taxon creation races).
     class BaseJob < Spree::BaseJob
       queue_as Spree.queues.imports
+
+      private
+
+      def with_store_content_locale(store, &block)
+        locale = store&.default_locale
+        return yield if locale.blank?
+
+        Spree::Current.content_locale = locale
+        I18n.with_locale(locale, &block)
+      end
     end
   end
 end

--- a/spree/core/app/jobs/spree/imports/create_categories_job.rb
+++ b/spree/core/app/jobs/spree/imports/create_categories_job.rb
@@ -9,9 +9,11 @@ module Spree
       def perform(product_id, store_id, taxon_pretty_names)
         product = Spree::Product.find(product_id)
         store = Spree::Store.find(store_id)
-        taxons = taxon_pretty_names.filter_map { |taxon_pretty_name| find_or_create_taxon(store, taxon_pretty_name) }
 
-        product.taxons = taxons
+        with_store_content_locale(store) do
+          taxons = taxon_pretty_names.filter_map { |taxon_pretty_name| find_or_create_taxon(store, taxon_pretty_name) }
+          product.taxons = taxons
+        end
       end
 
       private

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -25,43 +25,45 @@ module Spree
         import = Spree::Import.find(import_id)
         Spree::Current.store = import.store
 
-        mappings = import.mappings.mapped.to_a
-        schema_fields = import.schema_fields
-        large = import.large_import?
-        grouped = import.group_column.present? && mappings.any? { |m| m.schema_field == import.group_column }
-        started_at = Time.current
-        processed_rows = []
+        with_store_content_locale(import.store) do
+          mappings = import.mappings.mapped.to_a
+          schema_fields = import.schema_fields
+          large = import.large_import?
+          grouped = import.group_column.present? && mappings.any? { |m| m.schema_field == import.group_column }
+          started_at = Time.current
+          processed_rows = []
 
-        row_ids.each_slice(ROWS_BATCH_SIZE) do |ids|
-          # Skip rows already completed on a prior attempt so retries don't double-process them.
-          rows = import.rows.where(id: ids).pending_and_failed.order(:row_number).to_a
-          # Share the already-loaded import across rows: each row's processor reads
-          # `row.import` (store, ability, lookup cache), and without this every row
-          # lazily loads its own Import instance and rebuilds all of that per row.
-          rows.each { |row| row.association(:import).target = import }
+          row_ids.each_slice(ROWS_BATCH_SIZE) do |ids|
+            # Skip rows already completed on a prior attempt so retries don't double-process them.
+            rows = import.rows.where(id: ids).pending_and_failed.order(:row_number).to_a
+            # Share the already-loaded import across rows: each row's processor reads
+            # `row.import` (store, ability, lookup cache), and without this every row
+            # lazily loads its own Import instance and rebuilds all of that per row.
+            rows.each { |row| row.association(:import).target = import }
 
-          if large
-            Spree::Events.disable do
-              rows.each { |row| row.bulk_process!(mappings: mappings, schema_fields: schema_fields) }
+            if large
+              Spree::Events.disable do
+                rows.each { |row| row.bulk_process!(mappings: mappings, schema_fields: schema_fields) }
+              end
+            elsif grouped
+              # A group is one product plus its variants: per-record lifecycle
+              # events (variant.created, price.created, product.updated per
+              # touch) are noise to subscribers — one product event is published
+              # for the whole group below. import_row.* events still flow.
+              Spree::Events.disable_lifecycle do
+                rows.each { |row| row.process!(mappings: mappings, schema_fields: schema_fields) }
+              end
+            else
+              rows.each do |row|
+                row.process!(mappings: mappings, schema_fields: schema_fields)
+              end
             end
-          elsif grouped
-            # A group is one product plus its variants: per-record lifecycle
-            # events (variant.created, price.created, product.updated per
-            # touch) are noise to subscribers — one product event is published
-            # for the whole group below. import_row.* events still flow.
-            Spree::Events.disable_lifecycle do
-              rows.each { |row| row.process!(mappings: mappings, schema_fields: schema_fields) }
-            end
-          else
-            rows.each do |row|
-              row.process!(mappings: mappings, schema_fields: schema_fields)
-            end
+            processed_rows.concat(rows)
           end
-          processed_rows.concat(rows)
-        end
 
-        publish_group_events(processed_rows, started_at) if grouped
-        check_import_completion(import, large)
+          publish_group_events(processed_rows, started_at) if grouped
+          check_import_completion(import, large)
+        end
       end
 
       private

--- a/spree/core/spec/jobs/spree/imports/create_categories_job_spec.rb
+++ b/spree/core/spec/jobs/spree/imports/create_categories_job_spec.rb
@@ -37,6 +37,33 @@ RSpec.describe Spree::Imports::CreateCategoriesJob, type: :job do
       expect(product.reload.taxons.map(&:pretty_name)).to contain_exactly('Men -> Clothing')
     end
 
+    context "when the store's default locale differs from I18n.default_locale" do
+      before { store.update_columns(default_locale: 'de') }
+
+      it 'populates the NOT NULL base name columns instead of leaving them null' do
+        # Mimics the enqueue-time locale a non-en store's request captures into the job.
+        I18n.with_locale(:de) do
+          described_class.perform_now(product.id, store.id, ['Men -> Clothing'])
+        end
+
+        taxon = product.reload.taxons.first
+        expect(taxon).to be_present
+        # The raw NOT NULL base columns (not the translation) must be populated.
+        expect(taxon.read_attribute(:name)).to eq('Clothing')
+        expect(taxon.taxonomy.read_attribute(:name)).to eq('Men')
+      end
+
+      it "keeps Spree::Taxon's Mobility.with_locale(nil) permalink regeneration working" do
+        I18n.with_locale(:de) do
+          described_class.perform_now(product.id, store.id, ['Men -> Clothing'])
+        end
+
+        taxon = product.reload.taxons.first
+        expect(taxon.read_attribute(:permalink)).to eq('men/clothing')
+        expect(taxon.read_attribute(:pretty_name)).to eq('Men -> Clothing')
+      end
+    end
+
     context 'when taxonomies and taxons already exist' do
       let!(:men_taxonomy) { create(:taxonomy, name: 'Men', store: store) }
       let!(:clothing_taxon) { create(:taxon, name: 'Clothing', taxonomy: men_taxonomy, parent: men_taxonomy.root) }

--- a/spree/core/spec/jobs/spree/imports/process_group_job_spec.rb
+++ b/spree/core/spec/jobs/spree/imports/process_group_job_spec.rb
@@ -300,6 +300,24 @@ RSpec.describe Spree::Imports::ProcessGroupJob, type: :job do
     end
   end
 
+  context "when the store's default locale differs from I18n.default_locale" do
+    before { store.update_columns(default_locale: 'de') }
+
+    it 'authors the base columns in the store locale instead of leaving them null' do
+      # Mimics the enqueue-time locale a non-en store's request captures into the job.
+      I18n.with_locale(:de) do
+        expect {
+          described_class.perform_now(import.id, [row.id])
+        }.to change(Spree::Product, :count).by(1)
+      end
+
+      row.reload
+      expect(row.status).to eq('completed')
+      # The raw NOT NULL base column (not the translation) must be populated.
+      expect(row.item.product.read_attribute(:name)).to eq('Test Product')
+    end
+  end
+
   describe 'atomic completion tracking' do
     it 'uses atomic SQL increment for completed_groups_count' do
       # Leave another row pending so the import doesn't finalize on this run; we want


### PR DESCRIPTION
Product CSV imports failed with `PG::NotNullViolation` on `spree_products.name` for stores whose `default_locale` differs from the app default, because import jobs run in Sidekiq without the request's content locale - so `Mobility`'s `column_fallback` wrote translations but left the `NOT-NULL` base columns `null`. Fixed by authoring imported records under the store's locale in the import jobs (`ProcessGroupJob`, `CreateCategoriesJob`) via a shared `with_store_content_locale` helper.

Error: https://vendo-connect.sentry.io/issues/7626495392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imports now reliably apply each store’s default content language across category creation and group import processing.
  * Ensures imported category/product names populate correctly when store language differs from system default.
  * Preserves expected permalink and import completion behavior under localized imports.
* **Tests**
  * Added/expanded specs to cover imports running with non-default store languages and verify correct base-name and permalink outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->