### PR TITLE
Fixed setting admin language when running first time setup

### DIFF
--- a/spree/api/spec/controllers/spree/api/v3/admin/setup_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/setup_controller_spec.rb
@@ -125,6 +125,15 @@ RSpec.describe Spree::Api::V3::Admin::SetupController, type: :controller do
         expect(store.delivery_zones.find_by(name: 'Domestic').members.pluck(:country_code)).to eq(['DE'])
       end
 
+      # Setup asks for one language, so it has to reach the back office as
+      # well as the storefront — the dashboard reads its own setting.
+      it 'puts the back office in the chosen language' do
+        post :create, params: valid_params.merge(country_code: 'de', locale: 'de'), as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(@default_store.reload.preferred_admin_locale).to eq('de')
+      end
+
       it 'accepts a currency that differs from the country default' do
         post :create, params: valid_params.merge(country_code: 'PL', locale: 'pl', currency: 'eur'), as: :json
 

--- a/spree/core/app/services/spree/stores/provision_defaults.rb
+++ b/spree/core/app/services/spree/stores/provision_defaults.rb
@@ -83,6 +83,7 @@ module Spree
           default_locale: locale,
           updated_at: Time.current
         )
+        adopt_admin_locale
         store.association(:default_market).reset
 
         market = store.default_market
@@ -95,6 +96,24 @@ module Spree
         market.save!
 
         store.association(:default_market).reset
+      end
+
+      # The merchant is asked for one language, and expects it to apply to the
+      # back office as well as the storefront — those are separate settings,
+      # and setting only the storefront one leaves the dashboard in English.
+      # This is the store-wide default, the weakest of the three tiers: an
+      # admin's own choice still wins, and Settings can change it later.
+      #
+      # Written even when the dashboard ships no translations for it. Whether
+      # a language has an admin bundle is the dashboard's own fact, not one
+      # this side can check without going stale — an unsupported code is
+      # ignored there and falls back to English, and starts working on its
+      # own if a bundle lands later.
+      def adopt_admin_locale
+        return if store.preferred_admin_locale.present?
+
+        store.preferred_admin_locale = locale
+        store.save!
       end
 
       # Match on identity alone: folding the other attributes into the finder

--- a/spree/core/spec/services/spree/stores/provision_defaults_spec.rb
+++ b/spree/core/spec/services/spree/stores/provision_defaults_spec.rb
@@ -34,6 +34,30 @@ RSpec.describe Spree::Stores::ProvisionDefaults do
     end
   end
 
+  # The storefront language and the back-office language are separate
+  # settings, and setup only asks once — so the answer has to reach both.
+  describe 'the admin language' do
+    it 'puts the back office in the chosen language too' do
+      subject
+
+      expect(store.reload.preferred_admin_locale).to eq('de')
+    end
+
+    it 'leaves an existing choice alone' do
+      store.update!(preferred_admin_locale: 'fr')
+
+      expect { subject }.not_to change { store.reload.preferred_admin_locale }
+    end
+
+    # The dashboard ships its own set of admin translations, which this side
+    # cannot check; it ignores a code it has no bundle for.
+    it 'records the language even when it has no admin translations' do
+      described_class.call(store: store, country: Spree::Country.by_iso('AL'), locale: 'sq')
+
+      expect(store.reload.preferred_admin_locale).to eq('sq')
+    end
+  end
+
   describe 'the stock location' do
     it 'places the warehouse in the chosen country' do
       subject


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store setup now saves the selected language for the back-office experience.
  * Supported and unsupported locale selections are recorded appropriately.
  * Existing back-office language preferences are preserved.

* **Bug Fixes**
  * Ensures the chosen locale is applied when provisioning a new store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->