### PR TITLE
Improve currency/locale/country comboboxes

### DIFF
--- a/packages/dashboard-core/src/components/address-form-dialog.tsx
+++ b/packages/dashboard-core/src/components/address-form-dialog.tsx
@@ -242,12 +242,16 @@ export function AddressFormDialog({
                 <FieldError errors={[errors.address2]} />
               </Field>
               <Field>
-                <FieldLabel>{t('admin.fields.country_code.label')}</FieldLabel>
+                <FieldLabel htmlFor="addr-country">
+                  {t('admin.fields.country_code.label')}
+                </FieldLabel>
                 <Controller
                   name="country_code"
                   control={form.control}
                   render={({ field }) => (
                     <CountryCombobox
+                      id="addr-country"
+                      invalid={!!errors.country_code}
                       value={field.value}
                       onValueChange={(iso) => {
                         field.onChange(iso)
@@ -270,12 +274,16 @@ export function AddressFormDialog({
                 </Field>
                 {useStateCombobox ? (
                   <Field>
-                    <FieldLabel>{t('admin.fields.state_code.label')}</FieldLabel>
+                    <FieldLabel htmlFor="addr-state">
+                      {t('admin.fields.state_code.label')}
+                    </FieldLabel>
                     <Controller
                       name="state_code"
                       control={form.control}
                       render={({ field }) => (
                         <StateCombobox
+                          id="addr-state"
+                          invalid={!!errors.state_code}
                           countryCode={countryCode}
                           states={states}
                           value={field.value}

--- a/packages/dashboard-core/src/components/address-form-dialog.tsx
+++ b/packages/dashboard-core/src/components/address-form-dialog.tsx
@@ -253,6 +253,7 @@ export function AddressFormDialog({
                       id="addr-country"
                       invalid={!!errors.country_code}
                       value={field.value}
+                      onBlur={field.onBlur}
                       onValueChange={(iso) => {
                         field.onChange(iso)
                         form.setValue('state_code', '', { shouldDirty: true })
@@ -287,6 +288,7 @@ export function AddressFormDialog({
                           countryCode={countryCode}
                           states={states}
                           value={field.value}
+                          onBlur={field.onBlur}
                           onValueChange={field.onChange}
                         />
                       )}

--- a/packages/dashboard-core/src/components/country-combobox.tsx
+++ b/packages/dashboard-core/src/components/country-combobox.tsx
@@ -1,16 +1,17 @@
 import {
   Combobox,
+  ComboboxButtonTrigger,
   ComboboxChip,
   ComboboxChips,
   ComboboxChipsInput,
   ComboboxContent,
   ComboboxEmpty,
-  ComboboxInput,
   ComboboxItem,
   ComboboxList,
+  ComboboxSearch,
+  ComboboxTriggerPlaceholder,
   ComboboxValue,
   CountryFlag,
-  InputGroupAddon,
   useComboboxAnchor,
 } from '@spree/dashboard-ui'
 import { useCallback, useMemo, useState } from 'react'
@@ -87,34 +88,50 @@ function CountryRow({ country, label }: { country: CountryOption; label: string 
   )
 }
 
+/** Maps the cached country list onto the flat option shape both pickers use. */
+function useCountryOptions(): CountryOption[] {
+  const { countries } = useCountries()
+  return useMemo(
+    () => countries.map((c) => ({ iso: c.iso, iso3: c.iso3, name: c.name })),
+    [countries],
+  )
+}
+
 /**
  * Searchable single-select country picker. Value is the 2-letter ISO code
- * (so the field round-trips cleanly with the Spree API). Renders the country
- * name + flag in the trigger and `<CountryRow>` in the dropdown.
+ * (so the field round-trips cleanly with the Spree API).
+ *
+ * The field itself is a button showing the selected flag + name, with the
+ * search box inside the dropdown — see `<ComboboxButtonTrigger>` for why a
+ * text input is the wrong trigger for an address-adjacent picker.
  */
 export function CountryCombobox({
   id,
   value,
   onValueChange,
+  onBlur,
   placeholder,
+  searchPlaceholder,
+  invalid,
   disabled = false,
 }: {
-  /** Forwarded to the text input so a `<FieldLabel htmlFor>` can target it. */
+  /** Forwarded to the trigger so a `<FieldLabel htmlFor>` can target it. */
   id?: string
   value: string | null | undefined
   onValueChange: (iso: string) => void
+  /** Forwarded to the trigger so RHF's `<Controller>` can track touched state. */
+  onBlur?: () => void
+  /** Trigger text while nothing is selected. */
   placeholder?: string
+  /** Text in the dropdown's search box. */
+  searchPlaceholder?: string
+  invalid?: boolean
   disabled?: boolean
 }) {
   const { t } = useTranslation()
-  const { countries } = useCountries()
+  const items = useCountryOptions()
   const countryName = useCountryDisplayName()
   const filter = useCountryFilter()
-
-  const items: CountryOption[] = useMemo(
-    () => countries.map((c) => ({ iso: c.iso, iso3: c.iso3, name: c.name })),
-    [countries],
-  )
 
   // The Combobox holds the selected object internally; we adapt to a flat ISO
   // string at the boundary so callers don't have to thread the option shape.
@@ -132,22 +149,29 @@ export function CountryCombobox({
       // "Allemagne", "Germany", "DE", or "DEU" all find the country.
       filter={filter}
     >
-      <ComboboxInput
+      <ComboboxButtonTrigger
         id={id}
-        placeholder={placeholder ?? t('admin.components.country_combobox.search_placeholder')}
+        onBlur={onBlur}
         disabled={disabled}
+        aria-invalid={invalid || undefined}
       >
-        {/* When a country is picked the InputGroup gets a leading flag —
-            mirrors the dropdown items so the trigger shows the same shape.
-            Hidden while empty so the input doesn't lurch when typing a new
-            search query. */}
-        {selected?.iso && (
-          <InputGroupAddon align="inline-start">
+        {selected ? (
+          <>
             <CountryFlag iso={selected.iso} />
-          </InputGroupAddon>
+            <span className="truncate">{countryName(selected)}</span>
+          </>
+        ) : (
+          <ComboboxTriggerPlaceholder>
+            {placeholder ?? t('admin.components.country_combobox.placeholder')}
+          </ComboboxTriggerPlaceholder>
         )}
-      </ComboboxInput>
+      </ComboboxButtonTrigger>
       <ComboboxContent>
+        <ComboboxSearch
+          placeholder={
+            searchPlaceholder ?? t('admin.components.country_combobox.search_placeholder')
+          }
+        />
         <ComboboxEmpty>{t('admin.components.country_combobox.empty')}</ComboboxEmpty>
         <ComboboxList>
           {(country: CountryOption) => (
@@ -164,9 +188,13 @@ export function CountryCombobox({
 /**
  * Searchable multi-select country picker. Value is an array of 2-letter ISO
  * codes. Renders a flag + name per chip and `<CountryRow>` per dropdown row;
- * filters the cached `useCountries()` list client-side via `countryFilter`
- * (name + both ISO codes). Reused anywhere the admin picks multiple
+ * filters the cached `useCountries()` list client-side (localized name, raw
+ * name, and both ISO codes). Reused anywhere the admin picks multiple
  * countries (promotion Country rule, market/zone editors, …).
+ *
+ * Keeps the chips-with-inline-input shape rather than a button trigger: the
+ * chips are the selection display, and typing beside them is how a
+ * multi-select is expected to work.
  */
 export function CountryMultiCombobox({
   value,
@@ -184,16 +212,11 @@ export function CountryMultiCombobox({
   disabled?: boolean
 }) {
   const { t } = useTranslation()
-  const { countries } = useCountries()
+  const items = useCountryOptions()
   const countryName = useCountryDisplayName()
   const filter = useCountryFilter()
   const anchorRef = useComboboxAnchor()
   const [inputValue, setInputValue] = useState('')
-
-  const items: CountryOption[] = useMemo(
-    () => countries.map((c) => ({ iso: c.iso, iso3: c.iso3, name: c.name })),
-    [countries],
-  )
 
   // The Combobox holds full option objects; selection round-trips as ISO
   // strings. Selected ISOs not yet present in `items` (list still loading)
@@ -230,13 +253,13 @@ export function CountryMultiCombobox({
           }
         </ComboboxValue>
         <ComboboxChipsInput
-          placeholder={placeholder ?? t('admin.promotions.rules.country.search_placeholder')}
+          placeholder={placeholder ?? t('admin.components.country_combobox.search_placeholder')}
           value={inputValue}
           onChange={(e) => setInputValue((e.target as HTMLInputElement).value)}
         />
       </ComboboxChips>
       <ComboboxContent anchor={anchorRef}>
-        <ComboboxEmpty>{emptyText ?? t('admin.promotions.rules.country.empty')}</ComboboxEmpty>
+        <ComboboxEmpty>{emptyText ?? t('admin.components.country_combobox.empty')}</ComboboxEmpty>
         <ComboboxList>
           {(country: CountryOption) => (
             <ComboboxItem key={country.iso} value={country}>

--- a/packages/dashboard-core/src/components/country-state-fields.tsx
+++ b/packages/dashboard-core/src/components/country-state-fields.tsx
@@ -1,11 +1,13 @@
 import type { State } from '@spree/admin-sdk'
 import {
   Combobox,
+  ComboboxButtonTrigger,
   ComboboxContent,
   ComboboxEmpty,
-  ComboboxInput,
   ComboboxItem,
   ComboboxList,
+  ComboboxSearch,
+  ComboboxTriggerPlaceholder,
 } from '@spree/dashboard-ui'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -35,23 +37,39 @@ export function useCountryStates(countryCode: string | null | undefined) {
  * abbreviation (e.g. "CA"). Callers should hide this and render a free-text
  * Input when `useCountryStates(...).states` is empty.
  *
+ * Shares the country picker's button-trigger shape — the two sit side by side
+ * in every address form, so they have to look alike, and the state field is
+ * exactly as prone to being buried by the browser's saved-address panel.
+ *
  * Keyed on `countryCode` so the internal state is reset when the country
  * changes — prevents a stale highlight from a previous country.
  */
 export function StateCombobox({
+  id,
   countryCode,
   states,
   value,
   onValueChange,
+  onBlur,
   placeholder,
+  searchPlaceholder,
+  invalid,
   disabled = false,
 }: {
+  /** Forwarded to the trigger so a `<FieldLabel htmlFor>` can target it. */
+  id?: string
   countryCode: string | null | undefined
   /** State list for the active country (typically from `useCountryStates`). */
   states: Pick<State, 'abbr' | 'name'>[]
   value: string | null | undefined
   onValueChange: (abbr: string) => void
+  /** Forwarded to the trigger so RHF's `<Controller>` can track touched state. */
+  onBlur?: () => void
+  /** Trigger text while nothing is selected. */
   placeholder?: string
+  /** Text in the dropdown's search box. */
+  searchPlaceholder?: string
+  invalid?: boolean
   disabled?: boolean
 }) {
   const { t } = useTranslation()
@@ -66,12 +84,26 @@ export function StateCombobox({
       onValueChange={(s: StateOption | null) => onValueChange(s?.abbr ?? '')}
       itemToStringLabel={(s: StateOption | null) => s?.name ?? ''}
       itemToStringValue={(s: StateOption | null) => s?.abbr ?? ''}
+      disabled={disabled}
     >
-      <ComboboxInput
-        placeholder={placeholder ?? t('admin.components.state_combobox.search_placeholder')}
+      <ComboboxButtonTrigger
+        id={id}
+        onBlur={onBlur}
         disabled={disabled}
-      />
+        aria-invalid={invalid || undefined}
+      >
+        {selected ? (
+          <span className="truncate">{selected.name}</span>
+        ) : (
+          <ComboboxTriggerPlaceholder>
+            {placeholder ?? t('admin.components.state_combobox.placeholder')}
+          </ComboboxTriggerPlaceholder>
+        )}
+      </ComboboxButtonTrigger>
       <ComboboxContent>
+        <ComboboxSearch
+          placeholder={searchPlaceholder ?? t('admin.components.state_combobox.search_placeholder')}
+        />
         <ComboboxEmpty>{t('admin.components.state_combobox.empty')}</ComboboxEmpty>
         <ComboboxList>
           {(state: StateOption) => (

--- a/packages/dashboard-core/src/components/currency-select.tsx
+++ b/packages/dashboard-core/src/components/currency-select.tsx
@@ -47,7 +47,12 @@ interface CurrencySelectProps {
    * support — e.g. a market's currency.
    */
   options?: string[]
-  /** Marks the field required for screen readers + native form submission. */
+  /**
+   * Announces the field as required to screen readers. Enforcement is the
+   * form's job — every caller validates through react-hook-form, and the
+   * button trigger is not a form-associated control, so this never blocks a
+   * submit on its own.
+   */
   required?: boolean
   disabled?: boolean
   /** Text in the dropdown's search box. */

--- a/packages/dashboard-core/src/components/currency-select.tsx
+++ b/packages/dashboard-core/src/components/currency-select.tsx
@@ -1,15 +1,12 @@
 import {
   Combobox,
+  ComboboxButtonTrigger,
   ComboboxContent,
   ComboboxEmpty,
-  ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+  ComboboxSearch,
+  ComboboxTriggerPlaceholder,
 } from '@spree/dashboard-ui'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -47,17 +44,18 @@ interface CurrencySelectProps {
    * Currency codes to pick from. Defaults to the current store's
    * `supported_currencies`. Pass `ALL_CURRENCY_CODES` (or any custom list) for
    * contexts where the merchant chooses a currency the store doesn't yet
-   * support — e.g. a market's currency. Large lists switch to a searchable
-   * combobox automatically.
+   * support — e.g. a market's currency.
    */
   options?: string[]
   /** Marks the field required for screen readers + native form submission. */
   required?: boolean
   disabled?: boolean
+  /** Text in the dropdown's search box. */
+  searchPlaceholder?: string
+  invalid?: boolean
+  /** Forwarded to the trigger so RHF's `<Controller>` can track touched state. */
+  onBlur?: () => void
 }
-
-/** Above this many options a plain `<Select>` is unwieldy — switch to search. */
-const SEARCHABLE_THRESHOLD = 12
 
 /**
  * Picker for a currency code. Defaults to the current store's
@@ -66,7 +64,11 @@ const SEARCHABLE_THRESHOLD = 12
  * Pass `options` (e.g. `ALL_CURRENCY_CODES`) when the merchant may pick any
  * currency, such as a market's currency. Each option reads `CODE — Full Name`
  * (e.g. `USD — US Dollar`), with the name localized to the admin UI language.
- * Long option lists render a searchable combobox.
+ *
+ * Always searchable, whatever the list length. The picker used to fall back to
+ * a plain `<Select>` under a dozen options, which meant the same field behaved
+ * differently from one store to the next — typing to filter worked on a store
+ * with many currencies and did nothing on a store with three.
  */
 export function CurrencySelect({
   id,
@@ -77,6 +79,9 @@ export function CurrencySelect({
   options,
   required,
   disabled,
+  searchPlaceholder,
+  invalid,
+  onBlur,
 }: CurrencySelectProps) {
   const { t } = useTranslation()
   const { currencies, defaultCurrency } = useStore()
@@ -120,62 +125,51 @@ export function CurrencySelect({
 
   const hiddenInput = name ? <input type="hidden" name={name} value={value} /> : null
 
-  if (items.length > SEARCHABLE_THRESHOLD) {
-    return (
-      <>
-        {hiddenInput}
-        <Combobox
-          items={items}
-          value={value}
-          onValueChange={(next: string | null) => handleChange(next ?? '')}
-          itemToStringLabel={(code: string | null) => (code ? renderOption(code) : '')}
-          itemToStringValue={(code: string | null) => code ?? ''}
-          filter={filter}
-          disabled={disabled}
-        >
-          <ComboboxInput
-            id={id}
-            aria-required={required}
-            placeholder={t('admin.components.currency_select.placeholder')}
-            disabled={disabled}
-          />
-          <ComboboxContent>
-            <ComboboxEmpty>{t('admin.components.currency_select.empty')}</ComboboxEmpty>
-            <ComboboxList>
-              {(code: string) => (
-                <ComboboxItem key={code} value={code}>
-                  {renderOption(code)}
-                </ComboboxItem>
-              )}
-            </ComboboxList>
-          </ComboboxContent>
-        </Combobox>
-      </>
-    )
-  }
-
   return (
     <>
       {/* Hidden input keeps the parent `<form>` submit / FormData path working
           without each caller having to thread the value through state. */}
       {hiddenInput}
-      <Select value={value} onValueChange={handleChange} disabled={disabled}>
-        <SelectTrigger id={id} aria-required={required}>
-          {/* Base UI's `<SelectValue>` defaults to rendering the raw `value`
-              (the bare ISO code). Use the children render-prop so the
-              trigger shows the same `CODE — Full Name` as the items. */}
-          <SelectValue placeholder={t('admin.components.currency_select.placeholder')}>
-            {(v) => (v ? renderOption(v as string) : (v as string))}
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          {items.map((currency) => (
-            <SelectItem key={currency} value={currency}>
-              {renderOption(currency)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <Combobox
+        items={items}
+        value={value}
+        onValueChange={(next: string | null) => handleChange(next ?? '')}
+        itemToStringLabel={(code: string | null) => (code ? renderOption(code) : '')}
+        itemToStringValue={(code: string | null) => code ?? ''}
+        filter={filter}
+        disabled={disabled}
+      >
+        <ComboboxButtonTrigger
+          id={id}
+          onBlur={onBlur}
+          disabled={disabled}
+          aria-required={required}
+          aria-invalid={invalid || undefined}
+        >
+          {value ? (
+            <span className="truncate">{renderOption(value)}</span>
+          ) : (
+            <ComboboxTriggerPlaceholder>
+              {t('admin.components.currency_select.placeholder')}
+            </ComboboxTriggerPlaceholder>
+          )}
+        </ComboboxButtonTrigger>
+        <ComboboxContent>
+          <ComboboxSearch
+            placeholder={
+              searchPlaceholder ?? t('admin.components.currency_select.search_placeholder')
+            }
+          />
+          <ComboboxEmpty>{t('admin.components.currency_select.empty')}</ComboboxEmpty>
+          <ComboboxList>
+            {(code: string) => (
+              <ComboboxItem key={code} value={code}>
+                {renderOption(code)}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
     </>
   )
 }

--- a/packages/dashboard-core/src/components/currency-select.tsx
+++ b/packages/dashboard-core/src/components/currency-select.tsx
@@ -48,10 +48,10 @@ interface CurrencySelectProps {
    */
   options?: string[]
   /**
-   * Announces the field as required to screen readers. Enforcement is the
-   * form's job — every caller validates through react-hook-form, and the
-   * button trigger is not a form-associated control, so this never blocks a
-   * submit on its own.
+   * Announces the field as required to assistive technology (`aria-required`).
+   * It does not enforce anything: the trigger is a button, so there is no
+   * native constraint validation behind it. The consuming form owns
+   * enforcement.
    */
   required?: boolean
   disabled?: boolean

--- a/packages/dashboard-core/src/components/locale-select.tsx
+++ b/packages/dashboard-core/src/components/locale-select.tsx
@@ -24,10 +24,10 @@ interface BaseProps {
   /** Locale to filter out (e.g. the default locale when picking additional supported ones). */
   excludeCode?: string
   /**
-   * Announces the field as required to screen readers. Enforcement is the
-   * form's job — every caller validates through react-hook-form, and the
-   * button trigger is not a form-associated control, so this never blocks a
-   * submit on its own.
+   * Announces the field as required to assistive technology (`aria-required`).
+   * It does not enforce anything: the trigger is a button, so there is no
+   * native constraint validation behind it. The consuming form owns
+   * enforcement.
    */
   required?: boolean
   disabled?: boolean
@@ -37,11 +37,12 @@ interface BaseProps {
 }
 
 /**
- * Single-select only. The multi-select renders chips rather than one trigger,
- * so it has no single control to mark invalid or to blur, and no in-popup
- * search box of its own — the chips input is the search box. Declaring these
- * here rather than on `BaseProps` makes passing them to a `multiple` picker a
- * compile error instead of a prop that is silently dropped.
+ * Single-select only, by design — the multi-select deliberately does not
+ * support these. Its search box is the chips input itself rather than a box
+ * inside the popup, and its validity is a property of the whole selection
+ * rather than of one control. Declaring them here rather than on `BaseProps`
+ * makes passing them to a `multiple` picker a compile error instead of a prop
+ * that is silently dropped.
  */
 interface SingleProps extends BaseProps {
   multiple?: false

--- a/packages/dashboard-core/src/components/locale-select.tsx
+++ b/packages/dashboard-core/src/components/locale-select.tsx
@@ -1,19 +1,16 @@
 import {
   Combobox,
+  ComboboxButtonTrigger,
   ComboboxChip,
   ComboboxChips,
   ComboboxChipsInput,
   ComboboxContent,
   ComboboxEmpty,
-  ComboboxInput,
   ComboboxItem,
   ComboboxList,
+  ComboboxSearch,
+  ComboboxTriggerPlaceholder,
   ComboboxValue,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   useComboboxAnchor,
 } from '@spree/dashboard-ui'
 import { useMemo, useState } from 'react'
@@ -30,6 +27,11 @@ interface BaseProps {
   required?: boolean
   disabled?: boolean
   placeholder?: string
+  /** Text in the dropdown's search box (single-select only). */
+  searchPlaceholder?: string
+  invalid?: boolean
+  /** Forwarded to the trigger so RHF's `<Controller>` can track touched state. */
+  onBlur?: () => void
   /** ID for the trigger / chips input — paired with the parent `<FieldLabel htmlFor>`. */
   id?: string
 }
@@ -58,15 +60,15 @@ function useLocaleDisplayName() {
   return (code: string) => displayName(code) ?? code
 }
 
-/** Mirrors `CurrencySelect`'s row format: `CODE — Localized Name`. */
+/**
+ * Mirrors `CurrencySelect`'s row format: `CODE — Localized Name`. Codes the
+ * runtime cannot name (`Intl.DisplayNames` returns the code back, as it does
+ * for `dz`) render as the bare upper-cased code rather than `DZ — dz`.
+ */
 function formatOption(code: string, name: string) {
   const upper = code.toUpperCase()
-  return name === code ? upper : `${upper} — ${name}`
+  return !name || name.toLowerCase() === code.toLowerCase() ? upper : `${upper} — ${name}`
 }
-
-/** Above this many options a plain `<Select>` is unwieldy — switch to a
- *  searchable combobox. Matches `CurrencySelect`. */
-const SEARCHABLE_THRESHOLD = 12
 
 /**
  * Combobox `filter` factory shared by the single- and multi-select pickers:
@@ -100,6 +102,11 @@ export function LocaleLabel({ code }: { code: string }) {
  * `Intl.DisplayNames` against the store's `default_locale`. Use this anywhere
  * the merchant is choosing a storefront language (market default, supported
  * locales list, customer preference, etc.).
+ *
+ * The single-select field is a button showing the current locale, with the
+ * search box inside the dropdown; it is always searchable, whatever the list
+ * length, so the field behaves the same on a store with three locales as on
+ * one offering the full translatable set.
  */
 export function LocaleSelect(props: LocaleSelectProps) {
   const { t } = useTranslation()
@@ -153,52 +160,45 @@ export function LocaleSelect(props: LocaleSelectProps) {
   const value = props.value ?? ''
   const placeholder = props.placeholder ?? t('admin.components.locale_select.placeholder')
 
-  // Long lists (e.g. the full set of translatable locales) are unusable as a
-  // plain dropdown — switch to a searchable combobox, matching `CurrencySelect`.
-  if (items.length > SEARCHABLE_THRESHOLD) {
-    return (
-      <Combobox
-        items={items}
-        value={value}
-        onValueChange={(next: string | null) => props.onChange(next ?? '')}
-        itemToStringLabel={(locale: string | null) => (locale ? labelFor(locale) : '')}
-        itemToStringValue={(locale: string | null) => locale ?? ''}
-        filter={localeFilter(labelFor)}
-        disabled={props.disabled}
-      >
-        <ComboboxInput id={props.id} aria-required={props.required} placeholder={placeholder} />
-        <ComboboxContent>
-          <ComboboxEmpty>{t('admin.components.locale_select.empty')}</ComboboxEmpty>
-          <ComboboxList>
-            {(locale: string) => (
-              <ComboboxItem key={locale} value={locale}>
-                {labelFor(locale)}
-              </ComboboxItem>
-            )}
-          </ComboboxList>
-        </ComboboxContent>
-      </Combobox>
-    )
-  }
-
   return (
-    <Select value={value} onValueChange={props.onChange} disabled={props.disabled}>
-      <SelectTrigger id={props.id} aria-required={props.required}>
-        {/* Base UI's `<SelectValue>` defaults to the raw locale code. Use
-            the children render-prop so the trigger shows the same
-            `CODE — Name` as the items. */}
-        <SelectValue placeholder={placeholder}>
-          {(v) => (v ? labelFor(v as string) : (v as string))}
-        </SelectValue>
-      </SelectTrigger>
-      <SelectContent>
-        {items.map((locale) => (
-          <SelectItem key={locale} value={locale}>
-            {labelFor(locale)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <Combobox
+      items={items}
+      value={value}
+      onValueChange={(next: string | null) => props.onChange(next ?? '')}
+      itemToStringLabel={(locale: string | null) => (locale ? labelFor(locale) : '')}
+      itemToStringValue={(locale: string | null) => locale ?? ''}
+      filter={localeFilter(labelFor)}
+      disabled={props.disabled}
+    >
+      <ComboboxButtonTrigger
+        id={props.id}
+        onBlur={props.onBlur}
+        disabled={props.disabled}
+        aria-required={props.required}
+        aria-invalid={props.invalid || undefined}
+      >
+        {value ? (
+          <span className="truncate">{labelFor(value)}</span>
+        ) : (
+          <ComboboxTriggerPlaceholder>{placeholder}</ComboboxTriggerPlaceholder>
+        )}
+      </ComboboxButtonTrigger>
+      <ComboboxContent>
+        <ComboboxSearch
+          placeholder={
+            props.searchPlaceholder ?? t('admin.components.locale_select.search_placeholder')
+          }
+        />
+        <ComboboxEmpty>{t('admin.components.locale_select.empty')}</ComboboxEmpty>
+        <ComboboxList>
+          {(locale: string) => (
+            <ComboboxItem key={locale} value={locale}>
+              {labelFor(locale)}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
   )
 }
 

--- a/packages/dashboard-core/src/components/locale-select.tsx
+++ b/packages/dashboard-core/src/components/locale-select.tsx
@@ -23,23 +23,35 @@ interface BaseProps {
   options?: string[]
   /** Locale to filter out (e.g. the default locale when picking additional supported ones). */
   excludeCode?: string
-  /** Marks the field required for screen readers + native form submission. */
+  /**
+   * Announces the field as required to screen readers. Enforcement is the
+   * form's job — every caller validates through react-hook-form, and the
+   * button trigger is not a form-associated control, so this never blocks a
+   * submit on its own.
+   */
   required?: boolean
   disabled?: boolean
   placeholder?: string
-  /** Text in the dropdown's search box (single-select only). */
-  searchPlaceholder?: string
-  invalid?: boolean
-  /** Forwarded to the trigger so RHF's `<Controller>` can track touched state. */
-  onBlur?: () => void
   /** ID for the trigger / chips input — paired with the parent `<FieldLabel htmlFor>`. */
   id?: string
 }
 
+/**
+ * Single-select only. The multi-select renders chips rather than one trigger,
+ * so it has no single control to mark invalid or to blur, and no in-popup
+ * search box of its own — the chips input is the search box. Declaring these
+ * here rather than on `BaseProps` makes passing them to a `multiple` picker a
+ * compile error instead of a prop that is silently dropped.
+ */
 interface SingleProps extends BaseProps {
   multiple?: false
   value: string | null | undefined
   onChange: (locale: string) => void
+  /** Text in the dropdown's search box. */
+  searchPlaceholder?: string
+  invalid?: boolean
+  /** Forwarded to the trigger so RHF's `<Controller>` can track touched state. */
+  onBlur?: () => void
 }
 
 interface MultiProps extends BaseProps {

--- a/packages/dashboard-core/src/locales/ar.json
+++ b/packages/dashboard-core/src/locales/ar.json
@@ -378,6 +378,7 @@
     "components": {
       "currency_select": {
         "placeholder": "اختر عملة",
+        "search_placeholder": "البحث في العملات…",
         "empty": "لم يتم العثور على عملات"
       },
       "channel_select": {
@@ -395,13 +396,16 @@
       "locale_select": {
         "placeholder": "اختر لغة",
         "multi_placeholder": "إضافة لغات…",
+        "search_placeholder": "البحث في اللغات…",
         "empty": "لم يتم العثور على لغات"
       },
       "country_combobox": {
+        "placeholder": "اختر بلداً",
         "search_placeholder": "البحث في البلدان…",
         "empty": "لم يتم العثور على بلدان"
       },
       "state_combobox": {
+        "placeholder": "اختر ولاية",
         "search_placeholder": "البحث في الولايات…",
         "empty": "لم يتم العثور على ولايات"
       },

--- a/packages/dashboard-core/src/locales/de.json
+++ b/packages/dashboard-core/src/locales/de.json
@@ -378,6 +378,7 @@
     "components": {
       "currency_select": {
         "placeholder": "Währung auswählen",
+        "search_placeholder": "Währungen suchen…",
         "empty": "Keine Währungen gefunden"
       },
       "channel_select": {
@@ -395,13 +396,16 @@
       "locale_select": {
         "placeholder": "Sprache auswählen",
         "multi_placeholder": "Sprachen hinzufügen…",
+        "search_placeholder": "Sprachen suchen…",
         "empty": "Keine Sprachen gefunden"
       },
       "country_combobox": {
+        "placeholder": "Land auswählen",
         "search_placeholder": "Länder suchen…",
         "empty": "Keine Länder gefunden"
       },
       "state_combobox": {
+        "placeholder": "Bundesland auswählen",
         "search_placeholder": "Bundesländer suchen…",
         "empty": "Keine Bundesländer gefunden"
       },

--- a/packages/dashboard-core/src/locales/en.json
+++ b/packages/dashboard-core/src/locales/en.json
@@ -378,6 +378,7 @@
     "components": {
       "currency_select": {
         "placeholder": "Select a currency",
+        "search_placeholder": "Search currencies…",
         "empty": "No currencies found"
       },
       "channel_select": {
@@ -395,13 +396,16 @@
       "locale_select": {
         "placeholder": "Select a locale",
         "multi_placeholder": "Add locales…",
+        "search_placeholder": "Search languages…",
         "empty": "No locales found"
       },
       "country_combobox": {
+        "placeholder": "Select a country",
         "search_placeholder": "Search countries…",
         "empty": "No countries found"
       },
       "state_combobox": {
+        "placeholder": "Select a state",
         "search_placeholder": "Search states…",
         "empty": "No states found"
       },

--- a/packages/dashboard-core/src/locales/fr.json
+++ b/packages/dashboard-core/src/locales/fr.json
@@ -378,6 +378,7 @@
     "components": {
       "currency_select": {
         "placeholder": "Sélectionner une devise",
+        "search_placeholder": "Rechercher des devises…",
         "empty": "Aucune devise trouvée"
       },
       "channel_select": {
@@ -395,13 +396,16 @@
       "locale_select": {
         "placeholder": "Sélectionner une langue",
         "multi_placeholder": "Ajouter des langues…",
+        "search_placeholder": "Rechercher des langues…",
         "empty": "Aucune langue trouvée"
       },
       "country_combobox": {
+        "placeholder": "Sélectionner un pays",
         "search_placeholder": "Rechercher des pays…",
         "empty": "Aucun pays trouvé"
       },
       "state_combobox": {
+        "placeholder": "Sélectionner une région",
         "search_placeholder": "Rechercher des régions…",
         "empty": "Aucune région trouvée"
       },

--- a/packages/dashboard-core/src/locales/pl.json
+++ b/packages/dashboard-core/src/locales/pl.json
@@ -378,6 +378,7 @@
     "components": {
       "currency_select": {
         "placeholder": "Wybierz walutę",
+        "search_placeholder": "Szukaj walut…",
         "empty": "Nie znaleziono walut"
       },
       "channel_select": {
@@ -395,13 +396,16 @@
       "locale_select": {
         "placeholder": "Wybierz język",
         "multi_placeholder": "Dodaj języki…",
+        "search_placeholder": "Szukaj języków…",
         "empty": "Nie znaleziono języków"
       },
       "country_combobox": {
+        "placeholder": "Wybierz kraj",
         "search_placeholder": "Szukaj krajów…",
         "empty": "Nie znaleziono krajów"
       },
       "state_combobox": {
+        "placeholder": "Wybierz województwo",
         "search_placeholder": "Szukaj województw…",
         "empty": "Nie znaleziono województw"
       },

--- a/packages/dashboard-core/src/locales/zh-CN.json
+++ b/packages/dashboard-core/src/locales/zh-CN.json
@@ -378,6 +378,7 @@
     "components": {
       "currency_select": {
         "placeholder": "选择货币",
+        "search_placeholder": "搜索货币…",
         "empty": "未找到货币"
       },
       "channel_select": {
@@ -395,13 +396,16 @@
       "locale_select": {
         "placeholder": "选择语言区域",
         "multi_placeholder": "添加语言区域…",
+        "search_placeholder": "搜索语言…",
         "empty": "未找到语言区域"
       },
       "country_combobox": {
+        "placeholder": "选择国家/地区",
         "search_placeholder": "搜索国家/地区…",
         "empty": "未找到国家/地区"
       },
       "state_combobox": {
+        "placeholder": "选择州/省",
         "search_placeholder": "搜索州/省…",
         "empty": "未找到州/省"
       },

--- a/packages/dashboard-ui/src/ui/combobox.tsx
+++ b/packages/dashboard-ui/src/ui/combobox.tsx
@@ -27,6 +27,82 @@ function ComboboxTrigger({ className, children, ...props }: ComboboxPrimitive.Tr
   )
 }
 
+/**
+ * Button-shaped trigger for a searchable picker: the field renders the current
+ * selection (flag, formatted label) and the search box lives inside the popup,
+ * next to the results it filters.
+ *
+ * Preferred over the editable-input trigger (`<ComboboxInput>`) whenever the
+ * selection has a richer display than the raw query text. A text input has to
+ * show the typed query, so it erases the selected label the moment the user
+ * types, and the browser's address autofill treats a text field named after a
+ * country as part of an address form and covers the list with saved addresses.
+ * A button has nothing to autofill into, and the search box inside the popup
+ * sits outside the form's field flow where those heuristics don't reach.
+ *
+ * Deliberately matches `<SelectTrigger>` so a picker sitting beside a plain
+ * select is indistinguishable from it until opened.
+ */
+function ComboboxButtonTrigger({ className, children, ...props }: ComboboxPrimitive.Trigger.Props) {
+  return (
+    <ComboboxPrimitive.Trigger
+      data-slot="combobox-button-trigger"
+      className={cn(
+        "flex w-full min-h-8.5 cursor-pointer items-center justify-between gap-1.5 rounded-lg border border-border bg-card py-1.5 pr-2 pl-2.5 text-base font-normal leading-normal text-foreground shadow-xs transition-all duration-100 ease-in-out outline-none select-none focus:border-blue-500 focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--ring)_15%,transparent)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-muted disabled:border-border disabled:text-muted-foreground disabled:shadow-none aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="flex min-w-0 items-center gap-2 truncate">{children}</span>
+      <ChevronDownIcon className="pointer-events-none size-4 shrink-0 text-muted-foreground" />
+    </ComboboxPrimitive.Trigger>
+  )
+}
+
+/**
+ * Placeholder text for a `<ComboboxButtonTrigger>` with nothing selected.
+ * A span rather than the trigger's own `data-placeholder`, because the
+ * trigger renders arbitrary children (a flag beside a name) rather than a
+ * single value string.
+ */
+function ComboboxTriggerPlaceholder({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="combobox-trigger-placeholder"
+      className={cn('truncate text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * Search box for a button-triggered picker, rendered at the top of the popup.
+ * Autofill and spell-check are turned off across the board: this filters an
+ * on-screen list, so a password manager or a saved-address panel covering it
+ * is pure interference.
+ */
+function ComboboxSearch({ className, ...props }: ComboboxPrimitive.Input.Props) {
+  return (
+    <div className="border-b border-border p-1">
+      <ComboboxInput
+        data-slot="combobox-search"
+        className={cn(
+          'min-h-8.5 border-0 shadow-none has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:shadow-none',
+          className,
+        )}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        data-1p-ignore
+        data-lpignore="true"
+        showTrigger={false}
+        {...props}
+      />
+    </div>
+  )
+}
+
 function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
   return (
     <ComboboxPrimitive.Clear
@@ -275,6 +351,7 @@ function useComboboxAnchor() {
 
 export {
   Combobox,
+  ComboboxButtonTrigger,
   ComboboxChip,
   ComboboxChips,
   ComboboxChipsInput,
@@ -286,8 +363,10 @@ export {
   ComboboxItem,
   ComboboxLabel,
   ComboboxList,
+  ComboboxSearch,
   ComboboxSeparator,
   ComboboxTrigger,
+  ComboboxTriggerPlaceholder,
   ComboboxValue,
   useComboboxAnchor,
 }

--- a/packages/dashboard/e2e/helpers.ts
+++ b/packages/dashboard/e2e/helpers.ts
@@ -194,9 +194,8 @@ export interface AddressInput {
 
 /**
  * Fill the shared `<AddressFormDialog>` Sheet ("Add address" / "Edit address").
- * The country picker is a Base UI Combobox; we drive it by typing into the
- * input (placeholder "Search countries...") and clicking the matching option.
- * Same pattern for the state combobox when the country needs one.
+ * The country and state pickers are button-triggered comboboxes: open the
+ * field, type into the search box inside the popup, then click the option.
  */
 export async function fillAddressForm(page: Page, address: AddressInput) {
   if (address.label !== undefined) await page.locator('#addr-label').fill(address.label)
@@ -207,10 +206,12 @@ export async function fillAddressForm(page: Page, address: AddressInput) {
   if (address.postalCode !== undefined) await page.locator('#addr-zip').fill(address.postalCode)
   if (address.phone !== undefined) await page.locator('#addr-phone').fill(address.phone)
   if (address.country) {
+    await page.locator('#addr-country').click()
     await page.getByPlaceholder(/^search countries/i).fill(address.country)
     await page.getByRole('option', { name: address.country }).first().click()
   }
   if (address.state) {
+    await page.locator('#addr-state').click()
     await page.getByPlaceholder(/^search states/i).fill(address.state)
     await page.getByRole('option', { name: address.state }).first().click()
   }

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/markets.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/markets.tsx
@@ -366,7 +366,9 @@ function MarketFormFields({ form }: { form: UseFormReturn<MarketFormValues> }) {
             <LocaleSelect
               id="market-default-locale"
               required
+              invalid={!!errors.default_locale}
               value={field.value}
+              onBlur={field.onBlur}
               onChange={field.onChange}
               options={availableLocales}
             />

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/markets.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/markets.tsx
@@ -343,7 +343,9 @@ function MarketFormFields({ form }: { form: UseFormReturn<MarketFormValues> }) {
             <CurrencySelect
               id="market-currency"
               required
+              invalid={!!errors.currency}
               value={field.value}
+              onBlur={field.onBlur}
               onChange={field.onChange}
               options={ALL_CURRENCY_CODES}
             />

--- a/packages/dashboard/src/routes/setup.tsx
+++ b/packages/dashboard/src/routes/setup.tsx
@@ -10,12 +10,13 @@ import {
 import {
   Button,
   Combobox,
+  ComboboxButtonTrigger,
   ComboboxContent,
   ComboboxEmpty,
-  ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  ComboboxTrigger,
+  ComboboxSearch,
+  ComboboxTriggerPlaceholder,
   CountryFlag,
   Input,
   Label,
@@ -328,45 +329,24 @@ function SetupForm({ token }: { token: string }) {
                 itemToStringValue={(country: SetupCountry | null) => country?.code ?? ''}
                 disabled={countriesQuery.isPending}
               >
-                {/* A button, not a text input. Chrome decides a field is part
-                    of an address form from its value and its neighbours, not
-                    just its name — "United States" sitting above Email was
-                    enough, and no combination of autocomplete attributes
-                    stopped the saved-address panel covering this list. There
-                    is nothing to autofill into a button. The search box lives
-                    inside the popup, where the address heuristics don't reach
-                    because it is outside the form's field flow. */}
-                <ComboboxTrigger
+                <ComboboxButtonTrigger
                   id="setup-country-search"
-                  className="flex min-h-8.5 w-full items-center justify-between gap-1.5 rounded-lg border border-border bg-card py-1.5 pr-2 pl-2.5 text-base leading-normal shadow-xs outline-none focus:border-blue-500 focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--ring)_15%,transparent)] aria-invalid:border-destructive"
                   onBlur={field.onBlur}
                   aria-invalid={!!errors.country_code || undefined}
                 >
                   {selectedCountry ? (
-                    <span className="flex items-center gap-2">
+                    <>
                       <CountryFlag iso={selectedCountry.code} />
-                      {selectedCountry.name}
-                    </span>
+                      <span className="truncate">{selectedCountry.name}</span>
+                    </>
                   ) : (
-                    <span className="text-muted-foreground">
+                    <ComboboxTriggerPlaceholder>
                       {t('admin.fields.setup.country_code.placeholder')}
-                    </span>
+                    </ComboboxTriggerPlaceholder>
                   )}
-                </ComboboxTrigger>
+                </ComboboxButtonTrigger>
                 <ComboboxContent>
-                  <div className="border-b border-border p-1">
-                    <ComboboxInput
-                      className="min-h-8.5 border-0 shadow-none has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:shadow-none"
-                      autoComplete="off"
-                      autoCorrect="off"
-                      autoCapitalize="off"
-                      spellCheck={false}
-                      data-1p-ignore
-                      data-lpignore="true"
-                      showTrigger={false}
-                      placeholder={t('admin.fields.setup.country_code.placeholder')}
-                    />
-                  </div>
+                  <ComboboxSearch placeholder={t('admin.fields.setup.country_code.placeholder')} />
                   <ComboboxEmpty>{t('admin.common.no_results')}</ComboboxEmpty>
                   <ComboboxList>
                     {(country: SetupCountry) => (
@@ -434,37 +414,23 @@ function SetupForm({ token }: { token: string }) {
                   itemToStringLabel={(code: string | null) => (code ? currencyLabel(code) : '')}
                   itemToStringValue={(code: string | null) => code ?? ''}
                 >
-                  {/* Same shape as the country field: a button trigger keeps
-                      the browser's address autofill out, and matches the
-                      select beside it at min-h-8.5. */}
-                  <ComboboxTrigger
+                  {/* Same shape as the country field, so the two read as one
+                      pair of fields. */}
+                  <ComboboxButtonTrigger
                     id="setup-currency-search"
-                    className="flex min-h-8.5 w-full items-center justify-between gap-1.5 rounded-lg border border-border bg-card py-1.5 pr-2 pl-2.5 text-base leading-normal shadow-xs outline-none focus:border-blue-500 focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--ring)_15%,transparent)] aria-invalid:border-destructive"
                     onBlur={field.onBlur}
                     aria-invalid={!!errors.currency || undefined}
                   >
                     {field.value ? (
-                      currencyLabel(field.value)
+                      <span className="truncate">{currencyLabel(field.value)}</span>
                     ) : (
-                      <span className="text-muted-foreground">
+                      <ComboboxTriggerPlaceholder>
                         {t('admin.fields.setup.currency.placeholder')}
-                      </span>
+                      </ComboboxTriggerPlaceholder>
                     )}
-                  </ComboboxTrigger>
+                  </ComboboxButtonTrigger>
                   <ComboboxContent>
-                    <div className="border-b border-border p-1">
-                      <ComboboxInput
-                        className="min-h-8.5 border-0 shadow-none has-[[data-slot=input-group-control]:focus-visible]:border-transparent has-[[data-slot=input-group-control]:focus-visible]:shadow-none"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        autoCapitalize="off"
-                        spellCheck={false}
-                        data-1p-ignore
-                        data-lpignore="true"
-                        showTrigger={false}
-                        placeholder={t('admin.fields.setup.currency.placeholder')}
-                      />
-                    </div>
+                    <ComboboxSearch placeholder={t('admin.fields.setup.currency.placeholder')} />
                     <ComboboxEmpty>{t('admin.common.no_results')}</ComboboxEmpty>
                     <ComboboxList>
                       {(code: string) => (


### PR DESCRIPTION
These three pickers each behaved differently. The field was a text input, so typing replaced the chosen value with a raw query and the merchant lost sight of what was selected. There was no search box in the dropdown, leaving the full list of countries or locales to scroll. And currency and language quietly switched between a searchable field and a plain dropdown depending on how many options a store happened to have, so the same field worked differently from one store to the next.

They now share the shape the setup screen already used: a button showing the current selection, with the search box inside the dropdown beside the results it filters. Searching always works, whatever the length of the list. A button also keeps the browser's saved-address panel from covering the list, which no combination of autofill attributes achieved on a text field sitting in an address form.

Multi-select stays as chips with an inline input — the chips are the selection, and typing beside them is what a multi-select should do.

The pickers gained the props a form field needs: the address dialog's country and state labels pointed at nothing, so clicking them focused nothing.

Also fixes a locale reading as "DZ — dz": a code the runtime cannot name hands back the code itself, and only an exact-case comparison caught that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent button-triggered, searchable selectors for countries, states, currencies, and locales.
  * Added localized selection and search placeholders in supported languages.
* **Bug Fixes**
  * Improved form accessibility through clearer label associations.
  * Added validation-state indicators and blur handling to selector fields.
  * Improved display formatting for missing or unknown locale names.
* **Usability**
  * Standardized selector behavior across setup and settings forms.
  * Search fields now open within selector menus for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->