### PR TITLE
Refresh the cached store after a market write

### DIFF
--- a/packages/dashboard/src/hooks/use-markets.test.ts
+++ b/packages/dashboard/src/hooks/use-markets.test.ts
@@ -1,0 +1,70 @@
+import { STORE_QUERY_RESOURCE, withStoreScope } from '@spree/dashboard-core'
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import { marketUpdateInvalidations, marketWriteInvalidations } from './use-markets'
+
+const STORE_ID = 'store_abc123'
+
+/**
+ * Replays what `useResourceMutation` does on success — scope each logical key
+ * to the store, then invalidate — and reports which of the seeded queries went
+ * stale. Driving a real QueryClient means the assertions go through TanStack's
+ * own prefix matching rather than a hand-rolled key comparison.
+ */
+function staleKeysAfter(invalidate: ReturnType<typeof marketUpdateInvalidations>): string[] {
+  const queryClient = new QueryClient()
+
+  const seeded: Record<string, unknown[]> = {
+    store: [STORE_QUERY_RESOURCE, STORE_ID],
+    marketList: ['markets', STORE_ID, 'all'],
+    market: ['markets', STORE_ID, 'market_1'],
+    otherMarket: ['markets', STORE_ID, 'market_2'],
+    unrelated: ['products', STORE_ID],
+  }
+
+  for (const key of Object.values(seeded)) {
+    queryClient.setQueryData(key, {})
+  }
+
+  for (const key of invalidate) {
+    queryClient.invalidateQueries({ queryKey: withStoreScope(key, STORE_ID) })
+  }
+
+  return Object.entries(seeded)
+    .filter(([, key]) => queryClient.getQueryState(key)?.isInvalidated)
+    .map(([name]) => name)
+}
+
+describe('market write invalidations', () => {
+  // A store's supported currencies and locales are the union of its markets',
+  // so a market write leaves the cached store payload stale. Without this,
+  // pickers reading `useStore()` keep offering removed currencies/locales.
+  it('invalidates the store payload so derived currencies and locales refresh', () => {
+    expect(staleKeysAfter(marketWriteInvalidations)).toContain('store')
+    expect(staleKeysAfter(marketUpdateInvalidations('market_1'))).toContain('store')
+  })
+
+  it('invalidates every market query', () => {
+    const stale = staleKeysAfter(marketWriteInvalidations)
+
+    expect(stale).toContain('marketList')
+    expect(stale).toContain('market')
+  })
+
+  it('leaves unrelated resources cached', () => {
+    expect(staleKeysAfter(marketWriteInvalidations)).not.toContain('unrelated')
+    expect(staleKeysAfter(marketUpdateInvalidations('market_1'))).not.toContain('unrelated')
+  })
+
+  it('scopes invalidation to the current store', () => {
+    const queryClient = new QueryClient()
+    const otherStoreKey = [STORE_QUERY_RESOURCE, 'store_other']
+    queryClient.setQueryData(otherStoreKey, {})
+
+    for (const key of marketWriteInvalidations) {
+      queryClient.invalidateQueries({ queryKey: withStoreScope(key, STORE_ID) })
+    }
+
+    expect(queryClient.getQueryState(otherStoreKey)?.isInvalidated).toBe(false)
+  })
+})

--- a/packages/dashboard/src/hooks/use-markets.ts
+++ b/packages/dashboard/src/hooks/use-markets.ts
@@ -1,11 +1,12 @@
 import type { Market, MarketCreateParams, MarketUpdateParams } from '@spree/admin-sdk'
 import {
   adminClient,
+  STORE_QUERY_RESOURCE,
   useResourceKey,
   useResourceKeyBuilder,
   useResourceMutation,
 } from '@spree/dashboard-core'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { type QueryKey, useQuery, useQueryClient } from '@tanstack/react-query'
 import i18n from 'i18next'
 
 interface UseMarketsParams {
@@ -46,10 +47,27 @@ export function useMarket(id: string | undefined) {
   })
 }
 
+/**
+ * Query keys every market write invalidates.
+ *
+ * A store's supported currencies and locales are the union of its markets', so
+ * a market write makes the cached store payload stale — pickers built on
+ * `useStore()` would keep offering currencies and locales the markets no longer
+ * carry. `STORE_QUERY_RESOURCE` refreshes them alongside the market lists.
+ *
+ * Exported so the invalidation contract is assertable without rendering hooks.
+ */
+export const marketWriteInvalidations: QueryKey[] = [['markets'], [STORE_QUERY_RESOURCE]]
+
+/** As above, plus the single-market key the update writes through. */
+export function marketUpdateInvalidations(id: string): QueryKey[] {
+  return [['markets'], ['markets', id], [STORE_QUERY_RESOURCE]]
+}
+
 export function useCreateMarket() {
   return useResourceMutation<Market, Error, MarketCreateParams>({
     mutationFn: (params) => adminClient.markets.create(params),
-    invalidate: [['markets']],
+    invalidate: marketWriteInvalidations,
     successMessage: i18n.t('admin.markets.messages.created'),
     errorMessage: i18n.t('admin.markets.errors.failed_to_create'),
   })
@@ -58,7 +76,7 @@ export function useCreateMarket() {
 export function useUpdateMarket(id: string) {
   return useResourceMutation<Market, Error, MarketUpdateParams>({
     mutationFn: (params) => adminClient.markets.update(id, params),
-    invalidate: [['markets'], ['markets', id]],
+    invalidate: marketUpdateInvalidations(id),
     successMessage: i18n.t('admin.markets.messages.updated'),
     errorMessage: i18n.t('admin.markets.errors.failed_to_update'),
   })
@@ -70,7 +88,7 @@ export function useDeleteMarket() {
 
   return useResourceMutation<void, Error, string>({
     mutationFn: (id) => adminClient.markets.delete(id),
-    invalidate: [['markets']],
+    invalidate: marketWriteInvalidations,
     successMessage: i18n.t('admin.markets.messages.deleted'),
     errorMessage: i18n.t('admin.markets.errors.failed_to_delete'),
     onSuccess: (_data, id) => {


### PR DESCRIPTION
## What

A store's supported currencies and locales are the union of its markets (`Spree::Stores::Markets#supported_currencies_list` / `#supported_locales_list`). The dashboard caches the store payload under the `['store', storeId]` query key and `useStore()` hands it to consumers.

Market writes only invalidated the market lists, so after adding, editing or removing a market the cached store payload stayed as it was. Pickers reading it — `currency-select.tsx` among them — kept offering currencies and locales the markets no longer carried.

All three market mutations now invalidate the store query too, matching the pattern products, payment methods and store settings already follow.

## Notes

The invalidation lists moved into two exported constants so the contract is assertable without introducing React rendering tests — no package in the monorepo has that setup today. Behavior is unchanged.

The drag-reorder handler on the markets table calls `adminClient.markets.update` directly and so bypasses these invalidations. Left as is: reordering doesn't change which currencies or locales a store supports.

## Testing

New unit test drives a real `QueryClient`, replaying what `useResourceMutation` does on success, so assertions go through TanStack's own key matching rather than a hand-rolled comparison. It covers the store refresh, that market queries still invalidate, that unrelated resources stay cached, and that another store's payload is untouched.

Confirmed the test is not vacuously green: reverting the fix fails the store assertion (`expected [ 'marketList', 'market', …(1) ] to include 'store'`) while the other three still pass.

- `vitest run` — 93 passed across 11 files
- `tsc -b` — clean
- `biome check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market creation, updates, and deletions now refresh affected market and store data more reliably.
  * Updating a market refreshes its specific details without unnecessarily affecting unrelated resources.

* **Tests**
  * Added coverage to verify query refresh behavior and ensure unrelated cached data remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->