### PR TITLE
Drop worktree setup patches now carried by spree-starter

### DIFF
--- a/scripts/worktree/lib.sh
+++ b/scripts/worktree/lib.sh
@@ -14,22 +14,26 @@ worktree_root() { git rev-parse --show-toplevel; }
 # Both pieces below arrived in spree/spree-starter#1376. A clone predating it
 # passes provisioning but then either shares the default database or rejects
 # every proxied request, so check both before touching anything.
+# Renders database.yml with sentinel values and applies the host rule, rather
+# than grepping for tokens: a comment, or the same token in the wrong YAML
+# entry, would otherwise vouch for a config that still points at the defaults.
+# Ruby only — no Rails boot, so this runs before `bundle install`.
 require_current_starter() {
   local missing=()
+  local report
 
-  # Anchored so DATABASE_NAME_TEST on the test line can't vouch for the
-  # development one — a half-patched file would share spree_development.
-  if ! grep -qE 'ENV\.fetch\("DATABASE_NAME"\)' server/config/database.yml; then
-    missing+=("config/database.yml: no DATABASE_NAME support — worktrees would share spree_development")
-  fi
+  report=$(cd server && DATABASE_NAME=__dev_probe__ DATABASE_NAME_TEST=__test_probe__ ruby -ryaml -rerb -e '
+    config = YAML.safe_load(ERB.new(File.read("config/database.yml")).result, aliases: true)
+    puts "dev"  if config.dig("development", "database") == "__dev_probe__"
+    puts "test" if config.dig("test", "database") == "__test_probe__"
+    puts "host" if File.read("config/environments/development.rb")
+                       .then { |src| src[/config\.hosts\s*<<\s*(\S+localhost\S+)/, 1] }
+                       &.then { |rule| eval(rule) =~ "feature-x.spree.localhost:1355" }
+  ' 2>/dev/null) || true
 
-  if ! grep -qE 'ENV\.fetch\("DATABASE_NAME_TEST"\)' server/config/database.yml; then
-    missing+=("config/database.yml: no DATABASE_NAME_TEST support — worktrees would share spree_test")
-  fi
-
-  if ! grep -q 'localhost(:' server/config/environments/development.rb; then
-    missing+=("config/environments/development.rb: no port-tolerant .localhost host rule — Rails would block proxied requests")
-  fi
+  grep -qx dev  <<<"$report" || missing+=("config/database.yml: the development entry ignores DATABASE_NAME — worktrees would share spree_development")
+  grep -qx test <<<"$report" || missing+=("config/database.yml: the test entry ignores DATABASE_NAME_TEST — worktrees would share spree_test")
+  grep -qx host <<<"$report" || missing+=("config/environments/development.rb: no host rule accepting proxied .localhost names — Rails would block every request")
 
   if [ ${#missing[@]} -gt 0 ]; then
     echo "This server/ clone predates spree-starter#1376:" >&2

--- a/scripts/worktree/lib.sh
+++ b/scripts/worktree/lib.sh
@@ -7,7 +7,10 @@
 set -euo pipefail
 
 TEMPLATE_DB="spree_worktree_template"
-PG_ARGS=(-h localhost -p "${DATABASE_PORT:-5432}" -U "${DATABASE_USERNAME:-postgres}")
+# Same defaults as the starter's config/database.yml, so the psql tools and
+# Rails always agree on which server they are talking to. teardown runs after
+# the worktree (and its bundled Rails) is gone, so these cannot come from Rails.
+PG_ARGS=(-h "${DATABASE_HOST:-localhost}" -p "${DATABASE_PORT:-5432}" -U "${DATABASE_USERNAME:-postgres}")
 
 worktree_root() { git rev-parse --show-toplevel; }
 

--- a/scripts/worktree/lib.sh
+++ b/scripts/worktree/lib.sh
@@ -11,6 +11,34 @@ PG_ARGS=(-h localhost -p "${DATABASE_PORT:-5432}" -U "${DATABASE_USERNAME:-postg
 
 worktree_root() { git rev-parse --show-toplevel; }
 
+# Both pieces below arrived in spree/spree-starter#1376. A clone predating it
+# passes provisioning but then either shares the default database or rejects
+# every proxied request, so check both before touching anything.
+require_current_starter() {
+  local missing=()
+
+  # Anchored so DATABASE_NAME_TEST on the test line can't vouch for the
+  # development one — a half-patched file would share spree_development.
+  if ! grep -qE 'ENV\.fetch\("DATABASE_NAME"\)' server/config/database.yml; then
+    missing+=("config/database.yml: no DATABASE_NAME support — worktrees would share spree_development")
+  fi
+
+  if ! grep -qE 'ENV\.fetch\("DATABASE_NAME_TEST"\)' server/config/database.yml; then
+    missing+=("config/database.yml: no DATABASE_NAME_TEST support — worktrees would share spree_test")
+  fi
+
+  if ! grep -q 'localhost(:' server/config/environments/development.rb; then
+    missing+=("config/environments/development.rb: no port-tolerant .localhost host rule — Rails would block proxied requests")
+  fi
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "This server/ clone predates spree-starter#1376:" >&2
+    printf '  - %s\n' "${missing[@]}" >&2
+    echo "Refresh it: rm -rf server && re-run scripts/worktree/setup.sh" >&2
+    return 1
+  fi
+}
+
 branch_name() { echo "${WT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"; }
 
 # Readable prefix plus a hash of the full branch name: normalization alone maps

--- a/scripts/worktree/make-template.sh
+++ b/scripts/worktree/make-template.sh
@@ -10,10 +10,9 @@ cd "$(worktree_root)"
 [ -d server ] || { echo "server/ missing — run pnpm server:create (or scripts/worktree/setup.sh) first." >&2; exit 1; }
 
 if ! grep -q 'DATABASE_NAME' server/config/database.yml; then
-  sed -i '' \
-    -e 's|database: spree_development|database: <%= ENV.fetch("DATABASE_NAME") { "spree_development" } %>|' \
-    -e 's|database: spree_test|database: <%= ENV.fetch("DATABASE_NAME_TEST") { "spree_test" } %>|' \
-    server/config/database.yml
+  echo "server/config/database.yml has no DATABASE_NAME support — update the spree-starter clone." >&2
+  echo "Without it, the template rebuild would target the default spree_development database." >&2
+  exit 1
 fi
 
 echo "▸ Rebuilding $TEMPLATE_DB (migrations + seeds, ~2-3 min)"

--- a/scripts/worktree/make-template.sh
+++ b/scripts/worktree/make-template.sh
@@ -30,10 +30,11 @@ if [ "$resolved" != "$TEMPLATE_DB" ]; then
 fi
 
 echo "▸ Rebuilding $TEMPLATE_DB (migrations + seeds, ~2-3 min)"
-dropdb "${PG_ARGS[@]}" --if-exists "$TEMPLATE_DB"
-createdb "${PG_ARGS[@]}" "$TEMPLATE_DB"
 
+# db:drop/db:create rather than dropdb/createdb: Rails connects using the config
+# just verified, so the destructive step cannot reach a different host or port
+# than the name check covered.
 (cd server && DATABASE_NAME="$TEMPLATE_DB" DATABASE_NAME_TEST="$TEMPLATE_DB" \
-  bin/rails spree:install:migrations db:prepare)
+  bin/rails db:drop db:create spree:install:migrations db:prepare)
 
 echo "✓ $TEMPLATE_DB ready — new worktrees copy it via createdb -T"

--- a/scripts/worktree/make-template.sh
+++ b/scripts/worktree/make-template.sh
@@ -9,9 +9,16 @@ cd "$(worktree_root)"
 
 [ -d server ] || { echo "server/ missing — run pnpm server:create (or scripts/worktree/setup.sh) first." >&2; exit 1; }
 
-if ! grep -q 'DATABASE_NAME' server/config/database.yml; then
-  echo "server/config/database.yml has no DATABASE_NAME support — update the spree-starter clone." >&2
-  echo "Without it, the template rebuild would target the default spree_development database." >&2
+require_current_starter
+
+# Prove Rails resolves DATABASE_NAME before dropping anything: this script
+# rebuilds from scratch, so a config that ignored it would destroy the
+# developer's own spree_development database.
+resolved=$(cd server && DATABASE_NAME="$TEMPLATE_DB" \
+  bin/rails runner 'print ActiveRecord::Base.connection_db_config.database' 2>/dev/null)
+if [ "$resolved" != "$TEMPLATE_DB" ]; then
+  echo "Rails resolved the development database to '${resolved:-<unknown>}', not '$TEMPLATE_DB'." >&2
+  echo "Refusing to rebuild — check server/config/database.yml and server/.env." >&2
   exit 1
 fi
 

--- a/scripts/worktree/make-template.sh
+++ b/scripts/worktree/make-template.sh
@@ -11,13 +11,20 @@ cd "$(worktree_root)"
 
 require_current_starter
 
+(cd server && bundle install --quiet)
+
 # Prove Rails resolves DATABASE_NAME before dropping anything: this script
 # rebuilds from scratch, so a config that ignored it would destroy the
-# developer's own spree_development database.
+# developer's own spree_development database. Needs the bundle above, and
+# keeps stderr so a boot failure reports itself instead of looking like a
+# resolution mismatch.
 resolved=$(cd server && DATABASE_NAME="$TEMPLATE_DB" \
-  bin/rails runner 'print ActiveRecord::Base.connection_db_config.database' 2>/dev/null)
+  bin/rails runner 'print ActiveRecord::Base.connection_db_config.database') || {
+  echo "Could not read the database configuration from server/ — see the error above." >&2
+  exit 1
+}
 if [ "$resolved" != "$TEMPLATE_DB" ]; then
-  echo "Rails resolved the development database to '${resolved:-<unknown>}', not '$TEMPLATE_DB'." >&2
+  echo "Rails resolved the development database to '$resolved', not '$TEMPLATE_DB'." >&2
   echo "Refusing to rebuild — check server/config/database.yml and server/.env." >&2
   exit 1
 fi
@@ -26,8 +33,7 @@ echo "▸ Rebuilding $TEMPLATE_DB (migrations + seeds, ~2-3 min)"
 dropdb "${PG_ARGS[@]}" --if-exists "$TEMPLATE_DB"
 createdb "${PG_ARGS[@]}" "$TEMPLATE_DB"
 
-(cd server && bundle install --quiet && \
-  DATABASE_NAME="$TEMPLATE_DB" DATABASE_NAME_TEST="$TEMPLATE_DB" \
+(cd server && DATABASE_NAME="$TEMPLATE_DB" DATABASE_NAME_TEST="$TEMPLATE_DB" \
   bin/rails spree:install:migrations db:prepare)
 
 echo "✓ $TEMPLATE_DB ready — new worktrees copy it via createdb -T"

--- a/scripts/worktree/setup.sh
+++ b/scripts/worktree/setup.sh
@@ -26,23 +26,12 @@ DATABASE_NAME_TEST=$(test_db_name)
 EOF
 fi
 
-# The starter hardcodes database names; make them env-driven (defaults keep the
-# stock behavior). server/ is gitignored so the patch is invisible to git.
-# TODO: upstream this to spree-starter 6-0-dev, then drop the sed.
+# The starter carries DATABASE_NAME support and the port-tolerant .localhost
+# host rule since spree/spree-starter#1376 — fail loudly rather than silently
+# provisioning a worktree that would share the default database.
 if ! grep -q 'DATABASE_NAME' server/config/database.yml; then
-  sed -i '' \
-    -e 's|database: spree_development|database: <%= ENV.fetch("DATABASE_NAME") { "spree_development" } %>|' \
-    -e 's|database: spree_test|database: <%= ENV.fetch("DATABASE_NAME_TEST") { "spree_test" } %>|' \
-    server/config/database.yml
-fi
-
-# The Host header arrives from the portless proxy with its port attached
-# (foo.spree.localhost:1355 when the proxy isn't on 443), which Rails' default
-# ".localhost" rule rejects — allow .localhost hosts with or without a port.
-if [ ! -f server/config/initializers/worktree_hosts.rb ]; then
-  cat > server/config/initializers/worktree_hosts.rb <<'RUBY'
-Rails.application.config.hosts << /\A[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?\z/i
-RUBY
+  echo "server/config/database.yml has no DATABASE_NAME support — update the spree-starter clone." >&2
+  exit 1
 fi
 
 if ! db_exists "$(db_name)"; then

--- a/scripts/worktree/setup.sh
+++ b/scripts/worktree/setup.sh
@@ -26,13 +26,7 @@ DATABASE_NAME_TEST=$(test_db_name)
 EOF
 fi
 
-# The starter carries DATABASE_NAME support and the port-tolerant .localhost
-# host rule since spree/spree-starter#1376 — fail loudly rather than silently
-# provisioning a worktree that would share the default database.
-if ! grep -q 'DATABASE_NAME' server/config/database.yml; then
-  echo "server/config/database.yml has no DATABASE_NAME support — update the spree-starter clone." >&2
-  exit 1
-fi
+require_current_starter
 
 if ! db_exists "$(db_name)"; then
   if ! db_exists "$TEMPLATE_DB"; then


### PR DESCRIPTION
Follow-up to #14390, now that [spree/spree-starter#1376](https://github.com/spree/spree-starter/pull/1376) is merged into `6-0-dev`.

## What

Worktree provisioning no longer edits the starter clone. The starter now ships both pieces itself:

- `DATABASE_NAME` / `DATABASE_NAME_TEST` support in `config/database.yml` — so `setup.sh` and `make-template.sh` drop the `sed` that rewrote it.
- The port-tolerant `.localhost` host rule in `config/environments/development.rb` — so `setup.sh` no longer writes a `worktree_hosts.rb` initializer into every clone.

The `database.yml` check stays, as a guard rather than a patch: a starter clone without `DATABASE_NAME` support would silently provision every worktree against the shared `spree_development` database, which is the exact collision this setup exists to prevent. Failing loudly is better than sharing a database.

## Verification

Created a worktree from merged `main`, removed the local hosts initializer so only the upstream rule was in play, and booted it:

- `/up` returned 200 and the Store API responded through the portless proxy
- zero `Blocked hosts` errors in the Rails log
- the database was created with its hash suffix and fully seeded (240 countries, admin user)
- `wt remove` ran `post-remove` and dropped both databases automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how template databases are dropped/recreated and gates all worktree setup on starter version checks; misconfiguration could still be painful, but new Rails resolution checks reduce accidental damage to the wrong database.
> 
> **Overview**
> Worktree provisioning **stops mutating** the `server/` clone: the `sed` that rewrote `database.yml` for `DATABASE_NAME` / `DATABASE_NAME_TEST` and the generated `worktree_hosts.rb` initializer are removed now that spree-starter ships both.
> 
> **`require_current_starter`** in `lib.sh` runs before setup/template work and fails fast on stale clones—probing rendered `database.yml` with sentinel env vars and checking `development.rb` for a port-tolerant `.localhost` host rule—instead of grepping for tokens.
> 
> **`make-template.sh`** proves Rails resolves `DATABASE_NAME` to the template DB before any drop, then rebuilds via **`bin/rails db:drop db:create`** (not raw `dropdb`/`createdb`) so destructive steps use the same config/host as the check. **`PG_ARGS`** also honors **`DATABASE_HOST`** for parity with the starter defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ad6a1563df981e82c2a8abd1fbba9e834c42d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree setup now verifies database configuration compatibility before provisioning.
  * Setup stops with clear guidance when the starter lacks required database-name support.
  * Template rebuilding confirms the resolved database is the intended template database.
  * Database operations now use the configured host and Rails-managed tasks for improved reliability.
  * Removed automatic configuration changes during setup.
  * Improved localhost validation and refresh guidance for outdated starter setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->