### PR TITLE
Auto-enable the storefront wholesale portal on sample-data scaffolds 

### DIFF
--- a/.changeset/wholesale-portal-auto-setup.md
+++ b/.changeset/wholesale-portal-auto-setup.md
@@ -1,0 +1,6 @@
+---
+'create-spree-app': patch
+'@spree/cli': patch
+---
+
+Auto-enable the storefront wholesale B2B portal on sample-data scaffolds: create-spree-app writes `SPREE_WHOLESALE_CHANNEL=wholesale` into the storefront `.env.local`, and setup output points at the portal (`/wholesale`) with the buyer-approval flow. The portal runs on the default publishable key — no extra key or backend changes involved.

--- a/.changeset/wholesale-portal-auto-setup.md
+++ b/.changeset/wholesale-portal-auto-setup.md
@@ -1,6 +1,0 @@
----
-'create-spree-app': patch
-'@spree/cli': patch
----
-
-Auto-enable the storefront wholesale B2B portal on sample-data scaffolds: create-spree-app writes `SPREE_WHOLESALE_CHANNEL=wholesale` into the storefront `.env.local`, and setup output points at the portal (`/wholesale`) with the buyer-approval flow. The portal runs on the default publishable key — no extra key or backend changes involved.

--- a/docs/plans/5.6-store-channel-context-and-key-binding.md
+++ b/docs/plans/5.6-store-channel-context-and-key-binding.md
@@ -4,7 +4,7 @@
 **Target:** Spree 5.6
 **Depends on:** `6.0-channels-catalogs-b2b.md` (Phase 1 channels + Gated Storefront Access — both shipped)
 **Author:** Damian Legawiec + Claude
-**Last updated:** 2026-07-19
+**Last updated:** 2026-07-23
 
 ## Summary
 
@@ -16,7 +16,7 @@ The 5.5/5.6 channel work gave the v3 Store API server-enforced gated storefront 
 - **The endpoint opts out of the login gate** (`allow_guest_storefront_access!`) and exposes **resolved** values (`storefront_access`, `guest_checkout`) — a gated storefront must be able to read "this channel requires login" pre-auth to render a sign-in wall instead of an error page. Raw (`nil`-able) preference values are an Admin API concern; the Store API serves only what a client should act on.
 - **Publishable keys get an optional single-channel binding** (`channel_id`, nullable). `nil` keeps today's behavior (header → store default). A bound key server-assigns `Spree::Current.channel`; a conflicting `X-Spree-Channel` header is a `422` (`channel_mismatch`), a matching one is allowed. Single binding, not Medusa-style many-to-many — one key per storefront surface is the use case, and it matches the original intent in `6.0-channels-catalogs-b2b.md` ("each Channel can have its own PublishableApiKey"). Secret (admin) keys never bind — admin reads span channels.
 - **`customer_groups` (id + name) are exposed on the Store customer serializer.** The API's `login_required` gate is authenticated-vs-guest by design; group membership is the storefront's signal for "approved wholesale buyer" vs merely "logged in". Pricing/catalog correctness never depends on the storefront honoring it — price lists resolve server-side.
-- **Wholesale is seeded as a default channel on every store**: code `wholesale`, `storefront_access: login_required`, `guest_checkout: false`, inactive-by-default is **not** an option — gating already makes it invisible to guests. A matching "Wholesale" customer group and a channel-bound publishable key are seeded alongside.
+- **Wholesale is seeded as a default channel on every store**: code `wholesale`, `storefront_access: login_required`, `guest_checkout: false`, inactive-by-default is **not** an option — gating already makes it invisible to guests. A matching "Wholesale" customer group is seeded alongside. **No channel-bound key is seeded**: the default unbound key serves every channel via `X-Spree-Channel`, so binding stays a purely opt-in hardening (decision 2026-07-23; the original plan seeded a bound `Storefront (Wholesale)` key, since removed).
 
 ## Design Details
 
@@ -52,12 +52,20 @@ The 5.5/5.6 channel work gave the v3 Store API server-enforced gated storefront 
 
 - `Spree::Seeds::Channels` — for each store, ensure the default channel exists (already handled by Channel promotion callback) and create the `wholesale` channel with the gated posture.
 - `Spree::Seeds::CustomerGroups` — "Wholesale" group per store.
-- `Spree::Seeds::ApiKeys` — extend to also mint a `Storefront (Wholesale)` publishable key bound to the wholesale channel.
+- `Spree::Seeds::ApiKeys` — seeds only the unbound default key (see Key Decisions: no bound key is seeded).
 - Sample data: publish the sample catalog to the wholesale channel (subset + a few wholesale-only products), so a fresh install demos a differentiated gated catalog.
 
 ### SDK
 
 `client.channel.get()` on `@spree/sdk` (the `channel` config option + `setChannel()` already exist). Generated `StoreChannel` type via typelizer.
+
+### Scaffolding: wholesale portal auto-setup (create-spree-app + `spree init`)
+
+A project scaffolded with **storefront + sample data** gets the reference storefront's wholesale portal enabled with zero manual env editing:
+
+- create-spree-app writes `SPREE_WHOLESALE_CHANNEL=wholesale` into `apps/storefront/.env.local` — that's the whole setup: the portal runs on the storefront's regular `SPREE_PUBLISHABLE_KEY`, with the channel header selecting the channel (no bound key involved; `SPREE_WHOLESALE_PUBLISHABLE_KEY` stays an unset opt-in hardening). Gated on the sample-data choice — the channel is seeded regardless, but only sample data ships the "Wholesale" customer group + trade price list that make the portal walkable. Deliberately no pre-approved demo buyer: users register on the portal and approve the account by hand (add it to the "Wholesale" customer group in the admin) — the approval flow is part of the demo.
+- First-run setup (`spree init`, or the deferred path through `spree dev`) points at the portal in its summary when the storefront opted in and sample data was loaded; it does not mint or write any wholesale-specific key.
+- `spree:cli:ensure_api_key` now only returns **unbound** keys (`channel_id: nil`) — handing the storefront a channel-bound key would pin every request to that channel.
 
 ## Migration Path
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @spree/cli
 
+## 2.4.8
+
+### Patch Changes
+
+- [`61f85af`](https://github.com/spree/spree/commit/61f85af83531f3bf5f17aaf105f144b02336d73c) Thanks [@damianlegawiec](https://github.com/damianlegawiec)! - Auto-enable the storefront wholesale B2B portal on sample-data scaffolds: create-spree-app writes `SPREE_WHOLESALE_CHANNEL=wholesale` into the storefront `.env.local`, and setup output points at the portal (`/wholesale`) with the buyer-approval flow. The portal runs on the default publishable key — no extra key or backend changes involved.
+
 ## 2.4.7
 
 ### Patch Changes
@@ -199,7 +205,6 @@ dashboard` wrote `VITE_SPREE_API_URL=http://localhost:<port>` into
 ### Minor Changes
 
 - New `spree api` and `spree auth` command groups — a generic Admin API client (`get`/`post`/`patch`/`delete`) built into the CLI:
-
   - `spree api get|post|patch|delete <path>` — generic verbs with Ransack `-q` filters, `--sort`/`--page`/`--limit`/`--expand`/`--fields`, and JSON bodies from inline/`@file`/stdin
   - `spree api endpoints` / `spree api schema` — offline schema introspection over a bundled OpenAPI snapshot, including each endpoint's required scope
   - `spree api status` — resolved credentials + server reachability

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spree/cli",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "CLI for managing Spree Commerce projects",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -240,9 +240,13 @@ async function fetchApiKey(projectDir: string): Promise<string> {
 /** The channel code the storefront's wholesale portal is configured for, or null when disabled. */
 export function storefrontWholesaleChannel(projectDir: string): string | null {
   const envPath = path.join(projectDir, 'apps', 'storefront', '.env.local')
-  if (!fs.existsSync(envPath)) return null
-
-  return fs.readFileSync(envPath, 'utf-8').match(/^SPREE_WHOLESALE_CHANNEL=(\S+)/m)?.[1] ?? null
+  // Gates a summary hint only — a missing or unreadable env file must never
+  // fail setup reporting.
+  try {
+    return fs.readFileSync(envPath, 'utf-8').match(/^SPREE_WHOLESALE_CHANNEL=(\S+)/m)?.[1] ?? null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,7 +6,12 @@ import type { Command } from 'commander'
 import { execa, execaCommand } from 'execa'
 import pc from 'picocolors'
 import { mintProjectCredentials, writeProjectSetupMarker } from '../config.js'
-import { DASHBOARD_PORT, DEFAULT_ADMIN_EMAIL, DEFAULT_ADMIN_PASSWORD } from '../constants.js'
+import {
+  DASHBOARD_PORT,
+  DEFAULT_ADMIN_EMAIL,
+  DEFAULT_ADMIN_PASSWORD,
+  STOREFRONT_PORT,
+} from '../constants.js'
 import { detectProject, readSampleDataFromEnv } from '../context.js'
 import {
   dashboardDevRunnable,
@@ -123,6 +128,19 @@ export async function runFirstRunSetup(flags: {
         `  Password: ${DEFAULT_ADMIN_PASSWORD}`,
       ]
 
+  // The wholesale demo needs both the storefront env opt-in and the seeded
+  // group/prices (sampleData) to be walkable end to end. The portal runs on
+  // the default publishable key — the channel header selects the channel.
+  const wholesaleBlock =
+    sampleData && storefrontWholesaleChannel(ctx.projectDir)
+      ? [
+          pc.bold('Wholesale portal (B2B demo)'),
+          `  ${pc.cyan(`http://localhost:${STOREFRONT_PORT}/wholesale`)} ${pc.dim('— needs the storefront dev server running')}`,
+          `  ${pc.dim('Register a buyer, then approve them in the admin (add to the "Wholesale" customer group)')}`,
+          '',
+        ]
+      : []
+
   p.note(
     [
       '',
@@ -132,6 +150,7 @@ export async function runFirstRunSetup(flags: {
       `  ${pc.cyan(`http://localhost:${ctx.port}/api/v3/store`)}`,
       `  Publishable key: ${pc.cyan(publishableKey)}`,
       '',
+      ...wholesaleBlock,
       pc.bold('Admin API'),
       `  ${pc.cyan(`http://localhost:${ctx.port}/api/v3/admin`)}`,
       `  Secret key:      ${pc.cyan(secretKey)}`,
@@ -218,6 +237,14 @@ async function fetchApiKey(projectDir: string): Promise<string> {
   return match[0]
 }
 
+/** The channel code the storefront's wholesale portal is configured for, or null when disabled. */
+export function storefrontWholesaleChannel(projectDir: string): string | null {
+  const envPath = path.join(projectDir, 'apps', 'storefront', '.env.local')
+  if (!fs.existsSync(envPath)) return null
+
+  return fs.readFileSync(envPath, 'utf-8').match(/^SPREE_WHOLESALE_CHANNEL=(\S+)/m)?.[1] ?? null
+}
+
 /**
  * Mints a fresh read-only secret key into `.spree/credentials.json` so
  * `spree api` works without a first-use minting round-trip.
@@ -241,7 +268,7 @@ export function updateStorefrontEnv(projectDir: string, apiKey: string): void {
   const content = fs.readFileSync(envPath, 'utf-8')
   fs.writeFileSync(
     envPath,
-    content.replace(/SPREE_PUBLISHABLE_KEY=.*/, `SPREE_PUBLISHABLE_KEY=${apiKey}`),
+    content.replace(/^SPREE_PUBLISHABLE_KEY=.*/m, `SPREE_PUBLISHABLE_KEY=${apiKey}`),
   )
 }
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -2,3 +2,4 @@ export const DEFAULT_ADMIN_EMAIL = 'spree@example.com'
 export const DEFAULT_ADMIN_PASSWORD = 'spree123'
 export const DEFAULT_SPREE_PORT = 3000
 export const DASHBOARD_PORT = 5173
+export const STOREFRONT_PORT = 3001

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { updateStorefrontEnv } from '../src/commands/init'
+import { storefrontWholesaleChannel, updateStorefrontEnv } from '../src/commands/init'
 
 const tempDirs: string[] = []
 
@@ -10,6 +10,19 @@ function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spree-cli-init-test-'))
   tempDirs.push(dir)
   return dir
+}
+
+// Creates a project dir whose storefront .env.local has the given content.
+function makeProjectWithStorefrontEnv(content: string): string {
+  const dir = makeTempDir()
+  const storefrontDir = path.join(dir, 'apps', 'storefront')
+  fs.mkdirSync(storefrontDir, { recursive: true })
+  fs.writeFileSync(path.join(storefrontDir, '.env.local'), content)
+  return dir
+}
+
+function readStorefrontEnv(dir: string): string {
+  return fs.readFileSync(path.join(dir, 'apps', 'storefront', '.env.local'), 'utf-8')
 }
 
 afterEach(() => {
@@ -21,48 +34,35 @@ afterEach(() => {
 
 describe('updateStorefrontEnv', () => {
   it('replaces placeholder key with real API key', () => {
-    const dir = makeTempDir()
-    const envPath = path.join(dir, 'apps', 'storefront')
-    fs.mkdirSync(envPath, { recursive: true })
-    fs.writeFileSync(
-      path.join(envPath, '.env.local'),
+    const dir = makeProjectWithStorefrontEnv(
       'SPREE_API_URL=http://localhost:3000\nSPREE_PUBLISHABLE_KEY=pk_REPLACE_ME_AFTER_DOCKER_START\n',
     )
 
     updateStorefrontEnv(dir, 'pk_test_abc123')
 
-    const content = fs.readFileSync(path.join(envPath, '.env.local'), 'utf-8')
+    const content = readStorefrontEnv(dir)
     expect(content).toContain('SPREE_PUBLISHABLE_KEY=pk_test_abc123')
     expect(content).not.toContain('pk_REPLACE_ME_AFTER_DOCKER_START')
   })
 
   it('replaces any existing key value', () => {
-    const dir = makeTempDir()
-    const envPath = path.join(dir, 'apps', 'storefront')
-    fs.mkdirSync(envPath, { recursive: true })
-    fs.writeFileSync(
-      path.join(envPath, '.env.local'),
+    const dir = makeProjectWithStorefrontEnv(
       'SPREE_API_URL=http://localhost:3000\nSPREE_PUBLISHABLE_KEY=pk_old_key\n',
     )
 
     updateStorefrontEnv(dir, 'pk_new_key')
 
-    const content = fs.readFileSync(path.join(envPath, '.env.local'), 'utf-8')
-    expect(content).toContain('SPREE_PUBLISHABLE_KEY=pk_new_key')
+    expect(readStorefrontEnv(dir)).toContain('SPREE_PUBLISHABLE_KEY=pk_new_key')
   })
 
   it('preserves other env variables', () => {
-    const dir = makeTempDir()
-    const envPath = path.join(dir, 'apps', 'storefront')
-    fs.mkdirSync(envPath, { recursive: true })
-    fs.writeFileSync(
-      path.join(envPath, '.env.local'),
+    const dir = makeProjectWithStorefrontEnv(
       'SPREE_API_URL=http://localhost:4567\nSPREE_PUBLISHABLE_KEY=pk_REPLACE_ME_AFTER_DOCKER_START\n',
     )
 
     updateStorefrontEnv(dir, 'pk_real_key')
 
-    const content = fs.readFileSync(path.join(envPath, '.env.local'), 'utf-8')
+    const content = readStorefrontEnv(dir)
     expect(content).toContain('SPREE_API_URL=http://localhost:4567')
     expect(content).toContain('SPREE_PUBLISHABLE_KEY=pk_real_key')
   })
@@ -70,5 +70,42 @@ describe('updateStorefrontEnv', () => {
   it('does nothing when .env.local does not exist', () => {
     const dir = makeTempDir()
     expect(() => updateStorefrontEnv(dir, 'pk_test')).not.toThrow()
+  })
+
+  it('does not touch the wholesale channel opt-in', () => {
+    const dir = makeProjectWithStorefrontEnv(
+      'SPREE_PUBLISHABLE_KEY=pk_old\nSPREE_WHOLESALE_CHANNEL=wholesale\n',
+    )
+
+    updateStorefrontEnv(dir, 'pk_default')
+
+    const content = readStorefrontEnv(dir)
+    expect(content).toContain('SPREE_PUBLISHABLE_KEY=pk_default')
+    expect(content).toContain('SPREE_WHOLESALE_CHANNEL=wholesale')
+  })
+})
+
+describe('storefrontWholesaleChannel', () => {
+  it('returns the channel code when SPREE_WHOLESALE_CHANNEL has a value', () => {
+    const dir = makeProjectWithStorefrontEnv('SPREE_WHOLESALE_CHANNEL=wholesale\n')
+    expect(storefrontWholesaleChannel(dir)).toBe('wholesale')
+  })
+
+  it('returns null when the variable is empty, commented, or absent', () => {
+    expect(
+      storefrontWholesaleChannel(makeProjectWithStorefrontEnv('SPREE_WHOLESALE_CHANNEL=\n')),
+    ).toBeNull()
+    expect(
+      storefrontWholesaleChannel(
+        makeProjectWithStorefrontEnv('# SPREE_WHOLESALE_CHANNEL=wholesale\n'),
+      ),
+    ).toBeNull()
+    expect(
+      storefrontWholesaleChannel(makeProjectWithStorefrontEnv('SPREE_PUBLISHABLE_KEY=pk_x\n')),
+    ).toBeNull()
+  })
+
+  it('returns null when .env.local does not exist', () => {
+    expect(storefrontWholesaleChannel(makeTempDir())).toBeNull()
   })
 })

--- a/packages/create-spree-app/CHANGELOG.md
+++ b/packages/create-spree-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-spree-app
 
+## 1.2.1
+
+### Patch Changes
+
+- [`61f85af`](https://github.com/spree/spree/commit/61f85af83531f3bf5f17aaf105f144b02336d73c) Thanks [@damianlegawiec](https://github.com/damianlegawiec)! - Auto-enable the storefront wholesale B2B portal on sample-data scaffolds: create-spree-app writes `SPREE_WHOLESALE_CHANNEL=wholesale` into the storefront `.env.local`, and setup output points at the portal (`/wholesale`) with the buyer-approval flow. The portal runs on the default publishable key — no extra key or backend changes involved.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/create-spree-app/package.json
+++ b/packages/create-spree-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spree-app",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Create a new Spree Commerce project with a single command",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/create-spree-app/src/scaffold.ts
+++ b/packages/create-spree-app/src/scaffold.ts
@@ -8,6 +8,7 @@ import {
   DASHBOARD_PORT,
   DEFAULT_ADMIN_EMAIL,
   DEFAULT_ADMIN_PASSWORD,
+  STOREFRONT_PORT,
   STOREFRONT_REPO,
 } from './constants.js'
 import { scaffoldDashboard } from './dashboard.js'
@@ -122,7 +123,10 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
       await downloadStorefront(projectDir)
       s.stop('Storefront template downloaded.')
 
-      writeStorefrontEnv(projectDir, port)
+      // Sample data seeds the whole wholesale demo (gated channel, buyer,
+      // trade prices), so those scaffolds get the portal enabled up front —
+      // first-run setup fills in the channel-bound key.
+      writeStorefrontEnv(projectDir, port, options.sampleData)
 
       s.start('Installing storefront dependencies...')
       await installStorefrontDeps(projectDir, options.packageManager)
@@ -198,6 +202,11 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
       p.log.info(
         `${pc.bold('Storefront')}: ${pc.cyan(`cd ${projectName}/apps/storefront && ${storefrontPm(options.packageManager)} run dev`)}`,
       )
+      if (options.sampleData) {
+        p.log.info(
+          `${pc.bold('Wholesale portal')}: ${pc.cyan(`http://localhost:${STOREFRONT_PORT}/wholesale`)} — register a buyer, then approve them in the admin (add to the ${pc.bold('Wholesale')} customer group)`,
+        )
+      }
     }
     // No dashboard line here — with the dashboard chosen, `spree init`'s
     // summary already leads with it (served at /dashboard, plus the
@@ -209,6 +218,7 @@ export async function scaffold(options: ScaffoldOptions): Promise<void> {
       dashboardReady,
       port,
       options.packageManager,
+      options.sampleData,
     )
   }
 }
@@ -219,6 +229,7 @@ function printSuccessWithoutDocker(
   hasDashboard: boolean,
   port: number,
   pm: PackageManager,
+  sampleData: boolean,
 ): void {
   const run = runCommand(pm)
   const lines: string[] = [
@@ -237,6 +248,11 @@ function printSuccessWithoutDocker(
       `  ${installCommand(pm)}`,
       `  ${pm} run dev`,
     )
+    if (sampleData) {
+      lines.push(
+        `  ${pc.dim(`# Wholesale B2B portal: http://localhost:${STOREFRONT_PORT}/wholesale (approve buyers via the "Wholesale" customer group)`)}`,
+      )
+    }
   }
 
   // With the React Dashboard chosen, its dev server IS the admin — and

--- a/packages/create-spree-app/src/storefront.ts
+++ b/packages/create-spree-app/src/storefront.ts
@@ -143,7 +143,7 @@ export async function installStorefrontDeps(projectDir: string, pm: PackageManag
   await execa(cmd, args, { cwd: storefrontDir, stdio: 'ignore' })
 }
 
-export function writeStorefrontEnv(projectDir: string, port: number, apiKey?: string): void {
+export function writeStorefrontEnv(projectDir: string, port: number, wholesale = false): void {
   const envPath = path.join(projectDir, 'apps', 'storefront', '.env.local')
-  fs.writeFileSync(envPath, storefrontEnvContent(port, apiKey))
+  fs.writeFileSync(envPath, storefrontEnvContent(port, wholesale))
 }

--- a/packages/create-spree-app/src/templates/env.ts
+++ b/packages/create-spree-app/src/templates/env.ts
@@ -12,8 +12,19 @@ SPREE_SAMPLE_DATA=${sampleData}
 `
 }
 
-export function storefrontEnvContent(port: number, apiKey?: string): string {
-  return `SPREE_API_URL=http://localhost:${port}
-SPREE_PUBLISHABLE_KEY=${apiKey ?? 'pk_REPLACE_ME_AFTER_DOCKER_START'}
+export function storefrontEnvContent(port: number, wholesale = false): string {
+  let content = `SPREE_API_URL=http://localhost:${port}
+SPREE_PUBLISHABLE_KEY=pk_REPLACE_ME_AFTER_DOCKER_START
 `
+  if (wholesale) {
+    content += `
+# Wholesale B2B portal (/wholesale) — the gated channel and trade price list
+# ship with sample data. Buyers self-register; approve one by adding them to
+# the "Wholesale" customer group in the admin. The portal uses
+# SPREE_PUBLISHABLE_KEY (the channel header selects the channel); set
+# SPREE_WHOLESALE_PUBLISHABLE_KEY only to pin a channel-bound key.
+SPREE_WHOLESALE_CHANNEL=wholesale
+`
+  }
+  return content
 }

--- a/packages/create-spree-app/tests/scaffold.test.ts
+++ b/packages/create-spree-app/tests/scaffold.test.ts
@@ -127,6 +127,32 @@ describe('scaffold (no-start)', () => {
     expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(true)
   })
 
+  it('enables the wholesale portal in the storefront env only with sample data', async () => {
+    const { writeStorefrontEnv } = await import('../src/storefront')
+
+    await scaffold({
+      directory: getTempProjectDir(),
+      storefront: true,
+      dashboard: false,
+      sampleData: true,
+      start: false,
+      packageManager: 'npm',
+      port: 3000,
+    })
+    expect(writeStorefrontEnv).toHaveBeenLastCalledWith(expect.any(String), 3000, true)
+
+    await scaffold({
+      directory: getTempProjectDir(),
+      storefront: true,
+      dashboard: false,
+      sampleData: false,
+      start: false,
+      packageManager: 'npm',
+      port: 3000,
+    })
+    expect(writeStorefrontEnv).toHaveBeenLastCalledWith(expect.any(String), 3000, false)
+  })
+
   it('copies docker-compose.yml from backend template', async () => {
     const projectDir = getTempProjectDir()
 

--- a/packages/create-spree-app/tests/templates.test.ts
+++ b/packages/create-spree-app/tests/templates.test.ts
@@ -29,14 +29,9 @@ describe('envContent', () => {
 })
 
 describe('storefrontEnvContent', () => {
-  it('includes placeholder when no key provided', () => {
+  it('includes the key placeholder first-run setup replaces', () => {
     const content = storefrontEnvContent(3000)
-    expect(content).toContain('pk_REPLACE_ME_AFTER_DOCKER_START')
-  })
-
-  it('includes real key when provided', () => {
-    const content = storefrontEnvContent(3000, 'pk_test123')
-    expect(content).toContain('SPREE_PUBLISHABLE_KEY=pk_test123')
+    expect(content).toContain('SPREE_PUBLISHABLE_KEY=pk_REPLACE_ME_AFTER_DOCKER_START')
   })
 
   it('includes API URL with given port', () => {
@@ -47,6 +42,16 @@ describe('storefrontEnvContent', () => {
   it('uses custom port in API URL', () => {
     const content = storefrontEnvContent(4567)
     expect(content).toContain('SPREE_API_URL=http://localhost:4567')
+  })
+
+  it('omits the wholesale portal by default', () => {
+    const content = storefrontEnvContent(3000)
+    expect(content).not.toContain('SPREE_WHOLESALE_CHANNEL')
+  })
+
+  it('enables the wholesale portal when requested', () => {
+    const content = storefrontEnvContent(3000, true)
+    expect(content).toMatch(/^SPREE_WHOLESALE_CHANNEL=wholesale$/m)
   })
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sample storefront setup now automatically enables the wholesale B2B portal when sample data is selected.
  * Setup instructions now include the wholesale portal URL and the buyer-approval flow.
  * The portal works using the default publishable key, with wholesale configuration handled automatically.
* **Documentation**
  * Updated plan and changelogs to reflect the new wholesale portal scaffolding behavior and routing.
* **Bug Fixes**
  * Storefront environment updates now preserve the wholesale portal opt-in setting.
* **Tests**
  * Expanded coverage for wholesale portal enablement and storefront environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->