### PR TITLE
Fixes ability to zero-out Price via Price List

### DIFF
--- a/spree/core/lib/spree/core/pricing/resolver.rb
+++ b/spree/core/lib/spree/core/pricing/resolver.rb
@@ -62,18 +62,19 @@ module Spree
       def find_price_for_list(price_list)
         currency = context.currency&.upcase
 
+        # Zero is a valid override (free for this list); only nil placeholder
+        # rows (materialized by PriceList#add_products) are skipped.
         if prices.loaded?
           prices.detect do |p|
             p.currency == currency &&
               p.price_list_id == price_list.id &&
-              p.amount.present? &&
-              !p.amount.zero?
+              !p.amount.nil?
           end
         else
           context.variant.prices
                  .with_currency(currency)
                  .where(price_list_id: price_list.id)
-                 .non_zero
+                 .where.not(amount: nil)
                  .first
         end
       end

--- a/spree/core/spec/lib/spree/pricing/resolver_spec.rb
+++ b/spree/core/spec/lib/spree/pricing/resolver_spec.rb
@@ -42,6 +42,44 @@ describe Spree::Pricing::Resolver do
       end
     end
 
+    context 'with a zero-amount price list price' do
+      let!(:price_list) { create(:price_list, :active, store: store) }
+      let!(:list_price) { create(:price, variant: variant, currency: currency, amount: 0, price_list: price_list) }
+
+      it 'returns the free price list price instead of the base price' do
+        price = resolver.resolve
+        expect(price).to eq(list_price)
+        expect(price.amount).to eq(0)
+        expect(price.price_list_id).to eq(price_list.id)
+      end
+
+      it 'returns the free price list price when prices are already loaded' do
+        variant.prices.load
+        price = resolver.resolve
+        expect(price).to eq(list_price)
+        expect(price.amount).to eq(0)
+      end
+    end
+
+    context 'with a placeholder (nil amount) price list price' do
+      let!(:price_list) { create(:price_list, :active, store: store) }
+      let!(:list_price) { create(:price, variant: variant, currency: currency, amount: nil, price_list: price_list) }
+
+      it 'falls back to the base price' do
+        base_price = variant.prices.base_prices.with_currency(currency).first
+        price = resolver.resolve
+        expect(price).to eq(base_price)
+        expect(price.amount).to eq(19.99)
+      end
+
+      it 'falls back to the base price when prices are already loaded' do
+        variant.prices.load
+        price = resolver.resolve
+        expect(price.amount).to eq(19.99)
+        expect(price.price_list_id).to be_nil
+      end
+    end
+
     context 'with multiple applicable price lists' do
       let!(:second_position_list) { create(:price_list, :active, store: store, position: 2) }
       let!(:second_position_price) { create(:price, variant: variant, currency: currency, amount: 17.99, price_list: second_position_list) }


### PR DESCRIPTION
1. Saving "0.00" in the price list UI does persist it: PriceList#bulk_update_prices parses "0.00" → 0.0 (only blank becomes nil), so the spree_prices row exists with amount: 0.0 and the correct price_list_id.
2. When the draft order line item is created, LineItem#update_price builds a pricing context from the order (including the customer, so your Customer Group rule matches fine) and calls Spree::Pricing::Resolver.
3. The resolver is where it dies — spree/core/lib/spree/core/pricing/resolver.rb:62 (find_price_for_list):
  - loaded path: p.amount.present? && !p.amount.zero?
  - query path: the .non_zero scope, defined at spree/core/app/models/spree/price.rb:42 as where.not(amount: [nil, 0])

Either way, the $0.00 price-list price is filtered out, find_price_from_lists returns nothing, and find_base_price returns the $50.00 base price.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-value price-list prices are now recognized as valid overrides.
  * Prices with no amount correctly fall back to the base price.
  * Pricing behavior is now consistent whether price data is loaded or preloaded.

* **Tests**
  * Added coverage for zero-value and missing price amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->