### PR TITLE
Follow the Rails default for has_many inversing

### DIFF
--- a/spree/core/app/models/spree/base.rb
+++ b/spree/core/app/models/spree/base.rb
@@ -66,11 +66,6 @@ class Spree::Base < ApplicationRecord
     ApplicationRecord.try(:spree_base_uniqueness_scope) || []
   end
 
-  # FIXME: https://github.com/rails/rails/issues/40943
-  def self.has_many_inversing
-    false
-  end
-
   # this can overridden in subclasses to disallow deletion
   def can_be_deleted?
     true

--- a/spree/core/app/models/spree/cart.rb
+++ b/spree/core/app/models/spree/cart.rb
@@ -166,11 +166,15 @@ module Spree
       fulfillments.delete_all
       fulfillment_items.reset
 
-      self.fulfillments = Spree::Stock::Coordinator.new(self).fulfillments.map do |fulfillment|
+      # Appended rather than assigned: setting `cart` on each proposal already
+      # files it under this cart's `fulfillments` (the association is
+      # inverse_of it), so a collection assignment sees the rows as already
+      # present, writes none of them, and the cart ends up with no proposals at
+      # all.
+      Spree::Stock::Coordinator.new(self).fulfillments.each do |fulfillment|
         fulfillment.address_id = ship_address_id
         fulfillment.order = nil
-        fulfillment.cart = self
-        fulfillment
+        fulfillments << fulfillment
       end
       prune_undeliverable_fulfillments!
       fulfillments.reload

--- a/spree/core/app/models/spree/order_group.rb
+++ b/spree/core/app/models/spree/order_group.rb
@@ -144,9 +144,15 @@ module Spree
     #
 
     # @return [BigDecimal] completed payments on this group, less their refunds
+    #
+    # Reads the persisted rows rather than filtering the loaded association: a
+    # payment still being validated is already held by `payments` (the
+    # association is inverse_of this group), and counting it here would have the
+    # group treat money it has not taken yet as settled — which is what
+    # `max_amount` then subtracts from the total.
     def payment_total
       @payment_total ||= begin
-        settled = payments.select { |payment| payment.status == 'completed' }
+        settled = payments.completed.to_a
         settled.sum(&:amount) - Spree::Refund.where(payment_id: settled.map(&:id)).sum(:amount)
       end
     end

--- a/spree/core/app/models/spree/stock_movement.rb
+++ b/spree/core/app/models/spree/stock_movement.rb
@@ -90,8 +90,14 @@ module Spree
       Spree.t('stock_movement.reasons.manual_adjustment', locale: :en)
     end
 
+    # A movement is an immutable audit row: once written, nothing may rewrite
+    # it. The guard is against an *update*, so it reads `persisted?` at the
+    # moment the save begins rather than afterwards — a parent's autosave can
+    # insert this row while its own save is still in flight (the stock level
+    # holds it through `inverse_of`), which leaves it persisted mid-insert. That
+    # row is being created, not updated, so it must still be allowed to finish.
     def readonly?
-      persisted?
+      persisted? && !being_created?
     end
 
     # @deprecated Use {#stock_level}; removed in 6.1.
@@ -107,6 +113,21 @@ module Spree
     end
 
     private
+
+    # Re-entrant: a parent's autosave can call this again from inside the outer
+    # save, and the inner call must not clear the outer one's guard.
+    def create_or_update(...)
+      @create_depth = @create_depth.to_i + 1
+      @being_created = true if new_record?
+      super
+    ensure
+      @create_depth -= 1
+      @being_created = false if @create_depth.zero?
+    end
+
+    def being_created?
+      @being_created.present?
+    end
 
     # The single place count_on_hand and allocated_count change.
     #

--- a/spree/core/config/initializers/rails61_fixes.rb
+++ b/spree/core/config/initializers/rails61_fixes.rb
@@ -1,1 +1,0 @@
-ActiveRecord::Base.has_many_inversing = false


### PR DESCRIPTION
Spree has disabled `has_many_inversing` since December 2020, when Rails 6.1 turned it on and an inverse combined with `touch: true` raised a `FrozenError` (rails/rails#40943). That issue was closed upstream on 2021-01-07 — nine days after the workaround landed here. I re-ran the reproduction from the issue against Rails 8.1.3.1: it completes cleanly.

The workaround, however, had stopped being dead code. Turning inversing back on broke 109 specs, and every one of them was a real defect the flag had been hiding. The first three commits fix those; the fourth removes the overrides.

## What the flag was hiding

**`StockMovement` could not finish its own insert.** A movement is an immutable audit row, guarded by `readonly? = persisted?`. That is true both of a row already written and of one *currently being written* — and with inversing, the stock level holds the unsaved movement, so the level's autosave inserts it while its own save is still in flight. The movement's save then refused to continue. The guard now asks whether the save in progress is the one that created the row, and is re-entrant, because the autosave arrives from inside the outer save.

**An order group counted money it had not taken.** `payment_total` filtered the loaded association in Ruby, so a payment still being validated counted as settled — the group holds it, since the payment is `inverse_of` the group. `max_amount` then subtracted the payment's own amount from the total it was being measured against, and the payment refused itself with *"Amount is greater than the allowed maximum amount of 0.0"*. It now reads the persisted rows.

**A cart could rebuild its delivery proposals into nothing.** `rebuild_fulfillments!` pointed each proposal at the cart and then *assigned* the collection. Setting `cart` had already filed those rows under `cart.fulfillments`, so the assignment saw them as present, wrote none of them, and the cart came out of a rebuild with no proposals — no exception, no warning. Appending fixes it. This is the one worth a second pair of eyes: the failure mode is silent, and it is worth confirming nothing depended on assignment's replace semantics.

## The initializer

Two overrides went with the flag. `spree/core/config/initializers/rails61_fixes.rb` held a single line:

```ruby
ActiveRecord::Base.has_many_inversing = false
```

An engine initializer reaching into `ActiveRecord::Base`, so any application mounting Spree had the framework default turned off across all of its own models too. Confirmed on the server app: `ApplicationRecord.has_many_inversing` read `false` before and `true` after.

## Verification

| Suite | Result |
|---|---|
| `spree/core` models, services, workflows, jobs, subscribers, validators, finders, presenters, mailers, helpers, lib | 8635 examples, 0 failures |
| `spree/api` controllers, requests, services, serializers, jobs, subscribers, lib | 2559 examples, 0 failures |

109 → 90 → 68 → 0 across the three fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cart fulfillment rebuilding so generated fulfillment proposals are consistently retained.
  * Improved payment total calculations by reliably including completed payments and refunds.
  * Allowed new stock movements to be created while continuing to prevent changes to existing records.
  * Updated association handling to use Rails’ standard inverse-association behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->