### PR TITLE
Simplify BrandsListPage layout using ResourceTable's built-in toolbar

### DIFF
--- a/packages/dashboard-plugin-example/src/client.ts
+++ b/packages/dashboard-plugin-example/src/client.ts
@@ -23,7 +23,10 @@ import type { Brand, BrandCreateParams, BrandUpdateParams } from './types'
  * In practice, callers pass the same `{ page, limit, sort, search, … }`
  * keys built-in resources accept.
  */
-type BrandsListParams = Record<string, string | number | boolean | (string | number)[] | undefined>
+export type BrandsListParams = Record<
+  string,
+  string | number | boolean | (string | number)[] | undefined
+>
 
 export const brandsClient = {
   list: (params?: BrandsListParams) =>

--- a/packages/dashboard-plugin-example/src/locales/en.json
+++ b/packages/dashboard-plugin-example/src/locales/en.json
@@ -3,8 +3,6 @@
     "brands_plugin": {
       "nav": "Brands",
       "page": {
-        "title": "Brands",
-        "subtitle": "Manage product brands",
         "new_cta": "New brand"
       },
       "table": {

--- a/packages/dashboard-plugin-example/src/pages/brands-list.tsx
+++ b/packages/dashboard-plugin-example/src/pages/brands-list.tsx
@@ -1,3 +1,15 @@
+import { type ResourceSearch, ResourceTable } from '@spree/dashboard-core'
+import { Button } from '@spree/dashboard-ui'
+import { PlusIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { type BrandsListParams, brandsClient } from '../client'
+import type { Brand } from '../types'
+
+interface BrandsListPageProps {
+  /** URL-driven table state (page, sort, search, filters), validated by the route via `resourceSearchSchema`. */
+  searchParams: ResourceSearch
+}
+
 /**
  * Brands index page, rendered by the `brands.index` file route. Uses the
  * dashboard's `<ResourceTable>` for filtering, sorting, pagination, and
@@ -9,17 +21,6 @@
  * in `../index.tsx` (alongside the plugin entry); ResourceTable reads from
  * that registry by tableKey.
  */
-import { type ResourceSearch, ResourceTable } from '@spree/dashboard-core'
-import { Button } from '@spree/dashboard-ui'
-import { PlusIcon } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
-import { brandsClient } from '../client'
-import type { Brand } from '../types'
-
-interface BrandsListPageProps {
-  searchParams: ResourceSearch
-}
-
 export function BrandsListPage({ searchParams }: BrandsListPageProps) {
   const { t } = useTranslation()
 
@@ -29,8 +30,8 @@ export function BrandsListPage({ searchParams }: BrandsListPageProps) {
       queryKey="brands"
       // ResourceTable hands `params` to queryFn as `Record<string, unknown>`
       // (its internal builder doesn't know what each table's API accepts).
-      // We narrow to our client's known param shape at the boundary.
-      queryFn={(params) => brandsClient.list(params as Record<string, never>)}
+      // We narrow to our client's accepted param shape at the boundary.
+      queryFn={(params) => brandsClient.list(params as BrandsListParams)}
       searchParams={searchParams}
       actions={
         <Button size="sm" className="h-[2.125rem]">

--- a/packages/dashboard-plugin-example/src/pages/brands-list.tsx
+++ b/packages/dashboard-plugin-example/src/pages/brands-list.tsx
@@ -2,13 +2,15 @@
  * Brands index page, rendered by the `brands.index` file route. Uses the
  * dashboard's `<ResourceTable>` for filtering, sorting, pagination, and
  * bulk-action chrome — the same UX as core's Products/Customers/Orders pages.
+ * Like those pages, the table is the whole page: the toolbar carries the
+ * title (from the table definition) and the primary action.
  *
  * The table's columns and filters are declared via `defineTable('brands', ...)`
  * in `../index.tsx` (alongside the plugin entry); ResourceTable reads from
  * that registry by tableKey.
  */
-import { PageHeader, type ResourceSearch, ResourceTable } from '@spree/dashboard-core'
-import { Button, ResourceLayout } from '@spree/dashboard-ui'
+import { type ResourceSearch, ResourceTable } from '@spree/dashboard-core'
+import { Button } from '@spree/dashboard-ui'
 import { PlusIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { brandsClient } from '../client'
@@ -22,29 +24,19 @@ export function BrandsListPage({ searchParams }: BrandsListPageProps) {
   const { t } = useTranslation()
 
   return (
-    <ResourceLayout
-      header={
-        <PageHeader
-          title={t('admin.brands_plugin.page.title')}
-          subtitle={t('admin.brands_plugin.page.subtitle')}
-          actions={
-            <Button size="sm">
-              <PlusIcon className="size-4" />
-              {t('admin.brands_plugin.page.new_cta')}
-            </Button>
-          }
-        />
-      }
-      main={
-        <ResourceTable<Brand>
-          tableKey="brands"
-          queryKey="brands"
-          // ResourceTable hands `params` to queryFn as `Record<string, unknown>`
-          // (its internal builder doesn't know what each table's API accepts).
-          // We narrow to our client's known param shape at the boundary.
-          queryFn={(params) => brandsClient.list(params as Record<string, never>)}
-          searchParams={searchParams}
-        />
+    <ResourceTable<Brand>
+      tableKey="brands"
+      queryKey="brands"
+      // ResourceTable hands `params` to queryFn as `Record<string, unknown>`
+      // (its internal builder doesn't know what each table's API accepts).
+      // We narrow to our client's known param shape at the boundary.
+      queryFn={(params) => brandsClient.list(params as Record<string, never>)}
+      searchParams={searchParams}
+      actions={
+        <Button size="sm" className="h-[2.125rem]">
+          <PlusIcon className="size-4" />
+          {t('admin.brands_plugin.page.new_cta')}
+        </Button>
       }
     />
   )


### PR DESCRIPTION
## Summary
Refactors the BrandsListPage to leverage ResourceTable's native toolbar support, eliminating the need for a separate PageHeader and ResourceLayout wrapper. This aligns the example plugin with the core dashboard's UX pattern where the table itself is the whole page.

## Changes
- **Removed layout wrapper**: Deleted `ResourceLayout` and `PageHeader` components; ResourceTable now directly renders with integrated toolbar
- **Moved primary action**: Migrated the "New brand" button from PageHeader to ResourceTable's `actions` prop
- **Removed redundant i18n keys**: Deleted `page.title` and `page.subtitle` translation keys (now sourced from the table definition via `defineTable('brands', ...)`)
- **Updated button styling**: Added `className="h-[2.125rem]"` to match toolbar button height expectations

## Implementation Details
The ResourceTable component now handles both the table chrome (filtering, sorting, pagination, bulk actions) *and* the page toolbar (title from table definition + primary action button), matching the UX of core's Products/Customers/Orders pages. This reduces component nesting and centralizes layout concerns in the table registry.

https://claude.ai/code/session_012o4E9srUHxvs1R7bd3bREz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Brands page layout to use the table as the primary page content, removing the separate header layout.
  * Moved the “New” action button into the table’s toolbar for a more streamlined experience.
  * Removed redundant Brands page title and subtitle text from the page localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->