### PR TITLE
chore: point Ruby LSP at spree/Gemfile in Cursor/VS Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 .idea
 .loadpath
 .project
-.vscode
+.vscode/*
+!.vscode/settings.json
 public/dispatch.cgi
 public/dispatch.fcgi
 public/dispatch.rb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rubyLsp.bundleGemfile": "spree/Gemfile"
+}


### PR DESCRIPTION
## What

Adds `.vscode/settings.json` setting `rubyLsp.bundleGemfile` to `spree/Gemfile`, and tracks that single file by narrowing the `.gitignore` `.vscode` entry to `.vscode/*` with a `!.vscode/settings.json` exception.

## Why

This monorepo's Gemfile lives at `spree/Gemfile` rather than the repo root. In Cursor/VS Code the Ruby LSP extension boots from the workspace root and fails to locate the Gemfile. `rubyLsp.bundleGemfile` points the extension's composed bundle at the right file; because the extension runs RuboCop through that same bundle, this one setting covers both Ruby LSP and RuboCop.

This mirrors the equivalent Zed fix already on `main` (`.zed/settings.json`), extending the same convenience to Cursor/VS Code users. Personal `.vscode/` files remain ignored — only the shared LSP config is tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDw9uMM8W96qgN2RjMvdaW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added editor configuration to correctly locate the project’s Ruby dependencies.
  * Updated repository settings so the shared editor configuration is retained while other local editor files remain excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->