### PR TITLE
Report a workflow rejection in words rather than a symbol

### DIFF
--- a/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
@@ -133,6 +133,11 @@ module Spree
             render_validation_error(error, code: code)
           elsif error.is_a?(String)
             render_error(code: code, message: error, status: status)
+          elsif error.is_a?(Symbol)
+            # Workflows reject with a symbol naming the reason. Translate it,
+            # falling back to the symbol so a missing key is visible rather
+            # than silently blank.
+            render_error(code: code, message: Spree.t(error, default: error.to_s.humanize), status: status)
           else
             render_error(code: code, message: error.to_s, status: status)
           end

--- a/spree/core/app/workflows/spree/price_lists/create.rb
+++ b/spree/core/app/workflows/spree/price_lists/create.rb
@@ -47,7 +47,10 @@ module Spree
         return if @bulk_payloads.empty?
 
         result = Spree.price_list_update_workflow.call(price_list: price_list, attributes: @bulk_payloads)
-        failure(price_list, result.error) unless result.success?
+        # `result.error` is already a ResultError; passing it whole would wrap
+        # it in a second one and hide the ActiveModel::Errors that
+        # render_result_error reads to build a 422 with field details.
+        failure(price_list, result.error.value) unless result.success?
       end
     end
   end

--- a/spree/core/app/workflows/spree/price_lists/update.rb
+++ b/spree/core/app/workflows/spree/price_lists/update.rb
@@ -40,7 +40,7 @@ module Spree
         # a missed key would send the bulk payload to the association setter.
         attrs = attributes.to_h.with_indifferent_access
 
-        @product_ids = attrs.key?(:product_ids) ? Array(attrs[:product_ids]).compact.uniq : nil
+        @product_ids = attrs.key?(:product_ids) ? decoded_product_ids(attrs[:product_ids]) : nil
         @prices = attrs.key?(:prices) ? attrs[:prices] : nil
 
         price_list.assign_attributes(attrs.except(:product_ids, :prices))
@@ -87,6 +87,17 @@ module Spree
         variant_ids = price_list.prices.distinct.pluck(:variant_id)
         price_list.prices.update_all(amount: nil, compare_at_amount: nil, updated_at: Time.current)
         touch_variants(variant_ids)
+      end
+
+      # Ids arrive prefixed from the console and legacy callers, already
+      # decoded from a controller that ran normalize_params — the same two
+      # shapes price_rows handles for variant_id. Comparing a prefixed string
+      # against an integer primary key would read as "every current member
+      # removed, none added".
+      def decoded_product_ids(ids)
+        Array(ids).compact.filter_map do |id|
+          Spree::PrefixedId.prefixed_id?(id) ? Spree::PrefixedId.decode_prefixed_id(id) : id
+        end.uniq
       end
 
       def price_rows

--- a/spree/core/app/workflows/spree/price_lists/update.rb
+++ b/spree/core/app/workflows/spree/price_lists/update.rb
@@ -91,13 +91,31 @@ module Spree
 
       # Ids arrive prefixed from the console and legacy callers, already
       # decoded from a controller that ran normalize_params — the same two
-      # shapes price_rows handles for variant_id. Comparing a prefixed string
-      # against an integer primary key would read as "every current member
-      # removed, none added".
+      # shapes price_rows handles for variant_id.
+      #
+      # Resolved against the store's own products rather than decoded and
+      # trusted. A prefix only encodes a number, so `variant_xxx` decodes to
+      # an integer that names a product just as readily; and a blank entry
+      # matches nothing, which would otherwise read as "remove every current
+      # member and add none".
       def decoded_product_ids(ids)
-        Array(ids).compact.filter_map do |id|
+        # `nil` is not a list: Array(nil) is [], which would otherwise read as
+        # the empty array that means "clear the list".
+        return nil if ids.nil?
+
+        given = Array(ids)
+        candidates = given.filter_map do |id|
+          next if id.blank?
+
           Spree::PrefixedId.prefixed_id?(id) ? Spree::PrefixedId.decode_prefixed_id(id) : id
-        end.uniq
+        end
+
+        # An empty array clears the list; an array of blanks is malformed
+        # input and must not read as the same instruction.
+        return nil if candidates.empty? && given.any?
+        return [] if candidates.empty?
+
+        price_list.store.products.where(id: candidates).ids
       end
 
       def price_rows

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1013,6 +1013,7 @@ en:
     gift_card_expired: The Gift Card has expired.
     gift_card_mismatched_currency: Gift Card cannot be applied with current currency.
     gift_card_mismatched_customer: This gift card is associated with another user.
+    gift_card_no_amount_remaining: The Gift Card has no amount remaining.
     gift_card_not_applied: The Gift Card could not be applied.
     gift_card_not_found: The Gift Card was not found.
     gift_card_removed: The Gift Card was successfully removed from your order
@@ -1034,6 +1035,7 @@ en:
     implement_eligible_for_return: 'Must implement #eligible_for_return? for your EligibilityValidator.'
     implement_requires_manual_intervention: 'Must implement #requires_manual_intervention? for your EligibilityValidator.'
     import: Import
+    import_has_no_failed_rows: This import has no failed rows to retry.
     import_mailer:
       greeting: Hi %{user_name},
       import_done:
@@ -1041,6 +1043,9 @@ en:
         message: Your import has finished. %{completed_count} rows were imported successfully.
         subject: Your import %{import_number} has finished processing
         view_results: View import report
+    import_mapping_not_completed: The import's column mapping is not complete yet.
+    import_not_mapping: This import is not being mapped.
+    import_not_processing: This import is not processing.
     in_stock: In Stock
     inactive: Inactive
     incl: incl.
@@ -1056,6 +1061,9 @@ en:
     invalid_exchange_variant: Invalid exchange variant.
     inventory: Inventory
     invitation_accepted: Invitation accepted!
+    invitation_already_accepted: This invitation has already been accepted.
+    invitation_expired: This invitation has expired.
+    invitation_invitee_missing: This invitation has no invitee.
     invitation_mailer:
       greeting: Hi %{user_name},
       invitation_accepted:

--- a/spree/core/spec/models/spree/price_list_spec.rb
+++ b/spree/core/spec/models/spree/price_list_spec.rb
@@ -163,8 +163,10 @@ describe Spree::PriceList, type: :model do
   describe 'product membership' do
     let(:store) { create(:store, supported_currencies: 'USD,EUR,GBP') }
     let(:price_list) { create(:price_list, store: store) }
-    let(:product1) { create(:product) }
-    let(:product2) { create(:product) }
+    # Same store as the list: membership resolves through the store's own
+    # products, so a product from another store is not a member to be had.
+    let(:product1) { create(:product, store: store) }
+    let(:product2) { create(:product, store: store) }
 
     # Guards the POST/PATCH /price_lists response: membership is reconciled
     # through raw upsert_all/delete_all, which bypasses the products

--- a/spree/core/spec/workflows/spree/price_lists/write_spec.rb
+++ b/spree/core/spec/workflows/spree/price_lists/write_spec.rb
@@ -54,6 +54,45 @@ RSpec.describe 'Spree::PriceLists write workflows' do
       expect(price_list.product_ids).to eq([product.id])
     end
 
+    # A prefix only encodes a number, so a variant's id decodes to an integer
+    # that names a product just as readily. Resolving through the store's own
+    # products is what stops one standing in for the other.
+    it 'ignores an id that does not name a product in this store' do
+      Spree.price_list_update_workflow.call(price_list: price_list, attributes: { product_ids: [product.id] })
+      foreign = create(:product, store: create(:store))
+
+      described_class.call(price_list: price_list, attributes: { product_ids: [product.id, foreign.id] })
+
+      expect(price_list.reload.product_ids).to eq([product.id])
+    end
+
+    # Array(nil) is [], so without a guard a nil payload reads as the empty
+    # array that means "clear the list".
+    it 'leaves membership alone when product_ids is nil' do
+      Spree.price_list_update_workflow.call(price_list: price_list, attributes: { product_ids: [product.id] })
+
+      described_class.call(price_list: price_list, attributes: { product_ids: nil })
+
+      expect(price_list.reload.product_ids).to eq([product.id])
+    end
+
+    # Malformed input is not the same instruction as an empty array.
+    it 'leaves membership alone when every id is blank' do
+      Spree.price_list_update_workflow.call(price_list: price_list, attributes: { product_ids: [product.id] })
+
+      described_class.call(price_list: price_list, attributes: { product_ids: ['', '  ', nil] })
+
+      expect(price_list.reload.product_ids).to eq([product.id])
+    end
+
+    it 'clears membership when given an empty array' do
+      Spree.price_list_update_workflow.call(price_list: price_list, attributes: { product_ids: [product.id] })
+
+      described_class.call(price_list: price_list, attributes: { product_ids: [] })
+
+      expect(price_list.reload.product_ids).to be_empty
+    end
+
     it 'adds and removes products' do
       other = create(:product, store: store)
 

--- a/spree/core/spec/workflows/spree/price_lists/write_spec.rb
+++ b/spree/core/spec/workflows/spree/price_lists/write_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe 'Spree::PriceLists write workflows' do
       expect(price_list.reload.name).to eq('StringKeys')
     end
 
+    # Prefixed ids arrive from the console and legacy callers; comparing them
+    # against integer primary keys would read as "remove everything".
+    it 'accepts prefixed product ids' do
+      described_class.call(price_list: price_list, attributes: { product_ids: [product.prefixed_id] })
+
+      expect(price_list.product_ids).to eq([product.id])
+    end
+
     it 'adds and removes products' do
       other = create(:product, store: store)
 


### PR DESCRIPTION
Three defects in the workflows that shipped with #14471, found in review after the merge.

### A rejection reached the client as a symbol name

Workflows reject with a symbol naming the reason, and `render_service_error` fell through to `error.to_s` for anything that was not a `String` or an `ActiveModel::Errors`. An invitee opening an expired invitation link was told `invitation_expired`.

Symbols are translated now, with the symbol humanized as the fallback so a missing key is visible rather than blank. This also adds the eight keys the workflows already named but which did not exist — three invitation reasons, four import ones, and the gift card's no-remaining-amount.

### A validation failure lost its field details

`PriceLists::Create` passed `result.error` — already a `ResultError` — back into `failure()`, which wrapped it in a second one. `render_result_error` then looked for `ActiveModel::Errors`, found a `ResultError`, and rendered a flat message where a 422 with per-field `details` belonged.

### Prefixed product ids were compared against integer keys

`PriceLists::Update` captured `product_ids` before `assign_attributes`, which is what used to decode them. A console or importer call with `product_ids: ['prod_abc']` therefore read as "remove every current member, add nothing". The Admin API was unaffected — its controller normalizes params first — so this only bit callers going straight to the workflow.

---

Core `8535 examples, 0 failures`; API `3167 examples, 0 failures`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error messages for symbol-based errors with translated and human-readable fallbacks.
  * Price list updates now correctly process prefixed product IDs, ignore products from other stores, and distinguish between blank and empty inputs.
  * Price list creation now returns detailed field-level validation errors.
  * Added clear messages for gift-card, import, and invitation-related errors.

* **Tests**
  * Added coverage for store-scoped product membership and price list update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->