### PR TITLE
Make storefront_access preference nullable to inherit store default

### DIFF
--- a/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/channels_controller_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Spree::Api::V3::Admin::ChannelsController, type: :controller do
       expect(response).to have_http_status(:ok)
 
       channel.reload
-      expect(channel.preferred_storefront_access).to be_blank
+      expect(channel.preferred_storefront_access).to be_nil
       expect(channel.preferred_guest_checkout).to be_nil
     end
 

--- a/spree/core/app/models/concerns/spree/stores/setup.rb
+++ b/spree/core/app/models/concerns/spree/stores/setup.rb
@@ -55,6 +55,8 @@ module Spree
       # Payments count as set up only once customers can actually pay at
       # storefront checkout: admin-only (back_end) methods and store credit
       # don't complete the task.
+      #
+      # @return [Boolean]
       def payment_method_setup?
         payment_methods.active.storefront_visible.where.not(type: Spree::PaymentMethod::StoreCredit.to_s).any?
       end

--- a/spree/core/app/models/spree/channel/gating.rb
+++ b/spree/core/app/models/spree/channel/gating.rb
@@ -14,10 +14,10 @@ module Spree
       STOREFRONT_ACCESS = %w[public prices_hidden login_required].freeze
 
       included do
-        # Empty -> falls back to the Store-level preference. `guest_checkout` is
-        # `nullable` so a blank write stays nil (inherit) rather than coercing to
-        # false, while an explicit true/false remains a channel override.
-        preference :storefront_access, :string, default: nil
+        # Empty -> falls back to the Store-level preference. Both are `nullable`
+        # so a blank write stays nil (inherit) rather than coercing to "" or
+        # false, while an explicit value remains a channel override.
+        preference :storefront_access, :string, default: nil, nullable: true
         preference :guest_checkout, :boolean, default: nil, nullable: true
 
         validate :storefront_access_must_be_valid

--- a/spree/core/lib/spree/core/preferences/preferable.rb
+++ b/spree/core/lib/spree/core/preferences/preferable.rb
@@ -123,7 +123,13 @@ module Spree::Preferences::Preferable
   def convert_preference_value(value, type, nullable: false)
     case type
     when :string, :text
-      value.to_s
+      # A nullable string keeps "unset" (nil / empty string) as nil so it can
+      # fall back to another value, instead of collapsing it to "".
+      if nullable && (value.nil? || (value.respond_to?(:empty?) && value.empty?))
+        nil
+      else
+        value.to_s
+      end
     when :password
       value.to_s
     when :decimal

--- a/spree/core/spec/models/spree/channel/gating_spec.rb
+++ b/spree/core/spec/models/spree/channel/gating_spec.rb
@@ -24,6 +24,19 @@ RSpec.describe Spree::Channel::Gating, type: :model do
       channel.update!(preferred_storefront_access: 'public')
       expect(channel.resolved_storefront_access).to eq('public')
     end
+
+    it 'clears the override (restores inheritance) when written blank' do
+      store.update!(preferred_storefront_access: 'login_required')
+      channel.update!(preferred_storefront_access: 'public')
+      expect(channel.resolved_storefront_access).to eq('public')
+
+      # A plain string preference would coerce this to "", which is not a
+      # valid posture; the override must instead stay nil so the store value
+      # applies again.
+      channel.update!(preferred_storefront_access: '')
+      expect(channel.preferred_storefront_access).to be_nil
+      expect(channel.resolved_storefront_access).to eq('login_required')
+    end
   end
 
   describe '#resolved_guest_checkout' do


### PR DESCRIPTION
## Summary
Ensures that the `storefront_access` channel preference properly inherits from the store-level default when left unset, by making it nullable and updating the string preference conversion logic to preserve nil values.

## Changes
- **Channel gating preference**: Added `nullable: true` to the `storefront_access` preference definition and updated its comment to clarify that both `storefront_access` and `guest_checkout` use nullable semantics for inheritance
- **Preference value conversion**: Modified `convert_preference_value` in the Preferable concern to handle nullable string preferences — when a string preference is marked nullable and receives nil or an empty string, it now returns nil instead of coercing to an empty string, allowing fallback to store-level defaults
- **Test expectation**: Updated the channels controller spec to expect `nil` instead of a blank value when `storefront_access` is cleared
- **Documentation**: Added a return type annotation (`@return [Boolean]`) to the `payment_method_setup?` method in the Store setup concern

## Implementation Details
The fix addresses the inheritance pattern described in `6.0-channels-catalogs-b2b.md`: channel-level preferences with nil values should fall back to store-level defaults. Previously, string preferences would coerce empty/nil values to empty strings, breaking this fallback chain. The nullable flag now ensures that explicit "unset" states (nil or empty string writes) remain as nil, while explicit values are preserved as channel overrides.

https://claude.ai/code/session_018ud2Fsfy5yZPL8ZDnVowQY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Channel storefront access overrides can now remain unset, so they correctly fall back to the store-level value.
  * Clearing an override preserves a true `nil` (instead of coercing empty inputs), ensuring resolved storefront access re-inherits properly.

* **Documentation**
  * Improved the “Payments count as set up…” setup-check documentation, including explicit return value details.

* **Tests**
  * Added coverage for clearing `preferred_storefront_access` to confirm `nil` behavior and correct inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->