### PR TITLE
Add addresses table to customer page in admin dashboard

### DIFF
--- a/spree/admin/app/controllers/spree/admin/user_addresses_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/user_addresses_controller.rb
@@ -15,12 +15,9 @@ module Spree
         nil
       end
 
-      def parent_data
-        {
-          model_name: 'spree/user',
-          model_class: Spree.user_class,
-          find_by: :prefix_id
-        }
+      def parent
+        @parent ||= Spree.user_class.accessible_by(current_ability, :show).find_by_prefix_id!(params[:user_id])
+        @user = @parent
       end
 
       def scope
@@ -29,6 +26,10 @@ module Spree
 
       def collection_includes
         %i[country state]
+      end
+
+      def collection_url(_options = {})
+        spree.admin_users_path
       end
 
       def redirect_to_full_page

--- a/spree/admin/app/controllers/spree/admin/user_addresses_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/user_addresses_controller.rb
@@ -1,0 +1,41 @@
+module Spree
+  module Admin
+    class UserAddressesController < ResourceController
+      use_table :addresses
+
+      before_action :redirect_to_full_page, only: :index, unless: :turbo_frame_request?
+      skip_after_action :set_return_to, only: :index
+
+      private
+
+      def model_class
+        Spree::Address
+      end
+
+      # Addresses have no standalone admin page, so rows are not clickable.
+      def edit_object_url(_object, _options = {})
+        nil
+      end
+
+      def parent_data
+        {
+          model_name: 'spree/user',
+          model_class: Spree.user_class,
+          find_by: :prefix_id
+        }
+      end
+
+      def scope
+        parent.addresses.accessible_by(current_ability, :index).includes(collection_includes)
+      end
+
+      def collection_includes
+        %i[country state]
+      end
+
+      def redirect_to_full_page
+        redirect_to spree.admin_user_path(parent)
+      end
+    end
+  end
+end

--- a/spree/admin/app/controllers/spree/admin/user_addresses_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/user_addresses_controller.rb
@@ -4,7 +4,6 @@ module Spree
       use_table :addresses
 
       before_action :redirect_to_full_page, only: :index, unless: :turbo_frame_request?
-      skip_after_action :set_return_to, only: :index
 
       private
 
@@ -12,7 +11,6 @@ module Spree
         Spree::Address
       end
 
-      # Addresses have no standalone admin page, so rows are not clickable.
       def edit_object_url(_object, _options = {})
         nil
       end

--- a/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
@@ -1,9 +1,9 @@
 <div><%= record.full_name %></div>
 <div class="flex flex-col items-start gap-1 mt-1">
-  <% if @user && record == @user.billing_address %>
+  <% if record.is_default_billing? %>
     <span class="badge badge-info"><%= Spree.t(:default_billing_address) %></span>
   <% end %>
-  <% if @user && record == @user.shipping_address %>
+  <% if record.is_default_shipping? %>
     <span class="badge badge-info"><%= Spree.t(:default_shipping_address) %></span>
   <% end %>
 </div>

--- a/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
@@ -1,8 +1,10 @@
 <%# locals: (record:, column:, value:) %>
-<%= record.full_name %>
-<% if @user && record == @user.billing_address %>
-  <span class="badge badge-info"><%= Spree.t(:default_billing_address) %></span>
-<% end %>
-<% if @user && record == @user.shipping_address %>
-  <span class="badge badge-info"><%= Spree.t(:default_shipping_address) %></span>
-<% end %>
+<div><%= record.full_name %></div>
+<div class="flex flex-col items-start gap-1 mt-1">
+  <% if @user && record == @user.billing_address %>
+    <span class="badge badge-info"><%= Spree.t(:default_billing_address) %></span>
+  <% end %>
+  <% if @user && record == @user.shipping_address %>
+    <span class="badge badge-info"><%= Spree.t(:default_shipping_address) %></span>
+  <% end %>
+</div>

--- a/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
@@ -1,4 +1,3 @@
-<%# locals: (record:, column:, value:) %>
 <div><%= record.full_name %></div>
 <div class="flex flex-col items-start gap-1 mt-1">
   <% if @user && record == @user.billing_address %>

--- a/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
+++ b/spree/admin/app/views/spree/admin/tables/columns/_address_name.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (record:, column:, value:) %>
+<%= record.full_name %>
+<% if @user && record == @user.billing_address %>
+  <span class="badge badge-info"><%= Spree.t(:default_billing_address) %></span>
+<% end %>
+<% if @user && record == @user.shipping_address %>
+  <span class="badge badge-info"><%= Spree.t(:default_shipping_address) %></span>
+<% end %>

--- a/spree/admin/app/views/spree/admin/user_addresses/index.html.erb
+++ b/spree/admin/app/views/spree/admin/user_addresses/index.html.erb
@@ -1,0 +1,1 @@
+<%= render_table @collection, :addresses, frame_name: :addresses %>

--- a/spree/admin/app/views/spree/admin/users/_tabs.html.erb
+++ b/spree/admin/app/views/spree/admin/users/_tabs.html.erb
@@ -26,6 +26,12 @@
         <a class="nav-link" id="pills-store-credits-tab" data-tabs-target="tab" data-action="click->tabs#select" role="tab" aria-controls="pills-store-credits" aria-selected="false"><%= Spree.t(:store_credits) %></a>
       </li>
     <% end %>
+
+    <% if can?(:read, Spree::Address) %>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="pills-addresses-tab" data-tabs-target="tab" data-action="click->tabs#select" role="tab" aria-controls="pills-addresses" aria-selected="false"><%= Spree.t(:addresses) %></a>
+      </li>
+    <% end %>
   </ul>
 
   <% if spree.respond_to?(:admin_user_visits_path) %>
@@ -63,6 +69,14 @@
           <%= render 'spree/admin/shared/spinner' %>
         <% end %>
       </div>
+    </div>
+  <% end %>
+
+  <% if can?(:read, Spree::Address) %>
+    <div data-tabs-target="panel" id="pills-addresses" role="tabpanel" aria-labelledby="pills-addresses" hidden class="animate-fade-in">
+      <%= turbo_frame_tag :addresses, src: spree.admin_user_addresses_path(@user), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
+        <%= render 'spree/admin/shared/spinner' %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/spree/admin/app/views/spree/admin/users/_tabs.html.erb
+++ b/spree/admin/app/views/spree/admin/users/_tabs.html.erb
@@ -35,19 +35,19 @@
   </ul>
 
   <% if spree.respond_to?(:admin_user_visits_path) %>
-    <div data-tabs-target="panel" id="pills-overview" role="tabpanel" aria-labelledby="pills-overview" class="pt-4 animate-fade-in">
+    <div data-tabs-target="panel" id="pills-overview" role="tabpanel" aria-labelledby="pills-overview-tab" class="pt-4 animate-fade-in">
       <%= turbo_frame_tag :user_visits, src: spree.admin_user_visits_path(@user), target: '_top' %>
     </div>
   <% end %>
 
   <% if can?(:read, Spree::Order) %>
-    <div data-tabs-target="panel" id="pills-orders2" role="tabpanel" aria-labelledby="pills-orders2" class="animate-fade-in" <%= 'hidden' if spree.respond_to?(:admin_user_visits_path) %>>
+    <div data-tabs-target="panel" id="pills-orders2" role="tabpanel" aria-labelledby="pills-orders2-tab" class="animate-fade-in" <%= 'hidden' if spree.respond_to?(:admin_user_visits_path) %>>
       <%= turbo_frame_tag :orders, src: spree.admin_user_orders_path(@user), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
         <%= render 'spree/admin/shared/spinner' %>
       <% end %>
     </div>
 
-    <div data-tabs-target="panel" id="pills-checkouts" role="tabpanel" aria-labelledby="pills-checkouts" hidden class="animate-fade-in">
+    <div data-tabs-target="panel" id="pills-checkouts" role="tabpanel" aria-labelledby="pills-checkouts-tab" hidden class="animate-fade-in">
       <%= turbo_frame_tag :checkouts, src: spree.admin_user_checkouts_path(@user), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
         <%= render 'spree/admin/shared/spinner' %>
       <% end %>
@@ -55,7 +55,7 @@
   <% end %>
 
   <% if spree.respond_to?(:admin_user_gift_cards_path) && can?(:read, Spree::GiftCard) %>
-    <div data-tabs-target="panel" id="pills-gift-cards" role="tabpanel" aria-labelledby="pills-gift-cards" hidden class="animate-fade-in">
+    <div data-tabs-target="panel" id="pills-gift-cards" role="tabpanel" aria-labelledby="pills-gift-cards-tab" hidden class="animate-fade-in">
       <%= turbo_frame_tag :gift_cards, src: spree.admin_user_gift_cards_path(@user), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
         <%= render 'spree/admin/shared/spinner' %>
       <% end %>
@@ -63,7 +63,7 @@
   <% end %>
 
   <% if can?(:read, Spree::StoreCredit) %>
-    <div data-tabs-target="panel" id="pills-store-credits" role="tabpanel" aria-labelledby="pills-store-credits" hidden class="animate-fade-in">
+    <div data-tabs-target="panel" id="pills-store-credits" role="tabpanel" aria-labelledby="pills-store-credits-tab" hidden class="animate-fade-in">
       <div class="card-lg">
         <%= turbo_frame_tag :store_credits_list, src: spree.admin_user_store_credits_path(@user, frame_name: :store_credits_list), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
           <%= render 'spree/admin/shared/spinner' %>
@@ -73,7 +73,7 @@
   <% end %>
 
   <% if can?(:read, Spree::Address) %>
-    <div data-tabs-target="panel" id="pills-addresses" role="tabpanel" aria-labelledby="pills-addresses" hidden class="animate-fade-in">
+    <div data-tabs-target="panel" id="pills-addresses" role="tabpanel" aria-labelledby="pills-addresses-tab" hidden class="animate-fade-in">
       <%= turbo_frame_tag :addresses, src: spree.admin_user_addresses_path(@user), loading: :lazy, autoscroll: true, data: { autoscroll_block: :nearest, autoscroll_behavior: :smooth } do %>
         <%= render 'spree/admin/shared/spinner' %>
       <% end %>

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -2160,4 +2160,67 @@ Rails.application.config.after_initialize do
                                          filterable: true,
                                          default: true,
                                          position: 20
+
+  # Register Addresses table (customer address book)
+  Spree.admin.tables.register(:addresses, model_class: Spree::Address, search_param: :firstname_or_lastname_or_city_or_zipcode_cont, row_actions: false, new_resource: false)
+
+  Spree.admin.tables.addresses.add :name,
+                                   label: :name,
+                                   type: :custom,
+                                   sortable: false,
+                                   filterable: false,
+                                   default: true,
+                                   position: 10,
+                                   partial: 'spree/admin/tables/columns/address_name'
+
+  Spree.admin.tables.addresses.add :address,
+                                   label: :address,
+                                   type: :string,
+                                   sortable: false,
+                                   filterable: false,
+                                   default: true,
+                                   position: 20,
+                                   method: ->(address) { [address.address1, address.address2].reject(&:blank?).join(', ') }
+
+  Spree.admin.tables.addresses.add :city,
+                                   label: :city,
+                                   type: :string,
+                                   sortable: true,
+                                   filterable: true,
+                                   default: true,
+                                   position: 30
+
+  Spree.admin.tables.addresses.add :state,
+                                   label: :state,
+                                   type: :string,
+                                   sortable: false,
+                                   filterable: false,
+                                   default: true,
+                                   position: 40,
+                                   method: ->(address) { address.state_text }
+
+  Spree.admin.tables.addresses.add :zipcode,
+                                   label: :zipcode,
+                                   type: :string,
+                                   sortable: true,
+                                   filterable: true,
+                                   default: true,
+                                   position: 50
+
+  Spree.admin.tables.addresses.add :country,
+                                   label: :country,
+                                   type: :string,
+                                   sortable: false,
+                                   filterable: false,
+                                   default: true,
+                                   position: 60,
+                                   method: ->(address) { localized_country_name(address.country) if address.country }
+
+  Spree.admin.tables.addresses.add :phone,
+                                   label: :phone,
+                                   type: :string,
+                                   sortable: false,
+                                   filterable: true,
+                                   default: true,
+                                   position: 70
 end

--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -2162,7 +2162,7 @@ Rails.application.config.after_initialize do
                                          position: 20
 
   # Register Addresses table (customer address book)
-  Spree.admin.tables.register(:addresses, model_class: Spree::Address, search_param: :firstname_or_lastname_or_city_or_zipcode_cont, row_actions: false, new_resource: false)
+  Spree.admin.tables.register(:addresses, model_class: Spree::Address, search_param: :firstname_or_lastname_or_address1_or_address2_or_city_or_zipcode_cont, row_actions: false, new_resource: false)
 
   Spree.admin.tables.addresses.add :name,
                                    label: :name,

--- a/spree/admin/config/routes.rb
+++ b/spree/admin/config/routes.rb
@@ -133,6 +133,7 @@ Spree::Core::Engine.add_routes do
       resources :store_credits
       resources :orders, only: [:index]
       resources :checkouts, only: [:index]
+      resources :addresses, only: [:index], controller: 'user_addresses'
       resources :gift_cards
 
       collection do

--- a/spree/admin/spec/controllers/spree/admin/user_addresses_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/user_addresses_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::UserAddressesController, type: :controller do
+  stub_authorization!
+  render_views
+
+  let(:user) { create(:user) }
+  let!(:address) { create(:address, user: user) }
+  let!(:other_address) { create(:address, user: create(:user)) }
+
+  describe 'GET #index' do
+    context 'as a Turbo Frame request' do
+      before { request.headers['Turbo-Frame'] = 'addresses' }
+
+      it 'renders the addresses table scoped to the user' do
+        get :index, params: { user_id: user.to_param }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:index)
+        expect(assigns(:collection)).to contain_exactly(address)
+        expect(assigns(:user)).to eq(user)
+      end
+    end
+
+    context 'as a full-page request (not a Turbo Frame)' do
+      it 'redirects to the user page' do
+        get :index, params: { user_id: user.to_param }
+
+        expect(response).to redirect_to(spree.admin_user_path(user))
+      end
+    end
+
+    context 'when the user cannot be found' do
+      it 'redirects to the users list' do
+        get :index, params: { user_id: 'cus_nonexistent' }
+
+        expect(response).to redirect_to(spree.admin_users_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<img width="826" height="831" alt="Screenshot 2026-07-23 at 14 14 38" src="https://github.com/user-attachments/assets/a7f3069b-b0a8-4906-9f5e-832517d8d437" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Addresses** tab to admin user profiles with a Turbo frame for smoother loading.
  * Introduced a nested, permissions-aware admin address list for each user, including sorting/search across customer address fields.
  * Added address row badges for **default billing** and **default shipping**, and enhanced display of name and key address details (address, city, state, ZIP, country, phone).
  * Address tab loads are scoped to the selected user; non-frame access redirects to the user’s main admin page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->