### PR TITLE
Harden API

### DIFF
--- a/docs/developer/upgrades/5.5-to-5.6.mdx
+++ b/docs/developer/upgrades/5.5-to-5.6.mdx
@@ -1,0 +1,193 @@
+---
+title: Upgrading to Spree 5.6
+description: Step-by-step guide to upgrading a Spree 5.5 application to Spree 5.6, including gem updates, migrations, data backfills, and breaking changes to review.
+---
+
+<Info>
+  Before proceeding to upgrade, please ensure you're at [Spree 5.5](/developer/upgrades/5.4-to-5.5).
+</Info>
+
+The upgrade is usually completed in four steps:
+
+1. **Update the Ruby gems** which power Spree API
+2. **Run database migrations** — to migrate your existing schema to the new version
+3. **Run data backfills** — to move your existing data into the new schema and power new features
+4. Apply optional configuration and review behavior changes — to take advantage of new features and avoid surprises
+
+## How to upgrade
+
+For applications created via `create-spree-app` command we greatly recommend using the Spree CLI to perform the upgrade. It provides a guided experience with prompts and handles the first three steps for you. If you prefer to run the commands manually or not using docker for local development, you can follow the "Without Spree CLI" path.
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree upgrade
+```
+
+```bash Without Spree CLI
+# cd backend if you're in the monorepo root
+bundle update
+bundle exec rake spree:install:migrations && bin/rails db:migrate
+bundle exec rake spree:upgrade
+```
+
+</CodeGroup>
+
+The **Spree CLI** path runs all three commands for you with prompts. Recommended for local development. If you don't have the CLI yet, either install it globally or run it through `npx`:
+
+```bash
+# install once and use `spree …` everywhere
+npm install -g @spree/cli
+
+# or invoke without installing (each command runs through npx)
+npx @spree/cli upgrade
+```
+
+The **Without Spree CLI** path is the bare equivalent. Use this on production: `bundle update` and `db:migrate` are part of your existing deploy pipeline (Heroku release phase, K8s init container, Capistrano hook, Render auto-migrate). Once the 5.6 release is up, run `bundle exec rake spree:upgrade` from a one-off dyno / job container / `kubectl exec` to perform the data backfills.
+
+Skipping versions and re-running are both safe — `bundle exec rake spree:upgrade` figures out what still needs to happen and does nothing on data that's already migrated.
+
+## What the upgrade does
+
+This is reference material — what `bundle exec rake spree:upgrade` (and equivalently `spree upgrade`) actually executes on your data. Skip if you trust the tool; read on if something failed or you're curious. Every step is idempotent, so re-running the full manifest is safe.
+
+### Backfill store ownership on role assignments
+
+Spree 5.6 resolves admin roles per store. The migrations add `store_id` to `spree_role_users`, but existing assignments have a NULL value until backfilled:
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:role_users:backfill_store_ids
+```
+
+```bash Without Spree CLI
+bundle exec rake spree:role_users:backfill_store_ids
+```
+
+</CodeGroup>
+
+Sets `spree_role_users.store_id` from the store resource so `Spree::Ability` resolves roles by store. Store-scoped assignments only — extensions (e.g. `spree_multi_vendor`) backfill their own resource types. Until this runs, store admins stay authorized via the `spree_admin?` fallback.
+
+### Backfill store ownership on promotions and payment methods
+
+Spree 5.6 moves `Spree::Promotion` and `Spree::PaymentMethod` from multi-store sharing to single-owner `belongs_to :store`. The migrations add a `store_id` column to each; this task populates it:
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:upgrade:populate_single_store_associations
+```
+
+```bash Without Spree CLI
+bundle exec rake spree:upgrade:populate_single_store_associations
+```
+
+</CodeGroup>
+
+Sets `store_id` on `Spree::Promotion` and `Spree::PaymentMethod` from the legacy `spree_promotions_stores` / `spree_payment_methods_stores` join tables.
+
+<Warning>
+  Until this runs, migrated rows have a NULL `store_id` and are hidden from store-scoped lookups — a payment method with no `store_id` is unavailable at checkout. Run it right after `db:migrate`.
+</Warning>
+
+Records shared across several stores keep **one** owner (promotions: the earliest `spree_promotions_stores` row by `created_at`, then lowest `store_id`; payment methods: the lowest `store_id`, since that join has no timestamps) unless [`spree_multi_store`](#multi-store-deployments) is installed. Each shared record is logged so the loss is visible.
+
+### Backfill store ownership on taxons
+
+Categories carry a direct `store_id` in 5.6. The task sets it from each taxon's taxonomy, then resolves taxonomy-less rows through their parent chain:
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:taxons:backfill_store_id
+```
+
+```bash Without Spree CLI
+bundle exec rake spree:taxons:backfill_store_id
+```
+
+</CodeGroup>
+
+Until this runs, existing taxons keep resolving their store via the taxonomy join (`Taxon.for_store` fallback); taxonomy-less categories (`Spree::Category`) rely on the direct `store_id`, so the backfill is required for them.
+
+### Recompute taxon product counts
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:taxons:backfill_products_count
+```
+
+```bash Without Spree CLI
+bundle exec rake spree:taxons:backfill_products_count
+```
+
+</CodeGroup>
+
+Recomputes the descendant-inclusive `products_count` counter cache on every taxon, in batches.
+
+### Backfill the store tenant on product tags
+
+Spree 5.6 bounds product tag autocomplete to the owning store. Product taggings now carry a store `tenant` (like order taggings already did); this task sets it on tags created before the upgrade:
+
+<CodeGroup>
+
+```bash Spree CLI (Docker)
+spree rake spree:upgrade:backfill_product_tag_tenants
+```
+
+```bash Without Spree CLI
+bundle exec rake spree:upgrade:backfill_product_tag_tenants
+```
+
+</CodeGroup>
+
+Sets the `tenant` column on existing `Spree::Product` taggings from each product's `store_id`. New product taggings tenant themselves automatically — only rows created before the upgrade need this. Until it runs, product tags created before the upgrade are hidden from the store's tag-autocomplete vocabulary (they reappear once it completes; storefront and admin tag *display* are unaffected).
+
+## Update the Spree SDK
+
+Spree 5.6 ships alongside `@spree/sdk` 1.2. The backend upgrade never touches your frontend source — bump the SDK in every JavaScript consumer of the Store API and take it through your normal PR/CI cycle:
+
+```bash
+# create-spree-app projects: the Next.js storefront
+cd apps/storefront
+npm install @spree/sdk@^1.2
+```
+
+If you maintain a separate storefront repo or other integrations, repeat there.
+
+| Spree backend | `@spree/sdk` |
+|---|---|
+| 5.4 | 1.0.x |
+| 5.5 | 1.1+ |
+| 5.6 | 1.2+ |
+
+## Behavior changes to review
+
+These don't require any rake task — but storefronts, integrations, and merchant-facing dashboards may need code changes to handle them correctly.
+
+### Promotions and payment methods belong to a single store
+
+`Spree::Promotion` and `Spree::PaymentMethod` are now single-owner (`belongs_to :store`). Create them through the store association so the owner is set:
+
+```ruby
+store.payment_methods.create!(...)
+store.promotions.create!(...)
+```
+
+A record built off the association but not yet saved is invisible to `available_for_store?` until persisted. The `store_ids=` writer that used to fan a record across stores is removed; multi-store sharing moves to the [`spree_multi_store`](#multi-store-deployments) extension. The `spree_promotions_stores` / `spree_payment_methods_stores` join tables are kept as legacy compat surface and dropped in a later release.
+
+### Admin roles resolve per store
+
+With `store_id` on role assignments, an admin's abilities are scoped to the store they're assigned to. Until [the role backfill](#backfill-store-ownership-on-role-assignments) runs, existing store admins remain authorized through the `spree_admin?` fallback, so there is no lockout — but run it so role resolution is correct going forward.
+
+### Product tag autocomplete is store-scoped
+
+The Admin API tag-autocomplete endpoint (`GET /api/v3/admin/tags`) now returns only tags used within the current store for store-owned taggables (products and orders). Customer tags remain global. If an integration relied on this endpoint returning tags across every store, that cross-store vocabulary is no longer exposed. Run [the tag-tenant backfill](#backfill-the-store-tenant-on-product-tags) so pre-upgrade product tags are included.
+
+## Multi-store deployments
+
+Sharing a single promotion, payment method, or product across multiple stores is no longer part of Spree core — 5.6 assigns each of these to one owning store. If you run several stores from one installation and need shared records, install the `spree_multi_store` extension **before** running the backfills; without it, the backfills assign each shared record to a single owner store and the others lose it (every such case is logged).
+
+For single-store deployments this is invisible — the backfills assign every record to your one store, and you can move on.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -489,6 +489,7 @@
                   {
                     "group": "Upgrade Guides",
                     "pages": [
+                      "developer/upgrades/5.5-to-5.6",
                       "developer/upgrades/5.4-to-5.5",
                       "developer/upgrades/5.3-to-5.4",
                       "developer/upgrades/5.2-to-5.3",

--- a/spree/api/app/controllers/concerns/spree/api/v3/http_caching.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/http_caching.rb
@@ -22,10 +22,13 @@ module Spree
           current_user.nil?
         end
 
-        # Set Vary headers to ensure proper CDN caching by currency/locale
+        # Set Vary headers to ensure proper CDN caching by currency/locale/channel.
+        # X-Spree-Channel is included because the resolved channel changes the
+        # serialized body (price hiding + channel-scoped visibility), so a shared
+        # cache must not serve one channel's guest response to another channel.
         def set_vary_headers
           if guest_user?
-            response.headers['Vary'] = 'Accept, x-spree-currency, x-spree-locale'
+            response.headers['Vary'] = 'Accept, x-spree-currency, x-spree-locale, x-spree-channel'
           else
             response.headers['Cache-Control'] = 'private, no-store'
           end
@@ -67,14 +70,21 @@ module Spree
 
           expires_in expires_in, public: true
 
-          # Use Rails' stale? which handles ETag and Last-Modified
-          stale?(resource, public: true)
+          # Use Rails' stale? which handles ETag and Last-Modified. The channel
+          # is folded into the ETag so a shared cache never serves one channel's
+          # guest response to another; Last-Modified mirrors the resource's own
+          # timestamp as before.
+          stale?(
+            etag: [resource, cache_channel_fragment],
+            last_modified: resource.try(:updated_at),
+            public: true
+          )
         end
 
         private
 
         # Build a cache key for a collection
-        # Includes: latest updated_at, total count, query params, pagination, expand, currency, locale
+        # Includes: latest updated_at, total count, query params, pagination, expand, currency, locale, channel
         def collection_cache_key(collection)
           # For ActiveRecord collections use updated_at, for plain arrays use store's updated_at as proxy
           latest_updated_at = if collection.first&.respond_to?(:updated_at)
@@ -92,10 +102,21 @@ module Spree
             params[:page],
             params[:limit],
             current_currency,
-            current_locale
+            current_locale,
+            cache_channel_fragment
           ]
 
           parts.compact.join('/')
+        end
+
+        # Identifies the resolved channel for cache-key purposes. The channel
+        # changes the serialized body (price hiding + channel-scoped visibility),
+        # so it must be part of the guest cache identity. Uses the same
+        # +current_channel+ source of truth as serialization/gating.
+        def cache_channel_fragment
+          return nil unless respond_to?(:current_channel, true)
+
+          current_channel&.id
         end
       end
     end

--- a/spree/api/app/controllers/concerns/spree/api/v3/scoped_authorization.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/scoped_authorization.rb
@@ -56,9 +56,33 @@ module Spree
         private
 
         def authorize_api_key_scope!
-          return unless current_api_key
+          # Endpoints explicitly exempt from the scope mechanism (auth, me, public
+          # invitation acceptance, per-type-filtered exports, etc.) opt out first,
+          # before any key resolution or enforcement.
           return if self.class._scope_check_skipped
           return if self.class._scope_check_skipped_actions&.include?(action_name)
+
+          # Fail CLOSED, not open. A nil `current_api_key` legitimately means a
+          # non-secret-key request (JWT admin / publishable) authorized by other
+          # means, which correctly skips scope checks. But it ALSO happens when
+          # this guard runs before authentication resolved the key: a bare
+          # `return unless current_api_key` would then skip scope enforcement for
+          # an attacker-supplied secret key. So resolve the secret key in place
+          # here — never rely on before_action ordering. Only truly non-secret-key
+          # requests (nothing to resolve) are waved through.
+          resolve_current_api_key_for_scope_check!
+
+          unless current_api_key
+            return unless secret_key_request?
+
+            # A secret-key token was presented but did not resolve to a live key
+            # for this store — reject rather than silently skip the scope check.
+            return render_error(
+              code: Spree::Api::V3::ErrorHandler::ERROR_CODES[:invalid_token],
+              message: 'Valid secret API key required',
+              status: :unauthorized
+            )
+          end
 
           resource = scoped_resource_name
           # Fail closed: a controller authenticated by API key MUST declare
@@ -75,6 +99,29 @@ module Spree
             status: :forbidden,
             details: { required_scope: required }
           )
+        end
+
+        # True when the request presents a secret API key token (`sk_` prefix),
+        # regardless of whether authentication has resolved it into
+        # `current_api_key` yet. Used to keep the scope guard fail-closed even if
+        # it runs before the API key is loaded: a secret-key request whose key is
+        # still nil must be denied, never waved through.
+        def secret_key_request?
+          extract_api_key.to_s.start_with?(Spree::ApiKey::PREFIXES['secret'])
+        end
+
+        # Resolves the request's secret API key into `@current_api_key` if a
+        # secret-key token is present and it hasn't been resolved yet, so the scope
+        # check does not depend on `authenticate_admin!` having already run. Mirrors
+        # the secret-key resolution + store binding in AdminAuthentication, and is
+        # idempotent: when the key is already loaded (guard runs after auth) it does
+        # nothing.
+        def resolve_current_api_key_for_scope_check!
+          return if @current_api_key
+          return unless secret_key_request?
+
+          key = Spree::ApiKey.find_by_secret_token(extract_api_key)
+          @current_api_key = key if key && key.store_id == current_store.id
         end
 
         # The resource name used in scope strings (`read_<name>` / `write_<name>`).

--- a/spree/api/app/controllers/spree/api/v3/admin/base_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/base_controller.rb
@@ -4,9 +4,13 @@ module Spree
       module Admin
         class BaseController < Spree::Api::V3::BaseController
           include Spree::Api::V3::AdminAuthentication
-          include Spree::Api::V3::ScopedAuthorization
 
+          # Must be registered before ScopedAuthorization so authenticate_admin!
+          # resolves @current_api_key before authorize_api_key_scope! reads it —
+          # otherwise the scope guard short-circuits on a nil key and never runs.
           before_action :authenticate_admin!
+
+          include Spree::Api::V3::ScopedAuthorization
         end
       end
     end

--- a/spree/api/app/controllers/spree/api/v3/admin/tags_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/tags_controller.rb
@@ -60,13 +60,22 @@ module Spree
             false
           end
 
-          # Tagging filter. `Spree::Order` carries a `tenant` (store_id) column
-          # via `acts_as_taggable_tenant`, so its tag vocabulary is bounded to
-          # the current store; other taggables fall back to the type filter.
+          # Tagging filter. Store-owned taggables (`Spree::Product`,
+          # `Spree::Order`) tenant their taggings by `store_id` via
+          # `acts_as_taggable_tenant`, so their vocabulary is bounded to the
+          # current store with a single indexed `tenant` filter. Global
+          # taggables like the customer/user type carry no store, so their tags
+          # are not store-scoped here.
           def taggings_conditions
             conditions = { taggable_type: taggable_type, context: 'tags' }
-            conditions[:tenant] = current_store.id.to_s if taggable_type == 'Spree::Order'
+            conditions[:tenant] = current_store.id.to_s if store_tenanted_taggable?
             conditions
+          end
+
+          # True for taggables whose taggings carry a store `tenant`
+          # (`acts_as_taggable_tenant :store_id`), i.e. store-owned records.
+          def store_tenanted_taggable?
+            %w[Spree::Product Spree::Order].include?(taggable_type)
           end
 
           # Per-type scope check for API-key principals: a key listing product

--- a/spree/api/spec/controllers/concerns/spree/api/v3/http_caching_spec.rb
+++ b/spree/api/spec/controllers/concerns/spree/api/v3/http_caching_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
 
   let!(:product) { create(:product, status: 'active') }
   let!(:product2) { create(:product, status: 'active') }
+  let!(:pos_channel) { create(:channel, store: store, code: 'pos', name: 'POS') }
 
   before do
     request.headers['X-Spree-Api-Key'] = api_key.token
@@ -18,7 +19,7 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
         it 'sets Vary header for CDN caching' do
           get :index
 
-          expect(response.headers['Vary']).to eq('Accept, x-spree-currency, x-spree-locale')
+          expect(response.headers['Vary']).to eq('Accept, x-spree-currency, x-spree-locale, x-spree-channel')
         end
       end
 
@@ -136,6 +137,35 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
 
           expect(eur_etag).not_to eq(original_etag)
         end
+
+        # Publish the same products on both channels so the identical collection
+        # is served either way — isolating the channel as the sole cache
+        # dimension that differs (guards against a shared CDN cross-serving).
+        context 'when the same products are visible on two channels' do
+          before { pos_channel.add_products([product.id, product2.id]) }
+
+          it 'changes ETag when the resolved channel changes' do
+            get :index
+            default_channel_etag = response.headers['ETag']
+
+            request.headers['x-spree-channel'] = 'pos'
+            get :index
+            pos_channel_etag = response.headers['ETag']
+
+            expect(pos_channel_etag).not_to eq(default_channel_etag)
+          end
+
+          it 'does not serve a 304 across channels for the same fresh ETag' do
+            get :index
+            default_channel_etag = response.headers['ETag']
+
+            request.headers['x-spree-channel'] = 'pos'
+            request.headers['If-None-Match'] = default_channel_etag
+            get :index
+
+            expect(response).to have_http_status(:ok)
+          end
+        end
       end
 
       context 'for authenticated users' do
@@ -191,6 +221,34 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
           get :show, params: { id: product.prefixed_id }
 
           expect(response).to have_http_status(:ok)
+        end
+
+        # Publish the same product on both channels so it resolves either way —
+        # isolating the channel as the sole cache dimension that differs.
+        context 'when the product is visible on two channels' do
+          before { pos_channel.add_products([product.id]) }
+
+          it 'changes ETag when the resolved channel changes' do
+            get :show, params: { id: product.prefixed_id }
+            default_channel_etag = response.headers['ETag']
+
+            request.headers['x-spree-channel'] = 'pos'
+            get :show, params: { id: product.prefixed_id }
+            pos_channel_etag = response.headers['ETag']
+
+            expect(pos_channel_etag).not_to eq(default_channel_etag)
+          end
+
+          it 'does not serve a 304 across channels for the same fresh ETag' do
+            get :show, params: { id: product.prefixed_id }
+            default_channel_etag = response.headers['ETag']
+
+            request.headers['x-spree-channel'] = 'pos'
+            request.headers['If-None-Match'] = default_channel_etag
+            get :show, params: { id: product.prefixed_id }
+
+            expect(response).to have_http_status(:ok)
+          end
         end
       end
 

--- a/spree/api/spec/controllers/spree/api/v3/admin/store_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/store_controller_spec.rb
@@ -198,5 +198,38 @@ RSpec.describe Spree::Api::V3::Admin::StoreController, type: :controller do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    # Regression: StoreController inherits from Admin::BaseController (the
+    # non-resource branch). Its scope guard once ran before authenticate_admin!
+    # resolved the API key, so it short-circuited on a nil key and every
+    # API-key caller could rewrite store settings without write_settings.
+    context 'authenticated with a secret API key' do
+      include_context 'API v3 Admin'
+
+      let(:secret_api_key) { create(:api_key, :secret, store: store, scopes: scopes) }
+      let(:headers) { api_key_headers }
+      let(:params) { { name: 'Renamed Store' } }
+
+      context 'lacking the write_settings scope' do
+        let(:scopes) { ['read_orders'] }
+
+        it 'denies the write with the required scope' do
+          subject
+          expect(response).to have_http_status(:forbidden)
+          expect(json_response['error']['details']['required_scope']).to eq('write_settings')
+          expect(store.reload.name).not_to eq('Renamed Store')
+        end
+      end
+
+      context 'carrying the write_settings scope' do
+        let(:scopes) { ['write_settings'] }
+
+        it 'allows the write' do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(store.reload.name).to eq('Renamed Store')
+        end
+      end
+    end
   end
 end

--- a/spree/api/spec/controllers/spree/api/v3/admin/tags_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/tags_controller_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe Spree::Api::V3::Admin::TagsController, type: :controller do
       end
     end
 
+    context 'product tag vocabulary is store-scoped' do
+      let(:headers) { bearer_headers }
+
+      let(:other_store) { create(:store) }
+      let!(:own_product) { create(:product, store: store, tag_list: ['bestseller']) }
+      let!(:foreign_product) { create(:product, store: other_store, tag_list: ['clearance']) }
+
+      it 'excludes another store\'s product tags' do
+        get :index, params: { taggable_type: 'Spree::Product' }, as: :json
+
+        names = json_response['data'].map { |t| t['name'] }
+        expect(names).to include('bestseller')
+        expect(names).not_to include('clearance')
+      end
+    end
+
     describe 'API-key scope enforcement' do
       let(:headers) { { 'x-spree-api-key' => api_key.plaintext_token } }
       let!(:tagged_user) { create(:user, tag_list: ['vip']) }

--- a/spree/api/spec/controllers/spree/api/v3/scoped_authorization_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/scoped_authorization_spec.rb
@@ -132,3 +132,53 @@ RSpec.describe Spree::Api::V3::Admin::PromotionsController, type: :controller do
     end
   end
 end
+
+# Regression for the Admin::BaseController ordering bypass: on this branch the
+# `authorize_api_key_scope!` before_action runs BEFORE `authenticate_admin!`, so
+# `current_api_key` is nil at guard time. The guard must resolve the secret key
+# itself and fail CLOSED — never wave the request through — while still letting
+# JWT-authenticated admins (authorized by CanCanCan, no secret key) pass.
+RSpec.describe Spree::Api::V3::Admin::DashboardController, type: :controller do
+  render_views
+  include_context 'API v3 Admin'
+
+  describe 'secret-key request reaching the guard before the key is resolved' do
+    let(:secret_key) { create(:api_key, :secret, store: store, created_by: admin_user, scopes: scopes) }
+
+    before { request.headers['X-Spree-Api-Key'] = secret_key.plaintext_token }
+
+    context 'with the required scope' do
+      let(:scopes) { ['read_dashboard'] }
+
+      it 'enforces the scope and allows the read' do
+        get :analytics, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'without the required scope' do
+      let(:scopes) { ['read_orders'] }
+
+      it 'denies rather than silently skipping the scope check' do
+        get :analytics, as: :json
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body['error']['code']).to eq('access_denied')
+        expect(body['error']['details']['required_scope']).to eq('read_dashboard')
+      end
+    end
+  end
+
+  describe 'JWT-authenticated admin (no secret key)' do
+    before do
+      request.headers['X-Spree-Api-Key'] = nil
+      request.headers['Authorization'] = "Bearer #{admin_jwt_token}"
+    end
+
+    it 'passes the scope guard (CanCanCan applies instead)' do
+      get :analytics, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spree/core/app/models/concerns/spree/webhook_payload_redaction.rb
+++ b/spree/core/app/models/concerns/spree/webhook_payload_redaction.rb
@@ -17,7 +17,7 @@ module Spree
     extend ActiveSupport::Concern
 
     # Payload keys under `data` whose values are live credentials.
-    SENSITIVE_PAYLOAD_KEYS = %w[reset_token unsubscribe_token].freeze
+    SENSITIVE_PAYLOAD_KEYS = %w[reset_token unsubscribe_token verification_token].freeze
 
     REDACTION_PLACEHOLDER = '[REDACTED]'
 

--- a/spree/core/app/models/spree/digital_link.rb
+++ b/spree/core/app/models/spree/digital_link.rb
@@ -46,9 +46,15 @@ module Spree
 
     # This method should be called when a download is initiated.
     # It returns +true+ or +false+ depending on whether the authorization is granted.
+    #
+    # The access-limit check and the counter increment run inside a row lock so
+    # concurrent requests sharing the same token cannot each pass the cap before
+    # any of them increments the counter (TOCTOU race).
     def authorize!
       ActiveRecord::Base.connected_to(role: :writing) do
-        authorizable? && increment!(:access_counter, touch: true)
+        with_lock do
+          authorizable? && increment!(:access_counter, touch: true)
+        end
       end
     end
 

--- a/spree/core/app/models/spree/gift_card_batch.rb
+++ b/spree/core/app/models/spree/gift_card_batch.rb
@@ -62,7 +62,7 @@ module Spree
 
     def generate_code
       loop do
-        code = "#{prefix.downcase}#{SecureRandom.hex(3).downcase}"
+        code = "#{prefix.downcase}#{SecureRandom.hex(8).downcase}"
         break code unless Spree::GiftCard.exists?(code: code) || @gift_cards_to_insert.detect { |gc| gc[:code] == code }
       end
     end

--- a/spree/core/app/models/spree/product.rb
+++ b/spree/core/app/models/spree/product.rb
@@ -24,6 +24,7 @@ module Spree
 
     acts_as_paranoid
     acts_as_taggable_on :tags, :labels
+    acts_as_taggable_tenant :store_id
     normalizes :name, with: ->(value) { value&.to_s&.squish&.presence }
 
     include Spree::ProductScopes

--- a/spree/core/lib/spree/upgrades/5_5_to_5_6/manifest.yml
+++ b/spree/core/lib/spree/upgrades/5_5_to_5_6/manifest.yml
@@ -57,3 +57,13 @@ steps:
     notes: |
       Recomputes the descendant-inclusive products_count counter cache on every
       taxon in batches.
+
+  - id: product_tag_tenants
+    name: "Backfill tenant on product taggings"
+    task: "spree:upgrade:backfill_product_tag_tenants"
+    notes: |
+      Sets the tenant column on existing Spree::Product taggings from each
+      product's store_id, so product tag autocomplete is bounded to the owning
+      store (matching Spree::Order). New product taggings tenant themselves;
+      only rows created before the upgrade need this. Until it runs, older
+      product tags are hidden from the store-scoped tag vocabulary.

--- a/spree/core/lib/tasks/product_tag_tenants.rake
+++ b/spree/core/lib/tasks/product_tag_tenants.rake
@@ -1,0 +1,26 @@
+namespace :spree do
+  namespace :upgrade do
+    desc <<~DESC
+      Backfills the +tenant+ column on existing +Spree::Product+ taggings from
+      each product's +store_id+, so product tag vocabulary is bounded to the
+      owning store (matching +Spree::Order+, which already tenants its taggings).
+
+      Run once after upgrading to the release that adds
+      +acts_as_taggable_tenant :store_id+ to +Spree::Product+. New product
+      taggings get their tenant automatically; only rows created before the
+      upgrade need this. Idempotent — re-running only touches rows still
+      missing a tenant.
+    DESC
+    task backfill_product_tag_tenants: :environment do
+      taggings = ActsAsTaggableOn::Tagging.arel_table.name
+      products = Spree::Product.table_name
+
+      updated = ActsAsTaggableOn::Tagging.
+                where(taggable_type: 'Spree::Product', tenant: nil).
+                joins("INNER JOIN #{products} ON #{products}.id = #{taggings}.taggable_id").
+                update_all("tenant = #{products}.store_id")
+
+      puts "  Backfilled tenant on #{updated} product tagging(s)."
+    end
+  end
+end

--- a/spree/core/spec/models/concerns/spree/webhook_payload_redaction_spec.rb
+++ b/spree/core/spec/models/concerns/spree/webhook_payload_redaction_spec.rb
@@ -26,6 +26,22 @@ describe Spree::WebhookPayloadRedaction do
       expect(described_class.merge(payload, secrets)).to eq(original)
     end
 
+    # The newsletter double opt-in event carries a live has_secure_token that
+    # must never land in the persisted delivery log.
+    it 'redacts the newsletter verification_token and re-attaches it at send time' do
+      original = {
+        'name' => 'newsletter_subscriber.subscription_requested',
+        'data' => { 'email' => 'a@example.com', 'verification_token' => 'live-token' }
+      }
+
+      payload, secrets = described_class.split(original)
+
+      expect(payload['data']['verification_token']).to eq(placeholder)
+      expect(payload['data']['email']).to eq('a@example.com')
+      expect(secrets).to eq('verification_token' => 'live-token')
+      expect(described_class.merge(payload, secrets)).to eq(original)
+    end
+
     it 'returns the payload untouched when nothing is sensitive' do
       original = { 'data' => { 'number' => 'R123' } }
 

--- a/spree/core/spec/models/spree/digital_link_spec.rb
+++ b/spree/core/spec/models/spree/digital_link_spec.rb
@@ -214,5 +214,51 @@ describe Spree::DigitalLink, type: :model do
         end.not_to change { digital_link_expired.updated_at.to_s }
       end
     end
+
+    context 'when the access limit is reached' do
+      let(:limit) { store.preferred_digital_asset_authorized_clicks }
+      let!(:digital_link) { create(:digital_link, access_counter: limit - 1) }
+
+      after do
+        digital_link.update(access_counter: 2)
+        digital_link.save!
+        digital_link.reload
+      end
+
+      it 'allows exactly the configured number of downloads and denies the rest' do
+        expect(digital_link.authorize!).to be_truthy
+        expect(digital_link.reload.access_counter).to eq(limit)
+
+        expect(digital_link.authorize!).to be_falsey
+        expect(digital_link.reload.access_counter).to eq(limit)
+      end
+    end
+
+    # Proves the check-and-increment is atomic: two concurrent authorize! calls
+    # sharing the same token cannot both pass the cap. Requires a database with
+    # real concurrent connections and row-level locking (PostgreSQL).
+    context 'under concurrent access', if: ENV['DB'] == 'postgres' do
+      let(:limit) { store.preferred_digital_asset_authorized_clicks }
+      let!(:digital_link) { create(:digital_link, access_counter: limit - 1) }
+
+      after do
+        digital_link.update(access_counter: 2)
+        digital_link.save!
+        digital_link.reload
+      end
+
+      it 'never lets the counter exceed the limit' do
+        results = Array.new(5) do
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              Spree::DigitalLink.find(digital_link.id).authorize!
+            end
+          end
+        end.map(&:value)
+
+        expect(results.count { |granted| granted }).to eq(1)
+        expect(digital_link.reload.access_counter).to eq(limit)
+      end
+    end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Product tags and autocomplete are now correctly isolated by store.
  - Gift card codes are longer and more collision-resistant.
  - Digital download access limits are enforced reliably during concurrent requests.

- **Bug Fixes**
  - API caches now distinguish responses by sales channel.
  - API key permissions are enforced consistently, including store settings access.
  - Sensitive webhook data remains protected during newsletter events.

- **Documentation**
  - Added a step-by-step guide for upgrading from Spree 5.5 to 5.6, including data backfills, frontend SDK updates, behavior changes, and multi-store considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->