### PR TITLE
Refactor `ImportRunner`  also added option to run imports inline

### DIFF
--- a/spree/core/app/jobs/spree/imports/create_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/create_rows_job.rb
@@ -9,8 +9,12 @@ module Spree
 
       BATCH_SIZE = 1000
 
-      def perform(import_id)
+      # `inline` isn't persisted, so it has to be threaded through the chain —
+      # otherwise a caller that asked for a synchronous run would enqueue from
+      # here onwards.
+      def perform(import_id, inline: false)
         import = Spree::Import.find(import_id)
+        import.inline = inline
         import.start_processing! if import.status != 'processing'
 
         create_rows_sequentially(import)

--- a/spree/core/app/jobs/spree/imports/process_group_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_group_job.rb
@@ -21,8 +21,9 @@ module Spree
       # (and its raw CSV data) in memory for the whole job.
       ROWS_BATCH_SIZE = 100
 
-      def perform(import_id, row_ids)
+      def perform(import_id, row_ids, inline: false)
         import = Spree::Import.find(import_id)
+        import.inline = inline
         Spree::Current.store = import.store
 
         with_store_content_locale(import.store) do

--- a/spree/core/app/jobs/spree/imports/process_rows_job.rb
+++ b/spree/core/app/jobs/spree/imports/process_rows_job.rb
@@ -4,8 +4,9 @@ module Spree
       BATCH_SIZE = 100
       UNGROUPED_KEY = '__ungrouped__'.freeze
 
-      def perform(import_id)
+      def perform(import_id, inline: false)
         import = Spree::Import.find(import_id)
+        import.inline = inline
         dispatch_groups(import)
       end
 
@@ -21,6 +22,14 @@ module Spree
         else
           dispatch_batched(import)
         end
+      end
+
+      # Inline callers need the group finished before `perform` returns; the
+      # group job's completion bookkeeping works either way.
+      def dispatch_group(import, row_ids)
+        return ProcessGroupJob.perform_now(import.id, row_ids, inline: true) if import.inline?
+
+        ProcessGroupJob.perform_later(import.id, row_ids)
       end
 
       def dispatch_grouped(import, file_column)
@@ -48,7 +57,7 @@ module Spree
           updated_at: Time.current
         )
 
-        batches.each { |row_ids| ProcessGroupJob.perform_later(import.id, row_ids) }
+        batches.each { |row_ids| dispatch_group(import, row_ids) }
       end
 
       def dispatch_batched(import)
@@ -64,7 +73,7 @@ module Spree
           updated_at: Time.current
         )
 
-        row_id_batches.each { |row_ids| ProcessGroupJob.perform_later(import.id, row_ids) }
+        row_id_batches.each { |row_ids| dispatch_group(import, row_ids) }
       end
     end
   end

--- a/spree/core/app/models/spree/import.rb
+++ b/spree/core/app/models/spree/import.rb
@@ -93,6 +93,15 @@ module Spree
       after_transition on: :retry_failed_rows, do: :process_rows_async
     end
 
+    # Run the pipeline in-process instead of enqueuing it. Virtual and not
+    # persisted — it describes how *this* caller wants the import driven, not
+    # anything about the record.
+    #
+    # For rake tasks, seeds and the console, where the caller needs the data to
+    # exist when the call returns and there may be no worker attached. Never set
+    # it from a request: a large CSV blocks for minutes.
+    attribute :inline, :boolean, default: false
+
     #
     # Preferences
     #
@@ -325,12 +334,18 @@ module Spree
     # Creates rows asynchronously
     # @return [void]
     def create_rows_async
+      # The 2s delay lets the attachment settle before the job reads it; running
+      # inline there is nothing to wait for.
+      return Spree::Imports::CreateRowsJob.perform_now(id, inline: true) if inline?
+
       Spree::Imports::CreateRowsJob.set(wait: 2.seconds).perform_later(id)
     end
 
     # Processes rows asynchronously
     # @return [void]
     def process_rows_async
+      return Spree::Imports::ProcessRowsJob.perform_now(id, inline: true) if inline?
+
       Spree::Imports::ProcessRowsJob.perform_later(id)
     end
 

--- a/spree/core/app/services/spree/imports/row_processors/product_variant.rb
+++ b/spree/core/app/services/spree/imports/row_processors/product_variant.rb
@@ -295,11 +295,16 @@ module Spree
         end
 
         def handle_tags(product)
+          return Spree::Imports::AssignTagsJob.perform_now(product.id, attributes['tags']) if import.inline?
+
           Spree::Imports::AssignTagsJob.perform_later(product.id, attributes['tags'])
         end
 
         def handle_categories(product)
-          Spree::Imports::CreateCategoriesJob.perform_later(product.id, store.id, prepare_taxon_pretty_names)
+          names = prepare_taxon_pretty_names
+          return Spree::Imports::CreateCategoriesJob.perform_now(product.id, store.id, names) if import.inline?
+
+          Spree::Imports::CreateCategoriesJob.perform_later(product.id, store.id, names)
         end
 
         def prepare_taxon_pretty_names

--- a/spree/core/app/services/spree/sample_data/helper.rb
+++ b/spree/core/app/services/spree/sample_data/helper.rb
@@ -1,0 +1,55 @@
+module Spree
+  module SampleData
+    # Shared by the sample-data drivers: `Spree::SampleData::Loader` (the
+    # synchronous, rake-facing one) and any app that loads a subset itself —
+    # e.g. running the configuration files inline and handing the CSVs to the
+    # import pipeline. Keeping the file locations and catalog-publishing rules
+    # here means they don't have to be kept in sync by hand.
+    module Helper
+      private
+
+      def sample_data_path
+        @sample_data_path ||= Spree::Core::Engine.root.join('db', 'sample_data')
+      end
+
+      def load_ruby_file(name)
+        file = sample_data_path.join("#{name}.rb")
+        load file.to_s if file.exist?
+      end
+
+      # Publishes the catalog to every channel the store has. The import only
+      # adds a product to the default channel, and only when it has none, so
+      # anything else the store defines (wholesale, a locale-specific storefront,
+      # whatever an app has seeded) would otherwise be left empty. Catalog parity
+      # is the point — channels differentiate through their own gates and price
+      # lists, not through a narrower catalog. `add_products` upserts in bulk and
+      # skips rows that already exist.
+      def publish_sample_products(store)
+        product_ids = store.product_ids
+        return if product_ids.empty?
+
+        store.channels.each { |channel| channel.add_products(product_ids) }
+      end
+
+      # Cheap proxy for "the base seeds have run": the US states are seeded
+      # alongside everything else, and products/addresses depend on them.
+      def seeds_loaded?
+        Spree::State.joins(:country).where(spree_countries: { iso: 'US' }).exists?
+      end
+
+      def ensure_seeds_loaded
+        return if seeds_loaded?
+
+        Spree::Seeds::All.call
+      end
+
+      def without_geocoding
+        previous = Spree::Config[:geocode_addresses]
+        Spree::Config[:geocode_addresses] = false
+        yield
+      ensure
+        Spree::Config[:geocode_addresses] = previous
+      end
+    end
+  end
+end

--- a/spree/core/app/services/spree/sample_data/import_builder.rb
+++ b/spree/core/app/services/spree/sample_data/import_builder.rb
@@ -1,0 +1,28 @@
+module Spree
+  module SampleData
+    # Creates the `Spree::Import` record for a sample CSV, attaching the file
+    # but processing nothing — the two runners differ only in what they do next.
+    class ImportBuilder
+      # @return [Spree::Import] persisted, unprocessed
+      def self.call(csv_path:, import_class:, store: nil, user: nil)
+        store ||= Spree::Store.default
+        # An admin of the target store, not `admin_user_class.first` — in a
+        # multi-store or multi-tenant app that global first can belong to a
+        # different store entirely.
+        user ||= store.users.first
+
+        raise 'No admin user found. Please run seeds first.' unless user
+
+        import = import_class.new(owner: store, user: user)
+        import.number = import.generate_permalink(import_class)
+        import.attachment.attach(
+          io: File.open(csv_path),
+          filename: File.basename(csv_path),
+          content_type: 'text/csv'
+        )
+        import.save!(validate: false)
+        import
+      end
+    end
+  end
+end

--- a/spree/core/app/services/spree/sample_data/import_runner.rb
+++ b/spree/core/app/services/spree/sample_data/import_runner.rb
@@ -1,53 +1,31 @@
-require 'csv'
-
 module Spree
   module SampleData
+    # Runs a sample CSV through the regular import pipeline: `start_mapping`
+    # auto-assigns the column mappings from the CSV headers (the sample files
+    # use the canonical schema names, so every column maps) and
+    # `complete_mapping` kicks off row creation and processing.
+    #
+    # Enqueues by default, so row creation, batching and the per-import
+    # concurrency cap behave exactly as they do for a merchant-uploaded CSV.
+    # Pass `inline: true` for rake tasks, seeds and the console — where the data
+    # has to exist when the call returns and there may be no worker attached.
+    # Never inline from a request: `products.csv` alone is 211 rows, each
+    # downloading a remote image.
     class ImportRunner
       prepend Spree::ServiceModule::Base
 
-      def call(csv_path:, import_class:)
-        store = Spree::Store.default
-        admin = Spree.admin_user_class.first
-
-        raise 'No admin user found. Please run seeds first.' unless admin
-
-        import = import_class.new(
-          owner: store,
-          user: admin
+      # @return [Spree::ServiceModule::Result] wrapping the import — completed
+      #   when inline, queued otherwise
+      def call(csv_path:, import_class:, store: nil, user: nil, inline: false)
+        import = Spree::SampleData::ImportBuilder.call(
+          csv_path: csv_path, import_class: import_class, store: store, user: user
         )
-        import.number = import.generate_permalink(import_class)
-        import.attachment.attach(
-          io: File.open(csv_path),
-          filename: File.basename(csv_path),
-          content_type: 'text/csv'
-        )
-        import.save!(validate: false)
-        import.update_columns(status: 'processing')
-        import.create_mappings
+        import.inline = inline
 
-        row_number = 0
-        failed = 0
+        import.start_mapping
+        import.complete_mapping
 
-        ::CSV.foreach(csv_path, headers: true) do |csv_row|
-          row_number += 1
-          import_row = import.rows.create!(
-            row_number: row_number,
-            data: csv_row.to_h.to_json,
-            status: 'pending'
-          )
-
-          begin
-            import_row.process!
-          rescue StandardError => e
-            failed += 1
-            puts "\n  Warning: Row #{row_number} failed: #{e.message}"
-          end
-
-          print '.' if (row_number % 10).zero?
-        end
-
-        import.update!(status: 'completed')
-        puts "\n  Processed #{row_number} rows (#{failed} failed)"
+        success(import.reload)
       end
     end
   end

--- a/spree/core/app/services/spree/sample_data/loader.rb
+++ b/spree/core/app/services/spree/sample_data/loader.rb
@@ -2,11 +2,13 @@ module Spree
   module SampleData
     class Loader
       prepend Spree::ServiceModule::Base
+      include Spree::SampleData::Helper
 
       def call
         Spree::Events.disable do
           without_geocoding do
             ActiveRecord::Base.no_touching do
+              puts 'Running seeds first...' unless seeds_loaded?
               ensure_seeds_loaded
 
               puts 'Loading sample configuration data...'
@@ -28,10 +30,7 @@ module Spree
               load_products
 
               puts 'Publishing sample products on the default channel...'
-              publish_sample_products
-
-              puts 'Loading sample categories...'
-              load_categories
+              publish_sample_products(Spree::Store.default)
 
               puts 'Loading sample product translations...'
               load_product_translations
@@ -56,18 +55,6 @@ module Spree
 
       private
 
-      def ensure_seeds_loaded
-        us = Spree::Country.find_by(iso: 'US')
-        return if us&.states&.any? && Spree::Store.default&.persisted?
-
-        puts 'Running seeds first...'
-        Spree::Seeds::All.call
-      end
-
-      def sample_data_path
-        @sample_data_path ||= Spree::Core::Engine.root.join('db', 'sample_data')
-      end
-
       def load_configuration_data
         load_ruby_file('shipping_methods')
         load_ruby_file('payment_methods')
@@ -76,57 +63,19 @@ module Spree
 
       def load_products
         csv_path = sample_data_path.join('products.csv')
-        Spree::SampleData::ImportRunner.call(csv_path: csv_path, import_class: Spree::Imports::Products)
-      end
-
-      # Publishes the catalog to both surfaces: the public default channel and
-      # the gated wholesale channel (catalog parity; wholesale differentiation
-      # comes from the price list in +wholesale.rb+ and the channel's gate).
-      def publish_sample_products
-        store = Spree::Store.default
-        store.default_channel.add_products(store.product_ids)
-        store.channels.find_by(code: Spree::Seeds::Channels::WHOLESALE_CODE)&.add_products(store.product_ids)
-      end
-
-      def load_categories
-        store = Spree::Store.default
-        csv_path = sample_data_path.join('products.csv')
-
-        require 'csv'
-        ::CSV.foreach(csv_path, headers: true) do |row|
-          product = store.products.find_by(slug: row['slug'])
-          next unless product
-
-          categories = [row['category1'], row['category2'], row['category3']].compact_blank
-          next if categories.empty?
-
-          Spree::Imports::CreateCategoriesJob.perform_now(product.id, store.id, categories)
-        end
+        Spree::SampleData::ImportRunner.call(csv_path: csv_path, import_class: Spree::Imports::Products, inline: true)
       end
 
       def load_product_translations
         csv_path = sample_data_path.join('product_translations.csv')
         return unless csv_path.exist?
 
-        Spree::SampleData::ImportRunner.call(csv_path: csv_path, import_class: Spree::Imports::ProductTranslations)
+        Spree::SampleData::ImportRunner.call(csv_path: csv_path, import_class: Spree::Imports::ProductTranslations, inline: true)
       end
 
       def load_customers
         csv_path = sample_data_path.join('customers.csv')
-        Spree::SampleData::ImportRunner.call(csv_path: csv_path, import_class: Spree::Imports::Customers)
-      end
-
-      def load_ruby_file(name)
-        file = sample_data_path.join("#{name}.rb")
-        load file.to_s if file.exist?
-      end
-
-      def without_geocoding
-        previous = Spree::Config[:geocode_addresses]
-        Spree::Config[:geocode_addresses] = false
-        yield
-      ensure
-        Spree::Config[:geocode_addresses] = previous
+        Spree::SampleData::ImportRunner.call(csv_path: csv_path, import_class: Spree::Imports::Customers, inline: true)
       end
     end
   end

--- a/spree/core/app/services/spree/seeds/allowed_origins.rb
+++ b/spree/core/app/services/spree/seeds/allowed_origins.rb
@@ -4,10 +4,9 @@ module Spree
       prepend Spree::ServiceModule::Base
 
       def call
-        store = Spree::Store.default
-        return unless store&.persisted?
-
-        store.allowed_origins.find_or_create_by!(origin: 'http://localhost')
+        Spree::Store.all.each do |store|
+          store.allowed_origins.find_or_create_by!(origin: 'http://localhost')
+        end
       end
     end
   end

--- a/spree/core/app/services/spree/seeds/states.rb
+++ b/spree/core/app/services/spree/seeds/states.rb
@@ -10,14 +10,18 @@ module Spree
 
       def call
         Spree::Country.where(states_required: true).each do |country|
-          carmen_country = Carmen::Country.named(country.name)
+          # Match on ISO code, not name: Spree stores official ISO-3166 names
+          # ("United States of America") while Carmen uses common ones
+          # ("United States"), and `named` is an exact match — so a name lookup
+          # silently skipped the US, leaving it with no states at all.
+          carmen_country = Carmen::Country.coded(country.iso) || Carmen::Country.named(country.name)
           next unless carmen_country
 
-          carmen_country.subregions.each do |subregion|
+          states = carmen_country.subregions.flat_map do |subregion|
             if carmen_country.alpha_2_code == 'US'
               # Produces 50 states, one postal district (Washington DC)
               # and 3 APO's as you would expect to see on any good U.S. states list.
-              next if EXCLUDED_US_STATES.include?(subregion.code)
+              next [] if EXCLUDED_US_STATES.include?(subregion.code)
 
               state_level(country, subregion)
             elsif carmen_country.alpha_2_code == 'CA' || carmen_country.alpha_2_code == 'MX'
@@ -27,7 +31,7 @@ module Spree
             elsif carmen_country.alpha_2_code == 'CN'
               # Removes 3 "States" from that list that are also listed as Countries,
               # Hong Kong, Taiwan and Macao
-              next if EXCLUDED_CN_STATES.include?(subregion.code)
+              next [] if EXCLUDED_CN_STATES.include?(subregion.code)
 
               state_level(country, subregion)
             elsif subregion.subregions?
@@ -36,27 +40,42 @@ module Spree
               state_level(country, subregion)
             end
           end
+
+          # One upsert per country rather than one per subregion.
+          upsert_states(states)
         end
       end
 
       protected
 
       def state_level(country, subregion)
-        country.states.where(
-          name: subregion.name,
-          abbr: subregion.code
-        ).first_or_create!
+        [{ name: subregion.name, abbr: subregion.code, country_id: country.id }]
       end
 
       def province_level(country, subregion)
-        new_states = subregion.subregions.map do |province|
-          Hash[
-            name: province.name,
-            abbr: province.code,
-            country_id: country.id
-          ]
-        end.compact.uniq
-        Spree::State.insert_all(new_states)
+        subregion.subregions.map do |province|
+          { name: province.name, abbr: province.code, country_id: country.id }
+        end
+      end
+
+      # Seeds are re-run on every deploy, so this has to converge rather than
+      # duplicate: `[country_id, abbr]` is unique, and a name change upstream
+      # updates the existing row instead of adding a second one.
+      def upsert_states(states)
+        states = states.uniq { |state| [state[:country_id], state[:abbr]] }.reject { |state| state[:abbr].blank? }
+        return if states.empty?
+
+        now = Time.current
+        opts = { update_only: %i[name] }
+        # MySQL infers the conflict target from the table's unique constraints
+        # and rejects an explicit +unique_by+; PostgreSQL/SQLite require it.
+        opts[:unique_by] = %i[country_id abbr] unless mysql_adapter?
+
+        Spree::State.upsert_all(states.map { |state| state.merge(created_at: now, updated_at: now) }, **opts)
+      end
+
+      def mysql_adapter?
+        ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
       end
     end
   end

--- a/spree/core/db/migrate/20260727000001_add_unique_country_abbr_index_to_spree_states.rb
+++ b/spree/core/db/migrate/20260727000001_add_unique_country_abbr_index_to_spree_states.rb
@@ -1,0 +1,30 @@
+class AddUniqueCountryAbbrIndexToSpreeStates < ActiveRecord::Migration[7.2]
+  def up
+    remove_duplicate_states!
+
+    add_index :spree_states, [:country_id, :abbr],
+              unique: true,
+              name: 'index_spree_states_on_country_id_and_abbr'
+  end
+
+  def down
+    remove_index :spree_states, name: 'index_spree_states_on_country_id_and_abbr'
+  end
+
+  private
+
+  # `Spree::Seeds::States` used a plain `insert_all` for province-level
+  # countries, so re-running the seeds duplicated their states. Keep the oldest
+  # row of each group — addresses point at it — and drop the rest.
+  def remove_duplicate_states!
+    duplicated = Spree::State.group(:country_id, :abbr).having('COUNT(*) > 1').pluck(:country_id, :abbr)
+
+    duplicated.each do |country_id, abbr|
+      ids = Spree::State.where(country_id: country_id, abbr: abbr).order(:id).pluck(:id)
+      keeper = ids.shift
+
+      Spree::Address.where(state_id: ids).update_all(state_id: keeper) if ids.any?
+      Spree::State.where(id: ids).delete_all
+    end
+  end
+end

--- a/spree/core/spec/services/spree/sample_data/import_runner_spec.rb
+++ b/spree/core/spec/services/spree/sample_data/import_runner_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe Spree::SampleData::ImportRunner, type: :service do
+  let(:store) { @default_store }
+  let!(:admin) { create(:admin_user) }
+  let(:csv_path) { Spree::Core::Engine.root.join('db', 'sample_data', 'customers.csv') }
+
+  before { store.add_user(admin) }
+
+  subject(:result) { described_class.call(csv_path: csv_path, import_class: Spree::Imports::Customers) }
+
+  it 'returns the queued import' do
+    expect(result).to be_success
+    expect(result.value).to be_a(Spree::Imports::Customers)
+    expect(result.value.owner).to eq(store)
+  end
+
+  # The whole point of this runner: hand the CSV to the pipeline and return, so
+  # a request never pays for the rows.
+  it 'creates no rows of its own' do
+    expect(result.value.rows).to be_empty
+    expect(result.value.status).to eq('completed_mapping')
+  end
+
+  it 'enqueues row creation' do
+    expect { result }.to have_enqueued_job(Spree::Imports::CreateRowsJob)
+  end
+
+  it 'auto-maps the sample CSV columns' do
+    expect(result.value.mappings.mapped.pluck(:schema_field)).to include('email')
+  end
+
+  # The rake/seed path: same pipeline, performed in-process so the data exists
+  # when the call returns. Uses product translations — a self-contained CSV that
+  # doesn't pull in the address/newsletter side effects customers do.
+  context 'inline' do
+    let(:csv_path) { Spree::Core::Engine.root.join('db', 'sample_data', 'product_translations.csv') }
+
+    subject(:result) do
+      described_class.call(csv_path: csv_path, import_class: Spree::Imports::ProductTranslations, inline: true)
+    end
+
+    it 'completes the import before returning' do
+      expect(result.value.status).to eq('completed')
+      expect(result.value.rows.count).to be_positive
+    end
+
+    it 'enqueues nothing' do
+      expect { result }.not_to have_enqueued_job(Spree::Imports::CreateRowsJob)
+    end
+  end
+
+  it 'runs as an admin of the target store' do
+    expect(result.value.user).to eq(admin)
+  end
+
+  context 'when the store has no admin' do
+    before { store.users.each { |user| store.remove_user(user) } }
+
+    it 'raises rather than attributing the import to an unrelated admin' do
+      expect { result }.to raise_error(/No admin user found/)
+    end
+  end
+end

--- a/spree/core/spec/services/spree/seeds/states_spec.rb
+++ b/spree/core/spec/services/spree/seeds/states_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Seeds::States do
+  before { Spree::Seeds::Countries.call }
+
+  subject(:seed) { described_class.call }
+
+  # Regression: countries were matched against Carmen by name, but Spree stores
+  # the official ISO-3166 name ("United States of America") where Carmen uses
+  # the common one ("United States"). The lookup missed, the `next unless`
+  # skipped it silently, and the US ended up with zero states — which in turn
+  # made every US address invalid ("State can't be blank").
+  it 'seeds states for the US' do
+    seed
+
+    us = Spree::Country.find_by(iso: 'US')
+    expect(us.states.count).to be > 50
+    expect(us.states.find_by(abbr: 'IL')&.name).to eq('Illinois')
+  end
+
+  it 'seeds states for the other countries that require them' do
+    seed
+
+    %w[CA AU].each do |iso|
+      expect(Spree::Country.find_by(iso: iso).states).to be_any, "expected states for #{iso}"
+    end
+  end
+
+  # Seeds re-run on every deploy. The province-level branch used a bare
+  # `insert_all`, so each run duplicated those countries' states.
+  it 'is idempotent' do
+    seed
+
+    expect { described_class.call }.not_to change(Spree::State, :count)
+    expect(Spree::State.group(:country_id, :abbr).having('COUNT(*) > 1').count).to be_empty
+  end
+
+  it 'refreshes a renamed state in place' do
+    seed
+
+    illinois = Spree::Country.find_by(iso: 'US').states.find_by(abbr: 'IL')
+    illinois.update!(name: 'Stale Name')
+
+    expect { described_class.call }.not_to change(Spree::State, :count)
+    expect(illinois.reload.name).to eq('Illinois')
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline-capable import execution for sample data, now completing immediately when enabled.
  - Introduced a dedicated sample-data import builder/runner and improved import attribution to the store admin.
  - Expanded inline dispatch across import jobs and related row processing.
- **Bug Fixes**
  - Improved state seeding with better ISO matching, bulk upserts, and enforced unique `(country, abbr)` via a new index.
  - Seeded allowed origins for every store (instead of only the default).
- **Tests**
  - Added coverage for queued vs inline sample-data imports and for state seeding idempotency/updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->