### PR TITLE
Declare tailwindcss and shadcn dependencies in @spree/dashboard-ui

### DIFF
--- a/.changeset/dashboard-ui-declare-css-deps.md
+++ b/.changeset/dashboard-ui-declare-css-deps.md
@@ -1,0 +1,5 @@
+---
+"@spree/dashboard-ui": patch
+---
+
+Declare the dependencies behind `styles.css` imports: `tailwindcss` as a peer (plus dev) dependency and `shadcn` as a regular dependency. Previously both were undeclared for consumers, so `@import "tailwindcss"` and `@import "shadcn/tailwind.css"` only resolved when pnpm's on-disk layout happened to allow it, failing with `Cannot apply unknown utility class` otherwise.

--- a/packages/dashboard-ui/package.json
+++ b/packages/dashboard-ui/package.json
@@ -48,7 +48,8 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.75.0",
-    "react-i18next": "^17.0.8"
+    "react-i18next": "^17.0.8",
+    "tailwindcss": "^4.2.4"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -75,6 +76,7 @@
     "react-colorful": "^5.7.0",
     "react-day-picker": "^9.14.0",
     "recharts": "^3.8.1",
+    "shadcn": "^4.7.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },
@@ -82,7 +84,7 @@
     "@types/geojson": "^7946.0.16",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "shadcn": "^4.7.0",
+    "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",
     "vite": "^8.0.16"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.5)(react@19.2.6)(redux@5.0.1)
+      shadcn:
+        specifier: ^4.7.0
+        version: 4.7.0(@types/node@25.6.0)(typescript@6.0.3)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -602,9 +605,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      shadcn:
-        specifier: ^4.7.0
-        version: 4.7.0(@types/node@25.6.0)(typescript@6.0.3)
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
       typescript:
         specifier: ~6.0.3
         version: 6.0.3


### PR DESCRIPTION
The package's styles.css imports tailwindcss and shadcn/tailwind.css, but tailwindcss was undeclared and shadcn was only a devDependency. Under pnpm's isolated layout both imports resolved only when the packages happened to land in a reachable node_modules on disk, so builds failed non-deterministically with 'Cannot apply unknown utility class' — locally and for published consumers compiling the source package.

tailwindcss becomes a peer dependency (consumers compile the CSS with their own Tailwind) plus a devDependency for the workspace copy; shadcn moves to dependencies, matching the shadcn installation guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard UI styling compatibility for applications consuming the package.
  - Ensured required CSS tooling is available when importing dashboard UI styles.

- **Chores**
  - Updated package dependency declarations to support consistent styling behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->