### PR TITLE
Keep the delivery method sheet out of browser history

### DIFF
--- a/packages/dashboard/e2e/delivery-settings.spec.ts
+++ b/packages/dashboard/e2e/delivery-settings.spec.ts
@@ -112,6 +112,11 @@ test.describe('delivery profiles', () => {
     await page.getByRole('button', { name: /^cancel$/i }).click()
     await expect(page.getByRole('heading', { name: /new delivery method/i })).toHaveCount(0)
     await expect(page.getByRole('heading', { name: profileName })).toBeVisible()
+
+    // The sheet replaces its history entry rather than pushing one, so going
+    // back does not reopen what the merchant just dismissed.
+    await page.goBack()
+    await expect(page.getByRole('heading', { name: /new delivery method/i })).toHaveCount(0)
   })
 
   // Pickup is a separate card because it has no destination: the merchant
@@ -179,6 +184,11 @@ test.describe('delivery profiles', () => {
       timeout: 15_000,
     })
     await expect(page.getByText(methodName)).toBeVisible({ timeout: 15_000 })
+
+    // Opening and closing the sheet must not leave the header's back arrow
+    // walking through dismissed sheets — it goes to the profile list.
+    await page.getByRole('button', { name: /^back$/i }).click()
+    await expect(page.getByRole('button', { name: PROFILE_CTA })).toBeVisible({ timeout: 15_000 })
   })
 
   // The origin-group layer stays invisible until a profile is split, so this

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/$profileId/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/$profileId/index.tsx
@@ -106,12 +106,21 @@ export const Route = createFileRoute(
   component: DeliveryProfileDetailPage,
 })
 
-/** Opens the method sheet for an existing method, or for a new one. */
+/**
+ * Opens the method sheet for an existing method, or for a new one.
+ *
+ * Every move replaces the history entry rather than pushing one. The sheet
+ * lives in the URL so a deep link reopens it, but opening and closing one is
+ * not a place a merchant navigated to — pushing would leave the page's back
+ * arrow walking through sheets they already dismissed instead of returning to
+ * the profile list.
+ */
 function useMethodSheetNavigation() {
   const navigate = useNavigate()
 
   const openMethod = (methodId: string) =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) => {
         const { zone: _z, group: _g, provider: _p, ...rest } = prev
         return { ...rest, method: methodId } as never
@@ -120,6 +129,7 @@ function useMethodSheetNavigation() {
 
   const openNewMethod = (options: { zone?: string; group?: string; provider?: string } = {}) =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) =>
         ({
           ...prev,
@@ -132,6 +142,7 @@ function useMethodSheetNavigation() {
 
   const closeMethodSheet = () =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) => {
         const { method: _m, zone: _z, group: _g, provider: _p, ...rest } = prev
         return rest as never


### PR DESCRIPTION
The delivery method sheet lives in the URL so a deep link reopens it, but opening and closing it each pushed a browser history entry. After dismissing a sheet the history read *profile page → sheet open → sheet closed*, so the header's back arrow — a plain `history.back()` — landed on "sheet open" and reopened the sheet the merchant had just closed, instead of returning to the profile list.

Every sheet move now replaces its history entry instead of pushing one. Opening a sheet is not somewhere a merchant navigated to, so it should not occupy a history slot; the URL is still written, so deep links are unaffected. This matches how the webhook detail page already drives its sheets — the only other page combining a URL-driven sheet with a back arrow.

## Testing

The `delivery-settings` e2e suite covers it from both angles: going back after dismissing a sheet no longer reopens it, and the header's back arrow reaches the profile list after a sheet round-trip. Both assertions were confirmed to fail against the unfixed code before being kept.

6 e2e tests, 83 unit tests, typecheck and lint all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delivery-method sheets reopening unexpectedly when navigating back.
  * Updated navigation so dismissed sheets are not revisited in browser history.
  * Returning from a zoneless delivery profile now correctly opens the delivery-profile list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->