### PR TITLE
drop shoulda-matchers gem

### DIFF
--- a/spree/common_spree_dependencies.rb
+++ b/spree/common_spree_dependencies.rb
@@ -34,7 +34,6 @@ group :test do
   gem 'webmock'
   gem 'timecop'
   gem 'rails-controller-testing'
-  gem 'shoulda-matchers', '~> 6.0'
 end
 
 group :test, :development do

--- a/spree/core/spec/models/spree/allowed_origin_spec.rb
+++ b/spree/core/spec/models/spree/allowed_origin_spec.rb
@@ -5,14 +5,8 @@ require 'spec_helper'
 RSpec.describe Spree::AllowedOrigin, type: :model do
   let(:store) { create(:store) }
 
-  describe 'associations' do
-    it { is_expected.to belong_to(:store).class_name('Spree::Store').without_validating_presence }
-  end
-
   describe 'validations' do
     subject { build(:allowed_origin, store: store) }
-
-    it { is_expected.to validate_presence_of(:origin) }
 
     it 'validates uniqueness of origin scoped to store' do
       create(:allowed_origin, store: store, origin: 'https://example.com')

--- a/spree/core/spec/models/spree/concerns/admin_user_methods_spec.rb
+++ b/spree/core/spec/models/spree/concerns/admin_user_methods_spec.rb
@@ -4,22 +4,6 @@ describe Spree::AdminUserMethods do
   let(:admin_user) { create(:admin_user) }
   let(:current_store) { @default_store }
 
-  describe 'associations' do
-    it { expect(admin_user).to have_many(:identities).dependent(:destroy) }
-    it { expect(admin_user).to have_many(:canceled_orders) }
-    it { expect(admin_user).to have_many(:created_orders) }
-    it { expect(admin_user).to have_many(:approved_orders) }
-    it { expect(admin_user).to have_many(:created_gift_cards) }
-    it { expect(admin_user).to have_many(:created_gift_card_batches) }
-    it { expect(admin_user).to have_many(:refunded_refunds) }
-    it { expect(admin_user).to have_many(:created_returns) }
-    it { expect(admin_user).to have_many(:created_exchanges) }
-    it { expect(admin_user).to have_many(:created_claims) }
-    it { expect(admin_user).to have_many(:created_store_credits) }
-    it { expect(admin_user).to have_many(:reports) }
-    it { expect(admin_user).to have_many(:exports) }
-  end
-
   describe 'prefixed_id' do
     it 'generates a prefixed_id starting with adm_' do
       expect(admin_user.prefixed_id).to start_with('adm_')

--- a/spree/core/spec/models/spree/customer_group_spec.rb
+++ b/spree/core/spec/models/spree/customer_group_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Spree::CustomerGroup, type: :model do
   let(:customer_group) { create(:customer_group, store: store) }
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:name) }
-
     context 'uniqueness' do
       let!(:existing_group) { create(:customer_group, name: 'VIP', store: store) }
 

--- a/spree/core/spec/models/spree/customer_group_user_spec.rb
+++ b/spree/core/spec/models/spree/customer_group_user_spec.rb
@@ -4,15 +4,7 @@ RSpec.describe Spree::CustomerGroupUser, type: :model do
   let(:customer_group) { create(:customer_group) }
   let(:user) { create(:user) }
 
-  describe 'associations' do
-    it { is_expected.to belong_to(:customer_group).optional(false) }
-    it { is_expected.to belong_to(:customer).optional(false) }
-  end
-
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:customer_group) }
-    it { is_expected.to validate_presence_of(:customer) }
-
     context 'uniqueness' do
       let!(:existing) { create(:customer_group_user, customer_group: customer_group, customer: user) }
 

--- a/spree/core/spec/models/spree/import_mapping_spec.rb
+++ b/spree/core/spec/models/spree/import_mapping_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe Spree::ImportMapping, type: :model do
   let(:user) { create(:admin_user) }
   let(:import) { create(:product_import, owner: store, user: user) }
 
-  describe 'Associations' do
-    it { is_expected.to belong_to(:import) }
-  end
-
   describe 'Validations' do
     describe 'presence validations' do
       it 'validates presence of import' do

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Spree::Market, type: :model do
   describe 'validations' do
     subject { build(:market, store: store) }
 
-    it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:currency) }
-    it { is_expected.to validate_presence_of(:default_locale) }
-
     it 'validates presence of countries' do
       market = build(:market, store: store, countries: [])
       expect(market).not_to be_valid

--- a/spree/core/spec/models/spree/newsletter_subscriber_spec.rb
+++ b/spree/core/spec/models/spree/newsletter_subscriber_spec.rb
@@ -8,16 +8,17 @@ describe Spree::NewsletterSubscriber, type: :model, newsletter: true do
   it_behaves_like 'lifecycle events'
 
   describe 'normalizations' do
-    it { is_expected.to normalize(:email).from(" ME@XYZ.COM\n").to('me@xyz.com') }
-    it { is_expected.to normalize(:email).from('').to(nil) }
-    it { is_expected.to normalize(:email).from(nil).to(nil) }
-  end
+    it 'strips whitespace and downcases the email' do
+      expect(described_class.new(email: " ME@XYZ.COM\n").email).to eq('me@xyz.com')
+    end
 
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:email) }
-    it { is_expected.to validate_uniqueness_of(:email).scoped_to(:store_id).ignoring_case_sensitivity }
-    it { is_expected.to allow_value('test@example.com').for(:email) }
-    it { is_expected.not_to allow_value('test@').for(:email) }
+    it 'normalizes a blank email to nil' do
+      expect(described_class.new(email: '').email).to be_nil
+    end
+
+    it 'normalizes a nil email to nil' do
+      expect(described_class.new(email: nil).email).to be_nil
+    end
   end
 
   describe 'callbacks' do

--- a/spree/core/spec/models/spree/stock_reservation_spec.rb
+++ b/spree/core/spec/models/spree/stock_reservation_spec.rb
@@ -1,17 +1,8 @@
 require 'spec_helper'
 
 describe Spree::StockReservation, type: :model do
-  describe 'associations' do
-    it { is_expected.to belong_to(:stock_item).class_name('Spree::StockItem').without_validating_presence }
-    it { is_expected.to belong_to(:line_item).class_name('Spree::LineItem').without_validating_presence }
-    it { is_expected.to belong_to(:order).class_name('Spree::Order').without_validating_presence }
-  end
-
   describe 'validations' do
     let(:reservation) { build(:stock_reservation) }
-
-    it { is_expected.to validate_presence_of(:quantity) }
-    it { is_expected.to validate_presence_of(:expires_at) }
 
     it 'requires positive integer quantity' do
       reservation.quantity = 0

--- a/spree/core/spec/models/spree/user_identity_spec.rb
+++ b/spree/core/spec/models/spree/user_identity_spec.rb
@@ -1,15 +1,8 @@
 require 'spec_helper'
 
 describe Spree::UserIdentity, type: :model do
-  describe 'associations' do
-    it { is_expected.to belong_to(:user).required }
-  end
-
   describe 'validations' do
     subject { build(:user_identity) }
-
-    it { is_expected.to validate_presence_of(:provider) }
-    it { is_expected.to validate_presence_of(:uid) }
 
     it 'validates provider is a registered authentication strategy' do
       identity = build(:user_identity, provider: 'unsupported')

--- a/spree/core/spec/spec_helper.rb
+++ b/spree/core/spec/spec_helper.rb
@@ -49,7 +49,6 @@ end
 require 'rspec/rails'
 require 'database_cleaner/active_record'
 require 'ffaker'
-require 'shoulda-matchers'
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
@@ -106,11 +105,4 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
-end
-
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
-  end
 end


### PR DESCRIPTION
these tests were not exactly useful anyways

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated model test coverage by removing redundant association and presence-validation checks.
  - Added explicit coverage for newsletter email normalization, including whitespace removal, lowercasing, and blank-value handling.
  - Retained uniqueness and behavioral validation scenarios.

- **Chores**
  - Removed an unused test-support dependency and related test configuration.
  - Simplified the automated test setup and reduced maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->