### PR TITLE
fix: handle translated product sorting with locale fallbacks

### DIFF
--- a/spree/api/spec/controllers/spree/api/v3/store/products_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/products_controller_spec.rb
@@ -286,6 +286,59 @@ RSpec.describe Spree::Api::V3::Store::ProductsController, type: :controller do
         expect(names).to eq(names.sort)
       end
 
+      context 'with translated names', if: Spree::Product.include?(Spree::TranslatableResource) do
+        before do
+          allow(store).to receive(:supported_locales_list).and_return(%w[en fr])
+          allow(store).to receive(:default_locale).and_return('en')
+          request.headers['x-spree-locale'] = 'fr'
+
+          Mobility.with_locale(:fr) do
+            product.update!(name: 'Zèbre')
+            product2.update!(name: 'Alpha')
+            cheap_product.update!(name: 'Beta')
+            expensive_product.update!(name: 'Gamma')
+          end
+        end
+
+        it 'sorts by translated name ascending' do
+          get :index, params: { sort: 'name' }
+
+          expect(response).to have_http_status(:ok)
+          names = json_response['data'].map { |p| p['name'] }
+          expect(names).to eq(%w[Alpha Beta Gamma Zèbre])
+        end
+
+        it 'sorts by translated name descending' do
+          get :index, params: { sort: '-name' }
+
+          expect(response).to have_http_status(:ok)
+          names = json_response['data'].map { |p| p['name'] }
+          expect(names).to eq(%w[Zèbre Gamma Beta Alpha])
+        end
+
+        context 'when a product has no translation in the requested locale' do
+          let!(:fallback_product) do
+            Mobility.with_locale(:en) { create(:product, status: 'active', name: 'Aardvark') }
+          end
+
+          it 'sorts by the displayed fallback name ascending' do
+            get :index, params: { sort: 'name' }
+
+            expect(response).to have_http_status(:ok)
+            names = json_response['data'].map { |p| p['name'] }
+            expect(names).to eq(%w[Aardvark Alpha Beta Gamma Zèbre])
+          end
+
+          it 'sorts by the displayed fallback name descending' do
+            get :index, params: { sort: '-name' }
+
+            expect(response).to have_http_status(:ok)
+            names = json_response['data'].map { |p| p['name'] }
+            expect(names).to eq(%w[Zèbre Gamma Beta Alpha Aardvark])
+          end
+        end
+      end
+
       # Regression test: combining in_stock filter with price sorting caused
       # PG::UndefinedTable due to table alias conflicts on spree_variants
       it 'sorts by price while filtering in_stock' do

--- a/spree/core/app/models/spree/search_provider/database.rb
+++ b/spree/core/app/models/spree/search_provider/database.rb
@@ -127,8 +127,87 @@ module Spree
             end
           }.join(',')
 
-          scope.ransack(s: ransack_sort).result
+          translatable_fields = translatable_sort_fields(sort)
+          fallback_sort_expressions = {}
+          if translatable_fields.any?
+            # Mobility orders translated fields from the translations table. When
+            # the relation is DISTINCT, PostgreSQL requires those ordered fields
+            # to be present in the SELECT list as well.
+            scope = scope.for_ordering_with_translations(Spree::Product, translatable_fields)
+            scope, fallback_sort_expressions = apply_translation_sort_fallbacks(scope, translatable_fields)
+          end
+
+          search = scope.ransack(s: ransack_sort)
+          result = search.result
+          apply_translation_sort_order(result, search, fallback_sort_expressions)
         end
+      end
+
+      def translatable_sort_fields(sort)
+        return [] unless Spree.use_translations?
+
+        fields = sort.split(',').map { |field| field.delete_prefix('-') }
+        public_fields = Spree::Product.public_translatable_fields.map(&:to_s)
+        public_fields.select { |field| fields.include?(field) }
+      end
+
+      # Build SQL expressions that match Mobility's reader fallback chain. The
+      # active-locale translation is preferred, followed by the store's content
+      # locale. Product's column fallback is handled by the backend itself, so
+      # the second node may be the base product column rather than another join.
+      def apply_translation_sort_fallbacks(scope, fields)
+        fallback_locale = store.default_locale.presence || Spree::Current.content_locale
+        return [scope, {}] if fallback_locale.blank? || same_locale?(fallback_locale, Mobility.locale)
+
+        fallback_locale = fallback_locale.to_sym
+        expressions = {}
+        fields.each do |field|
+          backend = Spree::Product.mobility_backend_class(field)
+          active_node = backend.build_node(field, Mobility.locale)
+          fallback_node = backend.build_node(field, fallback_locale)
+          scope = backend.apply_scope(scope, fallback_node, fallback_locale)
+
+          expression = Arel::Nodes::NamedFunction.new(
+            'COALESCE',
+            [null_if_blank(active_node), null_if_blank(fallback_node)]
+          )
+          # The fallback expression is also used in ORDER BY, so project it
+          # explicitly for PostgreSQL's DISTINCT ordering rules.
+          scope = scope.select(expression.as("spree_sort_#{field}"))
+          expressions[field] = expression
+        end
+
+        [scope, expressions]
+      end
+
+      def apply_translation_sort_order(scope, search, fallback_sort_expressions)
+        return scope if fallback_sort_expressions.empty?
+
+        sorts = search.sorts
+        return scope if sorts.empty?
+
+        sort_offset = [scope.order_values.length - sorts.length, 0].max
+        order_values = scope.order_values.each_with_index.map do |order_value, index|
+          sort = sorts[index - sort_offset] if index >= sort_offset
+          field = sort&.attr_name.to_s
+          expression = fallback_sort_expressions[field]
+
+          if expression
+            expression.public_send(sort.dir == 'desc' ? :desc : :asc)
+          else
+            order_value
+          end
+        end
+
+        scope.reorder(*order_values)
+      end
+
+      def null_if_blank(node)
+        Arel::Nodes::NamedFunction.new('NULLIF', [node, Arel::Nodes.build_quoted('')])
+      end
+
+      def same_locale?(left, right)
+        Mobility.normalize_locale(left) == Mobility.normalize_locale(right)
       end
 
       # Which grouping a 'manual' sort orders within, inferred from the filter that


### PR DESCRIPTION
Project translated product fields into SELECT to satisfy PostgreSQL DISTINCT and ORDER BY requirements. Use the active translation with a default-locale fallback so sorting matches the name displayed by Mobility when the requested locale has no translation, and avoid creating Symbols from untrusted sort parameters.

Add PostgreSQL regression coverage for ascending and descending translated-name sorting, including default-locale fallback behavior.

Related: spree/storefront#210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product listings now sort correctly by translated product names when translations are enabled.
  * Sorting supports both ascending and descending order across selected locales.
  * Products without a translation automatically fall back to their default-language name.

* **Tests**
  * Added coverage for translated-name sorting and default-language fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->