### PR TITLE
Require storefront-visible payment methods for setup task

### DIFF
--- a/spree/core/app/models/concerns/spree/stores/setup.rb
+++ b/spree/core/app/models/concerns/spree/stores/setup.rb
@@ -52,8 +52,11 @@ module Spree
         (setup_tasks_done / setup_tasks_total.to_f * 100).to_i
       end
 
+      # Payments count as set up only once customers can actually pay at
+      # storefront checkout: admin-only (back_end) methods and store credit
+      # don't complete the task.
       def payment_method_setup?
-        payment_methods.active.where.not(type: Spree::PaymentMethod::StoreCredit.to_s).any?
+        payment_methods.active.storefront_visible.where.not(type: Spree::PaymentMethod::StoreCredit.to_s).any?
       end
 
       # A storefront counts as set up once the merchant has saved the storefront

--- a/spree/core/spec/models/spree/store_spec.rb
+++ b/spree/core/spec/models/spree/store_spec.rb
@@ -1026,4 +1026,47 @@ describe Spree::Store, type: :model, without_global_store: true do
       expect(store.reload.setup_tasks.find { |t| t.name == 'setup_storefront' }.done).to be true
     end
   end
+
+  describe '#payment_method_setup?' do
+    let(:store) { create(:store) }
+
+    subject { store.payment_method_setup? }
+
+    context 'with no payment methods' do
+      it { is_expected.to be false }
+    end
+
+    context 'with only a store credit payment method' do
+      before { create(:store_credit_payment_method, store: store) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the only non-store-credit methods are admin-only' do
+      before do
+        create(:credit_card_payment_method, store: store, display_on: 'back_end')
+        create(:check_payment_method, store: store, display_on: 'back_end')
+      end
+
+      it 'stays pending' do
+        expect(subject).to be false
+        expect(store.setup_task_done?(:setup_payment_method)).to be false
+      end
+    end
+
+    context 'with an active storefront-visible payment method' do
+      before { create(:credit_card_payment_method, store: store) }
+
+      it 'marks the setup task as done' do
+        expect(subject).to be true
+        expect(store.setup_task_done?(:setup_payment_method)).to be true
+      end
+    end
+
+    context 'when the storefront-visible method is inactive' do
+      before { create(:credit_card_payment_method, store: store, active: false) }
+
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Updates the payment method setup task validation to only count payment methods that are both active and storefront-visible. This ensures that admin-only payment methods and store credit do not incorrectly mark the payment setup task as complete.

## Changes
- **Modified `payment_method_setup?` method** in `spree/core/app/models/concerns/spree/stores/setup.rb`:
  - Added `.storefront_visible` scope to the payment method query
  - Updated comment to clarify that only customer-facing payment methods count toward setup completion
  - Admin-only (back_end) methods and store credit are now explicitly excluded

- **Added comprehensive test coverage** in `spree/core/spec/models/spree/store_spec.rb`:
  - Test for no payment methods (pending)
  - Test for store credit only (pending)
  - Test for admin-only payment methods (pending)
  - Test for active storefront-visible payment method (complete)
  - Test for inactive storefront-visible payment method (pending)

## Implementation Details
This change aligns with the `5.5-6.0-display-on-to-boolean.md` plan's bridge implementation, leveraging the `storefront_visible` accessor that was shipped in 5.5 as a bridge over the tri-state `display_on` column. The setup task now correctly validates that customers can actually complete payment at storefront checkout before marking the task as done.

https://claude.ai/code/session_01WyGx1XNS7xi6Ng9UNnAcTQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storefront payment setup is now considered complete only when customers can use an active, storefront-visible payment method.
  * Admin-only, store-credit, or inactive payment methods no longer incorrectly complete the setup task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->