### PR TITLE
Remove undefined setup_procfile call from template

### DIFF
--- a/spree/template.rb
+++ b/spree/template.rb
@@ -124,7 +124,6 @@ add_gems
 after_bundle do
   configure_development_environment
   install_spree
-  setup_procfile
   seed_database
   load_sample_data
   show_success_message


### PR DESCRIPTION
The `setup_procfile` method was intentionally removed in [c8c818e](https://github.com/spree/spree/commit/c8c818e64d154fe5e2b5682a472a2717d4623172) when the template switched to a headless setup, but the call was accidentally re-introduced in [dd81f1c](https://github.com/spree/spree/commit/dd81f1c3c950ecba1d172ef253d807c46417f6ec), causing a NameError on every fresh install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the application setup workflow after dependency installation.
  * Development environment configuration, Spree installation, database seeding, sample data loading, and completion messaging now run in the correct sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->