### PR TITLE
Fix backfill_product_tag_tenants rake task

### DIFF
--- a/spree/core/lib/tasks/product_tag_tenants.rake
+++ b/spree/core/lib/tasks/product_tag_tenants.rake
@@ -14,11 +14,9 @@ namespace :spree do
     task backfill_product_tag_tenants: :environment do
       taggings = ActsAsTaggableOn::Tagging.arel_table.name
       products = Spree::Product.table_name
-
       updated = ActsAsTaggableOn::Tagging.
                 where(taggable_type: 'Spree::Product', tenant: nil).
-                joins("INNER JOIN #{products} ON #{products}.id = #{taggings}.taggable_id").
-                update_all("tenant = #{products}.store_id")
+                update_all("tenant = (SELECT store_id FROM #{products} WHERE #{products}.id = #{taggings}.taggable_id)")
 
       puts "  Backfilled tenant on #{updated} product tagging(s)."
     end

--- a/spree/core/spec/lib/tasks/product_tag_tenants_spec.rb
+++ b/spree/core/spec/lib/tasks/product_tag_tenants_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'spree:upgrade:backfill_product_tag_tenants' do
+  subject { Rake::Task[task_name] }
+
+  let(:task_name) { 'spree:upgrade:backfill_product_tag_tenants' }
+
+  before(:all) do
+    Rake::Task.define_task(:environment)
+    load Spree::Core::Engine.root.join('lib', 'tasks', 'product_tag_tenants.rake')
+  end
+
+  before { subject.reenable }
+
+  let!(:store) { Spree::Store.default || create(:store, default: true) }
+  let!(:product) { create(:product, stores: [store], tag_list: ['eco']) }
+
+  def tagging_for(taggable)
+    ActsAsTaggableOn::Tagging.find_by(taggable: taggable, context: 'tags')
+  end
+
+  def downgrade!(tagging)
+    tagging.update_columns(tenant: nil)
+    tagging
+  end
+
+  context 'product tagging created before the tenant backfill' do
+    let!(:tagging) { downgrade!(tagging_for(product)) }
+
+    it "backfills tenant from the product's store_id" do
+      expect { subject.invoke }.to change { tagging.reload.tenant }.from(nil).to(store.id.to_s)
+    end
+
+    it 'is idempotent' do
+      subject.invoke
+      subject.reenable
+      expect { subject.invoke }.not_to change { tagging.reload.tenant }
+    end
+  end
+
+  context 'orphaned tagging whose product no longer exists' do
+    let(:tag) { ActsAsTaggableOn::Tag.create!(name: 'orphan') }
+    let!(:orphan) do
+      tagging = ActsAsTaggableOn::Tagging.new(
+        tag: tag, taggable_type: 'Spree::Product', taggable_id: 0, context: 'tags', tenant: nil
+      )
+      tagging.save!(validate: false) # taggable presence is validated; forge a row pointing at a deleted product
+      tagging
+    end
+
+    it 'leaves tenant nil (the store_id subquery resolves to NULL)' do
+      expect { subject.invoke }.not_to change { orphan.reload.tenant }.from(nil)
+    end
+  end
+end


### PR DESCRIPTION
Fixing rake task which is called when bumping to Spree 5.6,
errors is PostgreSQL specific, does not occur on MySQL:

```
   Step 5/5 [product_tag_tenants]
      Backfill tenant on product taggings
      > bin/rake spree:upgrade:backfill_product_tag_tenants
      Sets the tenant column on existing Spree::Product taggings from each
      product's store_id, so product tag autocomplete is bounded to the owning
      store (matching Spree::Order). New product taggings tenant themselves;
      only rows created before the upgrade need this. Until it runs, older
      product tags are hidden from the store-scoped tag vocabulary.
      Running spree:upgrade:backfill_product_tag_tenants...
  rake aborted!
  ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "spree_products" (ActiveRecord::StatementInvalid)
  LINE 1: UPDATE "spree_taggings" SET tenant = spree_products.store_id...
                                               ^
  /Users/kacpermekarski/.rbenv/versions/3.3.0/bin/bundle:25:in `load'
  /Users/kacpermekarski/.rbenv/versions/3.3.0/bin/bundle:25:in `<main>'

  Caused by:
  PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "spree_products" (PG::UndefinedTable)
  LINE 1: UPDATE "spree_taggings" SET tenant = spree_products.store_id...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant backfilling for product tags by deriving tenant information directly from the associated product.
  * Orphaned product taggings remain unchanged instead of receiving an incorrect tenant.
  * Re-running the backfill remains safe and does not alter already-populated records.

* **Tests**
  * Added coverage for successful backfills, idempotent execution, and orphaned taggings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->