### PR TITLE
Fix cart address updates not always recalculating tax

### DIFF
--- a/spree/core/app/services/spree/carts/update.rb
+++ b/spree/core/app/services/spree/carts/update.rb
@@ -68,25 +68,40 @@ module Spree
 
       def assign_address(address_type)
         address_id_param = params[:"#{address_type}_id"]
+        return resolve_and_assign(address_type, address_id_param) if address_id_param.present?
+
         address_params = params[address_type]
-
-        if address_id_param.present?
-          address_id = resolve_address_id(address_id_param)
-          cart.public_send(:"#{address_type}_id=", address_id) if address_id
-          return
-        end
-
         return unless address_params.is_a?(Hash)
 
         if address_params[:id].present?
-          address_id = resolve_address_id(address_params[:id])
-          cart.public_send(:"#{address_type}_id=", address_id) if address_id
+          resolve_and_assign(address_type, address_params[:id])
         else
-          # Only a shipping-address change invalidates delivery proposals;
-          # billing updates (e.g. during payment) must not rebuild them.
-          @address_invalidated = true if address_type == :shipping_address
-          cart.public_send(:"#{address_type}_attributes=", address_params)
+          with_address_recalc_tracking(address_type) do
+            cart.public_send(:"#{address_type}_attributes=", address_params)
+          end
         end
+      end
+
+      def resolve_and_assign(address_type, prefixed_id)
+        address_id = resolve_address_id(prefixed_id)
+        assign_address_id(address_type, address_id) if address_id
+      end
+
+      def assign_address_id(address_type, address_id)
+        return if cart.public_send(:"#{address_type}_id") == address_id
+
+        with_address_recalc_tracking(address_type) do
+          cart.public_send(:"#{address_type}_id=", address_id)
+        end
+      end
+
+      def with_address_recalc_tracking(address_type)
+        tax_address_was = cart.tax_address
+        yield
+
+        # Shipping changes always affect delivery proposals; billing changes only
+        # matter when they shift which address computes tax.
+        @address_invalidated = true if address_type == :shipping_address || cart.tax_address != tax_address_was
       end
 
       def process_items

--- a/spree/core/spec/services/spree/carts/update_spec.rb
+++ b/spree/core/spec/services/spree/carts/update_spec.rb
@@ -359,10 +359,72 @@ module Spree
               end
             end
           end
+
+          context 'with top-level shipping_address_id' do
+            let(:existing_address) { create(:address, user: user) }
+            let(:params) { { shipping_address_id: existing_address.prefixed_id } }
+
+            it 'recalculates when shipping address is picked by id' do
+              expect(cart).to receive(:recalculate_for_address_change!)
+
+              expect(subject).to be_success
+              expect(cart.reload.ship_address_id).to eq(existing_address.id)
+            end
+          end
         end
 
         describe 'billing_address' do
           include_examples 'address update', :billing_address
+
+          context 'with top-level billing_address_id' do
+            around do |example|
+              previous = Spree::Config[:tax_using_ship_address]
+              example.run
+            ensure
+              Spree::Config.set(tax_using_ship_address: previous)
+            end
+
+            let(:existing_bill) { create(:address, user: user) }
+            let(:other_bill) { create(:address, user: user) }
+            let(:cart) do
+              create(
+                :cart_with_line_items,
+                customer: user,
+                store: store,
+                currency: 'USD',
+                bill_address: existing_bill
+              )
+            end
+
+            context 'when tax is computed from the billing address' do
+              before { Spree::Config.set(tax_using_ship_address: false) }
+
+              it 'recalculates when the tax address is picked by id' do
+                expect(cart).to receive(:recalculate_for_address_change!)
+
+                result = described_class.call(cart: cart, params: { billing_address_id: other_bill.prefixed_id })
+
+                expect(result).to be_success
+                expect(cart.reload.bill_address_id).to eq(other_bill.id)
+              end
+            end
+
+            context 'when tax is computed from the shipping address' do
+              before { Spree::Config.set(tax_using_ship_address: true) }
+
+              it 'does not rebuild delivery proposals' do
+                cart.rebuild_fulfillments!
+                fulfillment_ids = cart.fulfillments.pluck(:id)
+
+                expect(cart).not_to receive(:recalculate_for_address_change!)
+
+                result = described_class.call(cart: cart, params: { billing_address_id: other_bill.prefixed_id })
+
+                expect(result).to be_success
+                expect(cart.reload.fulfillments.pluck(:id)).to eq(fulfillment_ids)
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shipping and billing address selection during cart updates.
  * Delivery options are recalculated when a different shipping address affects fulfillment or taxes.
  * Billing address changes now trigger recalculation when they affect tax calculations.
  * Existing delivery selections are preserved when billing changes do not affect the tax address.
  * Selected addresses, including those provided through nested address details, are saved reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->