### PR TITLE
Fix migrations for MariaDB 11

### DIFF
--- a/spree/core/db/migrate/20240303174340_fix_spree_stock_item_unique_index.rb
+++ b/spree/core/db/migrate/20240303174340_fix_spree_stock_item_unique_index.rb
@@ -7,18 +7,18 @@ class FixSpreeStockItemUniqueIndex < ActiveRecord::Migration[6.1]
       if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
         reversible do |dir|
           dir.up do
-            execute <<-SQL
-              CREATE UNIQUE INDEX index_spree_stock_items_unique_without_deleted_at
-              ON spree_stock_items(
-                stock_location_id,
-                variant_id,
-                (COALESCE(deleted_at, CAST('1970-01-01' AS DATETIME)))
-              );
-            SQL
+            add_column :spree_stock_items, :deleted_at_with_default, :virtual, type: :datetime, as: "IFNULL(deleted_at, '1970-01-01 00:00:00')", stored: false
+            add_index(
+              :spree_stock_items,
+              ['variant_id', 'stock_location_id', 'deleted_at_with_default'],
+              name: 'index_spree_stock_items_unique_without_deleted_at',
+              unique: true,
+            )
           end
 
           dir.down do
             remove_index :spree_stock_items, name: :index_spree_stock_items_unique_without_deleted_at
+            remove_column :spree_stock_items, :deleted_at_with_default
           end
         end
       else

--- a/spree/core/db/migrate/20260707000001_add_fingerprint_to_spree_credit_cards.rb
+++ b/spree/core/db/migrate/20260707000001_add_fingerprint_to_spree_credit_cards.rb
@@ -11,19 +11,13 @@ class AddFingerprintToSpreeCreditCards < ActiveRecord::Migration[7.2]
     # soft-deleted rows are left untouched.
     if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
       # MySQL has no partial indexes, but treats NULL as distinct in unique
-      # indexes, so NULL fingerprints are naturally allowed. COALESCE on
-      # deleted_at keeps soft-deleted rows from colliding with active ones.
-      execute <<-SQL
-        CREATE UNIQUE INDEX #{INDEX_NAME}
-        ON spree_credit_cards(
-          user_id,
-          payment_method_id,
-          fingerprint,
-          month,
-          year,
-          (COALESCE(deleted_at, CAST('1970-01-01' AS DATETIME)))
-        )
-      SQL
+      # indexes, so NULL fingerprints are naturally allowed. The default value of
+      # deleted_at in the virtual column enables enforcing uniqueness of non-deleted
+      # values and keeps soft-deleted rows from colliding with active ones.
+      add_column :spree_credit_cards, :deleted_at_with_default, :virtual, type: :datetime, as: "IFNULL(deleted_at, '1970-01-01 00:00:00')", stored: false
+      add_index :spree_credit_cards, [:user_id, :payment_method_id, :fingerprint, :month, :year, :deleted_at_with_default],
+                unique: true,
+                name: INDEX_NAME
     else
       add_index :spree_credit_cards, [:user_id, :payment_method_id, :fingerprint, :month, :year],
                 unique: true,
@@ -35,5 +29,8 @@ class AddFingerprintToSpreeCreditCards < ActiveRecord::Migration[7.2]
   def down
     remove_index :spree_credit_cards, name: INDEX_NAME
     remove_column :spree_credit_cards, :fingerprint
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      remove_column :spree_credit_cards, :deleted_at_with_default
+    end
   end
 end


### PR DESCRIPTION
I've recently tried to create a new MariaDB based installation and two of the migrations failed. The issue seems to be the `CAST()` function not being allowed in the SQL statement.

The new approach creates a virtual column that has a default value for the `deleted_at` column and creates the index using this virtual column. It should have the same result as a partial index. This change fixed the #14383 issue in my case.

I aimed to keep the change to minimal and prefer using Ruby code over SQL in the migration. I haven't run linters yet to avoid the change being mixed with formatting changes.

It might work just removing the `CAST()` function from the current implementation but I haven't tested that locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL compatibility for stock item and credit card uniqueness constraints.
  * Prevented duplicate active entries when records have been soft-deleted.
  * Ensured database rollbacks correctly remove associated indexes and temporary columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->