### PR TITLE
Follow the Rails default for belongs_to validation

### DIFF
--- a/docs/developer/upgrades/5.6-to-6.0.mdx
+++ b/docs/developer/upgrades/5.6-to-6.0.mdx
@@ -363,11 +363,30 @@ A store or channel still carrying `preferred_order_routing_strategy: 'Spree::Ord
 
 `Spree::Stock::Coordinator` itself stays — cart fulfillment building, exchanges, and claims still use it.
 
+### `belongs_to` is required by default
+
+Spree models followed Rails' pre-5 rule, where a `belongs_to` was optional
+unless you said otherwise. They now follow the modern default: a `belongs_to`
+is **required** unless it is declared `optional: true`.
+
+Two consequences for an application built on Spree:
+
+- **Your own models change with it.** Anything inheriting from `Spree::Base`
+  picks up the new default, so an association that is legitimately blank now
+  needs `optional: true` on it. A model that relied on the old behaviour will
+  start failing validation until you say which associations are optional.
+- **The message changed.** A missing association reports `"must exist"` rather
+  than `"can't be blank"`. Code that matches on the old wording — a test, or a
+  client reading `details` out of a 422 — needs updating.
+
+Setting a record's association to `nil` and saving it is the quickest way to
+tell whether an association is required.
+
 ### `Store.default` no longer builds a store
 
 `Spree::Store.default` returned an **unpersisted** `Store.new(default: true)` when no default store existed. It now returns `nil`.
 
-This matters more than it looks: `Spree::Current.store` falls back to `Store.default`, and every `Spree::SingleStoreResource` model resolves its own `store` from `Spree::Current.store`. Without a default store, those records now fail validation with "Store can't be blank" instead of silently attaching to a throwaway store.
+This matters more than it looks: `Spree::Current.store` falls back to `Store.default`, and every `Spree::SingleStoreResource` model resolves its own `store` from `Spree::Current.store`. Without a default store, those records now fail validation with "Store must exist" instead of silently attaching to a throwaway store.
 
 Make sure a default store exists before creating store-scoped records, and set `Spree::Current.store` in jobs, rake tasks, and tests that run outside a request.
 

--- a/spree/core/app/models/concerns/spree/purchase/channel.rb
+++ b/spree/core/app/models/concerns/spree/purchase/channel.rb
@@ -6,8 +6,6 @@ module Spree
       included do
         belongs_to :channel, class_name: 'Spree::Channel'
 
-        validates :channel, presence: true
-
         before_validation :ensure_channel_presence
       end
 

--- a/spree/core/app/models/concerns/spree/purchase/market.rb
+++ b/spree/core/app/models/concerns/spree/purchase/market.rb
@@ -6,9 +6,6 @@ module Spree
       included do
         belongs_to :market, class_name: 'Spree::Market'
 
-        validates :market, presence: true
-
-
         attr_accessor :skip_market_resolution
 
         before_validation :ensure_market_presence

--- a/spree/core/app/models/concerns/spree/single_store_resource.rb
+++ b/spree/core/app/models/concerns/spree/single_store_resource.rb
@@ -6,7 +6,6 @@ module Spree
       belongs_to :store, class_name: 'Spree::Store'
 
       before_validation :ensure_store, unless: :store_id?
-      validates :store, presence: true
       validate :ensure_store_association_is_not_changed
 
       scope :for_store, ->(store) { where(store_id: store.id) }

--- a/spree/core/app/models/spree/allowed_origin.rb
+++ b/spree/core/app/models/spree/allowed_origin.rb
@@ -12,7 +12,7 @@ module Spree
 
     belongs_to :store, class_name: 'Spree::Store'
 
-    validates :store, :origin, presence: true
+    validates :origin, presence: true
     validates :origin, uniqueness: { scope: [:store_id, *spree_base_uniqueness_scope] }
     validate :origin_must_be_valid_http_url
 

--- a/spree/core/app/models/spree/base.rb
+++ b/spree/core/app/models/spree/base.rb
@@ -48,10 +48,6 @@ class Spree::Base < ApplicationRecord
     select("#{klass.table_name}.*").select(*(fields || klass::TRANSLATABLE_FIELDS))
   }
 
-  def self.belongs_to_required_by_default
-    false
-  end
-
   def self.for_store(store)
     plural_model_name = model_name.plural.gsub(/spree_/, '').to_sym
 

--- a/spree/core/app/models/spree/category.rb
+++ b/spree/core/app/models/spree/category.rb
@@ -38,7 +38,7 @@ module Spree
     #
     # @deprecated Read only by the 5.6 -> 6.0 upgrade task, which needs the
     #   column to find the rows it migrates. Removed in 6.1 with Spree::Taxonomy.
-    belongs_to :taxonomy, class_name: 'Spree::Taxonomy', inverse_of: :taxons, deprecated: true
+    belongs_to :taxonomy, class_name: 'Spree::Taxonomy', inverse_of: :taxons, optional: true, deprecated: true
     has_many :product_categories, -> { order(:position) }, class_name: 'Spree::ProductCategory', dependent: :destroy_async, inverse_of: :category
     has_many :products, through: :product_categories
 

--- a/spree/core/app/models/spree/channel.rb
+++ b/spree/core/app/models/spree/channel.rb
@@ -37,7 +37,7 @@ module Spree
     before_validation :backfill_code_from_name, if: -> { code.blank? && name.present? }
     before_validation :promote_first_channel_to_default
 
-    validates :name, :store, presence: true
+    validates :name, presence: true
     validates :code, presence: true, uniqueness: { scope: spree_base_uniqueness_scope + [:store_id] }
 
     # Demote any prior default in the same transaction so the partial unique

--- a/spree/core/app/models/spree/claim.rb
+++ b/spree/core/app/models/spree/claim.rb
@@ -33,7 +33,6 @@ module Spree
                                 dependent: :destroy, inverse_of: :claim
     has_many :refunds, class_name: 'Spree::Refund', as: :originator, dependent: :nullify
 
-    validates :order, presence: true
     validates :claim_line_items, presence: true, on: :create
     validates :resolution, inclusion: { in: RESOLUTIONS }, allow_nil: true
 

--- a/spree/core/app/models/spree/claim_line_item.rb
+++ b/spree/core/app/models/spree/claim_line_item.rb
@@ -13,7 +13,6 @@ module Spree
     # Photographic evidence of damage, supplied by the customer.
     has_many_attached :images
 
-    validates :line_item, :variant, presence: true
     validates :quantity, numericality: { greater_than: 0 }
     validates :refund_amount, numericality: { greater_than_or_equal_to: 0 }
 

--- a/spree/core/app/models/spree/collection_rule.rb
+++ b/spree/core/app/models/spree/collection_rule.rb
@@ -8,7 +8,7 @@ module Spree
 
     belongs_to :collection, class_name: 'Spree::Collection', inverse_of: :rules, touch: true
 
-    validates :collection, :type, :value, presence: true
+    validates :type, :value, presence: true
     validates :match_policy, inclusion: { in: MATCH_POLICIES }, presence: true
 
     after_commit :regenerate_collection_products,

--- a/spree/core/app/models/spree/coupon_code.rb
+++ b/spree/core/app/models/spree/coupon_code.rb
@@ -29,7 +29,7 @@ module Spree
     end
 
     validates :code, presence: true, uniqueness: { scope: spree_base_uniqueness_scope, conditions: -> { where(deleted_at: nil) } }
-    validates :state, :promotion, presence: true
+    validates :state, presence: true
 
     self.whitelisted_ransackable_attributes = %w[state code promotion_id]
     self.whitelisted_ransackable_associations = %w[promotion]

--- a/spree/core/app/models/spree/custom_field.rb
+++ b/spree/core/app/models/spree/custom_field.rb
@@ -63,7 +63,7 @@ module Spree
     #
     # Validations
     #
-    validates :custom_field_definition, :type, :resource, :value, presence: true
+    validates :type, :resource, :value, presence: true
     validates :custom_field_definition_id, uniqueness: { scope: [:resource_type, :resource_id] }
     validate :type_must_match_custom_field_definition
     validate :resource_type_must_match_custom_field_definition

--- a/spree/core/app/models/spree/customer_group_user.rb
+++ b/spree/core/app/models/spree/customer_group_user.rb
@@ -12,7 +12,6 @@ module Spree
     #
     # Validations
     #
-    validates :customer_group, presence: true
     validates :customer, presence: true
     validates :customer_group_id, uniqueness: { scope: [:customer_id, :customer_type] }
   end

--- a/spree/core/app/models/spree/delivery_method_rule.rb
+++ b/spree/core/app/models/spree/delivery_method_rule.rb
@@ -17,7 +17,7 @@ module Spree
 
     attribute :active, :boolean, default: true
 
-    validates :type, :delivery_method, presence: true
+    validates :type, presence: true
     # One instance of each rule kind per method — duplicates would either be
     # a no-op or contradict themselves under AND semantics.
     validates :type, uniqueness: { scope: [:delivery_method_id, *spree_base_uniqueness_scope] }

--- a/spree/core/app/models/spree/delivery_method_rule_product.rb
+++ b/spree/core/app/models/spree/delivery_method_rule_product.rb
@@ -3,7 +3,6 @@ module Spree
     belongs_to :delivery_method_rule, class_name: 'Spree::DeliveryMethodRule'
     belongs_to :product, class_name: 'Spree::Product'
 
-    validates :delivery_method_rule, :product, presence: true
     validates :product_id, uniqueness: { scope: :delivery_method_rule_id }, allow_nil: true
   end
 end

--- a/spree/core/app/models/spree/delivery_method_stock_location.rb
+++ b/spree/core/app/models/spree/delivery_method_stock_location.rb
@@ -6,7 +6,6 @@ module Spree
     belongs_to :delivery_method, class_name: 'Spree::DeliveryMethod', inverse_of: :delivery_method_stock_locations
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
-    validates :delivery_method, :stock_location, presence: true
     validates :stock_location_id, uniqueness: { scope: :delivery_method_id }
   end
 end

--- a/spree/core/app/models/spree/delivery_rate.rb
+++ b/spree/core/app/models/spree/delivery_rate.rb
@@ -8,7 +8,7 @@ module Spree
     serialize :metadata, coder: Spree::Metadata::HashSerializer
 
     belongs_to :fulfillment, class_name: 'Spree::Fulfillment'
-    belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate'
+    belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate', optional: true
     belongs_to :delivery_method, -> { with_deleted }, class_name: 'Spree::DeliveryMethod', inverse_of: :delivery_rates
     # Legacy names — removed in 6.1.
     belongs_to :shipment, class_name: 'Spree::Fulfillment', foreign_key: :fulfillment_id, optional: true, deprecated: true

--- a/spree/core/app/models/spree/digital.rb
+++ b/spree/core/app/models/spree/digital.rb
@@ -10,7 +10,6 @@ module Spree
     has_one_attached :attachment, service: Spree.private_storage_service_name
 
     validates :attachment, attached: true
-    validates :variant, presence: true
 
     delegate :product, to: :variant
     delegate :filename, :content_type, to: :attachment

--- a/spree/core/app/models/spree/digital_link.rb
+++ b/spree/core/app/models/spree/digital_link.rb
@@ -18,7 +18,6 @@ module Spree
     belongs_to :line_item
 
     before_validation :set_defaults, on: :create
-    validates :digital, :line_item, presence: true
     validates :access_counter, numericality: { greater_than_or_equal_to: 0 }
 
     delegate :filename, :content_type, to: :digital

--- a/spree/core/app/models/spree/exchange.rb
+++ b/spree/core/app/models/spree/exchange.rb
@@ -32,7 +32,6 @@ module Spree
                                    dependent: :destroy, inverse_of: :exchange
     has_many :refunds, class_name: 'Spree::Refund', as: :originator, dependent: :nullify
 
-    validates :order, :stock_location, presence: true
     validates :exchange_line_items, presence: true, on: :create
 
     accepts_nested_attributes_for :exchange_line_items, allow_destroy: true

--- a/spree/core/app/models/spree/exchange_line_item.rb
+++ b/spree/core/app/models/spree/exchange_line_item.rb
@@ -10,7 +10,6 @@ module Spree
     belongs_to :original_variant, -> { with_deleted }, class_name: 'Spree::Variant'
     belongs_to :new_variant, -> { with_deleted }, class_name: 'Spree::Variant'
 
-    validates :fulfillment_item, :line_item, :original_variant, :new_variant, presence: true
     validates :quantity, numericality: { greater_than: 0 }
     validates :received_quantity, numericality: { greater_than_or_equal_to: 0 }
 

--- a/spree/core/app/models/spree/export.rb
+++ b/spree/core/app/models/spree/export.rb
@@ -30,7 +30,7 @@ module Spree
     #
     # Validations
     #
-    validates :format, :store, :type, presence: true
+    validates :format, :type, presence: true
 
     #
     # Enums

--- a/spree/core/app/models/spree/fulfillment.rb
+++ b/spree/core/app/models/spree/fulfillment.rb
@@ -46,7 +46,6 @@ module Spree
     before_validation :set_cost_zero_when_nil
     before_save :detect_tracking_carrier, if: -> { will_save_change_to_tracking? && tracking_carrier.blank? }
 
-    validates :stock_location, presence: true
     validate :exactly_one_owner
 
     attr_accessor :special_instructions

--- a/spree/core/app/models/spree/gateway_customer.rb
+++ b/spree/core/app/models/spree/gateway_customer.rb
@@ -6,7 +6,6 @@ module Spree
     belongs_to :customer, class_name: Spree.customer_class.to_s
     include Spree::DeprecatedCustomerAlias
 
-    validates :payment_method, presence: true
     validates :customer, presence: true
     validates :profile_id, presence: true
     validates :payment_method_id, uniqueness: { scope: :customer_id }

--- a/spree/core/app/models/spree/gift_card.rb
+++ b/spree/core/app/models/spree/gift_card.rb
@@ -24,7 +24,7 @@ module Spree
     # Validations
     #
     validates :code, presence: true, uniqueness: { scope: :store_id }
-    validates :store, :currency, presence: true
+    validates :currency, presence: true
     validates :amount, presence: true, numericality: { greater_than: 0 }
     validates :amount_used, :amount_authorized, presence: true, numericality: { greater_than_or_equal_to: 0 }
 

--- a/spree/core/app/models/spree/gift_card_batch.rb
+++ b/spree/core/app/models/spree/gift_card_batch.rb
@@ -22,7 +22,7 @@ module Spree
       greater_than: 0,
       less_than_or_equal_to: ->(_record) { Spree::Config[:gift_card_batch_limit].to_i }
     }
-    validates :store, :currency, presence: true
+    validates :currency, presence: true
     validates :amount, numericality: { greater_than: 0 }
 
     #

--- a/spree/core/app/models/spree/import_mapping.rb
+++ b/spree/core/app/models/spree/import_mapping.rb
@@ -10,7 +10,7 @@ module Spree
     #
     # Validations
     #
-    validates :import, :schema_field, presence: true
+    validates :schema_field, presence: true
     validates :schema_field, uniqueness: { scope: [:import_id] }
     validates :file_column, uniqueness: { scope: [:import_id] }, allow_blank: true
 

--- a/spree/core/app/models/spree/import_row.rb
+++ b/spree/core/app/models/spree/import_row.rb
@@ -15,7 +15,7 @@ module Spree
     #
     # Validations
     #
-    validates :import, :data, presence: true
+    validates :data, presence: true
     validates :row_number, uniqueness: { scope: :import_id }, numericality: { only_integer: true, greater_than: 0 }, presence: true
 
     #

--- a/spree/core/app/models/spree/invitation.rb
+++ b/spree/core/app/models/spree/invitation.rb
@@ -24,7 +24,7 @@ module Spree
     #
     validates :email, email: true, presence: true
     validates :token, presence: true, uniqueness: true
-    validates :inviter, :resource, :role, presence: true
+    validates :inviter, :resource, presence: true
     validate :invitee_is_not_inviter, on: :create
     validate :invitee_already_exists, on: :create
     validate :role_belongs_to_resource

--- a/spree/core/app/models/spree/line_item.rb
+++ b/spree/core/app/models/spree/line_item.rb
@@ -16,7 +16,7 @@ module Spree
       belongs_to :cart, class_name: 'Spree::Cart', touch: true, optional: true
       belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
     end
-    belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory'
+    belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory', optional: true
     belongs_to :price_list, class_name: 'Spree::PriceList', optional: true
     # Snapshotted from the variant when the line is added — see copy_seller.
     # Nil is the operator's own first-party item.

--- a/spree/core/app/models/spree/line_item.rb
+++ b/spree/core/app/models/spree/line_item.rb
@@ -38,7 +38,6 @@ module Spree
     before_validation :copy_tax_category
     before_validation :copy_seller
 
-    validates :variant, presence: true
     validate :exactly_one_owner
 
     DB_INTEGER_MAX = (2**31) - 1

--- a/spree/core/app/models/spree/market_country.rb
+++ b/spree/core/app/models/spree/market_country.rb
@@ -6,7 +6,6 @@ module Spree
 
     has_iso_geography state: false
 
-    validates :market, presence: true
     validates :country_code, presence: true
     validates :country_code, uniqueness: { scope: spree_base_uniqueness_scope + [:market_id] }
     validate :country_covered_by_shipping_zone

--- a/spree/core/app/models/spree/media.rb
+++ b/spree/core/app/models/spree/media.rb
@@ -25,7 +25,7 @@ module Spree
 
     after_initialize { self.media_type ||= 'image' }
 
-    belongs_to :viewable, polymorphic: true, touch: true
+    belongs_to :viewable, polymorphic: true, touch: true, optional: true
     has_many :variant_media, class_name: 'Spree::VariantMedia', foreign_key: :media_id,
              dependent: :destroy, inverse_of: :asset
     has_many :variants, through: :variant_media, source: :variant, class_name: 'Spree::Variant'

--- a/spree/core/app/models/spree/option_type_product_type.rb
+++ b/spree/core/app/models/spree/option_type_product_type.rb
@@ -3,7 +3,6 @@ module Spree
     belongs_to :option_type, class_name: 'Spree::OptionType'
     belongs_to :product_type, class_name: 'Spree::ProductType'
 
-    validates :product_type, :option_type, presence: true
     validates :product_type_id, uniqueness: { scope: :option_type_id }
   end
 end

--- a/spree/core/app/models/spree/option_value_variant.rb
+++ b/spree/core/app/models/spree/option_value_variant.rb
@@ -3,7 +3,6 @@ module Spree
     belongs_to :option_value, class_name: 'Spree::OptionValue'
     belongs_to :variant, touch: true, class_name: 'Spree::Variant'
 
-    validates :option_value, :variant, presence: true
     validates :option_value_id, uniqueness: { scope: :variant_id }
 
     scope :for_option_types, lambda { |option_types|

--- a/spree/core/app/models/spree/order_approval.rb
+++ b/spree/core/app/models/spree/order_approval.rb
@@ -9,7 +9,6 @@ module Spree
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :approvals
     belongs_to :approver, polymorphic: true, optional: true
 
-    validates :order, presence: true
     validates :status, presence: true, inclusion: { in: STATUSES }
 
     scope :approved, -> { where(status: 'approved') }

--- a/spree/core/app/models/spree/order_cancellation.rb
+++ b/spree/core/app/models/spree/order_cancellation.rb
@@ -12,7 +12,6 @@ module Spree
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :cancellations
     belongs_to :canceled_by, polymorphic: true, optional: true
 
-    validates :order, presence: true
     validates :reason, presence: true, inclusion: { in: REASONS }
     validates :refund_amount, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
   end

--- a/spree/core/app/models/spree/order_promotion.rb
+++ b/spree/core/app/models/spree/order_promotion.rb
@@ -11,7 +11,6 @@ module Spree
     delegate :name, :description, :code, to: :promotion
     delegate :currency, to: :owner
 
-    validates :promotion, presence: true
     validates :order, uniqueness: { scope: :promotion }, allow_nil: true
     validates :cart, uniqueness: { scope: :promotion }, allow_nil: true
     validate :exactly_one_owner

--- a/spree/core/app/models/spree/order_routing_rule.rb
+++ b/spree/core/app/models/spree/order_routing_rule.rb
@@ -34,7 +34,7 @@ module Spree
     # position would 422. Default to the end of the channel's list instead.
     before_validation :set_position_to_end, on: :create, if: -> { position.blank? && channel.present? }
 
-    validates :type, :channel, presence: true
+    validates :type, presence: true
     # One instance of each rule kind per channel — a duplicate signal would
     # either be a no-op or fight itself in the reducer walk.
     validates :type, uniqueness: { scope: [:channel_id, *spree_base_uniqueness_scope] }

--- a/spree/core/app/models/spree/payment.rb
+++ b/spree/core/app/models/spree/payment.rb
@@ -35,7 +35,7 @@ module Spree
     end
 
     has_many :payment_splits, class_name: 'Spree::PaymentSplit', dependent: :destroy, inverse_of: :payment
-    belongs_to :source, polymorphic: true
+    belongs_to :source, polymorphic: true, optional: true
 
     validate :exactly_one_owner
 

--- a/spree/core/app/models/spree/payment_session.rb
+++ b/spree/core/app/models/spree/payment_session.rb
@@ -19,7 +19,7 @@ module Spree
             foreign_key: :response_code,
             primary_key: :external_id
 
-    validates :payment_method, :external_id, :status, :currency, presence: true
+    validates :external_id, :status, :currency, presence: true
     validate :exactly_one_owner
     validates :external_id, uniqueness: { scope: [:order_id, :payment_method_id] }
     validates :amount, presence: true, numericality: { greater_than: 0 }

--- a/spree/core/app/models/spree/payment_setup_session.rb
+++ b/spree/core/app/models/spree/payment_setup_session.rb
@@ -14,7 +14,7 @@ module Spree
     belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
     belongs_to :payment_source, polymorphic: true, optional: true
 
-    validates :payment_method, :status, presence: true
+    validates :status, presence: true
     validates :external_id, uniqueness: { scope: :payment_method_id }, allow_nil: true
 
     include Spree::PaymentSessionTransitions

--- a/spree/core/app/models/spree/price_history.rb
+++ b/spree/core/app/models/spree/price_history.rb
@@ -3,7 +3,7 @@
 module Spree
   class PriceHistory < Spree.base_class
     belongs_to :price, class_name: 'Spree::Price'
-    belongs_to :variant, class_name: 'Spree::Variant'
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
 
     validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :currency, presence: true

--- a/spree/core/app/models/spree/price_list.rb
+++ b/spree/core/app/models/spree/price_list.rb
@@ -33,7 +33,7 @@ module Spree
       assign_typed_association(:price_rules, rows)
     end
 
-    validates :name, :store, presence: true
+    validates :name, presence: true
     validates :match_policy, presence: true, inclusion: { in: MATCH_POLICIES }
     validate :starts_at_before_ends_at
 

--- a/spree/core/app/models/spree/price_rule.rb
+++ b/spree/core/app/models/spree/price_rule.rb
@@ -6,7 +6,7 @@ module Spree
 
     delegate :store, to: :price_list
 
-    validates :type, :price_list, presence: true
+    validates :type, presence: true
     validates :type, uniqueness: { scope: [:price_list_id, *spree_base_uniqueness_scope] }
 
     # Returns true if the price rule is applicable to the context

--- a/spree/core/app/models/spree/product.rb
+++ b/spree/core/app/models/spree/product.rb
@@ -119,7 +119,7 @@ module Spree
                                                              class_name: 'Spree::Promotion',
                                                              source: :promotion
 
-    belongs_to :tax_category, class_name: 'Spree::TaxCategory'
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
     belongs_to :product_type, class_name: 'Spree::ProductType', optional: true, counter_cache: :products_count
     # The seller this product belongs to on a marketplace. Nil is the
     # operator's own catalog — which is everything, on a store selling only

--- a/spree/core/app/models/spree/product_category.rb
+++ b/spree/core/app/models/spree/product_category.rb
@@ -11,7 +11,6 @@ module Spree
       belongs_to :category, class_name: 'Spree::Category'
     end
 
-    validates :category, :product, presence: true
     validates :position, numericality: { only_integer: true, allow_blank: true, allow_nil: true }
     # For #3494
     validates :category_id, uniqueness: { scope: :product_id, message: :already_linked, allow_blank: true }

--- a/spree/core/app/models/spree/product_collection.rb
+++ b/spree/core/app/models/spree/product_collection.rb
@@ -12,7 +12,6 @@ module Spree
     belongs_to :collection, class_name: 'Spree::Collection', counter_cache: :products_count, touch: true,
                             inverse_of: :product_collections
 
-    validates :product, :collection, presence: true
     validates :position, numericality: { only_integer: true, allow_blank: true, allow_nil: true }
     validates :collection_id, uniqueness: { scope: :product_id, message: :already_linked, allow_blank: true }
 

--- a/spree/core/app/models/spree/product_option_type.rb
+++ b/spree/core/app/models/spree/product_option_type.rb
@@ -6,7 +6,6 @@ module Spree
     end
     acts_as_list scope: :product
 
-    validates :product, :option_type, presence: true
     validates :product_id, uniqueness: { scope: :option_type_id }, allow_nil: true
   end
 end

--- a/spree/core/app/models/spree/product_promotion_rule.rb
+++ b/spree/core/app/models/spree/product_promotion_rule.rb
@@ -3,7 +3,6 @@ module Spree
     belongs_to :product, class_name: 'Spree::Product'
     belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
 
-    validates :product, :promotion_rule, presence: true
     validates :product_id, uniqueness: { scope: :promotion_rule_id }, allow_nil: true
   end
 end

--- a/spree/core/app/models/spree/product_publication.rb
+++ b/spree/core/app/models/spree/product_publication.rb
@@ -13,7 +13,6 @@ module Spree
     belongs_to :product, class_name: 'Spree::Product', touch: true
     belongs_to :channel, class_name: 'Spree::Channel'
 
-    validates :product, :channel, presence: true
     validates :product_id, uniqueness: { scope: :channel_id }
     validate :unpublished_at_after_published_at, if: -> { published_at && unpublished_at }
 

--- a/spree/core/app/models/spree/product_type_category.rb
+++ b/spree/core/app/models/spree/product_type_category.rb
@@ -3,7 +3,6 @@ module Spree
     belongs_to :category, class_name: 'Spree::Category'
     belongs_to :product_type, class_name: 'Spree::ProductType'
 
-    validates :product_type, :category, presence: true
     validates :product_type_id, uniqueness: { scope: :category_id }
   end
 end

--- a/spree/core/app/models/spree/product_type_custom_field_definition.rb
+++ b/spree/core/app/models/spree/product_type_custom_field_definition.rb
@@ -10,7 +10,6 @@ module Spree
     # still named CustomFieldDefinition until the rename wave lands.
     belongs_to :custom_field_definition, class_name: 'Spree::CustomFieldDefinition'
 
-    validates :product_type, :custom_field_definition, presence: true
     validates :custom_field_definition_id, uniqueness: { scope: :product_type_id }
     validate :custom_field_definition_applies_to_products
 

--- a/spree/core/app/models/spree/promotion_action.rb
+++ b/spree/core/app/models/spree/promotion_action.rb
@@ -10,7 +10,7 @@ module Spree
 
     belongs_to :promotion, class_name: 'Spree::Promotion', touch: true
 
-    validates :promotion, :type, presence: true
+    validates :type, presence: true
 
     scope :of_type, ->(t) { where(type: t) }
 

--- a/spree/core/app/models/spree/promotion_action_line_item.rb
+++ b/spree/core/app/models/spree/promotion_action_line_item.rb
@@ -3,7 +3,7 @@ module Spree
     belongs_to :promotion_action, class_name: 'Spree::Promotion::Actions::CreateLineItems'
     belongs_to :variant, class_name: 'Spree::Variant'
 
-    validates :promotion_action, :variant, :quantity, presence: true
+    validates :quantity, presence: true
     validates :quantity, numericality: { only_integer: true, message: Spree.t('validation.must_be_int') }
   end
 end

--- a/spree/core/app/models/spree/promotion_rule.rb
+++ b/spree/core/app/models/spree/promotion_rule.rb
@@ -11,7 +11,6 @@ module Spree
 
     scope :of_type, ->(t) { where(type: t) }
 
-    validates :promotion, presence: true
     validates :type, uniqueness: { scope: [:promotion_id, *spree_base_uniqueness_scope] }
 
     def self.for(promotable)

--- a/spree/core/app/models/spree/promotion_rule_category.rb
+++ b/spree/core/app/models/spree/promotion_rule_category.rb
@@ -6,7 +6,6 @@ module Spree
     belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
     belongs_to :category, class_name: 'Spree::Category'
 
-    validates :promotion_rule, :category, presence: true
     validates :promotion_rule_id, uniqueness: { scope: :category_id }, allow_nil: true
 
     # @deprecated Use #category / #category=; removed in 6.1.

--- a/spree/core/app/models/spree/promotion_rule_user.rb
+++ b/spree/core/app/models/spree/promotion_rule_user.rb
@@ -4,7 +4,6 @@ module Spree
     belongs_to :customer, class_name: "::#{Spree.customer_class}"
     include Spree::DeprecatedCustomerAlias
 
-    validates :customer, :promotion_rule, presence: true
     validates :user_id, uniqueness: { scope: :promotion_rule_id }, allow_nil: true
   end
 end

--- a/spree/core/app/models/spree/promotion_rule_user.rb
+++ b/spree/core/app/models/spree/promotion_rule_user.rb
@@ -4,7 +4,7 @@ module Spree
     belongs_to :customer, class_name: "::#{Spree.customer_class}"
     include Spree::DeprecatedCustomerAlias
 
-    validates :user, :promotion_rule, presence: true
+    validates :customer, :promotion_rule, presence: true
     validates :user_id, uniqueness: { scope: :promotion_rule_id }, allow_nil: true
   end
 end

--- a/spree/core/app/models/spree/refund.rb
+++ b/spree/core/app/models/spree/refund.rb
@@ -25,7 +25,6 @@ module Spree
     belongs_to :originator, polymorphic: true, optional: true
 
     with_options presence: true do
-      validates :payment, :reason
       # not required on create — perform! sets it after the gateway credit
       validates :transaction_id, on: :update
       validates :amount, numericality: { greater_than: 0, allow_nil: true }

--- a/spree/core/app/models/spree/report.rb
+++ b/spree/core/app/models/spree/report.rb
@@ -25,7 +25,7 @@ module Spree
     #
     # Validations
     #
-    validates :store, :date_from, :date_to, :currency, presence: true
+    validates :date_from, :date_to, :currency, presence: true
 
     #
     # Attachments

--- a/spree/core/app/models/spree/return.rb
+++ b/spree/core/app/models/spree/return.rb
@@ -38,7 +38,6 @@ module Spree
     has_many :refunds, class_name: 'Spree::Refund', as: :originator, dependent: :nullify
     has_many :store_credits, class_name: 'Spree::StoreCredit', as: :originator, dependent: :nullify
 
-    validates :order, :stock_location, presence: true
     validates :return_line_items, presence: true, on: :create
 
     accepts_nested_attributes_for :return_line_items, allow_destroy: true

--- a/spree/core/app/models/spree/return_line_item.rb
+++ b/spree/core/app/models/spree/return_line_item.rb
@@ -11,7 +11,6 @@ module Spree
     belongs_to :line_item, class_name: 'Spree::LineItem'
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant'
 
-    validates :fulfillment_item, :line_item, :variant, presence: true
     validates :quantity, numericality: { greater_than: 0 }
     validates :received_quantity, numericality: { greater_than_or_equal_to: 0 }
     validates :pre_tax_amount, numericality: { greater_than_or_equal_to: 0 }

--- a/spree/core/app/models/spree/role_user.rb
+++ b/spree/core/app/models/spree/role_user.rb
@@ -13,7 +13,6 @@ module Spree
     #
     # Validations
     #
-    validates :role, presence: true
     validates :user, presence: true
     validates :role_id, uniqueness: { scope: [:user_id, :user_type] }
 

--- a/spree/core/app/models/spree/seller_requirement_custom_field.rb
+++ b/spree/core/app/models/spree/seller_requirement_custom_field.rb
@@ -9,7 +9,6 @@ module Spree
     belongs_to :seller_requirement, class_name: 'Spree::SellerRequirement'
     belongs_to :custom_field_definition, class_name: 'Spree::CustomFieldDefinition'
 
-    validates :seller_requirement, :custom_field_definition, presence: true
     validates :custom_field_definition_id, uniqueness: { scope: :seller_requirement_id }, allow_nil: true
     validate :definition_must_describe_a_seller
 

--- a/spree/core/app/models/spree/stock_level.rb
+++ b/spree/core/app/models/spree/stock_level.rb
@@ -19,7 +19,6 @@ module Spree
     has_many :stock_reservations, class_name: 'Spree::StockReservation', inverse_of: :stock_level, dependent: :destroy
     has_many :active_stock_reservations, -> { active }, class_name: 'Spree::StockReservation', inverse_of: :stock_level
 
-    validates :stock_location, :variant, presence: true
     validates :variant_id, uniqueness: { scope: :stock_location_id }, unless: :deleted_at
 
     validates :count_on_hand, numericality: {

--- a/spree/core/app/models/spree/stock_movement.rb
+++ b/spree/core/app/models/spree/stock_movement.rb
@@ -41,7 +41,7 @@ module Spree
 
     after_create :apply_to_stock_level
 
-    validates :stock_level, :quantity, :kind, presence: true
+    validates :quantity, :kind, presence: true
     validates :kind, inclusion: { in: KINDS }, allow_blank: true
     validates :quantity, numericality: {
       other_than: 0,

--- a/spree/core/app/models/spree/stock_reservation.rb
+++ b/spree/core/app/models/spree/stock_reservation.rb
@@ -11,7 +11,7 @@ module Spree
 
     alias_attribute :stock_item_id, :stock_level_id
 
-    validates :stock_level, :line_item, :quantity, :expires_at, presence: true
+    validates :quantity, :expires_at, presence: true
     validate :exactly_one_owner
     validates :quantity, numericality: { greater_than: 0, only_integer: true }, presence: true
     validates :line_item_id, uniqueness: { scope: :stock_level_id }, presence: true

--- a/spree/core/app/models/spree/stock_transfer.rb
+++ b/spree/core/app/models/spree/stock_transfer.rb
@@ -24,7 +24,6 @@ module Spree
 
     validate :source_location_is_not_destination_location
     validate :stock_movements_not_empty
-    validates :destination_location, presence: true
 
     # Transfers have no store of their own — they belong to the warehouses
     # they move stock between, and those are store-scoped. Used by

--- a/spree/core/app/models/spree/store_credit.rb
+++ b/spree/core/app/models/spree/store_credit.rb
@@ -19,7 +19,9 @@ module Spree
     ALLOCATION_ACTION = 'allocation'.freeze
 
     belongs_to :store, class_name: 'Spree::Store'
-    belongs_to :customer, class_name: "::#{Spree.customer_class}"
+    # A gift card applied to a guest cart issues store credit with no customer
+    # to attach it to.
+    belongs_to :customer, class_name: "::#{Spree.customer_class}", optional: true
     include Spree::DeprecatedCustomerAlias
     belongs_to :created_by, class_name: Spree.admin_user_class.to_s, foreign_key: 'created_by_id', optional: true
     belongs_to :originator, polymorphic: true, optional: true

--- a/spree/core/app/models/spree/store_credit.rb
+++ b/spree/core/app/models/spree/store_credit.rb
@@ -30,7 +30,7 @@ module Spree
     has_many :payments, as: :source, class_name: 'Spree::Payment'
     has_many :orders, through: :payments, class_name: 'Spree::Order'
 
-    validates :currency, :store, presence: true
+    validates :currency, presence: true
     validates :amount, numericality: { greater_than: 0 }
     validates :amount_used, numericality: { greater_than_or_equal_to: 0 }
     validate :amount_used_less_than_or_equal_to_amount

--- a/spree/core/app/models/spree/store_credit_event.rb
+++ b/spree/core/app/models/spree/store_credit_event.rb
@@ -7,7 +7,7 @@ module Spree
     #
     # Associations
     belongs_to :store_credit
-    belongs_to :originator, polymorphic: true
+    belongs_to :originator, polymorphic: true, optional: true
     has_one :payment, -> { where(source_type: Spree::StoreCredit.to_s) }, foreign_key: :response_code, primary_key: :authorization_code
     has_one :order, through: :payment
 

--- a/spree/core/app/models/spree/store_payment_method.rb
+++ b/spree/core/app/models/spree/store_payment_method.rb
@@ -9,7 +9,6 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store', touch: true
     belongs_to :payment_method, class_name: 'Spree::PaymentMethod', touch: true
 
-    validates :store, :payment_method, presence: true
     validates :store_id, uniqueness: { scope: :payment_method_id }
   end
 end

--- a/spree/core/app/models/spree/store_product.rb
+++ b/spree/core/app/models/spree/store_product.rb
@@ -11,7 +11,7 @@ module Spree
   class StoreProduct < Spree.base_class
     self.table_name = 'spree_products_stores'
 
-    belongs_to :product, class_name: 'Spree::Product'
-    belongs_to :store, class_name: 'Spree::Store'
+    belongs_to :product, class_name: 'Spree::Product', optional: true
+    belongs_to :store, class_name: 'Spree::Store', optional: true
   end
 end

--- a/spree/core/app/models/spree/store_promotion.rb
+++ b/spree/core/app/models/spree/store_promotion.rb
@@ -9,7 +9,6 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store', touch: true
     belongs_to :promotion, class_name: 'Spree::Promotion', touch: true
 
-    validates :store, :promotion, presence: true
     validates :store_id, uniqueness: { scope: :promotion_id }
   end
 end

--- a/spree/core/app/models/spree/tax_rate.rb
+++ b/spree/core/app/models/spree/tax_rate.rb
@@ -25,7 +25,7 @@ module Spree
 
     with_options presence: true do
       validates :amount, numericality: { allow_nil: true }
-      validates :tax_category, :name
+      validates :name
     end
 
     # The jurisdiction this rate applies in, held as codes: a blank country_code

--- a/spree/core/app/models/spree/taxon_rule.rb
+++ b/spree/core/app/models/spree/taxon_rule.rb
@@ -13,7 +13,7 @@ module Spree
     # manual in 6.0), so this is a plain belongs_to. Data-only until 6.1.
     belongs_to :taxon, class_name: 'Spree::Category', touch: true
 
-    validates :taxon, :type, :value, presence: true
+    validates :type, :value, presence: true
     validates :match_policy, inclusion: { in: MATCH_POLICIES }, presence: true
 
     delegate :store, to: :taxon

--- a/spree/core/app/models/spree/variant_media.rb
+++ b/spree/core/app/models/spree/variant_media.rb
@@ -7,7 +7,6 @@ module Spree
     belongs_to :variant, class_name: 'Spree::Variant', touch: true
     belongs_to :asset, class_name: 'Spree::Media', foreign_key: :media_id, inverse_of: :variant_media
 
-    validates :variant, :asset, presence: true
     validates :media_id, uniqueness: { scope: :variant_id }
     validate :asset_belongs_to_variant_product
 

--- a/spree/core/app/models/spree/webhook_endpoint.rb
+++ b/spree/core/app/models/spree/webhook_endpoint.rb
@@ -16,7 +16,7 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store'
     has_many :webhook_deliveries, class_name: 'Spree::WebhookDelivery', dependent: :destroy_async
 
-    validates :store, :url, presence: true
+    validates :url, presence: true
     validates :url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: :invalid_url }
     validates :active, inclusion: { in: [true, false] }
     validate :url_must_not_resolve_to_private_ip, if: -> { !Rails.env.development? && url.present? && url_changed? }

--- a/spree/core/app/models/spree/wished_item.rb
+++ b/spree/core/app/models/spree/wished_item.rb
@@ -12,7 +12,6 @@ module Spree
 
     has_one :product, class_name: 'Spree::Product', through: :variant
 
-    validates :variant, :wishlist, presence: true
     validates :variant, uniqueness: { scope: [:wishlist] }
     validates :quantity, numericality: { only_integer: true, greater_than: 0 }
 

--- a/spree/core/app/models/spree/wishlist.rb
+++ b/spree/core/app/models/spree/wishlist.rb
@@ -22,7 +22,7 @@ module Spree
     has_many :products, -> { distinct }, through: :variants, source: :product, class_name: 'Spree::Product'
 
     after_commit :ensure_default_exists_and_is_unique
-    validates :name, :store, :customer, presence: true
+    validates :name, presence: true
 
     def include?(variant_id)
       wished_items.exists?(variant_id: variant_id)

--- a/spree/core/app/models/spree/zone_member.rb
+++ b/spree/core/app/models/spree/zone_member.rb
@@ -6,6 +6,5 @@ module Spree
     # tables by the data-migration tasks.
     belongs_to :zone, class_name: 'Spree::Zone', inverse_of: :zone_members
 
-    validates :zone, presence: true
   end
 end

--- a/spree/core/db/sample_data/orders.rb
+++ b/spree/core/db/sample_data/orders.rb
@@ -115,6 +115,7 @@ if method
   end
 
   credit_card = Spree::CreditCard.find_or_initialize_by(gateway_customer_profile_id: 'BGS-1234')
+  credit_card.payment_method = method
   credit_card.cc_type = 'visa'
   credit_card.month = 12
   credit_card.year = 2.years.from_now.year

--- a/spree/core/spec/models/spree/base_spec.rb
+++ b/spree/core/spec/models/spree/base_spec.rb
@@ -1,51 +1,6 @@
 require 'spec_helper'
 
-module Test
-  class Parent < ActiveRecord::Base
-    self.table_name = 'test_parents'
-  end
-
-  class Child < ActiveRecord::Base
-    self.table_name = 'test_children'
-    belongs_to :parent, class_name: 'Test::Parent'
-  end
-end
-
 describe Spree::Base do
-  context 'AR overrides', skip: ENV['DB'] == 'mysql' do
-    let(:connection) { ActiveRecord::Base.connection }
-
-    before do
-      connection.create_table :test_parents, force: true
-      connection.create_table :test_children, force: true do |t|
-        t.belongs_to :test_parent
-      end
-    end
-
-    after do
-      connection.drop_table 'test_parents', if_exists: true
-      connection.drop_table 'test_children', if_exists: true
-    end
-
-    it 'does not override Rails 5 default belongs_to_required_by_default' do
-      expect(described_class.belongs_to_required_by_default).to eq(false)
-      expect(Spree::Product.belongs_to_required_by_default).to be(false)
-
-      expect(ApplicationRecord.belongs_to_required_by_default).to be(true)
-      expect(ActiveRecord::Base.belongs_to_required_by_default).to be(true)
-      expect(Test::Parent.belongs_to_required_by_default).to be(true)
-      expect(Test::Child.belongs_to_required_by_default).to be(true)
-    end
-
-    it 'does not disable non-spree, Rails 5 models to validate their associated belongs_to model' do
-      model_instance = Test::Child.new
-
-      expect(model_instance.validate).to eq(false)
-      expect(model_instance.errors.messages).to include(:parent)
-      expect(model_instance.errors.messages[:parent]).to include('must exist')
-    end
-  end
-
   describe '.api_type' do
     it { expect(Spree::FulfillmentItem.api_type).to eq('fulfillment_item') }
     it { expect(Spree::Address.api_type).to eq('address') }

--- a/spree/core/spec/models/spree/credit_card_spec.rb
+++ b/spree/core/spec/models/spree/credit_card_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::CreditCard, type: :model do
   it_behaves_like 'metadata'
 
-  let(:credit_card) { Spree::CreditCard.new }
+  let(:credit_card) { Spree::CreditCard.new(payment_method: payment_method) }
   let(:valid_credit_card_attributes) do
     {
       number: '4111111111111111',

--- a/spree/core/spec/models/spree/import_mapping_spec.rb
+++ b/spree/core/spec/models/spree/import_mapping_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Spree::ImportMapping, type: :model do
       it 'validates presence of import' do
         mapping = build(:import_mapping, import: nil)
         expect(mapping).not_to be_valid
-        expect(mapping.errors[:import]).to include("can't be blank")
+        expect(mapping.errors[:import]).to include('must exist')
       end
 
       it 'validates presence of schema_field' do

--- a/spree/core/spec/models/spree/inventory_unit_spec.rb
+++ b/spree/core/spec/models/spree/inventory_unit_spec.rb
@@ -75,7 +75,8 @@ describe Spree::InventoryUnit, type: :model do
     it "does not find inventory units that aren't backordered" do
       on_hand_unit = shipment.inventory_units.build
       on_hand_unit.state = 'on_hand'
-      on_hand_unit.variant_id = 1
+      on_hand_unit.variant = create(:variant)
+      on_hand_unit.line_item = order.line_items.first
       on_hand_unit.save!
 
       expect(Spree::InventoryUnit.backordered_for_stock_level(stock_level)).not_to include(on_hand_unit)
@@ -85,6 +86,7 @@ describe Spree::InventoryUnit, type: :model do
       other_variant_unit = shipment.inventory_units.build
       other_variant_unit.state = 'backordered'
       other_variant_unit.variant = create(:variant)
+      other_variant_unit.line_item = order.line_items.first
       other_variant_unit.save!
 
       expect(Spree::InventoryUnit.backordered_for_stock_level(stock_level)).not_to include(other_variant_unit)
@@ -101,7 +103,8 @@ describe Spree::InventoryUnit, type: :model do
       let(:other_order) do
         order = create(:order)
         order.completed_at = nil
-        order.completed_at = nil
+        create(:line_item, order: order, variant: stock_level.variant)
+        order.line_items.reload
         order.tap(&:save!)
       end
 
@@ -120,6 +123,7 @@ describe Spree::InventoryUnit, type: :model do
         unit.state = 'backordered'
         unit.variant_id = stock_level.variant.id
         unit.order_id = other_order.id
+        unit.line_item = other_order.line_items.first
         unit.tap(&:save!)
       end
 

--- a/spree/core/spec/models/spree/shipment_spec.rb
+++ b/spree/core/spec/models/spree/shipment_spec.rb
@@ -237,7 +237,9 @@ describe Spree::Shipment, type: :model do
     it 'equals line items final amount with tax' do
       shipment = create(:shipment, order: create(:order_with_line_item_quantity, line_items_quantity: 2))
       shipment.order.line_items.first.update_columns(adjustment_total: 2.0, additional_tax_total: 2.0)
-      expect(shipment.item_cost).to eq(22.0)
+      # update_columns writes behind the loaded associations, so the manifest
+      # has to re-read the line items to see the tax.
+      expect(shipment.reload.item_cost).to eq(22.0)
     end
   end
 
@@ -807,7 +809,8 @@ describe Spree::Shipment, type: :model do
     let(:shipment) { Spree::Shipment.create order_id: order.id, stock_location: create(:stock_location) }
 
     let(:shipping_rate) do
-      Spree::ShippingRate.create shipment_id: shipment.id, cost: 10
+      Spree::ShippingRate.create shipment_id: shipment.id, cost: 10,
+                                 delivery_method: create(:delivery_method)
     end
 
     before do

--- a/spree/core/spec/services/spree/commissions/commission_order_spec.rb
+++ b/spree/core/spec/services/spree/commissions/commission_order_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe Spree::Commissions::CommissionOrder do
     def fulfillment_carrying(*line_items, cost: 20)
       fulfillment = create(:fulfillment, order: order, cost: cost)
       fulfillment.fulfillment_items.destroy_all
-      line_items.each { |line_item| fulfillment.fulfillment_items.create!(line_item: line_item, quantity: 1) }
+      line_items.each do |line_item|
+        fulfillment.fulfillment_items.create!(line_item: line_item, variant: line_item.variant, quantity: 1)
+      end
       fulfillment
     end
 


### PR DESCRIPTION
`Spree::Base` has overridden `belongs_to_required_by_default` to `false` since the Rails 5 upgrade in May 2017, when the framework changed the default underneath an existing codebase. Nine years on it means a `belongs_to` in Spree says nothing about whether the record it points at is required, and Spree models behave differently from every other model in a host application.

This restores the Rails default, in three commits.

### 1. Declare the optional associations

Ten associations are genuinely optional and now say so. This has to land first — it is the only part that cannot be derived from the schema, and it is what makes removing the override safe.

`Payment#source` is the one worth a second look: it is required only when the gateway needs a stored source, which the existing `if: :source_required?` validation already expresses.

### 2. Remove the override

Three lines from `base.rb`, plus the fallout it exposed.

The base spec no longer asserts any of this — that `belongs_to` validates presence by default is Rails behaviour, not ours to test.

### 3. Drop the presence validations `belongs_to` now performs

70 hand-written `validates :x, presence: true` lines restating what the association already guarantees. Nothing becomes optional: every association whose validation was removed is required by its own `belongs_to`. The largest single line lived in `SingleStoreResource`, covering every store-scoped model in the engine.

## Bugs this surfaced

Three, all fixed here:

- **`db/sample_data/orders.rb` built a `CreditCard` with no payment method.** Shipped code, not a fixture — sample data loading was relying on the missing validation.
- **`PriceHistory#variant` lacked the `with_deleted` scope** its sibling `Price#variant` has, so recording history for a soft-deleted variant failed.
- **`Payment#source` would have become unconditionally required** despite being conditional. Caught before it shipped.

And one regression this branch introduced and then fixed, worth knowing about because it shows the shape of the risk: `StoreCredit#customer` looked required (the factory sets it, the model validated it) but a gift card applied to a **guest cart** issues store credit with no customer. Applying a gift card as a guest returned `422 Customer must exist` until it was declared optional. Only the API controller specs cover that path.

## Upgrade impact

Documented in `docs/developer/upgrades/5.6-to-6.0.mdx`. Two things affect applications built on Spree:

- **Their own models change with it.** Anything inheriting from `Spree::Base` picks up the new default, so an association that is legitimately blank needs `optional: true`.
- **The message changed** from `"can't be blank"` to `"must exist"`, which reaches API 422 `details`.

This is a breaking change for extensions and host-app decorators, so it belongs in a major — 6.0 is the window.

## Verification

| Suite | Result |
|---|---|
| `spree/core` models | 6240 examples, 0 failures |
| `spree/core` services, workflows, jobs, subscribers, validators, finders, presenters, mailers, helpers, lib | 2395 examples, 0 failures |
| `spree/api` controllers, requests, services, serializers, jobs, subscribers, lib | 2559 examples, 0 failures |

99 associations are required on a nullable column — those are the ones whose behaviour actually changed, and the suites above are what exercise them.