### PR TITLE
Align status badge colours with the Geist colour system

### DIFF
--- a/.changeset/dashboard-status-badge-colors.md
+++ b/.changeset/dashboard-status-badge-colors.md
@@ -1,0 +1,6 @@
+---
+"@spree/dashboard-ui": patch
+"@spree/dashboard": patch
+---
+
+Align status badge colours with the Geist colour system: each of the success, warning, destructive and info variants now pairs a tint with a matching reading colour from the same hue, in both light and dark themes, and every variant meets WCAG AA against its own fill. Fixes a `warning` badge that changed colour entirely on hover, and an outline badge whose border never rendered.

--- a/packages/dashboard-ui/src/styles.css
+++ b/packages/dashboard-ui/src/styles.css
@@ -89,6 +89,44 @@
   --sidebar-accent-foreground: oklch(0.2136 0.0555 255.9);
   --sidebar-border: oklch(0.928 0.0075 87.5);
   --sidebar-ring: var(--brand-blue);
+
+  /* Status ramps, following Vercel's Geist colour system.
+   *
+   * Geist gives each step of a ramp a fixed job: low steps are component
+   * backgrounds, mid steps borders, high steps text and icons. Its badges pair
+   * a light tint with a dark reading colour from the same hue, which is what
+   * these trios reproduce — a fill light enough to sit on a white card, under
+   * text that is a true text colour rather than the fill darkened.
+   *
+   * The values come from Tailwind's own palette rather than Geist's raw
+   * numbers: each step below is the closest match in oklch to its Geist
+   * counterpart, so the result reads the same while staying on the palette the
+   * rest of the dashboard is built from.
+   *
+   * Text lands on step 700 in every ramp, over a step-100 fill. Green is the
+   * one exception: Tailwind's green-700 is lighter than its siblings and lands
+   * at 4.497:1 on green-100, a hair under the 4.5:1 that 12px badge text
+   * needs, so green's fill drops one step to clear it. The difference is
+   * invisible beside the other three but keeps the whole set measurably legible
+   * rather than passing only by eye. */
+  --status-green-bg: var(--color-green-50);
+  --status-green-border: var(--color-green-100);
+  --status-green-fg: var(--color-green-700);
+
+  --status-amber-bg: var(--color-amber-100);
+  --status-amber-border: var(--color-amber-200);
+  --status-amber-fg: var(--color-amber-700);
+
+  --status-red-bg: var(--color-red-100);
+  --status-red-border: var(--color-red-200);
+  --status-red-fg: var(--color-red-700);
+
+  /* Blue reads off the sky ramp rather than Tailwind's blue: `--color-blue-500`
+     and `-600` are remapped to the brand accent further down, so a badge built
+     on those steps would read as a brand mark rather than a neutral status. */
+  --status-blue-bg: var(--color-sky-100);
+  --status-blue-border: var(--color-sky-200);
+  --status-blue-fg: var(--color-sky-700);
 }
 
 .dark {
@@ -131,6 +169,33 @@
   --sidebar-accent-foreground: oklch(0.95 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* Geist's dark ramps are not the light ones dimmed — the fill becomes a deep
+     shade of the hue and the text becomes brighter than its light-mode
+     counterpart. That inversion is why a tint expressed as an opacity over
+     black goes muddy: these are separate colours, not one hue at lower alpha.
+     Border and fill share a step here, since a deep fill already separates
+     from a black card and a lighter rule around it would draw more attention
+     than the badge itself.
+
+     Text sits on step 300 across all four ramps — the brightest of the steps
+     Geist treats as text, and the only one that clears 4.5:1 on a 900 fill for
+     every hue (red and sky fall under it by step 400). */
+  --status-green-bg: var(--color-green-900);
+  --status-green-border: var(--color-green-900);
+  --status-green-fg: var(--color-green-300);
+
+  --status-amber-bg: var(--color-amber-900);
+  --status-amber-border: var(--color-amber-900);
+  --status-amber-fg: var(--color-amber-300);
+
+  --status-red-bg: var(--color-red-900);
+  --status-red-border: var(--color-red-900);
+  --status-red-fg: var(--color-red-300);
+
+  --status-blue-bg: var(--color-sky-900);
+  --status-blue-border: var(--color-sky-900);
+  --status-blue-fg: var(--color-sky-300);
 }
 
 @theme inline {
@@ -200,11 +265,27 @@
   --color-foreground: var(--foreground);
   --color-background: var(--background);
 
-  /* Spree status colors — for badges & alerts */
-  --color-success: var(--color-lime-500);
-  --color-warning: var(--color-yellow-500);
-  --color-info: var(--color-sky-500);
-  --color-danger: var(--color-rose-500);
+  /* Status colours — badges, alerts and any other success/warning/error mark.
+     Each is a background/border/foreground trio rather than a single hue, so a
+     component states which role it wants instead of picking an opacity and
+     hoping it lands. This replaces the older single-value `--color-success`
+     family, which had to be re-tinted at every call site and was bypassed by
+     most of them for exactly that reason. */
+  --color-success: var(--status-green-fg);
+  --color-success-bg: var(--status-green-bg);
+  --color-success-border: var(--status-green-border);
+
+  --color-warning: var(--status-amber-fg);
+  --color-warning-bg: var(--status-amber-bg);
+  --color-warning-border: var(--status-amber-border);
+
+  --color-danger: var(--status-red-fg);
+  --color-danger-bg: var(--status-red-bg);
+  --color-danger-border: var(--status-red-border);
+
+  --color-info: var(--status-blue-fg);
+  --color-info-bg: var(--status-blue-bg);
+  --color-info-border: var(--status-blue-border);
 
   /* Re-point Tailwind's blue ramp at the brand accent. Interactive blue is
      used throughout the component layer for focus borders, checked states and

--- a/packages/dashboard-ui/src/ui/badge.tsx
+++ b/packages/dashboard-ui/src/ui/badge.tsx
@@ -6,25 +6,35 @@ import { cn } from '../lib/utils'
 import { Slot } from './slot'
 
 const badgeVariants = cva(
-  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow] duration-100 ease-out focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
+  // No `border-transparent` here: it and a variant's `border-*` have the same
+  // specificity, so the one Tailwind emits last wins regardless of the order
+  // they appear in the class list — which silently erased the outline
+  // variant's border. Each variant states its own border colour instead.
+  'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow] duration-100 ease-out focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
-        secondary: 'bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80',
+        default: 'border-transparent bg-primary text-primary-foreground [a]:hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80',
+        // The four status variants below share one recipe: a tint from the
+        // status ramp, text from the same ramp's reading step, and a border
+        // that firms the shape up on busy surfaces. Both themes get real
+        // colours rather than one hue at reduced opacity — an opacity tint
+        // takes on whatever sits behind it, which turns a badge muddy over a
+        // striped table row and washes it out entirely on a dark card. Linked
+        // badges darken to the border step on hover, which is the next stop up
+        // the same ramp rather than a second colour.
         destructive:
-          'bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20',
-        // Mirrors the `destructive` recipe (tinted bg + matching text) with a
-        // green hue for "succeeded / completed / paid / shipped" states. Dark
-        // mode bumps text to `green-400` so it stays legible on dark fills.
-        success:
-          'bg-green-500/15 text-green-700 dark:bg-green-500/15 dark:text-green-400 [a]:hover:bg-green-500/25',
+          'border-danger-border bg-danger-bg text-danger focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-danger-border',
+        success: 'border-success-border bg-success-bg text-success [a]:hover:bg-success-border',
+        info: 'border-info-border bg-info-bg text-info [a]:hover:bg-info-border',
+        warning: 'border-warning-border bg-warning-bg text-warning [a]:hover:bg-warning-border',
         outline:
           'border-border text-foreground/75 [a]:hover:bg-muted [a]:hover:text-muted-foreground',
-        ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
-        info: 'bg-info/10 text-info [a]:hover:bg-info/20',
-        warning: 'bg-yellow-300 text-yellow-900 [a]:hover:bg-warning/20',
-        link: 'text-primary underline-offset-4 hover:underline',
+        ghost:
+          'border-transparent hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
+        link: 'border-transparent text-primary underline-offset-4 hover:underline',
       },
     },
     defaultVariants: {

--- a/packages/dashboard/src/components/spree/price-list-editors/status-badge.tsx
+++ b/packages/dashboard/src/components/spree/price-list-editors/status-badge.tsx
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next'
 // range puts it live now — mirrors the legacy admin's
 // `price_list_status_badge` helper.
 const STATUS_STYLES = {
-  active: { className: 'bg-emerald-100 text-emerald-900 hover:bg-emerald-100' },
-  scheduled: { className: 'bg-sky-100 text-sky-900 hover:bg-sky-100' },
+  active: { variant: 'success' as const },
+  scheduled: { variant: 'info' as const },
   inactive: { variant: 'secondary' as const },
   draft: { variant: 'outline' as const },
 } as const
@@ -26,8 +26,9 @@ export function PriceListStatusBadge({ priceList }: { priceList: PriceList }) {
   // reports a stale `currently_active: true`.
   const status: PriceListStatus = priceList.currently_active && raw !== 'inactive' ? 'active' : raw
 
-  const style = STATUS_STYLES[status]
-  const label = t(`admin.fields.price_list.status.${status}`)
-  if ('variant' in style) return <Badge variant={style.variant}>{label}</Badge>
-  return <Badge className={style.className}>{label}</Badge>
+  return (
+    <Badge variant={STATUS_STYLES[status].variant}>
+      {t(`admin.fields.price_list.status.${status}`)}
+    </Badge>
+  )
 }


### PR DESCRIPTION
## What

Status badge colours are now defined as background/border/foreground trios drawn from the Tailwind palette, following the Geist colour system's rule for small elements: a badge pairs a light tint with a reading colour from the same hue.

Each value was matched to its Geist counterpart by oklch distance rather than by eye, so the result reads the same while staying on the palette the rest of the dashboard is built from.

| | light | dark |
|---|---|---|
| fill | step 100 | step 900 |
| border | step 200 | step 900 |
| text | step 700 | step 300 |

`info` reads off the sky ramp rather than blue, because `--color-blue-500`/`-600` are remapped to the brand accent — a badge on those steps would read as a brand mark rather than a neutral status.

## Why

Each status colour had been defined ad hoc, and three were wrong in ways worth calling out:

- **`warning` changed colour on hover.** The base was a flat `bg-yellow-300`, the hover `bg-warning/20` — a different, much lighter colour.
- **Opacity tints picked up their surroundings.** `success` was `bg-green-500/15`, so a badge read differently on a striped table row than on a card, and washed out on a dark one.
- **The outline badge had no border.** `border-transparent` on the base class shares specificity with each variant's own `border-*`, so the compiled output order decided the winner and the outline variant's border never rendered. Each variant now states its own border colour.

The price list badge also bypassed the variants entirely with `bg-emerald-100` — a different green from the one `success` used for the same "active" meaning. It now uses the shared variants.

This replaces the previous single-value `--color-success` family, which had to be re-tinted at every call site and was bypassed by most of them for that reason.

## Accessibility

Badge text is 12px, so it needs 4.5:1 against its own fill. Every variant now clears WCAG AA in both themes, measured against the compiled stylesheet:

| variant | light | dark |
|---|---|---|
| success | 4.72 | 6.46 |
| warning | 4.52 | 6.26 |
| destructive | 5.27 | 5.22 |
| info | 5.09 | 5.69 |
| outline | 7.68 | 9.90 |

Green's fill sits one step lighter than the other three: Tailwind's `green-700` on `green-100` measures 4.497:1, under the threshold by 0.003. Invisible beside the others, but this keeps the set passing by measurement rather than by rounding.

## Testing

- `pnpm exec tsc -b` and Biome both clean
- 83 dashboard tests pass
- Verified by rendering every variant against the compiled stylesheet in both themes and measuring computed colours, rather than reading the source

## Not included

The same hardcoded status colours still exist in `alert.tsx`, three hand-rolled warning callouts, and a few status dots. They're out of scope here but are now inconsistent with the badges — worth a follow-up to align the whole surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status badges with consistent success, warning, danger, and informational colors across light and dark themes.
  * Improved badge backgrounds, borders, and text colors for clearer status distinction.
  * Fixed warning hover colors and outline borders.
  * Improved contrast to meet WCAG AA accessibility guidelines.
  * Standardized active and scheduled price list status badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->