### PR TITLE
Fix sorting customers by name

### DIFF
--- a/spree/admin/config/initializers/spree_admin_tables.rb
+++ b/spree/admin/config/initializers/spree_admin_tables.rb
@@ -550,7 +550,7 @@ Rails.application.config.after_initialize do
                                      displayable: false,
                                      default: false,
                                      position: 70,
-                                     ransack_attribute: 'bill_address_firstname'
+                                     ransack_attribute: 'first_name'
 
   Spree.admin.tables.users.add :last_name,
                                      label: :last_name,
@@ -560,7 +560,7 @@ Rails.application.config.after_initialize do
                                      displayable: false,
                                      default: false,
                                      position: 80,
-                                     ransack_attribute: 'bill_address_lastname'
+                                     ransack_attribute: 'last_name'
 
   Spree.admin.tables.users.add :tags,
                                      label: :tags,

--- a/spree/admin/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/spree/admin/spec/controllers/spree/admin/users_controller_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe Spree::Admin::UsersController, type: :controller do
       expect(assigns(:collection).to_a).to eq([user_2])
     end
 
+    describe 'sorting' do
+      it 'sorts by the first name' do
+        get :index, params: { q: { s: 'first_name asc' } }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:collection).to_a).to eq([user_1, user_3, user_2])
+      end
+
+      it 'sorts by the last name' do
+        get :index, params: { q: { s: 'last_name asc' } }
+
+        expect(response).to have_http_status(:ok)
+        expect(assigns(:collection).to_a).to eq([user_3, user_1, user_2])
+      end
+    end
+
     describe 'search' do
       subject { get :index, params: { q: { search: search_param } } }
 


### PR DESCRIPTION
https://vendo-connect.sentry.io/issues/7653736156/?project=4509685278179328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small admin table configuration change with targeted request specs; no auth or data migration.
> 
> **Overview**
> Fixes **admin customer list sorting** when ordering by first or last name. The users table config pointed filter/sort Ransack attributes at **billing address** fields (`bill_address_firstname` / `bill_address_lastname`) instead of the user record’s **`first_name`** and **`last_name`**, which broke name-based sort (and aligned name filtering with the wrong source).
> 
> **`spree_admin_tables.rb`** now maps those filter-only name columns to `first_name` and `last_name`. **`users_controller_spec`** adds examples that assert ascending sort by each field returns the expected user order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2265a60c8a170757ec401fb985cafc73faf900fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected user filtering so searches by first and last name use the user’s actual name fields.
  * Improved accuracy when filtering users by name.

* **Tests**
  * Added coverage for ascending first-name and last-name sorting in the users list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->