### PR TITLE
Fix guest credit card fingerprint validation

### DIFF
--- a/spree/core/app/models/spree/credit_card.rb
+++ b/spree/core/app/models/spree/credit_card.rb
@@ -38,9 +38,9 @@ module Spree
     end
 
     # Prevents saving the same physical card (same gateway fingerprint + expiry)
-    # twice for a user and payment method. Skipped when the gateway does not
-    # provide a fingerprint.
-    validate :fingerprint_not_duplicated, if: -> { fingerprint.present? }
+    # twice for a user and payment method. Guest payment sources are not saved
+    # cards owned by a customer, so they are excluded from this validation.
+    validate :fingerprint_not_duplicated, if: -> { fingerprint.present? && user_id.present? }
 
     scope :with_payment_profile, -> { where.not(gateway_customer_profile_id: nil) }
     scope :capturable, -> { where.not(gateway_customer_profile_id: nil).or(where.not(gateway_payment_profile_id: nil)) }

--- a/spree/core/spec/models/spree/credit_card_spec.rb
+++ b/spree/core/spec/models/spree/credit_card_spec.rb
@@ -175,6 +175,13 @@ describe Spree::CreditCard, type: :model do
       expect(build_duplicate(payment_method: create(:credit_card_payment_method))).to be_valid
     end
 
+    it 'allows the same fingerprint for guest payment sources' do
+      create(:credit_card, user: nil, payment_method: payment_method,
+                           fingerprint: 'FZqjhq46SWprIY8i', month: 11, year: 2030)
+
+      expect(build_duplicate(user: nil)).to be_valid
+    end
+
     it 'does not enforce uniqueness when the fingerprint is missing' do
       create(:credit_card, user: user, payment_method: payment_method, fingerprint: nil, month: 11, year: 2030)
       expect(build_duplicate(fingerprint: nil)).to be_valid


### PR DESCRIPTION
Spree::CreditCard fingerprint deduplication is intended for customer-owned saved cards. Guest checkout sources have no user_id, but the validation currently groups all NULL user IDs together and rejects retries using the same gateway card fingerprint.

Skip fingerprint deduplication for guest payment sources while keeping the existing validation and database unique index for customer-owned cards. Add a regression spec covering repeated guest payment sources.

No migration is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guest payment cards can now reuse the same card fingerprint without being incorrectly rejected as duplicates.
  * Duplicate fingerprint validation continues to apply to cards associated with a user.

* **Tests**
  * Added coverage confirming that duplicate guest payment sources remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->