### PR TITLE
Configure LSP for Ruby development in Spree monorepo

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -7,6 +7,15 @@
     "source.fixAll.biome": true,
     "source.organizeImports.biome": true
   },
+  "lsp": {
+    "ruby-lsp": {
+      "binary": {
+        "env": {
+          "BUNDLE_GEMFILE": "spree/Gemfile"
+        }
+      }
+    }
+  },
   "languages": {
     "TypeScript": {
       "language_servers": ["biome", "vtsls", "!typescript-language-server", "!eslint"]

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -14,6 +14,13 @@
           "BUNDLE_GEMFILE": "spree/Gemfile"
         }
       }
+    },
+    "rubocop": {
+      "binary": {
+        "env": {
+          "BUNDLE_GEMFILE": "spree/Gemfile"
+        }
+      }
     }
   },
   "languages": {


### PR DESCRIPTION
## Summary
Configure Zed's Language Server Protocol (LSP) settings to properly resolve Ruby dependencies in the Spree monorepo by pointing both `ruby-lsp` and `rubocop` to the `spree/Gemfile`.

## Changes
- Added LSP configuration block to `.zed/settings.json`
- Configured `ruby-lsp` binary to use `BUNDLE_GEMFILE=spree/Gemfile` environment variable
- Configured `rubocop` binary to use `BUNDLE_GEMFILE=spree/Gemfile` environment variable

## Details
The Spree repository is organized as a monorepo with the main gem located in the `spree/` directory. Ruby language servers need to be aware of the correct Gemfile location to properly resolve dependencies and provide accurate linting/formatting. This configuration ensures that both the Ruby LSP and Rubocop linter use the correct bundle context when analyzing code in the editor.

https://claude.ai/code/session_01PDw9uMM8W96qgN2RjMvdaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added editor support for Ruby language tooling using the project-specific Gemfile.
  * Configured Ruby LSP and RuboCop to use the appropriate project environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->