### PR TITLE
Stop the dashboard reloading when a store speaks another language

### DIFF
--- a/.changeset/dashboard-locale-reload-loop.md
+++ b/.changeset/dashboard-locale-reload-loop.md
@@ -1,0 +1,9 @@
+---
+'@spree/dashboard-core': patch
+---
+
+Fix an endless reload when a store sets a non-English admin language.
+
+i18next was initialized with the stored language but only the English bundle, so it resolved the language to the fallback and reported English no matter what was stored. The store-default reconciler compares those two values to decide whether the page needs reloading, saw a permanent mismatch, and reloaded on every boot — each reload rotating a refresh token until the API's rate limit stopped it.
+
+Every bundle is now registered when i18next starts, so the stored language resolves to itself and the reconciler reloads only when the language genuinely changes.

--- a/packages/dashboard-core/src/lib/i18n.ts
+++ b/packages/dashboard-core/src/lib/i18n.ts
@@ -116,8 +116,9 @@ export function reconcileStoreDefaultLocale(
 }
 
 // All non-English core bundles, imported EAGERLY so the active language has its
-// resources synchronously available (registered just after init() below) —
-// no flash, no async race with module-load `i18n.t(...)` calls.
+// resources synchronously available when init() runs below — no flash, no async
+// race with module-load `i18n.t(...)` calls, and the stored language resolves
+// to itself rather than falling back.
 const coreLocales = import.meta.glob<{ default: Record<string, unknown> }>(
   ['../locales/*.json', '!../locales/en.json'],
   { eager: true },
@@ -160,10 +161,23 @@ export function switchLocale(code: string): void {
 // after this side-effect import has settled. The `deep` + `overwrite` flags
 // merge the extension into the base namespace without dropping framework keys.
 //
-// English ships eagerly; `lng` is read from localStorage so a previously
-// chosen language is the initial language on first paint (no flash).
+// `lng` is read from localStorage so a previously chosen language is the
+// initial language on first paint (no flash).
 i18n.use(initReactI18next).init({
-  resources: { en: { translation: en } },
+  // Every bundle is registered up front. Passing `lng` with only English
+  // loaded would resolve the language to the fallback and leave
+  // `resolvedLanguage` stuck on 'en' — which reads as "the stored language
+  // never took effect" and sends the store-default reconciler into a
+  // reload loop.
+  resources: {
+    en: { translation: en },
+    ...Object.fromEntries(
+      Object.entries(coreLocales).map(([path, mod]) => [
+        path.replace('../locales/', '').replace('.json', ''),
+        { translation: mod.default },
+      ]),
+    ),
+  },
   lng: readStoredLocale(),
   fallbackLng: 'en',
   interpolation: { escapeValue: false },
@@ -175,12 +189,6 @@ i18n.use(initReactI18next).init({
     ? (_lngs, _ns, key) => console.warn(`[i18n] Missing key: ${key}`)
     : undefined,
 })
-
-// Register the eager non-English core bundles now that i18next is initialized.
-for (const [path, mod] of Object.entries(coreLocales)) {
-  const code = path.replace('../locales/', '').replace('.json', '')
-  i18n.addResourceBundle(code, 'translation', mod.default, true, true)
-}
 
 // Reflect the active language on the root <html> element so the document
 // advertises the right `lang` (a11y, spellcheck, font selection) and `dir`

--- a/packages/dashboard-core/tests/i18n-init.test.ts
+++ b/packages/dashboard-core/tests/i18n-init.test.ts
@@ -1,0 +1,65 @@
+import { createInstance } from 'i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * `reconcileStoreDefaultLocale` decides whether to reload the page by comparing
+ * the store's language against `i18n.resolvedLanguage`. That comparison is only
+ * meaningful if the stored language actually resolved — and it resolves to the
+ * fallback when its bundle is missing at `init()` time.
+ *
+ * Registering bundles after init leaves `resolvedLanguage` on 'en' forever, so
+ * the reconciler sees a mismatch on every boot and reloads in a loop. These
+ * tests pin the ordering that avoids it.
+ */
+describe('i18n initialization ordering', () => {
+  it('resolves a non-English language when its bundle is present at init', async () => {
+    const i18n = createInstance()
+    await i18n.init({
+      resources: {
+        en: { translation: { hello: 'Hello' } },
+        pl: { translation: { hello: 'Cześć' } },
+      },
+      lng: 'pl',
+      fallbackLng: 'en',
+    })
+
+    expect(i18n.resolvedLanguage).toBe('pl')
+    expect(i18n.t('hello')).toBe('Cześć')
+  })
+
+  it('falls back to English when the bundle is registered only after init', async () => {
+    const i18n = createInstance()
+    await i18n.init({
+      resources: { en: { translation: { hello: 'Hello' } } },
+      lng: 'pl',
+      fallbackLng: 'en',
+    })
+    i18n.addResourceBundle('pl', 'translation', { hello: 'Cześć' }, true, true)
+
+    // The bundle is there, but the language resolved before it arrived — this
+    // is the state that made the reconciler reload endlessly.
+    expect(i18n.resolvedLanguage).toBe('en')
+  })
+
+  it('resolves the stored language, so the reconciler sees no mismatch', async () => {
+    // A store whose admin language is Polish, already adopted and persisted.
+    // The module reads this at import time to pick its initial language.
+    const store = new Map([
+      ['spree-admin-locale', 'pl'],
+      ['spree-admin-locale-auto-store', 'store_1'],
+    ])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+    })
+
+    const { i18n, coreLocaleCodes } = await import('../src/lib/i18n')
+
+    expect(coreLocaleCodes()).toContain('pl')
+    // The guard inside reconcileStoreDefaultLocale is `target !== current`,
+    // where current is this value. It must equal the stored language or the
+    // page reloads on every boot, forever.
+    expect(i18n.resolvedLanguage ?? i18n.language).toBe('pl')
+  })
+})


### PR DESCRIPTION
## The problem

A store whose admin language is not English put the dashboard into an endless reload. Every boot reloaded the page, and each reload rotated a refresh token until the API's rate limit answered 429:

```
POST /api/v3/admin/auth/refresh → 200   (token rotated)
GET  /api/v3/admin/me           → 200
POST /api/v3/admin/auth/refresh → 200   (~1.5s later)
...
POST /api/v3/admin/auth/refresh → 429 Too Many Requests
```

Reproduces with any store whose `preferred_admin_locale` is set and an admin account with no `selected_locale` of their own.

## The cause

`i18next.init()` received the stored language via `lng`, but its `resources` held only the English bundle — the other bundles were registered on the following line. With no resources for that language at init time, i18next resolved it to the fallback and left `resolvedLanguage` on `'en'` for good; registering the bundle afterwards did not revisit that decision.

`reconcileStoreDefaultLocale` decides whether a reload is needed by comparing the store's language against `i18n.resolvedLanguage`. That comparison was `'pl' !== 'en'` — permanently true — so it reloaded every time it ran.

The reload loop is what drove the refresh loop: each reload remounted `AuthProvider`, whose boot effect refreshes the access token.

## The fix

Register every locale bundle inside `init()` rather than after it, so the stored language resolves to itself and the reconciler reloads only on a genuine change.

## Verifying

`tests/i18n-init.test.ts` pins the ordering. The third case fails against the previous code and passes with the fix; the second documents the broken state directly, asserting that a bundle registered after init leaves the language resolved to English.

Worth noting the storage side was never at fault — `spree-admin-locale` and `spree-admin-locale-auto-store` were both written correctly. Only the comparison was wrong, which is why the loop survived a fresh login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed endless reloads when the dashboard is configured to use a non-English language.
  * Improved locale loading so saved language preferences are applied correctly at startup.
  * Ensured the dashboard falls back to English when a selected translation is unavailable.

* **Tests**
  * Added coverage for language initialization, fallback behavior, and persisted locale preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->