### PR TITLE
Publish the Seller API reference

### DIFF
--- a/docs/api-reference/admin.yaml
+++ b/docs/api-reference/admin.yaml
@@ -289,7 +289,11 @@ paths:
           })
 
           const me = await client.me.get()
-          if (me.permissions.some((r) => r.allow && r.actions.includes('manage') && r.subjects.includes('Spree::Product'))) {
+          if (
+            me.permissions.some(
+              (r) => r.allow && r.actions.includes('manage') && r.subjects.includes('Spree::Product'),
+            )
+          ) {
             // show "Create product" button
           }
       - lang: bash
@@ -2630,8 +2634,9 @@ paths:
           const key = await client.apiKeys.create({
             name: 'Backend integration',
             key_type: 'secret',
-            scopes: ['read_orders', 'write_orders']
+            scopes: ['read_orders', 'write_orders'],
           })
+
           // `key.plaintext_token` is available only on this response.
       - lang: bash
         label: Spree CLI
@@ -5715,11 +5720,9 @@ paths:
             secretKey: 'sk_xxx',
           })
 
-          const address = await client.customers.addresses.update(
-            'cus_UkLWZg9DAJ',
-            'addr_UkLWZg9DAJ',
-            { city: 'Manhattan' },
-          )
+          const address = await client.customers.addresses.update('cus_UkLWZg9DAJ', 'addr_UkLWZg9DAJ', {
+            city: 'Manhattan',
+          })
       - lang: bash
         label: Spree CLI
         source: spree api patch /customers/{customer_id}/addresses/{id} -d '{"city":"Manhattan"}'
@@ -6252,11 +6255,9 @@ paths:
             secretKey: 'sk_xxx',
           })
 
-          const credit = await client.customers.storeCredits.update(
-            'cus_UkLWZg9DAJ',
-            'sc_UkLWZg9DAJ',
-            { memo: 'Reissued for damaged shipment' },
-          )
+          const credit = await client.customers.storeCredits.update('cus_UkLWZg9DAJ', 'sc_UkLWZg9DAJ', {
+            memo: 'Reissued for damaged shipment',
+          })
       - lang: bash
         label: Spree CLI
         source: spree api patch /customers/{customer_id}/store_credits/{id} -d '{"memo":"Reissued
@@ -7226,7 +7227,7 @@ paths:
 
           const exp = await client.exports.create({
             type: 'Spree::Exports::Products',
-            search_params: { name_cont: 'shirt' }
+            search_params: { name_cont: 'shirt' },
           })
       - lang: bash
         label: Spree CLI
@@ -7429,13 +7430,13 @@ paths:
 
           // Fetch with the Bearer token, then drive the browser download:
           const res = await fetch(exp.download_url, {
-            headers: { Authorization: `Bearer ${token}` }
+            headers: { Authorization: `Bearer ${token}` },
           })
           const blob = await res.blob()
           const url = URL.createObjectURL(blob)
           const a = Object.assign(document.createElement('a'), {
             href: url,
-            download: exp.filename
+            download: exp.filename,
           })
           a.click()
           URL.revokeObjectURL(url)
@@ -20015,14 +20016,14 @@ paths:
                   label: Country
                   description:
                   preference_schema:
+                  - key: country_code
+                    type: string
+                    default:
                   - key: country_codes
                     type: array
                     default: []
                   - key: country_id
                     type: integer
-                    default:
-                  - key: country_code
-                    type: string
                     default:
                 - type: currency
                   label: Currency
@@ -20637,7 +20638,7 @@ paths:
           })
 
           const store = await client.store.update({
-            name: 'My Store'
+            name: 'My Store',
           })
       - lang: bash
         label: Spree CLI
@@ -21748,7 +21749,7 @@ paths:
 
           const staff = await client.adminUsers.update('admin_xxx', {
             first_name: 'Ada',
-            role_ids: ['role_xxx']
+            role_ids: ['role_xxx'],
           })
       - lang: bash
         label: Spree CLI
@@ -21945,7 +21946,7 @@ paths:
 
           const invitation = await client.invitations.create({
             email: 'ada@example.com',
-            role_id: 'role_xxx'
+            role_id: 'role_xxx',
           })
       - lang: bash
         label: Spree CLI
@@ -22902,6 +22903,8 @@ paths:
                   pickup_stock_policy: local
                   created_at: '2026-01-15T12:00:00.000Z'
                   updated_at: '2026-01-15T12:00:00.000Z'
+                  seller_id:
+                  seller_name:
                 meta:
                   page: 1
                   limit: 25
@@ -23018,6 +23021,8 @@ paths:
                 pickup_stock_policy: local
                 created_at: '2026-01-15T12:00:00.000Z'
                 updated_at: '2026-01-15T12:00:00.000Z'
+                seller_id:
+                seller_name:
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -23197,6 +23202,8 @@ paths:
                 pickup_stock_policy: local
                 created_at: '2026-01-15T12:00:00.000Z'
                 updated_at: '2026-01-15T12:00:00.000Z'
+                seller_id:
+                seller_name:
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '404':
@@ -23288,6 +23295,8 @@ paths:
                 pickup_stock_policy: local
                 created_at: '2026-01-15T12:00:00.000Z'
                 updated_at: '2026-01-15T12:00:00.000Z'
+                seller_id:
+                seller_name:
               schema:
                 "$ref": "#/components/schemas/StockLocation"
         '422':
@@ -24777,7 +24786,7 @@ paths:
                 created_at: '2026-01-15T12:00:00.000Z'
                 updated_at: '2026-01-15T12:00:00.000Z'
                 disabled_at:
-                secret_key: f44b508d518f47b9d42ae8a67ba913f7f7c4ee25be2e4dda1fbc06370fe29854
+                secret_key: 507fa8041773b106ae4242f7458a20bdbf22bcda1eaaafaafe5199e035271094
                 last_delivery_at:
                 recent_delivery_count: 0
                 recent_failure_count: 0
@@ -25142,7 +25151,7 @@ paths:
                 updated_at: '2026-01-15T12:00:00.000Z'
                 delivered_at:
                 payload:
-                  id: 98bd6b06-c704-47e3-a821-f23f15825658
+                  id: 163e6ba9-6301-4d28-a9a3-a65cd4861bd1
                   name: webhook.test
                   created_at: '2026-01-15T12:00:00Z'
                   data:
@@ -28870,9 +28879,9 @@ paths:
                   stock_location_ids: []
                   calculator_type: Spree::Calculator::Shipping::FlatRate
                   calculator_preferences:
+                    amounts: {}
                     amount: '10.0'
                     currency: USD
-                    amounts: {}
                 meta:
                   page: 1
                   limit: 25
@@ -28959,9 +28968,9 @@ paths:
                 stock_location_ids: []
                 calculator_type: Spree::Calculator::Shipping::FlatRate
                 calculator_preferences:
+                  amounts: {}
                   amount: '12.5'
                   currency: USD
-                  amounts: {}
       requestBody:
         content:
           application/json:
@@ -29066,21 +29075,18 @@ paths:
                 - type: Spree::Calculator::Shipping::FlatRate
                   name: Flat rate
                   preference_schema:
+                  - key: amounts
+                    type: hash
+                    default: {}
                   - key: amount
                     type: decimal
                     default: 0
                   - key: currency
                     type: string
                     default: USD
-                  - key: amounts
-                    type: hash
-                    default: {}
                 - type: Spree::Calculator::Shipping::FlexiRate
                   name: Flexible Rate per package item
                   preference_schema:
-                  - key: currency
-                    type: string
-                    default: USD
                   - key: first_item
                     type: decimal
                     default: 0.0
@@ -29090,6 +29096,9 @@ paths:
                   - key: max_items
                     type: integer
                     default: 0
+                  - key: currency
+                    type: string
+                    default: USD
                 - type: Spree::Calculator::Shipping::PerItem
                   name: Flat rate per package item
                   preference_schema:
@@ -29105,6 +29114,9 @@ paths:
                 - type: Spree::Calculator::Shipping::PriceSack
                   name: Price sack
                   preference_schema:
+                  - key: minimal_amount
+                    type: decimal
+                    default: 0
                   - key: normal_amount
                     type: decimal
                     default: 0
@@ -29114,9 +29126,6 @@ paths:
                   - key: currency
                     type: string
                     default: USD
-                  - key: minimal_amount
-                    type: decimal
-                    default: 0
                 - type: Spree::Calculator::Shipping::DigitalDelivery
                   name: Digital Delivery
                   preference_schema:
@@ -29582,13 +29591,13 @@ paths:
                   video_embed_url:
                   video_url:
                   poster_url:
-                  original_url: http://localhost:3000/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/thinking-cat.jpg
-                  mini_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjgsMTI4XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--8a107b5d4e446aa3ee77d65ab1096e23cae0ee44/thinking-cat.jpg
-                  small_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyNTYsMjU2XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--da2ae2189533c010082fde78750c129ef1d718a4/thinking-cat.jpg
-                  medium_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls0MDAsNDAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--9a1c74694521ceb8df2b28d1dde889c56fac300b/thinking-cat.jpg
-                  large_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls3MjAsNzIwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--0c5768a9354584db01b8bb3ae2726a844d337740/thinking-cat.jpg
-                  xlarge_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyMDAwLDIwMDBdLCJzYXZlciI6eyJzdHJpcCI6dHJ1ZSwicXVhbGl0eSI6NzUsImxvc3NsZXNzIjpmYWxzZSwiYWxwaGFfcSI6ODUsInJlZHVjdGlvbl9lZmZvcnQiOjYsInNtYXJ0X3N1YnNhbXBsZSI6dHJ1ZX19LCJwdXIiOiJ2YXJpYXRpb24ifX0=--c68d0ce1bedeb9500ff022cd16e7a91ea5a5f360/thinking-cat.jpg
-                  og_image_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjAwLDYzMF0sInNhdmVyIjp7InN0cmlwIjp0cnVlLCJxdWFsaXR5Ijo3NSwibG9zc2xlc3MiOmZhbHNlLCJhbHBoYV9xIjo4NSwicmVkdWN0aW9uX2VmZm9ydCI6Niwic21hcnRfc3Vic2FtcGxlIjp0cnVlfX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--19b2b7562418dc89aead349f4abaafa2a80c405d/thinking-cat.jpg
+                  original_url: http://localhost:3000/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/thinking-cat.jpg
+                  mini_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjgsMTI4XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--b4fdca80742482d33891bf229e1ada5ef52f97f2/thinking-cat.jpg
+                  small_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyNTYsMjU2XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--e1af0e4dee9872ed57300d1a76dd05789e09819b/thinking-cat.jpg
+                  medium_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls0MDAsNDAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--b79acb58d868a24b8cbeb21c17995269ea350926/thinking-cat.jpg
+                  large_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls3MjAsNzIwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--f326dc231706dceae653f168b050ec48126373f4/thinking-cat.jpg
+                  xlarge_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyMDAwLDIwMDBdLCJzYXZlciI6eyJzdHJpcCI6dHJ1ZSwicXVhbGl0eSI6NzUsImxvc3NsZXNzIjpmYWxzZSwiYWxwaGFfcSI6ODUsInJlZHVjdGlvbl9lZmZvcnQiOjYsInNtYXJ0X3N1YnNhbXBsZSI6dHJ1ZX19LCJwdXIiOiJ2YXJpYXRpb24ifX0=--641dedabe2c54d21584e60fc1c7e284d76b90a3d/thinking-cat.jpg
+                  og_image_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjAwLDYzMF0sInNhdmVyIjp7InN0cmlwIjp0cnVlLCJxdWFsaXR5Ijo3NSwibG9zc2xlc3MiOmZhbHNlLCJhbHBoYV9xIjo4NSwicmVkdWN0aW9uX2VmZm9ydCI6Niwic21hcnRfc3Vic2FtcGxlIjp0cnVlfX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--d8027178bc9184f1f089ca097f0b20aaa9c98235/thinking-cat.jpg
                   external_references: {}
                   created_at: '2026-01-15T12:00:00.000Z'
                   updated_at: '2026-01-15T12:00:00.000Z'
@@ -29596,10 +29605,10 @@ paths:
                   filename: thinking-cat.jpg
                   content_type: image/jpeg
                   byte_size: 18090
-                  embed_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2xpbWl0IjpbMTIwMCwxMjAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--eda7969089fec02a17e1151c5695256265dc45be/thinking-cat.jpg
-                  signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688
+                  embed_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2xpbWl0IjpbMTIwMCwxMjAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--e9e7c9ddcdbab79b823da04645b6a714e79c42a2/thinking-cat.jpg
+                  signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c
                   viewable_id: prod_UkLWZg9DAJ
-                  download_url: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/thinking-cat.jpg?disposition=attachment
+                  download_url: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/thinking-cat.jpg?disposition=attachment
                   metadata: {}
                   viewable_type: product
                 meta:
@@ -29670,13 +29679,13 @@ paths:
                 video_embed_url:
                 video_url:
                 poster_url:
-                original_url: http://localhost:3000/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/library-upload.jpg
-                mini_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjgsMTI4XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--8a107b5d4e446aa3ee77d65ab1096e23cae0ee44/library-upload.jpg
-                small_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyNTYsMjU2XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--da2ae2189533c010082fde78750c129ef1d718a4/library-upload.jpg
-                medium_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls0MDAsNDAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--9a1c74694521ceb8df2b28d1dde889c56fac300b/library-upload.jpg
-                large_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls3MjAsNzIwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--0c5768a9354584db01b8bb3ae2726a844d337740/library-upload.jpg
-                xlarge_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyMDAwLDIwMDBdLCJzYXZlciI6eyJzdHJpcCI6dHJ1ZSwicXVhbGl0eSI6NzUsImxvc3NsZXNzIjpmYWxzZSwiYWxwaGFfcSI6ODUsInJlZHVjdGlvbl9lZmZvcnQiOjYsInNtYXJ0X3N1YnNhbXBsZSI6dHJ1ZX19LCJwdXIiOiJ2YXJpYXRpb24ifX0=--c68d0ce1bedeb9500ff022cd16e7a91ea5a5f360/library-upload.jpg
-                og_image_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjAwLDYzMF0sInNhdmVyIjp7InN0cmlwIjp0cnVlLCJxdWFsaXR5Ijo3NSwibG9zc2xlc3MiOmZhbHNlLCJhbHBoYV9xIjo4NSwicmVkdWN0aW9uX2VmZm9ydCI6Niwic21hcnRfc3Vic2FtcGxlIjp0cnVlfX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--19b2b7562418dc89aead349f4abaafa2a80c405d/library-upload.jpg
+                original_url: http://localhost:3000/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/library-upload.jpg
+                mini_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjgsMTI4XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--b4fdca80742482d33891bf229e1ada5ef52f97f2/library-upload.jpg
+                small_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyNTYsMjU2XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--e1af0e4dee9872ed57300d1a76dd05789e09819b/library-upload.jpg
+                medium_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls0MDAsNDAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--b79acb58d868a24b8cbeb21c17995269ea350926/library-upload.jpg
+                large_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls3MjAsNzIwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--f326dc231706dceae653f168b050ec48126373f4/library-upload.jpg
+                xlarge_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyMDAwLDIwMDBdLCJzYXZlciI6eyJzdHJpcCI6dHJ1ZSwicXVhbGl0eSI6NzUsImxvc3NsZXNzIjpmYWxzZSwiYWxwaGFfcSI6ODUsInJlZHVjdGlvbl9lZmZvcnQiOjYsInNtYXJ0X3N1YnNhbXBsZSI6dHJ1ZX19LCJwdXIiOiJ2YXJpYXRpb24ifX0=--641dedabe2c54d21584e60fc1c7e284d76b90a3d/library-upload.jpg
+                og_image_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjAwLDYzMF0sInNhdmVyIjp7InN0cmlwIjp0cnVlLCJxdWFsaXR5Ijo3NSwibG9zc2xlc3MiOmZhbHNlLCJhbHBoYV9xIjo4NSwicmVkdWN0aW9uX2VmZm9ydCI6Niwic21hcnRfc3Vic2FtcGxlIjp0cnVlfX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--d8027178bc9184f1f089ca097f0b20aaa9c98235/library-upload.jpg
                 external_references: {}
                 created_at: '2026-01-15T12:00:00.000Z'
                 updated_at: '2026-01-15T12:00:00.000Z'
@@ -29684,10 +29693,10 @@ paths:
                 filename: library-upload.jpg
                 content_type: image/jpeg
                 byte_size: 18090
-                embed_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2xpbWl0IjpbMTIwMCwxMjAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--eda7969089fec02a17e1151c5695256265dc45be/library-upload.jpg
-                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3
+                embed_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2xpbWl0IjpbMTIwMCwxMjAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--e9e7c9ddcdbab79b823da04645b6a714e79c42a2/library-upload.jpg
+                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1
                 viewable_id:
-                download_url: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--58492de1ce78eb3d3af7e7aa79fb53a860727cd3/library-upload.jpg?disposition=attachment
+                download_url: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--01a3addec81e078b12b6c6d8e065da710f0f52c1/library-upload.jpg?disposition=attachment
                 metadata: {}
                 viewable_type:
               schema:
@@ -29844,13 +29853,13 @@ paths:
                 video_embed_url:
                 video_url:
                 poster_url:
-                original_url: http://localhost:3000/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/thinking-cat.jpg
-                mini_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjgsMTI4XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--8a107b5d4e446aa3ee77d65ab1096e23cae0ee44/thinking-cat.jpg
-                small_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyNTYsMjU2XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--da2ae2189533c010082fde78750c129ef1d718a4/thinking-cat.jpg
-                medium_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls0MDAsNDAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--9a1c74694521ceb8df2b28d1dde889c56fac300b/thinking-cat.jpg
-                large_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls3MjAsNzIwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--0c5768a9354584db01b8bb3ae2726a844d337740/thinking-cat.jpg
-                xlarge_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyMDAwLDIwMDBdLCJzYXZlciI6eyJzdHJpcCI6dHJ1ZSwicXVhbGl0eSI6NzUsImxvc3NsZXNzIjpmYWxzZSwiYWxwaGFfcSI6ODUsInJlZHVjdGlvbl9lZmZvcnQiOjYsInNtYXJ0X3N1YnNhbXBsZSI6dHJ1ZX19LCJwdXIiOiJ2YXJpYXRpb24ifX0=--c68d0ce1bedeb9500ff022cd16e7a91ea5a5f360/thinking-cat.jpg
-                og_image_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjAwLDYzMF0sInNhdmVyIjp7InN0cmlwIjp0cnVlLCJxdWFsaXR5Ijo3NSwibG9zc2xlc3MiOmZhbHNlLCJhbHBoYV9xIjo4NSwicmVkdWN0aW9uX2VmZm9ydCI6Niwic21hcnRfc3Vic2FtcGxlIjp0cnVlfX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--19b2b7562418dc89aead349f4abaafa2a80c405d/thinking-cat.jpg
+                original_url: http://localhost:3000/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/thinking-cat.jpg
+                mini_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjgsMTI4XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--b4fdca80742482d33891bf229e1ada5ef52f97f2/thinking-cat.jpg
+                small_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyNTYsMjU2XSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--e1af0e4dee9872ed57300d1a76dd05789e09819b/thinking-cat.jpg
+                medium_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls0MDAsNDAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--b79acb58d868a24b8cbeb21c17995269ea350926/thinking-cat.jpg
+                large_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOls3MjAsNzIwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--f326dc231706dceae653f168b050ec48126373f4/thinking-cat.jpg
+                xlarge_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsyMDAwLDIwMDBdLCJzYXZlciI6eyJzdHJpcCI6dHJ1ZSwicXVhbGl0eSI6NzUsImxvc3NsZXNzIjpmYWxzZSwiYWxwaGFfcSI6ODUsInJlZHVjdGlvbl9lZmZvcnQiOjYsInNtYXJ0X3N1YnNhbXBsZSI6dHJ1ZX19LCJwdXIiOiJ2YXJpYXRpb24ifX0=--641dedabe2c54d21584e60fc1c7e284d76b90a3d/thinking-cat.jpg
+                og_image_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2ZpbGwiOlsxMjAwLDYzMF0sInNhdmVyIjp7InN0cmlwIjp0cnVlLCJxdWFsaXR5Ijo3NSwibG9zc2xlc3MiOmZhbHNlLCJhbHBoYV9xIjo4NSwicmVkdWN0aW9uX2VmZm9ydCI6Niwic21hcnRfc3Vic2FtcGxlIjp0cnVlfX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--d8027178bc9184f1f089ca097f0b20aaa9c98235/thinking-cat.jpg
                 external_references: {}
                 created_at: '2026-01-15T12:00:00.000Z'
                 updated_at: '2026-01-15T12:00:00.000Z'
@@ -29858,10 +29867,10 @@ paths:
                 filename: thinking-cat.jpg
                 content_type: image/jpeg
                 byte_size: 18090
-                embed_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2xpbWl0IjpbMTIwMCwxMjAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--eda7969089fec02a17e1151c5695256265dc45be/thinking-cat.jpg
-                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688
+                embed_url: http://localhost:3000/rails/active_storage/representations/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJ3ZWJwIiwicmVzaXplX3RvX2xpbWl0IjpbMTIwMCwxMjAwXSwic2F2ZXIiOnsic3RyaXAiOnRydWUsInF1YWxpdHkiOjc1LCJsb3NzbGVzcyI6ZmFsc2UsImFscGhhX3EiOjg1LCJyZWR1Y3Rpb25fZWZmb3J0Ijo2LCJzbWFydF9zdWJzYW1wbGUiOnRydWV9fSwicHVyIjoidmFyaWF0aW9uIn19--e9e7c9ddcdbab79b823da04645b6a714e79c42a2/thinking-cat.jpg
+                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c
                 viewable_id: prod_gbHJdmfrXB
-                download_url: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--51494e939e43178323c022f9180ece19fd476688/thinking-cat.jpg?disposition=attachment
+                download_url: http://localhost:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c/thinking-cat.jpg?disposition=attachment
                 metadata: {}
                 viewable_type: product
               schema:
@@ -30355,6 +30364,7 @@ paths:
                   description: The seller has accepted your marketplace terms
                   preferences:
                     terms_effective_from:
+                    terms_url:
                   custom_field_definition_ids: []
                   allow_multiple: false
                   accepts_submissions: false
@@ -30579,6 +30589,9 @@ paths:
                   - key: terms_effective_from
                     type: string
                     default:
+                  - key: terms_url
+                    type: string
+                    default:
                 - type: complete_profile
                   name: Complete profile
                   description: The seller has filled in their public profile
@@ -30590,6 +30603,9 @@ paths:
                   accepted_content_types: []
                   association_fields: []
                   preference_schema:
+                  - key: require_about
+                    type: boolean
+                    default: true
                   - key: require_logo
                     type: boolean
                     default: true
@@ -30597,9 +30613,6 @@ paths:
                     type: boolean
                     default: false
                   - key: require_contact_email
-                    type: boolean
-                    default: true
-                  - key: require_about
                     type: boolean
                     default: true
                 - type: billing_address
@@ -30987,6 +31000,8 @@ paths:
                     done: 0
                     total: 0
                   onboarding_complete: true
+                  legal_name:
+                  registration_number:
                 meta:
                   page: 1
                   limit: 25
@@ -31101,6 +31116,8 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
               schema:
                 "$ref": "#/components/schemas/Seller"
         '422':
@@ -31243,6 +31260,8 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
               schema:
                 "$ref": "#/components/schemas/Seller"
         '404':
@@ -31335,17 +31354,19 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
                 billing_address:
                   id: addr_UkLWZg9DAJ
-                  first_name: Ada
-                  last_name: Lovelace
-                  full_name: Ada Lovelace
+                  first_name:
+                  last_name:
+                  full_name: ''
                   address1: 1 Seller Way
                   address2:
                   postal_code: EC1A 1BB
                   city: London
                   phone: '555'
-                  company:
+                  company: Sparks Trading Ltd
                   country_name: United Kingdom
                   country_code: GB
                   state_text:
@@ -31639,6 +31660,8 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
               schema:
                 "$ref": "#/components/schemas/Seller"
       requestBody:
@@ -31740,6 +31763,8 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
               schema:
                 "$ref": "#/components/schemas/Seller"
         '422':
@@ -31840,6 +31865,8 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
               schema:
                 "$ref": "#/components/schemas/Seller"
       requestBody:
@@ -31937,6 +31964,8 @@ paths:
                   done: 0
                   total: 0
                 onboarding_complete: true
+                legal_name:
+                registration_number:
               schema:
                 "$ref": "#/components/schemas/Seller"
       requestBody:
@@ -37533,6 +37562,12 @@ components:
           type: object
         onboarding_complete:
           type: boolean
+        legal_name:
+          type: string
+          nullable: true
+        registration_number:
+          type: string
+          nullable: true
         billing_address:
           "$ref": "#/components/schemas/Address"
         returns_address:
@@ -37564,6 +37599,41 @@ components:
       - users_count
       - onboarding_progress
       - onboarding_complete
+      - legal_name
+      - registration_number
+      x-typelizer: true
+    SellerTeamMember:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        full_name:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        avatar_url:
+          type: string
+          nullable: true
+      required:
+      - id
+      - email
+      - first_name
+      - last_name
+      - full_name
+      - created_at
+      - updated_at
+      - avatar_url
       x-typelizer: true
     SetupTask:
       type: object
@@ -37700,6 +37770,14 @@ components:
           type: string
         updated_at:
           type: string
+        seller_id:
+          type: string
+          nullable: true
+        seller_name:
+          type: string
+          nullable: true
+        seller:
+          "$ref": "#/components/schemas/Seller"
       required:
       - id
       - name
@@ -37727,6 +37805,8 @@ components:
       - pickup_stock_policy
       - created_at
       - updated_at
+      - seller_id
+      - seller_name
       x-typelizer: true
     StockMovement:
       type: object

--- a/docs/api-reference/seller-api/authentication.mdx
+++ b/docs/api-reference/seller-api/authentication.mdx
@@ -1,0 +1,115 @@
+---
+title: "Authenticate Seller API requests with JWTs and the seller header"
+sidebarTitle: "Authentication"
+description: "Authenticate Spree Seller API requests with a seller-audience JWT and select which seller to act as using the X-Spree-Seller-Id header."
+---
+
+The Seller API has exactly one authentication method: a **JWT issued to a signed-in seller**. There is deliberately no secret API key on this branch — a credential that could act as a seller without a seller signing in is exactly what the separate token audience exists to prevent.
+
+## Two things every request needs
+
+1. `Authorization: Bearer <token>` — the JWT returned by login.
+2. `X-Spree-Seller-Id: <seller_id>` — which seller the signed-in user is acting as.
+
+The only authenticated endpoint that does not need the second is `GET /api/v3/seller/me`, because that is what tells the panel which seller to name.
+
+## Signing in
+
+```typescript
+import { createSellerClient } from '@spree/seller-sdk'
+
+const client = createSellerClient({ baseUrl: 'https://store.example.com' })
+
+const { token, user, sellers } = await client.auth.login({
+  email: 'seller@example.com',
+  password: 'password123',
+})
+```
+
+The response carries three things: the access token, the team member who signed in, and **every seller this user may act for**.
+
+<Note>
+The refresh token is **not** in the response body. It is set as an HttpOnly cookie scoped to `/api/v3/seller/auth`, so a session issued for the seller panel cannot be redeemed on any other surface.
+</Note>
+
+### Membership is required, not just credentials
+
+A marketplace's own staff share the same user class as sellers. Authenticating is therefore not enough: a user who runs no seller is refused with `401`, because issuing a token would hand out an audience its holder can do nothing with.
+
+## Choosing a seller
+
+A person may run more than one seller — so capability is per seller, and a request that names none has no tenant at all.
+
+```typescript
+client.setToken(token)
+client.setSeller(sellers[0].id)
+
+// Every subsequent call now carries both headers
+const { data: products } = await client.products.list()
+```
+
+Sending a seller ID the caller has no role on resolves to nothing, so it reads as **"no such seller"** rather than "denied" — which is also what stops the header being used to enumerate the marketplace's sellers.
+
+<Warning>
+A request with a valid token but no `X-Spree-Seller-Id` header — or one naming a seller the caller does not belong to — is rejected with `403`. There is no fallback to a default seller.
+</Warning>
+
+## Token audiences
+
+Every Spree JWT carries an audience, and each surface accepts only its own:
+
+| Surface | Audience | Accepted by |
+|---|---|---|
+| Storefront | `store_api` | Store API |
+| Back office | `admin_api` | Admin API |
+| Seller panel | `seller_api` | Seller API |
+
+An admin token presented to the Seller API is a `401`, and a seller token presented to the Admin API is likewise refused. The refresh endpoint narrows by audience too, so a refresh token minted elsewhere cannot be exchanged for a seller session.
+
+## Refreshing a session
+
+```typescript
+const { token } = await client.auth.refresh()
+client.setToken(token)
+```
+
+No request body and no `Authorization` header — the cookie alone authenticates the call, and a fresh refresh cookie is rotated in.
+
+Membership is re-checked here, so a user whose last seller role was revoked mid-session is refused at their next refresh rather than continuing until the access token happens to expire.
+
+## Signing out
+
+```typescript
+await client.auth.logout()
+```
+
+Revokes the refresh token server-side and clears the cookie.
+
+## Accepting an invitation
+
+Someone invited onto a seller's team arrives through an emailed link carrying an invitation ID and a token. Both acceptance endpoints are unauthenticated — the link **is** the credential.
+
+```typescript
+// Read the invitation to decide what to ask for
+const invitation = await client.auth.lookupInvitation(invitationId, token)
+
+// Accept, and land in the panel already signed in
+const { token: jwt, sellers } = await client.auth.acceptInvitation(invitationId, token, {
+  password: 'password123',
+  password_confirmation: 'password123',
+  first_name: 'Robin',
+  last_name: 'Ellis',
+})
+```
+
+The invited email address is never taken from the request — it always comes from the invitation itself, which is what stops the link being redirected to another address.
+
+`password` sets a new password when no account exists for that address; when one does, the same field is how the person proves the account is theirs.
+
+<Note>
+A wrong token is indistinguishable from an unknown invitation: both answer `404`. So does an invitation onto the marketplace's own staff rather than a seller.
+</Note>
+
+## Rate limiting
+
+Sign-in, refresh, provider discovery, and invitation acceptance are all rate limited, and answer `429` with a `rate_limit_exceeded` code when a client exceeds the window.

--- a/docs/api-reference/seller-api/errors.mdx
+++ b/docs/api-reference/seller-api/errors.mdx
@@ -1,0 +1,130 @@
+---
+title: "Seller API error responses, status codes, and handling"
+sidebarTitle: "Errors"
+description: "Reference for the Spree Seller API error response format, HTTP status codes, and what a 403 versus a 404 means on the seller branch."
+---
+
+The Seller API uses the same error format as the rest of the Spree v3 API. Every error response carries a machine-readable `code` and a human-readable `message`.
+
+## Error response format
+
+```json
+{
+  "error": {
+    "code": "record_not_found",
+    "message": "Product not found"
+  }
+}
+```
+
+Validation errors include a `details` field with per-field messages:
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "Validation failed",
+    "details": {
+      "name": ["can't be blank"]
+    }
+  }
+}
+```
+
+Permission errors name the key the caller was missing:
+
+```json
+{
+  "error": {
+    "code": "access_denied",
+    "message": "Missing permission: write_products",
+    "details": {
+      "required_permission": "write_products"
+    }
+  }
+}
+```
+
+## Status codes
+
+| Status | Meaning on the seller branch |
+|---|---|
+| `200` | Success |
+| `201` | Resource created |
+| `204` | Success, no body — deletes and logout |
+| `401` | No token, an expired one, or a token minted for another surface |
+| `403` | Authenticated, but no seller named — or the acting seller's role lacks the permission |
+| `404` | The record does not exist **for this seller** |
+| `422` | Validation failed, or a workflow refused the request |
+| `429` | Rate limit exceeded |
+
+## 403 versus 404 — the distinction that matters
+
+This is the most important thing to understand about the seller branch, because the two codes answer different questions.
+
+**`403` means "you have not told me who you are acting as, or you may not do this."** It comes from one of two places:
+
+- No `X-Spree-Seller-Id` header, or one naming a seller the caller has no role on.
+- The acting seller's role lacks the permission key the action requires.
+
+**`404` means "no such record, for you."** Every lookup is rooted in the acting seller, so an ID belonging to another seller — or to the marketplace operator — is simply not found.
+
+```json
+{
+  "error": {
+    "code": "record_not_found",
+    "message": "Product not found"
+  }
+}
+```
+
+This is deliberate. Answering `403` for another seller's product would confirm the record exists, which is how a seller could probe the marketplace's catalog one ID at a time. The seller is never told the difference between "this belongs to someone else" and "this does not exist".
+
+## Common error codes
+
+| Code | Status | When |
+|---|---|---|
+| `authentication_failed` | 401 | Bad credentials, or a user who runs no seller |
+| `invalid_refresh_token` | 401 | The refresh cookie is missing, expired, or for another audience |
+| `access_denied` | 403 | No seller named, or a missing permission key |
+| `record_not_found` | 404 | The record does not belong to the acting seller |
+| `validation_error` | 422 | Model validation failed; see `details` |
+| `processing_error` | 422 | A workflow refused — for example, submitting for review with requirements outstanding |
+| `parameter_missing` | 400 | A required parameter was absent |
+| `rate_limit_exceeded` | 429 | Too many requests to an auth endpoint |
+
+## Handling errors with the SDK
+
+The SDK throws a `SpreeError` carrying the code, status, and details:
+
+```typescript
+import { SpreeError } from '@spree/seller-sdk'
+
+try {
+  await client.products.create({ name: '' })
+} catch (error) {
+  if (error instanceof SpreeError) {
+    if (error.status === 422) {
+      // error.details → { name: ["can't be blank"] }
+      showFieldErrors(error.details)
+    } else if (error.status === 403) {
+      showMessage("You don't have permission to do that.")
+    }
+  }
+}
+```
+
+## Requirements that block submission
+
+Submitting for review with something required still outstanding returns `422` with a message naming what is blocking. The seller's status is unchanged — nothing partial happens.
+
+```json
+{
+  "error": {
+    "code": "processing_error",
+    "message": "Add a billing address"
+  }
+}
+```
+
+Read the checklist from `GET /api/v3/seller/onboarding` to see each requirement's `status` and whether it is `blocking`.

--- a/docs/api-reference/seller-api/introduction.mdx
+++ b/docs/api-reference/seller-api/introduction.mdx
@@ -1,0 +1,98 @@
+---
+title: "Spree Seller API introduction and SDK quick start"
+sidebarTitle: "Introduction"
+description: "Overview of the Spree Seller API — the marketplace seller panel for managing a seller's own catalog, team, stock locations, and onboarding."
+---
+
+import { Since } from '/snippets/since.mdx';
+
+<Since version="6.0" />
+
+The Seller API is a REST API for the **marketplace seller panel** — where a seller runs their own shop inside someone else's marketplace. It powers a seller's catalog, their team, their stock locations, and the onboarding checklist the marketplace asks them to complete.
+
+All routes are prefixed with `/api/v3/seller`. During development the API is available under `http://localhost:3000/api/v3/seller`. For production, replace `http://localhost:3000` with your Spree application URL.
+
+## A branch of its own, not a narrowing of the Admin API
+
+Sellers never call the Admin API. Every Seller API endpoint is scoped server-side to the seller the request acts as, which makes cross-seller access impossible by construction rather than by rule: a product ID belonging to another seller answers `404`, not `403`.
+
+The store is **derived from the seller**, never sent alongside it, so no header a seller controls can widen what they reach.
+
+| | Seller API | Admin API |
+|---|---|---|
+| **Purpose** | Run one seller's shop | Run the whole marketplace |
+| **Audience** | Marketplace sellers and their staff | The marketplace operator's staff |
+| **Authentication** | Seller JWT only (`seller_api` audience) | Secret API key (`sk_…`) or admin JWT |
+| **Tenancy** | Scoped to the acting seller | Scoped to the store |
+| **Server-to-server credential** | None, by design | Secret API keys |
+
+The marketplace operator manages sellers — approving them, reviewing what they submit, setting commission — through the Admin API's own [seller endpoints](/api-reference/admin-api/introduction), not through this API.
+
+## Using the SDK
+
+We recommend `@spree/seller-sdk` for interacting with the Seller API. It provides typed clients, automatic retries, and handles the seller header for you.
+
+### Installation
+
+```bash
+npm install @spree/seller-sdk
+# or
+yarn add @spree/seller-sdk
+# or
+pnpm add @spree/seller-sdk
+```
+
+### Quick start
+
+```typescript
+import { createSellerClient } from '@spree/seller-sdk'
+
+const client = createSellerClient({
+  baseUrl: 'http://localhost:3000',
+})
+
+// Sign in, then pick which seller to act as
+const { token, sellers } = await client.auth.login({
+  email: 'seller@example.com',
+  password: 'password123',
+})
+
+client.setToken(token)
+client.setSeller(sellers[0].id)
+
+const { data: products } = await client.products.list({ limit: 25 })
+```
+
+## What a seller can do
+
+<CardGroup cols={2}>
+  <Card title="Catalog" icon="tag">
+    List, create, update, and delete the products they own outright.
+  </Card>
+  <Card title="Profile" icon="store">
+    Maintain presentation, contact details, addresses, and tax registration.
+  </Card>
+  <Card title="Team" icon="users">
+    Invite colleagues, list the team, and revoke access.
+  </Card>
+  <Card title="Onboarding" icon="list-check">
+    Read the marketplace's checklist and submit against each requirement.
+  </Card>
+  <Card title="Stock locations" icon="warehouse">
+    Manage where they keep stock, and so where returns are sent.
+  </Card>
+  <Card title="Uploads" icon="upload">
+    Presign direct uploads for the documents onboarding asks for.
+  </Card>
+</CardGroup>
+
+## What a seller cannot do
+
+Some fields are readable but never writable, because they belong to the marketplace rather than the seller:
+
+- **`status`** — the seller lifecycle belongs to the operator's workflows. A seller says they are ready via `POST /api/v3/seller/onboarding/submit_for_review`; the operator decides.
+- **`slug`** — renaming a storefront address would break every link pointing at it.
+- **Settlement and commission terms** — what the marketplace charges is the marketplace's to set.
+- **Tax category, delivery profile, and promotionability on products** — marketplace-wide merchandising settings.
+
+Sending these fields is not an error; they are simply ignored.

--- a/docs/api-reference/seller.yaml
+++ b/docs/api-reference/seller.yaml
@@ -1,0 +1,15208 @@
+---
+openapi: 3.0.3
+info:
+  title: Seller API
+  contact:
+    name: Spree Commerce
+    url: https://spreecommerce.org
+    email: hello@spreecommerce.org
+  description: |
+    Spree Seller API v3 - the marketplace seller panel, where a seller runs
+    their own shop inside someone else's marketplace.
+
+    This is a branch of its own, not a narrowing of the Admin API. Every
+    endpoint is scoped server-side to the seller the request acts as, which
+    is what makes cross-seller access impossible by construction rather
+    than by rule. Sellers never call the Admin API.
+
+    ## Authentication
+
+    Sign in at `POST /api/v3/seller/auth/login` and send the returned JWT as
+    `Authorization: Bearer <token>`. The token carries a `seller_api`
+    audience — a token minted for the storefront or the back office is not
+    accepted here, and vice versa.
+
+    There is deliberately **no secret API key** for this branch: a
+    credential that could act as a seller without a seller signing in is
+    exactly what the separate audience exists to prevent.
+
+    ### Choosing a seller
+
+    A user may run more than one seller. Login returns the list; send the
+    chosen seller's ID in the `X-Spree-Seller-Id` header on every
+    authenticated request. The store is derived from the seller — never
+    sent — so no header can widen what a seller reaches. A request that
+    names no seller the caller belongs to is rejected with `403`.
+
+    ## Response Format
+
+    All responses are JSON. List endpoints return paginated responses with
+    `data` and `meta` keys.
+
+    ## Error Handling
+
+    Errors return a consistent format:
+    ```json
+    {
+      "error": {
+        "code": "validation_error",
+        "message": "Validation failed",
+        "details": { "name": ["can't be blank"] }
+      }
+    }
+    ```
+  version: v3
+paths:
+  "/api/v3/seller/auth/login":
+    post:
+      summary: Login
+      tags:
+      - Authentication
+      description: |
+        Signs a seller in and returns a short-lived JWT access token carrying the
+        `seller_api` audience. The rotatable refresh token is set in an HttpOnly
+        cookie — it is not included in the response body.
+
+        The response lists every seller this user may act for. Pick one and send
+        its `id` as `X-Spree-Seller-Id` on every subsequent request; nothing else
+        on this API answers until a seller is named.
+
+        Authenticating is not on its own enough. A store's own staff share the
+        same user class, so a user who runs no seller is refused — issuing a
+        token would hand out an audience its holder can do nothing with.
+
+        The `provider` field selects the authentication method. When omitted it
+        defaults to `email`. Sellers and store staff read different provider
+        registries, so a marketplace can require SSO for its own back office
+        while still letting sellers sign in with a password.
+      parameters: []
+      responses:
+        '200':
+          description: login successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjE5NWY4OTE2LWI3NGQtNDg2MS1hMTQ3LTJmMDhiMzhiMWIzNSIsImlzcyI6InNwcmVlIiwiYXVkIjoic2VsbGVyX2FwaSIsImV4cCI6MTc2ODQ3ODcwMH0.e2XwsDONtD0x4j9jfjnHhDhAJpzhXBQ2LuIjWS1kY1k
+                user:
+                  id: adm_UkLWZg9DAJ
+                  email: seller@example.com
+                  first_name: Jan
+                  last_name: Cummerata
+                  full_name: Jan Cummerata
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  avatar_url:
+                sellers:
+                - id: sel_UkLWZg9DAJ
+                  name: Seller 1
+                  status: approved
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '401':
+          description: invalid credentials
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_failed
+                  message: Invalid email or password
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  enum:
+                  - email
+                  default: email
+                email:
+                  type: string
+                  format: email
+                  example: seller@example.com
+                password:
+                  type: string
+                  example: password123
+              required:
+              - email
+              - password
+  "/api/v3/seller/auth/refresh":
+    post:
+      summary: Refresh token
+      tags:
+      - Authentication
+      description: |
+        Exchanges the HttpOnly refresh-token cookie for a new access JWT and a
+        rotated refresh cookie. No request body or Authorization header is
+        required — the cookie alone authenticates the call.
+
+        The lookup is narrowed by audience, so a refresh token minted for the
+        storefront or the back office cannot be exchanged for a seller session.
+        Membership is rechecked here too: a user whose last seller role was
+        revoked mid-session is refused rather than renewed.
+      responses:
+        '200':
+          description: refresh successful
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjdjODEzNjdjLTBlYWEtNGUzOC1hNmRjLTJjMTYzOTIxY2Q1MiIsImlzcyI6InNwcmVlIiwiYXVkIjoic2VsbGVyX2FwaSIsImV4cCI6MTc2ODQ3ODcwMH0.N2ttey6pvsPoOdx0F9pdUNbdT1j25ejAzpghXTbB8zo
+                user:
+                  id: adm_UkLWZg9DAJ
+                  email: seller@example.com
+                  first_name: Magdalen
+                  last_name: Hayes
+                  full_name: Magdalen Hayes
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  avatar_url:
+                sellers:
+                - id: sel_UkLWZg9DAJ
+                  name: Seller 3
+                  status: approved
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '401':
+          description: missing or invalid refresh-token cookie
+          content:
+            application/json:
+              example:
+                error:
+                  code: invalid_refresh_token
+                  message: Refresh token cookie missing
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/auth/logout":
+    post:
+      summary: Logout
+      tags:
+      - Authentication
+      description: Revokes the refresh-token cookie, ending the seller session.
+      responses:
+        '204':
+          description: logout successful
+  "/api/v3/seller/auth/providers":
+    get:
+      summary: List authentication providers
+      tags:
+      - Authentication
+      description: |
+        The sign-in methods this marketplace offers sellers, for the login page
+        to render. Unauthenticated — a login page must be able to ask before
+        anyone has signed in.
+      responses:
+        '200':
+          description: providers listed
+          content:
+            application/json:
+              example:
+                providers:
+                - key: email
+                  kind: password
+              schema:
+                "$ref": "#/components/schemas/AuthProvidersResponse"
+  "/api/v3/seller/auth/invitations/{id}/lookup":
+    parameters:
+    - name: id
+      in: path
+      description: Invitation ID from the emailed link
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Look up an invitation
+      tags:
+      - Authentication
+      description: |
+        Reads an invitation from the emailed link, before anyone signs in.
+
+        The acceptance page needs the invited address to decide whether it is
+        asking someone to set a new password or to confirm one they already have.
+
+        Unauthenticated — the ID and token in the emailed link are the
+        credential. A wrong token is indistinguishable from an unknown
+        invitation: both answer `404`, so the endpoint cannot be used to
+        enumerate. An invitation onto the store's own staff rather than a seller
+        answers `404` here too.
+      parameters:
+      - name: token
+        in: query
+        required: true
+        description: The token from the emailed link
+        schema:
+          type: string
+      responses:
+        '200':
+          description: invitation found
+          content:
+            application/json:
+              example:
+                id: inv_UkLWZg9DAJ
+                email: newcomer@acme.test
+                created_at: '2026-01-15T12:00:00.000Z'
+                expires_at: '2026-01-29T12:00:00.000Z'
+                accepted_at:
+                status: pending
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=RgGhNP1euUCS75Nc3V1Y7YQF"
+              schema:
+                "$ref": "#/components/schemas/Invitation"
+        '404':
+          description: wrong token, or an invitation that can no longer be accepted
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Invitation not found, expired, or already accepted.
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/auth/invitations/{id}/accept":
+    parameters:
+    - name: id
+      in: path
+      description: Invitation ID from the emailed link
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Accept an invitation
+      tags:
+      - Authentication
+      description: |
+        Accepts the invitation and returns a signed-in seller session, so the new
+        member lands in the panel rather than on a login form.
+
+        The email is never taken from the request — it always comes from the
+        invitation, which is what stops the link being redirected to another
+        address.
+
+        `password` is required when no account exists for the invited address, in
+        which case it sets one. When an account already exists, the same field is
+        how the person proves the account is theirs.
+      parameters:
+      - name: token
+        in: query
+        required: true
+        description: The token from the emailed link
+        schema:
+          type: string
+      responses:
+        '200':
+          description: invitation accepted, session issued
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoyLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6IjRmYzVlNzBmLWU1ODAtNDExNi1hOWU5LTBjNDliMGExYjMxNCIsImlzcyI6InNwcmVlIiwiYXVkIjoic2VsbGVyX2FwaSIsImV4cCI6MTc2ODQ3ODcwMH0.H0mJ1zDqTi6mNs_BZBRTJ77OMsWAqeUXvQM09YPLefs
+                user:
+                  id: adm_gbHJdmfrXB
+                  email: newcomer@acme.test
+                  first_name: Robin
+                  last_name: Ellis
+                  full_name: Robin Ellis
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  avatar_url:
+                sellers:
+                - id: sel_UkLWZg9DAJ
+                  name: Seller 11
+                  status: approved
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '404':
+          description: wrong token, or an invitation that can no longer be accepted
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Invitation not found, expired, or already accepted.
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  example: password123
+                password_confirmation:
+                  type: string
+                  example: password123
+                first_name:
+                  type: string
+                  example: Robin
+                last_name:
+                  type: string
+                  example: Ellis
+  "/api/v3/seller/me":
+    get:
+      summary: Current user
+      tags:
+      - Account
+      security:
+      - bearer_auth: []
+      description: |
+        The signed-in user, the sellers they may act for, and what they may do on
+        the selected one.
+
+        This is the one authenticated endpoint that answers without
+        `X-Spree-Seller-Id` — it is what tells the panel which seller to name.
+        Sending the header narrows `permission_keys` and `permissions` to that
+        seller; without it both are empty, because capability is per seller and
+        there is no answer spanning all of them.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: false
+        description: The seller to report capability for. Omit to list sellers without
+          narrowing permissions.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: current user returned
+          content:
+            application/json:
+              example:
+                user:
+                  id: adm_UkLWZg9DAJ
+                  email: johnny_feest@hodkiewicz.ca
+                  first_name: Nadia
+                  last_name: Effertz
+                  full_name: Nadia Effertz
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  avatar_url:
+                sellers:
+                - id: sel_UkLWZg9DAJ
+                  name: Seller 20
+                  slug: seller-20
+                  status: approved
+                permissions:
+                - allow: true
+                  actions:
+                  - read
+                  subjects:
+                  - Spree::Country
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  subjects:
+                  - Spree::State
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  subjects:
+                  - Spree::Store
+                  has_conditions: true
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::Product
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::ProductType
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::Variant
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::OptionType
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::OptionValue
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::Price
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::PriceList
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::PriceRule
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::ProductPublication
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - read
+                  - admin
+                  subjects:
+                  - Spree::CustomField
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::Product
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::ProductType
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::Variant
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::OptionType
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::OptionValue
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::Price
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::PriceList
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::PriceRule
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::ProductPublication
+                  has_conditions: false
+                - allow: true
+                  actions:
+                  - manage
+                  subjects:
+                  - Spree::CustomField
+                  has_conditions: false
+                permission_keys:
+                - read_products
+                - write_products
+              schema:
+                "$ref": "#/components/schemas/SellerMeResponse"
+        '401':
+          description: missing or invalid token
+          content:
+            application/json:
+              example:
+                error:
+                  code: authentication_required
+                  message: Authentication required
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/countries":
+    get:
+      summary: List countries
+      tags:
+      - Countries
+      security:
+      - bearer_auth: []
+      description: |
+        Countries and their states, for the panel's address forms.
+
+        Public reference data — the same list the storefront serves — so it is
+        not narrowed to the markets this marketplace sells into: a seller filling
+        in a billing address needs every country.
+
+        Unpaginated. An address dropdown needs all ~250 at once.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: countries listed
+          content:
+            application/json:
+              example:
+                data:
+                - iso: AF
+                  iso3: AFG
+                  name: Afghanistan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BDS
+                    name: Badakhshan
+                  - abbr: BDG
+                    name: Badghis
+                  - abbr: BGL
+                    name: Baghlan
+                  - abbr: BAL
+                    name: Balkh
+                  - abbr: BAM
+                    name: Bamian
+                  - abbr: DAY
+                    name: Daykondi
+                  - abbr: FRA
+                    name: Farah
+                  - abbr: FYB
+                    name: Faryab
+                  - abbr: GHA
+                    name: Ghazni
+                  - abbr: GHO
+                    name: Ghowr
+                  - abbr: HEL
+                    name: Helmand
+                  - abbr: HER
+                    name: Herat
+                  - abbr: JOW
+                    name: Jowzjan
+                  - abbr: KAB
+                    name: Kabul [Kabol]
+                  - abbr: KAN
+                    name: Kandahar
+                  - abbr: KAP
+                    name: Kapisa
+                  - abbr: KHO
+                    name: Khowst
+                  - abbr: KNR
+                    name: Konar [Kunar]
+                  - abbr: KDZ
+                    name: Kondoz [Kunduz]
+                  - abbr: LAG
+                    name: Laghman
+                  - abbr: NAN
+                    name: Nangrahar [Nangarhar]
+                  - abbr: NIM
+                    name: Nimruz
+                  - abbr: NUR
+                    name: Nurestan
+                  - abbr: PIA
+                    name: Paktia
+                  - abbr: PKA
+                    name: Paktika
+                  - abbr: PAN
+                    name: Panjshir
+                  - abbr: PAR
+                    name: Parwan
+                  - abbr: SAM
+                    name: Samangan
+                  - abbr: SAR
+                    name: Sar-e Pol
+                  - abbr: TAK
+                    name: Takhar
+                  - abbr: WAR
+                    name: Wardak [Wardag]
+                  - abbr: ZAB
+                    name: Zabol [Zabul]
+                  - abbr: URU
+                    name: روزګان ولايت
+                  - abbr: LOG
+                    name: لوګر ولايت
+                - iso: AL
+                  iso3: ALB
+                  name: Albania
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Berat
+                  - abbr: '09'
+                    name: Dibër
+                  - abbr: '02'
+                    name: Durrës
+                  - abbr: '03'
+                    name: Elbasan
+                  - abbr: '04'
+                    name: Fier
+                  - abbr: '05'
+                    name: Gjirokastër
+                  - abbr: '06'
+                    name: Korçë
+                  - abbr: '07'
+                    name: Kukës
+                  - abbr: '08'
+                    name: Lezhë
+                  - abbr: '10'
+                    name: Shkodër
+                  - abbr: '11'
+                    name: Tiranë
+                  - abbr: '12'
+                    name: Vlorë
+                - iso: DZ
+                  iso3: DZA
+                  name: Algeria
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Adrar
+                  - abbr: '16'
+                    name: Alger
+                  - abbr: '23'
+                    name: Annaba
+                  - abbr: '44'
+                    name: Aïn Defla
+                  - abbr: '46'
+                    name: Aïn Témouchent
+                  - abbr: '05'
+                    name: Batna
+                  - abbr: '07'
+                    name: Biskra
+                  - abbr: '09'
+                    name: Blida
+                  - abbr: '34'
+                    name: Bordj Bou Arréridj
+                  - abbr: '10'
+                    name: Bouira
+                  - abbr: '35'
+                    name: Boumerdès
+                  - abbr: '08'
+                    name: Béchar
+                  - abbr: '06'
+                    name: Béjaïa
+                  - abbr: '02'
+                    name: Chlef
+                  - abbr: '25'
+                    name: Constantine
+                  - abbr: '17'
+                    name: Djelfa
+                  - abbr: '32'
+                    name: El Bayadh
+                  - abbr: '39'
+                    name: El Oued
+                  - abbr: '36'
+                    name: El Tarf
+                  - abbr: '47'
+                    name: Ghardaïa
+                  - abbr: '24'
+                    name: Guelma
+                  - abbr: '33'
+                    name: Illizi
+                  - abbr: '18'
+                    name: Jijel
+                  - abbr: '40'
+                    name: Khenchela
+                  - abbr: '03'
+                    name: Laghouat
+                  - abbr: '29'
+                    name: Mascara
+                  - abbr: '43'
+                    name: Mila
+                  - abbr: '27'
+                    name: Mostaganem
+                  - abbr: '28'
+                    name: Msila
+                  - abbr: '26'
+                    name: Médéa
+                  - abbr: '45'
+                    name: Naama
+                  - abbr: '31'
+                    name: Oran
+                  - abbr: '30'
+                    name: Ouargla
+                  - abbr: '04'
+                    name: Oum el Bouaghi
+                  - abbr: '48'
+                    name: Relizane
+                  - abbr: '20'
+                    name: Saïda
+                  - abbr: '22'
+                    name: Sidi Bel Abbès
+                  - abbr: '21'
+                    name: Skikda
+                  - abbr: '41'
+                    name: Souk Ahras
+                  - abbr: '19'
+                    name: Sétif
+                  - abbr: '11'
+                    name: Tamanghasset
+                  - abbr: '14'
+                    name: Tiaret
+                  - abbr: '37'
+                    name: Tindouf
+                  - abbr: '42'
+                    name: Tipaza
+                  - abbr: '38'
+                    name: Tissemsilt
+                  - abbr: '15'
+                    name: Tizi Ouzou
+                  - abbr: '13'
+                    name: Tlemcen
+                  - abbr: '12'
+                    name: Tébessa
+                - iso: AS
+                  iso3: ASM
+                  name: American Samoa
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: AD
+                  iso3: AND
+                  name: Andorra
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '07'
+                    name: Andorra la Vella
+                  - abbr: '02'
+                    name: Canillo
+                  - abbr: '03'
+                    name: Encamp
+                  - abbr: '08'
+                    name: Escaldes-Engordany
+                  - abbr: '04'
+                    name: La Massana
+                  - abbr: '05'
+                    name: Ordino
+                  - abbr: '06'
+                    name: Sant Julià de Lòria
+                - iso: AO
+                  iso3: AGO
+                  name: Angola
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BGO
+                    name: Bengo
+                  - abbr: BGU
+                    name: Benguela
+                  - abbr: BIE
+                    name: Bié
+                  - abbr: CAB
+                    name: Cabinda
+                  - abbr: CCU
+                    name: Cuando-Cubango
+                  - abbr: CNO
+                    name: Cuanza Norte
+                  - abbr: CUS
+                    name: Cuanza Sul
+                  - abbr: CNN
+                    name: Cunene
+                  - abbr: HUA
+                    name: Huambo
+                  - abbr: HUI
+                    name: Huíla
+                  - abbr: LUA
+                    name: Luanda
+                  - abbr: LNO
+                    name: Lunda Norte
+                  - abbr: LSU
+                    name: Lunda Sul
+                  - abbr: MAL
+                    name: Malange
+                  - abbr: MOX
+                    name: Moxico
+                  - abbr: NAM
+                    name: Namibe
+                  - abbr: UIG
+                    name: Uíge
+                  - abbr: ZAI
+                    name: Zaire
+                - iso: AI
+                  iso3: AIA
+                  name: Anguilla
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: AG
+                  iso3: ATG
+                  name: Antigua and Barbuda
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '10'
+                    name: Barbuda
+                  - abbr: '11'
+                    name: Redonda
+                  - abbr: '03'
+                    name: Saint George
+                  - abbr: '04'
+                    name: Saint John’s
+                  - abbr: '05'
+                    name: Saint Mary
+                  - abbr: '06'
+                    name: Saint Paul
+                  - abbr: '07'
+                    name: Saint Peter
+                  - abbr: '08'
+                    name: Saint Philip
+                - iso: AR
+                  iso3: ARG
+                  name: Argentina
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: B
+                    name: Buenos Aires
+                  - abbr: C
+                    name: Capital federal
+                  - abbr: K
+                    name: Catamarca
+                  - abbr: H
+                    name: Chaco
+                  - abbr: U
+                    name: Chubut
+                  - abbr: W
+                    name: Corrientes
+                  - abbr: X
+                    name: Córdoba
+                  - abbr: E
+                    name: Entre Ríos
+                  - abbr: P
+                    name: Formosa
+                  - abbr: "Y"
+                    name: Jujuy
+                  - abbr: L
+                    name: La Pampa
+                  - abbr: F
+                    name: La Rioja
+                  - abbr: M
+                    name: Mendoza
+                  - abbr: "N"
+                    name: Misiones
+                  - abbr: Q
+                    name: Neuquén
+                  - abbr: R
+                    name: Río Negro
+                  - abbr: A
+                    name: Salta
+                  - abbr: J
+                    name: San Juan
+                  - abbr: D
+                    name: San Luis
+                  - abbr: Z
+                    name: Santa Cruz
+                  - abbr: S
+                    name: Santa Fe
+                  - abbr: G
+                    name: Santiago del Estero
+                  - abbr: V
+                    name: Tierra del Fuego
+                  - abbr: T
+                    name: Tucumán
+                - iso: AM
+                  iso3: ARM
+                  name: Armenia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AG
+                    name: Aragacotn
+                  - abbr: AR
+                    name: Ararat
+                  - abbr: AV
+                    name: Armavir
+                  - abbr: ER
+                    name: Erevan
+                  - abbr: GR
+                    name: Gegark'unik'
+                  - abbr: KT
+                    name: Kotayk'
+                  - abbr: LO
+                    name: Lory
+                  - abbr: SU
+                    name: Syunik'
+                  - abbr: TV
+                    name: Tavuš
+                  - abbr: VD
+                    name: Vayoc Jor
+                  - abbr: SH
+                    name: Širak
+                - iso: AW
+                  iso3: ABW
+                  name: Aruba
+                  states_required: false
+                  zipcode_required: false
+                  states: []
+                - iso: AU
+                  iso3: AUS
+                  name: Australia
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: ACT
+                    name: Australian Capital Territory
+                  - abbr: NSW
+                    name: New South Wales
+                  - abbr: NT
+                    name: Northern Territory
+                  - abbr: QLD
+                    name: Queensland
+                  - abbr: SA
+                    name: South Australia
+                  - abbr: TAS
+                    name: Tasmania
+                  - abbr: VIC
+                    name: Victoria
+                  - abbr: WA
+                    name: Western Australia
+                - iso: AT
+                  iso3: AUT
+                  name: Austria
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '1'
+                    name: Burgenland
+                  - abbr: '2'
+                    name: Kärnten
+                  - abbr: '3'
+                    name: Niederösterreich
+                  - abbr: '4'
+                    name: Oberösterreich
+                  - abbr: '5'
+                    name: Salzburg
+                  - abbr: '6'
+                    name: Steiermark
+                  - abbr: '7'
+                    name: Tirol
+                  - abbr: '8'
+                    name: Vorarlberg
+                  - abbr: '9'
+                    name: Wien
+                - iso: AZ
+                  iso3: AZE
+                  name: Azerbaijan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ABS
+                    name: Abseron
+                  - abbr: AGC
+                    name: Agcabädi
+                  - abbr: AGM
+                    name: Agdam
+                  - abbr: AGS
+                    name: Agdas
+                  - abbr: AGA
+                    name: Agstafa
+                  - abbr: AGU
+                    name: Agsu
+                  - abbr: AST
+                    name: Astara
+                  - abbr: BAB
+                    name: Babäk
+                  - abbr: BA
+                    name: Baki
+                  - abbr: BAL
+                    name: Balakän
+                  - abbr: BEY
+                    name: Beyläqan
+                  - abbr: BIL
+                    name: Biläsuvar
+                  - abbr: BAR
+                    name: Bärdä
+                  - abbr: CUL
+                    name: Culfa
+                  - abbr: CAB
+                    name: Cäbrayil
+                  - abbr: CAL
+                    name: Cälilabab
+                  - abbr: DAS
+                    name: Daskäsän
+                  - abbr: FUZ
+                    name: Füzuli
+                  - abbr: GOR
+                    name: Goranboy
+                  - abbr: GAD
+                    name: Gädäbäy
+                  - abbr: GA
+                    name: Gäncä
+                  - abbr: GYG
+                    name: Göygöl
+                  - abbr: GOY
+                    name: Göyçay
+                  - abbr: HAC
+                    name: Haciqabul
+                  - abbr: IMI
+                    name: Imisli
+                  - abbr: ISM
+                    name: Ismayilli
+                  - abbr: KAL
+                    name: Kälbäcär
+                  - abbr: KUR
+                    name: Kürdämir
+                  - abbr: KAN
+                    name: Kəngərli
+                  - abbr: LAC
+                    name: Laçin
+                  - abbr: LER
+                    name: Lerik
+                  - abbr: LAN
+                    name: Länkäran
+                  - abbr: LA
+                    name: Länkäran City
+                  - abbr: MAS
+                    name: Masalli
+                  - abbr: MI
+                    name: Mingäçevir
+                  - abbr: NA
+                    name: Naftalan
+                  - abbr: NX
+                    name: Naxçivan
+                  - abbr: NV
+                    name: Naxçıvan
+                  - abbr: NEF
+                    name: Neftçala
+                  - abbr: OGU
+                    name: Oguz
+                  - abbr: ORD
+                    name: Ordubad
+                  - abbr: QAX
+                    name: Qax
+                  - abbr: QAZ
+                    name: Qazax
+                  - abbr: QOB
+                    name: Qobustan
+                  - abbr: QBA
+                    name: Quba
+                  - abbr: QBI
+                    name: Qubadli
+                  - abbr: QUS
+                    name: Qusar
+                  - abbr: QAB
+                    name: Qäbälä
+                  - abbr: SAT
+                    name: Saatli
+                  - abbr: SAB
+                    name: Sabirabad
+                  - abbr: SAH
+                    name: Sahbuz
+                  - abbr: SAL
+                    name: Salyan
+                  - abbr: SMI
+                    name: Samaxi
+                  - abbr: SMX
+                    name: Samux
+                  - abbr: SIY
+                    name: Siyäzän
+                  - abbr: SM
+                    name: Sumqayit
+                  - abbr: SUS
+                    name: Susa
+                  - abbr: SAD
+                    name: Sädäräk
+                  - abbr: SAK
+                    name: Säki
+                  - abbr: SA
+                    name: Säki City
+                  - abbr: SKR
+                    name: Sämkir
+                  - abbr: SAR
+                    name: Särur
+                  - abbr: TOV
+                    name: Tovuz
+                  - abbr: TAR
+                    name: Tärtär
+                  - abbr: UCA
+                    name: Ucar
+                  - abbr: XA
+                    name: Xankändi
+                  - abbr: XAC
+                    name: Xaçmaz
+                  - abbr: XIZ
+                    name: Xizi
+                  - abbr: XCI
+                    name: Xocali
+                  - abbr: XVD
+                    name: Xocavänd
+                  - abbr: YAR
+                    name: Yardimli
+                  - abbr: YEV
+                    name: Yevlax
+                  - abbr: YE
+                    name: Yevlax City
+                  - abbr: ZAQ
+                    name: Zaqatala
+                  - abbr: ZAN
+                    name: Zängilan
+                  - abbr: ZAR
+                    name: Zärdab
+                  - abbr: SBN
+                    name: Şabran (rayon)
+                  - abbr: SR
+                    name: Şirvan
+                - iso: BS
+                  iso3: BHS
+                  name: Bahamas
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AK
+                    name: Acklins
+                  - abbr: BY
+                    name: Berry Islands
+                  - abbr: BI
+                    name: Bimini
+                  - abbr: BP
+                    name: Black Point
+                  - abbr: CI
+                    name: Cat Island
+                  - abbr: CO
+                    name: Central Abaco
+                  - abbr: CS
+                    name: Central Andros
+                  - abbr: CE
+                    name: Central Eleuthera
+                  - abbr: CK
+                    name: Crooked Island
+                  - abbr: EG
+                    name: East Grand Bahama
+                  - abbr: EX
+                    name: Exuma
+                  - abbr: FP
+                    name: Freeport
+                  - abbr: GC
+                    name: Grand Cay
+                  - abbr: HI
+                    name: Harbour Island
+                  - abbr: HT
+                    name: Hope Town
+                  - abbr: IN
+                    name: Inagua
+                  - abbr: LI
+                    name: Long Island
+                  - abbr: MC
+                    name: Mangrove Cay
+                  - abbr: MG
+                    name: Mayaguana
+                  - abbr: MI
+                    name: Moore’s Island
+                  - abbr: NP
+                    name: New Providence
+                  - abbr: 'NO'
+                    name: North Abaco
+                  - abbr: NS
+                    name: North Andros
+                  - abbr: NE
+                    name: North Eleuthera
+                  - abbr: RI
+                    name: Ragged Island
+                  - abbr: RC
+                    name: Rum Cay
+                  - abbr: SS
+                    name: San Salvador
+                  - abbr: SO
+                    name: South Abaco
+                  - abbr: SA
+                    name: South Andros
+                  - abbr: SE
+                    name: South Eleuthera
+                  - abbr: SW
+                    name: Spanish Wells
+                  - abbr: WG
+                    name: West Grand Bahama
+                - iso: BH
+                  iso3: BHR
+                  name: Bahrain
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '14'
+                    name: Al Janubiyah
+                  - abbr: '13'
+                    name: Al Manamah (Al ‘Asimah)
+                  - abbr: '15'
+                    name: Al Muharraq
+                  - abbr: '17'
+                    name: Ash Shamaliyah
+                - iso: BD
+                  iso3: BGD
+                  name: Bangladesh
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '05'
+                    name: Bagerhat zila
+                  - abbr: '01'
+                    name: Bandarban zila
+                  - abbr: '02'
+                    name: Barguna zila
+                  - abbr: '06'
+                    name: Barisal zila
+                  - abbr: '07'
+                    name: Bhola zila
+                  - abbr: '03'
+                    name: Bogra zila
+                  - abbr: '04'
+                    name: Brahmanbaria zila
+                  - abbr: '09'
+                    name: Chandpur zila
+                  - abbr: '10'
+                    name: Chittagong zila
+                  - abbr: '12'
+                    name: Chuadanga zila
+                  - abbr: '08'
+                    name: Comilla zila
+                  - abbr: '11'
+                    name: Cox's Bazar zila
+                  - abbr: '13'
+                    name: Dhaka zila
+                  - abbr: '14'
+                    name: Dinajpur zila
+                  - abbr: '15'
+                    name: Faridpur zila
+                  - abbr: '16'
+                    name: Feni zila
+                  - abbr: '19'
+                    name: Gaibandha zila
+                  - abbr: '18'
+                    name: Gazipur zila
+                  - abbr: '17'
+                    name: Gopalganj zila
+                  - abbr: '20'
+                    name: Habiganj zila
+                  - abbr: '24'
+                    name: Jaipurhat zila
+                  - abbr: '21'
+                    name: Jamalpur zila
+                  - abbr: '22'
+                    name: Jessore zila
+                  - abbr: '25'
+                    name: Jhalakati zila
+                  - abbr: '23'
+                    name: Jhenaidah zila
+                  - abbr: '29'
+                    name: Khagrachari zila
+                  - abbr: '27'
+                    name: Khulna zila
+                  - abbr: '26'
+                    name: Kishoreganj zila
+                  - abbr: '28'
+                    name: Kurigram zila
+                  - abbr: '30'
+                    name: Kushtia zila
+                  - abbr: '31'
+                    name: Lakshmipur zila
+                  - abbr: '32'
+                    name: Lalmonirhat zila
+                  - abbr: '36'
+                    name: Madaripur zila
+                  - abbr: '37'
+                    name: Magura zila
+                  - abbr: '33'
+                    name: Manikganj zila
+                  - abbr: '39'
+                    name: Meherpur zila
+                  - abbr: '38'
+                    name: Moulvibazar zila
+                  - abbr: '35'
+                    name: Munshiganj zila
+                  - abbr: '34'
+                    name: Mymensingh zila
+                  - abbr: '48'
+                    name: Naogaon zila
+                  - abbr: '43'
+                    name: Narail zila
+                  - abbr: '40'
+                    name: Narayanganj zila
+                  - abbr: '42'
+                    name: Narsingdi zila
+                  - abbr: '44'
+                    name: Natore zila
+                  - abbr: '45'
+                    name: Nawabganj zila
+                  - abbr: '41'
+                    name: Netrakona zila
+                  - abbr: '46'
+                    name: Nilphamari zila
+                  - abbr: '47'
+                    name: Noakhali zila
+                  - abbr: '49'
+                    name: Pabna zila
+                  - abbr: '52'
+                    name: Panchagarh zila
+                  - abbr: '51'
+                    name: Patuakhali zila
+                  - abbr: '50'
+                    name: Pirojpur zila
+                  - abbr: '53'
+                    name: Rajbari zila
+                  - abbr: '54'
+                    name: Rajshahi zila
+                  - abbr: '56'
+                    name: Rangamati zila
+                  - abbr: '55'
+                    name: Rangpur zila
+                  - abbr: '58'
+                    name: Satkhira zila
+                  - abbr: '62'
+                    name: Shariatpur zila
+                  - abbr: '57'
+                    name: Sherpur zila
+                  - abbr: '59'
+                    name: Sirajganj zila
+                  - abbr: '61'
+                    name: Sunamganj zila
+                  - abbr: '60'
+                    name: Sylhet zila
+                  - abbr: '63'
+                    name: Tangail zila
+                  - abbr: '64'
+                    name: Thakurgaon zila
+                  - abbr: D
+                    name: খুলনা বিভাগ
+                  - abbr: B
+                    name: চট্টগ্রাম বিভাগ
+                  - abbr: C
+                    name: ঢাকা বিভাগ
+                  - abbr: A
+                    name: বরিশাল বিভাগ
+                  - abbr: H
+                    name: ময়মনসিংহ বিভাগ
+                  - abbr: F
+                    name: রংপুর বিভাগ
+                  - abbr: E
+                    name: রাজশাহী বিভাগ
+                  - abbr: G
+                    name: সিলেট বিভাগ
+                - iso: BB
+                  iso3: BRB
+                  name: Barbados
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Christ Church
+                  - abbr: '02'
+                    name: Saint Andrew
+                  - abbr: '03'
+                    name: Saint George
+                  - abbr: '04'
+                    name: Saint James
+                  - abbr: '05'
+                    name: Saint John
+                  - abbr: '06'
+                    name: Saint Joseph
+                  - abbr: '07'
+                    name: Saint Lucy
+                  - abbr: '08'
+                    name: Saint Michael
+                  - abbr: '09'
+                    name: Saint Peter
+                  - abbr: '10'
+                    name: Saint Philip
+                  - abbr: '11'
+                    name: Saint Thomas
+                - iso: BY
+                  iso3: BLR
+                  name: Belarus
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BR
+                    name: Brestskaya voblasts' (be) Brestskaya oblast' (ru)
+                  - abbr: HO
+                    name: Homyel'skaya voblasts' (be) Gomel'skaya oblast' (ru)
+                  - abbr: HR
+                    name: Hrodzenskaya voblasts' (be) Grodnenskaya oblast' (ru)
+                  - abbr: MA
+                    name: Mahilyowskaya voblasts' (be) Mogilevskaya oblast' (ru)
+                  - abbr: MI
+                    name: Minskaya voblasts' (be) Minskaya oblast' (ru)
+                  - abbr: VI
+                    name: Vitsyebskaya voblasts' (be) Vitebskaya oblast' (ru)
+                  - abbr: HM
+                    name: Мінск
+                - iso: BE
+                  iso3: BEL
+                  name: Belgium
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: VAN
+                    name: Antwerpen (nl)
+                  - abbr: WBR
+                    name: Brabant Wallon (fr)
+                  - abbr: BRU
+                    name: Brussels
+                  - abbr: WHT
+                    name: Hainaut (fr)
+                  - abbr: VLI
+                    name: Limburg (nl)
+                  - abbr: WLG
+                    name: Liège (fr)
+                  - abbr: WLX
+                    name: Luxembourg (fr)
+                  - abbr: WNA
+                    name: Namur (fr)
+                  - abbr: VOV
+                    name: Oost-Vlaanderen (nl)
+                  - abbr: VBR
+                    name: Vlaams Brabant (nl)
+                  - abbr: VLG
+                    name: Vlaams Gewest
+                  - abbr: WAL
+                    name: Wallonië
+                  - abbr: VWV
+                    name: West-Vlaanderen (nl)
+                - iso: BZ
+                  iso3: BLZ
+                  name: Belize
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BZ
+                    name: Belize
+                  - abbr: CY
+                    name: Cayo
+                  - abbr: CZL
+                    name: Corozal
+                  - abbr: OW
+                    name: Orange Walk
+                  - abbr: SC
+                    name: Stann Creek
+                  - abbr: TOL
+                    name: Toledo
+                - iso: BJ
+                  iso3: BEN
+                  name: Benin
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AL
+                    name: Alibori
+                  - abbr: AK
+                    name: Atakora
+                  - abbr: AQ
+                    name: Atlantique
+                  - abbr: BO
+                    name: Borgou
+                  - abbr: CO
+                    name: Collines
+                  - abbr: DO
+                    name: Donga
+                  - abbr: KO
+                    name: Kouffo
+                  - abbr: LI
+                    name: Littoral
+                  - abbr: MO
+                    name: Mono
+                  - abbr: OU
+                    name: Ouémé
+                  - abbr: PL
+                    name: Plateau
+                  - abbr: ZO
+                    name: Zou
+                - iso: BM
+                  iso3: BMU
+                  name: Bermuda
+                  states_required: false
+                  zipcode_required: false
+                  states: []
+                - iso: BT
+                  iso3: BTN
+                  name: Bhutan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '33'
+                    name: Bumthang
+                  - abbr: '12'
+                    name: Chhukha
+                  - abbr: '22'
+                    name: Dagana
+                  - abbr: GA
+                    name: Gasa
+                  - abbr: '13'
+                    name: Ha
+                  - abbr: '44'
+                    name: Lhuentse
+                  - abbr: '42'
+                    name: Monggar
+                  - abbr: '11'
+                    name: Paro
+                  - abbr: '43'
+                    name: Pemagatshel
+                  - abbr: '23'
+                    name: Punakha
+                  - abbr: '45'
+                    name: Samdrup Jongkha
+                  - abbr: '14'
+                    name: Samtse
+                  - abbr: '31'
+                    name: Sarpang
+                  - abbr: '15'
+                    name: Thimphu
+                  - abbr: TY
+                    name: Trashi Yangtse
+                  - abbr: '41'
+                    name: Trashigang
+                  - abbr: '32'
+                    name: Trongsa
+                  - abbr: '21'
+                    name: Tsirang
+                  - abbr: '24'
+                    name: Wangdue Phodrang
+                  - abbr: '34'
+                    name: Zhemgang
+                - iso: BO
+                  iso3: BOL
+                  name: Bolivia
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: H
+                    name: Chuquisaca
+                  - abbr: C
+                    name: Cochabamba
+                  - abbr: B
+                    name: El Beni
+                  - abbr: L
+                    name: La Paz
+                  - abbr: O
+                    name: Oruro
+                  - abbr: "N"
+                    name: Pando
+                  - abbr: P
+                    name: Potosí
+                  - abbr: S
+                    name: Santa Cruz
+                  - abbr: T
+                    name: Tarija
+                - iso: BQ
+                  iso3: BES
+                  name: Bonaire, Sint Eustatius and Saba
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BO
+                    name: Bonaire
+                  - abbr: SA
+                    name: Saba
+                  - abbr: SE
+                    name: Sint Eustatius
+                - iso: BA
+                  iso3: BIH
+                  name: Bosnia and Herzegovina
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BRC
+                    name: Brčko Distrikt
+                  - abbr: BIH
+                    name: Federacija Bosna i Hercegovina
+                  - abbr: SRP
+                    name: Republika Srpska
+                - iso: BW
+                  iso3: BWA
+                  name: Botswana
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: CE
+                    name: Central
+                  - abbr: CH
+                    name: Chobe
+                  - abbr: FR
+                    name: Francistown
+                  - abbr: GA
+                    name: Gaborone
+                  - abbr: GH
+                    name: Ghanzi
+                  - abbr: JW
+                    name: Jwaneng
+                  - abbr: KG
+                    name: Kgalagadi
+                  - abbr: KL
+                    name: Kgatleng
+                  - abbr: KW
+                    name: Kweneng
+                  - abbr: LO
+                    name: Lobatse
+                  - abbr: NE
+                    name: North-East
+                  - abbr: NW
+                    name: North-West
+                  - abbr: SP
+                    name: Selibe Phikwe
+                  - abbr: SE
+                    name: South-East
+                  - abbr: SO
+                    name: Southern
+                  - abbr: ST
+                    name: Sowa Town
+                - iso: BR
+                  iso3: BRA
+                  name: Brazil
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AC
+                    name: Acre
+                  - abbr: AL
+                    name: Alagoas
+                  - abbr: AP
+                    name: Amapá
+                  - abbr: AM
+                    name: Amazonas
+                  - abbr: BA
+                    name: Bahia
+                  - abbr: CE
+                    name: Ceará
+                  - abbr: DF
+                    name: Distrito Federal
+                  - abbr: ES
+                    name: Espírito Santo
+                  - abbr: GO
+                    name: Goiás
+                  - abbr: MA
+                    name: Maranhão
+                  - abbr: MT
+                    name: Mato Grosso
+                  - abbr: MS
+                    name: Mato Grosso do Sul
+                  - abbr: MG
+                    name: Minas Gerais
+                  - abbr: PR
+                    name: Paraná
+                  - abbr: PB
+                    name: Paraíba
+                  - abbr: PA
+                    name: Pará
+                  - abbr: PE
+                    name: Pernambuco
+                  - abbr: PI
+                    name: Piauí
+                  - abbr: RN
+                    name: Rio Grande do Norte
+                  - abbr: RS
+                    name: Rio Grande do Sul
+                  - abbr: RJ
+                    name: Rio de Janeiro
+                  - abbr: RO
+                    name: Rondônia
+                  - abbr: RR
+                    name: Roraima
+                  - abbr: SC
+                    name: Santa Catarina
+                  - abbr: SE
+                    name: Sergipe
+                  - abbr: SP
+                    name: São Paulo
+                  - abbr: TO
+                    name: Tocantins
+                - iso: BN
+                  iso3: BRN
+                  name: Brunei Darussalam
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BE
+                    name: Belait
+                  - abbr: BM
+                    name: Brunei-Muara
+                  - abbr: TE
+                    name: Temburong
+                  - abbr: TU
+                    name: Tutong
+                - iso: BG
+                  iso3: BGR
+                  name: Bulgaria
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Blagoevgrad
+                  - abbr: '02'
+                    name: Burgas
+                  - abbr: '08'
+                    name: Dobrich
+                  - abbr: '07'
+                    name: Gabrovo
+                  - abbr: '26'
+                    name: Haskovo
+                  - abbr: '09'
+                    name: Kardzhali
+                  - abbr: '10'
+                    name: Kjustendil
+                  - abbr: '11'
+                    name: Lovech
+                  - abbr: '12'
+                    name: Montana
+                  - abbr: '13'
+                    name: Pazardzhik
+                  - abbr: '14'
+                    name: Pernik
+                  - abbr: '15'
+                    name: Pleven
+                  - abbr: '16'
+                    name: Plovdiv
+                  - abbr: '17'
+                    name: Razgrad
+                  - abbr: '18'
+                    name: Ruse
+                  - abbr: '19'
+                    name: Silistra
+                  - abbr: '20'
+                    name: Sliven
+                  - abbr: '21'
+                    name: Smolyan
+                  - abbr: '23'
+                    name: Sofia
+                  - abbr: '22'
+                    name: Sofia-Grad
+                  - abbr: '24'
+                    name: Stara Zagora
+                  - abbr: '25'
+                    name: Targovishte
+                  - abbr: '03'
+                    name: Varna
+                  - abbr: '04'
+                    name: Veliko Tarnovo
+                  - abbr: '05'
+                    name: Vidin
+                  - abbr: '06'
+                    name: Vratsa
+                  - abbr: '28'
+                    name: Yambol
+                  - abbr: '27'
+                    name: Šumen
+                - iso: BF
+                  iso3: BFA
+                  name: Burkina Faso
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BAL
+                    name: Balé
+                  - abbr: BAM
+                    name: Bam
+                  - abbr: BAN
+                    name: Banwa
+                  - abbr: BAZ
+                    name: Bazèga
+                  - abbr: '01'
+                    name: Boucle du Mouhoun
+                  - abbr: BGR
+                    name: Bougouriba
+                  - abbr: BLG
+                    name: Boulgou
+                  - abbr: BLK
+                    name: Boulkiemdé
+                  - abbr: '02'
+                    name: Cascades
+                  - abbr: '03'
+                    name: Centre
+                  - abbr: '04'
+                    name: Centre-Est
+                  - abbr: '05'
+                    name: Centre-Nord
+                  - abbr: '06'
+                    name: Centre-Ouest
+                  - abbr: '07'
+                    name: Centre-Sud
+                  - abbr: COM
+                    name: Comoé
+                  - abbr: '08'
+                    name: Est
+                  - abbr: GAN
+                    name: Ganzourgou
+                  - abbr: GNA
+                    name: Gnagna
+                  - abbr: GOU
+                    name: Gourma
+                  - abbr: '09'
+                    name: Hauts-Bassins
+                  - abbr: HOU
+                    name: Houet
+                  - abbr: IOB
+                    name: Ioba
+                  - abbr: KAD
+                    name: Kadiogo
+                  - abbr: KMD
+                    name: Komondjari
+                  - abbr: KMP
+                    name: Kompienga
+                  - abbr: KOS
+                    name: Kossi
+                  - abbr: KOP
+                    name: Koulpélogo
+                  - abbr: KOT
+                    name: Kouritenga
+                  - abbr: KOW
+                    name: Kourwéogo
+                  - abbr: KEN
+                    name: Kénédougou
+                  - abbr: LOR
+                    name: Loroum
+                  - abbr: LER
+                    name: Léraba
+                  - abbr: MOU
+                    name: Mouhoun
+                  - abbr: NAO
+                    name: Nahouri
+                  - abbr: NAM
+                    name: Namentenga
+                  - abbr: NAY
+                    name: Nayala
+                  - abbr: '10'
+                    name: Nord
+                  - abbr: NOU
+                    name: Noumbiel
+                  - abbr: OUB
+                    name: Oubritenga
+                  - abbr: OUD
+                    name: Oudalan
+                  - abbr: PAS
+                    name: Passoré
+                  - abbr: '11'
+                    name: Plateau-Central
+                  - abbr: PON
+                    name: Poni
+                  - abbr: '12'
+                    name: Sahel
+                  - abbr: SNG
+                    name: Sanguié
+                  - abbr: SMT
+                    name: Sanmatenga
+                  - abbr: SIS
+                    name: Sissili
+                  - abbr: SOM
+                    name: Soum
+                  - abbr: SOR
+                    name: Sourou
+                  - abbr: '13'
+                    name: Sud-Ouest
+                  - abbr: SEN
+                    name: Séno
+                  - abbr: TAP
+                    name: Tapoa
+                  - abbr: TUI
+                    name: Tui
+                  - abbr: YAG
+                    name: Yagha
+                  - abbr: YAT
+                    name: Yatenga
+                  - abbr: ZIR
+                    name: Ziro
+                  - abbr: ZON
+                    name: Zondoma
+                  - abbr: ZOU
+                    name: Zoundwéogo
+                - iso: BI
+                  iso3: BDI
+                  name: Burundi
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BB
+                    name: Bubanza
+                  - abbr: BJ
+                    name: Bujumbura
+                  - abbr: BR
+                    name: Bururi
+                  - abbr: CA
+                    name: Cankuzo
+                  - abbr: CI
+                    name: Cibitoke
+                  - abbr: GI
+                    name: Gitega
+                  - abbr: KR
+                    name: Karuzi
+                  - abbr: KY
+                    name: Kayanza
+                  - abbr: KI
+                    name: Kirundo
+                  - abbr: MA
+                    name: Makamba
+                  - abbr: MU
+                    name: Muramvya
+                  - abbr: MY
+                    name: Muyinga
+                  - abbr: MW
+                    name: Mwaro
+                  - abbr: NG
+                    name: Ngozi
+                  - abbr: RM
+                    name: Province de Rumonge
+                  - abbr: RT
+                    name: Rutana
+                  - abbr: RY
+                    name: Ruyigi
+                  - abbr: BM
+                    name: province de Bujumbura Mairie
+                  - abbr: BL
+                    name: province de Bujumbura rural
+                - iso: CV
+                  iso3: CPV
+                  name: Cabo Verde
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BV
+                    name: Boa Vista
+                  - abbr: BR
+                    name: Brava
+                  - abbr: CS
+                    name: Calheta de São Miguel
+                  - abbr: B
+                    name: Ilhas de Barlavento
+                  - abbr: S
+                    name: Ilhas de Sotavento
+                  - abbr: MA
+                    name: Maio
+                  - abbr: MO
+                    name: Mosteiros
+                  - abbr: PA
+                    name: Paúl
+                  - abbr: PN
+                    name: Porto Novo
+                  - abbr: PR
+                    name: Praia
+                  - abbr: RB
+                    name: Ribeira Brava
+                  - abbr: RG
+                    name: Ribeira Grande
+                  - abbr: RS
+                    name: Ribeira Grande de Santiago
+                  - abbr: SL
+                    name: Sal
+                  - abbr: CA
+                    name: Santa Catarina
+                  - abbr: CF
+                    name: Santa Catarina do Fogo
+                  - abbr: CR
+                    name: Santa Cruz
+                  - abbr: SD
+                    name: São Domingos
+                  - abbr: SF
+                    name: São Filipe
+                  - abbr: SO
+                    name: São Lourenço dos Órgãos
+                  - abbr: SM
+                    name: São Miguel
+                  - abbr: SN
+                    name: São Nicolau
+                  - abbr: SS
+                    name: São Salvador do Mundo
+                  - abbr: SV
+                    name: São Vicente
+                  - abbr: TA
+                    name: Tarrafal
+                  - abbr: TS
+                    name: Tarrafal de São Nicolau
+                - iso: KH
+                  iso3: KHM
+                  name: Cambodia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '2'
+                    name: Baat Dambang [Batdâmbâng]
+                  - abbr: '1'
+                    name: Banteay Mean Chey [Bântéay Méanchey]
+                  - abbr: '3'
+                    name: Kampong Chaam [Kâmpóng Cham]
+                  - abbr: '4'
+                    name: Kampong Chhnang [Kâmpóng Chhnang]
+                  - abbr: '5'
+                    name: Kampong Spueu [Kâmpóng Spœ]
+                  - abbr: '6'
+                    name: Kampong Thum [Kâmpóng Thum]
+                  - abbr: '7'
+                    name: Kampot [Kâmpôt]
+                  - abbr: '8'
+                    name: Kandaal [Kândal]
+                  - abbr: '9'
+                    name: Kaoh Kong [Kaôh Kong]
+                  - abbr: '10'
+                    name: Kracheh [Krâchéh]
+                  - abbr: '23'
+                    name: Krong Kep [Krong Kêb]
+                  - abbr: '24'
+                    name: Krong Pailin [Krong Pailin]
+                  - abbr: '18'
+                    name: Krong Preah Sihanouk [Krong Preah Sihanouk]
+                  - abbr: '11'
+                    name: Mondol Kiri [Môndól Kiri]
+                  - abbr: '22'
+                    name: 'Otdar Mean Chey [Otdâr Méanchey] '
+                  - abbr: '12'
+                    name: Phnom Penh [Phnum Pénh]
+                  - abbr: '15'
+                    name: Pousaat [Pouthisat]
+                  - abbr: '13'
+                    name: Preah Vihear [Preah Vihéar]
+                  - abbr: '14'
+                    name: Prey Veaeng [Prey Vêng]
+                  - abbr: '16'
+                    name: Rotanak Kiri [Rôtânôkiri]
+                  - abbr: '17'
+                    name: Siem Reab [Siemréab]
+                  - abbr: '19'
+                    name: Stueng Traeng
+                  - abbr: '20'
+                    name: Svaay Rieng [Svay Rieng]
+                  - abbr: '21'
+                    name: Taakaev [Takêv]
+                  - abbr: '25'
+                    name: Tbong Khmum
+                - iso: CM
+                  iso3: CMR
+                  name: Cameroon
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AD
+                    name: Adamaoua
+                  - abbr: CE
+                    name: Centre
+                  - abbr: ES
+                    name: East
+                  - abbr: EN
+                    name: Far North
+                  - abbr: LT
+                    name: Littoral
+                  - abbr: 'NO'
+                    name: North
+                  - abbr: NW
+                    name: North-West
+                  - abbr: SU
+                    name: South
+                  - abbr: SW
+                    name: South-West
+                  - abbr: OU
+                    name: West
+                - iso: CA
+                  iso3: CAN
+                  name: Canada
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AB
+                    name: Alberta
+                  - abbr: BC
+                    name: British Columbia
+                  - abbr: MB
+                    name: Manitoba
+                  - abbr: NB
+                    name: New Brunswick
+                  - abbr: NL
+                    name: Newfoundland and Labrador
+                  - abbr: NT
+                    name: Northwest Territories
+                  - abbr: NS
+                    name: Nova Scotia
+                  - abbr: NU
+                    name: Nunavut
+                  - abbr: 'ON'
+                    name: Ontario
+                  - abbr: PE
+                    name: Prince Edward Island
+                  - abbr: QC
+                    name: Quebec
+                  - abbr: SK
+                    name: Saskatchewan
+                  - abbr: YT
+                    name: Yukon
+                - iso: KY
+                  iso3: CYM
+                  name: Cayman Islands
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: CF
+                  iso3: CAF
+                  name: Central African Republic
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BB
+                    name: Bamingui-Bangoran
+                  - abbr: BGF
+                    name: Bangui
+                  - abbr: BK
+                    name: Basse-Kotto
+                  - abbr: HM
+                    name: Haut-Mbomou
+                  - abbr: HK
+                    name: Haute-Kotto
+                  - abbr: KG
+                    name: Kémo
+                  - abbr: LB
+                    name: Lobaye
+                  - abbr: HS
+                    name: Mambéré-Kadéï
+                  - abbr: MB
+                    name: Mbomou
+                  - abbr: KB
+                    name: Nana-Grébizi
+                  - abbr: NM
+                    name: Nana-Mambéré
+                  - abbr: MP
+                    name: Ombella-Mpoko
+                  - abbr: UK
+                    name: Ouaka
+                  - abbr: AC
+                    name: Ouham
+                  - abbr: OP
+                    name: Ouham-Pendé
+                  - abbr: SE
+                    name: Sangha-Mbaéré
+                  - abbr: VK
+                    name: Vakaga
+                - iso: TD
+                  iso3: TCD
+                  name: Chad
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BA
+                    name: Batha
+                  - abbr: CB
+                    name: Chari-Baguirmi
+                  - abbr: GR
+                    name: Guéra
+                  - abbr: HL
+                    name: Hadjer Lamis
+                  - abbr: KA
+                    name: Kanem
+                  - abbr: LC
+                    name: Lac
+                  - abbr: LO
+                    name: Logone-Occidental
+                  - abbr: LR
+                    name: Logone-Oriental
+                  - abbr: MA
+                    name: Mandoul
+                  - abbr: ME
+                    name: Mayo-Kébbi-Est
+                  - abbr: MO
+                    name: Mayo-Kébbi-Ouest
+                  - abbr: MC
+                    name: Moyen-Chari
+                  - abbr: ND
+                    name: Ndjamena
+                  - abbr: OD
+                    name: Ouaddaï
+                  - abbr: SA
+                    name: Salamat
+                  - abbr: TA
+                    name: Tandjilé
+                  - abbr: WF
+                    name: Wadi Fira
+                  - abbr: EE
+                    name: إنيدي الشرقية
+                  - abbr: EO
+                    name: إنيدي الغربية
+                  - abbr: BG
+                    name: بحر الغزال
+                  - abbr: BO
+                    name: منطقة بوركو
+                  - abbr: TI
+                    name: منطقة تبستي
+                  - abbr: SI
+                    name: منطقة سيلا
+                - iso: CL
+                  iso3: CHL
+                  name: Chile
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AI
+                    name: Aisén del General Carlos Ibáñez del Campo
+                  - abbr: AN
+                    name: Antofagasta
+                  - abbr: AR
+                    name: Araucanía
+                  - abbr: AP
+                    name: Arica y Parinacota
+                  - abbr: AT
+                    name: Atacama
+                  - abbr: BI
+                    name: Bío-Bío
+                  - abbr: CO
+                    name: Coquimbo
+                  - abbr: LI
+                    name: Libertador General Bernardo O'Higgins
+                  - abbr: LL
+                    name: Los Lagos
+                  - abbr: LR
+                    name: Los Ríos
+                  - abbr: MA
+                    name: Magallanes
+                  - abbr: ML
+                    name: Maule
+                  - abbr: RM
+                    name: Región Metropolitana de Santiago
+                  - abbr: NB
+                    name: Región de Ñuble
+                  - abbr: TA
+                    name: Tarapacá
+                  - abbr: VS
+                    name: Valparaíso
+                - iso: CN
+                  iso3: CHN
+                  name: China
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AH
+                    name: Anhui
+                  - abbr: BJ
+                    name: Beijing
+                  - abbr: CQ
+                    name: Chongqing
+                  - abbr: FJ
+                    name: Fujian
+                  - abbr: GS
+                    name: Gansu
+                  - abbr: GD
+                    name: Guangdong
+                  - abbr: GX
+                    name: Guangxi
+                  - abbr: GZ
+                    name: Guizhou
+                  - abbr: HI
+                    name: Hainan
+                  - abbr: HE
+                    name: Hebei
+                  - abbr: HL
+                    name: Heilongjiang
+                  - abbr: HA
+                    name: Henan
+                  - abbr: HB
+                    name: Hubei
+                  - abbr: HN
+                    name: Hunan
+                  - abbr: JS
+                    name: Jiangsu
+                  - abbr: JX
+                    name: Jiangxi
+                  - abbr: JL
+                    name: Jilin
+                  - abbr: LN
+                    name: Liaoning
+                  - abbr: NM
+                    name: Nei Mongol (mn)
+                  - abbr: NX
+                    name: Ningxia
+                  - abbr: QH
+                    name: Qinghai
+                  - abbr: SN
+                    name: Shaanxi
+                  - abbr: SD
+                    name: Shandong
+                  - abbr: SH
+                    name: Shanghai
+                  - abbr: SX
+                    name: Shanxi
+                  - abbr: SC
+                    name: Sichuan
+                  - abbr: TJ
+                    name: Tianjin
+                  - abbr: XJ
+                    name: Xinjiang
+                  - abbr: XZ
+                    name: Xizang
+                  - abbr: YN
+                    name: Yunnan
+                  - abbr: ZJ
+                    name: Zhejiang
+                - iso: CX
+                  iso3: CXR
+                  name: Christmas Island
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: CC
+                  iso3: CCK
+                  name: Cocos (Keeling) Islands
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: CO
+                  iso3: COL
+                  name: Colombia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AMA
+                    name: Amazonas
+                  - abbr: ANT
+                    name: Antioquia
+                  - abbr: ARA
+                    name: Arauca
+                  - abbr: ATL
+                    name: Atlántico
+                  - abbr: BOL
+                    name: Bolívar
+                  - abbr: BOY
+                    name: Boyacá
+                  - abbr: CAL
+                    name: Caldas
+                  - abbr: CAQ
+                    name: Caquetá
+                  - abbr: CAS
+                    name: Casanare
+                  - abbr: CAU
+                    name: Cauca
+                  - abbr: CES
+                    name: Cesar
+                  - abbr: CHO
+                    name: Chocó
+                  - abbr: CUN
+                    name: Cundinamarca
+                  - abbr: COR
+                    name: Córdoba
+                  - abbr: DC
+                    name: Distrito Capital de Bogotá
+                  - abbr: GUA
+                    name: Guainía
+                  - abbr: GUV
+                    name: Guaviare
+                  - abbr: HUI
+                    name: Huila
+                  - abbr: LAG
+                    name: La Guajira
+                  - abbr: MAG
+                    name: Magdalena
+                  - abbr: MET
+                    name: Meta
+                  - abbr: NAR
+                    name: Nariño
+                  - abbr: NSA
+                    name: Norte de Santander
+                  - abbr: PUT
+                    name: Putumayo
+                  - abbr: QUI
+                    name: Quindío
+                  - abbr: RIS
+                    name: Risaralda
+                  - abbr: SAP
+                    name: San Andrés, Providencia y Santa Catalina
+                  - abbr: SAN
+                    name: Santander
+                  - abbr: SUC
+                    name: Sucre
+                  - abbr: TOL
+                    name: Tolima
+                  - abbr: VAC
+                    name: Valle del Cauca
+                  - abbr: VAU
+                    name: Vaupés
+                  - abbr: VID
+                    name: Vichada
+                - iso: KM
+                  iso3: COM
+                  name: Comoros
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: A
+                    name: Anjouan
+                  - abbr: G
+                    name: Grande Comore
+                  - abbr: M
+                    name: Mohéli
+                - iso: CG
+                  iso3: COG
+                  name: Congo
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '11'
+                    name: Bouenza
+                  - abbr: BZV
+                    name: Brazzaville
+                  - abbr: '8'
+                    name: Cuvette
+                  - abbr: '15'
+                    name: Cuvette-Ouest
+                  - abbr: '5'
+                    name: Kouilou
+                  - abbr: '7'
+                    name: Likouala
+                  - abbr: '2'
+                    name: Lékoumou
+                  - abbr: '9'
+                    name: Niari
+                  - abbr: '14'
+                    name: Plateaux
+                  - abbr: '16'
+                    name: Pointe-Noire
+                  - abbr: '12'
+                    name: Pool
+                  - abbr: '13'
+                    name: Sangha
+                - iso: CD
+                  iso3: COD
+                  name: Congo, The Democratic Republic of the
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BC
+                    name: Bas-Congo
+                  - abbr: BU
+                    name: Bas-Uele
+                  - abbr: HK
+                    name: Haut-Katanga
+                  - abbr: HL
+                    name: Haut-Lomami
+                  - abbr: HU
+                    name: Haut-Uele
+                  - abbr: IT
+                    name: Ituri
+                  - abbr: LO
+                    name: Kabinda
+                  - abbr: KE
+                    name: Kasai-Oriental
+                  - abbr: KS
+                    name: Kasaï
+                  - abbr: KN
+                    name: Kinshasa
+                  - abbr: KG
+                    name: Kwango
+                  - abbr: KL
+                    name: Kwilu
+                  - abbr: LU
+                    name: Lualaba
+                  - abbr: KC
+                    name: Lulua
+                  - abbr: MN
+                    name: Mai-Ndombe
+                  - abbr: MA
+                    name: Maniema
+                  - abbr: MO
+                    name: Mongala
+                  - abbr: NK
+                    name: Nord-Kivu
+                  - abbr: NU
+                    name: Nord-Ubangi
+                  - abbr: SA
+                    name: Sankuru
+                  - abbr: SK
+                    name: Sud-Kivu
+                  - abbr: SU
+                    name: Sud-Ubangi
+                  - abbr: TA
+                    name: Tanganyika
+                  - abbr: TO
+                    name: Tshopo
+                  - abbr: TU
+                    name: Tshuapa
+                  - abbr: EQ
+                    name: Équateur
+                - iso: CK
+                  iso3: COK
+                  name: Cook Islands
+                  states_required: false
+                  zipcode_required: false
+                  states: []
+                - iso: CR
+                  iso3: CRI
+                  name: Costa Rica
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: A
+                    name: Alajuela
+                  - abbr: C
+                    name: Cartago
+                  - abbr: G
+                    name: Guanacaste
+                  - abbr: H
+                    name: Heredia
+                  - abbr: L
+                    name: Limón
+                  - abbr: P
+                    name: Puntarenas
+                  - abbr: SJ
+                    name: San José
+                - iso: HR
+                  iso3: HRV
+                  name: Croatia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '07'
+                    name: Bjelovarsko-bilogorska županija
+                  - abbr: '12'
+                    name: Brodsko-posavska županija
+                  - abbr: '19'
+                    name: Dubrovačko-neretvanska županija
+                  - abbr: '21'
+                    name: Grad Zagreb
+                  - abbr: '18'
+                    name: Istarska županija
+                  - abbr: '04'
+                    name: Karlovačka županija
+                  - abbr: '06'
+                    name: Koprivničko-križevačka županija
+                  - abbr: '02'
+                    name: Krapinsko-zagorska županija
+                  - abbr: '09'
+                    name: Ličko-senjska županija
+                  - abbr: '20'
+                    name: Međimurska županija
+                  - abbr: '14'
+                    name: Osječko-baranjska županija
+                  - abbr: '11'
+                    name: Požeško-slavonska županija
+                  - abbr: '08'
+                    name: Primorsko-goranska županija
+                  - abbr: '03'
+                    name: Sisačko-moslavačka županija
+                  - abbr: '17'
+                    name: Splitsko-dalmatinska županija
+                  - abbr: '05'
+                    name: Varaždinska županija
+                  - abbr: '10'
+                    name: Virovitičko-podravska županija
+                  - abbr: '16'
+                    name: Vukovarsko-srijemska županija
+                  - abbr: '13'
+                    name: Zadarska županija
+                  - abbr: '01'
+                    name: Zagrebačka županija
+                  - abbr: '15'
+                    name: Šibensko-kninska županija
+                - iso: CU
+                  iso3: CUB
+                  name: Cuba
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '15'
+                    name: Artemisa
+                  - abbr: '09'
+                    name: Camagüey
+                  - abbr: '08'
+                    name: Ciego de Ávila
+                  - abbr: '06'
+                    name: Cienfuegos
+                  - abbr: '12'
+                    name: Granma
+                  - abbr: '14'
+                    name: Guantánamo
+                  - abbr: '11'
+                    name: Holguín
+                  - abbr: '99'
+                    name: Isla de la Juventud
+                  - abbr: '03'
+                    name: La Habana
+                  - abbr: '10'
+                    name: Las Tunas
+                  - abbr: '04'
+                    name: Matanzas
+                  - abbr: '16'
+                    name: Mayabeque
+                  - abbr: '01'
+                    name: Pinar del Río
+                  - abbr: '07'
+                    name: Sancti Spíritus
+                  - abbr: '13'
+                    name: Santiago de Cuba
+                  - abbr: '05'
+                    name: Villa Clara
+                - iso: CW
+                  iso3: CUW
+                  name: Curaçao
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: CY
+                  iso3: CYP
+                  name: Cyprus
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '04'
+                    name: Ammochostos
+                  - abbr: '06'
+                    name: Keryneia
+                  - abbr: '03'
+                    name: Larnaka
+                  - abbr: '01'
+                    name: Lefkosia
+                  - abbr: '02'
+                    name: Lemesos
+                  - abbr: '05'
+                    name: Pafos
+                - iso: CZ
+                  iso3: CZE
+                  name: Czechia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '201'
+                    name: Benešov
+                  - abbr: '202'
+                    name: Beroun
+                  - abbr: '641'
+                    name: Blansko
+                  - abbr: '642'
+                    name: Brno-město
+                  - abbr: '643'
+                    name: Brno-venkov
+                  - abbr: '801'
+                    name: Bruntál
+                  - abbr: '644'
+                    name: Břeclav
+                  - abbr: '411'
+                    name: Cheb
+                  - abbr: '422'
+                    name: Chomutov
+                  - abbr: '531'
+                    name: Chrudim
+                  - abbr: '321'
+                    name: Domažlice
+                  - abbr: '421'
+                    name: Děčín
+                  - abbr: '802'
+                    name: Frýdek-Místek
+                  - abbr: '631'
+                    name: Havlíčkův Brod
+                  - abbr: '645'
+                    name: Hodonín
+                  - abbr: '521'
+                    name: Hradec Králové
+                  - abbr: '512'
+                    name: Jablonec nad Nisou
+                  - abbr: '711'
+                    name: Jeseník
+                  - abbr: '632'
+                    name: Jihlava
+                  - abbr: '64'
+                    name: Jihomoravský kraj
+                  - abbr: '31'
+                    name: Jihočeský kraj
+                  - abbr: '313'
+                    name: Jindřichův Hradec
+                  - abbr: '522'
+                    name: Jičín
+                  - abbr: '41'
+                    name: Karlovarský kraj
+                  - abbr: '412'
+                    name: Karlovy Vary
+                  - abbr: '803'
+                    name: Karviná
+                  - abbr: '203'
+                    name: Kladno
+                  - abbr: '322'
+                    name: Klatovy
+                  - abbr: '204'
+                    name: Kolín
+                  - abbr: '63'
+                    name: Kraj Vysočina
+                  - abbr: '721'
+                    name: Kroměříž
+                  - abbr: '52'
+                    name: Královéhradecký kraj
+                  - abbr: '205'
+                    name: Kutná Hora
+                  - abbr: '513'
+                    name: Liberec
+                  - abbr: '51'
+                    name: Liberecký kraj
+                  - abbr: '423'
+                    name: Litoměřice
+                  - abbr: '424'
+                    name: Louny
+                  - abbr: '207'
+                    name: Mladá Boleslav
+                  - abbr: '80'
+                    name: Moravskoslezský kraj
+                  - abbr: '425'
+                    name: Most
+                  - abbr: '206'
+                    name: Mělník
+                  - abbr: '804'
+                    name: Nový Jičín
+                  - abbr: '208'
+                    name: Nymburk
+                  - abbr: '523'
+                    name: Náchod
+                  - abbr: '712'
+                    name: Olomouc
+                  - abbr: '71'
+                    name: Olomoucký kraj
+                  - abbr: '805'
+                    name: Opava
+                  - abbr: '806'
+                    name: Ostrava-město
+                  - abbr: '532'
+                    name: Pardubice
+                  - abbr: '53'
+                    name: Pardubický kraj
+                  - abbr: '633'
+                    name: Pelhřimov
+                  - abbr: '324'
+                    name: Plzeň-jih
+                  - abbr: '323'
+                    name: Plzeň-město
+                  - abbr: '325'
+                    name: Plzeň-sever
+                  - abbr: '32'
+                    name: Plzeňský kraj
+                  - abbr: '315'
+                    name: Prachatice
+                  - abbr: '10'
+                    name: Praha, Hlavní město
+                  - abbr: '209'
+                    name: Praha-východ
+                  - abbr: 20A
+                    name: Praha-západ
+                  - abbr: '713'
+                    name: Prostějov
+                  - abbr: '314'
+                    name: Písek
+                  - abbr: '714'
+                    name: Přerov
+                  - abbr: 20B
+                    name: Příbram
+                  - abbr: 20C
+                    name: Rakovník
+                  - abbr: '326'
+                    name: Rokycany
+                  - abbr: '524'
+                    name: Rychnov nad Kněžnou
+                  - abbr: '514'
+                    name: Semily
+                  - abbr: '413'
+                    name: Sokolov
+                  - abbr: '316'
+                    name: Strakonice
+                  - abbr: '20'
+                    name: Středočeský kraj
+                  - abbr: '533'
+                    name: Svitavy
+                  - abbr: '327'
+                    name: Tachov
+                  - abbr: '426'
+                    name: Teplice
+                  - abbr: '525'
+                    name: Trutnov
+                  - abbr: '317'
+                    name: Tábor
+                  - abbr: '634'
+                    name: Třebíč
+                  - abbr: '722'
+                    name: Uherské Hradiště
+                  - abbr: '723'
+                    name: Vsetín
+                  - abbr: '646'
+                    name: Vyškov
+                  - abbr: '724'
+                    name: Zlín
+                  - abbr: '72'
+                    name: Zlínský kraj
+                  - abbr: '647'
+                    name: Znojmo
+                  - abbr: '42'
+                    name: Ústecký kraj
+                  - abbr: '427'
+                    name: Ústí nad Labem
+                  - abbr: '534'
+                    name: Ústí nad Orlicí
+                  - abbr: '511'
+                    name: Česká Lípa
+                  - abbr: '311'
+                    name: České Budějovice
+                  - abbr: '312'
+                    name: Český Krumlov
+                  - abbr: '715'
+                    name: Šumperk
+                  - abbr: '635'
+                    name: Žďár nad Sázavou
+                - iso: CI
+                  iso3: CIV
+                  name: Côte d'Ivoire
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AB
+                    name: Abidjan
+                  - abbr: DN
+                    name: Denguélé
+                  - abbr: CM
+                    name: District de la Comoé
+                  - abbr: LC
+                    name: District des Lacs
+                  - abbr: LG
+                    name: District des Lagunes
+                  - abbr: MG
+                    name: District des Montagnes
+                  - abbr: BS
+                    name: District du Bas-Sassandra
+                  - abbr: SM
+                    name: District du Sassandra-Marahoué
+                  - abbr: WR
+                    name: District du Woroba
+                  - abbr: GD
+                    name: Gôh-Djiboua
+                  - abbr: SV
+                    name: Savanes
+                  - abbr: VB
+                    name: Vallée du Bandama
+                  - abbr: YM
+                    name: Yamoussoukro
+                  - abbr: ZZ
+                    name: Zanzan
+                - iso: DK
+                  iso3: DNK
+                  name: Denmark
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '84'
+                    name: Hovedstaden
+                  - abbr: '82'
+                    name: Midtjylland
+                  - abbr: '81'
+                    name: Nordjylland
+                  - abbr: '85'
+                    name: Sjælland
+                  - abbr: '83'
+                    name: Syddanmark
+                - iso: DJ
+                  iso3: DJI
+                  name: Djibouti
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AS
+                    name: Ali Sabieh
+                  - abbr: AR
+                    name: Arta
+                  - abbr: DI
+                    name: Dikhil
+                  - abbr: DJ
+                    name: Djibouti
+                  - abbr: OB
+                    name: Obock
+                  - abbr: TA
+                    name: Tadjourah
+                - iso: DM
+                  iso3: DMA
+                  name: Dominica
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '02'
+                    name: Saint Andrew
+                  - abbr: '03'
+                    name: Saint David
+                  - abbr: '04'
+                    name: Saint George
+                  - abbr: '05'
+                    name: Saint John
+                  - abbr: '06'
+                    name: Saint Joseph
+                  - abbr: '07'
+                    name: Saint Luke
+                  - abbr: '08'
+                    name: Saint Mark
+                  - abbr: '09'
+                    name: Saint Patrick
+                  - abbr: '10'
+                    name: Saint Paul
+                  - abbr: '11'
+                    name: Saint Peter
+                - iso: DO
+                  iso3: DOM
+                  name: Dominican Republic
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '02'
+                    name: Azua
+                  - abbr: '03'
+                    name: Bahoruco
+                  - abbr: '04'
+                    name: Barahona
+                  - abbr: '33'
+                    name: Cibao Nordeste
+                  - abbr: '34'
+                    name: Cibao Noroeste
+                  - abbr: '35'
+                    name: Cibao Norte
+                  - abbr: '36'
+                    name: Cibao Sur
+                  - abbr: '05'
+                    name: Dajabón
+                  - abbr: '01'
+                    name: Distrito Nacional (Santo Domingo)
+                  - abbr: '06'
+                    name: Duarte
+                  - abbr: '08'
+                    name: El Seybo [El Seibo]
+                  - abbr: '37'
+                    name: El Valle
+                  - abbr: '38'
+                    name: Enriquillo
+                  - abbr: '09'
+                    name: Espaillat
+                  - abbr: '30'
+                    name: Hato Mayor
+                  - abbr: '39'
+                    name: Higüamo
+                  - abbr: '10'
+                    name: Independencia
+                  - abbr: '11'
+                    name: La Altagracia
+                  - abbr: '07'
+                    name: La Estrelleta [Elías Piña]
+                  - abbr: '12'
+                    name: La Romana
+                  - abbr: '13'
+                    name: La Vega
+                  - abbr: '14'
+                    name: María Trinidad Sánchez
+                  - abbr: '28'
+                    name: Monseñor Nouel
+                  - abbr: '15'
+                    name: Monte Cristi
+                  - abbr: '29'
+                    name: Monte Plata
+                  - abbr: '40'
+                    name: Ozama
+                  - abbr: '16'
+                    name: Pedernales
+                  - abbr: '17'
+                    name: Peravia
+                  - abbr: '18'
+                    name: Puerto Plata
+                  - abbr: '19'
+                    name: Salcedo
+                  - abbr: '20'
+                    name: Samaná
+                  - abbr: '21'
+                    name: San Cristóbal
+                  - abbr: '31'
+                    name: San Jose de Ocoa
+                  - abbr: '22'
+                    name: San Juan
+                  - abbr: '23'
+                    name: San Pedro de Macorís
+                  - abbr: '25'
+                    name: Santiago
+                  - abbr: '26'
+                    name: Santiago Rodríguez
+                  - abbr: '32'
+                    name: Santo Domingo
+                  - abbr: '24'
+                    name: Sánchez Ramírez
+                  - abbr: '41'
+                    name: Valdesia
+                  - abbr: '27'
+                    name: Valverde
+                  - abbr: '42'
+                    name: Yuma
+                - iso: EC
+                  iso3: ECU
+                  name: Ecuador
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: A
+                    name: Azuay
+                  - abbr: B
+                    name: Bolívar
+                  - abbr: C
+                    name: Carchi
+                  - abbr: F
+                    name: Cañar
+                  - abbr: H
+                    name: Chimborazo
+                  - abbr: X
+                    name: Cotopaxi
+                  - abbr: O
+                    name: El Oro
+                  - abbr: E
+                    name: Esmeraldas
+                  - abbr: W
+                    name: Galápagos
+                  - abbr: G
+                    name: Guayas
+                  - abbr: I
+                    name: Imbabura
+                  - abbr: L
+                    name: Loja
+                  - abbr: R
+                    name: Los Ríos
+                  - abbr: M
+                    name: Manabí
+                  - abbr: S
+                    name: Morona-Santiago
+                  - abbr: "N"
+                    name: Napo
+                  - abbr: D
+                    name: Orellana
+                  - abbr: "Y"
+                    name: Pastaza
+                  - abbr: P
+                    name: Pichincha
+                  - abbr: SE
+                    name: Santa Elena
+                  - abbr: SD
+                    name: Santo Domingo de los Tsachilas
+                  - abbr: U
+                    name: Sucumbíos
+                  - abbr: T
+                    name: Tungurahua
+                  - abbr: Z
+                    name: Zamora-Chinchipe
+                - iso: EG
+                  iso3: EGY
+                  name: Egypt
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: DK
+                    name: Ad Daqahliyah
+                  - abbr: BA
+                    name: Al Bahr al Ahmar
+                  - abbr: BH
+                    name: Al Buhayrah
+                  - abbr: FYM
+                    name: Al Fayyum
+                  - abbr: GH
+                    name: Al Gharbiyah
+                  - abbr: ALX
+                    name: Al Iskandariyah
+                  - abbr: IS
+                    name: Al Ismā`īlīyah
+                  - abbr: GZ
+                    name: Al Jizah
+                  - abbr: MNF
+                    name: Al Minufiyah
+                  - abbr: MN
+                    name: Al Minya
+                  - abbr: C
+                    name: Al Qahirah
+                  - abbr: KB
+                    name: Al Qalyubiyah
+                  - abbr: WAD
+                    name: Al Wadi al Jadid
+                  - abbr: SUZ
+                    name: As Suways
+                  - abbr: SHR
+                    name: Ash Sharqiyah
+                  - abbr: ASN
+                    name: Aswan
+                  - abbr: AST
+                    name: Asyut
+                  - abbr: BNS
+                    name: Bani Suwayf
+                  - abbr: PTS
+                    name: Būr Sa`īd
+                  - abbr: DT
+                    name: Dumyat
+                  - abbr: JS
+                    name: Janub Sina'
+                  - abbr: KFS
+                    name: Kafr ash Shaykh
+                  - abbr: MT
+                    name: Matrūh
+                  - abbr: KN
+                    name: Qina
+                  - abbr: SIN
+                    name: Shamal Sina'
+                  - abbr: SHG
+                    name: Suhaj
+                  - abbr: LX
+                    name: al-Uqsur
+                - iso: SV
+                  iso3: SLV
+                  name: El Salvador
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AH
+                    name: Ahuachapán
+                  - abbr: CA
+                    name: Cabañas
+                  - abbr: CH
+                    name: Chalatenango
+                  - abbr: CU
+                    name: Cuscatlán
+                  - abbr: LI
+                    name: La Libertad
+                  - abbr: PA
+                    name: La Paz
+                  - abbr: UN
+                    name: La Unión
+                  - abbr: MO
+                    name: Morazán
+                  - abbr: SM
+                    name: San Miguel
+                  - abbr: SS
+                    name: San Salvador
+                  - abbr: SV
+                    name: San Vicente
+                  - abbr: SA
+                    name: Santa Ana
+                  - abbr: SO
+                    name: Sonsonate
+                  - abbr: US
+                    name: Usulután
+                - iso: GQ
+                  iso3: GNQ
+                  name: Equatorial Guinea
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AN
+                    name: Annobón
+                  - abbr: BN
+                    name: Bioko Norte
+                  - abbr: BS
+                    name: Bioko Sur
+                  - abbr: CS
+                    name: Centro Sur
+                  - abbr: DJ
+                    name: Djibloho
+                  - abbr: KN
+                    name: Kie-Ntem
+                  - abbr: LI
+                    name: Litoral
+                  - abbr: C
+                    name: Región Continental
+                  - abbr: I
+                    name: Región Insular
+                  - abbr: WN
+                    name: Wele-Nzás
+                - iso: ER
+                  iso3: ERI
+                  name: Eritrea
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AN
+                    name: Anseba
+                  - abbr: DU
+                    name: Debub
+                  - abbr: DK
+                    name: Debubawi Keyih Bahri [Debub-Keih-Bahri]
+                  - abbr: GB
+                    name: Gash-Barka
+                  - abbr: MA
+                    name: Maakel [Maekel]
+                  - abbr: SK
+                    name: Semenawi Keyih Bahri [Semien-Keih-Bahri]
+                - iso: EE
+                  iso3: EST
+                  name: Estonia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '130'
+                    name: Alutaguse
+                  - abbr: '141'
+                    name: Anija
+                  - abbr: '142'
+                    name: Antsla
+                  - abbr: '171'
+                    name: Elva
+                  - abbr: '184'
+                    name: Haapsalu
+                  - abbr: '191'
+                    name: Haljala
+                  - abbr: '37'
+                    name: Harjumaa
+                  - abbr: '198'
+                    name: Harku
+                  - abbr: '205'
+                    name: Hiiumaa
+                  - abbr: '39'
+                    name: Hiiumaa
+                  - abbr: '214'
+                    name: Häädemeeste
+                  - abbr: '45'
+                    name: Ida-Virumaa
+                  - abbr: '255'
+                    name: Järva
+                  - abbr: '52'
+                    name: Järvamaa
+                  - abbr: '245'
+                    name: Jõelähtme
+                  - abbr: '247'
+                    name: Jõgeva
+                  - abbr: '50'
+                    name: Jõgevamaa
+                  - abbr: '251'
+                    name: Jõhvi
+                  - abbr: '272'
+                    name: Kadrina
+                  - abbr: '283'
+                    name: Kambja
+                  - abbr: '284'
+                    name: Kanepi
+                  - abbr: '291'
+                    name: Kastre
+                  - abbr: '293'
+                    name: Kehtna
+                  - abbr: '296'
+                    name: Keila
+                  - abbr: '303'
+                    name: Kihnu
+                  - abbr: '305'
+                    name: Kiili
+                  - abbr: '317'
+                    name: Kohila
+                  - abbr: '321'
+                    name: Kohtla-Järve
+                  - abbr: '338'
+                    name: Kose
+                  - abbr: '353'
+                    name: Kuusalu
+                  - abbr: '424'
+                    name: Loksa
+                  - abbr: '432'
+                    name: Luunja
+                  - abbr: '431'
+                    name: Lääne-Harju
+                  - abbr: '441'
+                    name: Lääne-Nigula
+                  - abbr: '60'
+                    name: Lääne-Virumaa
+                  - abbr: '56'
+                    name: Läänemaa
+                  - abbr: '430'
+                    name: Lääneranna
+                  - abbr: '442'
+                    name: Lüganuse
+                  - abbr: '446'
+                    name: Maardu
+                  - abbr: '478'
+                    name: Muhu
+                  - abbr: '480'
+                    name: Mulgi
+                  - abbr: '486'
+                    name: Mustvee
+                  - abbr: '503'
+                    name: Märjamaa
+                  - abbr: '511'
+                    name: Narva
+                  - abbr: '514'
+                    name: Narva-Jõesuu
+                  - abbr: '528'
+                    name: Nõo
+                  - abbr: '557'
+                    name: Otepää
+                  - abbr: '567'
+                    name: Paide
+                  - abbr: '586'
+                    name: Peipsiääre
+                  - abbr: '624'
+                    name: Pärnu
+                  - abbr: '68'
+                    name: Pärnumaa
+                  - abbr: '638'
+                    name: Põhja-Pärnumaa
+                  - abbr: '615'
+                    name: Põhja-Sakala
+                  - abbr: '618'
+                    name: Põltsamaa
+                  - abbr: '622'
+                    name: Põlva
+                  - abbr: '64'
+                    name: Põlvamaa
+                  - abbr: '651'
+                    name: Raasiku
+                  - abbr: '653'
+                    name: Rae
+                  - abbr: '661'
+                    name: Rakvere
+                  - abbr: '663'
+                    name: Rakvere
+                  - abbr: '668'
+                    name: Rapla
+                  - abbr: '71'
+                    name: Raplamaa
+                  - abbr: '689'
+                    name: Ruhnu
+                  - abbr: '708'
+                    name: Räpina
+                  - abbr: '698'
+                    name: Rõuge
+                  - abbr: '712'
+                    name: Saarde
+                  - abbr: '714'
+                    name: Saaremaa
+                  - abbr: '74'
+                    name: Saaremaa
+                  - abbr: '719'
+                    name: Saku
+                  - abbr: '726'
+                    name: Saue
+                  - abbr: '732'
+                    name: Setomaa
+                  - abbr: '735'
+                    name: Sillamäe
+                  - abbr: '784'
+                    name: Tallinn
+                  - abbr: '792'
+                    name: Tapa
+                  - abbr: '793'
+                    name: Tartu
+                  - abbr: '796'
+                    name: Tartu
+                  - abbr: '79'
+                    name: Tartumaa
+                  - abbr: '803'
+                    name: Toila
+                  - abbr: '809'
+                    name: Tori
+                  - abbr: '824'
+                    name: Tõrva
+                  - abbr: '834'
+                    name: Türi
+                  - abbr: '855'
+                    name: Valga
+                  - abbr: '81'
+                    name: Valgamaa
+                  - abbr: '890'
+                    name: Viimsi
+                  - abbr: '899'
+                    name: Viljandi
+                  - abbr: '897'
+                    name: Viljandi
+                  - abbr: '84'
+                    name: Viljandimaa
+                  - abbr: '901'
+                    name: Vinni
+                  - abbr: '903'
+                    name: Viru-Nigula
+                  - abbr: '907'
+                    name: Vormsi
+                  - abbr: '928'
+                    name: Väike-Maarja
+                  - abbr: '917'
+                    name: Võru
+                  - abbr: '919'
+                    name: Võru
+                  - abbr: '87'
+                    name: Võrumaa
+                - iso: SZ
+                  iso3: SWZ
+                  name: Eswatini
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: HH
+                    name: Hhohho
+                  - abbr: LU
+                    name: Lubombo
+                  - abbr: MA
+                    name: Manzini
+                  - abbr: SH
+                    name: Shiselweni
+                - iso: ET
+                  iso3: ETH
+                  name: Ethiopia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AA
+                    name: Adis Abeba
+                  - abbr: AF
+                    name: Afar
+                  - abbr: AM
+                    name: Amara
+                  - abbr: BE
+                    name: Binshangul Gumuz
+                  - abbr: DD
+                    name: Dire Dawa
+                  - abbr: GA
+                    name: Gambela Hizboch
+                  - abbr: HA
+                    name: Hareri Hizb
+                  - abbr: OR
+                    name: Oromiya
+                  - abbr: SO
+                    name: Sumale
+                  - abbr: TI
+                    name: Tigray
+                  - abbr: SN
+                    name: YeDebub Biheroch Bihereseboch na Hizboch
+                - iso: FK
+                  iso3: FLK
+                  name: Falkland Islands (Malvinas)
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: FO
+                  iso3: FRO
+                  name: Faroe Islands
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: FJ
+                  iso3: FJI
+                  name: Fiji
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: Ba
+                  - abbr: '02'
+                    name: Bua
+                  - abbr: '03'
+                    name: Cakaudrove
+                  - abbr: C
+                    name: Central
+                  - abbr: E
+                    name: Eastern
+                  - abbr: '04'
+                    name: Kadavu
+                  - abbr: '05'
+                    name: Lau
+                  - abbr: '06'
+                    name: Lomaiviti
+                  - abbr: '07'
+                    name: Macuata
+                  - abbr: '08'
+                    name: Nadroga-Navosa
+                  - abbr: '09'
+                    name: Naitasiri
+                  - abbr: '10'
+                    name: Namosi
+                  - abbr: "N"
+                    name: Northern
+                  - abbr: '11'
+                    name: Ra
+                  - abbr: '12'
+                    name: Rewa
+                  - abbr: R
+                    name: Rotuma
+                  - abbr: '13'
+                    name: Serua
+                  - abbr: '14'
+                    name: Tailevu
+                  - abbr: W
+                    name: Western
+                - iso: FI
+                  iso3: FIN
+                  name: Finland
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Ahvenanmaan maakunta
+                  - abbr: '02'
+                    name: Etelä-Karjala
+                  - abbr: '03'
+                    name: Etelä-Pohjanmaa
+                  - abbr: '04'
+                    name: Etelä-Savo
+                  - abbr: '05'
+                    name: Kainuu
+                  - abbr: '06'
+                    name: Kanta-Häme
+                  - abbr: '07'
+                    name: Keski-Pohjanmaa
+                  - abbr: '08'
+                    name: Keski-Suomi
+                  - abbr: '09'
+                    name: Kymenlaakso
+                  - abbr: '10'
+                    name: Lappi
+                  - abbr: '11'
+                    name: Pirkanmaa
+                  - abbr: '12'
+                    name: Pohjanmaa
+                  - abbr: '13'
+                    name: Pohjois-Karjala
+                  - abbr: '14'
+                    name: Pohjois-Pohjanmaa
+                  - abbr: '15'
+                    name: Pohjois-Savo
+                  - abbr: '16'
+                    name: Päijät-Häme
+                  - abbr: '17'
+                    name: Satakunta
+                  - abbr: '18'
+                    name: Uusimaa
+                  - abbr: '19'
+                    name: Varsinais-Suomi
+                - iso: FR
+                  iso3: FRA
+                  name: France
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Ain
+                  - abbr: '02'
+                    name: Aisne
+                  - abbr: '03'
+                    name: Allier
+                  - abbr: '06'
+                    name: Alpes-Maritimes
+                  - abbr: '04'
+                    name: Alpes-de-Haute-Provence
+                  - abbr: 6AE
+                    name: Alsace
+                  - abbr: '08'
+                    name: Ardennes
+                  - abbr: '07'
+                    name: Ardèche
+                  - abbr: '09'
+                    name: Ariège
+                  - abbr: '10'
+                    name: Aube
+                  - abbr: '11'
+                    name: Aude
+                  - abbr: ARA
+                    name: Auvergne-Rhône-Alpes
+                  - abbr: '12'
+                    name: Aveyron
+                  - abbr: '67'
+                    name: Bas-Rhin
+                  - abbr: '13'
+                    name: Bouches-du-Rhône
+                  - abbr: BFC
+                    name: Bourgogne-Franche-Comté
+                  - abbr: BRE
+                    name: Bretagne
+                  - abbr: '14'
+                    name: Calvados
+                  - abbr: '15'
+                    name: Cantal
+                  - abbr: CVL
+                    name: Centre-Val de Loire
+                  - abbr: '16'
+                    name: Charente
+                  - abbr: '17'
+                    name: Charente-Maritime
+                  - abbr: '18'
+                    name: Cher
+                  - abbr: CP
+                    name: Clipperton
+                  - abbr: '19'
+                    name: Corrèze
+                  - abbr: 20R
+                    name: Corse
+                  - abbr: 2A
+                    name: Corse-du-Sud
+                  - abbr: '23'
+                    name: Creuse
+                  - abbr: '21'
+                    name: Côte-d'Or
+                  - abbr: '22'
+                    name: Côtes-d'Armor
+                  - abbr: '79'
+                    name: Deux-Sèvres
+                  - abbr: '24'
+                    name: Dordogne
+                  - abbr: '25'
+                    name: Doubs
+                  - abbr: '26'
+                    name: Drôme
+                  - abbr: '91'
+                    name: Essonne
+                  - abbr: '27'
+                    name: Eure
+                  - abbr: '28'
+                    name: Eure-et-Loir
+                  - abbr: '29'
+                    name: Finistère
+                  - abbr: '30'
+                    name: Gard
+                  - abbr: '32'
+                    name: Gers
+                  - abbr: '33'
+                    name: Gironde
+                  - abbr: GES
+                    name: Grand Est
+                  - abbr: '971'
+                    name: Guadeloupe
+                  - abbr: '973'
+                    name: Guyane (française)
+                  - abbr: '68'
+                    name: Haut-Rhin
+                  - abbr: 2B
+                    name: Haute-Corse
+                  - abbr: '31'
+                    name: Haute-Garonne
+                  - abbr: '43'
+                    name: Haute-Loire
+                  - abbr: '52'
+                    name: Haute-Marne
+                  - abbr: '74'
+                    name: Haute-Savoie
+                  - abbr: '70'
+                    name: Haute-Saône
+                  - abbr: '87'
+                    name: Haute-Vienne
+                  - abbr: '05'
+                    name: Hautes-Alpes
+                  - abbr: '65'
+                    name: Hautes-Pyrénées
+                  - abbr: HDF
+                    name: Hauts-de-France
+                  - abbr: '92'
+                    name: Hauts-de-Seine
+                  - abbr: '34'
+                    name: Hérault
+                  - abbr: '35'
+                    name: Ille-et-Vilaine
+                  - abbr: '36'
+                    name: Indre
+                  - abbr: '37'
+                    name: Indre-et-Loire
+                  - abbr: '38'
+                    name: Isère
+                  - abbr: '39'
+                    name: Jura
+                  - abbr: '974'
+                    name: La Réunion
+                  - abbr: '40'
+                    name: Landes
+                  - abbr: '41'
+                    name: Loir-et-Cher
+                  - abbr: '42'
+                    name: Loire
+                  - abbr: '44'
+                    name: Loire-Atlantique
+                  - abbr: '45'
+                    name: Loiret
+                  - abbr: '46'
+                    name: Lot
+                  - abbr: '47'
+                    name: Lot-et-Garonne
+                  - abbr: '48'
+                    name: Lozère
+                  - abbr: '49'
+                    name: Maine-et-Loire
+                  - abbr: '50'
+                    name: Manche
+                  - abbr: '51'
+                    name: Marne
+                  - abbr: '972'
+                    name: Martinique
+                  - abbr: '53'
+                    name: Mayenne
+                  - abbr: '976'
+                    name: Mayotte
+                  - abbr: '54'
+                    name: Meurthe-et-Moselle
+                  - abbr: '55'
+                    name: Meuse
+                  - abbr: '56'
+                    name: Morbihan
+                  - abbr: '57'
+                    name: Moselle
+                  - abbr: 69M
+                    name: Métropole de Lyon
+                  - abbr: '58'
+                    name: Nièvre
+                  - abbr: '59'
+                    name: Nord
+                  - abbr: NOR
+                    name: Normandie
+                  - abbr: NAQ
+                    name: Nouvelle-Aquitaine
+                  - abbr: NC
+                    name: Nouvelle-Calédonie
+                  - abbr: OCC
+                    name: Occitanie
+                  - abbr: '60'
+                    name: Oise
+                  - abbr: '61'
+                    name: Orne
+                  - abbr: 75C
+                    name: Paris
+                  - abbr: '62'
+                    name: Pas-de-Calais
+                  - abbr: PDL
+                    name: Pays de la Loire
+                  - abbr: PF
+                    name: Polynésie française
+                  - abbr: PAC
+                    name: Provence-Alpes-Côte d'Azur
+                  - abbr: '63'
+                    name: Puy-de-Dôme
+                  - abbr: '64'
+                    name: Pyrénées-Atlantiques
+                  - abbr: '66'
+                    name: Pyrénées-Orientales
+                  - abbr: '69'
+                    name: Rhône
+                  - abbr: BL
+                    name: Saint-Barthélemy
+                  - abbr: MF
+                    name: Saint-Martin
+                  - abbr: PM
+                    name: Saint-Pierre-et-Miquelon
+                  - abbr: '72'
+                    name: Sarthe
+                  - abbr: '73'
+                    name: Savoie
+                  - abbr: '71'
+                    name: Saône-et-Loire
+                  - abbr: '76'
+                    name: Seine-Maritime
+                  - abbr: '93'
+                    name: Seine-Saint-Denis
+                  - abbr: '77'
+                    name: Seine-et-Marne
+                  - abbr: '80'
+                    name: Somme
+                  - abbr: '81'
+                    name: Tarn
+                  - abbr: '82'
+                    name: Tarn-et-Garonne
+                  - abbr: TF
+                    name: Terres Australes Françaises
+                  - abbr: '90'
+                    name: Territoire de Belfort
+                  - abbr: '95'
+                    name: Val-d'Oise
+                  - abbr: '94'
+                    name: Val-de-Marne
+                  - abbr: '83'
+                    name: Var
+                  - abbr: '84'
+                    name: Vaucluse
+                  - abbr: '85'
+                    name: Vendée
+                  - abbr: '86'
+                    name: Vienne
+                  - abbr: '88'
+                    name: Vosges
+                  - abbr: WF
+                    name: Wallis-et-Futuna
+                  - abbr: '89'
+                    name: Yonne
+                  - abbr: '78'
+                    name: Yvelines
+                  - abbr: IDF
+                    name: Île-de-France
+                - iso: GF
+                  iso3: GUF
+                  name: French Guiana
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: PF
+                  iso3: PYF
+                  name: French Polynesia
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: GA
+                  iso3: GAB
+                  name: Gabon
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '1'
+                    name: Estuaire
+                  - abbr: '2'
+                    name: Haut-Ogooué
+                  - abbr: '3'
+                    name: Moyen-Ogooué
+                  - abbr: '4'
+                    name: Ngounié
+                  - abbr: '5'
+                    name: Nyanga
+                  - abbr: '6'
+                    name: Ogooué-Ivindo
+                  - abbr: '7'
+                    name: Ogooué-Lolo
+                  - abbr: '8'
+                    name: Ogooué-Maritime
+                  - abbr: '9'
+                    name: Woleu-Ntem
+                - iso: GM
+                  iso3: GMB
+                  name: Gambia
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: B
+                    name: Banjul
+                  - abbr: L
+                    name: Lower River
+                  - abbr: M
+                    name: MacCarthy Island
+                  - abbr: "N"
+                    name: North Bank
+                  - abbr: U
+                    name: Upper River
+                  - abbr: W
+                    name: Western
+                - iso: GE
+                  iso3: GEO
+                  name: Georgia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AB
+                    name: Abkhazia
+                  - abbr: AJ
+                    name: Ajaria
+                  - abbr: GU
+                    name: Guria
+                  - abbr: IM
+                    name: Imereti
+                  - abbr: KA
+                    name: Kakheti
+                  - abbr: KK
+                    name: Kvemo Kartli
+                  - abbr: MM
+                    name: Mtskheta-Mtianeti
+                  - abbr: RL
+                    name: Racha-Lechkhumi [and] Kvemo Svaneti
+                  - abbr: SZ
+                    name: Samegrelo-Zemo Svaneti
+                  - abbr: SJ
+                    name: Samtskhe-Javakheti
+                  - abbr: SK
+                    name: Shida Kartli
+                  - abbr: TB
+                    name: Tbilisi
+                - iso: DE
+                  iso3: DEU
+                  name: Germany
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BW
+                    name: Baden-Württemberg
+                  - abbr: BY
+                    name: Bayern
+                  - abbr: BE
+                    name: Berlin
+                  - abbr: BB
+                    name: Brandenburg
+                  - abbr: HB
+                    name: Bremen
+                  - abbr: HH
+                    name: Hamburg
+                  - abbr: HE
+                    name: Hessen
+                  - abbr: MV
+                    name: Mecklenburg-Vorpommern
+                  - abbr: NI
+                    name: Niedersachsen
+                  - abbr: NW
+                    name: Nordrhein-Westfalen
+                  - abbr: RP
+                    name: Rheinland-Pfalz
+                  - abbr: SL
+                    name: Saarland
+                  - abbr: SN
+                    name: Sachsen
+                  - abbr: ST
+                    name: Sachsen-Anhalt
+                  - abbr: SH
+                    name: Schleswig-Holstein
+                  - abbr: TH
+                    name: Thüringen
+                - iso: GH
+                  iso3: GHA
+                  name: Ghana
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AF
+                    name: Ahafo
+                  - abbr: AH
+                    name: Ashanti
+                  - abbr: BO
+                    name: Bono
+                  - abbr: BE
+                    name: Bono East
+                  - abbr: CP
+                    name: Central
+                  - abbr: EP
+                    name: Eastern
+                  - abbr: AA
+                    name: Greater Accra
+                  - abbr: NE
+                    name: North East
+                  - abbr: NP
+                    name: Northern
+                  - abbr: OT
+                    name: Oti
+                  - abbr: SV
+                    name: Savannah
+                  - abbr: UE
+                    name: Upper East
+                  - abbr: UW
+                    name: Upper West
+                  - abbr: TV
+                    name: Volta
+                  - abbr: WP
+                    name: Western
+                  - abbr: WN
+                    name: Western North
+                - iso: GI
+                  iso3: GIB
+                  name: Gibraltar
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: GR
+                  iso3: GRC
+                  name: Greece
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: A
+                    name: Anatolikí Makedonía kai Thráki
+                  - abbr: I
+                    name: Attikí
+                  - abbr: G
+                    name: Dytikí Elláda
+                  - abbr: C
+                    name: Dytikí Makedonía
+                  - abbr: F
+                    name: Ionía Nísia
+                  - abbr: B
+                    name: Kentrikí Makedonía
+                  - abbr: M
+                    name: Kríti
+                  - abbr: L
+                    name: Nótio Aigaío
+                  - abbr: J
+                    name: Pelopónnisos
+                  - abbr: H
+                    name: Stereá Elláda
+                  - abbr: E
+                    name: Thessalía
+                  - abbr: K
+                    name: Vóreio Aigaío
+                  - abbr: '69'
+                    name: Ágion Óros
+                  - abbr: D
+                    name: Ípeiros
+                - iso: GL
+                  iso3: GRL
+                  name: Greenland
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AV
+                    name: Avannaata Kommunia
+                  - abbr: QT
+                    name: Kommune Qeqertalik
+                  - abbr: KU
+                    name: Kujalleq
+                  - abbr: QE
+                    name: Qeqqata
+                  - abbr: SM
+                    name: Sermersooq
+                - iso: GD
+                  iso3: GRD
+                  name: Grenada
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: Saint Andrew
+                  - abbr: '02'
+                    name: Saint David
+                  - abbr: '03'
+                    name: Saint George
+                  - abbr: '04'
+                    name: Saint John
+                  - abbr: '05'
+                    name: Saint Mark
+                  - abbr: '06'
+                    name: Saint Patrick
+                  - abbr: '10'
+                    name: Southern Grenadine Islands
+                - iso: GP
+                  iso3: GLP
+                  name: Guadeloupe
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: GU
+                  iso3: GUM
+                  name: Guam
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: GT
+                  iso3: GTM
+                  name: Guatemala
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '16'
+                    name: Alta Verapaz
+                  - abbr: '15'
+                    name: Baja Verapaz
+                  - abbr: '04'
+                    name: Chimaltenango
+                  - abbr: '20'
+                    name: Chiquimula
+                  - abbr: '02'
+                    name: El Progreso
+                  - abbr: '05'
+                    name: Escuintla
+                  - abbr: '01'
+                    name: Guatemala
+                  - abbr: '13'
+                    name: Huehuetenango
+                  - abbr: '18'
+                    name: Izabal
+                  - abbr: '21'
+                    name: Jalapa
+                  - abbr: '22'
+                    name: Jutiapa
+                  - abbr: '17'
+                    name: Petén
+                  - abbr: '09'
+                    name: Quetzaltenango
+                  - abbr: '14'
+                    name: Quiché
+                  - abbr: '11'
+                    name: Retalhuleu
+                  - abbr: '03'
+                    name: Sacatepéquez
+                  - abbr: '12'
+                    name: San Marcos
+                  - abbr: '06'
+                    name: Santa Rosa
+                  - abbr: '07'
+                    name: Sololá
+                  - abbr: '10'
+                    name: Suchitepéquez
+                  - abbr: '08'
+                    name: Totonicapán
+                  - abbr: '19'
+                    name: Zacapa
+                - iso: GG
+                  iso3: GGY
+                  name: Guernsey
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: GN
+                  iso3: GIN
+                  name: Guinea
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BE
+                    name: Beyla
+                  - abbr: BF
+                    name: Boffa
+                  - abbr: BK
+                    name: Boké
+                  - abbr: C
+                    name: Conakry
+                  - abbr: CO
+                    name: Coyah
+                  - abbr: DB
+                    name: Dabola
+                  - abbr: DL
+                    name: Dalaba
+                  - abbr: DI
+                    name: Dinguiraye
+                  - abbr: DU
+                    name: Dubréka
+                  - abbr: FA
+                    name: Faranah
+                  - abbr: FO
+                    name: Forécariah
+                  - abbr: FR
+                    name: Fria
+                  - abbr: GA
+                    name: Gaoual
+                  - abbr: GU
+                    name: Guékédou
+                  - abbr: KA
+                    name: Kankan
+                  - abbr: KD
+                    name: Kindia
+                  - abbr: KS
+                    name: Kissidougou
+                  - abbr: KB
+                    name: Koubia
+                  - abbr: KN
+                    name: Koundara
+                  - abbr: KO
+                    name: Kouroussa
+                  - abbr: KE
+                    name: Kérouané
+                  - abbr: LA
+                    name: Labé
+                  - abbr: LO
+                    name: Lola
+                  - abbr: LE
+                    name: Lélouma
+                  - abbr: MC
+                    name: Macenta
+                  - abbr: ML
+                    name: Mali
+                  - abbr: MM
+                    name: Mamou
+                  - abbr: MD
+                    name: Mandiana
+                  - abbr: NZ
+                    name: Nzérékoré
+                  - abbr: PI
+                    name: Pita
+                  - abbr: B
+                    name: Région de Boké
+                  - abbr: F
+                    name: Région de Faranah
+                  - abbr: K
+                    name: Région de Kankan
+                  - abbr: D
+                    name: Région de Kindia
+                  - abbr: L
+                    name: Région de Labé
+                  - abbr: M
+                    name: Région de Mamou
+                  - abbr: "N"
+                    name: Région de Nzérékoré
+                  - abbr: SI
+                    name: Siguiri
+                  - abbr: TO
+                    name: Tougué
+                  - abbr: TE
+                    name: Télimélé
+                  - abbr: YO
+                    name: Yomou
+                - iso: GW
+                  iso3: GNB
+                  name: Guinea-Bissau
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BA
+                    name: Bafatá
+                  - abbr: BM
+                    name: Biombo
+                  - abbr: BS
+                    name: Bissau
+                  - abbr: BL
+                    name: Bolama
+                  - abbr: CA
+                    name: Cacheu
+                  - abbr: GA
+                    name: Gabú
+                  - abbr: L
+                    name: Leste
+                  - abbr: "N"
+                    name: Norte
+                  - abbr: OI
+                    name: Oio
+                  - abbr: QU
+                    name: Quinara
+                  - abbr: S
+                    name: Sul
+                  - abbr: TO
+                    name: Tombali
+                - iso: GY
+                  iso3: GUY
+                  name: Guyana
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BA
+                    name: Barima-Waini
+                  - abbr: CU
+                    name: Cuyuni-Mazaruni
+                  - abbr: DE
+                    name: Demerara-Mahaica
+                  - abbr: EB
+                    name: East Berbice-Corentyne
+                  - abbr: ES
+                    name: Essequibo Islands-West Demerara
+                  - abbr: MA
+                    name: Mahaica-Berbice
+                  - abbr: PM
+                    name: Pomeroon-Supenaam
+                  - abbr: PT
+                    name: Potaro-Siparuni
+                  - abbr: UD
+                    name: Upper Demerara-Berbice
+                  - abbr: UT
+                    name: Upper Takutu-Upper Essequibo
+                - iso: HT
+                  iso3: HTI
+                  name: Haiti
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AR
+                    name: Artibonite
+                  - abbr: CE
+                    name: Centre
+                  - abbr: GA
+                    name: Grande-Anse
+                  - abbr: NI
+                    name: Nippes
+                  - abbr: ND
+                    name: Nord
+                  - abbr: NE
+                    name: Nord-Est
+                  - abbr: 'NO'
+                    name: Nord-Ouest
+                  - abbr: OU
+                    name: Ouest
+                  - abbr: SD
+                    name: Sud
+                  - abbr: SE
+                    name: Sud-Est
+                - iso: VA
+                  iso3: VAT
+                  name: Holy See (Vatican City State)
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: HN
+                  iso3: HND
+                  name: Honduras
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AT
+                    name: Atlántida
+                  - abbr: CH
+                    name: Choluteca
+                  - abbr: CL
+                    name: Colón
+                  - abbr: CM
+                    name: Comayagua
+                  - abbr: CP
+                    name: Copán
+                  - abbr: CR
+                    name: Cortés
+                  - abbr: EP
+                    name: El Paraíso
+                  - abbr: FM
+                    name: Francisco Morazán
+                  - abbr: GD
+                    name: Gracias a Dios
+                  - abbr: IN
+                    name: Intibucá
+                  - abbr: IB
+                    name: Islas de la Bahía
+                  - abbr: LP
+                    name: La Paz
+                  - abbr: LE
+                    name: Lempira
+                  - abbr: OC
+                    name: Ocotepeque
+                  - abbr: OL
+                    name: Olancho
+                  - abbr: SB
+                    name: Santa Bárbara
+                  - abbr: VA
+                    name: Valle
+                  - abbr: YO
+                    name: Yoro
+                - iso: HK
+                  iso3: HKG
+                  name: Hong Kong
+                  states_required: true
+                  zipcode_required: false
+                  states: []
+                - iso: HU
+                  iso3: HUN
+                  name: Hungary
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BA
+                    name: Baranya
+                  - abbr: BZ
+                    name: Borsod-Abaúj-Zemplén
+                  - abbr: BU
+                    name: Budapest
+                  - abbr: BK
+                    name: Bács-Kiskun
+                  - abbr: BE
+                    name: Békés
+                  - abbr: BC
+                    name: Békéscsaba
+                  - abbr: CS
+                    name: Csongrád
+                  - abbr: DE
+                    name: Debrecen
+                  - abbr: DU
+                    name: Dunaújváros
+                  - abbr: EG
+                    name: Eger
+                  - abbr: FE
+                    name: Fejér
+                  - abbr: GY
+                    name: Győr
+                  - abbr: GS
+                    name: Győr-Moson-Sopron
+                  - abbr: HB
+                    name: Hajdú-Bihar
+                  - abbr: HE
+                    name: Heves
+                  - abbr: HV
+                    name: Hódmezővásárhely
+                  - abbr: JN
+                    name: Jász-Nagykun-Szolnok
+                  - abbr: KV
+                    name: Kaposvár
+                  - abbr: KM
+                    name: Kecskemét
+                  - abbr: KE
+                    name: Komárom-Esztergom
+                  - abbr: MI
+                    name: Miskolc
+                  - abbr: NK
+                    name: Nagykanizsa
+                  - abbr: NY
+                    name: Nyíregyháza
+                  - abbr: 'NO'
+                    name: Nógrád
+                  - abbr: PE
+                    name: Pest
+                  - abbr: PS
+                    name: Pécs
+                  - abbr: ST
+                    name: Salgótarján
+                  - abbr: SO
+                    name: Somogy
+                  - abbr: SN
+                    name: Sopron
+                  - abbr: SZ
+                    name: Szabolcs-Szatmár-Bereg
+                  - abbr: SD
+                    name: Szeged
+                  - abbr: SS
+                    name: Szekszárd
+                  - abbr: SK
+                    name: Szolnok
+                  - abbr: SH
+                    name: Szombathely
+                  - abbr: SF
+                    name: Székesfehérvár
+                  - abbr: TB
+                    name: Tatabánya
+                  - abbr: TO
+                    name: Tolna
+                  - abbr: VA
+                    name: Vas
+                  - abbr: VE
+                    name: Veszprém
+                  - abbr: VM
+                    name: Veszprém
+                  - abbr: ZA
+                    name: Zala
+                  - abbr: ZE
+                    name: Zalaegerszeg
+                  - abbr: ER
+                    name: Érd
+                - iso: IS
+                  iso3: ISL
+                  name: Iceland
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AKH
+                    name: Akrahreppur
+                  - abbr: AKN
+                    name: Akraneskaupstaður
+                  - abbr: AKU
+                    name: Akureyrarbær
+                  - abbr: '7'
+                    name: Austurland
+                  - abbr: BLA
+                    name: Bláskógabyggð
+                  - abbr: BLO
+                    name: Blönduósbær
+                  - abbr: BOL
+                    name: Bolungarvíkurkaupstaður
+                  - abbr: BOG
+                    name: Borgarbyggð
+                  - abbr: DAB
+                    name: Dalabyggð
+                  - abbr: DAV
+                    name: Dalvíkurbyggð
+                  - abbr: EOM
+                    name: Eyja- og Miklaholtshreppur
+                  - abbr: EYF
+                    name: Eyjafjarðarsveit
+                  - abbr: FJL
+                    name: Fjallabyggð
+                  - abbr: FJD
+                    name: Fjarðabyggð
+                  - abbr: FLR
+                    name: Fljótsdalshreppur
+                  - abbr: FLA
+                    name: Flóahreppur
+                  - abbr: GAR
+                    name: Garðabær
+                  - abbr: GRN
+                    name: Grindavíkurbær
+                  - abbr: GRU
+                    name: Grundarfjarðarbær
+                  - abbr: GOG
+                    name: Grímsnes- og Grafningshreppur
+                  - abbr: GRY
+                    name: Grýtubakkahreppur
+                  - abbr: HAF
+                    name: Hafnarfjarðarkaupstaður
+                  - abbr: HEL
+                    name: Helgafellssveit
+                  - abbr: HRU
+                    name: Hrunamannahreppur
+                  - abbr: HVA
+                    name: Hvalfjarðarsveit
+                  - abbr: HVE
+                    name: Hveragerðisbær
+                  - abbr: '1'
+                    name: Höfuðborgarsvæði utan Reykjavíkur
+                  - abbr: HRG
+                    name: Hörgársveit
+                  - abbr: HUT
+                    name: Húnavatnshreppur
+                  - abbr: HUV
+                    name: Húnaþing vestra
+                  - abbr: KAL
+                    name: Kaldrananeshreppur
+                  - abbr: KJO
+                    name: Kjósarhreppur
+                  - abbr: KOP
+                    name: Kópavogsbær
+                  - abbr: LAN
+                    name: Langanesbyggð
+                  - abbr: MOS
+                    name: Mosfellsbær
+                  - abbr: MUL
+                    name: Múlaþing
+                  - abbr: MYR
+                    name: Mýrdalshreppur
+                  - abbr: '6'
+                    name: Norðurland eystra
+                  - abbr: '5'
+                    name: Norðurland vestra
+                  - abbr: NOR
+                    name: Norðurþing
+                  - abbr: RGE
+                    name: Rangárþing eystra
+                  - abbr: RGY
+                    name: Rangárþing ytra
+                  - abbr: RHH
+                    name: Reykhólahreppur
+                  - abbr: RKN
+                    name: Reykjanesbær
+                  - abbr: '0'
+                    name: Reykjavík
+                  - abbr: RKV
+                    name: Reykjavíkurborg
+                  - abbr: SEL
+                    name: Seltjarnarnesbær
+                  - abbr: SKF
+                    name: Skaftárhreppur
+                  - abbr: SKG
+                    name: Skagabyggð
+                  - abbr: SOG
+                    name: Skeiða- og Gnúpverjahreppur
+                  - abbr: SKO
+                    name: Skorradalshreppur
+                  - abbr: SKU
+                    name: Skútustaðahreppur
+                  - abbr: SNF
+                    name: Snæfellsbær
+                  - abbr: STR
+                    name: Strandabyggð
+                  - abbr: STY
+                    name: Stykkishólmsbær
+                  - abbr: '8'
+                    name: Suðurland
+                  - abbr: '2'
+                    name: Suðurnes
+                  - abbr: SDN
+                    name: Suðurnesjabær
+                  - abbr: SBH
+                    name: Svalbarðshreppur
+                  - abbr: SBT
+                    name: Svalbarðsstrandarhreppur
+                  - abbr: SHF
+                    name: Sveitarfélagið Hornafjörður
+                  - abbr: SSF
+                    name: Sveitarfélagið Skagafjörður
+                  - abbr: SSS
+                    name: Sveitarfélagið Skagaströnd
+                  - abbr: SVG
+                    name: Sveitarfélagið Vogar
+                  - abbr: SFA
+                    name: Sveitarfélagið Árborg
+                  - abbr: SOL
+                    name: Sveitarfélagið Ölfus
+                  - abbr: SDV
+                    name: Súðavíkurhreppur
+                  - abbr: TJO
+                    name: Tjörneshreppur
+                  - abbr: TAL
+                    name: Tálknafjarðarhreppur
+                  - abbr: '4'
+                    name: Vestfirðir
+                  - abbr: VEM
+                    name: Vestmannaeyjabær
+                  - abbr: VER
+                    name: Vesturbyggð
+                  - abbr: '3'
+                    name: Vesturland
+                  - abbr: VOP
+                    name: Vopnafjarðarhreppur
+                  - abbr: ARN
+                    name: Árneshreppur
+                  - abbr: ASA
+                    name: Ásahreppur
+                  - abbr: ISA
+                    name: Ísafjarðarbær
+                  - abbr: THG
+                    name: Þingeyjarsveit
+                - iso: IN
+                  iso3: IND
+                  name: India
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AN
+                    name: Andaman and Nicobar Islands
+                  - abbr: AP
+                    name: Andhra Pradesh
+                  - abbr: AR
+                    name: Arunachal Pradesh
+                  - abbr: AS
+                    name: Assam
+                  - abbr: BR
+                    name: Bihar
+                  - abbr: CH
+                    name: Chandigarh
+                  - abbr: CG
+                    name: Chhattisgarh
+                  - abbr: DL
+                    name: Delhi
+                  - abbr: DH
+                    name: Dādra and Nagar Haveli and Damān and Diu
+                  - abbr: GA
+                    name: Goa
+                  - abbr: GJ
+                    name: Gujarat
+                  - abbr: HR
+                    name: Haryana
+                  - abbr: HP
+                    name: Himachal Pradesh
+                  - abbr: JK
+                    name: Jammu and Kashmir
+                  - abbr: JH
+                    name: Jharkhand
+                  - abbr: KA
+                    name: Karnataka
+                  - abbr: KL
+                    name: Kerala
+                  - abbr: LA
+                    name: Ladakh
+                  - abbr: LD
+                    name: Lakshadweep
+                  - abbr: MP
+                    name: Madhya Pradesh
+                  - abbr: MH
+                    name: Maharashtra
+                  - abbr: MN
+                    name: Manipur
+                  - abbr: ML
+                    name: Meghalaya
+                  - abbr: MZ
+                    name: Mizoram
+                  - abbr: NL
+                    name: Nagaland
+                  - abbr: OD
+                    name: Odisha
+                  - abbr: PY
+                    name: Pondicherry
+                  - abbr: PB
+                    name: Punjab
+                  - abbr: RJ
+                    name: Rajasthan
+                  - abbr: SK
+                    name: Sikkim
+                  - abbr: TN
+                    name: Tamil Nadu
+                  - abbr: TR
+                    name: Tripura
+                  - abbr: UP
+                    name: Uttar Pradesh
+                  - abbr: WB
+                    name: West Bengal
+                  - abbr: UK
+                    name: उत्तराखण्ड
+                  - abbr: TS
+                    name: तेलंगाना
+                - iso: ID
+                  iso3: IDN
+                  name: Indonesia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AC
+                    name: Aceh
+                  - abbr: BA
+                    name: Bali
+                  - abbr: BT
+                    name: Banten
+                  - abbr: BE
+                    name: Bengkulu
+                  - abbr: JK
+                    name: Daerah Khusus Ibukota Jakarta
+                  - abbr: GO
+                    name: Gorontalo
+                  - abbr: JA
+                    name: Jambi
+                  - abbr: JW
+                    name: Jawa
+                  - abbr: JB
+                    name: Jawa Barat
+                  - abbr: JT
+                    name: Jawa Tengah
+                  - abbr: JI
+                    name: Jawa Timur
+                  - abbr: KA
+                    name: Kalimantan
+                  - abbr: KB
+                    name: Kalimantan Barat
+                  - abbr: KS
+                    name: Kalimantan Selatan
+                  - abbr: KT
+                    name: Kalimantan Tengah
+                  - abbr: KI
+                    name: Kalimantan Timur
+                  - abbr: KU
+                    name: Kalimantan Utara
+                  - abbr: BB
+                    name: Kepulauan Bangka Belitung
+                  - abbr: ML
+                    name: Kepulauan Maluku
+                  - abbr: NU
+                    name: Kepulauan Nusa Tenggara
+                  - abbr: KR
+                    name: Kepulauan Riau
+                  - abbr: LA
+                    name: Lampung
+                  - abbr: MA
+                    name: Maluku
+                  - abbr: MU
+                    name: Maluku Utara
+                  - abbr: NB
+                    name: Nusa Tenggara Barat
+                  - abbr: NT
+                    name: Nusa Tenggara Timur
+                  - abbr: PA
+                    name: Papua
+                  - abbr: PB
+                    name: Papua Barat
+                  - abbr: PP
+                    name: Papua bagian barat
+                  - abbr: RI
+                    name: Riau
+                  - abbr: SL
+                    name: Sulawesi
+                  - abbr: SR
+                    name: Sulawesi Barat
+                  - abbr: SN
+                    name: Sulawesi Selatan
+                  - abbr: ST
+                    name: Sulawesi Tengah
+                  - abbr: SG
+                    name: Sulawesi Tenggara
+                  - abbr: SA
+                    name: Sulawesi Utara
+                  - abbr: SM
+                    name: Sumatera
+                  - abbr: SB
+                    name: Sumatera Barat
+                  - abbr: SS
+                    name: Sumatera Selatan
+                  - abbr: SU
+                    name: Sumatera Utara
+                  - abbr: YO
+                    name: Yogyakarta
+                - iso: IR
+                  iso3: IRN
+                  name: Iran
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '24'
+                    name: Ardabil
+                  - abbr: '04'
+                    name: Az¯arbayjan-e Gharbi
+                  - abbr: '03'
+                    name: Az¯arbayjan-e Sharqi
+                  - abbr: '18'
+                    name: Bushehr
+                  - abbr: '14'
+                    name: Chahar Mah¸all va Bakhtiari
+                  - abbr: '10'
+                    name: Esfahan
+                  - abbr: '07'
+                    name: Fars
+                  - abbr: '01'
+                    name: Gilan
+                  - abbr: '27'
+                    name: Golestan
+                  - abbr: '13'
+                    name: Hamadan
+                  - abbr: '22'
+                    name: Hormozgan
+                  - abbr: '16'
+                    name: Ilam
+                  - abbr: '08'
+                    name: Kerman
+                  - abbr: '05'
+                    name: Kermanshah
+                  - abbr: '29'
+                    name: Khorasan-e Janubi
+                  - abbr: '09'
+                    name: Khorasan-e Razavi
+                  - abbr: '28'
+                    name: Khorasan-e Shemali
+                  - abbr: '06'
+                    name: Khuzestan
+                  - abbr: '17'
+                    name: Kohkiluyeh va Buyer Ahmad
+                  - abbr: '12'
+                    name: Kordestan
+                  - abbr: '15'
+                    name: Lorestan
+                  - abbr: '00'
+                    name: Markazi
+                  - abbr: '02'
+                    name: Mazandaran
+                  - abbr: '26'
+                    name: Qazvin
+                  - abbr: '25'
+                    name: Qom
+                  - abbr: '20'
+                    name: Semnan
+                  - abbr: '11'
+                    name: Sistan va Baluchestan
+                  - abbr: '23'
+                    name: Tehran
+                  - abbr: '21'
+                    name: Yazd
+                  - abbr: '19'
+                    name: Zanjan
+                  - abbr: '30'
+                    name: استان البرز
+                - iso: IQ
+                  iso3: IRQ
+                  name: Iraq
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AN
+                    name: Al Anbar
+                  - abbr: BA
+                    name: Al Basrah
+                  - abbr: MU
+                    name: Al Muthanná
+                  - abbr: QA
+                    name: Al Qadisiyah
+                  - abbr: NA
+                    name: An Najaf
+                  - abbr: AR
+                    name: Arbil
+                  - abbr: SU
+                    name: As Sulaymaniyah
+                  - abbr: BB
+                    name: Babil
+                  - abbr: BG
+                    name: Baghdad
+                  - abbr: DA
+                    name: Dahuk
+                  - abbr: DQ
+                    name: Dhi Qar
+                  - abbr: DI
+                    name: Diyalá
+                  - abbr: KA
+                    name: Karbala'
+                  - abbr: MA
+                    name: Maysan
+                  - abbr: NI
+                    name: Ninawá
+                  - abbr: SD
+                    name: Salah ad Din
+                  - abbr: WA
+                    name: Wasit
+                  - abbr: KR
+                    name: إقليم كردستان
+                  - abbr: KI
+                    name: كركوك
+                - iso: IE
+                  iso3: IRL
+                  name: Ireland
+                  states_required: true
+                  zipcode_required: false
+                  states:
+                  - abbr: CW
+                    name: Carlow
+                  - abbr: CN
+                    name: Cavan
+                  - abbr: CE
+                    name: Clare
+                  - abbr: C
+                    name: Connacht
+                  - abbr: CO
+                    name: Cork
+                  - abbr: DL
+                    name: Donegal
+                  - abbr: D
+                    name: Dublin
+                  - abbr: G
+                    name: Galway
+                  - abbr: KY
+                    name: Kerry
+                  - abbr: KE
+                    name: Kildare
+                  - abbr: KK
+                    name: Kilkenny
+                  - abbr: LS
+                    name: Laois
+                  - abbr: L
+                    name: Leinster
+                  - abbr: LM
+                    name: Leitrim
+                  - abbr: LK
+                    name: Limerick
+                  - abbr: LD
+                    name: Longford
+                  - abbr: LH
+                    name: Louth
+                  - abbr: MO
+                    name: Mayo
+                  - abbr: MH
+                    name: Meath
+                  - abbr: MN
+                    name: Monaghan
+                  - abbr: M
+                    name: Munster
+                  - abbr: OY
+                    name: Offaly
+                  - abbr: RN
+                    name: Roscommon
+                  - abbr: SO
+                    name: Sligo
+                  - abbr: TA
+                    name: Tipperary
+                  - abbr: U
+                    name: Ulster
+                  - abbr: WD
+                    name: Waterford
+                  - abbr: WH
+                    name: Westmeath
+                  - abbr: WX
+                    name: Wexford
+                  - abbr: WW
+                    name: Wicklow
+                - iso: IM
+                  iso3: IMN
+                  name: Isle of Man
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: IL
+                  iso3: ISR
+                  name: Israel
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: D
+                    name: HaDarom
+                  - abbr: M
+                    name: HaMerkaz
+                  - abbr: Z
+                    name: HaZafon
+                  - abbr: HA
+                    name: Haifa
+                  - abbr: TA
+                    name: Tel-Aviv
+                  - abbr: JM
+                    name: Yerushalayim
+                - iso: IT
+                  iso3: ITA
+                  name: Italy
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: '65'
+                    name: Abruzzo
+                  - abbr: AG
+                    name: Agrigento
+                  - abbr: AL
+                    name: Alessandria
+                  - abbr: AN
+                    name: Ancona
+                  - abbr: AR
+                    name: Arezzo
+                  - abbr: AP
+                    name: Ascoli Piceno
+                  - abbr: AT
+                    name: Asti
+                  - abbr: AV
+                    name: Avellino
+                  - abbr: BA
+                    name: Bari
+                  - abbr: BT
+                    name: Barletta-Andria-Trani
+                  - abbr: '77'
+                    name: Basilicata
+                  - abbr: BL
+                    name: Belluno
+                  - abbr: BN
+                    name: Benevento
+                  - abbr: BG
+                    name: Bergamo
+                  - abbr: BI
+                    name: Biella
+                  - abbr: BO
+                    name: Bologna
+                  - abbr: BZ
+                    name: Bolzano
+                  - abbr: BS
+                    name: Brescia
+                  - abbr: BR
+                    name: Brindisi
+                  - abbr: CA
+                    name: Cagliari
+                  - abbr: '78'
+                    name: Calabria
+                  - abbr: CL
+                    name: Caltanissetta
+                  - abbr: '72'
+                    name: Campania
+                  - abbr: CB
+                    name: Campobasso
+                  - abbr: CI
+                    name: Carbonia-Iglesias
+                  - abbr: CE
+                    name: Caserta
+                  - abbr: CT
+                    name: Catania
+                  - abbr: CZ
+                    name: Catanzaro
+                  - abbr: CH
+                    name: Chieti
+                  - abbr: CO
+                    name: Como
+                  - abbr: CS
+                    name: Cosenza
+                  - abbr: CR
+                    name: Cremona
+                  - abbr: KR
+                    name: Crotone
+                  - abbr: CN
+                    name: Cuneo
+                  - abbr: '45'
+                    name: Emilia-Romagna
+                  - abbr: EN
+                    name: Enna
+                  - abbr: FM
+                    name: Fermo
+                  - abbr: FE
+                    name: Ferrara
+                  - abbr: FI
+                    name: Firenze
+                  - abbr: FG
+                    name: Foggia
+                  - abbr: FC
+                    name: Forlì-Cesena
+                  - abbr: '36'
+                    name: Friuli Venezia Giulia
+                  - abbr: FR
+                    name: Frosinone
+                  - abbr: GE
+                    name: Genova
+                  - abbr: GO
+                    name: Gorizia
+                  - abbr: GR
+                    name: Grosseto
+                  - abbr: IM
+                    name: Imperia
+                  - abbr: IS
+                    name: Isernia
+                  - abbr: AQ
+                    name: L'Aquila
+                  - abbr: SP
+                    name: La Spezia
+                  - abbr: LT
+                    name: Latina
+                  - abbr: '62'
+                    name: Lazio
+                  - abbr: LE
+                    name: Lecce
+                  - abbr: LC
+                    name: Lecco
+                  - abbr: '42'
+                    name: Liguria
+                  - abbr: LI
+                    name: Livorno
+                  - abbr: LO
+                    name: Lodi
+                  - abbr: '25'
+                    name: Lombardia
+                  - abbr: LU
+                    name: Lucca
+                  - abbr: MC
+                    name: Macerata
+                  - abbr: MN
+                    name: Mantova
+                  - abbr: '57'
+                    name: Marche
+                  - abbr: MS
+                    name: Massa-Carrara
+                  - abbr: MT
+                    name: Matera
+                  - abbr: VS
+                    name: Medio Campidano
+                  - abbr: ME
+                    name: Messina
+                  - abbr: MI
+                    name: Milano
+                  - abbr: MO
+                    name: Modena
+                  - abbr: '67'
+                    name: Molise
+                  - abbr: MB
+                    name: Monza e Brianza
+                  - abbr: NA
+                    name: Napoli
+                  - abbr: 'NO'
+                    name: Novara
+                  - abbr: NU
+                    name: Nuoro
+                  - abbr: OG
+                    name: Ogliastra
+                  - abbr: OT
+                    name: Olbia-Tempio
+                  - abbr: OR
+                    name: Oristano
+                  - abbr: PD
+                    name: Padova
+                  - abbr: PA
+                    name: Palermo
+                  - abbr: PR
+                    name: Parma
+                  - abbr: PV
+                    name: Pavia
+                  - abbr: PG
+                    name: Perugia
+                  - abbr: PU
+                    name: Pesaro e Urbino
+                  - abbr: PE
+                    name: Pescara
+                  - abbr: PC
+                    name: Piacenza
+                  - abbr: '21'
+                    name: Piemonte
+                  - abbr: PI
+                    name: Pisa
+                  - abbr: PT
+                    name: Pistoia
+                  - abbr: PN
+                    name: Pordenone
+                  - abbr: PZ
+                    name: Potenza
+                  - abbr: PO
+                    name: Prato
+                  - abbr: '75'
+                    name: Puglia
+                  - abbr: RG
+                    name: Ragusa
+                  - abbr: RA
+                    name: Ravenna
+                  - abbr: RC
+                    name: Reggio Calabria
+                  - abbr: RE
+                    name: Reggio Emilia
+                  - abbr: RI
+                    name: Rieti
+                  - abbr: RN
+                    name: Rimini
+                  - abbr: RM
+                    name: Roma
+                  - abbr: RO
+                    name: Rovigo
+                  - abbr: SA
+                    name: Salerno
+                  - abbr: '88'
+                    name: Sardegna
+                  - abbr: SS
+                    name: Sassari
+                  - abbr: SV
+                    name: Savona
+                  - abbr: '82'
+                    name: Sicilia
+                  - abbr: SI
+                    name: Siena
+                  - abbr: SR
+                    name: Siracusa
+                  - abbr: SO
+                    name: Sondrio
+                  - abbr: SU
+                    name: Sud Sardegna
+                  - abbr: TA
+                    name: Taranto
+                  - abbr: TE
+                    name: Teramo
+                  - abbr: TR
+                    name: Terni
+                  - abbr: TO
+                    name: Torino
+                  - abbr: '52'
+                    name: Toscana
+                  - abbr: TP
+                    name: Trapani
+                  - abbr: '32'
+                    name: Trentino-Alto Adige
+                  - abbr: TN
+                    name: Trento
+                  - abbr: TV
+                    name: Treviso
+                  - abbr: TS
+                    name: Trieste
+                  - abbr: UD
+                    name: Udine
+                  - abbr: '55'
+                    name: Umbria
+                  - abbr: '23'
+                    name: Valle d'Aosta
+                  - abbr: VA
+                    name: Varese
+                  - abbr: '34'
+                    name: Veneto
+                  - abbr: VE
+                    name: Venezia
+                  - abbr: VB
+                    name: Verbano-Cusio-Ossola
+                  - abbr: VC
+                    name: Vercelli
+                  - abbr: VR
+                    name: Verona
+                  - abbr: VV
+                    name: Vibo Valentia
+                  - abbr: VI
+                    name: Vicenza
+                  - abbr: VT
+                    name: Viterbo
+                - iso: JM
+                  iso3: JAM
+                  name: Jamaica
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '13'
+                    name: Clarendon
+                  - abbr: '09'
+                    name: Hanover
+                  - abbr: '01'
+                    name: Kingston
+                  - abbr: '12'
+                    name: Manchester
+                  - abbr: '04'
+                    name: Portland
+                  - abbr: '02'
+                    name: Saint Andrew
+                  - abbr: '06'
+                    name: Saint Ann
+                  - abbr: '14'
+                    name: Saint Catherine
+                  - abbr: '11'
+                    name: Saint Elizabeth
+                  - abbr: '08'
+                    name: Saint James
+                  - abbr: '05'
+                    name: Saint Mary
+                  - abbr: '03'
+                    name: Saint Thomas
+                  - abbr: '07'
+                    name: Trelawny
+                  - abbr: '10'
+                    name: Westmoreland
+                - iso: JP
+                  iso3: JPN
+                  name: Japan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '23'
+                    name: Aichi
+                  - abbr: '05'
+                    name: Akita
+                  - abbr: '02'
+                    name: Aomori
+                  - abbr: '12'
+                    name: Chiba
+                  - abbr: '38'
+                    name: Ehime
+                  - abbr: '18'
+                    name: Fukui
+                  - abbr: '40'
+                    name: Fukuoka
+                  - abbr: '07'
+                    name: Fukushima
+                  - abbr: '21'
+                    name: Gifu
+                  - abbr: '10'
+                    name: Gunma
+                  - abbr: '34'
+                    name: Hiroshima
+                  - abbr: '01'
+                    name: Hokkaido
+                  - abbr: '28'
+                    name: Hyogo
+                  - abbr: '08'
+                    name: Ibaraki
+                  - abbr: '17'
+                    name: Ishikawa
+                  - abbr: '03'
+                    name: Iwate
+                  - abbr: '37'
+                    name: Kagawa
+                  - abbr: '46'
+                    name: Kagoshima
+                  - abbr: '14'
+                    name: Kanagawa
+                  - abbr: '39'
+                    name: Kochi
+                  - abbr: '43'
+                    name: Kumamoto
+                  - abbr: '26'
+                    name: Kyoto
+                  - abbr: '24'
+                    name: Mie
+                  - abbr: '04'
+                    name: Miyagi
+                  - abbr: '45'
+                    name: Miyazaki
+                  - abbr: '20'
+                    name: Nagano
+                  - abbr: '42'
+                    name: Nagasaki
+                  - abbr: '29'
+                    name: Nara
+                  - abbr: '15'
+                    name: Niigata
+                  - abbr: '44'
+                    name: Oita
+                  - abbr: '33'
+                    name: Okayama
+                  - abbr: '47'
+                    name: Okinawa
+                  - abbr: '27'
+                    name: Osaka
+                  - abbr: '41'
+                    name: Saga
+                  - abbr: '11'
+                    name: Saitama
+                  - abbr: '25'
+                    name: Shiga
+                  - abbr: '32'
+                    name: Shimane
+                  - abbr: '22'
+                    name: Shizuoka
+                  - abbr: '09'
+                    name: Tochigi
+                  - abbr: '36'
+                    name: Tokushima
+                  - abbr: '13'
+                    name: Tokyo
+                  - abbr: '31'
+                    name: Tottori
+                  - abbr: '16'
+                    name: Toyama
+                  - abbr: '30'
+                    name: Wakayama
+                  - abbr: '06'
+                    name: Yamagata
+                  - abbr: '35'
+                    name: Yamaguchi
+                  - abbr: '19'
+                    name: Yamanashi
+                - iso: JE
+                  iso3: JEY
+                  name: Jersey
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: JO
+                  iso3: JOR
+                  name: Jordan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AJ
+                    name: Ajlun
+                  - abbr: BA
+                    name: Al Balqa'
+                  - abbr: KA
+                    name: Al Karak
+                  - abbr: MA
+                    name: Al Mafraq
+                  - abbr: AM
+                    name: Amman
+                  - abbr: AQ
+                    name: Aqaba
+                  - abbr: AT
+                    name: At Tafilah
+                  - abbr: AZ
+                    name: Az Zarqa'
+                  - abbr: IR
+                    name: Irbid
+                  - abbr: JA
+                    name: Jarash
+                  - abbr: MN
+                    name: Ma`an
+                  - abbr: MD
+                    name: Madaba
+                - iso: KZ
+                  iso3: KAZ
+                  name: Kazakhstan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ALA
+                    name: Almaty
+                  - abbr: ALM
+                    name: Almaty oblysy
+                  - abbr: AKM
+                    name: Aqmola oblysy
+                  - abbr: AKT
+                    name: Aqtöbe oblysy
+                  - abbr: AST
+                    name: Astana
+                  - abbr: ATY
+                    name: Atyrau oblysy
+                  - abbr: ZAP
+                    name: Batys Qazaqstan oblysy
+                  - abbr: MAN
+                    name: Mangghystau oblysy
+                  - abbr: YUZ
+                    name: Ongtüstik Qazaqstan oblysy
+                  - abbr: PAV
+                    name: Pavlodar oblysy
+                  - abbr: KAR
+                    name: Qaraghandy oblysy
+                  - abbr: KUS
+                    name: Qostanay oblysy
+                  - abbr: KZY
+                    name: Qyzylorda oblysy
+                  - abbr: VOS
+                    name: Shyghys Qazaqstan oblysy
+                  - abbr: SHY
+                    name: Shymkent
+                  - abbr: SEV
+                    name: Soltüstik Qazaqstan oblysy
+                  - abbr: ZHA
+                    name: Zhambyl oblysy
+                - iso: KE
+                  iso3: KEN
+                  name: Kenya
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Baringo
+                  - abbr: '02'
+                    name: Bomet
+                  - abbr: '03'
+                    name: Bungoma
+                  - abbr: '04'
+                    name: Busia
+                  - abbr: '05'
+                    name: Elgeyo/Marakwet
+                  - abbr: '06'
+                    name: Embu
+                  - abbr: '07'
+                    name: Garissa
+                  - abbr: '08'
+                    name: Homa Bay
+                  - abbr: '09'
+                    name: Isiolo
+                  - abbr: '10'
+                    name: Kajiado
+                  - abbr: '11'
+                    name: Kakamega
+                  - abbr: '12'
+                    name: Kericho
+                  - abbr: '13'
+                    name: Kiambu
+                  - abbr: '14'
+                    name: Kilifi
+                  - abbr: '15'
+                    name: Kirinyaga
+                  - abbr: '16'
+                    name: Kisii
+                  - abbr: '17'
+                    name: Kisumu
+                  - abbr: '18'
+                    name: Kitui
+                  - abbr: '19'
+                    name: Kwale
+                  - abbr: '20'
+                    name: Laikipia
+                  - abbr: '21'
+                    name: Lamu
+                  - abbr: '22'
+                    name: Machakos
+                  - abbr: '23'
+                    name: Makueni
+                  - abbr: '24'
+                    name: Mandera
+                  - abbr: '25'
+                    name: Marsabit
+                  - abbr: '26'
+                    name: Meru
+                  - abbr: '27'
+                    name: Migori
+                  - abbr: '28'
+                    name: Mombasa
+                  - abbr: '29'
+                    name: Murang’a
+                  - abbr: '30'
+                    name: Nairobi City
+                  - abbr: '31'
+                    name: Nakuru
+                  - abbr: '32'
+                    name: Nandi
+                  - abbr: '33'
+                    name: Narok
+                  - abbr: '34'
+                    name: Nyamira
+                  - abbr: '35'
+                    name: Nyandarua
+                  - abbr: '36'
+                    name: Nyeri
+                  - abbr: '37'
+                    name: Samburu
+                  - abbr: '38'
+                    name: Siaya
+                  - abbr: '39'
+                    name: Taita-Taveta
+                  - abbr: '40'
+                    name: Tana River
+                  - abbr: '41'
+                    name: Tharaka-Nithi
+                  - abbr: '42'
+                    name: Trans-Nzoia
+                  - abbr: '43'
+                    name: Turkana
+                  - abbr: '44'
+                    name: Uasin Gishu
+                  - abbr: '45'
+                    name: Vihiga
+                  - abbr: '46'
+                    name: Wajir
+                  - abbr: '47'
+                    name: West Pokot
+                - iso: KI
+                  iso3: KIR
+                  name: Kiribati
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: G
+                    name: Gilbert Islands
+                  - abbr: L
+                    name: Line Islands
+                  - abbr: P
+                    name: Phoenix Islands
+                - iso: KW
+                  iso3: KWT
+                  name: Kuwait
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AH
+                    name: Al Ahmadi
+                  - abbr: FA
+                    name: Al Farwaniyah
+                  - abbr: JA
+                    name: Al Jahrah
+                  - abbr: KU
+                    name: Al Kuwayt
+                  - abbr: HA
+                    name: Hawalli
+                  - abbr: MU
+                    name: Mubarak al-Kabir
+                - iso: KG
+                  iso3: KGZ
+                  name: Kyrgyzstan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: B
+                    name: Batken
+                  - abbr: GB
+                    name: Bishkek
+                  - abbr: C
+                    name: Chü
+                  - abbr: J
+                    name: Jalal-Abad
+                  - abbr: "N"
+                    name: Naryn
+                  - abbr: O
+                    name: Osh
+                  - abbr: T
+                    name: Talas
+                  - abbr: "Y"
+                    name: Ysyk-Köl
+                  - abbr: GO
+                    name: Ош
+                - iso: LA
+                  iso3: LAO
+                  name: Lao People's Democratic Republic
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AT
+                    name: Attapu [Attopeu]
+                  - abbr: BK
+                    name: Bokèo
+                  - abbr: BL
+                    name: Bolikhamxai [Borikhane]
+                  - abbr: CH
+                    name: Champasak [Champassak]
+                  - abbr: HO
+                    name: Houaphan
+                  - abbr: KH
+                    name: Khammouan
+                  - abbr: LM
+                    name: Louang Namtha
+                  - abbr: LP
+                    name: Louangphabang [Louang Prabang]
+                  - abbr: OU
+                    name: Oudômxai [Oudomsai]
+                  - abbr: PH
+                    name: Phôngsali [Phong Saly]
+                  - abbr: SL
+                    name: Salavan [Saravane]
+                  - abbr: SV
+                    name: Savannakhét
+                  - abbr: VI
+                    name: Vientiane
+                  - abbr: VT
+                    name: Vientiane Prefecture
+                  - abbr: XA
+                    name: Xaignabouli [Sayaboury]
+                  - abbr: XI
+                    name: Xiangkhoang [Xieng Khouang]
+                  - abbr: XE
+                    name: Xékong [Sékong]
+                  - abbr: XS
+                    name: ແຂວງໄຊສົມບູນ
+                - iso: LV
+                  iso3: LVA
+                  name: Latvia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '002'
+                    name: Aizkraukles novads
+                  - abbr: '007'
+                    name: Alūksnes novads
+                  - abbr: '111'
+                    name: Augšdaugavas novads
+                  - abbr: '015'
+                    name: Balvu novads
+                  - abbr: '016'
+                    name: Bauskas novads
+                  - abbr: '022'
+                    name: Cēsu novads
+                  - abbr: DGV
+                    name: Daugavpils
+                  - abbr: '112'
+                    name: Dienvidkurzemes Novads
+                  - abbr: '026'
+                    name: Dobeles novads
+                  - abbr: '033'
+                    name: Gulbenes novads
+                  - abbr: JEL
+                    name: Jelgava
+                  - abbr: '041'
+                    name: Jelgavas novads
+                  - abbr: JUR
+                    name: Jurmala
+                  - abbr: '042'
+                    name: Jēkabpils novads
+                  - abbr: '047'
+                    name: Krāslavas novads
+                  - abbr: '050'
+                    name: Kuldīgas novads
+                  - abbr: LPX
+                    name: Liepaja
+                  - abbr: '054'
+                    name: Limbažu novads
+                  - abbr: '058'
+                    name: Ludzas novads
+                  - abbr: '056'
+                    name: Līvānu novads
+                  - abbr: '059'
+                    name: Madonas novads
+                  - abbr: '062'
+                    name: Mārupes novads
+                  - abbr: '067'
+                    name: Ogres novads
+                  - abbr: '068'
+                    name: Olaines novads
+                  - abbr: '073'
+                    name: Preiļu novads
+                  - abbr: REZ
+                    name: Rezekne
+                  - abbr: RIX
+                    name: Riga
+                  - abbr: '080'
+                    name: Ropažu novads
+                  - abbr: '077'
+                    name: Rēzeknes novads
+                  - abbr: '087'
+                    name: Salaspils novads
+                  - abbr: '088'
+                    name: Saldus novads
+                  - abbr: '089'
+                    name: Saulkrastu novads
+                  - abbr: '091'
+                    name: Siguldas novads
+                  - abbr: '094'
+                    name: Smiltenes novads
+                  - abbr: '097'
+                    name: Talsu novads
+                  - abbr: '099'
+                    name: Tukuma novads
+                  - abbr: '101'
+                    name: Valkas novads
+                  - abbr: '113'
+                    name: Valmieras Novads
+                  - abbr: '102'
+                    name: Varakļānu novads
+                  - abbr: VEN
+                    name: Ventspils
+                  - abbr: '106'
+                    name: Ventspils novads
+                  - abbr: '011'
+                    name: Ādažu novads
+                  - abbr: '052'
+                    name: Ķekavas novads
+                - iso: LB
+                  iso3: LBN
+                  name: Lebanon
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BA
+                    name: Beirut
+                  - abbr: BI
+                    name: El Béqaa
+                  - abbr: JL
+                    name: Jabal Loubnâne
+                  - abbr: AS
+                    name: Loubnâne ech Chemâli
+                  - abbr: JA
+                    name: Loubnâne ej Jnoûbi
+                  - abbr: NA
+                    name: Nabatîyé
+                  - abbr: BH
+                    name: محافظة بعلبك الهرمل
+                  - abbr: AK
+                    name: محافظة عكار
+                - iso: LS
+                  iso3: LSO
+                  name: Lesotho
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: D
+                    name: Berea
+                  - abbr: B
+                    name: Butha-Buthe
+                  - abbr: C
+                    name: Leribe
+                  - abbr: E
+                    name: Mafeteng
+                  - abbr: A
+                    name: Maseru
+                  - abbr: F
+                    name: Mohale's Hoek
+                  - abbr: J
+                    name: Mokhotlong
+                  - abbr: H
+                    name: Qacha's Nek
+                  - abbr: G
+                    name: Quthing
+                  - abbr: K
+                    name: Thaba-Tseka
+                - iso: LR
+                  iso3: LBR
+                  name: Liberia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BM
+                    name: Bomi
+                  - abbr: BG
+                    name: Bong
+                  - abbr: X1~
+                    name: Gbarpolu
+                  - abbr: GP
+                    name: Gbarpolu
+                  - abbr: GB
+                    name: Grand Bassa
+                  - abbr: CM
+                    name: Grand Cape Mount
+                  - abbr: GG
+                    name: Grand Gedeh
+                  - abbr: GK
+                    name: Grand Kru
+                  - abbr: LO
+                    name: Lofa
+                  - abbr: MG
+                    name: Margibi
+                  - abbr: MY
+                    name: Maryland
+                  - abbr: MO
+                    name: Montserrado
+                  - abbr: NI
+                    name: Nimba
+                  - abbr: RG
+                    name: River Gee
+                  - abbr: X2~
+                    name: River Gee
+                  - abbr: RI
+                    name: Rivercess
+                  - abbr: SI
+                    name: Sinoe
+                - iso: LY
+                  iso3: LBY
+                  name: Libya
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BU
+                    name: Al Butnan
+                  - abbr: JA
+                    name: Al Jabal al Akhḑar
+                  - abbr: JG
+                    name: Al Jabal al Gharbī
+                  - abbr: JI
+                    name: Al Jifarah
+                  - abbr: JU
+                    name: Al Jufrah
+                  - abbr: KF
+                    name: Al Kufrah
+                  - abbr: MJ
+                    name: Al Marj
+                  - abbr: MB
+                    name: Al Murqub
+                  - abbr: WA
+                    name: Al Wahat
+                  - abbr: NQ
+                    name: An Nuqaţ al Khams
+                  - abbr: ZA
+                    name: Az Zawiyah
+                  - abbr: BA
+                    name: Banghazi
+                  - abbr: DR
+                    name: Darnah
+                  - abbr: GT
+                    name: Ghat
+                  - abbr: MI
+                    name: Mişrātah
+                  - abbr: MQ
+                    name: Murzuq
+                  - abbr: NL
+                    name: Nālūt
+                  - abbr: SB
+                    name: Sabhā
+                  - abbr: SR
+                    name: Sirte
+                  - abbr: TB
+                    name: Tarabulus
+                  - abbr: WD
+                    name: Wādī al Ḩayāt
+                  - abbr: WS
+                    name: Wādī ash Shāţiʾ
+                - iso: LI
+                  iso3: LIE
+                  name: Liechtenstein
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Balzers
+                  - abbr: '02'
+                    name: Eschen
+                  - abbr: '03'
+                    name: Gamprin
+                  - abbr: '04'
+                    name: Mauren
+                  - abbr: '05'
+                    name: Planken
+                  - abbr: '06'
+                    name: Ruggell
+                  - abbr: '07'
+                    name: Schaan
+                  - abbr: '08'
+                    name: Schellenberg
+                  - abbr: '09'
+                    name: Triesen
+                  - abbr: '10'
+                    name: Triesenberg
+                  - abbr: '11'
+                    name: Vaduz
+                - iso: LT
+                  iso3: LTU
+                  name: Lithuania
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Akmenės rajono savivaldybė
+                  - abbr: AL
+                    name: Alytaus Apskritis
+                  - abbr: '02'
+                    name: Alytaus miesto savivaldybė
+                  - abbr: '03'
+                    name: Alytaus rajono savivaldybė
+                  - abbr: '04'
+                    name: Anykščių rajono savivaldybė
+                  - abbr: '05'
+                    name: Birštono savivaldybė
+                  - abbr: '06'
+                    name: Biržų rajono savivaldybė
+                  - abbr: '07'
+                    name: Druskininkų savivaldybė
+                  - abbr: '08'
+                    name: Elektrėnų savivaldybė
+                  - abbr: '09'
+                    name: Ignalinos rajono savivaldybė
+                  - abbr: '10'
+                    name: Jonavos rajono savivaldybė
+                  - abbr: '11'
+                    name: Joniškio rajono savivaldybė
+                  - abbr: '12'
+                    name: Jurbarko rajono savivaldybė
+                  - abbr: '13'
+                    name: Kaišiadorių rajono savivaldybė
+                  - abbr: '14'
+                    name: Kalvarijos savivaldybė
+                  - abbr: KU
+                    name: Kauno Apskritis
+                  - abbr: '15'
+                    name: Kauno miesto savivaldybė
+                  - abbr: '16'
+                    name: Kauno rajono savivaldybė
+                  - abbr: '17'
+                    name: Kazlų Rūdos savivaldybė
+                  - abbr: '19'
+                    name: Kelmės rajono savivaldybė
+                  - abbr: KL
+                    name: Klaipedos Apskritis
+                  - abbr: '20'
+                    name: Klaipėdos miesto savivaldybė
+                  - abbr: '21'
+                    name: Klaipėdos rajono savivaldybė
+                  - abbr: '22'
+                    name: Kretingos rajono savivaldybė
+                  - abbr: '23'
+                    name: Kupiškio rajono savivaldybė
+                  - abbr: '18'
+                    name: Kėdainių rajono savivaldybė
+                  - abbr: '24'
+                    name: Lazdijų rajono savivaldybė
+                  - abbr: MR
+                    name: Marijampoles Apskritis
+                  - abbr: '25'
+                    name: Marijampolės savivaldybė
+                  - abbr: '26'
+                    name: Mažeikių rajono savivaldybė
+                  - abbr: '27'
+                    name: Molėtų rajono savivaldybė
+                  - abbr: '28'
+                    name: Neringos savivaldybė
+                  - abbr: '29'
+                    name: Pagėgių savivaldybė
+                  - abbr: '30'
+                    name: Pakruojo rajono savivaldybė
+                  - abbr: '31'
+                    name: Palangos miesto savivaldybė
+                  - abbr: PN
+                    name: Panevežio Apskritis
+                  - abbr: '32'
+                    name: Panevėžio miesto savivaldybė
+                  - abbr: '33'
+                    name: Panevėžio rajono savivaldybė
+                  - abbr: '34'
+                    name: Pasvalio rajono savivaldybė
+                  - abbr: '35'
+                    name: Plungės rajono savivaldybė
+                  - abbr: '36'
+                    name: Prienų rajono savivaldybė
+                  - abbr: '37'
+                    name: Radviliškio rajono savivaldybė
+                  - abbr: '38'
+                    name: Raseinių rajono savivaldybė
+                  - abbr: '39'
+                    name: Rietavo savivaldybė
+                  - abbr: '40'
+                    name: Rokiškio rajono savivaldybė
+                  - abbr: '48'
+                    name: Skuodo rajono savivaldybė
+                  - abbr: TA
+                    name: Taurages Apskritis
+                  - abbr: '50'
+                    name: Tauragės rajono savivaldybė
+                  - abbr: TE
+                    name: Telšiu Apskritis
+                  - abbr: '51'
+                    name: Telšių rajono savivaldybė
+                  - abbr: '52'
+                    name: Trakų rajono savivaldybė
+                  - abbr: '53'
+                    name: Ukmergės rajono savivaldybė
+                  - abbr: UT
+                    name: Utenos Apskritis
+                  - abbr: '54'
+                    name: Utenos rajono savivaldybė
+                  - abbr: '55'
+                    name: Varėnos rajono savivaldybė
+                  - abbr: '56'
+                    name: Vilkaviškio rajono savivaldybė
+                  - abbr: VL
+                    name: Vilniaus Apskritis
+                  - abbr: '57'
+                    name: Vilniaus miesto savivaldybė
+                  - abbr: '58'
+                    name: Vilniaus rajono savivaldybė
+                  - abbr: '59'
+                    name: Visagino savivaldybė
+                  - abbr: '60'
+                    name: Zarasų rajono savivaldybė
+                  - abbr: '41'
+                    name: Šakių rajono savivaldybė
+                  - abbr: '42'
+                    name: Šalčininkų rajono savivaldybė
+                  - abbr: SA
+                    name: Šiauliu Apskritis
+                  - abbr: '43'
+                    name: Šiaulių miesto savivaldybė
+                  - abbr: '44'
+                    name: Šiaulių rajono savivaldybė
+                  - abbr: '45'
+                    name: Šilalės rajono savivaldybė
+                  - abbr: '46'
+                    name: Šilutės rajono savivaldybė
+                  - abbr: '47'
+                    name: Širvintų rajono savivaldybė
+                  - abbr: '49'
+                    name: Švenčionių rajono savivaldybė
+                - iso: LU
+                  iso3: LUX
+                  name: Luxembourg
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: DI
+                    name: Diekrech
+                  - abbr: ES
+                    name: Esch-Uelzecht
+                  - abbr: GR
+                    name: Gréivemaacher
+                  - abbr: EC
+                    name: Iechternach
+                  - abbr: CA
+                    name: Kapellen
+                  - abbr: CL
+                    name: Klierf
+                  - abbr: LU
+                    name: Lëtzebuerg
+                  - abbr: ME
+                    name: Miersch
+                  - abbr: RD
+                    name: Réiden-Atert
+                  - abbr: RM
+                    name: Réimech
+                  - abbr: VD
+                    name: Veianen
+                  - abbr: WI
+                    name: Wolz
+                - iso: MO
+                  iso3: MAC
+                  name: Macao
+                  states_required: false
+                  zipcode_required: false
+                  states: []
+                - iso: MG
+                  iso3: MDG
+                  name: Madagascar
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: T
+                    name: Antananarivo
+                  - abbr: D
+                    name: Antsiranana
+                  - abbr: F
+                    name: Fianarantsoa
+                  - abbr: M
+                    name: Mahajanga
+                  - abbr: A
+                    name: Toamasina
+                  - abbr: U
+                    name: Toliara
+                - iso: MW
+                  iso3: MWI
+                  name: Malawi
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BA
+                    name: Balaka
+                  - abbr: BL
+                    name: Blantyre
+                  - abbr: C
+                    name: Central
+                  - abbr: CK
+                    name: Chikwawa
+                  - abbr: CR
+                    name: Chiradzulu
+                  - abbr: CT
+                    name: Chitipa
+                  - abbr: DE
+                    name: Dedza
+                  - abbr: DO
+                    name: Dowa
+                  - abbr: KR
+                    name: Karonga
+                  - abbr: KS
+                    name: Kasungu
+                  - abbr: LK
+                    name: Likoma Island
+                  - abbr: LI
+                    name: Lilongwe
+                  - abbr: MH
+                    name: Machinga
+                  - abbr: MG
+                    name: Mangochi
+                  - abbr: MC
+                    name: Mchinji
+                  - abbr: MU
+                    name: Mulanje
+                  - abbr: MW
+                    name: Mwanza
+                  - abbr: MZ
+                    name: Mzimba
+                  - abbr: NE
+                    name: Neno
+                  - abbr: NB
+                    name: Nkhata Bay
+                  - abbr: NK
+                    name: Nkhotakota
+                  - abbr: "N"
+                    name: Northern
+                  - abbr: NS
+                    name: Nsanje
+                  - abbr: NU
+                    name: Ntcheu
+                  - abbr: NI
+                    name: Ntchisi
+                  - abbr: PH
+                    name: Phalombe
+                  - abbr: RU
+                    name: Rumphi
+                  - abbr: SA
+                    name: Salima
+                  - abbr: S
+                    name: Southern
+                  - abbr: TH
+                    name: Thyolo
+                  - abbr: ZO
+                    name: Zomba
+                - iso: MY
+                  iso3: MYS
+                  name: Malaysia
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Johor
+                  - abbr: '02'
+                    name: Kedah
+                  - abbr: '03'
+                    name: Kelantan
+                  - abbr: '04'
+                    name: Melaka
+                  - abbr: '05'
+                    name: Negeri Sembilan
+                  - abbr: '06'
+                    name: Pahang
+                  - abbr: '08'
+                    name: Perak
+                  - abbr: '09'
+                    name: Perlis
+                  - abbr: '07'
+                    name: Pulau Pinang
+                  - abbr: '12'
+                    name: Sabah
+                  - abbr: '13'
+                    name: Sarawak
+                  - abbr: '10'
+                    name: Selangor
+                  - abbr: '11'
+                    name: Terengganu
+                  - abbr: '14'
+                    name: Wilayah Persekutuan Kuala Lumpur
+                  - abbr: '15'
+                    name: Wilayah Persekutuan Labuan
+                  - abbr: '16'
+                    name: Wilayah Persekutuan Putrajaya
+                - iso: MV
+                  iso3: MDV
+                  name: Maldives
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Addu
+                  - abbr: '00'
+                    name: Ariatholhu Dhekunuburi
+                  - abbr: '02'
+                    name: Ariatholhu Uthuruburi
+                  - abbr: '03'
+                    name: Faadhippolhu
+                  - abbr: '04'
+                    name: Felidheatholhu
+                  - abbr: '29'
+                    name: Fuvammulah
+                  - abbr: '05'
+                    name: Hahdhunmathi
+                  - abbr: '28'
+                    name: Huvadhuatholhu Dhekunuburi
+                  - abbr: '27'
+                    name: Huvadhuatholhu Uthuruburi
+                  - abbr: '08'
+                    name: Kolhumadulu
+                  - abbr: '26'
+                    name: Maaleatholhu
+                  - abbr: '20'
+                    name: Maalhosmadulu Dhekunuburi
+                  - abbr: '13'
+                    name: Maalhosmadulu Uthuruburi
+                  - abbr: MLE
+                    name: Male
+                  - abbr: '25'
+                    name: Miladhunmadulu Dhekunuburi
+                  - abbr: '24'
+                    name: Miladhunmadulu Uthuruburi
+                  - abbr: '12'
+                    name: Mulakatholhu
+                  - abbr: '17'
+                    name: Nilandheatholhu Dhekunuburi
+                  - abbr: '14'
+                    name: Nilandheatholhu Uthuruburi
+                  - abbr: '23'
+                    name: Thiladhunmathee Dhekunuburi
+                  - abbr: '07'
+                    name: Thiladhunmathee Uthuruburi
+                - iso: ML
+                  iso3: MLI
+                  name: Mali
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BKO
+                    name: Bamako
+                  - abbr: '7'
+                    name: Gao
+                  - abbr: '1'
+                    name: Kayes
+                  - abbr: '8'
+                    name: Kidal
+                  - abbr: '2'
+                    name: Koulikoro
+                  - abbr: '5'
+                    name: Mopti
+                  - abbr: '9'
+                    name: Région de Ménaka
+                  - abbr: '10'
+                    name: Région de Taoudénit
+                  - abbr: '3'
+                    name: Sikasso
+                  - abbr: '4'
+                    name: Ségou
+                  - abbr: '6'
+                    name: Tombouctou
+                - iso: MT
+                  iso3: MLT
+                  name: Malta
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Attard
+                  - abbr: '02'
+                    name: Balzan
+                  - abbr: '03'
+                    name: Birgu
+                  - abbr: '04'
+                    name: Birkirkara
+                  - abbr: '05'
+                    name: Birżebbuġa
+                  - abbr: '06'
+                    name: Bormla
+                  - abbr: '07'
+                    name: Dingli
+                  - abbr: '08'
+                    name: Fgura
+                  - abbr: '09'
+                    name: Floriana
+                  - abbr: '10'
+                    name: Fontana
+                  - abbr: '11'
+                    name: Gudja
+                  - abbr: '13'
+                    name: Għajnsielem
+                  - abbr: '14'
+                    name: Għarb
+                  - abbr: '15'
+                    name: Għargħur
+                  - abbr: '16'
+                    name: Għasri
+                  - abbr: '17'
+                    name: Għaxaq
+                  - abbr: '12'
+                    name: Gżira
+                  - abbr: '19'
+                    name: Iklin
+                  - abbr: '20'
+                    name: Isla
+                  - abbr: '21'
+                    name: Kalkara
+                  - abbr: '22'
+                    name: Kerċem
+                  - abbr: '23'
+                    name: Kirkop
+                  - abbr: '24'
+                    name: Lija
+                  - abbr: '25'
+                    name: Luqa
+                  - abbr: '26'
+                    name: Marsa
+                  - abbr: '27'
+                    name: Marsaskala
+                  - abbr: '28'
+                    name: Marsaxlokk
+                  - abbr: '29'
+                    name: Mdina
+                  - abbr: '30'
+                    name: Mellieħa
+                  - abbr: '32'
+                    name: Mosta
+                  - abbr: '33'
+                    name: Mqabba
+                  - abbr: '34'
+                    name: Msida
+                  - abbr: '35'
+                    name: Mtarfa
+                  - abbr: '36'
+                    name: Munxar
+                  - abbr: '31'
+                    name: Mġarr
+                  - abbr: '37'
+                    name: Nadur
+                  - abbr: '38'
+                    name: Naxxar
+                  - abbr: '39'
+                    name: Paola
+                  - abbr: '40'
+                    name: Pembroke
+                  - abbr: '41'
+                    name: Pietà
+                  - abbr: '42'
+                    name: Qala
+                  - abbr: '43'
+                    name: Qormi
+                  - abbr: '44'
+                    name: Qrendi
+                  - abbr: '45'
+                    name: Rabat Gozo
+                  - abbr: '46'
+                    name: Rabat Malta
+                  - abbr: '47'
+                    name: Safi
+                  - abbr: '49'
+                    name: Saint John
+                  - abbr: '48'
+                    name: Saint Julian's
+                  - abbr: '50'
+                    name: Saint Lawrence
+                  - abbr: '53'
+                    name: Saint Lucia's
+                  - abbr: '51'
+                    name: Saint Paul's Bay
+                  - abbr: '52'
+                    name: Sannat
+                  - abbr: '54'
+                    name: Santa Venera
+                  - abbr: '55'
+                    name: Siġġiewi
+                  - abbr: '56'
+                    name: Sliema
+                  - abbr: '57'
+                    name: Swieqi
+                  - abbr: '58'
+                    name: Ta' Xbiex
+                  - abbr: '59'
+                    name: Tarxien
+                  - abbr: '60'
+                    name: Valletta
+                  - abbr: '61'
+                    name: Xagħra
+                  - abbr: '62'
+                    name: Xewkija
+                  - abbr: '63'
+                    name: Xgħajra
+                  - abbr: '18'
+                    name: Ħamrun
+                  - abbr: '64'
+                    name: Żabbar
+                  - abbr: '65'
+                    name: Żebbuġ Gozo
+                  - abbr: '66'
+                    name: Żebbuġ Malta
+                  - abbr: '67'
+                    name: Żejtun
+                  - abbr: '68'
+                    name: Żurrieq
+                - iso: MH
+                  iso3: MHL
+                  name: Marshall Islands
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ALL
+                    name: Ailinglapalap
+                  - abbr: ALK
+                    name: Ailuk
+                  - abbr: ARN
+                    name: Arno
+                  - abbr: AUR
+                    name: Aur
+                  - abbr: EBO
+                    name: Ebon
+                  - abbr: ENI
+                    name: Eniwetok
+                  - abbr: JAB
+                    name: Jabat
+                  - abbr: JAL
+                    name: Jaluit
+                  - abbr: KIL
+                    name: Kili
+                  - abbr: KWA
+                    name: Kwajalein
+                  - abbr: LAE
+                    name: Lae
+                  - abbr: LIB
+                    name: Lib
+                  - abbr: LIK
+                    name: Likiep
+                  - abbr: MAJ
+                    name: Majuro
+                  - abbr: MAL
+                    name: Maloelap
+                  - abbr: MEJ
+                    name: Mejit
+                  - abbr: MIL
+                    name: Mili
+                  - abbr: NMK
+                    name: Namorik
+                  - abbr: NMU
+                    name: Namu
+                  - abbr: L
+                    name: Ralik Chain
+                  - abbr: T
+                    name: Ratak Chain
+                  - abbr: RON
+                    name: Rongelap
+                  - abbr: UJA
+                    name: Ujae
+                  - abbr: UJL
+                    name: Ujelang
+                  - abbr: UTI
+                    name: Utirik
+                  - abbr: WTH
+                    name: Wotho
+                  - abbr: WTJ
+                    name: Wotje
+                - iso: MQ
+                  iso3: MTQ
+                  name: Martinique
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: MR
+                  iso3: MRT
+                  name: Mauritania
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '07'
+                    name: Adrar
+                  - abbr: '03'
+                    name: Assaba
+                  - abbr: '05'
+                    name: Brakna
+                  - abbr: '08'
+                    name: Dakhlet Nouâdhibou
+                  - abbr: '04'
+                    name: Gorgol
+                  - abbr: '10'
+                    name: Guidimaka
+                  - abbr: '01'
+                    name: Hodh ech Chargui
+                  - abbr: '02'
+                    name: Hodh el Gharbi
+                  - abbr: '12'
+                    name: Inchiri
+                  - abbr: '13'
+                    name: Nouakchott Ouest
+                  - abbr: '09'
+                    name: Tagant
+                  - abbr: '11'
+                    name: Tiris Zemmour
+                  - abbr: '06'
+                    name: Trarza
+                  - abbr: '15'
+                    name: نواكشوط الجنوبية
+                  - abbr: '14'
+                    name: نواكشوط الشمالية
+                - iso: MU
+                  iso3: MUS
+                  name: Mauritius
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AG
+                    name: Agalega Islands
+                  - abbr: BL
+                    name: Black River
+                  - abbr: CC
+                    name: Cargados Carajos Shoals [Saint Brandon Islands]
+                  - abbr: FL
+                    name: Flacq
+                  - abbr: GP
+                    name: Grand Port
+                  - abbr: MO
+                    name: Moka
+                  - abbr: PA
+                    name: Pamplemousses
+                  - abbr: PW
+                    name: Plaines Wilhems
+                  - abbr: PL
+                    name: Port Louis City
+                  - abbr: RR
+                    name: Rivière du Rempart
+                  - abbr: RO
+                    name: Rodrigues Island
+                  - abbr: SA
+                    name: Savanne
+                - iso: YT
+                  iso3: MYT
+                  name: Mayotte
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: MX
+                  iso3: MEX
+                  name: Mexico
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AGU
+                    name: Aguascalientes
+                  - abbr: BCN
+                    name: Baja California
+                  - abbr: BCS
+                    name: Baja California Sur
+                  - abbr: CAM
+                    name: Campeche
+                  - abbr: CHP
+                    name: Chiapas
+                  - abbr: CHH
+                    name: Chihuahua
+                  - abbr: CMX
+                    name: Ciudad de México
+                  - abbr: COA
+                    name: Coahuila
+                  - abbr: COL
+                    name: Colima
+                  - abbr: DUR
+                    name: Durango
+                  - abbr: GUA
+                    name: Guanajuato
+                  - abbr: GRO
+                    name: Guerrero
+                  - abbr: HID
+                    name: Hidalgo
+                  - abbr: JAL
+                    name: Jalisco
+                  - abbr: MIC
+                    name: Michoacán
+                  - abbr: MOR
+                    name: Morelos
+                  - abbr: MEX
+                    name: México
+                  - abbr: NAY
+                    name: Nayarit
+                  - abbr: NLE
+                    name: Nuevo León
+                  - abbr: OAX
+                    name: Oaxaca
+                  - abbr: PUE
+                    name: Puebla
+                  - abbr: QUE
+                    name: Querétaro
+                  - abbr: ROO
+                    name: Quintana Roo
+                  - abbr: SLP
+                    name: San Luis Potosí
+                  - abbr: SIN
+                    name: Sinaloa
+                  - abbr: SON
+                    name: Sonora
+                  - abbr: TAB
+                    name: Tabasco
+                  - abbr: TAM
+                    name: Tamaulipas
+                  - abbr: TLA
+                    name: Tlaxcala
+                  - abbr: VER
+                    name: Veracruz
+                  - abbr: YUC
+                    name: Yucatán
+                  - abbr: ZAC
+                    name: Zacatecas
+                - iso: FM
+                  iso3: FSM
+                  name: Micronesia, Federated States of
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: TRK
+                    name: Chuuk
+                  - abbr: KSA
+                    name: Kosrae
+                  - abbr: PNI
+                    name: Pohnpei
+                  - abbr: YAP
+                    name: Yap
+                - iso: MD
+                  iso3: MDA
+                  name: Moldova
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AN
+                    name: Anenii Noi
+                  - abbr: BA
+                    name: Balti
+                  - abbr: BS
+                    name: Basarabeasca
+                  - abbr: BD
+                    name: Bender [Tighina]
+                  - abbr: BR
+                    name: Briceni
+                  - abbr: CA
+                    name: Cahul
+                  - abbr: CT
+                    name: Cantemir
+                  - abbr: CU
+                    name: Chisinau
+                  - abbr: CM
+                    name: Cimișlia
+                  - abbr: CR
+                    name: Criuleni
+                  - abbr: CL
+                    name: Călărași
+                  - abbr: CS
+                    name: Căușeni
+                  - abbr: DO
+                    name: Dondușeni
+                  - abbr: DR
+                    name: Drochia
+                  - abbr: DU
+                    name: Dubăsari
+                  - abbr: ED
+                    name: Edinet
+                  - abbr: FL
+                    name: Florești
+                  - abbr: FA
+                    name: Fălești
+                  - abbr: GA
+                    name: Gagauzia, Unitate Teritoriala Autonoma (UTAG)
+                  - abbr: GL
+                    name: Glodeni
+                  - abbr: HI
+                    name: Hîncești
+                  - abbr: IA
+                    name: Ialoveni
+                  - abbr: LE
+                    name: Leova
+                  - abbr: NI
+                    name: Nisporeni
+                  - abbr: OC
+                    name: Ocnița
+                  - abbr: OR
+                    name: Orhei
+                  - abbr: RE
+                    name: Rezina
+                  - abbr: RI
+                    name: Rîșcani
+                  - abbr: SO
+                    name: Soroca
+                  - abbr: ST
+                    name: Strășeni
+                  - abbr: SN
+                    name: Stînga Nistrului, unitatea teritoriala din
+                  - abbr: SI
+                    name: Sîngerei
+                  - abbr: TA
+                    name: Taraclia
+                  - abbr: TE
+                    name: Telenești
+                  - abbr: UN
+                    name: Ungheni
+                  - abbr: SD
+                    name: Șoldănești
+                  - abbr: SV
+                    name: Ștefan Vodă
+                - iso: MC
+                  iso3: MCO
+                  name: Monaco
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: FO
+                    name: Fontvieille
+                  - abbr: CL
+                    name: La Colle
+                  - abbr: CO
+                    name: La Condamine
+                  - abbr: GA
+                    name: La Gare
+                  - abbr: SR
+                    name: La Rousse
+                  - abbr: SO
+                    name: La Source
+                  - abbr: LA
+                    name: Larvotto/Bas Moulins
+                  - abbr: MA
+                    name: Malbousquet
+                  - abbr: MO
+                    name: Monaco-Ville
+                  - abbr: MG
+                    name: Moneghetti
+                  - abbr: MC
+                    name: Monte-Carlo
+                  - abbr: MU
+                    name: Moulins
+                  - abbr: PH
+                    name: Port Hercule
+                  - abbr: SP
+                    name: Spélugues
+                  - abbr: VR
+                    name: Vallon de la Rousse
+                  - abbr: JE
+                    name: jardin exotique de Monaco
+                  - abbr: SD
+                    name: église Sainte-Dévote
+                - iso: MN
+                  iso3: MNG
+                  name: Mongolia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '073'
+                    name: Arhangay
+                  - abbr: '071'
+                    name: Bayan-Ölgiy
+                  - abbr: '069'
+                    name: Bayanhongor
+                  - abbr: '067'
+                    name: Bulgan
+                  - abbr: '037'
+                    name: Darhan uul
+                  - abbr: '061'
+                    name: Dornod
+                  - abbr: '063'
+                    name: Dornogovi
+                  - abbr: '059'
+                    name: Dundgovi
+                  - abbr: '057'
+                    name: Dzavhan
+                  - abbr: '065'
+                    name: Govi-Altay
+                  - abbr: '064'
+                    name: Govi-Sümber
+                  - abbr: '039'
+                    name: Hentiy
+                  - abbr: '043'
+                    name: Hovd
+                  - abbr: '041'
+                    name: Hövsgöl
+                  - abbr: '035'
+                    name: Orhon
+                  - abbr: '049'
+                    name: Selenge
+                  - abbr: '051'
+                    name: Sühbaatar
+                  - abbr: '047'
+                    name: Töv
+                  - abbr: '1'
+                    name: Ulaanbaatar
+                  - abbr: '046'
+                    name: Uvs
+                  - abbr: '053'
+                    name: Ömnögovi
+                  - abbr: '055'
+                    name: Övörhangay
+                - iso: ME
+                  iso3: MNE
+                  name: Montenegro
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Andrijevica
+                  - abbr: '02'
+                    name: Bar
+                  - abbr: '03'
+                    name: Berane
+                  - abbr: '04'
+                    name: Bijelo Polje
+                  - abbr: '05'
+                    name: Budva
+                  - abbr: '06'
+                    name: Cetinje
+                  - abbr: '07'
+                    name: Danilovgrad
+                  - abbr: '08'
+                    name: Herceg-Novi
+                  - abbr: '09'
+                    name: Kolašin
+                  - abbr: '10'
+                    name: Kotor
+                  - abbr: '11'
+                    name: Mojkovac
+                  - abbr: '12'
+                    name: Nikšic´
+                  - abbr: '13'
+                    name: Plav
+                  - abbr: '14'
+                    name: Pljevlja
+                  - abbr: '15'
+                    name: Plužine
+                  - abbr: '16'
+                    name: Podgorica
+                  - abbr: '17'
+                    name: Rožaje
+                  - abbr: '19'
+                    name: Tivat
+                  - abbr: '24'
+                    name: Tuzi
+                  - abbr: '20'
+                    name: Ulcinj
+                  - abbr: '18'
+                    name: Šavnik
+                  - abbr: '21'
+                    name: Žabljak
+                  - abbr: '22'
+                    name: Општина Гусиње
+                  - abbr: '23'
+                    name: Општина Петњица
+                - iso: MS
+                  iso3: MSR
+                  name: Montserrat
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: MA
+                  iso3: MAR
+                  name: Morocco
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AGD
+                    name: Agadir*
+                  - abbr: HAO
+                    name: Al Haouz
+                  - abbr: HOC
+                    name: Al Hoceïma
+                  - abbr: AOU
+                    name: Aousserd
+                  - abbr: ASZ
+                    name: Assa-Zag
+                  - abbr: AZI
+                    name: Azilal
+                  - abbr: BAH
+                    name: Aït Baha
+                  - abbr: MEL
+                    name: Aït Melloul
+                  - abbr: BES
+                    name: Ben Slimane
+                  - abbr: BEM
+                    name: Beni Mellal
+                  - abbr: BER
+                    name: Berkane
+                  - abbr: BRR
+                    name: Berrechid
+                  - abbr: BOD
+                    name: Boujdour (EH)
+                  - abbr: BOM
+                    name: Boulemane
+                  - abbr: '05'
+                    name: Béni Mellal-Khénifra
+                  - abbr: CAS
+                    name: Casablanca [Dar el Beïda]
+                  - abbr: '06'
+                    name: Casablanca-Settat
+                  - abbr: CHE
+                    name: Chefchaouene
+                  - abbr: CHI
+                    name: Chichaoua
+                  - abbr: CHT
+                    name: Chtouka-Ait Baha
+                  - abbr: '12'
+                    name: Dakhla-Oued Ed-Dahab (EH)
+                  - abbr: DRI
+                    name: Driouch
+                  - abbr: '08'
+                    name: Drâa-Tafilalet
+                  - abbr: HAJ
+                    name: El Hajeb
+                  - abbr: JDI
+                    name: El Jadida
+                  - abbr: ERR
+                    name: Errachidia
+                  - abbr: ESM
+                    name: Es Smara (EH)
+                  - abbr: ESI
+                    name: Essaouira
+                  - abbr: FAH
+                    name: Fahs-Beni Makada
+                  - abbr: FIG
+                    name: Figuig
+                  - abbr: FQH
+                    name: Fquih Ben Salah
+                  - abbr: FES
+                    name: Fès
+                  - abbr: '03'
+                    name: Fès-Meknès
+                  - abbr: GUE
+                    name: Guelmim
+                  - abbr: '10'
+                    name: Guelmim-Oued Noun (EH-partial)
+                  - abbr: GUF
+                    name: Guercif
+                  - abbr: IFR
+                    name: Ifrane
+                  - abbr: JRA
+                    name: Jerada
+                  - abbr: KES
+                    name: Kelaat Sraghna
+                  - abbr: KHE
+                    name: Khemisset
+                  - abbr: KHN
+                    name: Khenifra
+                  - abbr: KHO
+                    name: Khouribga
+                  - abbr: KEN
+                    name: Kénitra
+                  - abbr: '02'
+                    name: L'Oriental
+                  - abbr: X1~
+                    name: Laayoune-Boujdour-Sakia El Hamra
+                  - abbr: LAR
+                    name: Larache
+                  - abbr: LAA
+                    name: Laâyoune* (EH)
+                  - abbr: '11'
+                    name: Laâyoune-Sakia El Hamra (EH-partial)
+                  - abbr: MAR
+                    name: Marrakech
+                  - abbr: '07'
+                    name: Marrakech-Safi
+                  - abbr: MEK
+                    name: Meknès*
+                  - abbr: MID
+                    name: Midelt
+                  - abbr: MOU
+                    name: Moulay Yacoub
+                  - abbr: MED
+                    name: Médiouna
+                  - abbr: MDF
+                    name: M’diq-Fnideq
+                  - abbr: NAD
+                    name: Nador
+                  - abbr: NOU
+                    name: Nouaceur
+                  - abbr: OUA
+                    name: Ouarzazate
+                  - abbr: OUD
+                    name: Oued ed Dahab (EH)
+                  - abbr: OUZ
+                    name: Ouezzane
+                  - abbr: OUJ
+                    name: Oujda-Angad
+                  - abbr: '04'
+                    name: Rabat-Salé-Kénitra
+                  - abbr: REH
+                    name: Rehamna
+                  - abbr: SAF
+                    name: Safi
+                  - abbr: SAL
+                    name: Salé
+                  - abbr: SEF
+                    name: Sefrou
+                  - abbr: SET
+                    name: Settat
+                  - abbr: SIB
+                    name: Sidi Bennour
+                  - abbr: SIF
+                    name: Sidi Ifni
+                  - abbr: SIK
+                    name: Sidi Kacem
+                  - abbr: SIL
+                    name: Sidi Slimane
+                  - abbr: SYB
+                    name: Sidi Youssef Ben Ali
+                  - abbr: SKH
+                    name: Skhirate-Témara
+                  - abbr: '09'
+                    name: Souss-Massa
+                  - abbr: TNT
+                    name: Tan-Tan
+                  - abbr: TNG
+                    name: Tanger-Assilah
+                  - abbr: '01'
+                    name: Tanger-Tétouan-Al Hoceïma
+                  - abbr: TAO
+                    name: Taounate
+                  - abbr: TAI
+                    name: Taourirt
+                  - abbr: TAF
+                    name: Tarfaya (EH-partial)
+                  - abbr: TAR
+                    name: Taroudannt
+                  - abbr: TAT
+                    name: Tata
+                  - abbr: TAZ
+                    name: Taza
+                  - abbr: TIN
+                    name: Tinghir
+                  - abbr: TIZ
+                    name: Tiznit
+                  - abbr: TET
+                    name: Tétouan*
+                  - abbr: YUS
+                    name: Youssoufia
+                  - abbr: ZAG
+                    name: Zagora
+                  - abbr: RAB
+                    name: الرباط
+                  - abbr: MOH
+                    name: المحمدية
+                  - abbr: INE
+                    name: عمالة إنزكان آيت ملول
+                  - abbr: MMD
+                    name: مراكش
+                  - abbr: MMN
+                    name: مراكش²
+                - iso: MZ
+                  iso3: MOZ
+                  name: Mozambique
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: P
+                    name: Cabo Delgado
+                  - abbr: G
+                    name: Gaza
+                  - abbr: I
+                    name: Inhambane
+                  - abbr: B
+                    name: Manica
+                  - abbr: L
+                    name: Maputo
+                  - abbr: MPM
+                    name: Maputo City
+                  - abbr: "N"
+                    name: Nampula
+                  - abbr: A
+                    name: Niassa
+                  - abbr: S
+                    name: Sofala
+                  - abbr: T
+                    name: Tete
+                  - abbr: Q
+                    name: Zambézia
+                - iso: MM
+                  iso3: MMR
+                  name: Myanmar
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '07'
+                    name: Ayeyarwady
+                  - abbr: '02'
+                    name: Bago
+                  - abbr: '14'
+                    name: Chin
+                  - abbr: '11'
+                    name: Kachin
+                  - abbr: '12'
+                    name: Kayah
+                  - abbr: '13'
+                    name: Kayin
+                  - abbr: '03'
+                    name: Magway
+                  - abbr: '04'
+                    name: Mandalay
+                  - abbr: '15'
+                    name: Mon
+                  - abbr: '16'
+                    name: Rakhine
+                  - abbr: '01'
+                    name: Sagaing
+                  - abbr: '17'
+                    name: Shan
+                  - abbr: '05'
+                    name: Tanintharyi
+                  - abbr: '06'
+                    name: Yangon
+                  - abbr: '18'
+                    name: နေပြည်တော် ပြည်ထောင်စုနယ်မြေ
+                - iso: NA
+                  iso3: NAM
+                  name: Namibia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ER
+                    name: Erongo
+                  - abbr: HA
+                    name: Hardap
+                  - abbr: KA
+                    name: Karas
+                  - abbr: KE
+                    name: Kavango East
+                  - abbr: KW
+                    name: Kavango West
+                  - abbr: KH
+                    name: Khomas
+                  - abbr: KU
+                    name: Kunene
+                  - abbr: OW
+                    name: Ohangwena
+                  - abbr: OH
+                    name: Omaheke
+                  - abbr: OS
+                    name: Omusati
+                  - abbr: 'ON'
+                    name: Oshana
+                  - abbr: OT
+                    name: Oshikoto
+                  - abbr: OD
+                    name: Otjozondjupa
+                  - abbr: CA
+                    name: Zambezi
+                - iso: NR
+                  iso3: NRU
+                  name: Nauru
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: Aiwo
+                  - abbr: '02'
+                    name: Anabar
+                  - abbr: '03'
+                    name: Anetan
+                  - abbr: '04'
+                    name: Anibare
+                  - abbr: '05'
+                    name: Baiti
+                  - abbr: '06'
+                    name: Boe
+                  - abbr: '07'
+                    name: Buada
+                  - abbr: '08'
+                    name: Denigomodu
+                  - abbr: '09'
+                    name: Ewa
+                  - abbr: '10'
+                    name: Ijuw
+                  - abbr: '11'
+                    name: Meneng
+                  - abbr: '12'
+                    name: Nibok
+                  - abbr: '13'
+                    name: Uaboe
+                  - abbr: '14'
+                    name: Yaren
+                - iso: NP
+                  iso3: NPL
+                  name: Nepal
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BA
+                    name: Bagmati
+                  - abbr: P3
+                    name: Bagmati Province
+                  - abbr: BH
+                    name: Bheri
+                  - abbr: DH
+                    name: Dhawalagiri
+                  - abbr: GA
+                    name: Gandaki
+                  - abbr: P4
+                    name: Gandaki Province
+                  - abbr: JA
+                    name: Janakpur
+                  - abbr: KA
+                    name: Karnali
+                  - abbr: P6
+                    name: Karnali Province
+                  - abbr: P1
+                    name: Koshi Province
+                  - abbr: KO
+                    name: Kosi [Koshi]
+                  - abbr: LU
+                    name: Lumbini
+                  - abbr: P5
+                    name: Lumbini Province
+                  - abbr: P2
+                    name: Madhesh Province
+                  - abbr: MA
+                    name: Mahakali
+                  - abbr: ME
+                    name: Mechi
+                  - abbr: NA
+                    name: Narayani
+                  - abbr: RA
+                    name: Rapti
+                  - abbr: SA
+                    name: Sagarmatha
+                  - abbr: SE
+                    name: Seti
+                  - abbr: P7
+                    name: Sudurpashchim Province
+                  - abbr: '3'
+                    name: पश्चिमाञ्चल विकास क्षेत्र
+                  - abbr: '4'
+                    name: पूर्वाञ्चल विकास क्षेत्र
+                  - abbr: '2'
+                    name: मध्य-पश्चिमाञ्चल विकास क्षेत्र
+                  - abbr: '1'
+                    name: मध्यमाञ्चल विकास क्षेत्र
+                  - abbr: '5'
+                    name: सुदूर-पश्चिमाञ्चल विकास क्षेत्र
+                - iso: NL
+                  iso3: NLD
+                  name: Netherlands
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AW
+                    name: Aruba
+                  - abbr: BQ1
+                    name: Bonaire
+                  - abbr: CW
+                    name: Curaçao
+                  - abbr: DR
+                    name: Drenthe
+                  - abbr: FL
+                    name: Flevoland
+                  - abbr: FR
+                    name: Friesland
+                  - abbr: GE
+                    name: Gelderland
+                  - abbr: GR
+                    name: Groningen
+                  - abbr: LI
+                    name: Limburg
+                  - abbr: NB
+                    name: Noord-Brabant
+                  - abbr: NH
+                    name: Noord-Holland
+                  - abbr: OV
+                    name: Overijssel
+                  - abbr: BQ2
+                    name: Saba
+                  - abbr: BQ3
+                    name: Sint Eustatius
+                  - abbr: SX
+                    name: Sint Maarten
+                  - abbr: UT
+                    name: Utrecht
+                  - abbr: ZE
+                    name: Zeeland
+                  - abbr: ZH
+                    name: Zuid-Holland
+                - iso: NC
+                  iso3: NCL
+                  name: New Caledonia
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: NZ
+                  iso3: NZL
+                  name: New Zealand
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AUK
+                    name: Auckland
+                  - abbr: BOP
+                    name: Bay of Plenty
+                  - abbr: CAN
+                    name: Canterbury
+                  - abbr: CIT
+                    name: Chatham Islands Territory
+                  - abbr: GIS
+                    name: Gisborne
+                  - abbr: HKB
+                    name: Hawke's Bay
+                  - abbr: MWT
+                    name: Manawatu-Wanganui
+                  - abbr: MBH
+                    name: Marlborough
+                  - abbr: NSN
+                    name: Nelson
+                  - abbr: NTL
+                    name: Northland
+                  - abbr: OTA
+                    name: Otago
+                  - abbr: STL
+                    name: Southland
+                  - abbr: TKI
+                    name: Taranaki
+                  - abbr: TAS
+                    name: Tasman
+                  - abbr: WKO
+                    name: Waikato
+                  - abbr: WGN
+                    name: Wellington
+                  - abbr: WTC
+                    name: West Coast
+                - iso: NI
+                  iso3: NIC
+                  name: Nicaragua
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AN
+                    name: Atlántico Norte*
+                  - abbr: AS
+                    name: Atlántico Sur*
+                  - abbr: BO
+                    name: Boaco
+                  - abbr: CA
+                    name: Carazo
+                  - abbr: CI
+                    name: Chinandega
+                  - abbr: CO
+                    name: Chontales
+                  - abbr: ES
+                    name: Estelí
+                  - abbr: GR
+                    name: Granada
+                  - abbr: JI
+                    name: Jinotega
+                  - abbr: LE
+                    name: León
+                  - abbr: MD
+                    name: Madriz
+                  - abbr: MN
+                    name: Managua
+                  - abbr: MS
+                    name: Masaya
+                  - abbr: MT
+                    name: Matagalpa
+                  - abbr: NS
+                    name: Nueva Segovia
+                  - abbr: RI
+                    name: Rivas
+                  - abbr: SJ
+                    name: Río San Juan
+                - iso: NE
+                  iso3: NER
+                  name: Niger
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '1'
+                    name: Agadez
+                  - abbr: '2'
+                    name: Diffa
+                  - abbr: '3'
+                    name: Dosso
+                  - abbr: '4'
+                    name: Maradi
+                  - abbr: '8'
+                    name: Niamey
+                  - abbr: '5'
+                    name: Tahoua
+                  - abbr: '6'
+                    name: Tillabéri
+                  - abbr: '7'
+                    name: Zinder
+                - iso: NG
+                  iso3: NGA
+                  name: Nigeria
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AB
+                    name: Abia
+                  - abbr: FC
+                    name: Abuja Capital Territory
+                  - abbr: AD
+                    name: Adamawa
+                  - abbr: AK
+                    name: Akwa Ibom
+                  - abbr: AN
+                    name: Anambra
+                  - abbr: BA
+                    name: Bauchi
+                  - abbr: BY
+                    name: Bayelsa
+                  - abbr: BE
+                    name: Benue
+                  - abbr: BO
+                    name: Borno
+                  - abbr: CR
+                    name: Cross River
+                  - abbr: DE
+                    name: Delta
+                  - abbr: EB
+                    name: Ebonyi
+                  - abbr: ED
+                    name: Edo
+                  - abbr: EK
+                    name: Ekiti
+                  - abbr: EN
+                    name: Enugu
+                  - abbr: GO
+                    name: Gombe
+                  - abbr: IM
+                    name: Imo
+                  - abbr: JI
+                    name: Jigawa
+                  - abbr: KD
+                    name: Kaduna
+                  - abbr: KN
+                    name: Kano
+                  - abbr: KT
+                    name: Katsina
+                  - abbr: KE
+                    name: Kebbi
+                  - abbr: KO
+                    name: Kogi
+                  - abbr: KW
+                    name: Kwara
+                  - abbr: LA
+                    name: Lagos
+                  - abbr: NA
+                    name: Nassarawa
+                  - abbr: NI
+                    name: Niger
+                  - abbr: OG
+                    name: Ogun
+                  - abbr: 'ON'
+                    name: Ondo
+                  - abbr: OS
+                    name: Osun
+                  - abbr: OY
+                    name: Oyo
+                  - abbr: PL
+                    name: Plateau
+                  - abbr: RI
+                    name: Rivers
+                  - abbr: SO
+                    name: Sokoto
+                  - abbr: TA
+                    name: Taraba
+                  - abbr: YO
+                    name: Yobe
+                  - abbr: ZA
+                    name: Zamfara
+                - iso: NU
+                  iso3: NIU
+                  name: Niue
+                  states_required: false
+                  zipcode_required: false
+                  states: []
+                - iso: NF
+                  iso3: NFK
+                  name: Norfolk Island
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: KP
+                  iso3: PRK
+                  name: North Korea
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '07'
+                    name: 강원도
+                  - abbr: '14'
+                    name: 남포특별시
+                  - abbr: '13'
+                    name: 라선특별시
+                  - abbr: '10'
+                    name: 량강도
+                  - abbr: '04'
+                    name: 자강도
+                  - abbr: '02'
+                    name: 평안남도
+                  - abbr: '03'
+                    name: 평안북도
+                  - abbr: '01'
+                    name: 평양직할시
+                  - abbr: '08'
+                    name: 함경남도
+                  - abbr: '09'
+                    name: 함경북도
+                  - abbr: '05'
+                    name: 황해남도
+                  - abbr: '06'
+                    name: 황해북도
+                - iso: MK
+                  iso3: MKD
+                  name: North Macedonia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '801'
+                    name: Aerodrom †
+                  - abbr: '802'
+                    name: Aračinovo
+                  - abbr: '201'
+                    name: Berovo
+                  - abbr: '501'
+                    name: Bitola
+                  - abbr: '401'
+                    name: Bogdanci
+                  - abbr: '601'
+                    name: Bogovinje
+                  - abbr: '402'
+                    name: Bosilovo
+                  - abbr: '602'
+                    name: Brvenica
+                  - abbr: '803'
+                    name: Butel †
+                  - abbr: '313'
+                    name: Centar Župa
+                  - abbr: '814'
+                    name: Centar †
+                  - abbr: '303'
+                    name: Debar
+                  - abbr: '304'
+                    name: Debarca
+                  - abbr: '203'
+                    name: Delčevo
+                  - abbr: '502'
+                    name: Demir Hisar
+                  - abbr: '103'
+                    name: Demir Kapija
+                  - abbr: '406'
+                    name: Dojran
+                  - abbr: '503'
+                    name: Dolneni
+                  - abbr: '804'
+                    name: Gazi Baba †
+                  - abbr: '405'
+                    name: Gevgelija
+                  - abbr: '805'
+                    name: Gjorče Petrov †
+                  - abbr: '604'
+                    name: Gostivar
+                  - abbr: '102'
+                    name: Gradsko
+                  - abbr: '807'
+                    name: Ilinden
+                  - abbr: '606'
+                    name: Jegunovce
+                  - abbr: '205'
+                    name: Karbinci
+                  - abbr: '808'
+                    name: Karpoš †
+                  - abbr: '104'
+                    name: Kavadarci
+                  - abbr: '809'
+                    name: Kisela Voda †
+                  - abbr: '307'
+                    name: Kičevo
+                  - abbr: '407'
+                    name: Konče
+                  - abbr: '206'
+                    name: Kočani
+                  - abbr: '701'
+                    name: Kratovo
+                  - abbr: '702'
+                    name: Kriva Palanka
+                  - abbr: '504'
+                    name: Krivogaštani
+                  - abbr: '505'
+                    name: Kruševo
+                  - abbr: '703'
+                    name: Kumanovo
+                  - abbr: '704'
+                    name: Lipkovo
+                  - abbr: '105'
+                    name: Lozovo
+                  - abbr: '207'
+                    name: Makedonska Kamenica
+                  - abbr: '308'
+                    name: Makedonski Brod
+                  - abbr: '607'
+                    name: Mavrovo i Rostuša
+                  - abbr: '506'
+                    name: Mogila
+                  - abbr: '106'
+                    name: Negotino
+                  - abbr: '507'
+                    name: Novaci
+                  - abbr: '408'
+                    name: Novo Selo
+                  - abbr: '310'
+                    name: Ohrid
+                  - abbr: '208'
+                    name: Pehčevo
+                  - abbr: '810'
+                    name: Petrovec
+                  - abbr: '311'
+                    name: Plasnica
+                  - abbr: '508'
+                    name: Prilep
+                  - abbr: '209'
+                    name: Probištip
+                  - abbr: '409'
+                    name: Radoviš
+                  - abbr: '705'
+                    name: Rankovce
+                  - abbr: '509'
+                    name: Resen
+                  - abbr: '107'
+                    name: Rosoman
+                  - abbr: '811'
+                    name: Saraj †
+                  - abbr: '812'
+                    name: Sopište
+                  - abbr: '706'
+                    name: Staro Nagoričane
+                  - abbr: '312'
+                    name: Struga
+                  - abbr: '410'
+                    name: Strumica
+                  - abbr: '813'
+                    name: Studeničani
+                  - abbr: '108'
+                    name: Sveti Nikole
+                  - abbr: '608'
+                    name: Tearce
+                  - abbr: '609'
+                    name: Tetovo
+                  - abbr: '403'
+                    name: Valandovo
+                  - abbr: '404'
+                    name: Vasilevo
+                  - abbr: '101'
+                    name: Veles
+                  - abbr: '301'
+                    name: Vevčani
+                  - abbr: '202'
+                    name: Vinica
+                  - abbr: '603'
+                    name: Vrapčište
+                  - abbr: '806'
+                    name: Zelenikovo
+                  - abbr: '204'
+                    name: Zrnovci
+                  - abbr: '815'
+                    name: Čair †
+                  - abbr: '109'
+                    name: Čaška
+                  - abbr: '210'
+                    name: Češinovo-Obleševo
+                  - abbr: '816'
+                    name: Čučer-Sandevo
+                  - abbr: '211'
+                    name: Štip
+                  - abbr: '817'
+                    name: Šuto Orizari †
+                  - abbr: '605'
+                    name: Želino
+                - iso: MP
+                  iso3: MNP
+                  name: Northern Mariana Islands
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: 'NO'
+                  iso3: NOR
+                  name: Norway
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '42'
+                    name: Agder
+                  - abbr: '34'
+                    name: Innlandet
+                  - abbr: '22'
+                    name: Jan Mayen (Arctic Region)
+                  - abbr: '15'
+                    name: Møre og Romsdal
+                  - abbr: '18'
+                    name: Nordland
+                  - abbr: '03'
+                    name: Oslo
+                  - abbr: '11'
+                    name: Rogaland
+                  - abbr: '21'
+                    name: Svalbard (Arctic Region)
+                  - abbr: '54'
+                    name: Troms og Finnmark
+                  - abbr: '50'
+                    name: Trøndelag
+                  - abbr: '38'
+                    name: Vestfold og Telemark
+                  - abbr: '46'
+                    name: Vestland
+                  - abbr: '30'
+                    name: Viken
+                - iso: OM
+                  iso3: OMN
+                  name: Oman
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: DA
+                    name: Ad Dakhiliyah
+                  - abbr: ZA
+                    name: Adh Dhahirah
+                  - abbr: WU
+                    name: Al Wustá
+                  - abbr: MA
+                    name: Masqat
+                  - abbr: MU
+                    name: Musandam
+                  - abbr: BU
+                    name: محافظة البريمي
+                  - abbr: BJ
+                    name: محافظة جنوب الباطنة
+                  - abbr: SJ
+                    name: محافظة جنوب الشرقية
+                  - abbr: BS
+                    name: محافظة شمال الباطنة
+                  - abbr: SS
+                    name: محافظة شمال الشرقية
+                  - abbr: ZU
+                    name: محافظة ظفار
+                - iso: PK
+                  iso3: PAK
+                  name: Pakistan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: JK
+                    name: Azad Kashmir
+                  - abbr: BA
+                    name: Baluchistan (en)
+                  - abbr: GB
+                    name: Gilgit-Baltistan
+                  - abbr: IS
+                    name: Islamabad
+                  - abbr: KP
+                    name: Khyber Pakhtunkhwa
+                  - abbr: PB
+                    name: Punjab
+                  - abbr: SD
+                    name: Sind (en)
+                - iso: PW
+                  iso3: PLW
+                  name: Palau
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '002'
+                    name: Aimeliik
+                  - abbr: '004'
+                    name: Airai
+                  - abbr: '010'
+                    name: Angaur
+                  - abbr: '050'
+                    name: Hatobohei
+                  - abbr: '100'
+                    name: Kayangel
+                  - abbr: '150'
+                    name: Koror
+                  - abbr: '212'
+                    name: Melekeok
+                  - abbr: '214'
+                    name: Ngaraard
+                  - abbr: '218'
+                    name: Ngarchelong
+                  - abbr: '222'
+                    name: Ngardmau
+                  - abbr: '224'
+                    name: Ngatpang
+                  - abbr: '226'
+                    name: Ngchesar
+                  - abbr: '227'
+                    name: Ngeremlengui
+                  - abbr: '228'
+                    name: Ngiwal
+                  - abbr: '350'
+                    name: Peleliu
+                  - abbr: '370'
+                    name: Sonsorol
+                - iso: PS
+                  iso3: PSE
+                  name: Palestine, State of
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: JRH
+                    name: أريحا
+                  - abbr: JEM
+                    name: القدس
+                  - abbr: DEB
+                    name: الوسطى
+                  - abbr: JEN
+                    name: جنين
+                  - abbr: RBH
+                    name: رام الله والبيرة
+                  - abbr: NGZ
+                    name: شمال غزة
+                  - abbr: HBN
+                    name: محافظة الخليل
+                  - abbr: BTH
+                    name: محافظة بيت لحم
+                  - abbr: KYS
+                    name: محافظة خان يونس
+                  - abbr: RFH
+                    name: محافظة رفح الفلسطينية
+                  - abbr: SLT
+                    name: محافظة سلفيت
+                  - abbr: TBS
+                    name: محافظة طوباس
+                  - abbr: TKM
+                    name: محافظة طولكرم
+                  - abbr: GZA
+                    name: محافظة غزة
+                  - abbr: QQA
+                    name: محافظة قلقيلية
+                  - abbr: NBS
+                    name: محافظة نابلس
+                - iso: PA
+                  iso3: PAN
+                  name: Panama
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '1'
+                    name: Bocas del Toro
+                  - abbr: '4'
+                    name: Chiriquí
+                  - abbr: '2'
+                    name: Coclé
+                  - abbr: '3'
+                    name: Colón
+                  - abbr: '5'
+                    name: Darién
+                  - abbr: EM
+                    name: Emberá-Wounaan
+                  - abbr: KY
+                    name: Guna Yala
+                  - abbr: '6'
+                    name: Herrera
+                  - abbr: '7'
+                    name: Los Santos
+                  - abbr: NB
+                    name: Ngäbe-Buglé
+                  - abbr: '8'
+                    name: Panamá
+                  - abbr: '10'
+                    name: Panamá Oeste
+                  - abbr: '9'
+                    name: Veraguas
+                - iso: PG
+                  iso3: PNG
+                  name: Papua New Guinea
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: NSB
+                    name: Bougainville
+                  - abbr: CPM
+                    name: Central
+                  - abbr: CPK
+                    name: Chimbu
+                  - abbr: EBR
+                    name: East New Britain
+                  - abbr: ESW
+                    name: East Sepik
+                  - abbr: EHG
+                    name: Eastern Highlands
+                  - abbr: EPW
+                    name: Enga
+                  - abbr: GPK
+                    name: Gulf
+                  - abbr: HLA
+                    name: Hela
+                  - abbr: JWK
+                    name: Jiwaka
+                  - abbr: MPM
+                    name: Madang
+                  - abbr: MRL
+                    name: Manus
+                  - abbr: MBA
+                    name: Milne Bay
+                  - abbr: MPL
+                    name: Morobe
+                  - abbr: NCD
+                    name: National Capital District (Port Moresby)
+                  - abbr: NIK
+                    name: New Ireland
+                  - abbr: NPP
+                    name: Northern
+                  - abbr: SAN
+                    name: Sandaun [West Sepik]
+                  - abbr: SHM
+                    name: Southern Highlands
+                  - abbr: WBK
+                    name: West New Britain
+                  - abbr: WPD
+                    name: Western
+                  - abbr: WHM
+                    name: Western Highlands
+                - iso: PY
+                  iso3: PRY
+                  name: Paraguay
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '16'
+                    name: Alto Paraguay
+                  - abbr: '10'
+                    name: Alto Paraná
+                  - abbr: '13'
+                    name: Amambay
+                  - abbr: ASU
+                    name: Asunción
+                  - abbr: '19'
+                    name: Boquerón
+                  - abbr: '5'
+                    name: Caaguazú
+                  - abbr: '6'
+                    name: Caazapá
+                  - abbr: '14'
+                    name: Canindeyú
+                  - abbr: '11'
+                    name: Central
+                  - abbr: '1'
+                    name: Concepción
+                  - abbr: '3'
+                    name: Cordillera
+                  - abbr: '4'
+                    name: Guairá
+                  - abbr: '7'
+                    name: Itapúa
+                  - abbr: '8'
+                    name: Misiones
+                  - abbr: '9'
+                    name: Paraguarí
+                  - abbr: '15'
+                    name: Presidente Hayes
+                  - abbr: '2'
+                    name: San Pedro
+                  - abbr: '12'
+                    name: Ñeembucú
+                - iso: PE
+                  iso3: PER
+                  name: Peru
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AMA
+                    name: Amazonas
+                  - abbr: ANC
+                    name: Ancash
+                  - abbr: APU
+                    name: Apurímac
+                  - abbr: ARE
+                    name: Arequipa
+                  - abbr: AYA
+                    name: Ayacucho
+                  - abbr: CAJ
+                    name: Cajamarca
+                  - abbr: CUS
+                    name: Cuzco [Cusco]
+                  - abbr: CAL
+                    name: El Callao
+                  - abbr: HUV
+                    name: Huancavelica
+                  - abbr: HUC
+                    name: Huánuco
+                  - abbr: ICA
+                    name: Ica
+                  - abbr: JUN
+                    name: Junín
+                  - abbr: LAL
+                    name: La Libertad
+                  - abbr: LAM
+                    name: Lambayeque
+                  - abbr: LIM
+                    name: Lima
+                  - abbr: LMA
+                    name: Lima Metropolitana
+                  - abbr: LOR
+                    name: Loreto
+                  - abbr: MDD
+                    name: Madre de Dios
+                  - abbr: MOQ
+                    name: Moquegua
+                  - abbr: PAS
+                    name: Pasco
+                  - abbr: PIU
+                    name: Piura
+                  - abbr: PUN
+                    name: Puno
+                  - abbr: SAM
+                    name: San Martín
+                  - abbr: TAC
+                    name: Tacna
+                  - abbr: TUM
+                    name: Tumbes
+                  - abbr: UCA
+                    name: Ucayali
+                - iso: PH
+                  iso3: PHL
+                  name: Philippines
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ABR
+                    name: Abra
+                  - abbr: AGN
+                    name: Agusan del Norte
+                  - abbr: AGS
+                    name: Agusan del Sur
+                  - abbr: AKL
+                    name: Aklan
+                  - abbr: ALB
+                    name: Albay
+                  - abbr: ANT
+                    name: Antique
+                  - abbr: APA
+                    name: Apayao
+                  - abbr: AUR
+                    name: Aurora
+                  - abbr: BAS
+                    name: Basilan
+                  - abbr: BAN
+                    name: Bataan
+                  - abbr: BTN
+                    name: Batanes
+                  - abbr: BTG
+                    name: Batangas
+                  - abbr: BEN
+                    name: Benguet
+                  - abbr: '05'
+                    name: Bicol
+                  - abbr: BIL
+                    name: Biliran
+                  - abbr: BOH
+                    name: Bohol
+                  - abbr: BUK
+                    name: Bukidnon
+                  - abbr: BUL
+                    name: Bulacan
+                  - abbr: CAG
+                    name: Cagayan
+                  - abbr: '02'
+                    name: Cagayan Valley
+                  - abbr: '40'
+                    name: Calabarzon
+                  - abbr: CAN
+                    name: Camarines Norte
+                  - abbr: CAS
+                    name: Camarines Sur
+                  - abbr: CAM
+                    name: Camiguin
+                  - abbr: CAP
+                    name: Capiz
+                  - abbr: '13'
+                    name: Caraga
+                  - abbr: CAT
+                    name: Catanduanes
+                  - abbr: CAV
+                    name: Cavite
+                  - abbr: CEB
+                    name: Cebu
+                  - abbr: '03'
+                    name: Central Luzon
+                  - abbr: '07'
+                    name: Central Visayas
+                  - abbr: COM
+                    name: Compostela Valley
+                  - abbr: '15'
+                    name: Cordillera Administrative
+                  - abbr: '11'
+                    name: Davao
+                  - abbr: DVO
+                    name: Davao Occidental
+                  - abbr: DAO
+                    name: Davao Oriental
+                  - abbr: DAV
+                    name: Davao del Norte
+                  - abbr: DAS
+                    name: Davao del Sur
+                  - abbr: DIN
+                    name: Dinagat Islands
+                  - abbr: EAS
+                    name: Eastern Samar
+                  - abbr: '08'
+                    name: Eastern Visayas
+                  - abbr: GUI
+                    name: Guimaras
+                  - abbr: IFU
+                    name: Ifugao
+                  - abbr: '01'
+                    name: Ilocos
+                  - abbr: ILN
+                    name: Ilocos Norte
+                  - abbr: ILS
+                    name: Ilocos Sur
+                  - abbr: ILI
+                    name: Iloilo
+                  - abbr: ISA
+                    name: Isabela
+                  - abbr: KAL
+                    name: Kalinga
+                  - abbr: LUN
+                    name: La Union
+                  - abbr: LAG
+                    name: Laguna
+                  - abbr: LAN
+                    name: Lanao del Norte
+                  - abbr: LAS
+                    name: Lanao del Sur
+                  - abbr: LEY
+                    name: Leyte
+                  - abbr: MAG
+                    name: Maguindanao
+                  - abbr: MAD
+                    name: Marinduque
+                  - abbr: MAS
+                    name: Masbate
+                  - abbr: '41'
+                    name: Mimaropa
+                  - abbr: MDC
+                    name: Mindoro Occidental
+                  - abbr: MDR
+                    name: Mindoro Oriental
+                  - abbr: MSC
+                    name: Misamis Occidental
+                  - abbr: MSR
+                    name: Misamis Oriental
+                  - abbr: MOU
+                    name: Mountain Province
+                  - abbr: '14'
+                    name: Muslim Mindanao
+                  - abbr: '00'
+                    name: National Capital Region
+                  - abbr: NEC
+                    name: Negros Occidental
+                  - abbr: NER
+                    name: Negros Oriental
+                  - abbr: NCO
+                    name: North Cotabato
+                  - abbr: '10'
+                    name: Northern Mindanao
+                  - abbr: NSA
+                    name: Northern Samar
+                  - abbr: NUE
+                    name: Nueva Ecija
+                  - abbr: NUV
+                    name: Nueva Vizcaya
+                  - abbr: PLW
+                    name: Palawan
+                  - abbr: PAM
+                    name: Pampanga
+                  - abbr: PAN
+                    name: Pangasinan
+                  - abbr: QUE
+                    name: Quezon
+                  - abbr: QUI
+                    name: Quirino
+                  - abbr: RIZ
+                    name: Rizal
+                  - abbr: ROM
+                    name: Romblon
+                  - abbr: SAR
+                    name: Sarangani
+                  - abbr: SIG
+                    name: Siquijor
+                  - abbr: '12'
+                    name: Soccsksargen
+                  - abbr: SOR
+                    name: Sorsogon
+                  - abbr: SCO
+                    name: South Cotabato
+                  - abbr: SLE
+                    name: Southern Leyte
+                  - abbr: SUK
+                    name: Sultan Kudarat
+                  - abbr: SLU
+                    name: Sulu
+                  - abbr: SUN
+                    name: Surigao del Norte
+                  - abbr: SUR
+                    name: Surigao del Sur
+                  - abbr: TAR
+                    name: Tarlac
+                  - abbr: TAW
+                    name: Tawi-Tawi
+                  - abbr: WSA
+                    name: Western Samar
+                  - abbr: '06'
+                    name: Western Visayas
+                  - abbr: ZMB
+                    name: Zambales
+                  - abbr: '09'
+                    name: Zamboanga Peninsula
+                  - abbr: ZSI
+                    name: Zamboanga Sibuguey [Zamboanga Sibugay]
+                  - abbr: ZAN
+                    name: Zamboanga del Norte
+                  - abbr: ZAS
+                    name: Zamboanga del Sur
+                - iso: PN
+                  iso3: PCN
+                  name: Pitcairn
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: PL
+                  iso3: POL
+                  name: Poland
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '02'
+                    name: Dolnośląskie
+                  - abbr: '04'
+                    name: Kujawsko-pomorskie
+                  - abbr: '06'
+                    name: Lubelskie
+                  - abbr: '08'
+                    name: Lubuskie
+                  - abbr: '14'
+                    name: Mazowieckie
+                  - abbr: '12'
+                    name: Małopolskie
+                  - abbr: '16'
+                    name: Opolskie
+                  - abbr: '18'
+                    name: Podkarpackie
+                  - abbr: '20'
+                    name: Podlaskie
+                  - abbr: '22'
+                    name: Pomorskie
+                  - abbr: '28'
+                    name: Warmińsko-mazurskie
+                  - abbr: '30'
+                    name: Wielkopolskie
+                  - abbr: '32'
+                    name: Zachodniopomorskie
+                  - abbr: '10'
+                    name: Łódzkie
+                  - abbr: '24'
+                    name: Śląskie
+                  - abbr: '26'
+                    name: Świętokrzyskie
+                - iso: PT
+                  iso3: PRT
+                  name: Portugal
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Aveiro
+                  - abbr: '20'
+                    name: Açores
+                  - abbr: '02'
+                    name: Beja
+                  - abbr: '03'
+                    name: Braga
+                  - abbr: '04'
+                    name: Bragança
+                  - abbr: '05'
+                    name: Castelo Branco
+                  - abbr: '06'
+                    name: Coimbra
+                  - abbr: '08'
+                    name: Faro
+                  - abbr: '09'
+                    name: Guarda
+                  - abbr: '10'
+                    name: Leiria
+                  - abbr: '11'
+                    name: Lisboa
+                  - abbr: '30'
+                    name: Madeira
+                  - abbr: '12'
+                    name: Portalegre
+                  - abbr: '13'
+                    name: Porto
+                  - abbr: '14'
+                    name: Santarém
+                  - abbr: '15'
+                    name: Setúbal
+                  - abbr: '16'
+                    name: Viana do Castelo
+                  - abbr: '17'
+                    name: Vila Real
+                  - abbr: '18'
+                    name: Viseu
+                  - abbr: '07'
+                    name: Évora
+                - iso: PR
+                  iso3: PRI
+                  name: Puerto Rico
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: QA
+                  iso3: QAT
+                  name: Qatar
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: DA
+                    name: Ad Dawhah
+                  - abbr: KH
+                    name: Al Khawr
+                  - abbr: WA
+                    name: Al Wakrah
+                  - abbr: RA
+                    name: Ar Rayyan
+                  - abbr: MS
+                    name: Madinat ash Shamal
+                  - abbr: US
+                    name: Umm Salal
+                  - abbr: SH
+                    name: الشحانية
+                  - abbr: ZA
+                    name: بلدية الضعاين
+                - iso: RO
+                  iso3: ROU
+                  name: Romania
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AB
+                    name: Alba
+                  - abbr: AR
+                    name: Arad
+                  - abbr: AG
+                    name: Arges
+                  - abbr: BC
+                    name: Bacau
+                  - abbr: BH
+                    name: Bihor
+                  - abbr: BN
+                    name: Bistrita-Nasaud
+                  - abbr: BT
+                    name: Botosani
+                  - abbr: BR
+                    name: Braila
+                  - abbr: BV
+                    name: Brasov
+                  - abbr: B
+                    name: Bucuresti
+                  - abbr: BZ
+                    name: Buzau
+                  - abbr: CL
+                    name: Calarasi
+                  - abbr: CS
+                    name: Caras-Severin
+                  - abbr: CJ
+                    name: Cluj
+                  - abbr: CT
+                    name: Constanta
+                  - abbr: CV
+                    name: Covasna
+                  - abbr: DJ
+                    name: Dolj
+                  - abbr: DB
+                    name: Dâmbovita
+                  - abbr: GL
+                    name: Galati
+                  - abbr: GR
+                    name: Giurgiu
+                  - abbr: GJ
+                    name: Gorj
+                  - abbr: HR
+                    name: Harghita
+                  - abbr: HD
+                    name: Hunedoara
+                  - abbr: IL
+                    name: Ialomita
+                  - abbr: IS
+                    name: Iasi
+                  - abbr: IF
+                    name: Ilfov
+                  - abbr: MM
+                    name: Maramures
+                  - abbr: MH
+                    name: Mehedinti
+                  - abbr: MS
+                    name: Mures
+                  - abbr: NT
+                    name: Neamt
+                  - abbr: OT
+                    name: Olt
+                  - abbr: PH
+                    name: Prahova
+                  - abbr: SJ
+                    name: Salaj
+                  - abbr: SM
+                    name: Satu Mare
+                  - abbr: SB
+                    name: Sibiu
+                  - abbr: SV
+                    name: Suceava
+                  - abbr: TR
+                    name: Teleorman
+                  - abbr: TM
+                    name: Timis
+                  - abbr: TL
+                    name: Tulcea
+                  - abbr: VS
+                    name: Vaslui
+                  - abbr: VN
+                    name: Vrancea
+                  - abbr: VL
+                    name: Vâlcea
+                - iso: RU
+                  iso3: RUS
+                  name: Russian Federation
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AD
+                    name: Adygeya, Respublika
+                  - abbr: AL
+                    name: Altay, Respublika
+                  - abbr: ALT
+                    name: Altayskiy kray
+                  - abbr: AMU
+                    name: Amurskaya oblast'
+                  - abbr: ARK
+                    name: Arkhangel'skaya oblast'
+                  - abbr: AST
+                    name: Astrakhanskaya oblast'
+                  - abbr: BA
+                    name: Bashkortostan, Respublika
+                  - abbr: BEL
+                    name: Belgorodskaya oblast'
+                  - abbr: BRY
+                    name: Bryanskaya oblast'
+                  - abbr: BU
+                    name: Buryatiya, Respublika
+                  - abbr: CE
+                    name: Chechenskaya Respublika
+                  - abbr: CHE
+                    name: Chelyabinskaya oblast'
+                  - abbr: CHU
+                    name: Chukotskiy avtonomnyy okrug
+                  - abbr: CU
+                    name: Chuvashskaya Respublika
+                  - abbr: DA
+                    name: Dagestan, Respublika
+                  - abbr: IN
+                    name: Ingushskaya Respublika [Respublika Ingushetiya]
+                  - abbr: IRK
+                    name: Irkutskaya oblast'
+                  - abbr: IVA
+                    name: Ivanovskaya oblast'
+                  - abbr: KB
+                    name: Kabardino-Balkarskaya Respublika
+                  - abbr: KGD
+                    name: Kaliningradskaya oblast'
+                  - abbr: KL
+                    name: Kalmykiya, Respublika
+                  - abbr: KLU
+                    name: Kaluzhskaya oblast'
+                  - abbr: KAM
+                    name: Kamchatskaya oblast'
+                  - abbr: KC
+                    name: Karachayevo-Cherkesskaya Respublika
+                  - abbr: KR
+                    name: Kareliya, Respublika
+                  - abbr: KEM
+                    name: Kemerovskaya oblast'
+                  - abbr: KHA
+                    name: Khabarovskiy kray
+                  - abbr: KK
+                    name: Khakasiya, Respublika
+                  - abbr: KHM
+                    name: Khanty-Mansiyskiy avtonomnyy okrug [Yugra]
+                  - abbr: KIR
+                    name: Kirovskaya oblast'
+                  - abbr: KO
+                    name: Komi, Respublika
+                  - abbr: KOS
+                    name: Kostromskaya oblast'
+                  - abbr: KDA
+                    name: Krasnodarskiy kray
+                  - abbr: KYA
+                    name: Krasnoyarskiy kray
+                  - abbr: KGN
+                    name: Kurganskaya oblast'
+                  - abbr: KRS
+                    name: Kurskaya oblast'
+                  - abbr: LEN
+                    name: Leningradskaya oblast'
+                  - abbr: LIP
+                    name: Lipetskaya oblast'
+                  - abbr: MAG
+                    name: Magadanskaya oblast'
+                  - abbr: ME
+                    name: Mariy El, Respublika
+                  - abbr: MO
+                    name: Mordoviya, Respublika
+                  - abbr: MOS
+                    name: Moskovskaya oblast'
+                  - abbr: MOW
+                    name: Moskva
+                  - abbr: MUR
+                    name: Murmanskaya oblast'
+                  - abbr: NEN
+                    name: Nenetskiy avtonomnyy okrug
+                  - abbr: NIZ
+                    name: Nizhegorodskaya oblast'
+                  - abbr: NGR
+                    name: Novgorodskaya oblast'
+                  - abbr: NVS
+                    name: Novosibirskaya oblast'
+                  - abbr: OMS
+                    name: Omskaya oblast'
+                  - abbr: ORE
+                    name: Orenburgskaya oblast'
+                  - abbr: ORL
+                    name: Orlovskaya oblast'
+                  - abbr: PNZ
+                    name: Penzenskaya oblast'
+                  - abbr: PER
+                    name: Perm
+                  - abbr: PRI
+                    name: Primorskiy kray
+                  - abbr: PSK
+                    name: Pskovskaya oblast'
+                  - abbr: ROS
+                    name: Rostovskaya oblast'
+                  - abbr: RYA
+                    name: Ryazanskaya oblast'
+                  - abbr: SA
+                    name: Sakha, Respublika [Yakutiya]
+                  - abbr: SAK
+                    name: Sakhalinskaya oblast'
+                  - abbr: SAM
+                    name: Samarskaya oblast'
+                  - abbr: SPE
+                    name: Sankt-Peterburg
+                  - abbr: SAR
+                    name: Saratovskaya oblast'
+                  - abbr: SE
+                    name: Severnaya Osetiya, Respublika [Alaniya] [Respublika Severnaya
+                      Osetiya-Alaniya]
+                  - abbr: SMO
+                    name: Smolenskaya oblast'
+                  - abbr: STA
+                    name: Stavropol'skiy kray
+                  - abbr: SVE
+                    name: Sverdlovskaya oblast'
+                  - abbr: TAM
+                    name: Tambovskaya oblast'
+                  - abbr: TA
+                    name: Tatarstan, Respublika
+                  - abbr: TOM
+                    name: Tomskaya oblast'
+                  - abbr: TUL
+                    name: Tul'skaya oblast'
+                  - abbr: TVE
+                    name: Tverskaya oblast'
+                  - abbr: TYU
+                    name: Tyumenskaya oblast'
+                  - abbr: TY
+                    name: Tyva, Respublika [Tuva]
+                  - abbr: UD
+                    name: Udmurtskaya Respublika
+                  - abbr: ULY
+                    name: Ul'yanovskaya oblast'
+                  - abbr: VLA
+                    name: Vladimirskaya oblast'
+                  - abbr: VGG
+                    name: Volgogradskaya oblast'
+                  - abbr: VLG
+                    name: Vologodskaya oblast'
+                  - abbr: VOR
+                    name: Voronezhskaya oblast'
+                  - abbr: YAN
+                    name: Yamalo-Nenetskiy avtonomnyy okrug
+                  - abbr: YAR
+                    name: Yaroslavskaya oblast'
+                  - abbr: YEV
+                    name: Yevreyskaya avtonomnaya oblast'
+                  - abbr: ZAB
+                    name: Zabaykal'skij kray
+                - iso: RW
+                  iso3: RWA
+                  name: Rwanda
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '02'
+                    name: Est
+                  - abbr: '03'
+                    name: Nord
+                  - abbr: '04'
+                    name: Ouest
+                  - abbr: '05'
+                    name: Sud
+                  - abbr: '01'
+                    name: Ville de Kigali
+                - iso: RE
+                  iso3: REU
+                  name: Réunion
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: BL
+                  iso3: BLM
+                  name: Saint Barthélemy
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: SH
+                  iso3: SHN
+                  name: Saint Helena, Ascension and Tristan da Cunha
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AC
+                    name: Ascension
+                  - abbr: HL
+                    name: Saint Helena
+                  - abbr: TA
+                    name: Tristan da Cunha
+                - iso: KN
+                  iso3: KNA
+                  name: Saint Kitts and Nevis
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: Christ Church Nichola Town
+                  - abbr: "N"
+                    name: Nevis
+                  - abbr: '02'
+                    name: Saint Anne Sandy Point
+                  - abbr: '03'
+                    name: Saint George Basseterre
+                  - abbr: '04'
+                    name: Saint George Gingerland
+                  - abbr: '05'
+                    name: Saint James Windward
+                  - abbr: '06'
+                    name: Saint John Capisterre
+                  - abbr: '07'
+                    name: Saint John Figtree
+                  - abbr: K
+                    name: Saint Kitts
+                  - abbr: '08'
+                    name: Saint Mary Cayon
+                  - abbr: '09'
+                    name: Saint Paul Capisterre
+                  - abbr: '10'
+                    name: Saint Paul Charlestown
+                  - abbr: '11'
+                    name: Saint Peter Basseterre
+                  - abbr: '12'
+                    name: Saint Thomas Lowland
+                  - abbr: '13'
+                    name: Saint Thomas Middle Island
+                  - abbr: '15'
+                    name: Trinity Palmetto Point
+                - iso: LC
+                  iso3: LCA
+                  name: Saint Lucia
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: Anse la Raye
+                  - abbr: '12'
+                    name: Canaries
+                  - abbr: '02'
+                    name: Castries
+                  - abbr: '03'
+                    name: Choiseul
+                  - abbr: '05'
+                    name: Dennery
+                  - abbr: '06'
+                    name: Gros Islet
+                  - abbr: '07'
+                    name: Laborie
+                  - abbr: '08'
+                    name: Micoud
+                  - abbr: '10'
+                    name: Soufrière
+                  - abbr: '11'
+                    name: Vieux Fort
+                - iso: MF
+                  iso3: MAF
+                  name: Saint Martin (French part)
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: PM
+                  iso3: SPM
+                  name: Saint Pierre and Miquelon
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: VC
+                  iso3: VCT
+                  name: Saint Vincent and the Grenadines
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Charlotte
+                  - abbr: '06'
+                    name: Grenadines
+                  - abbr: '02'
+                    name: Saint Andrew
+                  - abbr: '03'
+                    name: Saint David
+                  - abbr: '04'
+                    name: Saint George
+                  - abbr: '05'
+                    name: Saint Patrick
+                - iso: WS
+                  iso3: WSM
+                  name: Samoa
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AA
+                    name: A'ana
+                  - abbr: AL
+                    name: Aiga-i-le-Tai
+                  - abbr: AT
+                    name: Atua
+                  - abbr: FA
+                    name: Fa'asaleleaga
+                  - abbr: GE
+                    name: Gaga'emauga
+                  - abbr: GI
+                    name: Gagaifomauga
+                  - abbr: PA
+                    name: Palauli
+                  - abbr: SA
+                    name: Satupa'itea
+                  - abbr: TU
+                    name: Tuamasaga
+                  - abbr: VF
+                    name: Va'a-o-Fonoti
+                  - abbr: VS
+                    name: Vaisigano
+                - iso: SM
+                  iso3: SMR
+                  name: San Marino
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Acquaviva
+                  - abbr: '06'
+                    name: Borgo Maggiore
+                  - abbr: '02'
+                    name: Chiesanuova
+                  - abbr: '03'
+                    name: Domagnano
+                  - abbr: '04'
+                    name: Faetano
+                  - abbr: '05'
+                    name: Fiorentino
+                  - abbr: '08'
+                    name: Montegiardino
+                  - abbr: '07'
+                    name: San Marino
+                  - abbr: '09'
+                    name: Serravalle
+                - iso: ST
+                  iso3: STP
+                  name: Sao Tome and Principe
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '02'
+                    name: Cantagalo
+                  - abbr: '03'
+                    name: Caué
+                  - abbr: '04'
+                    name: Lembá
+                  - abbr: '05'
+                    name: Lobata
+                  - abbr: '06'
+                    name: Mé-Zóchi
+                  - abbr: P
+                    name: Príncipe
+                  - abbr: '01'
+                    name: Água Grande
+                - iso: SA
+                  iso3: SAU
+                  name: Saudi Arabia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '14'
+                    name: "'Asīr"
+                  - abbr: '11'
+                    name: Al Bāḩah
+                  - abbr: '12'
+                    name: Al Jawf
+                  - abbr: '03'
+                    name: Al Madinah
+                  - abbr: '05'
+                    name: Al Qasim
+                  - abbr: '08'
+                    name: Al Ḩudūd ash Shamālīyah
+                  - abbr: '01'
+                    name: Ar Riyāḑ
+                  - abbr: '04'
+                    name: Ash Sharqiyah
+                  - abbr: '09'
+                    name: Jāzān
+                  - abbr: '02'
+                    name: Makkah al Mukarramah
+                  - abbr: '10'
+                    name: Najrān
+                  - abbr: '07'
+                    name: Tabūk
+                  - abbr: '06'
+                    name: Ḩā'il
+                - iso: SN
+                  iso3: SEN
+                  name: Senegal
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: DK
+                    name: Dakar
+                  - abbr: DB
+                    name: Diourbel
+                  - abbr: FK
+                    name: Fatick
+                  - abbr: KA
+                    name: Kaffrine
+                  - abbr: KL
+                    name: Kaolack
+                  - abbr: KD
+                    name: Kolda
+                  - abbr: KE
+                    name: Kédougou
+                  - abbr: LG
+                    name: Louga
+                  - abbr: MT
+                    name: Matam
+                  - abbr: SL
+                    name: Saint-Louis
+                  - abbr: SE
+                    name: Sédhiou
+                  - abbr: TC
+                    name: Tambacounda
+                  - abbr: TH
+                    name: Thiès
+                  - abbr: ZG
+                    name: Ziguinchor
+                - iso: RS
+                  iso3: SRB
+                  name: Serbia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '00'
+                    name: Belgrade
+                  - abbr: '14'
+                    name: Bor
+                  - abbr: '11'
+                    name: Branicevo
+                  - abbr: '23'
+                    name: Jablanica
+                  - abbr: '06'
+                    name: Južna Backa
+                  - abbr: '04'
+                    name: Južni Banat
+                  - abbr: '09'
+                    name: Kolubara
+                  - abbr: '25'
+                    name: Kosovo
+                  - abbr: '29'
+                    name: Kosovo-Pomoravlje
+                  - abbr: '28'
+                    name: Kosovska Mitrovica
+                  - abbr: '08'
+                    name: Macva
+                  - abbr: '17'
+                    name: Moravica
+                  - abbr: '20'
+                    name: Nišava
+                  - abbr: '24'
+                    name: Pcinja
+                  - abbr: '26'
+                    name: Pec´
+                  - abbr: '22'
+                    name: Pirot
+                  - abbr: '10'
+                    name: Podunavlje
+                  - abbr: '13'
+                    name: Pomoravlje
+                  - abbr: '27'
+                    name: Prizren
+                  - abbr: '19'
+                    name: Rasina
+                  - abbr: '18'
+                    name: Raška
+                  - abbr: '01'
+                    name: Severna Backa
+                  - abbr: '03'
+                    name: Severni Banat
+                  - abbr: '02'
+                    name: Srednji Banat
+                  - abbr: '07'
+                    name: Srem
+                  - abbr: '21'
+                    name: Toplica
+                  - abbr: '15'
+                    name: Zajecar
+                  - abbr: '05'
+                    name: Zapadna Backa
+                  - abbr: '16'
+                    name: Zlatibor
+                  - abbr: '12'
+                    name: Šumadija
+                  - abbr: VO
+                    name: Војводина
+                  - abbr: KM
+                    name: Косово и Метохија
+                - iso: SC
+                  iso3: SYC
+                  name: Seychelles
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '02'
+                    name: Anse Boileau
+                  - abbr: '04'
+                    name: Anse Louis
+                  - abbr: '05'
+                    name: Anse Royale
+                  - abbr: '01'
+                    name: Anse aux Pins
+                  - abbr: '03'
+                    name: Anse Étoile
+                  - abbr: '06'
+                    name: Baie Lazare
+                  - abbr: '07'
+                    name: Baie Sainte Anne
+                  - abbr: '08'
+                    name: Beau Vallon
+                  - abbr: '09'
+                    name: Bel Air
+                  - abbr: '10'
+                    name: Bel Ombre
+                  - abbr: '11'
+                    name: Cascade
+                  - abbr: '12'
+                    name: Glacis
+                  - abbr: '13'
+                    name: Grand' Anse (Mahé)
+                  - abbr: '14'
+                    name: Grand' Anse (Praslin)
+                  - abbr: '26'
+                    name: Ile Perseverance I
+                  - abbr: '27'
+                    name: Ile Perseverance II
+                  - abbr: '15'
+                    name: La Digue
+                  - abbr: '16'
+                    name: La Rivière Anglaise
+                  - abbr: '24'
+                    name: Les Mamelles
+                  - abbr: '17'
+                    name: Mont Buxton
+                  - abbr: '18'
+                    name: Mont Fleuri
+                  - abbr: '19'
+                    name: Plaisance
+                  - abbr: '20'
+                    name: Pointe La Rue
+                  - abbr: '21'
+                    name: Port Glaud
+                  - abbr: '25'
+                    name: Roche Caïman
+                  - abbr: '22'
+                    name: Saint Louis
+                  - abbr: '23'
+                    name: Takamaka
+                - iso: SL
+                  iso3: SLE
+                  name: Sierra Leone
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: E
+                    name: Eastern
+                  - abbr: NW
+                    name: North Western
+                  - abbr: "N"
+                    name: Northern
+                  - abbr: S
+                    name: Southern
+                  - abbr: W
+                    name: Western Area (Freetown)
+                - iso: SG
+                  iso3: SGP
+                  name: Singapore
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Central Singapore
+                  - abbr: '02'
+                    name: North East
+                  - abbr: '03'
+                    name: North West
+                  - abbr: '04'
+                    name: South East
+                  - abbr: '05'
+                    name: South West
+                - iso: SX
+                  iso3: SXM
+                  name: Sint Maarten (Dutch part)
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: SK
+                  iso3: SVK
+                  name: Slovakia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: BC
+                    name: Banskobystrický kraj
+                  - abbr: BL
+                    name: Bratislavský kraj
+                  - abbr: KI
+                    name: Košický kraj
+                  - abbr: NI
+                    name: Nitriansky kraj
+                  - abbr: PV
+                    name: Prešovský kraj
+                  - abbr: TC
+                    name: Trenciansky kraj
+                  - abbr: TA
+                    name: Trnavský kraj
+                  - abbr: ZI
+                    name: Žilinský kraj
+                - iso: SI
+                  iso3: SVN
+                  name: Slovenia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '001'
+                    name: Ajdovšcina
+                  - abbr: '002'
+                    name: Beltinci
+                  - abbr: '148'
+                    name: Benedikt
+                  - abbr: '149'
+                    name: Bistrica ob Sotli
+                  - abbr: '003'
+                    name: Bled
+                  - abbr: '150'
+                    name: Bloke
+                  - abbr: '004'
+                    name: Bohinj
+                  - abbr: '005'
+                    name: Borovnica
+                  - abbr: '006'
+                    name: Bovec
+                  - abbr: '151'
+                    name: Braslovce
+                  - abbr: '007'
+                    name: Brda
+                  - abbr: '008'
+                    name: Brezovica
+                  - abbr: '009'
+                    name: Brežice
+                  - abbr: '152'
+                    name: Cankova
+                  - abbr: '011'
+                    name: Celje
+                  - abbr: '012'
+                    name: Cerklje na Gorenjskem
+                  - abbr: '013'
+                    name: Cerknica
+                  - abbr: '014'
+                    name: Cerkno
+                  - abbr: '153'
+                    name: Cerkvenjak
+                  - abbr: '015'
+                    name: Crenšovci
+                  - abbr: '016'
+                    name: Crna na Koroškem
+                  - abbr: '017'
+                    name: Crnomelj
+                  - abbr: '018'
+                    name: Destrnik
+                  - abbr: '019'
+                    name: Divaca
+                  - abbr: '154'
+                    name: Dobje
+                  - abbr: '020'
+                    name: Dobrepolje
+                  - abbr: '155'
+                    name: Dobrna
+                  - abbr: '021'
+                    name: Dobrova-Polhov Gradec
+                  - abbr: '156'
+                    name: Dobrovnik/Dobronak
+                  - abbr: '022'
+                    name: Dol pri Ljubljani
+                  - abbr: '157'
+                    name: Dolenjske Toplice
+                  - abbr: '023'
+                    name: Domžale
+                  - abbr: '024'
+                    name: Dornava
+                  - abbr: '025'
+                    name: Dravograd
+                  - abbr: '026'
+                    name: Duplek
+                  - abbr: '027'
+                    name: Gorenja vas-Poljane
+                  - abbr: '028'
+                    name: Gorišnica
+                  - abbr: '029'
+                    name: Gornja Radgona
+                  - abbr: '030'
+                    name: Gornji Grad
+                  - abbr: '031'
+                    name: Gornji Petrovci
+                  - abbr: '158'
+                    name: Grad
+                  - abbr: '032'
+                    name: Grosuplje
+                  - abbr: '159'
+                    name: Hajdina
+                  - abbr: '160'
+                    name: Hoce-Slivnica
+                  - abbr: '161'
+                    name: Hodoš/Hodos
+                  - abbr: '162'
+                    name: Horjul
+                  - abbr: '034'
+                    name: Hrastnik
+                  - abbr: '035'
+                    name: Hrpelje-Kozina
+                  - abbr: '036'
+                    name: Idrija
+                  - abbr: '037'
+                    name: Ig
+                  - abbr: '038'
+                    name: Ilirska Bistrica
+                  - abbr: '039'
+                    name: Ivancna Gorica
+                  - abbr: '040'
+                    name: Izola/Isola
+                  - abbr: '041'
+                    name: Jesenice
+                  - abbr: '163'
+                    name: Jezersko
+                  - abbr: '042'
+                    name: Juršinci
+                  - abbr: '043'
+                    name: Kamnik
+                  - abbr: '044'
+                    name: Kanal
+                  - abbr: '045'
+                    name: Kidricevo
+                  - abbr: '046'
+                    name: Kobarid
+                  - abbr: '047'
+                    name: Kobilje
+                  - abbr: '048'
+                    name: Kocevje
+                  - abbr: '049'
+                    name: Komen
+                  - abbr: '164'
+                    name: Komenda
+                  - abbr: '050'
+                    name: Koper/Capodistria
+                  - abbr: '165'
+                    name: Kostel
+                  - abbr: '051'
+                    name: Kozje
+                  - abbr: '052'
+                    name: Kranj
+                  - abbr: '053'
+                    name: Kranjska Gora
+                  - abbr: '166'
+                    name: Križevci
+                  - abbr: '054'
+                    name: Krško
+                  - abbr: '055'
+                    name: Kungota
+                  - abbr: '056'
+                    name: Kuzma
+                  - abbr: '057'
+                    name: Laško
+                  - abbr: '058'
+                    name: Lenart
+                  - abbr: '059'
+                    name: Lendava/Lendva
+                  - abbr: '060'
+                    name: Litija
+                  - abbr: '061'
+                    name: Ljubljana
+                  - abbr: '062'
+                    name: Ljubno
+                  - abbr: '063'
+                    name: Ljutomer
+                  - abbr: '064'
+                    name: Logatec
+                  - abbr: '167'
+                    name: Lovrenc na Pohorju
+                  - abbr: '065'
+                    name: Loška dolina
+                  - abbr: '066'
+                    name: Loški Potok
+                  - abbr: '067'
+                    name: Luce
+                  - abbr: '068'
+                    name: Lukovica
+                  - abbr: '069'
+                    name: Majšperk
+                  - abbr: '070'
+                    name: Maribor
+                  - abbr: '168'
+                    name: Markovci
+                  - abbr: '071'
+                    name: Medvode
+                  - abbr: '072'
+                    name: Mengeš
+                  - abbr: '073'
+                    name: Metlika
+                  - abbr: '074'
+                    name: Mežica
+                  - abbr: '169'
+                    name: Miklavž na Dravskem polju
+                  - abbr: '075'
+                    name: Miren-Kostanjevica
+                  - abbr: '212'
+                    name: Mirna
+                  - abbr: '170'
+                    name: Mirna Pec
+                  - abbr: '076'
+                    name: Mislinja
+                  - abbr: '077'
+                    name: Moravce
+                  - abbr: '078'
+                    name: Moravske Toplice
+                  - abbr: '079'
+                    name: Mozirje
+                  - abbr: '080'
+                    name: Murska Sobota
+                  - abbr: '081'
+                    name: Muta
+                  - abbr: '082'
+                    name: Naklo
+                  - abbr: '083'
+                    name: Nazarje
+                  - abbr: '084'
+                    name: Nova Gorica
+                  - abbr: '085'
+                    name: Novo mesto
+                  - abbr: '213'
+                    name: Občina Ankaran
+                  - abbr: '195'
+                    name: Občina Apače
+                  - abbr: '196'
+                    name: Občina Cirkulane
+                  - abbr: '207'
+                    name: Občina Gorje
+                  - abbr: '197'
+                    name: Občina Kostanjevica na Krki
+                  - abbr: '208'
+                    name: Občina Log - Dragomer
+                  - abbr: '198'
+                    name: Občina Makole
+                  - abbr: '199'
+                    name: Občina Mokronog - Trebelno
+                  - abbr: '200'
+                    name: Občina Poljčane
+                  - abbr: '201'
+                    name: Občina Renče - Vogrsko
+                  - abbr: '209'
+                    name: Občina Rečica ob Savinji
+                  - abbr: '202'
+                    name: Občina Središče ob Dravi
+                  - abbr: '203'
+                    name: Občina Straža
+                  - abbr: '204'
+                    name: Občina Sveta Trojica v Slovenskih goricah
+                  - abbr: '210'
+                    name: Občina Sveti Jurij v Slovenskih goricah
+                  - abbr: '205'
+                    name: Občina Sveti Tomaž
+                  - abbr: '211'
+                    name: Občina Šentrupert
+                  - abbr: '206'
+                    name: Občina Šmarješke Toplice
+                  - abbr: '086'
+                    name: Odranci
+                  - abbr: '171'
+                    name: Oplotnica
+                  - abbr: '087'
+                    name: Ormož
+                  - abbr: '088'
+                    name: Osilnica
+                  - abbr: '089'
+                    name: Pesnica
+                  - abbr: '090'
+                    name: Piran/Pirano
+                  - abbr: '091'
+                    name: Pivka
+                  - abbr: '092'
+                    name: Podcetrtek
+                  - abbr: '172'
+                    name: Podlehnik
+                  - abbr: '093'
+                    name: Podvelka
+                  - abbr: '173'
+                    name: Polzela
+                  - abbr: '094'
+                    name: Postojna
+                  - abbr: '174'
+                    name: Prebold
+                  - abbr: '095'
+                    name: Preddvor
+                  - abbr: '175'
+                    name: Prevalje
+                  - abbr: '096'
+                    name: Ptuj
+                  - abbr: '097'
+                    name: Puconci
+                  - abbr: '098'
+                    name: Race-Fram
+                  - abbr: '099'
+                    name: Radece
+                  - abbr: '100'
+                    name: Radenci
+                  - abbr: '101'
+                    name: Radlje ob Dravi
+                  - abbr: '102'
+                    name: Radovljica
+                  - abbr: '103'
+                    name: Ravne na Koroškem
+                  - abbr: '176'
+                    name: Razkrižje
+                  - abbr: '104'
+                    name: Ribnica
+                  - abbr: '177'
+                    name: Ribnica na Pohorju
+                  - abbr: '107'
+                    name: Rogatec
+                  - abbr: '106'
+                    name: Rogaška Slatina
+                  - abbr: '105'
+                    name: Rogašovci
+                  - abbr: '108'
+                    name: Ruše
+                  - abbr: '178'
+                    name: Selnica ob Dravi
+                  - abbr: '109'
+                    name: Semic
+                  - abbr: '110'
+                    name: Sevnica
+                  - abbr: '111'
+                    name: Sežana
+                  - abbr: '112'
+                    name: Slovenj Gradec
+                  - abbr: '113'
+                    name: Slovenska Bistrica
+                  - abbr: '114'
+                    name: Slovenske Konjice
+                  - abbr: '179'
+                    name: Sodražica
+                  - abbr: '180'
+                    name: Solcava
+                  - abbr: '115'
+                    name: Starše
+                  - abbr: '181'
+                    name: Sveta Ana
+                  - abbr: '182'
+                    name: Sveti Andraž v Slovenskih goricah
+                  - abbr: '116'
+                    name: Sveti Jurij
+                  - abbr: '184'
+                    name: Tabor
+                  - abbr: '010'
+                    name: Tišina
+                  - abbr: '128'
+                    name: Tolmin
+                  - abbr: '129'
+                    name: Trbovlje
+                  - abbr: '130'
+                    name: Trebnje
+                  - abbr: '185'
+                    name: Trnovska vas
+                  - abbr: '186'
+                    name: Trzin
+                  - abbr: '131'
+                    name: Tržic
+                  - abbr: '132'
+                    name: Turnišce
+                  - abbr: '133'
+                    name: Velenje
+                  - abbr: '187'
+                    name: Velika Polana
+                  - abbr: '134'
+                    name: Velike Lašce
+                  - abbr: '188'
+                    name: Veržej
+                  - abbr: '135'
+                    name: Videm
+                  - abbr: '136'
+                    name: Vipava
+                  - abbr: '137'
+                    name: Vitanje
+                  - abbr: '138'
+                    name: Vodice
+                  - abbr: '139'
+                    name: Vojnik
+                  - abbr: '189'
+                    name: Vransko
+                  - abbr: '140'
+                    name: Vrhnika
+                  - abbr: '141'
+                    name: Vuzenica
+                  - abbr: '142'
+                    name: Zagorje ob Savi
+                  - abbr: '143'
+                    name: Zavrc
+                  - abbr: '144'
+                    name: Zrece
+                  - abbr: '033'
+                    name: Šalovci
+                  - abbr: '183'
+                    name: Šempeter-Vrtojba
+                  - abbr: '117'
+                    name: Šencur
+                  - abbr: '118'
+                    name: Šentilj
+                  - abbr: '119'
+                    name: Šentjernej
+                  - abbr: '120'
+                    name: Šentjur pri Celju
+                  - abbr: '121'
+                    name: Škocjan
+                  - abbr: '122'
+                    name: Škofja Loka
+                  - abbr: '123'
+                    name: Škofljica
+                  - abbr: '124'
+                    name: Šmarje pri Jelšah
+                  - abbr: '125'
+                    name: Šmartno ob Paki
+                  - abbr: '194'
+                    name: Šmartno pri Litiji
+                  - abbr: '126'
+                    name: Šoštanj
+                  - abbr: '127'
+                    name: Štore
+                  - abbr: '190'
+                    name: Žalec
+                  - abbr: '146'
+                    name: Železniki
+                  - abbr: '191'
+                    name: Žetale
+                  - abbr: '147'
+                    name: Žiri
+                  - abbr: '192'
+                    name: Žirovnica
+                  - abbr: '193'
+                    name: Žužemberk
+                - iso: SB
+                  iso3: SLB
+                  name: Solomon Islands
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: CT
+                    name: Capital Territory (Honiara)
+                  - abbr: CE
+                    name: Central
+                  - abbr: CH
+                    name: Choiseul
+                  - abbr: GU
+                    name: Guadalcanal
+                  - abbr: IS
+                    name: Isabel
+                  - abbr: MK
+                    name: Makira
+                  - abbr: ML
+                    name: Malaita
+                  - abbr: RB
+                    name: Rennell and Bellona
+                  - abbr: TE
+                    name: Temotu
+                  - abbr: WE
+                    name: Western
+                - iso: SO
+                  iso3: SOM
+                  name: Somalia
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AW
+                    name: Awdal
+                  - abbr: BK
+                    name: Bakool
+                  - abbr: BN
+                    name: Banaadir
+                  - abbr: BR
+                    name: Bari
+                  - abbr: BY
+                    name: Bay
+                  - abbr: GA
+                    name: Galguduud
+                  - abbr: GE
+                    name: Gedo
+                  - abbr: HI
+                    name: Hiiraan
+                  - abbr: JD
+                    name: Jubbada Dhexe
+                  - abbr: JH
+                    name: Jubbada Hoose
+                  - abbr: MU
+                    name: Mudug
+                  - abbr: NU
+                    name: Nugaal
+                  - abbr: SA
+                    name: Sanaag
+                  - abbr: SD
+                    name: Shabeellaha Dhexe
+                  - abbr: SH
+                    name: Shabeellaha Hoose
+                  - abbr: SO
+                    name: Sool
+                  - abbr: TO
+                    name: Togdheer
+                  - abbr: WO
+                    name: Woqooyi Galbeed
+                - iso: ZA
+                  iso3: ZAF
+                  name: South Africa
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: EC
+                    name: Eastern Cape
+                  - abbr: FS
+                    name: Free State
+                  - abbr: GP
+                    name: Gauteng
+                  - abbr: ZN
+                    name: KwaZulu-Natal
+                  - abbr: LP
+                    name: Limpopo
+                  - abbr: MP
+                    name: Mpumalanga
+                  - abbr: NW
+                    name: North West
+                  - abbr: NC
+                    name: Northern Cape
+                  - abbr: WC
+                    name: Western Cape
+                - iso: KR
+                  iso3: KOR
+                  name: South Korea
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '26'
+                    name: Busan Gwang'yeogsi [Pusan-Kwangyokshi]
+                  - abbr: '43'
+                    name: Chungcheongbugdo [Ch'ungch'ongbuk-do]
+                  - abbr: '44'
+                    name: Chungcheongnamdo [Ch'ungch'ongnam-do]
+                  - abbr: '27'
+                    name: Daegu Gwang'yeogsi [Taegu-Kwangyokshi]
+                  - abbr: '30'
+                    name: Daejeon Gwang'yeogsi [Taejon-Kwangyokshi]
+                  - abbr: '42'
+                    name: Gang'weondo [Kang-won-do]
+                  - abbr: '29'
+                    name: Gwangju Gwang'yeogsi [Kwangju-Kwangyokshi]
+                  - abbr: '41'
+                    name: Gyeonggido [Kyonggi-do]
+                  - abbr: '47'
+                    name: Gyeongsangbugdo [Kyongsangbuk-do]
+                  - abbr: '48'
+                    name: Gyeongsangnamdo [Kyongsangnam-do]
+                  - abbr: '28'
+                    name: Incheon Gwang'yeogsi [Inch'n-Kwangyokshi]
+                  - abbr: '49'
+                    name: Jejudo [Cheju-do]
+                  - abbr: '45'
+                    name: Jeonrabugdo[Chollabuk-do]
+                  - abbr: '46'
+                    name: Jeonranamdo [Chollanam-do]
+                  - abbr: '11'
+                    name: Seoul Teugbyeolsi [Seoul-T'ukpyolshi]
+                  - abbr: '31'
+                    name: Ulsan Gwang'yeogsi [Ulsan-Kwangyokshi]
+                  - abbr: '50'
+                    name: 세종특별자치시
+                - iso: SS
+                  iso3: SSD
+                  name: South Sudan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: NU
+                    name: أعالي النيل
+                  - abbr: LK
+                    name: البحيرات
+                  - abbr: UY
+                    name: الوحدة
+                  - abbr: JG
+                    name: جونقلي
+                  - abbr: EE
+                    name: شرق الاستوائية
+                  - abbr: BN
+                    name: شمال بحر الغزال
+                  - abbr: EW
+                    name: غرب الاستوائية
+                  - abbr: BW
+                    name: غرب بحر الغزال
+                  - abbr: WR
+                    name: واراب
+                  - abbr: EC
+                    name: وسط الاستوائية
+                - iso: ES
+                  iso3: ESP
+                  name: Spain
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AB
+                    name: Albacete
+                  - abbr: A
+                    name: Alicante/Alacant
+                  - abbr: AL
+                    name: Almería
+                  - abbr: AN
+                    name: Andalucía
+                  - abbr: VI
+                    name: Araba/Álava
+                  - abbr: AR
+                    name: Aragón
+                  - abbr: O
+                    name: Asturias
+                  - abbr: BA
+                    name: Badajoz
+                  - abbr: PM
+                    name: Balears, Illes
+                  - abbr: B
+                    name: Barcelona
+                  - abbr: BI
+                    name: Bizkaia
+                  - abbr: BU
+                    name: Burgos
+                  - abbr: CN
+                    name: Canary Islands
+                  - abbr: CB
+                    name: Cantabria
+                  - abbr: S
+                    name: Cantabria
+                  - abbr: CS
+                    name: Castellón/Castelló
+                  - abbr: CL
+                    name: Castilla y León
+                  - abbr: CM
+                    name: Castilla-La Mancha
+                  - abbr: CT
+                    name: Cataluña
+                  - abbr: CE
+                    name: Ceuta
+                  - abbr: CR
+                    name: Ciudad Real
+                  - abbr: VC
+                    name: Comunidad Valenciana
+                  - abbr: MD
+                    name: Comunidad de Madrid
+                  - abbr: C
+                    name: Coruña, A
+                  - abbr: CU
+                    name: Cuenca
+                  - abbr: CC
+                    name: Cáceres
+                  - abbr: CA
+                    name: Cádiz
+                  - abbr: CO
+                    name: Córdoba
+                  - abbr: EX
+                    name: Extremadura
+                  - abbr: GA
+                    name: Galicia
+                  - abbr: SS
+                    name: Gipuzkoa
+                  - abbr: GI
+                    name: Girona
+                  - abbr: GR
+                    name: Granada
+                  - abbr: GU
+                    name: Guadalajara
+                  - abbr: H
+                    name: Huelva
+                  - abbr: HU
+                    name: Huesca
+                  - abbr: IB
+                    name: Islas Baleares
+                  - abbr: J
+                    name: Jaén
+                  - abbr: RI
+                    name: La Rioja
+                  - abbr: LE
+                    name: León
+                  - abbr: L
+                    name: Lleida
+                  - abbr: LU
+                    name: Lugo
+                  - abbr: M
+                    name: Madrid
+                  - abbr: ML
+                    name: Melilla
+                  - abbr: MU
+                    name: Murcia
+                  - abbr: MA
+                    name: Málaga
+                  - abbr: NC
+                    name: Navarra
+                  - abbr: NA
+                    name: Navarra
+                  - abbr: OR
+                    name: Ourense
+                  - abbr: P
+                    name: Palencia
+                  - abbr: GC
+                    name: Palmas, Las
+                  - abbr: PV
+                    name: País Vasco
+                  - abbr: PO
+                    name: Pontevedra
+                  - abbr: AS
+                    name: Principado de Asturias
+                  - abbr: MC
+                    name: Región de Murcia
+                  - abbr: LO
+                    name: Rioja, La
+                  - abbr: SA
+                    name: Salamanca
+                  - abbr: TF
+                    name: Santa Cruz de Tenerife
+                  - abbr: SG
+                    name: Segovia
+                  - abbr: SE
+                    name: Sevilla
+                  - abbr: SO
+                    name: Soria
+                  - abbr: T
+                    name: Tarragona
+                  - abbr: TE
+                    name: Teruel
+                  - abbr: TO
+                    name: Toledo
+                  - abbr: V
+                    name: Valencia/València
+                  - abbr: VA
+                    name: Valladolid
+                  - abbr: ZA
+                    name: Zamora
+                  - abbr: Z
+                    name: Zaragoza
+                  - abbr: AV
+                    name: Ávila
+                - iso: LK
+                  iso3: LKA
+                  name: Sri Lanka
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '52'
+                    name: Ampara
+                  - abbr: '71'
+                    name: Anuradhapura
+                  - abbr: '81'
+                    name: Badulla
+                  - abbr: '51'
+                    name: Batticaloa
+                  - abbr: '11'
+                    name: Colombo
+                  - abbr: '31'
+                    name: Galle
+                  - abbr: '12'
+                    name: Gampaha
+                  - abbr: '33'
+                    name: Hambantota
+                  - abbr: '41'
+                    name: Jaffna
+                  - abbr: '13'
+                    name: Kalutara
+                  - abbr: '21'
+                    name: Kandy
+                  - abbr: '92'
+                    name: Kegalla
+                  - abbr: '42'
+                    name: Kilinochchi
+                  - abbr: '61'
+                    name: Kurunegala
+                  - abbr: '43'
+                    name: Mannar
+                  - abbr: '22'
+                    name: Matale
+                  - abbr: '32'
+                    name: Matara
+                  - abbr: '82'
+                    name: Monaragala
+                  - abbr: '45'
+                    name: Mullaittivu
+                  - abbr: '23'
+                    name: Nuwara Eliya
+                  - abbr: '72'
+                    name: Polonnaruwa
+                  - abbr: '62'
+                    name: Puttalam
+                  - abbr: '91'
+                    name: Ratnapura
+                  - abbr: '53'
+                    name: Trincomalee
+                  - abbr: '44'
+                    name: Vavuniya
+                  - abbr: '4'
+                    name: උතුරු පළාත
+                  - abbr: '7'
+                    name: උතුරු මැද පළාත
+                  - abbr: '8'
+                    name: ඌව පළාත
+                  - abbr: '3'
+                    name: දකුණු පළාත
+                  - abbr: '5'
+                    name: නැගෙනහිර පළාත, ශ් රී ලංකාව
+                  - abbr: '1'
+                    name: බස්නාහිර පළාත, ශ් රී ලංකාව
+                  - abbr: '2'
+                    name: මධ්‍යම පළාත, ශ්‍රී ලංකාව
+                  - abbr: '6'
+                    name: වයඹ පළාත, ශ්‍රී ලංකාව
+                  - abbr: '9'
+                    name: සබරගමුව පළාත
+                - iso: SD
+                  iso3: SDN
+                  name: Sudan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: RS
+                    name: Al Baḩr al Aḩmar
+                  - abbr: GZ
+                    name: Al Jazīrah
+                  - abbr: KH
+                    name: Al Kharţūm
+                  - abbr: GD
+                    name: Al Qaḑārif
+                  - abbr: NW
+                    name: An Nīl al Abyaḑ
+                  - abbr: NB
+                    name: An Nīl al Azraq
+                  - abbr: 'NO'
+                    name: Ash Shamālīyah
+                  - abbr: DW
+                    name: Gharb Dārfūr
+                  - abbr: GK
+                    name: Gharb Kurdufān
+                  - abbr: DS
+                    name: Janūb Dārfūr
+                  - abbr: KS
+                    name: Janūb Kurdufān
+                  - abbr: KA
+                    name: Kassalā
+                  - abbr: NR
+                    name: Nahr an Nīl
+                  - abbr: DN
+                    name: Shamāl Dārfūr
+                  - abbr: DE
+                    name: Sharq Dārfūr
+                  - abbr: KN
+                    name: Shiamāl Kurdufān
+                  - abbr: SI
+                    name: Sinnār
+                  - abbr: DC
+                    name: Wasaţ Dārfūr Zālinjay
+                - iso: SR
+                  iso3: SUR
+                  name: Suriname
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BR
+                    name: Brokopondo
+                  - abbr: CM
+                    name: Commewijne
+                  - abbr: CR
+                    name: Coronie
+                  - abbr: MA
+                    name: Marowijne
+                  - abbr: NI
+                    name: Nickerie
+                  - abbr: PR
+                    name: Para
+                  - abbr: PM
+                    name: Paramaribo
+                  - abbr: SA
+                    name: Saramacca
+                  - abbr: SI
+                    name: Sipaliwini
+                  - abbr: WA
+                    name: Wanica
+                - iso: SJ
+                  iso3: SJM
+                  name: Svalbard and Jan Mayen
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: SE
+                  iso3: SWE
+                  name: Sweden
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: K
+                    name: Blekinge län
+                  - abbr: W
+                    name: Dalarnas län
+                  - abbr: I
+                    name: Gotlands län
+                  - abbr: X
+                    name: Gävleborgs län
+                  - abbr: "N"
+                    name: Hallands län
+                  - abbr: Z
+                    name: Jämtlands län
+                  - abbr: F
+                    name: Jönköpings län
+                  - abbr: H
+                    name: Kalmar län
+                  - abbr: G
+                    name: Kronobergs län
+                  - abbr: BD
+                    name: Norrbottens län
+                  - abbr: M
+                    name: Skåne län
+                  - abbr: AB
+                    name: Stockholms län
+                  - abbr: D
+                    name: Södermanlands län
+                  - abbr: C
+                    name: Uppsala län
+                  - abbr: S
+                    name: Värmlands län
+                  - abbr: AC
+                    name: Västerbottens län
+                  - abbr: "Y"
+                    name: Västernorrlands län
+                  - abbr: U
+                    name: Västmanlands län
+                  - abbr: O
+                    name: Västra Götalands län
+                  - abbr: T
+                    name: Örebro län
+                  - abbr: E
+                    name: Östergötlands län
+                - iso: CH
+                  iso3: CHE
+                  name: Switzerland
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AG
+                    name: Aargau (de)
+                  - abbr: AR
+                    name: Appenzell Ausserrhoden (de)
+                  - abbr: AI
+                    name: Appenzell Innerrhoden (de)
+                  - abbr: BL
+                    name: Basel-Landschaft (de)
+                  - abbr: BS
+                    name: Basel-Stadt (de)
+                  - abbr: BE
+                    name: Bern (de)
+                  - abbr: FR
+                    name: Fribourg (fr)
+                  - abbr: GE
+                    name: Genève (fr)
+                  - abbr: GL
+                    name: Glarus (de)
+                  - abbr: GR
+                    name: Graubünden (de)
+                  - abbr: JU
+                    name: Jura (fr)
+                  - abbr: LU
+                    name: Luzern (de)
+                  - abbr: NE
+                    name: Neuchâtel (fr)
+                  - abbr: NW
+                    name: Nidwalden (de)
+                  - abbr: OW
+                    name: Obwalden (de)
+                  - abbr: SG
+                    name: Sankt Gallen (de)
+                  - abbr: SH
+                    name: Schaffhausen (de)
+                  - abbr: SZ
+                    name: Schwyz (de)
+                  - abbr: SO
+                    name: Solothurn (de)
+                  - abbr: TG
+                    name: Thurgau (de)
+                  - abbr: TI
+                    name: Ticino (it)
+                  - abbr: UR
+                    name: Uri (de)
+                  - abbr: VS
+                    name: Valais (fr)
+                  - abbr: VD
+                    name: Vaud (fr)
+                  - abbr: ZG
+                    name: Zug (de)
+                  - abbr: ZH
+                    name: Zürich (de)
+                - iso: SY
+                  iso3: SYR
+                  name: Syrian Arab Republic
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: LA
+                    name: Al Ladhiqiyah
+                  - abbr: QU
+                    name: Al Qunaytirah
+                  - abbr: HA
+                    name: Al Ḩasakah
+                  - abbr: RA
+                    name: Ar Raqqah
+                  - abbr: SU
+                    name: As Suwayda'
+                  - abbr: DR
+                    name: Dar'ā
+                  - abbr: DY
+                    name: Dayr az Zawr
+                  - abbr: DI
+                    name: Dimashq
+                  - abbr: ID
+                    name: Idlib
+                  - abbr: RD
+                    name: Rif Dimashq
+                  - abbr: TA
+                    name: Tartus
+                  - abbr: HL
+                    name: Ḩalab
+                  - abbr: HM
+                    name: Ḩamāh
+                  - abbr: HI
+                    name: Ḩimş
+                - iso: TW
+                  iso3: TWN
+                  name: Taiwan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: CHA
+                    name: Changhua
+                  - abbr: CYQ
+                    name: Chiayi
+                  - abbr: CYI
+                    name: Chiayi Municipality
+                  - abbr: HSQ
+                    name: Hsinchu
+                  - abbr: HSZ
+                    name: Hsinchu Municipality
+                  - abbr: HUA
+                    name: Hualien
+                  - abbr: ILA
+                    name: Ilan
+                  - abbr: KHH
+                    name: Kaohsiung Special Municipality
+                  - abbr: KEE
+                    name: Keelung Municipality
+                  - abbr: MIA
+                    name: Miaoli
+                  - abbr: NAN
+                    name: Nantou
+                  - abbr: NWT
+                    name: New Taipei
+                  - abbr: PEN
+                    name: Penghu
+                  - abbr: PIF
+                    name: Pingtung
+                  - abbr: TXG
+                    name: Taichung Municipality
+                  - abbr: TNN
+                    name: Tainan Municipality
+                  - abbr: TPE
+                    name: Taipei Special Municipality
+                  - abbr: TTT
+                    name: Taitung
+                  - abbr: TAO
+                    name: Taoyuan
+                  - abbr: YUN
+                    name: Yunlin
+                  - abbr: LIE
+                    name: 連江縣
+                  - abbr: KIN
+                    name: 金門縣
+                - iso: TJ
+                  iso3: TJK
+                  name: Tajikistan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: DU
+                    name: Dushanbe
+                  - abbr: GB
+                    name: Gorno-Badakhshan
+                  - abbr: KT
+                    name: Khatlon
+                  - abbr: RA
+                    name: Nohiyahoi Tobei Jumhurí
+                  - abbr: SU
+                    name: Sughd
+                - iso: TZ
+                  iso3: TZA
+                  name: Tanzania
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: Arusha
+                  - abbr: '02'
+                    name: Dar es Salaam
+                  - abbr: '03'
+                    name: Dodoma
+                  - abbr: '04'
+                    name: Iringa
+                  - abbr: '05'
+                    name: Kagera
+                  - abbr: '06'
+                    name: Kaskazini Pemba
+                  - abbr: '07'
+                    name: Kaskazini Unguja
+                  - abbr: '08'
+                    name: Kigoma
+                  - abbr: '09'
+                    name: Kilimanjaro
+                  - abbr: '10'
+                    name: Kusini Pemba
+                  - abbr: '11'
+                    name: Kusini Unguja
+                  - abbr: '12'
+                    name: Lindi
+                  - abbr: '26'
+                    name: Manyara
+                  - abbr: '13'
+                    name: Mara
+                  - abbr: '14'
+                    name: Mbeya
+                  - abbr: '15'
+                    name: Mjini Magharibi
+                  - abbr: '27'
+                    name: Mkoa wa Geita
+                  - abbr: '28'
+                    name: Mkoa wa Katavi
+                  - abbr: '29'
+                    name: Mkoa wa Njombe
+                  - abbr: '30'
+                    name: Mkoa wa Simiyu
+                  - abbr: '16'
+                    name: Morogoro
+                  - abbr: '17'
+                    name: Mtwara
+                  - abbr: '18'
+                    name: Mwanza
+                  - abbr: '19'
+                    name: Pwani
+                  - abbr: '20'
+                    name: Rukwa
+                  - abbr: '21'
+                    name: Ruvuma
+                  - abbr: '22'
+                    name: Shinyanga
+                  - abbr: '23'
+                    name: Singida
+                  - abbr: '31'
+                    name: Songwe
+                  - abbr: '24'
+                    name: Tabora
+                  - abbr: '25'
+                    name: Tanga
+                - iso: TH
+                  iso3: THA
+                  name: Thailand
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: '37'
+                    name: Amnat Charoen
+                  - abbr: '15'
+                    name: Ang Thong
+                  - abbr: '31'
+                    name: Buri Ram
+                  - abbr: '24'
+                    name: Chachoengsao
+                  - abbr: '18'
+                    name: Chai Nat
+                  - abbr: '36'
+                    name: Chaiyaphum
+                  - abbr: '22'
+                    name: Chanthaburi
+                  - abbr: '50'
+                    name: Chiang Mai
+                  - abbr: '57'
+                    name: Chiang Rai
+                  - abbr: '20'
+                    name: Chon Buri
+                  - abbr: '86'
+                    name: Chumphon
+                  - abbr: '46'
+                    name: Kalasin
+                  - abbr: '62'
+                    name: Kamphaeng Phet
+                  - abbr: '71'
+                    name: Kanchanaburi
+                  - abbr: '40'
+                    name: Khon Kaen
+                  - abbr: '81'
+                    name: Krabi
+                  - abbr: '10'
+                    name: Krung Thep Maha Nakhon [Bangkok]
+                  - abbr: '52'
+                    name: Lampang
+                  - abbr: '51'
+                    name: Lamphun
+                  - abbr: '42'
+                    name: Loei
+                  - abbr: '16'
+                    name: Lop Buri
+                  - abbr: '58'
+                    name: Mae Hong Son
+                  - abbr: '44'
+                    name: Maha Sarakham
+                  - abbr: '49'
+                    name: Mukdahan
+                  - abbr: '26'
+                    name: Nakhon Nayok
+                  - abbr: '73'
+                    name: Nakhon Pathom
+                  - abbr: '48'
+                    name: Nakhon Phanom
+                  - abbr: '30'
+                    name: Nakhon Ratchasima
+                  - abbr: '60'
+                    name: Nakhon Sawan
+                  - abbr: '80'
+                    name: Nakhon Si Thammarat
+                  - abbr: '55'
+                    name: Nan
+                  - abbr: '96'
+                    name: Narathiwat
+                  - abbr: '39'
+                    name: Nong Bua Lam Phu
+                  - abbr: '43'
+                    name: Nong Khai
+                  - abbr: '12'
+                    name: Nonthaburi
+                  - abbr: '13'
+                    name: Pathum Thani
+                  - abbr: '94'
+                    name: Pattani
+                  - abbr: '82'
+                    name: Phangnga
+                  - abbr: '93'
+                    name: Phatthalung
+                  - abbr: S
+                    name: Phatthaya
+                  - abbr: '56'
+                    name: Phayao
+                  - abbr: '67'
+                    name: Phetchabun
+                  - abbr: '76'
+                    name: Phetchaburi
+                  - abbr: '66'
+                    name: Phichit
+                  - abbr: '65'
+                    name: Phitsanulok
+                  - abbr: '14'
+                    name: Phra Nakhon Si Ayutthaya
+                  - abbr: '54'
+                    name: Phrae
+                  - abbr: '83'
+                    name: Phuket
+                  - abbr: '25'
+                    name: Prachin Buri
+                  - abbr: '77'
+                    name: Prachuap Khiri Khan
+                  - abbr: '85'
+                    name: Ranong
+                  - abbr: '70'
+                    name: Ratchaburi
+                  - abbr: '21'
+                    name: Rayong
+                  - abbr: '45'
+                    name: Roi Et
+                  - abbr: '27'
+                    name: Sa Kaeo
+                  - abbr: '47'
+                    name: Sakon Nakhon
+                  - abbr: '11'
+                    name: Samut Prakan
+                  - abbr: '74'
+                    name: Samut Sakhon
+                  - abbr: '75'
+                    name: Samut Songkhram
+                  - abbr: '19'
+                    name: Saraburi
+                  - abbr: '91'
+                    name: Satun
+                  - abbr: '33'
+                    name: Si Sa Ket
+                  - abbr: '17'
+                    name: Sing Buri
+                  - abbr: '90'
+                    name: Songkhla
+                  - abbr: '64'
+                    name: Sukhothai
+                  - abbr: '72'
+                    name: Suphan Buri
+                  - abbr: '84'
+                    name: Surat Thani
+                  - abbr: '32'
+                    name: Surin
+                  - abbr: '63'
+                    name: Tak
+                  - abbr: '92'
+                    name: Trang
+                  - abbr: '23'
+                    name: Trat
+                  - abbr: '34'
+                    name: Ubon Ratchathani
+                  - abbr: '41'
+                    name: Udon Thani
+                  - abbr: '61'
+                    name: Uthai Thani
+                  - abbr: '53'
+                    name: Uttaradit
+                  - abbr: '95'
+                    name: Yala
+                  - abbr: '35'
+                    name: Yasothon
+                  - abbr: '38'
+                    name: จังหวัดบึงกาฬ
+                - iso: TL
+                  iso3: TLS
+                  name: Timor-Leste
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AL
+                    name: Aileu
+                  - abbr: AN
+                    name: Ainaro
+                  - abbr: BA
+                    name: Baucau
+                  - abbr: BO
+                    name: Bobonaro
+                  - abbr: CO
+                    name: Cova Lima
+                  - abbr: DI
+                    name: Dili
+                  - abbr: ER
+                    name: Ermera
+                  - abbr: LA
+                    name: Lautem
+                  - abbr: LI
+                    name: Liquiça
+                  - abbr: MT
+                    name: Manatuto
+                  - abbr: MF
+                    name: Manufahi
+                  - abbr: OE
+                    name: Oecussi
+                  - abbr: VI
+                    name: Viqueque
+                - iso: TG
+                  iso3: TGO
+                  name: Togo
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: C
+                    name: Centre
+                  - abbr: K
+                    name: Kara
+                  - abbr: M
+                    name: Maritime (Région)
+                  - abbr: P
+                    name: Plateaux
+                  - abbr: S
+                    name: Savannes
+                - iso: TK
+                  iso3: TKL
+                  name: Tokelau
+                  states_required: false
+                  zipcode_required: false
+                  states: []
+                - iso: TO
+                  iso3: TON
+                  name: Tonga
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '01'
+                    name: "'Eua"
+                  - abbr: '02'
+                    name: Ha'apai
+                  - abbr: '03'
+                    name: Niuas
+                  - abbr: '04'
+                    name: Tongatapu
+                  - abbr: '05'
+                    name: Vava'u
+                - iso: TT
+                  iso3: TTO
+                  name: Trinidad and Tobago
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ARI
+                    name: Arima
+                  - abbr: CHA
+                    name: Chaguanas
+                  - abbr: CTT
+                    name: Couva-Tabaquite-Talparo
+                  - abbr: DMN
+                    name: Diego Martin
+                  - abbr: MRC
+                    name: Mayaro-Rio Claro
+                  - abbr: PED
+                    name: Penal-Debe
+                  - abbr: PTF
+                    name: Point Fortin
+                  - abbr: POS
+                    name: Port of Spain
+                  - abbr: PRT
+                    name: Princes Town
+                  - abbr: SFO
+                    name: San Fernando
+                  - abbr: SJL
+                    name: San Juan-Laventille
+                  - abbr: SGE
+                    name: Sangre Grande
+                  - abbr: SIP
+                    name: Siparia
+                  - abbr: TOB
+                    name: Tobago
+                  - abbr: TUP
+                    name: Tunapuna-Piarco
+                - iso: TN
+                  iso3: TUN
+                  name: Tunisia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '13'
+                    name: Ben Arous
+                  - abbr: '23'
+                    name: Bizerte
+                  - abbr: '31'
+                    name: Béja
+                  - abbr: '81'
+                    name: Gabès
+                  - abbr: '71'
+                    name: Gafsa
+                  - abbr: '32'
+                    name: Jendouba
+                  - abbr: '41'
+                    name: Kairouan
+                  - abbr: '42'
+                    name: Kasserine
+                  - abbr: '73'
+                    name: Kebili
+                  - abbr: '12'
+                    name: L'Ariana
+                  - abbr: '14'
+                    name: La Manouba
+                  - abbr: '33'
+                    name: Le Kef
+                  - abbr: '53'
+                    name: Mahdia
+                  - abbr: '82'
+                    name: Medenine
+                  - abbr: '52'
+                    name: Monastir
+                  - abbr: '21'
+                    name: Nabeul
+                  - abbr: '61'
+                    name: Sfax
+                  - abbr: '43'
+                    name: Sidi Bouzid
+                  - abbr: '34'
+                    name: Siliana
+                  - abbr: '51'
+                    name: Sousse
+                  - abbr: '83'
+                    name: Tataouine
+                  - abbr: '72'
+                    name: Tozeur
+                  - abbr: '11'
+                    name: Tunis
+                  - abbr: '22'
+                    name: Zaghouan
+                - iso: TM
+                  iso3: TKM
+                  name: Turkmenistan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: A
+                    name: Ahal
+                  - abbr: S
+                    name: Aşgabat
+                  - abbr: B
+                    name: Balkan
+                  - abbr: D
+                    name: Dasoguz
+                  - abbr: L
+                    name: Lebap
+                  - abbr: M
+                    name: Mary
+                - iso: TC
+                  iso3: TCA
+                  name: Turks and Caicos Islands
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: TV
+                  iso3: TUV
+                  name: Tuvalu
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: FUN
+                    name: Funafuti
+                  - abbr: NMG
+                    name: Nanumanga
+                  - abbr: NMA
+                    name: Nanumea
+                  - abbr: NIT
+                    name: Niutao
+                  - abbr: NUI
+                    name: Nui
+                  - abbr: NKF
+                    name: Nukufetau
+                  - abbr: NKL
+                    name: Nukulaelae
+                  - abbr: VAI
+                    name: Vaitupu
+                - iso: TR
+                  iso3: TUR
+                  name: Türkiye
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '01'
+                    name: Adana
+                  - abbr: '02'
+                    name: Adıyaman
+                  - abbr: '03'
+                    name: Afyon
+                  - abbr: '68'
+                    name: Aksaray
+                  - abbr: '05'
+                    name: Amasya
+                  - abbr: '06'
+                    name: Ankara
+                  - abbr: '07'
+                    name: Antalya
+                  - abbr: '75'
+                    name: Ardahan
+                  - abbr: '08'
+                    name: Artvin
+                  - abbr: '09'
+                    name: Aydın
+                  - abbr: '04'
+                    name: Ağrı
+                  - abbr: '10'
+                    name: Balıkesir
+                  - abbr: '74'
+                    name: Bartın
+                  - abbr: '72'
+                    name: Batman
+                  - abbr: '69'
+                    name: Bayburt
+                  - abbr: '11'
+                    name: Bilecik
+                  - abbr: '12'
+                    name: Bingöl
+                  - abbr: '13'
+                    name: Bitlis
+                  - abbr: '14'
+                    name: Bolu
+                  - abbr: '15'
+                    name: Burdur
+                  - abbr: '16'
+                    name: Bursa
+                  - abbr: '20'
+                    name: Denizli
+                  - abbr: '21'
+                    name: Diyarbakır
+                  - abbr: '81'
+                    name: Düzce
+                  - abbr: '22'
+                    name: Edirne
+                  - abbr: '23'
+                    name: Elazığ
+                  - abbr: '24'
+                    name: Erzincan
+                  - abbr: '25'
+                    name: Erzurum
+                  - abbr: '26'
+                    name: Eskişehir
+                  - abbr: '27'
+                    name: Gaziantep
+                  - abbr: '28'
+                    name: Giresun
+                  - abbr: '29'
+                    name: Gümüşhane
+                  - abbr: '30'
+                    name: Hakkâri
+                  - abbr: '31'
+                    name: Hatay
+                  - abbr: '32'
+                    name: Isparta
+                  - abbr: '76'
+                    name: Iğdır
+                  - abbr: '46'
+                    name: Kahramanmaraş
+                  - abbr: '78'
+                    name: Karabük
+                  - abbr: '70'
+                    name: Karaman
+                  - abbr: '36'
+                    name: Kars
+                  - abbr: '37'
+                    name: Kastamonu
+                  - abbr: '38'
+                    name: Kayseri
+                  - abbr: '79'
+                    name: Kilis
+                  - abbr: '41'
+                    name: Kocaeli
+                  - abbr: '42'
+                    name: Konya
+                  - abbr: '43'
+                    name: Kütahya
+                  - abbr: '39'
+                    name: Kırklareli
+                  - abbr: '71'
+                    name: Kırıkkale
+                  - abbr: '40'
+                    name: Kırşehir
+                  - abbr: '44'
+                    name: Malatya
+                  - abbr: '45'
+                    name: Manisa
+                  - abbr: '47'
+                    name: Mardin
+                  - abbr: '48'
+                    name: Muğla
+                  - abbr: '49'
+                    name: Muş
+                  - abbr: '50'
+                    name: Nevşehir
+                  - abbr: '51'
+                    name: Niğde
+                  - abbr: '52'
+                    name: Ordu
+                  - abbr: '80'
+                    name: Osmaniye
+                  - abbr: '53'
+                    name: Rize
+                  - abbr: '54'
+                    name: Sakarya
+                  - abbr: '55'
+                    name: Samsun
+                  - abbr: '56'
+                    name: Siirt
+                  - abbr: '57'
+                    name: Sinop
+                  - abbr: '58'
+                    name: Sivas
+                  - abbr: '59'
+                    name: Tekirdağ
+                  - abbr: '60'
+                    name: Tokat
+                  - abbr: '61'
+                    name: Trabzon
+                  - abbr: '62'
+                    name: Tunceli
+                  - abbr: '64'
+                    name: Uşak
+                  - abbr: '65'
+                    name: Van
+                  - abbr: '77'
+                    name: Yalova
+                  - abbr: '66'
+                    name: Yozgat
+                  - abbr: '67'
+                    name: Zonguldak
+                  - abbr: '17'
+                    name: Çanakkale
+                  - abbr: '18'
+                    name: Çankırı
+                  - abbr: '19'
+                    name: Çorum
+                  - abbr: '34'
+                    name: İstanbul
+                  - abbr: '35'
+                    name: İzmir
+                  - abbr: '33'
+                    name: İçel
+                  - abbr: '63'
+                    name: Şanlıurfa
+                  - abbr: '73'
+                    name: Şırnak
+                - iso: UG
+                  iso3: UGA
+                  name: Uganda
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: '317'
+                    name: Abim
+                  - abbr: '301'
+                    name: Adjumani
+                  - abbr: '322'
+                    name: Agago
+                  - abbr: '323'
+                    name: Alebtong
+                  - abbr: '314'
+                    name: Amolatar
+                  - abbr: '324'
+                    name: Amudat
+                  - abbr: '216'
+                    name: Amuria
+                  - abbr: '319'
+                    name: Amuru
+                  - abbr: '302'
+                    name: Apac
+                  - abbr: '303'
+                    name: Arua
+                  - abbr: '217'
+                    name: Budaka
+                  - abbr: '223'
+                    name: Bududa
+                  - abbr: '201'
+                    name: Bugiri
+                  - abbr: '235'
+                    name: Bugweri
+                  - abbr: '420'
+                    name: Buhweju
+                  - abbr: '117'
+                    name: Buikwe
+                  - abbr: '224'
+                    name: Bukedea
+                  - abbr: '118'
+                    name: Bukomansibi
+                  - abbr: '218'
+                    name: Bukwa
+                  - abbr: '225'
+                    name: Bulambuli
+                  - abbr: '419'
+                    name: Buliisa
+                  - abbr: '401'
+                    name: Bundibugyo
+                  - abbr: '430'
+                    name: Bunyangabu
+                  - abbr: '402'
+                    name: Bushenyi
+                  - abbr: '202'
+                    name: Busia
+                  - abbr: '219'
+                    name: Butaleja
+                  - abbr: '119'
+                    name: Butambala
+                  - abbr: '233'
+                    name: Butebo
+                  - abbr: '120'
+                    name: Buvuma
+                  - abbr: '226'
+                    name: Buyende
+                  - abbr: C
+                    name: Central
+                  - abbr: '318'
+                    name: Dokolo
+                  - abbr: E
+                    name: Eastern
+                  - abbr: '121'
+                    name: Gomba
+                  - abbr: '304'
+                    name: Gulu
+                  - abbr: '403'
+                    name: Hoima
+                  - abbr: '416'
+                    name: Ibanda
+                  - abbr: '203'
+                    name: Iganga
+                  - abbr: '417'
+                    name: Isingiro
+                  - abbr: '204'
+                    name: Jinja
+                  - abbr: '315'
+                    name: Kaabong
+                  - abbr: '404'
+                    name: Kabale
+                  - abbr: '405'
+                    name: Kabarole
+                  - abbr: '213'
+                    name: Kaberamaido
+                  - abbr: '427'
+                    name: Kagadi
+                  - abbr: '428'
+                    name: Kakumiro
+                  - abbr: '237'
+                    name: Kalaki
+                  - abbr: '101'
+                    name: Kalangala
+                  - abbr: '220'
+                    name: Kaliro
+                  - abbr: '122'
+                    name: Kalungu
+                  - abbr: '102'
+                    name: Kampala
+                  - abbr: '205'
+                    name: Kamuli
+                  - abbr: '413'
+                    name: Kamwenge
+                  - abbr: '414'
+                    name: Kanungu
+                  - abbr: '206'
+                    name: Kapchorwa
+                  - abbr: '236'
+                    name: Kapelebyong
+                  - abbr: '335'
+                    name: Karenga
+                  - abbr: '126'
+                    name: Kasanda
+                  - abbr: '406'
+                    name: Kasese
+                  - abbr: '207'
+                    name: Katakwi
+                  - abbr: '112'
+                    name: Kayunga
+                  - abbr: '433'
+                    name: Kazo
+                  - abbr: '407'
+                    name: Kibaale
+                  - abbr: '103'
+                    name: Kiboga
+                  - abbr: '227'
+                    name: Kibuku
+                  - abbr: '432'
+                    name: Kikuube
+                  - abbr: '418'
+                    name: Kiruhura
+                  - abbr: '421'
+                    name: Kiryandongo
+                  - abbr: '408'
+                    name: Kisoro
+                  - abbr: '434'
+                    name: Kitagwenda
+                  - abbr: '305'
+                    name: Kitgum
+                  - abbr: '316'
+                    name: Koboko
+                  - abbr: '325'
+                    name: Kole
+                  - abbr: '306'
+                    name: Kotido
+                  - abbr: '208'
+                    name: Kumi
+                  - abbr: '333'
+                    name: Kwania
+                  - abbr: '228'
+                    name: Kween
+                  - abbr: '123'
+                    name: Kyankwanzi
+                  - abbr: '422'
+                    name: Kyegegwa
+                  - abbr: '415'
+                    name: Kyenjojo
+                  - abbr: '125'
+                    name: Kyotera
+                  - abbr: '326'
+                    name: Lamwo
+                  - abbr: '307'
+                    name: Lira
+                  - abbr: '229'
+                    name: Luuka
+                  - abbr: '104'
+                    name: Luwero
+                  - abbr: '124'
+                    name: Lwengo
+                  - abbr: '116'
+                    name: Lyantonde
+                  - abbr: '336'
+                    name: Madi-Okollo
+                  - abbr: '221'
+                    name: Manafwa
+                  - abbr: '320'
+                    name: Maracha
+                  - abbr: '105'
+                    name: Masaka
+                  - abbr: '409'
+                    name: Masindi
+                  - abbr: '214'
+                    name: Mayuge
+                  - abbr: '209'
+                    name: Mbale
+                  - abbr: '410'
+                    name: Mbarara
+                  - abbr: '423'
+                    name: Mitooma
+                  - abbr: '114'
+                    name: Mityana
+                  - abbr: '308'
+                    name: Moroto
+                  - abbr: '309'
+                    name: Moyo
+                  - abbr: '106'
+                    name: Mpigi
+                  - abbr: '107'
+                    name: Mubende
+                  - abbr: '108'
+                    name: Mukono
+                  - abbr: '334'
+                    name: Nabilatuk
+                  - abbr: '311'
+                    name: Nakapiripirit
+                  - abbr: '115'
+                    name: Nakaseke
+                  - abbr: '109'
+                    name: Nakasongola
+                  - abbr: '230'
+                    name: Namayingo
+                  - abbr: '234'
+                    name: Namisindwa
+                  - abbr: '222'
+                    name: Namutumba
+                  - abbr: '327'
+                    name: Napak
+                  - abbr: '310'
+                    name: Nebbi
+                  - abbr: '231'
+                    name: Ngora
+                  - abbr: "N"
+                    name: Northern
+                  - abbr: '424'
+                    name: Ntoroko
+                  - abbr: '411'
+                    name: Ntungamo
+                  - abbr: '328'
+                    name: Nwoya
+                  - abbr: '337'
+                    name: Obongi
+                  - abbr: '329'
+                    name: Otuke
+                  - abbr: '321'
+                    name: Oyam
+                  - abbr: '312'
+                    name: Pader
+                  - abbr: '332'
+                    name: Pakwach
+                  - abbr: '210'
+                    name: Pallisa
+                  - abbr: '110'
+                    name: Rakai
+                  - abbr: '429'
+                    name: Rubanda
+                  - abbr: '425'
+                    name: Rubirizi
+                  - abbr: '431'
+                    name: Rukiga
+                  - abbr: '412'
+                    name: Rukungiri
+                  - abbr: '435'
+                    name: Rwampara
+                  - abbr: '111'
+                    name: Sembabule
+                  - abbr: '232'
+                    name: Serere
+                  - abbr: '426'
+                    name: Sheema
+                  - abbr: '215'
+                    name: Sironko
+                  - abbr: '211'
+                    name: Soroti
+                  - abbr: '212'
+                    name: Tororo
+                  - abbr: '113'
+                    name: Wakiso
+                  - abbr: W
+                    name: Western
+                  - abbr: '313'
+                    name: Yumbe
+                  - abbr: '331'
+                    name: Zombo
+                  - abbr: '330'
+                    name: Zombo²
+                - iso: UA
+                  iso3: UKR
+                  name: Ukraine
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '71'
+                    name: Cherkas'ka Oblast'
+                  - abbr: '74'
+                    name: Chernihivs'ka Oblast'
+                  - abbr: '77'
+                    name: Chernivets'ka Oblast'
+                  - abbr: '12'
+                    name: Dnipropetrovs'ka Oblast'
+                  - abbr: '14'
+                    name: Donets'ka Oblast'
+                  - abbr: '26'
+                    name: Ivano-Frankivs'ka Oblast'
+                  - abbr: '63'
+                    name: Kharkivs'ka Oblast'
+                  - abbr: '65'
+                    name: Khersons'ka Oblast'
+                  - abbr: '68'
+                    name: Khmel'nyts'ka Oblast'
+                  - abbr: '35'
+                    name: Kirovohrads'ka Oblast'
+                  - abbr: '30'
+                    name: Kyïv
+                  - abbr: '32'
+                    name: Kyïvs'ka Oblast'
+                  - abbr: '46'
+                    name: L'vivs'ka Oblast'
+                  - abbr: '09'
+                    name: Luhans'ka Oblast'
+                  - abbr: '48'
+                    name: Mykolaïvs'ka Oblast'
+                  - abbr: '51'
+                    name: Odes'ka Oblast'
+                  - abbr: '53'
+                    name: Poltavs'ka Oblast'
+                  - abbr: '43'
+                    name: Respublika Krym
+                  - abbr: '56'
+                    name: Rivnens'ka Oblast'
+                  - abbr: '40'
+                    name: Sevastopol'
+                  - abbr: '59'
+                    name: Sums'ka Oblast'
+                  - abbr: '61'
+                    name: Ternopil's'ka Oblast'
+                  - abbr: '05'
+                    name: Vinnyts'ka Oblast'
+                  - abbr: '07'
+                    name: Volyns'ka Oblast'
+                  - abbr: '21'
+                    name: Zakarpats'ka Oblast'
+                  - abbr: '23'
+                    name: Zaporiz'ka Oblast'
+                  - abbr: '18'
+                    name: Zhytomyrs'ka Oblast'
+                - iso: AE
+                  iso3: ARE
+                  name: United Arab Emirates
+                  states_required: true
+                  zipcode_required: false
+                  states:
+                  - abbr: AJ
+                    name: "'Ajmān"
+                  - abbr: AZ
+                    name: Abū Z̧aby [Abu Dhabi]
+                  - abbr: FU
+                    name: Al Fujayrah
+                  - abbr: SH
+                    name: Ash Shariqah [Sharjah]
+                  - abbr: DU
+                    name: Dubayy
+                  - abbr: RK
+                    name: Ra's al Khaymah
+                  - abbr: UQ
+                    name: Umm al Qaywayn
+                - iso: GB
+                  iso3: GBR
+                  name: United Kingdom
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: ABE
+                    name: Aberdeen City
+                  - abbr: ABD
+                    name: Aberdeenshire
+                  - abbr: ANS
+                    name: Angus
+                  - abbr: ANN
+                    name: Antrim and Newtownabbey
+                  - abbr: AND
+                    name: Ards and North Down
+                  - abbr: AGB
+                    name: Argyll and Bute
+                  - abbr: ABC
+                    name: Armagh City, Banbridge and Craigavon
+                  - abbr: BDG
+                    name: Barking and Dagenham
+                  - abbr: BNE
+                    name: Barnet
+                  - abbr: BNS
+                    name: Barnsley
+                  - abbr: BAS
+                    name: Bath and North East Somerset
+                  - abbr: BDF
+                    name: Bedfordshire
+                  - abbr: BFS
+                    name: Belfast
+                  - abbr: BEX
+                    name: Bexley
+                  - abbr: BIR
+                    name: Birmingham
+                  - abbr: BBD
+                    name: Blackburn with Darwen
+                  - abbr: BPL
+                    name: Blackpool
+                  - abbr: BGW
+                    name: Blaenau Gwent
+                  - abbr: BOL
+                    name: Bolton
+                  - abbr: BCP
+                    name: Bournemouth, Christchurch and Poole
+                  - abbr: BRC
+                    name: Bracknell Forest
+                  - abbr: BRD
+                    name: Bradford
+                  - abbr: BEN
+                    name: Brent
+                  - abbr: BGE
+                    name: Bridgend [Pen-y-bont ar Ogwr GB-POG]
+                  - abbr: BNH
+                    name: Brighton and Hove
+                  - abbr: BST
+                    name: Bristol, City of
+                  - abbr: BRY
+                    name: Bromley
+                  - abbr: BKM
+                    name: Buckinghamshire
+                  - abbr: BUR
+                    name: Bury
+                  - abbr: CAY
+                    name: Caerphilly [Caerffili GB-CAF]
+                  - abbr: CLD
+                    name: Calderdale
+                  - abbr: CAM
+                    name: Cambridgeshire
+                  - abbr: CMD
+                    name: Camden
+                  - abbr: CRF
+                    name: Cardiff [Caerdydd GB-CRD]
+                  - abbr: CMN
+                    name: Carmarthenshire [Sir Gaerfyrddin GB-GFY]
+                  - abbr: CCG
+                    name: Causeway Coast and Glens
+                  - abbr: CBF
+                    name: Central Bedfordshire
+                  - abbr: CGN
+                    name: Ceredigion [Sir Ceredigion]
+                  - abbr: CHE
+                    name: Cheshire East
+                  - abbr: CHW
+                    name: Cheshire West and Chester
+                  - abbr: CLK
+                    name: Clackmannanshire
+                  - abbr: CWY
+                    name: Conwy
+                  - abbr: CON
+                    name: Cornwall
+                  - abbr: COV
+                    name: Coventry
+                  - abbr: CRY
+                    name: Croydon
+                  - abbr: CMA
+                    name: Cumbria
+                  - abbr: DAL
+                    name: Darlington
+                  - abbr: DEN
+                    name: Denbighshire [Sir Ddinbych GB-DDB]
+                  - abbr: DER
+                    name: Derby
+                  - abbr: DBY
+                    name: Derbyshire
+                  - abbr: DRS
+                    name: Derry and Strabane
+                  - abbr: DEV
+                    name: Devon
+                  - abbr: DNC
+                    name: Doncaster
+                  - abbr: DOR
+                    name: Dorset
+                  - abbr: DUD
+                    name: Dudley
+                  - abbr: DGY
+                    name: Dumfries and Galloway
+                  - abbr: DND
+                    name: Dundee City
+                  - abbr: DUR
+                    name: Durham
+                  - abbr: EAL
+                    name: Ealing
+                  - abbr: EAY
+                    name: East Ayrshire
+                  - abbr: EDU
+                    name: East Dunbartonshire
+                  - abbr: ELN
+                    name: East Lothian
+                  - abbr: ERW
+                    name: East Renfrewshire
+                  - abbr: ERY
+                    name: East Riding of Yorkshire
+                  - abbr: ESX
+                    name: East Sussex
+                  - abbr: EDH
+                    name: Edinburgh, City of
+                  - abbr: ELS
+                    name: Eilean Siar
+                  - abbr: ENF
+                    name: Enfield
+                  - abbr: ENG
+                    name: England
+                  - abbr: ESS
+                    name: Essex
+                  - abbr: FAL
+                    name: Falkirk
+                  - abbr: FMO
+                    name: Fermanagh and Omagh
+                  - abbr: FIF
+                    name: Fife
+                  - abbr: FLN
+                    name: Flintshire [Sir y Fflint GB-FFL]
+                  - abbr: GAT
+                    name: Gateshead
+                  - abbr: GLG
+                    name: Glasgow City
+                  - abbr: GLS
+                    name: Gloucestershire
+                  - abbr: GRE
+                    name: Greenwich
+                  - abbr: GWN
+                    name: Gwynedd
+                  - abbr: HCK
+                    name: Hackney
+                  - abbr: HAL
+                    name: Halton
+                  - abbr: HMF
+                    name: Hammersmith and Fulham
+                  - abbr: HAM
+                    name: Hampshire
+                  - abbr: HRY
+                    name: Haringey
+                  - abbr: HRW
+                    name: Harrow
+                  - abbr: HPL
+                    name: Hartlepool
+                  - abbr: HAV
+                    name: Havering
+                  - abbr: HEF
+                    name: Herefordshire, County of
+                  - abbr: HRT
+                    name: Hertfordshire
+                  - abbr: HLD
+                    name: Highland
+                  - abbr: HIL
+                    name: Hillingdon
+                  - abbr: HNS
+                    name: Hounslow
+                  - abbr: IVC
+                    name: Inverclyde
+                  - abbr: AGY
+                    name: Isle of Anglesey [Sir Ynys Môn GB-YNM]
+                  - abbr: IOW
+                    name: Isle of Wight
+                  - abbr: IOS
+                    name: Isles of Scilly
+                  - abbr: ISL
+                    name: Islington
+                  - abbr: KEC
+                    name: Kensington and Chelsea
+                  - abbr: KEN
+                    name: Kent
+                  - abbr: KHL
+                    name: Kingston upon Hull, City of
+                  - abbr: KTT
+                    name: Kingston upon Thames
+                  - abbr: KIR
+                    name: Kirklees
+                  - abbr: KWL
+                    name: Knowsley
+                  - abbr: LBH
+                    name: Lambeth
+                  - abbr: LAN
+                    name: Lancashire
+                  - abbr: LDS
+                    name: Leeds
+                  - abbr: LCE
+                    name: Leicester
+                  - abbr: LEC
+                    name: Leicestershire
+                  - abbr: LEW
+                    name: Lewisham
+                  - abbr: LIN
+                    name: Lincolnshire
+                  - abbr: LBC
+                    name: Lisburn and Castlereagh
+                  - abbr: LIV
+                    name: Liverpool
+                  - abbr: LND
+                    name: London, City of
+                  - abbr: LUT
+                    name: Luton
+                  - abbr: MAN
+                    name: Manchester
+                  - abbr: MDW
+                    name: Medway
+                  - abbr: MTY
+                    name: Merthyr Tydfil [Merthyr Tudful GB-MTU]
+                  - abbr: MRT
+                    name: Merton
+                  - abbr: MUL
+                    name: Mid Ulster
+                  - abbr: MEA
+                    name: Mid and East Antrim
+                  - abbr: MDB
+                    name: Middlesbrough
+                  - abbr: MLN
+                    name: Midlothian
+                  - abbr: MIK
+                    name: Milton Keynes
+                  - abbr: MON
+                    name: Monmouthshire [Sir Fynwy GB-FYN]
+                  - abbr: MRY
+                    name: Moray
+                  - abbr: NTL
+                    name: Neath Port Talbot [Castell-nedd Port Talbot GB-CTL]
+                  - abbr: NET
+                    name: Newcastle upon Tyne
+                  - abbr: NWM
+                    name: Newham
+                  - abbr: NWP
+                    name: Newport [Casnewydd GB-CNW]
+                  - abbr: NMD
+                    name: Newry, Mourne and Down
+                  - abbr: NFK
+                    name: Norfolk
+                  - abbr: NAY
+                    name: North Ayrshire
+                  - abbr: NEL
+                    name: North East Lincolnshire
+                  - abbr: NLK
+                    name: North Lanarkshire
+                  - abbr: NLN
+                    name: North Lincolnshire
+                  - abbr: NSM
+                    name: North Somerset
+                  - abbr: NTY
+                    name: North Tyneside
+                  - abbr: NYK
+                    name: North Yorkshire
+                  - abbr: NTH
+                    name: Northamptonshire
+                  - abbr: NIR
+                    name: Northern Ireland
+                  - abbr: NBL
+                    name: Northumberland
+                  - abbr: NGM
+                    name: Nottingham
+                  - abbr: NTT
+                    name: Nottinghamshire
+                  - abbr: OLD
+                    name: Oldham
+                  - abbr: ORK
+                    name: Orkney Islands
+                  - abbr: OXF
+                    name: Oxfordshire
+                  - abbr: PEM
+                    name: Pembrokeshire [Sir Benfro GB-BNF]
+                  - abbr: PKN
+                    name: Perth and Kinross
+                  - abbr: PTE
+                    name: Peterborough
+                  - abbr: PLY
+                    name: Plymouth
+                  - abbr: POR
+                    name: Portsmouth
+                  - abbr: POW
+                    name: Powys
+                  - abbr: RDG
+                    name: Reading
+                  - abbr: RDB
+                    name: Redbridge
+                  - abbr: RCC
+                    name: Redcar and Cleveland
+                  - abbr: RFW
+                    name: Renfrewshire
+                  - abbr: RCT
+                    name: Rhondda, Cynon, Taff [Rhondda, Cynon,Taf]
+                  - abbr: RIC
+                    name: Richmond upon Thames
+                  - abbr: RCH
+                    name: Rochdale
+                  - abbr: ROT
+                    name: Rotherham
+                  - abbr: RUT
+                    name: Rutland
+                  - abbr: SLF
+                    name: Salford
+                  - abbr: SAW
+                    name: Sandwell
+                  - abbr: SCT
+                    name: Scotland
+                  - abbr: SCB
+                    name: Scottish Borders, The
+                  - abbr: SFT
+                    name: Sefton
+                  - abbr: SHF
+                    name: Sheffield
+                  - abbr: ZET
+                    name: Shetland Islands
+                  - abbr: SHR
+                    name: Shropshire
+                  - abbr: SLG
+                    name: Slough
+                  - abbr: SOL
+                    name: Solihull
+                  - abbr: SOM
+                    name: Somerset
+                  - abbr: SAY
+                    name: South Ayrshire
+                  - abbr: SGC
+                    name: South Gloucestershire
+                  - abbr: SLK
+                    name: South Lanarkshire
+                  - abbr: STY
+                    name: South Tyneside
+                  - abbr: STH
+                    name: Southampton
+                  - abbr: SOS
+                    name: Southend-on-Sea
+                  - abbr: SWK
+                    name: Southwark
+                  - abbr: SHN
+                    name: St. Helens
+                  - abbr: STS
+                    name: Staffordshire
+                  - abbr: STG
+                    name: Stirling
+                  - abbr: SKP
+                    name: Stockport
+                  - abbr: STT
+                    name: Stockton-on-Tees
+                  - abbr: STE
+                    name: Stoke-on-Trent
+                  - abbr: SFK
+                    name: Suffolk
+                  - abbr: SND
+                    name: Sunderland
+                  - abbr: SRY
+                    name: Surrey
+                  - abbr: STN
+                    name: Sutton
+                  - abbr: SWA
+                    name: Swansea [Abertawe GB-ATA]
+                  - abbr: SWD
+                    name: Swindon
+                  - abbr: TAM
+                    name: Tameside
+                  - abbr: TFW
+                    name: Telford and Wrekin
+                  - abbr: THR
+                    name: Thurrock
+                  - abbr: TOB
+                    name: Torbay
+                  - abbr: TOF
+                    name: Torfaen [Tor-faen]
+                  - abbr: TWH
+                    name: Tower Hamlets
+                  - abbr: TRF
+                    name: Trafford
+                  - abbr: VGL
+                    name: Vale of Glamorgan, The [Bro Morgannwg GB-BMG]
+                  - abbr: WKF
+                    name: Wakefield
+                  - abbr: WLS
+                    name: Wales
+                  - abbr: WLL
+                    name: Walsall
+                  - abbr: WFT
+                    name: Waltham Forest
+                  - abbr: WND
+                    name: Wandsworth
+                  - abbr: WRT
+                    name: Warrington
+                  - abbr: WAR
+                    name: Warwickshire
+                  - abbr: WBK
+                    name: West Berkshire
+                  - abbr: WDU
+                    name: West Dunbartonshire
+                  - abbr: WLN
+                    name: West Lothian
+                  - abbr: WSX
+                    name: West Sussex
+                  - abbr: WSM
+                    name: Westminster
+                  - abbr: WGN
+                    name: Wigan
+                  - abbr: WIL
+                    name: Wiltshire
+                  - abbr: WNM
+                    name: Windsor and Maidenhead
+                  - abbr: WRL
+                    name: Wirral
+                  - abbr: WOK
+                    name: Wokingham
+                  - abbr: WLV
+                    name: Wolverhampton
+                  - abbr: WOR
+                    name: Worcestershire
+                  - abbr: WRX
+                    name: Wrexham [Wrecsam GB-WRC]
+                  - abbr: YOR
+                    name: York
+                - iso: US
+                  iso3: USA
+                  name: United States
+                  states_required: true
+                  zipcode_required: true
+                  states:
+                  - abbr: AL
+                    name: Alabama
+                  - abbr: AK
+                    name: Alaska
+                  - abbr: AZ
+                    name: Arizona
+                  - abbr: AR
+                    name: Arkansas
+                  - abbr: AA
+                    name: Armed Forces Americas
+                  - abbr: AE
+                    name: Armed Forces Europe
+                  - abbr: AP
+                    name: Armed Forces Pacific
+                  - abbr: CA
+                    name: California
+                  - abbr: CO
+                    name: Colorado
+                  - abbr: CT
+                    name: Connecticut
+                  - abbr: DE
+                    name: Delaware
+                  - abbr: DC
+                    name: District of Columbia
+                  - abbr: FL
+                    name: Florida
+                  - abbr: GA
+                    name: Georgia
+                  - abbr: HI
+                    name: Hawaii
+                  - abbr: ID
+                    name: Idaho
+                  - abbr: IL
+                    name: Illinois
+                  - abbr: IN
+                    name: Indiana
+                  - abbr: IA
+                    name: Iowa
+                  - abbr: KS
+                    name: Kansas
+                  - abbr: KY
+                    name: Kentucky
+                  - abbr: LA
+                    name: Louisiana
+                  - abbr: ME
+                    name: Maine
+                  - abbr: MD
+                    name: Maryland
+                  - abbr: MA
+                    name: Massachusetts
+                  - abbr: MI
+                    name: Michigan
+                  - abbr: MN
+                    name: Minnesota
+                  - abbr: MS
+                    name: Mississippi
+                  - abbr: MO
+                    name: Missouri
+                  - abbr: MT
+                    name: Montana
+                  - abbr: NE
+                    name: Nebraska
+                  - abbr: NV
+                    name: Nevada
+                  - abbr: NH
+                    name: New Hampshire
+                  - abbr: NJ
+                    name: New Jersey
+                  - abbr: NM
+                    name: New Mexico
+                  - abbr: NY
+                    name: New York
+                  - abbr: NC
+                    name: North Carolina
+                  - abbr: ND
+                    name: North Dakota
+                  - abbr: OH
+                    name: Ohio
+                  - abbr: OK
+                    name: Oklahoma
+                  - abbr: OR
+                    name: Oregon
+                  - abbr: PA
+                    name: Pennsylvania
+                  - abbr: RI
+                    name: Rhode Island
+                  - abbr: SC
+                    name: South Carolina
+                  - abbr: SD
+                    name: South Dakota
+                  - abbr: TN
+                    name: Tennessee
+                  - abbr: TX
+                    name: Texas
+                  - abbr: UT
+                    name: Utah
+                  - abbr: VT
+                    name: Vermont
+                  - abbr: VA
+                    name: Virginia
+                  - abbr: WA
+                    name: Washington
+                  - abbr: WV
+                    name: West Virginia
+                  - abbr: WI
+                    name: Wisconsin
+                  - abbr: WY
+                    name: Wyoming
+                - iso: UY
+                  iso3: URY
+                  name: Uruguay
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AR
+                    name: Artigas
+                  - abbr: CA
+                    name: Canelones
+                  - abbr: CL
+                    name: Cerro Lago
+                  - abbr: CO
+                    name: Colonia
+                  - abbr: DU
+                    name: Durazno
+                  - abbr: FS
+                    name: Flores
+                  - abbr: FD
+                    name: Florida
+                  - abbr: LA
+                    name: Lavalleja
+                  - abbr: MA
+                    name: Maldonado
+                  - abbr: MO
+                    name: Montevideo
+                  - abbr: PA
+                    name: Paysandú
+                  - abbr: RV
+                    name: Rivera
+                  - abbr: RO
+                    name: Rocha
+                  - abbr: RN
+                    name: Río Negro
+                  - abbr: SA
+                    name: Salto
+                  - abbr: SJ
+                    name: San José
+                  - abbr: SO
+                    name: Soriano
+                  - abbr: TA
+                    name: Tacuarembó
+                  - abbr: TT
+                    name: Treinta y Tres
+                - iso: UZ
+                  iso3: UZB
+                  name: Uzbekistan
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AN
+                    name: Andijon
+                  - abbr: BU
+                    name: Buxoro
+                  - abbr: FA
+                    name: Farg‘ona
+                  - abbr: JI
+                    name: Jizzax
+                  - abbr: NG
+                    name: Namangan
+                  - abbr: NW
+                    name: Navoiy
+                  - abbr: QA
+                    name: Qashqadaryo
+                  - abbr: QR
+                    name: Qoraqalpog‘iston Respublikasi
+                  - abbr: SA
+                    name: Samarqand
+                  - abbr: SI
+                    name: Sirdaryo
+                  - abbr: SU
+                    name: Surxondaryo
+                  - abbr: TO
+                    name: Toshkent
+                  - abbr: TK
+                    name: Toshkent City
+                  - abbr: XO
+                    name: Xorazm
+                - iso: VU
+                  iso3: VUT
+                  name: Vanuatu
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: MAP
+                    name: Malampa
+                  - abbr: PAM
+                    name: Pénama
+                  - abbr: SAM
+                    name: Sanma
+                  - abbr: SEE
+                    name: Shéfa
+                  - abbr: TAE
+                    name: Taféa
+                  - abbr: TOB
+                    name: Torba
+                - iso: VE
+                  iso3: VEN
+                  name: Venezuela
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: Z
+                    name: Amazonas
+                  - abbr: B
+                    name: Anzoátegui
+                  - abbr: C
+                    name: Apure
+                  - abbr: D
+                    name: Aragua
+                  - abbr: E
+                    name: Barinas
+                  - abbr: F
+                    name: Bolívar
+                  - abbr: G
+                    name: Carabobo
+                  - abbr: H
+                    name: Cojedes
+                  - abbr: "Y"
+                    name: Delta Amacuro
+                  - abbr: W
+                    name: Dependencias Federales
+                  - abbr: A
+                    name: Distrito Federal
+                  - abbr: I
+                    name: Falcón
+                  - abbr: J
+                    name: Guárico
+                  - abbr: K
+                    name: Lara
+                  - abbr: M
+                    name: Miranda
+                  - abbr: "N"
+                    name: Monagas
+                  - abbr: L
+                    name: Mérida
+                  - abbr: O
+                    name: Nueva Esparta
+                  - abbr: P
+                    name: Portuguesa
+                  - abbr: R
+                    name: Sucre
+                  - abbr: T
+                    name: Trujillo
+                  - abbr: S
+                    name: Táchira
+                  - abbr: X
+                    name: Vargas
+                  - abbr: U
+                    name: Yaracuy
+                  - abbr: V
+                    name: Zulia
+                - iso: VN
+                  iso3: VNM
+                  name: Vietnam
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '44'
+                    name: An Giang
+                  - abbr: '43'
+                    name: Ba Ria - Vung Tau
+                  - abbr: '53'
+                    name: Bac Can
+                  - abbr: '54'
+                    name: Bac Giang
+                  - abbr: '55'
+                    name: Bac Lieu
+                  - abbr: '56'
+                    name: Bac Ninh
+                  - abbr: '50'
+                    name: Ben Tre
+                  - abbr: '31'
+                    name: Binh Dinh
+                  - abbr: '57'
+                    name: Binh Duong
+                  - abbr: '58'
+                    name: Binh Phuoc
+                  - abbr: '40'
+                    name: Binh Thuan
+                  - abbr: '59'
+                    name: Ca Mau
+                  - abbr: CT
+                    name: Can Tho
+                  - abbr: '04'
+                    name: Cao Bang
+                  - abbr: DN
+                    name: Da Nang
+                  - abbr: '33'
+                    name: Dac Lac
+                  - abbr: '72'
+                    name: Dak Nong
+                  - abbr: '71'
+                    name: Dien Bien
+                  - abbr: '39'
+                    name: Dong Nai
+                  - abbr: '45'
+                    name: Dong Thap
+                  - abbr: '30'
+                    name: Gia Lai
+                  - abbr: '03'
+                    name: Ha Giang
+                  - abbr: '63'
+                    name: Ha Nam
+                  - abbr: HN
+                    name: Ha Noi
+                  - abbr: '23'
+                    name: Ha Tinh
+                  - abbr: '61'
+                    name: Hai Duong
+                  - abbr: HP
+                    name: Hai Phong
+                  - abbr: '73'
+                    name: Hau Giang
+                  - abbr: SG
+                    name: Ho Chi Minh
+                  - abbr: '14'
+                    name: Hoa Binh
+                  - abbr: '66'
+                    name: Hung Yen
+                  - abbr: '34'
+                    name: Khanh Hoa
+                  - abbr: '47'
+                    name: Kien Giang
+                  - abbr: '28'
+                    name: Kon Tum
+                  - abbr: '01'
+                    name: Lai Chau
+                  - abbr: '35'
+                    name: Lam Dong
+                  - abbr: '09'
+                    name: Lang Son
+                  - abbr: '02'
+                    name: Lao Cai
+                  - abbr: '41'
+                    name: Long An
+                  - abbr: '67'
+                    name: Nam Dinh
+                  - abbr: '22'
+                    name: Nghe An
+                  - abbr: '18'
+                    name: Ninh Binh
+                  - abbr: '36'
+                    name: Ninh Thuan
+                  - abbr: '68'
+                    name: Phu Tho
+                  - abbr: '32'
+                    name: Phu Yen
+                  - abbr: '24'
+                    name: Quang Binh
+                  - abbr: '27'
+                    name: Quang Nam
+                  - abbr: '29'
+                    name: Quang Ngai
+                  - abbr: '13'
+                    name: Quang Ninh
+                  - abbr: '25'
+                    name: Quang Tri
+                  - abbr: '52'
+                    name: Soc Trang
+                  - abbr: '05'
+                    name: Son La
+                  - abbr: '37'
+                    name: Tay Ninh
+                  - abbr: '20'
+                    name: Thai Binh
+                  - abbr: '69'
+                    name: Thai Nguyen
+                  - abbr: '21'
+                    name: Thanh Hoa
+                  - abbr: '26'
+                    name: Thua Thien-Hue
+                  - abbr: '46'
+                    name: Tien Giang
+                  - abbr: '51'
+                    name: Tra Vinh
+                  - abbr: '07'
+                    name: Tuyen Quang
+                  - abbr: '49'
+                    name: Vinh Long
+                  - abbr: '70'
+                    name: Vinh Phuc
+                  - abbr: '06'
+                    name: Yen Bai
+                - iso: VG
+                  iso3: VGB
+                  name: Virgin Islands, British
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: VI
+                  iso3: VIR
+                  name: Virgin Islands, U.S.
+                  states_required: false
+                  zipcode_required: true
+                  states: []
+                - iso: WF
+                  iso3: WLF
+                  name: Wallis and Futuna
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: AL
+                    name: Alo
+                  - abbr: SG
+                    name: Sigave
+                  - abbr: UV
+                    name: Uvea
+                - iso: YE
+                  iso3: YEM
+                  name: Yemen
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: AM
+                    name: "'Amran"
+                  - abbr: AB
+                    name: Abyan
+                  - abbr: DA
+                    name: Ad¸ D¸ali'
+                  - abbr: BA
+                    name: Al Bayḑā’
+                  - abbr: JA
+                    name: Al Jawf
+                  - abbr: MR
+                    name: Al Mahrah
+                  - abbr: MW
+                    name: Al Mahwit
+                  - abbr: HU
+                    name: Al Ḩudaydah
+                  - abbr: DH
+                    name: Dhamar
+                  - abbr: HD
+                    name: Hadramawt
+                  - abbr: HJ
+                    name: Hajjah
+                  - abbr: IB
+                    name: Ibb
+                  - abbr: LA
+                    name: Laḩij
+                  - abbr: MA
+                    name: Ma'rib
+                  - abbr: SD
+                    name: Sa`dah
+                  - abbr: SN
+                    name: Sanʿā
+                  - abbr: SH
+                    name: Shabwah
+                  - abbr: TA
+                    name: Taʿizz
+                  - abbr: AD
+                    name: ʿAdan
+                  - abbr: SA
+                    name: صنعاء
+                  - abbr: SU
+                    name: محافظة أرخبيل سقطرى
+                  - abbr: RA
+                    name: محافظة ريمة
+                - iso: ZM
+                  iso3: ZMB
+                  name: Zambia
+                  states_required: false
+                  zipcode_required: true
+                  states:
+                  - abbr: '02'
+                    name: Central
+                  - abbr: '08'
+                    name: Copperbelt
+                  - abbr: '03'
+                    name: Eastern
+                  - abbr: '04'
+                    name: Luapula
+                  - abbr: '09'
+                    name: Lusaka
+                  - abbr: '10'
+                    name: Muchinga
+                  - abbr: '06'
+                    name: North-Western
+                  - abbr: '05'
+                    name: Northern
+                  - abbr: '07'
+                    name: Southern
+                  - abbr: '01'
+                    name: Western
+                - iso: ZW
+                  iso3: ZWE
+                  name: Zimbabwe
+                  states_required: false
+                  zipcode_required: false
+                  states:
+                  - abbr: BU
+                    name: Bulawayo
+                  - abbr: HA
+                    name: Harare
+                  - abbr: MA
+                    name: Manicaland
+                  - abbr: MC
+                    name: Mashonaland Central
+                  - abbr: ME
+                    name: Mashonaland East
+                  - abbr: MW
+                    name: Mashonaland West
+                  - abbr: MV
+                    name: Masvingo
+                  - abbr: MN
+                    name: Matabeleland North
+                  - abbr: MS
+                    name: Matabeleland South
+                  - abbr: MI
+                    name: Midlands
+                meta:
+                  count: 240
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/SellerCountry"
+                  meta:
+                    type: object
+                    properties:
+                      count:
+                        type: integer
+                        example: 250
+                    required:
+                    - count
+                required:
+                - data
+                - meta
+  "/api/v3/seller/onboarding":
+    get:
+      summary: Get onboarding checklist
+      tags:
+      - Onboarding
+      security:
+      - bearer_auth: []
+      description: |
+        What this marketplace asks of the seller before it will admit them.
+
+        Singular: the checklist is always the acting seller's. Every answer is
+        computed server-side by the same evaluator the operator's own view uses,
+        so the panel and the operator can never show different progress.
+
+        `progress` counts optional requirements too — it is how far along the
+        checklist is, not how close to approval. Read `blocking` on each
+        requirement for that.
+
+        Each requirement's `id` is what a submission is posted against. A
+        marketplace that asks for nothing returns an empty list, which is a
+        complete answer rather than a missing one.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: checklist returned
+          content:
+            application/json:
+              example:
+                status: approved
+                progress:
+                  done: 0
+                  total: 0
+                requirements: []
+              schema:
+                "$ref": "#/components/schemas/SellerOnboardingResponse"
+        '403':
+          description: no seller named, or not a member of it
+          content:
+            application/json:
+              example:
+                error:
+                  code: access_denied
+                  message: You do not have access to this seller.
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/onboarding/submit_for_review":
+    post:
+      summary: Submit for review
+      tags:
+      - Onboarding
+      security:
+      - bearer_auth: []
+      description: |
+        Says the seller is ready, moving them from `onboarding` to
+        `ready_for_review`.
+
+        Refused with `422` when something required is still outstanding — the
+        message names the blocking requirements, and the seller's status is
+        unchanged. Returns the same payload as the checklist so the panel can
+        re-render from one response.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: submitted for review
+          content:
+            application/json:
+              example:
+                status: ready_for_review
+                progress:
+                  done: 0
+                  total: 0
+                requirements: []
+              schema:
+                "$ref": "#/components/schemas/SellerOnboardingResponse"
+  "/api/v3/seller/requirements/{requirement_id}/submissions":
+    parameters:
+    - name: requirement_id
+      in: path
+      description: Requirement ID, as returned by `GET /api/v3/seller/onboarding`
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Submit against a requirement
+      tags:
+      - Onboarding
+      security:
+      - bearer_auth: []
+      description: |
+        What the seller says about one requirement: an attestation they tick, a
+        document they upload, a reference they paste.
+
+        Create only. A submission records what was said and when, so a seller who
+        needs to correct something submits again rather than editing, and the
+        latest one counts.
+
+        `file` is **not** a multipart upload — it is the `signed_id` returned by
+        `POST /api/v3/seller/direct_uploads`, so the bytes are already in storage
+        by the time this runs.
+
+        An attestation is accepted on the spot; a requirement the operator
+        reviews comes back `pending`.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: submission recorded
+          content:
+            application/json:
+              example:
+                id: selsub_UkLWZg9DAJ
+                status: accepted
+                note: Confirmed.
+                review_note:
+                reference:
+                reviewed_at: '2026-01-15T12:00:00.000Z'
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+                file_url:
+                file_name:
+              schema:
+                "$ref": "#/components/schemas/RequirementSubmission"
+        '404':
+          description: a requirement belonging to another marketplace
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Seller requirement not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  type: string
+                  description: Anything the seller wants to say alongside the submission
+                reference:
+                  type: string
+                  description: A reference number or external identifier, for requirements
+                    that ask for one
+                file:
+                  type: string
+                  description: A direct-upload `signed_id`, for requirements that
+                    ask for a document
+  "/api/v3/seller/requirement_submissions/{id}/download":
+    parameters:
+    - name: id
+      in: path
+      description: Submission ID
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Download a submitted document
+      tags:
+      - Onboarding
+      security:
+      - bearer_auth: []
+      description: |
+        Streams the file attached to one of this seller's submissions.
+
+        Served through the API rather than from a storage URL on purpose: these
+        are identity and registration documents, so every read is authorized
+        against the acting seller. Another seller's submission answers `404`.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '404':
+          description: another seller's submission
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Seller requirement submission not found
+            application/octet-stream:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/products":
+    get:
+      summary: List products
+      tags:
+      - Products
+      security:
+      - bearer_auth: []
+      description: |
+        The seller's own catalog — the products they own outright.
+
+        Every call is rooted in the acting seller server-side, so this can never
+        return another seller's product or one the marketplace operator sells
+        first-party.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: Page number
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        description: Records per page (max 100)
+        schema:
+          type: integer
+      - name: sort
+        in: query
+        required: false
+        description: Sort field; prefix with `-` for descending
+        schema:
+          type: string
+      responses:
+        '200':
+          description: products listed
+          content:
+            application/json:
+              example:
+                data:
+                - id: prod_UkLWZg9DAJ
+                  name: Product 1233250
+                  slug: product-1233250
+                  meta_title:
+                  meta_description:
+                  meta_keywords:
+                  variant_count: 1
+                  available_on:
+                  preorder_ships_at:
+                  purchasable: true
+                  preorder: false
+                  in_stock: false
+                  backorderable: true
+                  available: true
+                  description: Maiores ut qui dolores ab autem. Architecto quos sequi
+                    minus debitis tempora molestiae. Quasi officiis minus voluptatum
+                    eveniet incidunt. Nisi laboriosam a aliquam eveniet occaecati
+                    ducimus. Provident quo amet nostrum sed assumenda cum odio. Distinctio
+                    perferendis quasi nisi exercitationem veritatis minima esse. In
+                    velit at corporis nobis. Voluptate mollitia nam pariatur enim.
+                    Recusandae necessitatibus earum deserunt sapiente eveniet quidem
+                    unde. Consectetur ab perspiciatis veniam dolor tempora. Omnis
+                    odit autem quae repellat. Delectus corrupti ea nisi reiciendis
+                    atque iure a molestias. Repellendus laboriosam sint molestias
+                    debitis in. Minima omnis accusantium modi accusamus doloribus
+                    fugit. Accusamus autem sequi perferendis saepe quos perspiciatis.
+                  description_html: |-
+                    Maiores ut qui dolores ab autem. Architecto quos sequi minus debitis tempora molestiae. Quasi officiis minus voluptatum eveniet incidunt. Nisi laboriosam a aliquam eveniet occaecati ducimus. Provident quo amet nostrum sed assumenda cum odio.
+                    Distinctio perferendis quasi nisi exercitationem veritatis minima esse. In velit at corporis nobis. Voluptate mollitia nam pariatur enim. Recusandae necessitatibus earum deserunt sapiente eveniet quidem unde.
+                    Consectetur ab perspiciatis veniam dolor tempora. Omnis odit autem quae repellat. Delectus corrupti ea nisi reiciendis atque iure a molestias.
+                    Repellendus laboriosam sint molestias debitis in. Minima omnis accusantium modi accusamus doloribus fugit. Accusamus autem sequi perferendis saepe quos perspiciatis.
+                  default_variant_id: variant_UkLWZg9DAJ
+                  buy_box_variant_id: variant_UkLWZg9DAJ
+                  thumbnail_url:
+                  tags: []
+                  price:
+                    id: price_UkLWZg9DAJ
+                    amount: '19.99'
+                    amount_in_cents: 1999
+                    compare_at_amount:
+                    compare_at_amount_in_cents:
+                    currency: USD
+                    display_amount: "$19.99"
+                    display_compare_at_amount:
+                    price_list_id:
+                  original_price:
+                  seller_id: sel_UkLWZg9DAJ
+                  status: active
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  updated_at: '2026-01-15T12:00:00.000Z'
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Product"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+                required:
+                - data
+                - meta
+    post:
+      summary: Create a product
+      tags:
+      - Products
+      security:
+      - bearer_auth: []
+      description: |
+        Creates a product owned by the acting seller.
+
+        The seller and the store are taken from the request context whatever the
+        payload says, so a product cannot be created against another seller.
+
+        The operator's own settings — tax category, delivery profile and whether
+        the product is promotionable — are not writable here; they belong to the
+        marketplace, not the seller.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: product created
+          content:
+            application/json:
+              example:
+                id: prod_gbHJdmfrXB
+                name: Hand-thrown mug
+                slug: hand-thrown-mug
+                meta_title:
+                meta_description:
+                meta_keywords:
+                variant_count: 0
+                available_on:
+                preorder_ships_at:
+                purchasable: false
+                preorder: false
+                in_stock: false
+                backorderable: false
+                available: false
+                description:
+                description_html:
+                default_variant_id: variant_gbHJdmfrXB
+                buy_box_variant_id: variant_gbHJdmfrXB
+                thumbnail_url:
+                tags: []
+                price:
+                  id: price_gbHJdmfrXB
+                  amount: '24.0'
+                  amount_in_cents: 2400
+                  compare_at_amount:
+                  compare_at_amount_in_cents:
+                  currency: USD
+                  display_amount: "$24.00"
+                  display_compare_at_amount:
+                  price_list_id:
+                original_price:
+                seller_id: sel_UkLWZg9DAJ
+                status: draft
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+              schema:
+                "$ref": "#/components/schemas/Product"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Name can't be blank
+                  details:
+                    name:
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Hand-thrown mug
+                description:
+                  type: string
+                slug:
+                  type: string
+                  example: hand-thrown-mug
+                status:
+                  type: string
+                  example: draft
+                meta_title:
+                  type: string
+                meta_description:
+                  type: string
+                meta_keywords:
+                  type: string
+                product_type_id:
+                  type: string
+                  example: ptype_abc123
+                tags:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - ceramics
+                  - handmade
+                category_ids:
+                  type: array
+                  items:
+                    type: string
+                  example:
+                  - cat_abc123
+                metadata:
+                  type: object
+                  additionalProperties: true
+                prices:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      amount:
+                        type: string
+                        example: '24.00'
+                      compare_at_amount:
+                        type: string
+                        example: '30.00'
+                      currency:
+                        type: string
+                        example: USD
+              required:
+              - name
+  "/api/v3/seller/products/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: Product ID
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Get a product
+      tags:
+      - Products
+      security:
+      - bearer_auth: []
+      description: |
+        A product the acting seller owns.
+
+        An id belonging to another seller answers `404`, not `403` — the seller
+        is not told the record exists.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: product returned
+          content:
+            application/json:
+              example:
+                id: prod_UkLWZg9DAJ
+                name: Product 1266710
+                slug: product-1266710
+                meta_title:
+                meta_description:
+                meta_keywords:
+                variant_count: 1
+                available_on:
+                preorder_ships_at:
+                purchasable: true
+                preorder: false
+                in_stock: false
+                backorderable: true
+                available: true
+                description: Aliquid voluptate laudantium necessitatibus quidem eaque.
+                  Sapiente at autem eveniet exercitationem odio in dolores. Laborum
+                  accusantium nulla autem tempora qui inventore assumenda molestiae.
+                  Quisquam voluptas delectus ipsum totam ab incidunt. Sunt excepturi
+                  eius provident unde neque in. Earum pariatur enim odit delectus
+                  accusamus recusandae. Dolorem eligendi debitis iste voluptate laboriosam
+                  ab. Ab aut suscipit illo occaecati. Dolores libero cupiditate provident
+                  at itaque temporibus. Adipisci iste beatae quibusdam perferendis
+                  ea blanditiis saepe facilis.
+                description_html: |-
+                  Aliquid voluptate laudantium necessitatibus quidem eaque. Sapiente at autem eveniet exercitationem odio in dolores. Laborum accusantium nulla autem tempora qui inventore assumenda molestiae. Quisquam voluptas delectus ipsum totam ab incidunt. Sunt excepturi eius provident unde neque in.
+                  Earum pariatur enim odit delectus accusamus recusandae. Dolorem eligendi debitis iste voluptate laboriosam ab. Ab aut suscipit illo occaecati. Dolores libero cupiditate provident at itaque temporibus. Adipisci iste beatae quibusdam perferendis ea blanditiis saepe facilis.
+                default_variant_id: variant_UkLWZg9DAJ
+                buy_box_variant_id: variant_UkLWZg9DAJ
+                thumbnail_url:
+                tags: []
+                price:
+                  id: price_UkLWZg9DAJ
+                  amount: '19.99'
+                  amount_in_cents: 1999
+                  compare_at_amount:
+                  compare_at_amount_in_cents:
+                  currency: USD
+                  display_amount: "$19.99"
+                  display_compare_at_amount:
+                  price_list_id:
+                original_price:
+                seller_id: sel_UkLWZg9DAJ
+                status: active
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+              schema:
+                "$ref": "#/components/schemas/Product"
+        '404':
+          description: another seller's product
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Product not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update a product
+      tags:
+      - Products
+      security:
+      - bearer_auth: []
+      description: Edits a product the acting seller owns.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: product updated
+          content:
+            application/json:
+              example:
+                id: prod_UkLWZg9DAJ
+                name: Hand-thrown mug, large
+                slug: product-1298212
+                meta_title:
+                meta_description:
+                meta_keywords:
+                variant_count: 1
+                available_on:
+                preorder_ships_at:
+                purchasable: true
+                preorder: false
+                in_stock: false
+                backorderable: true
+                available: true
+                description: Vel minima recusandae iure deserunt non. Corrupti soluta
+                  pariatur recusandae saepe eveniet. Sequi deserunt fugiat architecto
+                  animi. Eum facilis veniam a consequatur minus. Dolor iure facilis
+                  repellendus tenetur. Nobis harum perferendis ab maiores labore eius
+                  eum quo.
+                description_html: |-
+                  Vel minima recusandae iure deserunt non. Corrupti soluta pariatur recusandae saepe eveniet. Sequi deserunt fugiat architecto animi.
+                  Eum facilis veniam a consequatur minus. Dolor iure facilis repellendus tenetur. Nobis harum perferendis ab maiores labore eius eum quo.
+                default_variant_id: variant_UkLWZg9DAJ
+                buy_box_variant_id: variant_UkLWZg9DAJ
+                thumbnail_url:
+                tags: []
+                price:
+                  id: price_UkLWZg9DAJ
+                  amount: '19.99'
+                  amount_in_cents: 1999
+                  compare_at_amount:
+                  compare_at_amount_in_cents:
+                  currency: USD
+                  display_amount: "$19.99"
+                  display_compare_at_amount:
+                  price_list_id:
+                original_price:
+                seller_id: sel_UkLWZg9DAJ
+                status: active
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+              schema:
+                "$ref": "#/components/schemas/Product"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Hand-thrown mug, large
+                description:
+                  type: string
+                slug:
+                  type: string
+                status:
+                  type: string
+                  example: active
+                tags:
+                  type: array
+                  items:
+                    type: string
+                category_ids:
+                  type: array
+                  items:
+                    type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+    delete:
+      summary: Delete a product
+      tags:
+      - Products
+      security:
+      - bearer_auth: []
+      description: Deletes a product the acting seller owns.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: product deleted
+  "/api/v3/seller/profile":
+    get:
+      summary: Get profile
+      tags:
+      - Profile
+      security:
+      - bearer_auth: []
+      description: |
+        The seller's own record.
+
+        Singular by nature: the seller in play is always the one named by
+        `X-Spree-Seller-Id`, never an id in the path — so a seller cannot address
+        another seller here even by guessing one.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: profile returned
+          content:
+            application/json:
+              example:
+                id: sel_UkLWZg9DAJ
+                name: Seller 33
+                slug: seller-33
+                about: ''
+                about_html: ''
+                logo_url:
+                square_logo_url:
+                cover_photo_url:
+                status: approved
+                legal_name:
+                registration_number:
+                contact_email:
+                billing_email:
+                tax_remittance: seller
+                payouts_schedule_interval:
+                holiday_mode_until:
+                terms_accepted_at: '2026-01-15T12:00:00.000Z'
+                created_at: '2026-01-15T12:00:00.000Z'
+                minimum_payout_amount:
+                on_holiday: false
+                sellable: true
+                products_count: 0
+                tax_identifiers: []
+              schema:
+                "$ref": "#/components/schemas/Profile"
+        '403':
+          description: no seller named, or not a member of it
+          content:
+            application/json:
+              example:
+                error:
+                  code: access_denied
+                  message: You do not have access to this seller.
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update profile
+      tags:
+      - Profile
+      security:
+      - bearer_auth: []
+      description: |
+        Edits presentation, contact details and addresses.
+
+        Readable but **not** writable, by design: `status` — the lifecycle belongs
+        to the marketplace operator's workflows — the settlement terms, and
+        `slug`, since a seller renaming their own storefront address would break
+        every link pointing at it.
+
+        `tax_identifier` holds one registration per kind: re-sending a kind
+        corrects the number, and an empty value removes it. A changed number
+        drops its validation verdict, because that answer was about the old one.
+
+        `accept_terms: true` stamps the moment the seller accepted the
+        marketplace's terms, which is what the matching onboarding requirement
+        reads. One-way — sending `false` does not unmake the stamp.
+
+        `custom_fields` is narrowed server-side to the definitions this
+        marketplace's onboarding actually asks this seller for; a field nothing
+        asked for is ignored rather than written.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: profile updated
+          content:
+            application/json:
+              example:
+                id: sel_UkLWZg9DAJ
+                name: Acme Supplies
+                slug: seller-35
+                about: ''
+                about_html: ''
+                logo_url:
+                square_logo_url:
+                cover_photo_url:
+                status: approved
+                legal_name:
+                registration_number:
+                contact_email: hello@acme.test
+                billing_email:
+                tax_remittance: seller
+                payouts_schedule_interval:
+                holiday_mode_until:
+                terms_accepted_at: '2026-01-15T12:00:00.000Z'
+                created_at: '2026-01-15T12:00:00.000Z'
+                minimum_payout_amount:
+                on_holiday: false
+                sellable: true
+                products_count: 0
+                tax_identifiers: []
+              schema:
+                "$ref": "#/components/schemas/Profile"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Name can't be blank
+                  details:
+                    name:
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Acme Supplies
+                contact_email:
+                  type: string
+                  format: email
+                  nullable: true
+                  example: hello@acme.test
+                billing_email:
+                  type: string
+                  format: email
+                  nullable: true
+                  example: billing@acme.test
+                about:
+                  type: string
+                  nullable: true
+                  description: Sanitized HTML — the seller's public description
+                legal_name:
+                  type: string
+                  nullable: true
+                  description: The business a commission invoice is made out to
+                registration_number:
+                  type: string
+                  nullable: true
+                logo:
+                  type: string
+                  nullable: true
+                  description: ActiveStorage signed id; `null` removes the attachment
+                square_logo:
+                  type: string
+                  nullable: true
+                cover_photo:
+                  type: string
+                  nullable: true
+                accept_terms:
+                  type: boolean
+                  description: Stamps acceptance of the marketplace terms
+                tax_identifier:
+                  type: object
+                  properties:
+                    kind:
+                      type: string
+                      example: eu_vat
+                    value:
+                      type: string
+                      example: PL1234567890
+                billing_address:
+                  type: object
+                  additionalProperties: true
+                custom_fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      custom_field_definition_id:
+                        type: string
+                        example: cfd_abc123
+                      value:
+                        description: Any JSON value the definition accepts
+  "/api/v3/seller/stock_locations":
+    get:
+      summary: List stock locations
+      tags:
+      - Stock Locations
+      security:
+      - bearer_auth: []
+      description: |
+        Where this seller keeps stock, and so where their returns are sent.
+
+        Rooted in the acting seller, so the marketplace operator's own warehouses
+        never appear here.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: Page number
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        description: Records per page (max 100)
+        schema:
+          type: integer
+      - name: sort
+        in: query
+        required: false
+        description: Sort field; prefix with `-` for descending
+        schema:
+          type: string
+      responses:
+        '200':
+          description: stock locations listed
+          content:
+            application/json:
+              example:
+                data:
+                - id: sloc_UkLWZg9DAJ
+                  name: Lesha Stroman
+                  address1: 1600 Pennsylvania Ave NW
+                  city: Washington
+                  zipcode: '20500'
+                  country_code: US
+                  country_name: United States
+                  state_code: AL
+                  state_text: AL
+                  pickup_ready_in_minutes:
+                  pickup_instructions:
+                  address2:
+                  state_name:
+                  phone: "(202) 456-1111"
+                  company:
+                  active: true
+                  default: false
+                  kind: warehouse
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  updated_at: '2026-01-15T12:00:00.000Z'
+                meta:
+                  page: 1
+                  limit: 25
+                  count: 1
+                  pages: 1
+                  from: 1
+                  to: 1
+                  in: 1
+                  previous:
+                  next:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/StockLocation"
+                  meta:
+                    "$ref": "#/components/schemas/PaginationMeta"
+                required:
+                - data
+                - meta
+    post:
+      summary: Create a stock location
+      tags:
+      - Stock Locations
+      security:
+      - bearer_auth: []
+      description: |
+        Adds a place this seller ships from.
+
+        The seller and the store come from the request context whatever the
+        payload says.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: stock location created
+          content:
+            application/json:
+              example:
+                id: sloc_gbHJdmfrXB
+                name: Main warehouse
+                address1:
+                city: Portland
+                zipcode:
+                country_code: US
+                country_name: United States
+                state_code:
+                state_text:
+                pickup_ready_in_minutes:
+                pickup_instructions:
+                address2:
+                state_name:
+                phone:
+                company:
+                active: true
+                default: false
+                kind: warehouse
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+              schema:
+                "$ref": "#/components/schemas/StockLocation"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Name can't be blank
+                  details:
+                    name:
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Main warehouse
+                company:
+                  type: string
+                  nullable: true
+                address1:
+                  type: string
+                  nullable: true
+                  example: 1 Kiln Lane
+                address2:
+                  type: string
+                  nullable: true
+                city:
+                  type: string
+                  nullable: true
+                  example: Portland
+                zipcode:
+                  type: string
+                  nullable: true
+                  example: '97205'
+                country_code:
+                  type: string
+                  nullable: true
+                  example: US
+                state_code:
+                  type: string
+                  nullable: true
+                  example: OR
+                state_name:
+                  type: string
+                  nullable: true
+                phone:
+                  type: string
+                  nullable: true
+                active:
+                  type: boolean
+                  description: Set `false` to retire a location — there is no delete
+                default:
+                  type: boolean
+                kind:
+                  type: string
+                  example: warehouse
+              required:
+              - name
+  "/api/v3/seller/stock_locations/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: Stock location ID
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Get a stock location
+      tags:
+      - Stock Locations
+      security:
+      - bearer_auth: []
+      description: |
+        A stock location the acting seller owns. An id belonging to another
+        seller — or to the marketplace operator — answers `404`.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: stock location returned
+          content:
+            application/json:
+              example:
+                id: sloc_UkLWZg9DAJ
+                name: Marsha Turner
+                address1: 1600 Pennsylvania Ave NW
+                city: Washington
+                zipcode: '20500'
+                country_code: US
+                country_name: United States
+                state_code: AL
+                state_text: AL
+                pickup_ready_in_minutes:
+                pickup_instructions:
+                address2:
+                state_name:
+                phone: "(202) 456-1111"
+                company:
+                active: true
+                default: false
+                kind: warehouse
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+              schema:
+                "$ref": "#/components/schemas/StockLocation"
+        '404':
+          description: another seller's stock location
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Stock location not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+    patch:
+      summary: Update a stock location
+      tags:
+      - Stock Locations
+      security:
+      - bearer_auth: []
+      description: |
+        Edits a stock location the acting seller owns.
+
+        There is no delete: a location holds stock levels and is named on
+        historical fulfillments, so a seller retires one by setting `active` to
+        `false`.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: stock location updated
+          content:
+            application/json:
+              example:
+                id: sloc_UkLWZg9DAJ
+                name: Kiln Lane warehouse
+                address1: 1600 Pennsylvania Ave NW
+                city: Washington
+                zipcode: '20500'
+                country_code: US
+                country_name: United States
+                state_code: AL
+                state_text: AL
+                pickup_ready_in_minutes:
+                pickup_instructions:
+                address2:
+                state_name:
+                phone: "(202) 456-1111"
+                company:
+                active: true
+                default: false
+                kind: warehouse
+                created_at: '2026-01-15T12:00:00.000Z'
+                updated_at: '2026-01-15T12:00:00.000Z'
+              schema:
+                "$ref": "#/components/schemas/StockLocation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Main warehouse
+                address1:
+                  type: string
+                  nullable: true
+                city:
+                  type: string
+                  nullable: true
+                zipcode:
+                  type: string
+                  nullable: true
+                country_code:
+                  type: string
+                  nullable: true
+                state_code:
+                  type: string
+                  nullable: true
+                phone:
+                  type: string
+                  nullable: true
+                active:
+                  type: boolean
+                default:
+                  type: boolean
+  "/api/v3/seller/invitations":
+    get:
+      summary: List pending invitations
+      tags:
+      - Team
+      security:
+      - bearer_auth: []
+      description: |
+        Offers nobody has accepted yet, newest first.
+
+        Pending only — an accepted invitation is a team member, and shows up on
+        `GET /api/v3/seller/team` instead.
+
+        Sending an invitation lives on `team`, because that is hiring. Chasing or
+        withdrawing one is bookkeeping on the offer itself, so it lives here.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: invitations listed
+          content:
+            application/json:
+              example:
+                data:
+                - id: inv_UkLWZg9DAJ
+                  email: colleague@acme.test
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  expires_at: '2026-01-29T12:00:00.000Z'
+                  accepted_at:
+                  status: pending
+                  acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=gybGAXxVP79yKWNTZLAC94ui"
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/Invitation"
+                required:
+                - data
+  "/api/v3/seller/invitations/{id}/resend":
+    parameters:
+    - name: id
+      in: path
+      description: Invitation ID
+      required: true
+      schema:
+        type: string
+    patch:
+      summary: Resend an invitation
+      tags:
+      - Team
+      security:
+      - bearer_auth: []
+      description: |
+        Sends the invitation email again, for a colleague who never got the first
+        one. An invitation whose window has closed is refused rather than
+        re-sent.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: invitation resent
+          content:
+            application/json:
+              example:
+                id: inv_UkLWZg9DAJ
+                email: colleague@acme.test
+                created_at: '2026-01-15T12:00:00.000Z'
+                expires_at: '2026-01-29T12:00:00.000Z'
+                accepted_at:
+                status: pending
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=3uJFfKUSiHtnc9TGAXMJUXsB"
+              schema:
+                "$ref": "#/components/schemas/Invitation"
+        '404':
+          description: another seller's invitation
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Invitation not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/invitations/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: Invitation ID
+      required: true
+      schema:
+        type: string
+    delete:
+      summary: Revoke an invitation
+      tags:
+      - Team
+      security:
+      - bearer_auth: []
+      description: Withdraws an offer that has not been accepted.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: invitation revoked
+        '404':
+          description: another seller's invitation
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Invitation not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/team":
+    get:
+      summary: List team members
+      tags:
+      - Team
+      security:
+      - bearer_auth: []
+      description: |
+        The people who run this seller.
+
+        Rooted at the acting seller throughout, so a seller only ever sees their
+        own team. Unpaginated — a seller's team is small by nature.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: team members listed
+          content:
+            application/json:
+              example:
+                data:
+                - id: adm_UkLWZg9DAJ
+                  email: twyla_haley@nikolaus.ca
+                  first_name: Bill
+                  last_name: Towne
+                  full_name: Bill Towne
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  avatar_url:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/TeamMember"
+                required:
+                - data
+    post:
+      summary: Invite a team member
+      tags:
+      - Team
+      security:
+      - bearer_auth: []
+      description: |
+        Invites a colleague onto this seller's team. They join when they accept,
+        on the same invitation rail — and the same email — the marketplace
+        operator's own invitations use.
+
+        Hiring is not a lifecycle transition: a trading seller's status is
+        untouched by taking someone on.
+
+        The role is not a parameter. Every member holds the seller's own seeded
+        role, which already carries the whole seller vocabulary.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: invitation sent
+          content:
+            application/json:
+              example:
+                id: inv_UkLWZg9DAJ
+                email: colleague@acme.test
+                created_at: '2026-01-15T12:00:00.000Z'
+                expires_at: '2026-01-29T12:00:00.000Z'
+                accepted_at:
+                status: pending
+                acceptance_url: "/accept-invitation/inv_UkLWZg9DAJ?token=3K6BfBtHGFeQgToPE45qUDWE"
+              schema:
+                "$ref": "#/components/schemas/Invitation"
+        '422':
+          description: validation failed
+          content:
+            application/json:
+              example:
+                error:
+                  code: validation_error
+                  message: Email is invalid and Email can't be blank
+                  details:
+                    email:
+                    - is invalid
+                    - can't be blank
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: colleague@acme.test
+              required:
+              - email
+  "/api/v3/seller/team/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: Team member (user) ID
+      required: true
+      schema:
+        type: string
+    delete:
+      summary: Remove a team member
+      tags:
+      - Team
+      security:
+      - bearer_auth: []
+      description: |
+        Revokes a member's access, removing every role they hold on this seller.
+
+        The team can never reach zero: emptying it would leave a seller nobody
+        can sign in to, and only the marketplace operator could put someone back.
+        The last remaining member is refused with `422`.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: member removed
+        '422':
+          description: cannot remove the last remaining member
+          content:
+            application/json:
+              example:
+                error:
+                  code: processing_error
+                  message: A seller needs at least one team member. Invite someone
+                    else before removing this one.
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '404':
+          description: not a member of this seller
+          content:
+            application/json:
+              example:
+                error:
+                  code: record_not_found
+                  message: Admin user not found
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v3/seller/direct_uploads":
+    post:
+      summary: Create a direct upload
+      tags:
+      - Uploads
+      security:
+      - bearer_auth: []
+      description: |
+        Presigns an upload target for a file the seller is about to send.
+
+        Three steps: post the file's metadata here, `PUT` the bytes to the
+        returned `direct_upload.url` with the headers it names, then send the
+        returned `signed_id` wherever the file belongs — as a requirement
+        submission's `file`, or as `logo`, `square_logo` or `cover_photo` on the
+        profile.
+
+        The blob is attached to nothing at this point. The endpoint that consumes
+        the `signed_id` is the one that checks ownership.
+
+        `checksum` is the file's MD5 digest, base64-encoded — the storage service
+        verifies the upload against it.
+      parameters:
+      - name: X-Spree-Seller-Id
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: upload target created
+          content:
+            application/json:
+              example:
+                direct_upload:
+                  url: http://www.example.com/rails/active_storage/disk/eyJfcmFpbHMiOnsiZGF0YSI6eyJrZXkiOiJuem5oOGdra3VxendvbDc1ODBxNHNwZmpmMjVxIiwiY29udGVudF90eXBlIjoiYXBwbGljYXRpb24vcGRmIiwiY29udGVudF9sZW5ndGgiOjUxMjM0LCJjaGVja3N1bSI6IlZqaHowNGxRdUVHdXY0bkR2aHNhTlE9PSIsInNlcnZpY2VfbmFtZSI6InRlc3QifSwiZXhwIjoiMjAyNi0wMS0xNVQxMjowNTowMC4wMDBaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--c79d164b6cf3869619d5c5d61ce1ef2d5ffd7f10
+                  headers:
+                    Content-Type: application/pdf
+                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--acc69b8fc52bc6da57b08d7e981df3db825f5c5c
+              schema:
+                "$ref": "#/components/schemas/DirectUploadResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                blob:
+                  type: object
+                  properties:
+                    filename:
+                      type: string
+                      example: registration.pdf
+                    byte_size:
+                      type: integer
+                      example: 51234
+                    checksum:
+                      type: string
+                      description: Base64-encoded MD5 digest of the file
+                      example: rL0Y20zC+Fzt72VPzMSk2A==
+                    content_type:
+                      type: string
+                      example: application/pdf
+                  required:
+                  - filename
+                  - byte_size
+                  - checksum
+                  - content_type
+              required:
+              - blob
+servers:
+- url: http://{defaultHost}
+  variables:
+    defaultHost:
+      default: localhost:3000
+tags:
+- name: Authentication
+  description: Seller sign-in, token refresh, logout, and invitation acceptance
+- name: Account
+  description: The signed-in user, the sellers they may act for, and what they may
+    do
+- name: Countries
+  description: Country and state reference data for the panel's address forms
+- name: Onboarding
+  description: The marketplace checklist a seller completes before admission, and
+    what they submit against it
+- name: Products
+  description: The seller's own catalog
+- name: Profile
+  description: The seller's own record — presentation, contact details, addresses,
+    and tax registration
+- name: Stock Locations
+  description: Where the seller keeps stock, and so where their returns are sent
+- name: Team
+  description: Who runs this seller, and the invitations nobody has accepted yet
+- name: Uploads
+  description: Presigned direct uploads for the documents onboarding asks for
+components:
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token for an authenticated seller session (`seller_api` audience)
+  schemas:
+    PaginationMeta:
+      type: object
+      properties:
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 25
+        count:
+          type: integer
+          example: 100
+          description: Total number of records
+        pages:
+          type: integer
+          example: 4
+          description: Total number of pages
+        from:
+          type: integer
+          example: 1
+          description: Index of first record on this page
+        to:
+          type: integer
+          example: 25
+          description: Index of last record on this page
+        in:
+          type: integer
+          example: 25
+          description: Number of records on this page
+        previous:
+          type: integer
+          nullable: true
+          example:
+          description: Previous page number
+        next:
+          type: integer
+          nullable: true
+          example: 2
+          description: Next page number
+      required:
+      - page
+      - limit
+      - count
+      - pages
+      - from
+      - to
+      - in
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              example: record_not_found
+            message:
+              type: string
+              example: Record not found
+            details:
+              type: object
+              description: Field-specific validation errors
+              nullable: true
+              example:
+                name:
+                - is too short
+                - is required
+                email:
+                - is invalid
+          required:
+          - code
+          - message
+      required:
+      - error
+      example:
+        error:
+          code: validation_error
+          message: Validation failed
+          details:
+            name:
+            - is too short
+            email:
+            - is invalid
+    AuthResponse:
+      type: object
+      properties:
+        token:
+          type: string
+          description: JWT access token, `seller_api` audience
+        user:
+          "$ref": "#/components/schemas/TeamMember"
+        sellers:
+          type: array
+          description: The sellers this user may act for. Pick one and send its `id`
+            as `X-Spree-Seller-Id` on every subsequent request.
+          items:
+            "$ref": "#/components/schemas/SellerSummary"
+      required:
+      - token
+      - user
+      - sellers
+    PermissionRule:
+      type: object
+      description: A single permission rule (CanCanCan rule). Rules are applied in
+        order, last-matching-wins.
+      properties:
+        allow:
+          type: boolean
+          description: true for `can`, false for `cannot`
+        actions:
+          type: array
+          items:
+            type: string
+          description: Action names, e.g. ["read", "update"] or ["manage"]
+        subjects:
+          type: array
+          items:
+            type: string
+          description: Subject class names, e.g. ["Spree::Product"] or ["all"]
+        has_conditions:
+          type: boolean
+          description: True if the server-side rule has per-record conditions. The
+            SPA shows the action optimistically and handles 403 from the API.
+      required:
+      - allow
+      - actions
+      - subjects
+      - has_conditions
+    MeResponse:
+      type: object
+      description: Current admin user profile and serialized permissions
+      properties:
+        user:
+          "$ref": "#/components/schemas/AdminUser"
+        permissions:
+          type: array
+          items:
+            "$ref": "#/components/schemas/PermissionRule"
+      required:
+      - user
+      - permissions
+    ImportSchemaField:
+      type: object
+      description: A canonical column of an import type, including per-store custom
+        field columns
+      properties:
+        name:
+          type: string
+          description: Canonical field name used in mappings
+          example: slug
+        label:
+          type: string
+          description: Human-readable label
+          example: Slug
+        required:
+          type: boolean
+          description: Whether the field must be mapped before processing
+      required:
+      - name
+      - label
+      - required
+    CheckoutRequirement:
+      type: object
+      properties:
+        step:
+          type: string
+          description: Checkout step this requirement belongs to
+          example: payment
+        field:
+          type: string
+          description: Field that needs to be satisfied
+          example: payment
+        message:
+          type: string
+          description: Human-readable requirement message
+          example: Add a payment method
+      required:
+      - step
+      - field
+      - message
+    CartWarning:
+      type: object
+      description: A warning about a cart issue (e.g., item removed due to stock change)
+      properties:
+        code:
+          type: string
+          description: Machine-readable warning code
+          example: line_item_removed
+        message:
+          type: string
+          description: Human-readable warning message
+          example: Blue T-Shirt was removed because it was sold out
+        line_item_id:
+          type: string
+          nullable: true
+          description: Prefixed line item ID (when applicable)
+          example: li_abc123
+        variant_id:
+          type: string
+          nullable: true
+          description: Prefixed variant ID (when applicable)
+          example: variant_abc123
+        item_index:
+          type: integer
+          nullable: true
+          description: Position in the submitted items array, for warnings raised
+            while applying a batch of item changes
+          example: 1
+      required:
+      - code
+      - message
+    FulfillmentManifestItem:
+      type: object
+      description: An item within a fulfillment — which line item and how many units
+        are in this fulfillment
+      properties:
+        item_id:
+          type: string
+          description: Line item ID
+          example: li_abc123
+        variant_id:
+          type: string
+          description: Variant ID
+          example: variant_abc123
+        quantity:
+          type: integer
+          description: Quantity in this fulfillment
+          example: 2
+      required:
+      - item_id
+      - variant_id
+      - quantity
+    AdminUserRoleAssignment:
+      type: object
+      description: A role assignment for the current store on a staff member
+      properties:
+        id:
+          type: string
+          description: Prefixed role ID
+          example: role_abc123
+        name:
+          type: string
+          description: Role name
+          example: admin
+      required:
+      - id
+      - name
+    AdminUserStore:
+      type: object
+      description: A store the staff member can access through a role assignment
+      properties:
+        id:
+          type: string
+          description: Prefixed store ID
+          example: store_abc123
+        name:
+          type: string
+          description: Store name
+          example: My Store
+        code:
+          type: string
+          description: Store code
+          example: my-store
+      required:
+      - id
+      - name
+      - code
+    PreferenceField:
+      type: object
+      description: A single configurable preference on a payment method, promotion
+        rule/action, or calculator. The frontend uses `type` + `default` to render
+        a sensible input.
+      properties:
+        key:
+          type: string
+          example: amount_min
+        type:
+          type: string
+          example: decimal
+          description: string | text | password | integer | decimal | boolean | array
+            | hash
+        default:
+          description: Default value (any JSON type), null when there is no default
+          nullable: true
+      required:
+      - key
+      - type
+    PromotionActionCalculator:
+      type: object
+      description: The action's nested calculator (when the action carries one — null
+        for actions like `free_shipping`)
+      properties:
+        type:
+          type: string
+          example: flat_rate
+          description: Wire shorthand for the calculator subclass
+        label:
+          type: string
+          example: Flat Rate
+        preferences:
+          type: object
+          additionalProperties: true
+        preference_schema:
+          type: array
+          items:
+            "$ref": "#/components/schemas/PreferenceField"
+      required:
+      - type
+      - label
+      - preferences
+      - preference_schema
+    PromotionActionLineItem:
+      type: object
+      description: One row in a `create_line_items` action — the variant added to
+        the order and how many
+      properties:
+        variant_id:
+          type: string
+          example: variant_abc123
+        quantity:
+          type: integer
+          example: 1
+      required:
+      - variant_id
+      - quantity
+    SellerSummary:
+      type: object
+      description: A seller the signed-in user may act for
+      properties:
+        id:
+          type: string
+          description: Prefixed seller ID — send as `X-Spree-Seller-Id`
+          example: sel_abc123
+        name:
+          type: string
+          example: Acme Supplies
+        status:
+          type: string
+          example: approved
+          description: Seller lifecycle status
+      required:
+      - id
+      - name
+      - status
+    SellerMeSummary:
+      type: object
+      description: A seller the signed-in user may act for, as `/me` reports it —
+        the login response carries the same fields without `slug`.
+      properties:
+        id:
+          type: string
+          description: Prefixed seller ID — send as `X-Spree-Seller-Id`
+          example: sel_abc123
+        name:
+          type: string
+          example: Acme Supplies
+        slug:
+          type: string
+          example: acme-supplies
+        status:
+          type: string
+          example: approved
+          description: Seller lifecycle status
+      required:
+      - id
+      - name
+      - slug
+      - status
+    SellerMeResponse:
+      type: object
+      description: The signed-in user, the sellers they may act for, and what they
+        may do on the selected one
+      properties:
+        user:
+          "$ref": "#/components/schemas/TeamMember"
+        sellers:
+          type: array
+          items:
+            "$ref": "#/components/schemas/SellerMeSummary"
+        permissions:
+          type: array
+          items:
+            "$ref": "#/components/schemas/PermissionRule"
+        permission_keys:
+          type: array
+          items:
+            type: string
+          description: Permission keys on the selected seller. Empty until `X-Spree-Seller-Id`
+            names one — capability is per seller.
+          example:
+          - read_products
+          - write_products
+      required:
+      - user
+      - sellers
+      - permissions
+      - permission_keys
+    OnboardingProgress:
+      type: object
+      description: |
+        How far along the checklist is — not how close to approval, since
+        optional requirements count towards it too.
+
+        Deliberately just the two counts. A percentage is arithmetic over
+        them, which a client can do and which would otherwise be a second
+        definition of the same fact.
+      properties:
+        done:
+          type: integer
+          example: 3
+        total:
+          type: integer
+          example: 5
+      required:
+      - done
+      - total
+    SellerOnboardingResponse:
+      type: object
+      description: What the marketplace asks of this seller before it will admit them
+      properties:
+        status:
+          type: string
+          example: onboarding
+          description: The seller's lifecycle status
+        progress:
+          "$ref": "#/components/schemas/OnboardingProgress"
+        requirements:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RequirementStatus"
+      required:
+      - status
+      - progress
+      - requirements
+    SellerCountry:
+      type: object
+      description: A country as the panel's address forms need it
+      properties:
+        iso:
+          type: string
+          example: US
+        iso3:
+          type: string
+          example: USA
+        name:
+          type: string
+          example: United States
+        states_required:
+          type: boolean
+          example: true
+        zipcode_required:
+          type: boolean
+          example: true
+        states:
+          type: array
+          items:
+            type: object
+            properties:
+              abbr:
+                type: string
+                example: CA
+              name:
+                type: string
+                example: California
+            required:
+            - abbr
+            - name
+      required:
+      - iso
+      - iso3
+      - name
+    DirectUploadResponse:
+      type: object
+      description: A presigned upload target. PUT the file to `direct_upload.url`
+        with the given headers, then send `signed_id` as the submission's `file`.
+      properties:
+        signed_id:
+          type: string
+          description: Send this as a submission's `file`
+          example: eyJfcmFpbHMiOnsibWVzc2FnZSI6...
+        direct_upload:
+          type: object
+          properties:
+            url:
+              type: string
+              example: https://storage.example.com/uploads/abc123
+            headers:
+              type: object
+              additionalProperties:
+                type: string
+          required:
+          - url
+          - headers
+      required:
+      - signed_id
+      - direct_upload
+    AuthProvidersResponse:
+      type: object
+      description: Sign-in methods this marketplace offers sellers, for the login
+        page
+      properties:
+        providers:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      required:
+      - providers
+    Address:
+      type: object
+      properties:
+        id:
+          type: string
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        full_name:
+          type: string
+        address1:
+          type: string
+          nullable: true
+        address2:
+          type: string
+          nullable: true
+        postal_code:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        company:
+          type: string
+          nullable: true
+        country_name:
+          type: string
+        country_code:
+          type: string
+        state_text:
+          type: string
+          nullable: true
+        state_code:
+          type: string
+          nullable: true
+        quick_checkout:
+          type: boolean
+        is_default_billing:
+          type: boolean
+        is_default_shipping:
+          type: boolean
+        state_abbr:
+          type: string
+          nullable: true
+        country_iso:
+          type: string
+        state_name:
+          type: string
+          nullable: true
+      required:
+      - id
+      - first_name
+      - last_name
+      - full_name
+      - address1
+      - address2
+      - postal_code
+      - city
+      - phone
+      - company
+      - country_name
+      - country_code
+      - state_text
+      - state_code
+      - quick_checkout
+      - is_default_billing
+      - is_default_shipping
+      - state_abbr
+      - country_iso
+      - state_name
+      x-typelizer: true
+    Category:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        permalink:
+          type: string
+        position:
+          type: number
+        depth:
+          type: number
+        meta_title:
+          type: string
+          nullable: true
+        meta_description:
+          type: string
+          nullable: true
+        meta_keywords:
+          type: string
+          nullable: true
+        children_count:
+          type: number
+        parent_id:
+          type: string
+          nullable: true
+        description:
+          type: string
+        description_html:
+          type: string
+        image_url:
+          type: string
+          nullable: true
+        square_image_url:
+          type: string
+          nullable: true
+        is_root:
+          type: boolean
+        is_child:
+          type: boolean
+        is_leaf:
+          type: boolean
+        parent:
+          "$ref": "#/components/schemas/Category"
+        children:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Category"
+        ancestors:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Category"
+        custom_fields:
+          type: array
+          items:
+            "$ref": "#/components/schemas/CustomField"
+      required:
+      - id
+      - name
+      - permalink
+      - position
+      - depth
+      - meta_title
+      - meta_description
+      - meta_keywords
+      - children_count
+      - parent_id
+      - description
+      - description_html
+      - image_url
+      - square_image_url
+      - is_root
+      - is_child
+      - is_leaf
+      x-typelizer: true
+    CustomField:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        type:
+          type: string
+          deprecated: true
+        field_type:
+          type: string
+          enum:
+          - short_text
+          - long_text
+          - rich_text
+          - number
+          - boolean
+          - json
+        key:
+          type: string
+        value:
+          type: object
+      required:
+      - id
+      - label
+      - type
+      - field_type
+      - key
+      - value
+      x-typelizer: true
+    Media:
+      type: object
+      properties:
+        id:
+          type: string
+        product_id:
+          type: string
+          nullable: true
+        variant_ids:
+          type: array
+          items:
+            type: string
+        position:
+          type: number
+        alt:
+          type: string
+          nullable: true
+        media_type:
+          type: string
+        focal_point_x:
+          type: number
+          nullable: true
+        focal_point_y:
+          type: number
+          nullable: true
+        external_video_url:
+          type: string
+          nullable: true
+        video_provider:
+          type: string
+          nullable: true
+        video_embed_url:
+          type: string
+          nullable: true
+        video_url:
+          type: string
+          nullable: true
+        poster_url:
+          type: string
+          nullable: true
+        original_url:
+          type: string
+          nullable: true
+        mini_url:
+          type: string
+          nullable: true
+        small_url:
+          type: string
+          nullable: true
+        medium_url:
+          type: string
+          nullable: true
+        large_url:
+          type: string
+          nullable: true
+        xlarge_url:
+          type: string
+          nullable: true
+        og_image_url:
+          type: string
+          nullable: true
+      required:
+      - id
+      - product_id
+      - variant_ids
+      - position
+      - alt
+      - media_type
+      - focal_point_x
+      - focal_point_y
+      - external_video_url
+      - video_provider
+      - video_embed_url
+      - video_url
+      - poster_url
+      - original_url
+      - mini_url
+      - small_url
+      - medium_url
+      - large_url
+      - xlarge_url
+      - og_image_url
+      x-typelizer: true
+    OptionType:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        label:
+          type: string
+        position:
+          type: number
+        kind:
+          type: string
+      required:
+      - id
+      - name
+      - label
+      - position
+      - kind
+      x-typelizer: true
+    OptionValue:
+      type: object
+      properties:
+        id:
+          type: string
+        option_type_id:
+          type: string
+        name:
+          type: string
+        label:
+          type: string
+        position:
+          type: number
+        color_code:
+          type: string
+          nullable: true
+        option_type_name:
+          type: string
+        option_type_label:
+          type: string
+        image_url:
+          type: string
+          nullable: true
+      required:
+      - id
+      - option_type_id
+      - name
+      - label
+      - position
+      - color_code
+      - option_type_name
+      - option_type_label
+      - image_url
+      x-typelizer: true
+    PriceHistory:
+      type: object
+      properties:
+        id:
+          type: string
+        amount:
+          type: string
+        amount_in_cents:
+          type: number
+        currency:
+          type: string
+        display_amount:
+          type: string
+        recorded_at:
+          type: string
+      required:
+      - id
+      - amount
+      - amount_in_cents
+      - currency
+      - display_amount
+      - recorded_at
+      x-typelizer: true
+    Price:
+      type: object
+      properties:
+        id:
+          type: string
+        amount:
+          type: string
+          nullable: true
+        amount_in_cents:
+          type: number
+          nullable: true
+        compare_at_amount:
+          type: string
+          nullable: true
+        compare_at_amount_in_cents:
+          type: number
+          nullable: true
+        currency:
+          type: string
+          nullable: true
+        display_amount:
+          type: string
+          nullable: true
+        display_compare_at_amount:
+          type: string
+          nullable: true
+        price_list_id:
+          type: string
+          nullable: true
+      required:
+      - id
+      - amount
+      - amount_in_cents
+      - compare_at_amount
+      - compare_at_amount_in_cents
+      - currency
+      - display_amount
+      - display_compare_at_amount
+      - price_list_id
+      x-typelizer: true
+    Invitation:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        created_at:
+          type: string
+        expires_at:
+          type: string
+          nullable: true
+        accepted_at:
+          type: string
+          nullable: true
+        status:
+          type: string
+        acceptance_url:
+          type: string
+      required:
+      - id
+      - email
+      - created_at
+      - expires_at
+      - accepted_at
+      - status
+      - acceptance_url
+      x-typelizer: true
+    Product:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        meta_title:
+          type: string
+          nullable: true
+        meta_description:
+          type: string
+          nullable: true
+        meta_keywords:
+          type: string
+          nullable: true
+        variant_count:
+          type: number
+        available_on:
+          type: string
+          nullable: true
+        preorder_ships_at:
+          type: string
+          nullable: true
+        purchasable:
+          type: boolean
+        preorder:
+          type: boolean
+        in_stock:
+          type: boolean
+        backorderable:
+          type: boolean
+        available:
+          type: boolean
+        description:
+          type: string
+          nullable: true
+        description_html:
+          type: string
+          nullable: true
+        default_variant_id:
+          type: string
+        buy_box_variant_id:
+          type: string
+          nullable: true
+        thumbnail_url:
+          type: string
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        price:
+          "$ref": "#/components/schemas/Price"
+        original_price:
+          allOf:
+          - "$ref": "#/components/schemas/Price"
+          nullable: true
+        seller_id:
+          type: string
+          nullable: true
+        seller:
+          "$ref": "#/components/schemas/Seller"
+        primary_media:
+          "$ref": "#/components/schemas/Media"
+        media:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Media"
+        variants:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Variant"
+        default_variant:
+          "$ref": "#/components/schemas/Variant"
+        option_types:
+          type: array
+          items:
+            "$ref": "#/components/schemas/OptionType"
+        option_values:
+          type: array
+          items:
+            "$ref": "#/components/schemas/OptionValue"
+        categories:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Category"
+        custom_fields:
+          type: array
+          items:
+            "$ref": "#/components/schemas/CustomField"
+        prior_price:
+          allOf:
+          - "$ref": "#/components/schemas/PriceHistory"
+          nullable: true
+        status:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+      - id
+      - name
+      - slug
+      - meta_title
+      - meta_description
+      - meta_keywords
+      - variant_count
+      - available_on
+      - preorder_ships_at
+      - purchasable
+      - preorder
+      - in_stock
+      - backorderable
+      - available
+      - description
+      - description_html
+      - default_variant_id
+      - buy_box_variant_id
+      - thumbnail_url
+      - tags
+      - price
+      - original_price
+      - seller_id
+      - status
+      - created_at
+      - updated_at
+      x-typelizer: true
+    Profile:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        about:
+          type: string
+        about_html:
+          type: string
+        logo_url:
+          type: string
+          nullable: true
+        square_logo_url:
+          type: string
+          nullable: true
+        cover_photo_url:
+          type: string
+          nullable: true
+        status:
+          type: string
+        legal_name:
+          type: string
+          nullable: true
+        registration_number:
+          type: string
+          nullable: true
+        contact_email:
+          type: string
+          nullable: true
+        billing_email:
+          type: string
+          nullable: true
+        tax_remittance:
+          type: string
+        payouts_schedule_interval:
+          type: string
+          nullable: true
+        holiday_mode_until:
+          type: string
+          nullable: true
+        terms_accepted_at:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        minimum_payout_amount:
+          type: string
+          nullable: true
+        on_holiday:
+          type: boolean
+        sellable:
+          type: boolean
+        products_count:
+          type: number
+        tax_identifiers:
+          type: array
+          items:
+            "$ref": "#/components/schemas/TaxIdentifier"
+        billing_address:
+          "$ref": "#/components/schemas/Address"
+        returns_address:
+          "$ref": "#/components/schemas/Address"
+      required:
+      - id
+      - name
+      - slug
+      - about
+      - about_html
+      - logo_url
+      - square_logo_url
+      - cover_photo_url
+      - status
+      - legal_name
+      - registration_number
+      - contact_email
+      - billing_email
+      - tax_remittance
+      - payouts_schedule_interval
+      - holiday_mode_until
+      - terms_accepted_at
+      - created_at
+      - minimum_payout_amount
+      - on_holiday
+      - sellable
+      - products_count
+      - tax_identifiers
+      x-typelizer: true
+    RequirementCustomField:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        label:
+          type: string
+        field_type:
+          type: string
+          enum:
+          - short_text
+          - long_text
+          - rich_text
+          - number
+          - boolean
+          - json
+        value:
+          type: object
+      required:
+      - id
+      - key
+      - label
+      - field_type
+      - value
+      x-typelizer: true
+    RequirementStatus:
+      type: object
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        required:
+          type: boolean
+        position:
+          type: number
+        status:
+          type: string
+        action_url:
+          type: string
+          nullable: true
+        blocking:
+          type: boolean
+        accepts_submissions:
+          type: boolean
+        requires_file:
+          type: boolean
+        accepted_content_types:
+          type: array
+          items:
+            type: string
+        submission:
+          "$ref": "#/components/schemas/RequirementSubmission"
+        custom_fields:
+          type: array
+          items:
+            "$ref": "#/components/schemas/RequirementCustomField"
+      required:
+      - id
+      - kind
+      - name
+      - description
+      - required
+      - position
+      - status
+      - action_url
+      - blocking
+      - accepts_submissions
+      - requires_file
+      - accepted_content_types
+      x-typelizer: true
+    RequirementSubmission:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+        note:
+          type: string
+          nullable: true
+        review_note:
+          type: string
+          nullable: true
+        reference:
+          type: string
+          nullable: true
+        reviewed_at:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        file_url:
+          type: string
+          nullable: true
+        file_name:
+          type: string
+          nullable: true
+      required:
+      - id
+      - status
+      - note
+      - review_note
+      - reference
+      - reviewed_at
+      - created_at
+      - updated_at
+      - file_url
+      - file_name
+      x-typelizer: true
+    StockLocation:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        address1:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        zipcode:
+          type: string
+          nullable: true
+        country_code:
+          type: string
+          nullable: true
+        country_name:
+          type: string
+          nullable: true
+        state_code:
+          type: string
+          nullable: true
+        state_text:
+          type: string
+          nullable: true
+        pickup_ready_in_minutes:
+          type: number
+          nullable: true
+        pickup_instructions:
+          type: string
+          nullable: true
+        address2:
+          type: string
+          nullable: true
+        state_name:
+          type: string
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        company:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+        default:
+          type: boolean
+        kind:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+      - id
+      - name
+      - address1
+      - city
+      - zipcode
+      - country_code
+      - country_name
+      - state_code
+      - state_text
+      - pickup_ready_in_minutes
+      - pickup_instructions
+      - address2
+      - state_name
+      - phone
+      - company
+      - active
+      - default
+      - kind
+      - created_at
+      - updated_at
+      x-typelizer: true
+    TaxIdentifier:
+      type: object
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        value:
+          type: string
+        validation_status:
+          type: string
+          nullable: true
+        validated_at:
+          type: string
+          nullable: true
+      required:
+      - id
+      - kind
+      - value
+      - validation_status
+      - validated_at
+      x-typelizer: true
+    TeamMember:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        full_name:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        avatar_url:
+          type: string
+          nullable: true
+      required:
+      - id
+      - email
+      - first_name
+      - last_name
+      - full_name
+      - created_at
+      - avatar_url
+      x-typelizer: true
+    Seller:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+        about:
+          type: string
+        about_html:
+          type: string
+        logo_url:
+          type: string
+          nullable: true
+        square_logo_url:
+          type: string
+          nullable: true
+        cover_photo_url:
+          type: string
+          nullable: true
+      required:
+      - id
+      - name
+      - slug
+      - about
+      - about_html
+      - logo_url
+      - square_logo_url
+      - cover_photo_url
+      x-typelizer: true
+    Variant:
+      type: object
+      properties:
+        id:
+          type: string
+        product_id:
+          type: string
+        sku:
+          type: string
+          nullable: true
+        options_text:
+          type: string
+        track_inventory:
+          type: boolean
+        media_count:
+          type: number
+        preorder_ships_at:
+          type: string
+          nullable: true
+        thumbnail_url:
+          type: string
+          nullable: true
+        purchasable:
+          type: boolean
+        in_stock:
+          type: boolean
+        backorderable:
+          type: boolean
+        preorder:
+          type: boolean
+        weight:
+          type: number
+          nullable: true
+        height:
+          type: number
+          nullable: true
+        width:
+          type: number
+          nullable: true
+        depth:
+          type: number
+          nullable: true
+        price:
+          "$ref": "#/components/schemas/Price"
+        original_price:
+          allOf:
+          - "$ref": "#/components/schemas/Price"
+          nullable: true
+        seller_id:
+          type: string
+          nullable: true
+        seller:
+          "$ref": "#/components/schemas/Seller"
+        primary_media:
+          "$ref": "#/components/schemas/Media"
+        media:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Media"
+        option_values:
+          type: array
+          items:
+            "$ref": "#/components/schemas/OptionValue"
+        custom_fields:
+          type: array
+          items:
+            "$ref": "#/components/schemas/CustomField"
+        prior_price:
+          allOf:
+          - "$ref": "#/components/schemas/PriceHistory"
+          nullable: true
+      required:
+      - id
+      - product_id
+      - sku
+      - options_text
+      - track_inventory
+      - media_count
+      - preorder_ships_at
+      - thumbnail_url
+      - purchasable
+      - in_stock
+      - backorderable
+      - preorder
+      - weight
+      - height
+      - width
+      - depth
+      - price
+      - original_price
+      - seller_id
+      - option_values
+      x-typelizer: true

--- a/docs/api-reference/store.yaml
+++ b/docs/api-reference/store.yaml
@@ -368,13 +368,10 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const auth = await client.passwordResets.update(
-            'reset-token-from-email',
-            {
-              password: 'newsecurepassword',
-              password_confirmation: 'newsecurepassword',
-            }
-          )
+          const auth = await client.passwordResets.update('reset-token-from-email', {
+            password: 'newsecurepassword',
+            password_confirmation: 'newsecurepassword',
+          })
       parameters:
       - name: x-spree-api-key
         in: header
@@ -879,8 +876,8 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1496979
-                  slug: product-1496979
+                  name: Product 1576979
+                  slug: product-1576979
                   meta_title:
                   meta_description:
                   meta_keywords:
@@ -1054,8 +1051,8 @@ paths:
               example:
                 data:
                 - id: prod_UkLWZg9DAJ
-                  name: Product 1949085
-                  slug: product-1949085
+                  name: Product 2029085
+                  slug: product-2029085
                   meta_title:
                   meta_description:
                   meta_keywords:
@@ -1086,8 +1083,8 @@ paths:
                   original_price:
                   seller_id:
                 - id: prod_gbHJdmfrXB
-                  name: Product 1958209
-                  slug: product-1958209
+                  name: Product 2038209
+                  slug: product-2038209
                   meta_title:
                   meta_description:
                   meta_keywords:
@@ -1215,8 +1212,8 @@ paths:
             application/json:
               example:
                 id: prod_UkLWZg9DAJ
-                name: Product 2226885
-                slug: product-2226885
+                name: Product 2306885
+                slug: product-2306885
                 meta_title:
                 meta_description:
                 meta_keywords:
@@ -1565,8 +1562,8 @@ paths:
                     preorder_ships_at:
                     quantity: 1
                     currency: USD
-                    name: Product 123715
-                    slug: product-123715
+                    name: Product 131715
+                    slug: product-131715
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1674,8 +1671,8 @@ paths:
                     preorder_ships_at:
                     quantity: 1
                     currency: USD
-                    name: Product 1242171
-                    slug: product-1242171
+                    name: Product 1322171
+                    slug: product-1322171
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -1760,9 +1757,7 @@ paths:
 
           // Create a cart with items
           const cartWithItems = await client.carts.create({
-            items: [
-              { variant_id: 'variant_abc123', quantity: 2 },
-            ],
+            items: [{ variant_id: 'variant_abc123', quantity: 2 }],
           })
       parameters:
       - name: x-spree-api-key
@@ -1969,7 +1964,7 @@ paths:
                 total_quantity: 0
                 warnings:
                 - code: line_item_removed
-                  message: Product 128307 was removed because it was sold out
+                  message: Product 136307 was removed because it was sold out
                   line_item_id: li_UkLWZg9DAJ
                   variant_id: variant_UkLWZg9DAJ
                 coupon_code:
@@ -2177,8 +2172,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1293263
-                  slug: product-1293263
+                  name: Product 1373263
+                  slug: product-1373263
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -2453,8 +2448,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1318992
-                  slug: product-1318992
+                  name: Product 1398992
+                  slug: product-1398992
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -2657,8 +2652,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1344794
-                  slug: product-1344794
+                  name: Product 1424794
+                  slug: product-1424794
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -2986,8 +2981,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1604241
-                  slug: product-1604241
+                  name: Product 1684241
+                  slug: product-1684241
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3175,8 +3170,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1623461
-                  slug: product-1623461
+                  name: Product 1703461
+                  slug: product-1703461
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3249,11 +3244,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const cart = await client.carts.fulfillments.update('cart_abc123', 'ful_abc123', {
-            selected_delivery_rate_id: 'dr_abc123',
-          }, {
-            token: '<token>',
-          })
+          const cart = await client.carts.fulfillments.update(
+            'cart_abc123',
+            'ful_abc123',
+            {
+              selected_delivery_rate_id: 'dr_abc123',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -3347,8 +3347,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1648182
-                  slug: product-1648182
+                  name: Product 1728182
+                  slug: product-1728182
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3633,8 +3633,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1665702
-                  slug: product-1665702
+                  name: Product 1745702
+                  slug: product-1745702
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3877,8 +3877,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1709569
-                  slug: product-1709569
+                  name: Product 1789569
+                  slug: product-1789569
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -3966,12 +3966,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const cart = await client.carts.items.create('cart_abc123', {
-            variant_id: 'variant_abc123',
-            quantity: 2,
-          }, {
-            token: '<token>',
-          })
+          const cart = await client.carts.items.create(
+            'cart_abc123',
+            {
+              variant_id: 'variant_abc123',
+              quantity: 2,
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -4021,10 +4025,10 @@ paths:
                 total_quantity: 2
                 warnings:
                 - code: delivery_unavailable
-                  message: Product 17363 cannot be delivered to the selected address
+                  message: Product 18163 cannot be delivered to the selected address
                   line_item_id: li_UkLWZg9DAJ
                 - code: delivery_unavailable
-                  message: Product 174298 cannot be delivered to the selected address
+                  message: Product 182298 cannot be delivered to the selected address
                   line_item_id: li_gbHJdmfrXB
                 coupon_code:
                 item_total: '29.99'
@@ -4078,8 +4082,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 17363
-                  slug: product-17363
+                  name: Product 18163
+                  slug: product-18163
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4109,8 +4113,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 174298
-                  slug: product-174298
+                  name: Product 182298
+                  slug: product-182298
                   options_text: ''
                   price: '19.99'
                   display_price: "$19.99"
@@ -4217,11 +4221,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const cart = await client.carts.items.update('cart_abc123', 'li_abc123', {
-            quantity: 5,
-          }, {
-            token: '<token>',
-          })
+          const cart = await client.carts.items.update(
+            'cart_abc123',
+            'li_abc123',
+            {
+              quantity: 5,
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -4324,8 +4333,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1809165
-                  slug: product-1809165
+                  name: Product 1889165
+                  slug: product-1889165
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -4542,11 +4551,15 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const session = await client.carts.paymentSessions.create('cart_abc123', {
-            payment_method_id: 'pm_abc123',
-          }, {
-            token: '<token>',
-          })
+          const session = await client.carts.paymentSessions.create(
+            'cart_abc123',
+            {
+              payment_method_id: 'pm_abc123',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -4735,11 +4748,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const session = await client.carts.paymentSessions.update('cart_abc123', 'ps_abc123', {
-            amount: '50.00',
-          }, {
-            token: '<token>',
-          })
+          const session = await client.carts.paymentSessions.update(
+            'cart_abc123',
+            'ps_abc123',
+            {
+              amount: '50.00',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters: []
       responses:
         '200':
@@ -4832,11 +4850,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const session = await client.carts.paymentSessions.complete('cart_abc123', 'ps_abc123', {
-            session_result: 'success',
-          }, {
-            token: '<token>',
-          })
+          const session = await client.carts.paymentSessions.complete(
+            'cart_abc123',
+            'ps_abc123',
+            {
+              session_result: 'success',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: Idempotency-Key
         in: header
@@ -4915,11 +4938,15 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const payment = await client.carts.payments.create('cart_abc123', {
-            payment_method_id: 'pm_abc123',
-          }, {
-            token: '<token>',
-          })
+          const payment = await client.carts.payments.create(
+            'cart_abc123',
+            {
+              payment_method_id: 'pm_abc123',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -5116,8 +5143,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 2429789
-                  slug: product-2429789
+                  name: Product 2509789
+                  slug: product-2509789
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5324,8 +5351,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 244179
-                  slug: product-244179
+                  name: Product 252179
+                  slug: product-252179
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5388,9 +5415,13 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const order = await client.orders.get('or_abc123', {}, {
-            token: '<token>',
-          })
+          const order = await client.orders.get(
+            'or_abc123',
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -5485,8 +5516,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 184496
-                  slug: product-184496
+                  name: Product 192496
+                  slug: product-192496
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -5675,9 +5706,12 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const addresses = await client.customer.addresses.list({}, {
-            token: '<token>',
-          })
+          const addresses = await client.customer.addresses.list(
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -6059,11 +6093,15 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const address = await client.customer.addresses.update('addr_abc123', {
-            city: 'Los Angeles',
-          }, {
-            token: '<token>',
-          })
+          const address = await client.customer.addresses.update(
+            'addr_abc123',
+            {
+              city: 'Los Angeles',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -6205,9 +6243,12 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const cards = await client.customer.creditCards.list({}, {
-            token: '<token>',
-          })
+          const cards = await client.customer.creditCards.list(
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -6575,8 +6616,8 @@ paths:
                     preorder_ships_at:
                     quantity: 1
                     currency: USD
-                    name: Product 1505270
-                    slug: product-1505270
+                    name: Product 1585270
+                    slug: product-1585270
                     options_text: ''
                     price: '10.0'
                     display_price: "$10.00"
@@ -6785,9 +6826,13 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const order = await client.customer.orders.get('or_abc123', {}, {
-            token: '<token>',
-          })
+          const order = await client.customer.orders.get(
+            'or_abc123',
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -6875,8 +6920,8 @@ paths:
                   preorder_ships_at:
                   quantity: 1
                   currency: USD
-                  name: Product 1525633
-                  slug: product-1525633
+                  name: Product 1605633
+                  slug: product-1605633
                   options_text: ''
                   price: '10.0'
                   display_price: "$10.00"
@@ -7334,13 +7379,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const customer = await client.customer.update({
-            first_name: 'John',
-            last_name: 'Doe',
-            metadata: { preferred_contact: 'email' },
-          }, {
-            token: '<token>',
-          })
+          const customer = await client.customer.update(
+            {
+              first_name: 'John',
+              last_name: 'Doe',
+              metadata: { preferred_contact: 'email' },
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -7519,9 +7567,12 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const giftCards = await client.customer.giftCards.list({}, {
-            token: '<token>',
-          })
+          const giftCards = await client.customer.giftCards.list(
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -7702,11 +7753,14 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const session = await client.customer.paymentSetupSessions.create({
-            payment_method_id: 'pm_abc123',
-          }, {
-            token: '<token>',
-          })
+          const session = await client.customer.paymentSetupSessions.create(
+            {
+              payment_method_id: 'pm_abc123',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -7891,9 +7945,13 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const session = await client.customer.paymentSetupSessions.complete('pss_abc123', {}, {
-            token: '<token>',
-          })
+          const session = await client.customer.paymentSetupSessions.complete(
+            'pss_abc123',
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters: []
       responses:
         '200':
@@ -7960,9 +8018,12 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const credits = await client.customer.storeCredits.list({}, {
-            token: '<token>',
-          })
+          const credits = await client.customer.storeCredits.list(
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -8808,9 +8869,12 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const wishlists = await client.wishlists.list({}, {
-            token: '<token>',
-          })
+          const wishlists = await client.wishlists.list(
+            {},
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -8899,12 +8963,15 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const wishlist = await client.wishlists.create({
-            name: 'Birthday Ideas',
-            is_private: true,
-          }, {
-            token: '<token>',
-          })
+          const wishlist = await client.wishlists.create(
+            {
+              name: 'Birthday Ideas',
+              is_private: true,
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -9058,11 +9125,15 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const wishlist = await client.wishlists.update('wl_abc123', {
-            name: 'Updated Name',
-          }, {
-            token: '<token>',
-          })
+          const wishlist = await client.wishlists.update(
+            'wl_abc123',
+            {
+              name: 'Updated Name',
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -9167,12 +9238,16 @@ paths:
             publishableKey: '<api-key>',
           })
 
-          const item = await client.wishlists.items.create('wl_abc123', {
-            variant_id: 'variant_abc123',
-            quantity: 1,
-          }, {
-            token: '<token>',
-          })
+          const item = await client.wishlists.items.create(
+            'wl_abc123',
+            {
+              variant_id: 'variant_abc123',
+              quantity: 1,
+            },
+            {
+              token: '<token>',
+            },
+          )
       parameters:
       - name: x-spree-api-key
         in: header
@@ -9203,7 +9278,7 @@ paths:
                 variant:
                   id: variant_gbHJdmfrXB
                   product_id: prod_gbHJdmfrXB
-                  sku: SKU-298
+                  sku: SKU-306
                   options_text: ''
                   track_inventory: true
                   media_count: 0

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -846,6 +846,28 @@
                 ]
               },
               {
+                "item": "Seller API",
+                "icon": "shop",
+                "description": "REST API for the marketplace seller panel",
+                "groups": [
+                  {
+                    "group": "API basics",
+                    "pages": [
+                      "api-reference/seller-api/introduction",
+                      "api-reference/seller-api/authentication",
+                      "api-reference/seller-api/errors"
+                    ]
+                  },
+                  {
+                    "group": "Endpoints",
+                    "openapi": {
+                      "source": "api-reference/seller.yaml",
+                      "directory": "api-reference/seller-api"
+                    }
+                  }
+                ]
+              },
+              {
                 "item": "Webhooks",
                 "icon": "webhook",
                 "description": "Event payloads and delivery reference",
@@ -2331,6 +2353,28 @@
                 "openapi": {
                   "source": "api-reference/admin.yaml",
                   "directory": "api-reference/admin-api"
+                }
+              }
+            ]
+          },
+          {
+            "item": "Seller API",
+            "icon": "shop",
+            "description": "REST API for the marketplace seller panel",
+            "groups": [
+              {
+                "group": "API basics",
+                "pages": [
+                  "api-reference/seller-api/introduction",
+                  "api-reference/seller-api/authentication",
+                  "api-reference/seller-api/errors"
+                ]
+              },
+              {
+                "group": "Endpoints",
+                "openapi": {
+                  "source": "api-reference/seller.yaml",
+                  "directory": "api-reference/seller-api"
                 }
               }
             ]

--- a/packages/seller-sdk/src/seller-client.ts
+++ b/packages/seller-sdk/src/seller-client.ts
@@ -301,8 +301,12 @@ export interface SellerCountry {
 export interface OnboardingResponse {
   /** The seller's lifecycle status, e.g. `onboarding`, `ready_for_review`. */
   status: string
-  /** Optional requirements included — this is how far along, not how close to approval. */
-  progress: { done: number; total: number; percentage: number }
+  /**
+   * Optional requirements included — this is how far along, not how close to
+   * approval. Just the two counts: a percentage is arithmetic over them, and a
+   * copy here would be a second definition of the same fact.
+   */
+  progress: { done: number; total: number }
   requirements: RequirementStatus[]
 }
 

--- a/spree/api/Rakefile
+++ b/spree/api/Rakefile
@@ -37,7 +37,7 @@ namespace :rswag do
       require 'spree/api/openapi/path_sorter'
 
       docs = File.expand_path('../../docs/api-reference', __dir__)
-      %w[admin.yaml store.yaml].each do |name|
+      %w[admin.yaml store.yaml seller.yaml].each do |name|
         path = File.join(docs, name)
         next unless File.exist?(path)
 

--- a/spree/api/lib/spree/api/openapi/schema_helper.rb
+++ b/spree/api/lib/spree/api/openapi/schema_helper.rb
@@ -241,6 +241,160 @@ module Spree
           schemas
         end
 
+        # Get all seller schemas (Typelizer + common).
+        #
+        # The seller branch has no API-key credential, so its AuthResponse is
+        # neither the store's nor the admin's: signing in returns the JWT, the
+        # team member who signed in, and the sellers they may act for — the
+        # panel cannot make another request until it has picked one.
+        def seller_schemas
+          schemas = common_schemas
+
+          schemas[:AuthResponse] = {
+            type: :object,
+            properties: {
+              token: { type: :string, description: 'JWT access token, `seller_api` audience' },
+              user: { '$ref' => '#/components/schemas/TeamMember' },
+              sellers: {
+                type: :array,
+                description: 'The sellers this user may act for. Pick one and send its `id` as `X-Spree-Seller-Id` on every subsequent request.',
+                items: { '$ref' => '#/components/schemas/SellerSummary' }
+              }
+            },
+            required: %w[token user sellers]
+          }
+
+          schemas.merge!(seller_common_schemas)
+
+          begin
+            schemas.merge!(typelizer_schemas(:seller))
+          rescue StandardError => e
+            Rails.logger.warn "Failed to load Typelizer seller schemas: #{e.message}"
+          end
+
+          schemas
+        end
+
+        # Hand-written shapes the seller branch answers with that no serializer
+        # produces — bespoke controller hashes rather than Alba output.
+        def seller_common_schemas
+          {
+            SellerSummary: {
+              type: :object,
+              description: 'A seller the signed-in user may act for',
+              properties: {
+                id: { type: :string, description: 'Prefixed seller ID — send as `X-Spree-Seller-Id`', example: 'sel_abc123' },
+                name: { type: :string, example: 'Acme Supplies' },
+                status: { type: :string, example: 'approved', description: 'Seller lifecycle status' }
+              },
+              required: %w[id name status]
+            },
+            SellerMeSummary: {
+              type: :object,
+              description: 'A seller the signed-in user may act for, as `/me` reports it — the login response carries the same fields without `slug`.',
+              properties: {
+                id: { type: :string, description: 'Prefixed seller ID — send as `X-Spree-Seller-Id`', example: 'sel_abc123' },
+                name: { type: :string, example: 'Acme Supplies' },
+                slug: { type: :string, example: 'acme-supplies' },
+                status: { type: :string, example: 'approved', description: 'Seller lifecycle status' }
+              },
+              required: %w[id name slug status]
+            },
+            SellerMeResponse: {
+              type: :object,
+              description: 'The signed-in user, the sellers they may act for, and what they may do on the selected one',
+              properties: {
+                user: { '$ref' => '#/components/schemas/TeamMember' },
+                sellers: { type: :array, items: { '$ref' => '#/components/schemas/SellerMeSummary' } },
+                permissions: { type: :array, items: { '$ref' => '#/components/schemas/PermissionRule' } },
+                permission_keys: {
+                  type: :array,
+                  items: { type: :string },
+                  description: 'Permission keys on the selected seller. Empty until `X-Spree-Seller-Id` names one — capability is per seller.',
+                  example: %w[read_products write_products]
+                }
+              },
+              required: %w[user sellers permissions permission_keys]
+            },
+            OnboardingProgress: {
+              type: :object,
+              description: <<~DESC,
+                How far along the checklist is — not how close to approval, since
+                optional requirements count towards it too.
+
+                Deliberately just the two counts. A percentage is arithmetic over
+                them, which a client can do and which would otherwise be a second
+                definition of the same fact.
+              DESC
+              properties: {
+                done: { type: :integer, example: 3 },
+                total: { type: :integer, example: 5 }
+              },
+              required: %w[done total]
+            },
+            SellerOnboardingResponse: {
+              type: :object,
+              description: "What the marketplace asks of this seller before it will admit them",
+              properties: {
+                status: { type: :string, example: 'onboarding', description: "The seller's lifecycle status" },
+                progress: { '$ref' => '#/components/schemas/OnboardingProgress' },
+                requirements: { type: :array, items: { '$ref' => '#/components/schemas/RequirementStatus' } }
+              },
+              required: %w[status progress requirements]
+            },
+            SellerCountry: {
+              type: :object,
+              description: "A country as the panel's address forms need it",
+              properties: {
+                iso: { type: :string, example: 'US' },
+                iso3: { type: :string, example: 'USA' },
+                name: { type: :string, example: 'United States' },
+                states_required: { type: :boolean, example: true },
+                zipcode_required: { type: :boolean, example: true },
+                states: {
+                  type: :array,
+                  items: {
+                    type: :object,
+                    properties: {
+                      abbr: { type: :string, example: 'CA' },
+                      name: { type: :string, example: 'California' }
+                    },
+                    required: %w[abbr name]
+                  }
+                }
+              },
+              required: %w[iso iso3 name]
+            },
+            DirectUploadResponse: {
+              type: :object,
+              description: 'A presigned upload target. PUT the file to `direct_upload.url` with the given headers, then send `signed_id` as the submission\'s `file`.',
+              properties: {
+                signed_id: { type: :string, description: 'Send this as a submission\'s `file`', example: 'eyJfcmFpbHMiOnsibWVzc2FnZSI6...' },
+                direct_upload: {
+                  type: :object,
+                  properties: {
+                    url: { type: :string, example: 'https://storage.example.com/uploads/abc123' },
+                    headers: { type: :object, additionalProperties: { type: :string } }
+                  },
+                  required: %w[url headers]
+                }
+              },
+              required: %w[signed_id direct_upload]
+            },
+            AuthProvidersResponse: {
+              type: :object,
+              description: 'Sign-in methods this marketplace offers sellers, for the login page',
+              properties: {
+                providers: {
+                  type: :array,
+                  items: { type: :object, additionalProperties: true }
+                }
+              },
+              required: %w[providers]
+            }
+          }
+        end
+
         private
 
         def typelizer_schemas(writer_name)

--- a/spree/api/spec/integration/spree/api/v3/seller/auth_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/auth_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Authentication API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  let!(:existing_seller_user) do
+    create(:admin_user, :without_admin_role, email: 'seller@example.com', password: 'password123').tap do |user|
+      seller.add_user(user, seller_role)
+    end
+  end
+
+  path '/api/v3/seller/auth/login' do
+    post 'Login' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+      description <<~DESC
+        Signs a seller in and returns a short-lived JWT access token carrying the
+        `seller_api` audience. The rotatable refresh token is set in an HttpOnly
+        cookie — it is not included in the response body.
+
+        The response lists every seller this user may act for. Pick one and send
+        its `id` as `X-Spree-Seller-Id` on every subsequent request; nothing else
+        on this API answers until a seller is named.
+
+        Authenticating is not on its own enough. A store's own staff share the
+        same user class, so a user who runs no seller is refused — issuing a
+        token would hand out an audience its holder can do nothing with.
+
+        The `provider` field selects the authentication method. When omitted it
+        defaults to `email`. Sellers and store staff read different provider
+        registries, so a marketplace can require SSO for its own back office
+        while still letting sellers sign in with a password.
+      DESC
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          provider: { type: :string, enum: ['email'], default: 'email' },
+          email: { type: :string, format: 'email', example: 'seller@example.com' },
+          password: { type: :string, example: 'password123' }
+        },
+        required: %w[email password]
+      }
+
+      response '200', 'login successful' do
+        let(:body) { { email: existing_seller_user.email, password: 'password123' } }
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data['user']['email']).to eq(existing_seller_user.email)
+          expect(data['sellers'].first['id']).to eq(seller.prefixed_id)
+          expect(data).not_to have_key('refresh_token')
+        end
+      end
+
+      response '401', 'invalid credentials' do
+        let(:body) { { email: existing_seller_user.email, password: 'wrong_password' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/auth/refresh' do
+    post 'Refresh token' do
+      tags 'Authentication'
+      produces 'application/json'
+      description <<~DESC
+        Exchanges the HttpOnly refresh-token cookie for a new access JWT and a
+        rotated refresh cookie. No request body or Authorization header is
+        required — the cookie alone authenticates the call.
+
+        The lookup is narrowed by audience, so a refresh token minted for the
+        storefront or the back office cannot be exchanged for a seller session.
+        Membership is rechecked here too: a user whose last seller role was
+        revoked mid-session is refused rather than renewed.
+      DESC
+
+      response '200', 'refresh successful' do
+        let(:refresh_token_record) do
+          create(:refresh_token, :for_admin, user: existing_seller_user,
+                                             audience: Spree::Api::V3::JwtAuthentication::JWT_AUDIENCE_SELLER)
+        end
+
+        # rswag drives requests through Rack::Test, whose cookie jar can't sign
+        # cookies the way Rails does. Stub the cookie reader so the integration
+        # test can exercise the success path without reimplementing signing.
+        before do
+          token = refresh_token_record.token
+          allow_any_instance_of(Spree::Api::V3::Seller::AuthCookies).to receive(:refresh_token_from_cookie).and_return(token)
+        end
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data).not_to have_key('refresh_token')
+        end
+      end
+
+      response '401', 'missing or invalid refresh-token cookie' do
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/auth/logout' do
+    post 'Logout' do
+      tags 'Authentication'
+      produces 'application/json'
+      description 'Revokes the refresh-token cookie, ending the seller session.'
+
+      response '204', 'logout successful' do
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/auth/providers' do
+    get 'List authentication providers' do
+      tags 'Authentication'
+      produces 'application/json'
+      description <<~DESC
+        The sign-in methods this marketplace offers sellers, for the login page
+        to render. Unauthenticated — a login page must be able to ask before
+        anyone has signed in.
+      DESC
+
+      response '200', 'providers listed' do
+        schema '$ref' => '#/components/schemas/AuthProvidersResponse'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)).to have_key('providers')
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/countries_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/countries_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Countries API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  path '/api/v3/seller/countries' do
+    get 'List countries' do
+      tags 'Countries'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Countries and their states, for the panel's address forms.
+
+        Public reference data — the same list the storefront serves — so it is
+        not narrowed to the markets this marketplace sells into: a seller filling
+        in a billing address needs every country.
+
+        Unpaginated. An address dropdown needs all ~250 at once.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'countries listed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema type: :object,
+               properties: {
+                 data: { type: :array, items: { '$ref' => '#/components/schemas/SellerCountry' } },
+                 meta: {
+                   type: :object,
+                   properties: { count: { type: :integer, example: 250 } },
+                   required: %w[count]
+                 }
+               },
+               required: %w[data meta]
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['data']).to be_an(Array)
+          expect(data['meta']['count']).to eq(data['data'].size)
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/direct_uploads_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/direct_uploads_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Direct Uploads API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — this
+  # is what a member of a seller's team actually holds on their own seller.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  path '/api/v3/seller/direct_uploads' do
+    post 'Create a direct upload' do
+      tags 'Uploads'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Presigns an upload target for a file the seller is about to send.
+
+        Three steps: post the file's metadata here, `PUT` the bytes to the
+        returned `direct_upload.url` with the headers it names, then send the
+        returned `signed_id` wherever the file belongs — as a requirement
+        submission's `file`, or as `logo`, `square_logo` or `cover_photo` on the
+        profile.
+
+        The blob is attached to nothing at this point. The endpoint that consumes
+        the `signed_id` is the one that checks ownership.
+
+        `checksum` is the file's MD5 digest, base64-encoded — the storage service
+        verifies the upload against it.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          blob: {
+            type: :object,
+            properties: {
+              filename: { type: :string, example: 'registration.pdf' },
+              byte_size: { type: :integer, example: 51_234 },
+              checksum: { type: :string, description: 'Base64-encoded MD5 digest of the file', example: 'rL0Y20zC+Fzt72VPzMSk2A==' },
+              content_type: { type: :string, example: 'application/pdf' }
+            },
+            required: %w[filename byte_size checksum content_type]
+          }
+        },
+        required: %w[blob]
+      }
+
+      response '201', 'upload target created' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) do
+          {
+            blob: {
+              filename: 'registration.pdf',
+              byte_size: 51_234,
+              checksum: Digest::MD5.base64digest('registration'),
+              content_type: 'application/pdf'
+            }
+          }
+        end
+
+        schema '$ref' => '#/components/schemas/DirectUploadResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['signed_id']).to be_present
+          expect(data['direct_upload']['url']).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/invitation_acceptances_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/invitation_acceptances_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Invitation Acceptance API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  let(:inviter) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+  let(:invitation) { create(:invitation, resource: seller, inviter: inviter, email: 'newcomer@acme.test') }
+
+  path '/api/v3/seller/auth/invitations/{id}/lookup' do
+    parameter name: :id, in: :path, type: :string, description: 'Invitation ID from the emailed link'
+
+    get 'Look up an invitation' do
+      tags 'Authentication'
+      produces 'application/json'
+      description <<~DESC
+        Reads an invitation from the emailed link, before anyone signs in.
+
+        The acceptance page needs the invited address to decide whether it is
+        asking someone to set a new password or to confirm one they already have.
+
+        Unauthenticated — the ID and token in the emailed link are the
+        credential. A wrong token is indistinguishable from an unknown
+        invitation: both answer `404`, so the endpoint cannot be used to
+        enumerate. An invitation onto the store's own staff rather than a seller
+        answers `404` here too.
+      DESC
+
+      parameter name: :token, in: :query, type: :string, required: true,
+                description: 'The token from the emailed link'
+
+      response '200', 'invitation found' do
+        let(:id) { invitation.prefixed_id }
+        let(:token) { invitation.token }
+
+        schema '$ref' => '#/components/schemas/Invitation'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['email']).to eq('newcomer@acme.test')
+        end
+      end
+
+      response '404', 'wrong token, or an invitation that can no longer be accepted' do
+        let(:id) { invitation.prefixed_id }
+        let(:token) { 'not-the-token' }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/auth/invitations/{id}/accept' do
+    parameter name: :id, in: :path, type: :string, description: 'Invitation ID from the emailed link'
+
+    post 'Accept an invitation' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+      description <<~DESC
+        Accepts the invitation and returns a signed-in seller session, so the new
+        member lands in the panel rather than on a login form.
+
+        The email is never taken from the request — it always comes from the
+        invitation, which is what stops the link being redirected to another
+        address.
+
+        `password` is required when no account exists for the invited address, in
+        which case it sets one. When an account already exists, the same field is
+        how the person proves the account is theirs.
+      DESC
+
+      parameter name: :token, in: :query, type: :string, required: true,
+                description: 'The token from the emailed link'
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          password: { type: :string, example: 'password123' },
+          password_confirmation: { type: :string, example: 'password123' },
+          first_name: { type: :string, example: 'Robin' },
+          last_name: { type: :string, example: 'Ellis' }
+        }
+      }
+
+      response '200', 'invitation accepted, session issued' do
+        let(:id) { invitation.prefixed_id }
+        let(:token) { invitation.token }
+        let(:body) do
+          { password: 'password123', password_confirmation: 'password123', first_name: 'Robin', last_name: 'Ellis' }
+        end
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data['user']['email']).to eq('newcomer@acme.test')
+          expect(data['sellers'].first['id']).to eq(seller.prefixed_id)
+        end
+      end
+
+      response '404', 'wrong token, or an invitation that can no longer be accepted' do
+        let(:id) { invitation.prefixed_id }
+        let(:token) { 'not-the-token' }
+        let(:body) { { password: 'password123', password_confirmation: 'password123' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/invitations_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/invitations_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Invitations API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — this
+  # is what a member of a seller's team actually holds on their own seller.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  let(:pending_invitation) do
+    create(:invitation, resource: seller, inviter: seller_user, email: 'colleague@acme.test')
+  end
+
+  path '/api/v3/seller/invitations' do
+    get 'List pending invitations' do
+      tags 'Team'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Offers nobody has accepted yet, newest first.
+
+        Pending only — an accepted invitation is a team member, and shows up on
+        `GET /api/v3/seller/team` instead.
+
+        Sending an invitation lives on `team`, because that is hiring. Chasing or
+        withdrawing one is bookkeeping on the offer itself, so it lives here.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'invitations listed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        before { pending_invitation }
+
+        schema type: :object,
+               properties: {
+                 data: { type: :array, items: { '$ref' => '#/components/schemas/Invitation' } }
+               },
+               required: %w[data]
+
+        run_test! do |response|
+          data = JSON.parse(response.body)['data']
+          expect(data.map { |invitation| invitation['id'] }).to include(pending_invitation.prefixed_id)
+        end
+      end
+    end
+  end
+
+  path '/api/v3/seller/invitations/{id}/resend' do
+    parameter name: :id, in: :path, type: :string, description: 'Invitation ID'
+
+    patch 'Resend an invitation' do
+      tags 'Team'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Sends the invitation email again, for a colleague who never got the first
+        one. An invitation whose window has closed is refused rather than
+        re-sent.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'invitation resent' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { pending_invitation.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/Invitation'
+
+        run_test!
+      end
+
+      response '404', "another seller's invitation" do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:other_seller) { create(:seller, :approved, store: store) }
+        let(:id) do
+          create(:invitation, resource: other_seller, inviter: seller_user, email: 'elsewhere@acme.test').prefixed_id
+        end
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/invitations/{id}' do
+    parameter name: :id, in: :path, type: :string, description: 'Invitation ID'
+
+    delete 'Revoke an invitation' do
+      tags 'Team'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description 'Withdraws an offer that has not been accepted.'
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '204', 'invitation revoked' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { pending_invitation.prefixed_id }
+
+        run_test!
+      end
+
+      response '404', "another seller's invitation" do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:other_seller) { create(:seller, :approved, store: store) }
+        let(:id) do
+          create(:invitation, resource: other_seller, inviter: seller_user, email: 'elsewhere@acme.test').prefixed_id
+        end
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/me_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/me_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Account API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  path '/api/v3/seller/me' do
+    get 'Current user' do
+      tags 'Account'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        The signed-in user, the sellers they may act for, and what they may do on
+        the selected one.
+
+        This is the one authenticated endpoint that answers without
+        `X-Spree-Seller-Id` — it is what tells the panel which seller to name.
+        Sending the header narrows `permission_keys` and `permissions` to that
+        seller; without it both are empty, because capability is per seller and
+        there is no answer spanning all of them.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: false,
+                description: 'The seller to report capability for. Omit to list sellers without narrowing permissions.'
+
+      response '200', 'current user returned' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/SellerMeResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['user']['id']).to eq(seller_user.prefixed_id)
+          expect(data['sellers'].first['id']).to eq(seller.prefixed_id)
+          expect(data['permission_keys']).to include('write_products')
+        end
+      end
+
+      response '401', 'missing or invalid token' do
+        let(:Authorization) { nil }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/onboarding_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/onboarding_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Onboarding API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — this
+  # is what a member of a seller's team actually holds on their own seller.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  path '/api/v3/seller/onboarding' do
+    get 'Get onboarding checklist' do
+      tags 'Onboarding'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        What this marketplace asks of the seller before it will admit them.
+
+        Singular: the checklist is always the acting seller's. Every answer is
+        computed server-side by the same evaluator the operator's own view uses,
+        so the panel and the operator can never show different progress.
+
+        `progress` counts optional requirements too — it is how far along the
+        checklist is, not how close to approval. Read `blocking` on each
+        requirement for that.
+
+        Each requirement's `id` is what a submission is posted against. A
+        marketplace that asks for nothing returns an empty list, which is a
+        complete answer rather than a missing one.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'checklist returned' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/SellerOnboardingResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['status']).to be_present
+          expect(data['requirements']).to be_an(Array)
+        end
+      end
+
+      response '403', 'no seller named, or not a member of it' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { nil }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/onboarding/submit_for_review' do
+    post 'Submit for review' do
+      tags 'Onboarding'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Says the seller is ready, moving them from `onboarding` to
+        `ready_for_review`.
+
+        Refused with `422` when something required is still outstanding — the
+        message names the blocking requirements, and the seller's status is
+        unchanged. Returns the same payload as the checklist so the panel can
+        re-render from one response.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'submitted for review' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:seller) { create(:seller, :onboarding, store: store) }
+
+        schema '$ref' => '#/components/schemas/SellerOnboardingResponse'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['status']).to eq('ready_for_review')
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/products_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/products_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Products API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  let!(:product) { create(:product, store: store, seller: seller) }
+
+  path '/api/v3/seller/products' do
+    get 'List products' do
+      tags 'Products'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        The seller's own catalog — the products they own outright.
+
+        Every call is rooted in the acting seller server-side, so this can never
+        return another seller's product or one the marketplace operator sells
+        first-party.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :page, in: :query, type: :integer, required: false, description: 'Page number'
+      parameter name: :limit, in: :query, type: :integer, required: false, description: 'Records per page (max 100)'
+      parameter name: :sort, in: :query, type: :string, required: false, description: 'Sort field; prefix with `-` for descending'
+
+      response '200', 'products listed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema type: :object,
+               properties: {
+                 data: { type: :array, items: { '$ref' => '#/components/schemas/Product' } },
+                 meta: { '$ref' => '#/components/schemas/PaginationMeta' }
+               },
+               required: %w[data meta]
+
+        run_test! do |response|
+          data = JSON.parse(response.body)['data']
+          expect(data.map { |item| item['id'] }).to include(product.prefixed_id)
+        end
+      end
+    end
+
+    post 'Create a product' do
+      tags 'Products'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Creates a product owned by the acting seller.
+
+        The seller and the store are taken from the request context whatever the
+        payload says, so a product cannot be created against another seller.
+
+        The operator's own settings — tax category, delivery profile and whether
+        the product is promotionable — are not writable here; they belong to the
+        marketplace, not the seller.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          name: { type: :string, example: 'Hand-thrown mug' },
+          description: { type: :string },
+          slug: { type: :string, example: 'hand-thrown-mug' },
+          status: { type: :string, example: 'draft' },
+          meta_title: { type: :string },
+          meta_description: { type: :string },
+          meta_keywords: { type: :string },
+          product_type_id: { type: :string, example: 'ptype_abc123' },
+          tags: { type: :array, items: { type: :string }, example: %w[ceramics handmade] },
+          category_ids: { type: :array, items: { type: :string }, example: ['cat_abc123'] },
+          metadata: { type: :object, additionalProperties: true },
+          prices: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                amount: { type: :string, example: '24.00' },
+                compare_at_amount: { type: :string, example: '30.00' },
+                currency: { type: :string, example: 'USD' }
+              }
+            }
+          }
+        },
+        required: %w[name]
+      }
+
+      response '201', 'product created' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { name: 'Hand-thrown mug', prices: [{ amount: '24.00', currency: 'USD' }] } }
+
+        schema '$ref' => '#/components/schemas/Product'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['name']).to eq('Hand-thrown mug')
+        end
+      end
+
+      response '422', 'validation failed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { name: '' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/products/{id}' do
+    parameter name: :id, in: :path, type: :string, description: 'Product ID'
+
+    get 'Get a product' do
+      tags 'Products'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        A product the acting seller owns.
+
+        An id belonging to another seller answers `404`, not `403` — the seller
+        is not told the record exists.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'product returned' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { product.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/Product'
+
+        run_test!
+      end
+
+      response '404', "another seller's product" do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:other_seller) { create(:seller, :approved, store: store) }
+        let(:id) { create(:product, store: store, seller: other_seller).prefixed_id }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+
+    patch 'Update a product' do
+      tags 'Products'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description 'Edits a product the acting seller owns.'
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          name: { type: :string, example: 'Hand-thrown mug, large' },
+          description: { type: :string },
+          slug: { type: :string },
+          status: { type: :string, example: 'active' },
+          tags: { type: :array, items: { type: :string } },
+          category_ids: { type: :array, items: { type: :string } },
+          metadata: { type: :object, additionalProperties: true }
+        }
+      }
+
+      response '200', 'product updated' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { product.prefixed_id }
+        let(:body) { { name: 'Hand-thrown mug, large' } }
+
+        schema '$ref' => '#/components/schemas/Product'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['name']).to eq('Hand-thrown mug, large')
+        end
+      end
+    end
+
+    delete 'Delete a product' do
+      tags 'Products'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description 'Deletes a product the acting seller owns.'
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '204', 'product deleted' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { product.prefixed_id }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/profile_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/profile_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Profile API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — this
+  # is what a member of a seller's team actually holds on their own seller.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  path '/api/v3/seller/profile' do
+    get 'Get profile' do
+      tags 'Profile'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        The seller's own record.
+
+        Singular by nature: the seller in play is always the one named by
+        `X-Spree-Seller-Id`, never an id in the path — so a seller cannot address
+        another seller here even by guessing one.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'profile returned' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/Profile'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['id']).to eq(seller.prefixed_id)
+        end
+      end
+
+      response '403', 'no seller named, or not a member of it' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { nil }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+
+    patch 'Update profile' do
+      tags 'Profile'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Edits presentation, contact details and addresses.
+
+        Readable but **not** writable, by design: `status` — the lifecycle belongs
+        to the marketplace operator's workflows — the settlement terms, and
+        `slug`, since a seller renaming their own storefront address would break
+        every link pointing at it.
+
+        `tax_identifier` holds one registration per kind: re-sending a kind
+        corrects the number, and an empty value removes it. A changed number
+        drops its validation verdict, because that answer was about the old one.
+
+        `accept_terms: true` stamps the moment the seller accepted the
+        marketplace's terms, which is what the matching onboarding requirement
+        reads. One-way — sending `false` does not unmake the stamp.
+
+        `custom_fields` is narrowed server-side to the definitions this
+        marketplace's onboarding actually asks this seller for; a field nothing
+        asked for is ignored rather than written.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          name: { type: :string, example: 'Acme Supplies' },
+          contact_email: { type: :string, format: 'email', nullable: true, example: 'hello@acme.test' },
+          billing_email: { type: :string, format: 'email', nullable: true, example: 'billing@acme.test' },
+          about: { type: :string, nullable: true, description: 'Sanitized HTML — the seller\'s public description' },
+          legal_name: { type: :string, nullable: true, description: 'The business a commission invoice is made out to' },
+          registration_number: { type: :string, nullable: true },
+          logo: { type: :string, nullable: true, description: 'ActiveStorage signed id; `null` removes the attachment' },
+          square_logo: { type: :string, nullable: true },
+          cover_photo: { type: :string, nullable: true },
+          accept_terms: { type: :boolean, description: 'Stamps acceptance of the marketplace terms' },
+          tax_identifier: {
+            type: :object,
+            properties: {
+              kind: { type: :string, example: 'eu_vat' },
+              value: { type: :string, example: 'PL1234567890' }
+            }
+          },
+          billing_address: { type: :object, additionalProperties: true },
+          custom_fields: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                custom_field_definition_id: { type: :string, example: 'cfd_abc123' },
+                value: { description: 'Any JSON value the definition accepts' }
+              }
+            }
+          }
+        }
+      }
+
+      response '200', 'profile updated' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { name: 'Acme Supplies', contact_email: 'hello@acme.test' } }
+
+        schema '$ref' => '#/components/schemas/Profile'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['name']).to eq('Acme Supplies')
+        end
+      end
+
+      response '422', 'validation failed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { name: '' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/requirement_submissions_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/requirement_submissions_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Requirement Submissions API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — this
+  # is what a member of a seller's team actually holds on their own seller.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  let(:requirement) { create(:attestation_requirement, store: store) }
+
+  path '/api/v3/seller/requirements/{requirement_id}/submissions' do
+    parameter name: :requirement_id, in: :path, type: :string,
+              description: 'Requirement ID, as returned by `GET /api/v3/seller/onboarding`'
+
+    post 'Submit against a requirement' do
+      tags 'Onboarding'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        What the seller says about one requirement: an attestation they tick, a
+        document they upload, a reference they paste.
+
+        Create only. A submission records what was said and when, so a seller who
+        needs to correct something submits again rather than editing, and the
+        latest one counts.
+
+        `file` is **not** a multipart upload — it is the `signed_id` returned by
+        `POST /api/v3/seller/direct_uploads`, so the bytes are already in storage
+        by the time this runs.
+
+        An attestation is accepted on the spot; a requirement the operator
+        reviews comes back `pending`.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          note: { type: :string, description: 'Anything the seller wants to say alongside the submission' },
+          reference: { type: :string, description: 'A reference number or external identifier, for requirements that ask for one' },
+          file: { type: :string, description: 'A direct-upload `signed_id`, for requirements that ask for a document' }
+        }
+      }
+
+      response '201', 'submission recorded' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:requirement_id) { requirement.prefixed_id }
+        let(:body) { { note: 'Confirmed.' } }
+
+        schema '$ref' => '#/components/schemas/RequirementSubmission'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['status']).to be_present
+        end
+      end
+
+      response '404', "a requirement belonging to another marketplace" do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:requirement_id) { create(:attestation_requirement, store: create(:store)).prefixed_id }
+        let(:body) { { note: 'Confirmed.' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/requirement_submissions/{id}/download' do
+    parameter name: :id, in: :path, type: :string, description: 'Submission ID'
+
+    get 'Download a submitted document' do
+      tags 'Onboarding'
+      produces 'application/octet-stream'
+      security [bearer_auth: []]
+      description <<~DESC
+        Streams the file attached to one of this seller's submissions.
+
+        Served through the API rather than from a storage URL on purpose: these
+        are identity and registration documents, so every read is authorized
+        against the acting seller. Another seller's submission answers `404`.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '404', "another seller's submission" do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:other_seller) { create(:seller, :approved, store: store) }
+        let(:id) do
+          create(:seller_requirement_submission, seller: other_seller, requirement: requirement).prefixed_id
+        end
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/stock_locations_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/stock_locations_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Stock Locations API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — stock
+  # locations are gated on the `stock` permission, which that role omits.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  let!(:stock_location) { create(:stock_location, store: store, seller: seller) }
+
+  path '/api/v3/seller/stock_locations' do
+    get 'List stock locations' do
+      tags 'Stock Locations'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Where this seller keeps stock, and so where their returns are sent.
+
+        Rooted in the acting seller, so the marketplace operator's own warehouses
+        never appear here.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :page, in: :query, type: :integer, required: false, description: 'Page number'
+      parameter name: :limit, in: :query, type: :integer, required: false, description: 'Records per page (max 100)'
+      parameter name: :sort, in: :query, type: :string, required: false, description: 'Sort field; prefix with `-` for descending'
+
+      response '200', 'stock locations listed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema type: :object,
+               properties: {
+                 data: { type: :array, items: { '$ref' => '#/components/schemas/StockLocation' } },
+                 meta: { '$ref' => '#/components/schemas/PaginationMeta' }
+               },
+               required: %w[data meta]
+
+        run_test! do |response|
+          data = JSON.parse(response.body)['data']
+          expect(data.map { |item| item['id'] }).to include(stock_location.prefixed_id)
+        end
+      end
+    end
+
+    post 'Create a stock location' do
+      tags 'Stock Locations'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Adds a place this seller ships from.
+
+        The seller and the store come from the request context whatever the
+        payload says.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          name: { type: :string, example: 'Main warehouse' },
+          company: { type: :string, nullable: true },
+          address1: { type: :string, nullable: true, example: '1 Kiln Lane' },
+          address2: { type: :string, nullable: true },
+          city: { type: :string, nullable: true, example: 'Portland' },
+          zipcode: { type: :string, nullable: true, example: '97205' },
+          country_code: { type: :string, nullable: true, example: 'US' },
+          state_code: { type: :string, nullable: true, example: 'OR' },
+          state_name: { type: :string, nullable: true },
+          phone: { type: :string, nullable: true },
+          active: { type: :boolean, description: 'Set `false` to retire a location — there is no delete' },
+          default: { type: :boolean },
+          kind: { type: :string, example: 'warehouse' }
+        },
+        required: %w[name]
+      }
+
+      response '201', 'stock location created' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { name: 'Main warehouse', city: 'Portland', country_code: 'US' } }
+
+        schema '$ref' => '#/components/schemas/StockLocation'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['name']).to eq('Main warehouse')
+        end
+      end
+
+      response '422', 'validation failed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { name: '' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/stock_locations/{id}' do
+    parameter name: :id, in: :path, type: :string, description: 'Stock location ID'
+
+    get 'Get a stock location' do
+      tags 'Stock Locations'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        A stock location the acting seller owns. An id belonging to another
+        seller — or to the marketplace operator — answers `404`.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'stock location returned' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { stock_location.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/StockLocation'
+
+        run_test!
+      end
+
+      response '404', "another seller's stock location" do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:other_seller) { create(:seller, :approved, store: store) }
+        let(:id) { create(:stock_location, store: store, seller: other_seller).prefixed_id }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+
+    patch 'Update a stock location' do
+      tags 'Stock Locations'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Edits a stock location the acting seller owns.
+
+        There is no delete: a location holds stock levels and is named on
+        historical fulfillments, so a seller retires one by setting `active` to
+        `false`.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          name: { type: :string, example: 'Main warehouse' },
+          address1: { type: :string, nullable: true },
+          city: { type: :string, nullable: true },
+          zipcode: { type: :string, nullable: true },
+          country_code: { type: :string, nullable: true },
+          state_code: { type: :string, nullable: true },
+          phone: { type: :string, nullable: true },
+          active: { type: :boolean },
+          default: { type: :boolean }
+        }
+      }
+
+      response '200', 'stock location updated' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { stock_location.prefixed_id }
+        let(:body) { { name: 'Kiln Lane warehouse' } }
+
+        schema '$ref' => '#/components/schemas/StockLocation'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['name']).to eq('Kiln Lane warehouse')
+        end
+      end
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/team_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/team_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Team API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  # The seeded role rather than the shared context's products-only one — this
+  # is what a member of a seller's team actually holds on their own seller.
+  let(:seller_user) do
+    create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+  end
+
+  path '/api/v3/seller/team' do
+    get 'List team members' do
+      tags 'Team'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        The people who run this seller.
+
+        Rooted at the acting seller throughout, so a seller only ever sees their
+        own team. Unpaginated — a seller's team is small by nature.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '200', 'team members listed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+
+        schema type: :object,
+               properties: {
+                 data: { type: :array, items: { '$ref' => '#/components/schemas/TeamMember' } }
+               },
+               required: %w[data]
+
+        run_test! do |response|
+          data = JSON.parse(response.body)['data']
+          expect(data.map { |member| member['id'] }).to include(seller_user.prefixed_id)
+        end
+      end
+    end
+
+    post 'Invite a team member' do
+      tags 'Team'
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Invites a colleague onto this seller's team. They join when they accept,
+        on the same invitation rail — and the same email — the marketplace
+        operator's own invitations use.
+
+        Hiring is not a lifecycle transition: a trading seller's status is
+        untouched by taking someone on.
+
+        The role is not a parameter. Every member holds the seller's own seeded
+        role, which already carries the whole seller vocabulary.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string, format: 'email', example: 'colleague@acme.test' }
+        },
+        required: %w[email]
+      }
+
+      response '201', 'invitation sent' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { email: 'colleague@acme.test' } }
+
+        schema '$ref' => '#/components/schemas/Invitation'
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['email']).to eq('colleague@acme.test')
+        end
+      end
+
+      response '422', 'validation failed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:body) { { email: '' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/seller/team/{id}' do
+    parameter name: :id, in: :path, type: :string, description: 'Team member (user) ID'
+
+    delete 'Remove a team member' do
+      tags 'Team'
+      produces 'application/json'
+      security [bearer_auth: []]
+      description <<~DESC
+        Revokes a member's access, removing every role they hold on this seller.
+
+        The team can never reach zero: emptying it would leave a seller nobody
+        can sign in to, and only the marketplace operator could put someone back.
+        The last remaining member is refused with `422`.
+      DESC
+
+      parameter name: 'X-Spree-Seller-Id', in: :header, type: :string, required: true
+
+      response '204', 'member removed' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:colleague) do
+          create(:admin_user, :without_admin_role).tap { |user| seller.add_user(user) }
+        end
+        let(:id) { colleague.prefixed_id }
+
+        run_test!
+      end
+
+      response '422', 'cannot remove the last remaining member' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { seller_user.prefixed_id }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+
+      response '404', 'not a member of this seller' do
+        let(:Authorization) { "Bearer #{seller_jwt_token}" }
+        let(:'X-Spree-Seller-Id') { seller.prefixed_id }
+        let(:id) { create(:admin_user, :without_admin_role).prefixed_id }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/api/spec/swagger_helper.rb
+++ b/spree/api/spec/swagger_helper.rb
@@ -202,6 +202,102 @@ RSpec.configure do |config|
         },
         schemas: Spree::Api::OpenAPI::SchemaHelper.admin_schemas
       }
+    },
+
+    # Seller API v3 - The marketplace seller panel
+    'api-reference/seller.yaml' => {
+      openapi: '3.0.3',
+      info: {
+        title: 'Seller API',
+        contact: {
+          name: 'Spree Commerce',
+          url: 'https://spreecommerce.org',
+          email: 'hello@spreecommerce.org',
+        },
+        description: <<~DESC,
+          Spree Seller API v3 - the marketplace seller panel, where a seller runs
+          their own shop inside someone else's marketplace.
+
+          This is a branch of its own, not a narrowing of the Admin API. Every
+          endpoint is scoped server-side to the seller the request acts as, which
+          is what makes cross-seller access impossible by construction rather
+          than by rule. Sellers never call the Admin API.
+
+          ## Authentication
+
+          Sign in at `POST /api/v3/seller/auth/login` and send the returned JWT as
+          `Authorization: Bearer <token>`. The token carries a `seller_api`
+          audience — a token minted for the storefront or the back office is not
+          accepted here, and vice versa.
+
+          There is deliberately **no secret API key** for this branch: a
+          credential that could act as a seller without a seller signing in is
+          exactly what the separate audience exists to prevent.
+
+          ### Choosing a seller
+
+          A user may run more than one seller. Login returns the list; send the
+          chosen seller's ID in the `X-Spree-Seller-Id` header on every
+          authenticated request. The store is derived from the seller — never
+          sent — so no header can widen what a seller reaches. A request that
+          names no seller the caller belongs to is rejected with `403`.
+
+          ## Response Format
+
+          All responses are JSON. List endpoints return paginated responses with
+          `data` and `meta` keys.
+
+          ## Error Handling
+
+          Errors return a consistent format:
+          ```json
+          {
+            "error": {
+              "code": "validation_error",
+              "message": "Validation failed",
+              "details": { "name": ["can't be blank"] }
+            }
+          }
+          ```
+        DESC
+        version: 'v3'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'http://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'localhost:3000'
+            }
+          }
+        }
+      ],
+      # Authentication first, the rest alphabetical — see the Admin API's
+      # note above: Mintlify renders one sidebar group per tag in this
+      # order, so every operation tag must be listed here.
+      tags: [
+        { name: 'Authentication', description: 'Seller sign-in, token refresh, logout, and invitation acceptance' },
+        { name: 'Account', description: 'The signed-in user, the sellers they may act for, and what they may do' },
+        { name: 'Countries', description: 'Country and state reference data for the panel\'s address forms' },
+        { name: 'Onboarding', description: 'The marketplace checklist a seller completes before admission, and what they submit against it' },
+        { name: 'Products', description: "The seller's own catalog" },
+        { name: 'Profile', description: "The seller's own record — presentation, contact details, addresses, and tax registration" },
+        { name: 'Stock Locations', description: 'Where the seller keeps stock, and so where their returns are sent' },
+        { name: 'Team', description: 'Who runs this seller, and the invitations nobody has accepted yet' },
+        { name: 'Uploads', description: 'Presigned direct uploads for the documents onboarding asks for' }
+      ],
+      components: {
+        securitySchemes: {
+          bearer_auth: {
+            type: :http,
+            scheme: :bearer,
+            bearerFormat: 'JWT',
+            description: 'JWT token for an authenticated seller session (`seller_api` audience)'
+          }
+        },
+        schemas: Spree::Api::OpenAPI::SchemaHelper.seller_schemas
+      }
     }
   }
 


### PR DESCRIPTION
The marketplace seller panel had no published reference, so anyone building against it had to read the controllers. This generates one the same way the Store and Admin specs are generated, and gives it its own section in the docs site alongside them.

## Generation

`seller.yaml` now rides the existing pipeline rather than a parallel one:

- **`spec/swagger_helper.rb`** — a third doc entry, with its own tag list and a `bearer_auth`-only security scheme. There is no API-key scheme because the seller branch deliberately has no server-to-server credential.
- **`lib/spree/api/openapi/schema_helper.rb`** — `seller_schemas`, feeding off the `:seller` Typelizer writer that already existed, plus the hand-written shapes for responses no serializer produces (`/me`, onboarding, countries, direct uploads, and the seller-specific auth response carrying `token` + `user` + `sellers`).
- **`Rakefile`** — `seller.yaml` added to the path sorter, so its sidebar follows the curated tag order.

## Coverage

12 integration specs covering all 23 paths — 48 examples. As elsewhere, the documented responses are real ones captured from the tests.

Authentication · Account · Countries · Onboarding · Products · Profile · Stock Locations · Team · Uploads

## Documentation

Three hand-written pages (introduction, authentication, errors) plus the generated endpoints, inserted after Admin API in both the v6.x and current navigation. v5.x is left alone, since the Seller API is 6.0.

The pages document the branch on its own terms rather than the Admin API's: it authenticates only by seller JWT, it asks every request to name the seller it acts as via `X-Spree-Seller-Id`, and it answers `404` where the Admin API would answer `403` — telling a seller that another seller's record exists is itself a disclosure.

## Notes for review

**The first commit is unrelated drift.** `admin.yaml` and `store.yaml` had fallen behind their sources — the seller columns on an operator's stock location list (added in e570048954 on this branch) were never regenerated, and the SDK code samples still carried their pre-formatting wrapping. Separated into its own commit so this PR's second commit is only the new surface.

**A stale seller SDK type is fixed here too.** `OnboardingResponse` still declared `progress.percentage`, which the endpoint no longer returns — a client reading it got `undefined` from a field the types promised. Nothing consumed it, so removing it breaks no caller.

**Regeneration caveat:** running `swaggerize` with a `PATTERN` filter blanks the paths of whichever docs' specs did not run. The full task is the only safe invocation. Verified determinism by generating twice and diffing — byte-identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive Seller API documentation and OpenAPI coverage for authentication, profiles, onboarding, products, invitations, team management, stock locations, uploads, countries, and requirements.
  - Added guidance for seller access boundaries, errors, invitations, sessions, and SDK workflows.
  - Expanded API schemas with seller profiles, team members, onboarding, authentication, and seller-linked stock-location details.

- **Documentation**
  - Refreshed Admin and Store API examples, schemas, sample values, navigation, and formatting.

- **Breaking Changes**
  - Seller onboarding progress now reports only completed and total counts; calculate percentages from these values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->