### PR TITLE
Restrict cancelled order management

### DIFF
--- a/spree/admin/app/controllers/spree/admin/orders/adjustments_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/orders/adjustments_controller.rb
@@ -11,13 +11,12 @@ module Spree
 
         # GET /admin/orders/:order_id/adjustments/new
         def new
-          @adjustment = @order.adjustments.new
+          @adjustment = build_adjustment
         end
 
         # POST /admin/orders/:order_id/adjustments
         def create
-          @adjustment = @order.adjustments.new(permitted_resource_params)
-          @adjustment.order = @order
+          @adjustment = build_adjustment(permitted_resource_params)
           @adjustment.label = params.dig(:adjustment, :label).presence || Spree.t(:manual_adjustment)
           @adjustment.state = 'closed'
 
@@ -109,6 +108,13 @@ module Spree
         def load_adjustment
           @adjustment = @order.all_adjustments.find_by_prefix_id!(params[:id])
           authorize! action, @adjustment
+        end
+
+        def build_adjustment(attributes = {})
+          @order.adjustments.new(attributes).tap do |adjustment|
+            adjustment.order = @order
+            authorize! :create, adjustment
+          end
         end
 
         def permitted_resource_params

--- a/spree/admin/app/controllers/spree/admin/orders/order_promotions_controller.rb
+++ b/spree/admin/app/controllers/spree/admin/orders/order_promotions_controller.rb
@@ -15,6 +15,7 @@ module Spree
         # POST /admin/orders/:order_id/order_promotions
         def create
           authorize! :update, @order
+          authorize! :create, @order.order_promotions.new(order: @order)
 
           @order.coupon_code = params[:coupon_code]
 
@@ -33,6 +34,7 @@ module Spree
         # DELETE /admin/orders/:order_id/promotions/:id
         def destroy
           authorize! :update, @order
+          authorize! :destroy, @order_promotion
 
           coupon_code = @order_promotion.code.presence || @order_promotion.name
 

--- a/spree/admin/spec/controllers/spree/admin/orders/adjustments_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/orders/adjustments_controller_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe Spree::Admin::Orders::AdjustmentsController do
       expect(response).to be_successful
       expect(response).to render_template(:new)
     end
+
+    context 'for a canceled order' do
+      let(:order) { create(:order_with_line_items, store: store, state: 'canceled') }
+
+      it 'denies access' do
+        subject
+        expect(response).to redirect_to spree.admin_forbidden_path
+      end
+    end
   end
 
   describe '#create' do
@@ -30,6 +39,19 @@ RSpec.describe Spree::Admin::Orders::AdjustmentsController do
       it 'responds with turbo_stream' do
         subject
         expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+      end
+    end
+
+    context 'for a canceled order' do
+      subject { post :create, params: { order_id: order.to_param, adjustment: adjustment_params } }
+
+      let(:order) { create(:order_with_line_items, store: store, state: 'canceled') }
+
+      it 'does not create an adjustment' do
+        expect { subject }.not_to change(Spree::Adjustment, :count)
+
+        expect(flash[:error]).to eq Spree.t(:authorization_failure)
+        expect(response).to redirect_to spree.admin_forbidden_path
       end
     end
   end

--- a/spree/admin/spec/controllers/spree/admin/orders/order_promotions_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/orders/order_promotions_controller_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe Spree::Admin::Orders::OrderPromotionsController do
         expect(flash[:error]).to be_present
       end
     end
+
+    context 'for a canceled order' do
+      subject { post :create, params: { order_id: order.to_param, coupon_code: coupon_code }, format: :turbo_stream }
+
+      let(:order) { create(:order_with_line_items, store: store, state: 'canceled') }
+      let(:promotion) { create(:promotion, :with_order_adjustment, code: 'TESTCODE') }
+      let(:coupon_code) { promotion.code }
+
+      it 'does not apply the promotion' do
+        expect { subject }.not_to change { order.order_promotions.count }
+
+        expect(flash[:error]).to eq Spree.t(:authorization_failure)
+        expect(response).to redirect_to spree.admin_forbidden_path
+      end
+    end
   end
 
   describe '#destroy' do
@@ -105,6 +120,28 @@ RSpec.describe Spree::Admin::Orders::OrderPromotionsController do
         subject
         expect(assigns(:handler)).to be_a(Spree::PromotionHandler::Coupon)
         expect(assigns(:handler)).to be_successful
+      end
+    end
+
+    context 'for a canceled order' do
+      subject { delete :destroy, params: { order_id: order.to_param, id: order_promotion.id }, format: :turbo_stream }
+
+      let(:order) { create(:order_with_line_items, store: store) }
+      let(:promotion) { create(:promotion, :with_order_adjustment, code: 'REMOVE') }
+      let(:order_promotion) { order.order_promotions.find_by(promotion: promotion) }
+
+      before do
+        order.coupon_code = promotion.code
+        Spree::PromotionHandler::Coupon.new(order).apply
+        order.update_column(:state, 'canceled')
+        order.reload
+      end
+
+      it 'does not remove the promotion' do
+        expect { subject }.not_to change { order.order_promotions.count }
+
+        expect(flash[:error]).to eq Spree.t(:authorization_failure)
+        expect(response).to redirect_to spree.admin_forbidden_path
       end
     end
   end

--- a/spree/core/app/models/spree/permission_sets/base.rb
+++ b/spree/core/app/models/spree/permission_sets/base.rb
@@ -42,7 +42,7 @@ module Spree
       #
       # @return [void]
       def restrict_cancelled_order_management!
-        RESTRICTED_MODELS.each do |klass|
+        [Spree::LineItem, Spree::Adjustment, Spree::OrderPromotion].each do |klass|
           cannot [:create, :edit, :destroy], klass do |record|
             record.order.canceled?
           end

--- a/spree/core/app/models/spree/permission_sets/base.rb
+++ b/spree/core/app/models/spree/permission_sets/base.rb
@@ -38,6 +38,17 @@ module Spree
 
       protected
 
+      # Disallows managing order-owned records once their order is canceled.
+      #
+      # @return [void]
+      def restrict_cancelled_order_management!
+        RESTRICTED_MODELS.each do |klass|
+          cannot [:create, :edit, :destroy], klass do |record|
+            record.order.canceled?
+          end
+        end
+      end
+
       # Delegates the `can` method to the ability instance.
       #
       # @param args [Array] arguments to pass to CanCan::Ability#can

--- a/spree/core/app/models/spree/permission_sets/base.rb
+++ b/spree/core/app/models/spree/permission_sets/base.rb
@@ -19,6 +19,8 @@
 module Spree
   module PermissionSets
     class Base
+      RESTRICTED_MODELS = [Spree::LineItem, Spree::Adjustment, Spree::OrderPromotion].freeze
+
       # @return [CanCan::Ability] the ability instance to add permissions to
       attr_reader :ability
 
@@ -42,8 +44,8 @@ module Spree
       #
       # @return [void]
       def restrict_cancelled_order_management!
-        [Spree::LineItem, Spree::Adjustment, Spree::OrderPromotion].each do |klass|
-          cannot [:create, :edit, :destroy], klass do |record|
+        RESTRICTED_MODELS.each do |klass|
+          cannot [:create, :edit, :update, :destroy], klass do |record|
             record.order.canceled?
           end
         end

--- a/spree/core/app/models/spree/permission_sets/order_management.rb
+++ b/spree/core/app/models/spree/permission_sets/order_management.rb
@@ -27,6 +27,8 @@ module Spree
         can :cancel, Spree::Order, &:allow_cancel?
         cannot :destroy, Spree::Order
         can :destroy, Spree::Order, &:can_be_deleted?
+
+        restrict_cancelled_order_management!
       end
     end
   end

--- a/spree/core/app/models/spree/permission_sets/super_user.rb
+++ b/spree/core/app/models/spree/permission_sets/super_user.rb
@@ -22,6 +22,8 @@ module Spree
 
         # Protect the admin role from modification
         cannot [:update, :destroy], Spree::Role, name: ['admin']
+
+        restrict_cancelled_order_management!
       end
     end
   end

--- a/spree/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -85,9 +85,6 @@ RSpec.describe Spree::PermissionSets::OrderManagement do
       let(:active_order) { build(:order) }
 
       before do
-        # OrderPromotion has no positive grant in this set; grant it so the
-        # cannot-restriction has something to override, then re-activate so the
-        # restriction is defined last and takes precedence.
         ability.can :manage, Spree::OrderPromotion
         permission_set.activate!
         allow(canceled_order).to receive(:canceled?).and_return(true)

--- a/spree/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -79,5 +79,39 @@ RSpec.describe Spree::PermissionSets::OrderManagement do
         expect(ability.can?(:destroy, non_deletable_order)).to be false
       end
     end
+
+    context 'order-owned record restrictions on canceled orders' do
+      let(:canceled_order) { build(:order) }
+      let(:active_order) { build(:order) }
+
+      before do
+        # OrderPromotion has no positive grant in this set; grant it so the
+        # cannot-restriction has something to override, then re-activate so the
+        # restriction is defined last and takes precedence.
+        ability.can :manage, Spree::OrderPromotion
+        permission_set.activate!
+        allow(canceled_order).to receive(:canceled?).and_return(true)
+        allow(active_order).to receive(:canceled?).and_return(false)
+      end
+
+      described_class::RESTRICTED_MODELS.each do |klass|
+        context klass.name do
+          let(:record_on_canceled_order) { klass.new.tap { |r| allow(r).to receive(:order).and_return(canceled_order) } }
+          let(:record_on_active_order) { klass.new.tap { |r| allow(r).to receive(:order).and_return(active_order) } }
+
+          it 'prevents managing records on canceled orders' do
+            expect(ability.can?(:create, record_on_canceled_order)).to be false
+            expect(ability.can?(:edit, record_on_canceled_order)).to be false
+            expect(ability.can?(:destroy, record_on_canceled_order)).to be false
+          end
+
+          it 'allows managing records on non-canceled orders' do
+            expect(ability.can?(:create, record_on_active_order)).to be true
+            expect(ability.can?(:edit, record_on_active_order)).to be true
+            expect(ability.can?(:destroy, record_on_active_order)).to be true
+          end
+        end
+      end
+    end
   end
 end

--- a/spree/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -99,12 +99,14 @@ RSpec.describe Spree::PermissionSets::OrderManagement do
           it 'prevents managing records on canceled orders' do
             expect(ability.can?(:create, record_on_canceled_order)).to be false
             expect(ability.can?(:edit, record_on_canceled_order)).to be false
+            expect(ability.can?(:update, record_on_canceled_order)).to be false
             expect(ability.can?(:destroy, record_on_canceled_order)).to be false
           end
 
           it 'allows managing records on non-canceled orders' do
             expect(ability.can?(:create, record_on_active_order)).to be true
             expect(ability.can?(:edit, record_on_active_order)).to be true
+            expect(ability.can?(:update, record_on_active_order)).to be true
             expect(ability.can?(:destroy, record_on_active_order)).to be true
           end
         end

--- a/spree/core/spec/models/spree/permission_sets/super_user_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/super_user_spec.rb
@@ -69,12 +69,14 @@ RSpec.describe Spree::PermissionSets::SuperUser do
           it 'prevents managing records on canceled orders' do
             expect(ability.can?(:create, record_on_canceled_order)).to be false
             expect(ability.can?(:edit, record_on_canceled_order)).to be false
+            expect(ability.can?(:update, record_on_canceled_order)).to be false
             expect(ability.can?(:destroy, record_on_canceled_order)).to be false
           end
 
           it 'allows managing records on non-canceled orders' do
             expect(ability.can?(:create, record_on_active_order)).to be true
             expect(ability.can?(:edit, record_on_active_order)).to be true
+            expect(ability.can?(:update, record_on_active_order)).to be true
             expect(ability.can?(:destroy, record_on_active_order)).to be true
           end
         end

--- a/spree/core/spec/models/spree/permission_sets/super_user_spec.rb
+++ b/spree/core/spec/models/spree/permission_sets/super_user_spec.rb
@@ -52,6 +52,35 @@ RSpec.describe Spree::PermissionSets::SuperUser do
       end
     end
 
+    context 'order-owned record restrictions on canceled orders' do
+      let(:canceled_order) { build(:order) }
+      let(:active_order) { build(:order) }
+
+      before do
+        allow(canceled_order).to receive(:canceled?).and_return(true)
+        allow(active_order).to receive(:canceled?).and_return(false)
+      end
+
+      described_class::RESTRICTED_MODELS.each do |klass|
+        context klass.name do
+          let(:record_on_canceled_order) { klass.new.tap { |r| allow(r).to receive(:order).and_return(canceled_order) } }
+          let(:record_on_active_order) { klass.new.tap { |r| allow(r).to receive(:order).and_return(active_order) } }
+
+          it 'prevents managing records on canceled orders' do
+            expect(ability.can?(:create, record_on_canceled_order)).to be false
+            expect(ability.can?(:edit, record_on_canceled_order)).to be false
+            expect(ability.can?(:destroy, record_on_canceled_order)).to be false
+          end
+
+          it 'allows managing records on non-canceled orders' do
+            expect(ability.can?(:create, record_on_active_order)).to be true
+            expect(ability.can?(:edit, record_on_active_order)).to be true
+            expect(ability.can?(:destroy, record_on_active_order)).to be true
+          end
+        end
+      end
+    end
+
     context 'immutable types' do
       let(:mutable_refund_reason) { build(:refund_reason, mutable: true) }
       let(:immutable_refund_reason) { build(:refund_reason, mutable: false) }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creating, editing, or deleting order-related records when their order has been canceled.
  * Applied the restriction consistently to order management and super-user permissions.
  * Active orders remain unaffected.

* **Tests**
  * Added coverage verifying permissions for canceled and active orders across affected record types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->