### PR TITLE
Pin the secret the example JWTs are signed with

### DIFF
--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -92,7 +92,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjE3NmVlN2M3LWJkYzktNGM1MS1hMzFiLTEwMDYxOTc3NGZmNCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDc4NzAwfQ.t4sBqJCtgn1Ww6o_sUUdRiL1sUF3aK-bpQNBkBVfNjQ
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjE3NmVlN2M3LWJkYzktNGM1MS1hMzFiLTEwMDYxOTc3NGZmNCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDc4NzAwfQ.t4Ntas5E8dwfI8wxMdwcC-XVFXWzaFSAFL8_Mv4HnlU
                 user:
                   id: adm_UkLWZg9DAJ
                   email: admin@example.com
@@ -204,7 +204,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImFiN2M4YjAxLTY0MGYtNDJhZi1hZTY1LTQxY2NmOTk1YmVlMCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDc4NzAwfQ.QSVm-Fge_dvjki3TVfaFHZAOwHOtDTX55usdDgTMJSE
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImFiN2M4YjAxLTY0MGYtNDJhZi1hZTY1LTQxY2NmOTk1YmVlMCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDc4NzAwfQ.oXS2FwkI2rK4WOX4QUNW4oTPu7gzMmB9Y9oqsJpW7SY
                 user:
                   id: adm_UkLWZg9DAJ
                   email: admin@example.com
@@ -638,7 +638,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjBiZTdhM2RmLWEyYzYtNDZkOC1hNTZiLWE4NDg4MGIyZGZiNCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.im6r-eLsMyncHhKJBdUc31ek8kPN37htiTWO_-T2TXE
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjBiZTdhM2RmLWEyYzYtNDZkOC1hNTZiLWE4NDg4MGIyZGZiNCIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.Vo2RzprqsH2XBa8DaSQ6awyXqlBA5QDFA5R7ygTezXY
                 user:
                   id: adm_UkLWZg9DAJ
                   email: admin@example.com
@@ -716,7 +716,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjZjMjg1ODk5LTExMzUtNDBhMi1hNDBiLTE4NjNiODcwZDRjYyIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDc4NzAwfQ.-3TXNB4thifTF3dCUfDtyN8M188-pzLOIe2QFGe1zlY
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjZjMjg1ODk5LTExMzUtNDBhMi1hNDBiLTE4NjNiODcwZDRjYyIsImlzcyI6InNwcmVlIiwiYXVkIjoiYWRtaW5fYXBpIiwiZXhwIjoxNzY4NDc4NzAwfQ.Go2eUEiXf7rVD5mwtNMqkWqUGcBfhxk3b7JT8dw8uiE
                 user:
                   id: adm_UkLWZg9DAJ
                   email: owner@example.com

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -87,7 +87,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImRlZmM5YWZhLTUzOTYtNDEwYy1hZDY4LTE4YTBiN2M5MmMwMyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.akOKNDAyxSYPdQ7hQBFm_w36ArJ087ekUpMmP19m0BM
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6ImRlZmM5YWZhLTUzOTYtNDEwYy1hZDY4LTE4YTBiN2M5MmMwMyIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.ha-8UOgpGEgYAVWjEqzhLZ9LPtI6uTlsDB3We7qbrdU
                 refresh_token: CxKP3VYWQzkXqrfxTmPLB446
                 user:
                   id: cust_UkLWZg9DAJ
@@ -194,7 +194,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjFmMzM5OGY2LTczZDgtNDdjNi1hNDk4LTUxNDc3MGUxYTUyNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.73sLD9Vh5WdgsHDOPwZWz2C2nwroY8xEgfTTLNK9shc
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjFmMzM5OGY2LTczZDgtNDdjNi1hNDk4LTUxNDc3MGUxYTUyNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.Zpvl-ISrctLW34O3zJFteOf3wMDNvlymVKsbkCIfeew
                 refresh_token: mWbQ77onTSsXQta8Z4SAVaTU
                 user:
                   id: cust_UkLWZg9DAJ
@@ -393,7 +393,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjdlOGI2Njc5LTBjNzYtNDQ1Mi1hMWMyLWJhY2U0MWNhN2IyMCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.6EFpedkEaJ4XJpv5fAEqv2UANfrh8_SXIAiubf_E5ss
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjdlOGI2Njc5LTBjNzYtNDQ1Mi1hMWMyLWJhY2U0MWNhN2IyMCIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.grC4diUECUp8b3p6jJBHAZp_MyiSUQwA4rdQLel_zuM
                 refresh_token: JNJKeT5cELhdSfb2tWHj3ctp
                 user:
                   id: cust_UkLWZg9DAJ
@@ -7086,7 +7086,7 @@ paths:
           content:
             application/json:
               example:
-                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjY0OWM2NTkzLTBhZWQtNDA5Ny1hYTI3LThhMjVmYTU4OGI3OSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.wQpdI2FvcK9dEVIZdwEyePE8Vb-oBq6vsfwPpvnwR3o
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJjdXN0b21lciIsImp0aSI6IjY0OWM2NTkzLTBhZWQtNDA5Ny1hYTI3LThhMjVmYTU4OGI3OSIsImlzcyI6InNwcmVlIiwiYXVkIjoic3RvcmVfYXBpIiwiZXhwIjoxNzY4NDgyMDAwfQ.llCt1j8kVryteixNYywlzA1x8CGqCNBaKiT3-ihDrsE
                 refresh_token: mLm6vdSzLUgPhw8SCzDiagfL
                 user:
                   id: cust_UkLWZg9DAJ

--- a/spree/api/spec/support/deterministic_openapi.rb
+++ b/spree/api/spec/support/deterministic_openapi.rb
@@ -32,6 +32,12 @@ if ENV['OPENAPI'] == 'true'
       # unique ones then collide on a real index.
       RANDOM_SEED = 20_260_115
 
+      # Signing secret for the JWTs shown in the examples. It signs nothing
+      # real — these tokens are documentation, generated against a throwaway
+      # dummy app — but it has to be the same everywhere for the signatures
+      # to match across machines.
+      JWT_SECRET = 'openapi-example-signing-secret'
+
       # SecureRandom bypasses the global PRNG (it reads from the OS), so seeding
       # alone leaves API keys, invitation tokens and JWT ids churning. These
       # counter-backed replacements produce values with the right shape and
@@ -130,6 +136,17 @@ if ENV['OPENAPI'] == 'true'
       srand(example_seed)
       FFaker::Random.seed = example_seed
       Spree::OpenAPIDeterminism::PredictableSecureRandom.scope!(example_key)
+
+      # The examples include signed JWTs. Their payloads are already stable
+      # (a frozen clock fixes `exp`, the SecureRandom override fixes `jti`),
+      # but the signature also depends on the signing secret, which otherwise
+      # falls through to the dummy app's `secret_key_base` — generated when
+      # that app is built and so different on every machine. Without this the
+      # specs reproduce for whoever generated them and for nobody else.
+      #
+      # Set per example, not once for the suite: the suite resets Spree's
+      # preferences before every example, which would wipe a one-off value.
+      Spree::Api::Config[:jwt_secret_key] = Spree::OpenAPIDeterminism::JWT_SECRET
     end
   end
 end


### PR DESCRIPTION
Follow-up to #14480, which left one gap in the reproducibility guarantee.

## The gap

The JWTs shown in the examples already had **fully deterministic payloads** — the frozen clock fixes `exp`, and the `SecureRandom` override fixes `jti`. I confirmed this by decoding them: two runs produce byte-identical payloads.

The signature was the loose end. It also depends on the signing secret, which fell through the resolution chain to the dummy app's `secret_key_base`. That app is built by `rake test_app` and is **gitignored**, so the secret is:

- stable *within* one machine — which is why #14480's three consecutive runs came out byte-identical, and why I reported it as reproducible
- different *between* machines, and after any fresh `rake test_app`

So the specs reproduced for whoever last generated them, and for nobody else. The `CLAUDE.md` guarantee was stronger than what the code actually delivered.

## The fix

Set `Spree::Api::Config[:jwt_secret_key]` to a fixed value — it sits first in the resolution chain, so it covers both the test helper and the app's own signing path.

The secret protects nothing: these tokens are documentation, minted against a throwaway dummy app, and are already expired relative to any real clock. It only has to be *the same everywhere* for the signatures to agree.

Set **per example rather than once for the suite**, because the suite resets preferences before each one — a `before(:suite)` assignment is silently wiped, which I confirmed by probing the value from inside a running example.

## Diff

8 lines in each spec file: the same 4 tokens, same payloads, new signatures. A one-time transition, stable from here on any machine.

## Verification

- 627 integration examples, 0 failures
- Regenerating on this branch leaves a **completely clean tree** — no diff at all
- Verified the committed tokens now re-sign byte-identically from their decoded payloads under the pinned secret

## Known gap, deliberately not fixed here

Product names still shift when a spec that creates products is added. `product_factory` renders `"Product #{n}#{Kernel.rand(9999)}"`, and while the random half is now pinned per example, `n` is a global FactoryBot counter that advances with run position — so inserting an earlier spec shifts every later name. That is ~42 names across 51,570 lines.

I looked into fixing it here and decided against it, for a reason worth recording: the obvious fix of dropping the counter is **not** safe. Product names have only a presence validation, and duplicates are allowed — but slugs derive from the name, and I confirmed by test that the slug generator disambiguates a collision by falling back to the **SKU**, which carries the same run-position problem. Removing the counter would relocate the instability into `slug` rather than remove it, and with ~235 products per run a 4-digit random alone collides often enough to matter.

A correct fix reworks the shared factory used by core, api and the dashboard e2e suite, so it deserves its own change and its own full-suite run rather than riding along here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JWT token examples in the admin and store API references.
  * Refreshed examples for login, token refresh, password reset, and customer registration.
  * API endpoints, schemas, and surrounding example data remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->