### PR TITLE
Redesign user dropdown preferences into compact theme & language controls

### DIFF
--- a/.changeset/dashboard-preferences-theme-language.md
+++ b/.changeset/dashboard-preferences-theme-language.md
@@ -1,0 +1,6 @@
+---
+"@spree/dashboard-core": patch
+"@spree/dashboard-ui": patch
+---
+
+Redesign the user dropdown's theme and language controls into a compact "Preferences" section: theme is now a segmented control (System / Light / Dark) and language is a select-style pill.

--- a/packages/dashboard-core/src/components/top-bar.tsx
+++ b/packages/dashboard-core/src/components/top-bar.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   LanguageMenuItems,
@@ -164,15 +165,18 @@ function TopBarUser({ uiLocales }: { uiLocales: ReadonlyArray<{ code: string; na
           </div>
         </div>
         <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {t('admin.account.preferences')}
+        </DropdownMenuLabel>
         <ThemeMenuItems />
-        {/* Compact nested submenu; self-hides when < 2 languages are installed. */}
+        {/* Select-style pill; self-hides when < 2 languages are installed. */}
         <LanguageMenuItems
           label={t('admin.account.language.label')}
           locales={uiLocales}
           value={i18n.language}
           onSelect={handleSelectLocale}
         />
-        {uiLocales.length >= 2 && <DropdownMenuSeparator />}
+        <DropdownMenuSeparator />
         {store && (
           <DropdownMenuItem asChild>
             <Link

--- a/packages/dashboard-core/src/locales/ar.json
+++ b/packages/dashboard-core/src/locales/ar.json
@@ -588,6 +588,7 @@
     },
     "account": {
       "edit_profile": "تعديل الملف الشخصي",
+      "preferences": "التفضيلات",
       "language": {
         "label": "اللغة",
         "update_failed": "تعذّر حفظ تفضيل اللغة. يرجى المحاولة مجددًا."

--- a/packages/dashboard-core/src/locales/de.json
+++ b/packages/dashboard-core/src/locales/de.json
@@ -588,6 +588,7 @@
     },
     "account": {
       "edit_profile": "Profil bearbeiten",
+      "preferences": "Einstellungen",
       "language": {
         "label": "Sprache",
         "update_failed": "Spracheinstellung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut."

--- a/packages/dashboard-core/src/locales/en.json
+++ b/packages/dashboard-core/src/locales/en.json
@@ -590,6 +590,7 @@
     },
     "account": {
       "edit_profile": "Edit Profile",
+      "preferences": "Preferences",
       "language": {
         "label": "Language",
         "update_failed": "Could not save your language preference. Please try again."

--- a/packages/dashboard-core/src/locales/fr.json
+++ b/packages/dashboard-core/src/locales/fr.json
@@ -588,6 +588,7 @@
     },
     "account": {
       "edit_profile": "Modifier le profil",
+      "preferences": "Préférences",
       "language": {
         "label": "Langue",
         "update_failed": "Impossible d’enregistrer votre préférence de langue. Veuillez réessayer."

--- a/packages/dashboard-core/src/locales/pl.json
+++ b/packages/dashboard-core/src/locales/pl.json
@@ -588,6 +588,7 @@
     },
     "account": {
       "edit_profile": "Edytuj profil",
+      "preferences": "Preferencje",
       "language": {
         "label": "Język",
         "update_failed": "Nie udało się zapisać preferencji języka. Spróbuj ponownie."

--- a/packages/dashboard-core/src/locales/zh-CN.json
+++ b/packages/dashboard-core/src/locales/zh-CN.json
@@ -588,6 +588,7 @@
     },
     "account": {
       "edit_profile": "编辑个人资料",
+      "preferences": "偏好设置",
       "language": {
         "label": "语言",
         "update_failed": "无法保存您的语言偏好。请重试。"

--- a/packages/dashboard-ui/src/spree/language-menu-items.tsx
+++ b/packages/dashboard-ui/src/spree/language-menu-items.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, LanguagesIcon } from 'lucide-react'
+import { CheckIcon, ChevronsUpDownIcon } from 'lucide-react'
 import {
   DropdownMenuItem,
   DropdownMenuSub,
@@ -7,7 +7,7 @@ import {
 } from '../ui/dropdown-menu'
 
 interface LanguageMenuItemsProps {
-  /** Translated "Language" label for the submenu trigger (passed by the app). */
+  /** Translated "Language" label for the row (passed by the app). */
   label: string
   /** Admin UI languages available to switch to ({ code, name } pairs). */
   locales: ReadonlyArray<{ code: string; name: string }>
@@ -17,9 +17,10 @@ interface LanguageMenuItemsProps {
 }
 
 /**
- * Admin UI language picker rendered inside the user dropdown menu as a nested
- * submenu (a single "Language ▸" row that expands to the list), so the menu
- * stays compact no matter how many languages are installed.
+ * Admin UI language picker rendered inside the user dropdown's Preferences
+ * section. The row shows a select-style pill with the current language; opening
+ * it reveals the full list as a nested submenu (kept within the menu system so
+ * it stays robust inside the dropdown's portal tree).
  *
  * Headless: the label, locale list, and change handler are passed in, so this
  * component imports no i18n/data runtime. Renders nothing when fewer than two
@@ -32,10 +33,12 @@ export function LanguageMenuItems({ label, locales, value, onSelect }: LanguageM
 
   return (
     <DropdownMenuSub>
-      <DropdownMenuSubTrigger>
-        <LanguagesIcon className="size-4" />
-        {label}
-        {current && <span className="ml-auto text-xs text-muted-foreground">{current.name}</span>}
+      <DropdownMenuSubTrigger hideChevron className="justify-between">
+        <span className="text-sm text-foreground">{label}</span>
+        <span className="ml-auto inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-2 py-1 text-xs font-normal text-foreground">
+          {current?.name ?? value}
+          <ChevronsUpDownIcon className="size-3 text-muted-foreground" />
+        </span>
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent>
         {locales.map((locale) => (

--- a/packages/dashboard-ui/src/spree/theme-toggle.tsx
+++ b/packages/dashboard-ui/src/spree/theme-toggle.tsx
@@ -1,35 +1,48 @@
-import { CheckIcon, MonitorIcon, MoonIcon, SunIcon } from 'lucide-react'
+import { MonitorIcon, MoonStarIcon, SunIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from '../ui/dropdown-menu'
+import { cn } from '../lib/utils'
 import { useTheme } from './theme-provider'
 
+const OPTIONS = [
+  { value: 'system', icon: MonitorIcon, labelKey: 'admin.components.theme_toggle.system' },
+  { value: 'light', icon: SunIcon, labelKey: 'admin.components.theme_toggle.light' },
+  { value: 'dark', icon: MoonStarIcon, labelKey: 'admin.components.theme_toggle.dark' },
+] as const
+
 /**
- * Theme picker rendered inside the user dropdown menu. Three-way (Light / Dark
- * / System) — System follows `prefers-color-scheme`.
+ * Theme picker rendered inside the user dropdown's Preferences section as a
+ * compact segmented control (System / Light / Dark). System follows
+ * `prefers-color-scheme`. The buttons are plain (not menu items) so activating
+ * one switches the theme without closing the dropdown.
  */
 export function ThemeMenuItems() {
   const { mode, setMode } = useTheme()
   const { t } = useTranslation()
 
-  const items = [
-    { value: 'light', label: t('admin.components.theme_toggle.light'), icon: SunIcon },
-    { value: 'dark', label: t('admin.components.theme_toggle.dark'), icon: MoonIcon },
-    { value: 'system', label: t('admin.components.theme_toggle.system'), icon: MonitorIcon },
-  ] as const
-
   return (
-    <>
-      <DropdownMenuLabel className="text-xs">
-        {t('admin.components.theme_toggle.label')}
-      </DropdownMenuLabel>
-      {items.map(({ value, label, icon: Icon }) => (
-        <DropdownMenuItem key={value} closeOnClick={false} onClick={() => setMode(value)}>
-          <Icon className="size-4" />
-          {label}
-          {mode === value && <CheckIcon className="ml-auto size-3.5" />}
-        </DropdownMenuItem>
-      ))}
-      <DropdownMenuSeparator />
-    </>
+    <div className="flex items-center justify-between gap-2 px-2.5 py-1.5">
+      <span className="text-sm text-foreground">{t('admin.components.theme_toggle.label')}</span>
+      <div className="flex items-center gap-0.5 rounded-lg border border-border bg-muted/40 p-0.5">
+        {OPTIONS.map(({ value, icon: Icon, labelKey }) => {
+          const active = mode === value
+          return (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={active}
+              aria-label={t(labelKey)}
+              title={t(labelKey)}
+              onClick={() => setMode(value)}
+              className={cn(
+                'flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground',
+                active && 'bg-background text-foreground shadow-sm',
+              )}
+            >
+              <Icon className="size-4" />
+            </button>
+          )
+        })}
+      </div>
+    </div>
   )
 }

--- a/packages/dashboard-ui/src/ui/dropdown-menu.tsx
+++ b/packages/dashboard-ui/src/ui/dropdown-menu.tsx
@@ -280,9 +280,12 @@ function DropdownMenuSubTrigger({
   className,
   inset,
   children,
+  hideChevron,
   ...props
 }: React.ComponentProps<typeof MenuPrimitive.SubmenuTrigger> & {
   inset?: boolean
+  /** Suppress the default trailing chevron when the trigger renders its own affordance. */
+  hideChevron?: boolean
 }) {
   return (
     <MenuPrimitive.SubmenuTrigger
@@ -295,7 +298,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      {!hideChevron && <ChevronRightIcon className="ml-auto" />}
     </MenuPrimitive.SubmenuTrigger>
   )
 }


### PR DESCRIPTION
## Summary

Refactors the user dropdown menu's theme and language controls into a dedicated "Preferences" section with improved UX:
- **Theme picker** transforms from a dropdown menu with checkmarks into a segmented control (System / Light / Dark) that doesn't close the menu on selection
- **Language picker** becomes a select-style pill showing the current language, with the submenu kept within the dropdown's portal tree for robustness
- Both controls are now visually grouped under a "Preferences" label

## Changes

### Theme Toggle (`theme-toggle.tsx`)
- Replaced `DropdownMenuItem` components with plain `<button>` elements in a segmented control layout
- Removed `CheckIcon` dependency; added `cn` utility import for conditional styling
- Moved icon/label definitions to a constant `OPTIONS` array for cleaner iteration
- Active state now uses `aria-pressed` attribute and background styling instead of checkmarks
- Buttons remain focused within the dropdown (no `closeOnClick` behavior)
- Updated JSDoc to reflect the new segmented control design

### Language Menu Items (`language-menu-items.tsx`)
- Converted `DropdownMenuSubTrigger` to display a select-style pill with current language and chevron icon
- Added `hideChevron` prop support to `DropdownMenuSubTrigger` to suppress the default trailing chevron
- Replaced `LanguagesIcon` with `ChevronsUpDownIcon` for select affordance
- Styled the trigger to show language name in a bordered pill (`border-border bg-card`)
- Updated JSDoc to clarify the new select-style presentation

### Top Bar (`top-bar.tsx`)
- Added "Preferences" section label above theme and language controls
- Moved `ThemeMenuItems` and `LanguageMenuItems` into the new preferences grouping
- Simplified separator logic (removed conditional separator after language items)
- Added `DropdownMenuLabel` import

### Dropdown Menu Primitive (`dropdown-menu.tsx`)
- Added optional `hideChevron` prop to `DropdownMenuSubTrigger` to allow custom affordances
- Conditionally renders the trailing chevron based on the prop

### Localization
- Added `admin.account.preferences` translation key across all supported locales (en, ar, de, fr, pl, zh-CN)

## Implementation Details

- The theme segmented control uses `aria-pressed` for accessibility and maintains visual feedback through background/text color changes
- Language pill uses `ChevronsUpDownIcon` (size-3) to signal interactivity without the default menu chevron
- Both controls are wrapped in a flex container with consistent spacing and typography
- The "Preferences" label uses uppercase tracking for visual hierarchy
- All changes maintain the dropdown's portal behavior and don't interfere with menu closing on other actions

https://claude.ai/code/session_014ErzhGfeoZ7Sza41Fhn5zK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact Preferences section to the account menu.
  * Added segmented theme selection for System, Light, and Dark modes.
  * Updated language selection to a pill-style control with the current language displayed.
* **Localization**
  * Added translated “Preferences” labels across supported languages.
* **Accessibility**
  * Improved theme controls with clearer labels and selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->