### PR TITLE
Let sellers reset their password from the seller panel

### DIFF
--- a/docs/api-reference/seller.yaml
+++ b/docs/api-reference/seller.yaml
@@ -336,6 +336,119 @@ paths:
                 last_name:
                   type: string
                   example: Ellis
+  "/api/v3/seller/auth/password_resets":
+    post:
+      summary: Request password reset
+      tags:
+      - Authentication
+      description: |
+        Requests a password reset email for a seller.
+
+        Unauthenticated. Always answers `202`, whether or not the address
+        belongs to a seller, so this cannot be used to discover which accounts
+        exist. A store staff member who runs no seller is treated as no match:
+        they have no seller panel to be sent to.
+
+        `redirect_url` is where the emailed link should point, with the reset
+        token appended as a `token` query param. It is honoured only when it
+        matches one of the store's allowed origins; otherwise it is silently
+        ignored and the server resolves the seller panel origin itself. The
+        email is delivered by Spree via the
+        `seller_user.password_reset_requested` event, which is never forwarded
+        to webhook endpoints.
+      parameters: []
+      responses:
+        '202':
+          description: reset requested
+          content:
+            application/json:
+              example:
+                message: If an account exists for that email, password reset instructions
+                  have been sent.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: seller@acme.test
+                redirect_url:
+                  type: string
+                  example: https://sellers.your-store.com/reset-password
+                  description: Must match an allowed origin of the store; ignored
+                    otherwise.
+              required:
+              - email
+  "/api/v3/seller/auth/password_resets/{id}":
+    patch:
+      summary: Reset password
+      tags:
+      - Authentication
+      description: |
+        Spends a password reset token (the `token` query param from the emailed
+        link), sets the new password and signs the seller in: the response
+        carries a seller JWT and the rotatable refresh token is set in an
+        HttpOnly cookie, so they land in the panel rather than on a login form.
+
+        The token is single-use, and resetting revokes every other session the
+        account holds. A token whose seller membership has since been revoked is
+        refused exactly as an expired one.
+      parameters:
+      - name: id
+        in: path
+        description: The reset token from the emailed link
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: password reset
+          content:
+            application/json:
+              example:
+                token: eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImp0aSI6ImJjMDM3NTNhLTEzN2MtNGM1Zi1hMzM2LWUzMjBlZTNiMjQ5YyIsImlzcyI6InNwcmVlIiwiYXVkIjoic2VsbGVyX2FwaSIsImV4cCI6MTc2ODQ3ODcwMH0.EASrzbGpJVyAl10SJyzs8na68Wmvedkm7G66wTBq_0k
+                user:
+                  id: adm_UkLWZg9DAJ
+                  email: lon@veum.us
+                  first_name: Ariana
+                  last_name: Wiza
+                  full_name: Ariana Wiza
+                  created_at: '2026-01-15T12:00:00.000Z'
+                  avatar_url:
+                sellers:
+                - id: sel_UkLWZg9DAJ
+                  name: Seller 34
+                  status: approved
+              schema:
+                "$ref": "#/components/schemas/AuthResponse"
+        '422':
+          description: invalid or expired token
+          content:
+            application/json:
+              example:
+                error:
+                  code: password_reset_token_invalid
+                  message: Password reset token is invalid or has expired.
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                  example: new-password-123
+                password_confirmation:
+                  type: string
+                  example: new-password-123
+              required:
+              - password
+              - password_confirmation
   "/api/v3/seller/me":
     get:
       summary: Current user
@@ -12826,8 +12939,8 @@ paths:
             application/json:
               example:
                 id: sel_UkLWZg9DAJ
-                name: Seller 41
-                slug: seller-41
+                name: Seller 43
+                slug: seller-43
                 about: ''
                 about_html: ''
                 logo_url:
@@ -12904,7 +13017,7 @@ paths:
               example:
                 id: sel_UkLWZg9DAJ
                 name: Acme Supplies
-                slug: seller-43
+                slug: seller-45
                 about: ''
                 about_html: ''
                 logo_url:
@@ -13657,10 +13770,10 @@ paths:
             application/json:
               example:
                 direct_upload:
-                  url: http://www.example.com/rails/active_storage/disk/eyJfcmFpbHMiOnsiZGF0YSI6eyJrZXkiOiJuem5oOGdra3VxendvbDc1ODBxNHNwZmpmMjVxIiwiY29udGVudF90eXBlIjoiYXBwbGljYXRpb24vcGRmIiwiY29udGVudF9sZW5ndGgiOjUxMjM0LCJjaGVja3N1bSI6IlZqaHowNGxRdUVHdXY0bkR2aHNhTlE9PSIsInNlcnZpY2VfbmFtZSI6InRlc3QifSwiZXhwIjoiMjAyNi0wMS0xNVQxMjowNTowMC4wMDBaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--897bd6eaca845284e2c28b2c3ceb093da93e052f
+                  url: http://www.example.com/rails/active_storage/disk/eyJfcmFpbHMiOnsiZGF0YSI6eyJrZXkiOiJuem5oOGdra3VxendvbDc1ODBxNHNwZmpmMjVxIiwiY29udGVudF90eXBlIjoiYXBwbGljYXRpb24vcGRmIiwiY29udGVudF9sZW5ndGgiOjUxMjM0LCJjaGVja3N1bSI6IlZqaHowNGxRdUVHdXY0bkR2aHNhTlE9PSIsInNlcnZpY2VfbmFtZSI6InRlc3QifSwiZXhwIjoiMjAyNi0wMS0xNVQxMjowNTowMC4wMDBaIiwicHVyIjoiYmxvYl90b2tlbiJ9fQ==--30faf1d39ba989134d7fe027e953533e52e21ebc
                   headers:
                     Content-Type: application/pdf
-                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--7e997276f575254f6208378baeb704195aea876e
+                signed_id: eyJfcmFpbHMiOnsiZGF0YSI6MSwicHVyIjoiYmxvYl9pZCJ9fQ==--944daf99a3cc3cf9ec8207d8aca9beebf253cc22
               schema:
                 "$ref": "#/components/schemas/DirectUploadResponse"
       requestBody:

--- a/packages/dashboard-core/src/api-client.ts
+++ b/packages/dashboard-core/src/api-client.ts
@@ -34,10 +34,10 @@ export interface PanelApiClient {
     logout(): Promise<void>
     /**
      * Optional sign-in flows, because not every panel offers all of them.
-     * Both panels accept invitations — each against its own API, so the
-     * session that comes back carries the right audience. Password reset and
-     * first-run setup remain the marketplace's own, so a seller's client
-     * leaves them undefined.
+     * Both panels accept invitations and reset passwords — each against its
+     * own API, so the session that comes back carries the right audience and
+     * the emailed link opens the right panel. First-run setup remains the
+     * marketplace's own, so a seller's client leaves it undefined.
      */
     acceptInvitation?(id: string, token: string, params: unknown): Promise<PanelSession>
     resetPassword?(token: string, params: unknown): Promise<PanelSession>

--- a/packages/seller-dashboard-starter/src/routeTree.gen.ts
+++ b/packages/seller-dashboard-starter/src/routeTree.gen.ts
@@ -9,7 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './../../seller-dashboard/src/routes/__root'
+import { Route as resetPasswordRouteImport } from './../../seller-dashboard/src/routes/reset-password'
 import { Route as loginRouteImport } from './../../seller-dashboard/src/routes/login'
+import { Route as forgotPasswordRouteImport } from './../../seller-dashboard/src/routes/forgot-password'
 import { Route as authenticatedRouteImport } from './../../seller-dashboard/src/routes/_authenticated'
 import { Route as authenticatedIndexRouteImport } from './../../seller-dashboard/src/routes/_authenticated/index'
 import { Route as acceptInvitationDotinvitationIdRouteImport } from './../../seller-dashboard/src/routes/accept-invitation.$invitationId'
@@ -27,9 +29,19 @@ import { Route as ProductsNewRouteImport } from './../../seller-dashboard/src/ro
 import { Route as ProductsProductIdRouteImport } from './../../seller-dashboard/src/routes/_authenticated/$sellerId/products/$productId'
 import { Route as OrdersOrderIdRouteImport } from './../../seller-dashboard/src/routes/_authenticated/$sellerId/orders/$orderId'
 
+const resetPasswordRoute = resetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const loginRoute = loginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const forgotPasswordRoute = forgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authenticatedRoute = authenticatedRouteImport.update({
@@ -115,7 +127,9 @@ const OrdersOrderIdRoute = OrdersOrderIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof authenticatedIndexRoute
+  '/forgot-password': typeof forgotPasswordRoute
   '/login': typeof loginRoute
+  '/reset-password': typeof resetPasswordRoute
   '/$sellerId': typeof authenticatedSellerIdRouteWithChildren
   '/accept-invitation/$invitationId': typeof acceptInvitationDotinvitationIdRoute
   '/$sellerId/onboarding': typeof OnboardingRoute
@@ -132,7 +146,9 @@ export interface FileRoutesByFullPath {
   '/$sellerId/settings/': typeof SettingsIndexRoute
 }
 export interface FileRoutesByTo {
+  '/forgot-password': typeof forgotPasswordRoute
   '/login': typeof loginRoute
+  '/reset-password': typeof resetPasswordRoute
   '/accept-invitation/$invitationId': typeof acceptInvitationDotinvitationIdRoute
   '/': typeof authenticatedIndexRoute
   '/$sellerId/onboarding': typeof OnboardingRoute
@@ -150,7 +166,9 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authenticated': typeof authenticatedRouteWithChildren
+  '/forgot-password': typeof forgotPasswordRoute
   '/login': typeof loginRoute
+  '/reset-password': typeof resetPasswordRoute
   '/_authenticated/$sellerId': typeof authenticatedSellerIdRouteWithChildren
   '/accept-invitation/$invitationId': typeof acceptInvitationDotinvitationIdRoute
   '/_authenticated/': typeof authenticatedIndexRoute
@@ -171,7 +189,9 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/$sellerId'
     | '/accept-invitation/$invitationId'
     | '/$sellerId/onboarding'
@@ -188,7 +208,9 @@ export interface FileRouteTypes {
     | '/$sellerId/settings/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/accept-invitation/$invitationId'
     | '/'
     | '/$sellerId/onboarding'
@@ -205,7 +227,9 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/_authenticated'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/_authenticated/$sellerId'
     | '/accept-invitation/$invitationId'
     | '/_authenticated/'
@@ -225,17 +249,33 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   authenticatedRoute: typeof authenticatedRouteWithChildren
+  forgotPasswordRoute: typeof forgotPasswordRoute
   loginRoute: typeof loginRoute
+  resetPasswordRoute: typeof resetPasswordRoute
   acceptInvitationDotinvitationIdRoute: typeof acceptInvitationDotinvitationIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/reset-password': {
+      id: '/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof resetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof loginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/forgot-password': {
+      id: '/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof forgotPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated': {
@@ -414,7 +454,9 @@ const authenticatedRouteWithChildren = authenticatedRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   authenticatedRoute: authenticatedRouteWithChildren,
+  forgotPasswordRoute: forgotPasswordRoute,
   loginRoute: loginRoute,
+  resetPasswordRoute: resetPasswordRoute,
   acceptInvitationDotinvitationIdRoute: acceptInvitationDotinvitationIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/packages/seller-dashboard/src/locales/en.json
+++ b/packages/seller-dashboard/src/locales/en.json
@@ -24,6 +24,17 @@
     "save": "Save",
     "saving": "Saving…"
   },
+  "forgot_password": {
+    "back_to_login": "Back to sign in",
+    "email": "Email",
+    "failed": "That request could not be sent. Try again in a moment.",
+    "sent_subtitle": "If that address belongs to a seller account, a reset link is on its way. The link expires shortly.",
+    "sent_title": "Check your email",
+    "submit": "Send reset link",
+    "submitting": "Sending…",
+    "subtitle": "Enter your email and we will send you a link to choose a new one.",
+    "title": "Forgot your password?"
+  },
   "home": {
     "products": "Products",
     "selling_no": "Your products are not on sale yet.",
@@ -40,6 +51,7 @@
   "login": {
     "email": "Email",
     "failed": "That email and password did not match a seller account.",
+    "forgot_password": "Forgot your password?",
     "no_seller": "This account does not run a seller on this marketplace.",
     "password": "Password",
     "submit": "Sign in",
@@ -249,6 +261,18 @@
       "unsupported": "This number is recorded as entered; we cannot check it automatically.",
       "unverified": "This number could not be verified."
     }
+  },
+  "reset_password": {
+    "failed": "That link could not be used. It may have expired, or the password was not accepted.",
+    "invalid_link": "This link is missing its token. Open the link from your reset email.",
+    "mismatch": "Both passwords must match.",
+    "password": "New password",
+    "password_confirmation": "Confirm new password",
+    "request_new_link": "Request a new link",
+    "submit": "Change password",
+    "submitting": "Saving…",
+    "subtitle": "Choose a new password to finish signing in.",
+    "title": "Choose a new password"
   },
   "seller_picker": {
     "status": "Status",

--- a/packages/seller-dashboard/src/pages/forgot-password.tsx
+++ b/packages/seller-dashboard/src/pages/forgot-password.tsx
@@ -1,0 +1,100 @@
+import { Button, Field, FieldError, FieldGroup, FieldLabel, Input } from '@spree/dashboard-ui'
+import { Link } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { sellerClient } from '../api-client'
+
+interface ForgotValues {
+  email: string
+}
+
+/**
+ * Asking for a reset link.
+ *
+ * Its own surface rather than the dashboard's: the link has to open the seller
+ * panel, and a seller sent to the staff dashboard would land on a form that
+ * resets them into an admin session they cannot use.
+ */
+export function ForgotPasswordPage() {
+  const { t } = useTranslation()
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const form = useForm<ForgotValues>({ defaultValues: { email: '' } })
+
+  async function onSubmit(values: ForgotValues) {
+    setError(null)
+    try {
+      await sellerClient().auth.requestPasswordReset({
+        email: values.email,
+        // Where this panel serves its reset page. The server honours it only
+        // if the origin is one the marketplace has vouched for, and resolves
+        // the panel origin itself otherwise.
+        redirect_url: `${window.location.origin}/reset-password`,
+      })
+      // Confirmed either way — the API never reveals whether the address
+      // matched, and neither may this page.
+      setSent(true)
+    } catch {
+      setError(t('forgot_password.failed'))
+    }
+  }
+
+  const { errors, isSubmitting } = form.formState
+
+  if (sent) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <h1 className="font-medium text-xl">{t('forgot_password.sent_title')}</h1>
+          <p className="mt-1 mb-6 text-muted-foreground text-sm">
+            {t('forgot_password.sent_subtitle')}
+          </p>
+          <Link to="/login" className="text-sm underline underline-offset-4">
+            {t('forgot_password.back_to_login')}
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <div className="w-full max-w-sm">
+        <h1 className="font-medium text-xl">{t('forgot_password.title')}</h1>
+        <p className="mt-1 mb-6 text-muted-foreground text-sm">{t('forgot_password.subtitle')}</p>
+
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FieldGroup>
+            {error && (
+              <p className="text-destructive text-sm" role="alert">
+                {error}
+              </p>
+            )}
+
+            <Field>
+              <FieldLabel htmlFor="email">{t('forgot_password.email')}</FieldLabel>
+              <Input
+                id="email"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                aria-invalid={!!errors.email || undefined}
+                {...form.register('email', { required: true })}
+              />
+              <FieldError errors={[errors.email]} />
+            </Field>
+
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? t('forgot_password.submitting') : t('forgot_password.submit')}
+            </Button>
+
+            <Link to="/login" className="text-sm underline underline-offset-4">
+              {t('forgot_password.back_to_login')}
+            </Link>
+          </FieldGroup>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/packages/seller-dashboard/src/pages/login.tsx
+++ b/packages/seller-dashboard/src/pages/login.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@spree/dashboard-core'
 import { Button, Field, FieldError, FieldGroup, FieldLabel, Input } from '@spree/dashboard-ui'
+import { Link } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -81,6 +82,10 @@ export function LoginPage() {
             <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? t('login.submitting') : t('login.submit')}
             </Button>
+
+            <Link to="/forgot-password" className="text-sm underline underline-offset-4">
+              {t('login.forgot_password')}
+            </Link>
           </FieldGroup>
         </form>
       </div>

--- a/packages/seller-dashboard/src/pages/reset-password.tsx
+++ b/packages/seller-dashboard/src/pages/reset-password.tsx
@@ -1,0 +1,105 @@
+import { useAuth } from '@spree/dashboard-core'
+import { Button, Field, FieldError, FieldGroup, FieldLabel, Input } from '@spree/dashboard-ui'
+import { Link, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { CenteredMessage } from '../components/centered-message'
+
+interface ResetValues {
+  password: string
+  password_confirmation: string
+}
+
+/**
+ * Choosing a new password from the emailed link.
+ *
+ * The token in the URL is the whole credential — nobody is signed in yet.
+ * Spending it returns a seller session, so they land in the panel rather than
+ * being bounced to a login form.
+ */
+export function ResetPasswordPage({ token }: { token?: string }) {
+  const { t } = useTranslation()
+  const { resetPassword } = useAuth()
+  const navigate = useNavigate()
+  const [error, setError] = useState<string | null>(null)
+  const form = useForm<ResetValues>({
+    defaultValues: { password: '', password_confirmation: '' },
+  })
+
+  if (!token) return <CenteredMessage>{t('reset_password.invalid_link')}</CenteredMessage>
+
+  async function onSubmit(values: ResetValues) {
+    setError(null)
+    try {
+      await resetPassword(token ?? '', values)
+      // The index route decides where to go from there — it already knows how
+      // to skip the picker for someone who runs exactly one seller.
+      navigate({ to: '/', replace: true })
+    } catch {
+      // A rejected token and a refused password are reported the same way the
+      // API reports them: it will not say whether the address exists.
+      setError(t('reset_password.failed'))
+    }
+  }
+
+  const { errors, isSubmitting } = form.formState
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <div className="w-full max-w-sm">
+        <h1 className="font-medium text-xl">{t('reset_password.title')}</h1>
+        <p className="mt-1 mb-6 text-muted-foreground text-sm">{t('reset_password.subtitle')}</p>
+
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FieldGroup>
+            {error && (
+              <p className="text-destructive text-sm" role="alert">
+                {error}
+              </p>
+            )}
+
+            <Field>
+              <FieldLabel htmlFor="password">{t('reset_password.password')}</FieldLabel>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                autoFocus
+                aria-invalid={!!errors.password || undefined}
+                {...form.register('password', { required: true, minLength: 8 })}
+              />
+              <FieldError errors={[errors.password]} />
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="password_confirmation">
+                {t('reset_password.password_confirmation')}
+              </FieldLabel>
+              <Input
+                id="password_confirmation"
+                type="password"
+                autoComplete="new-password"
+                aria-invalid={!!errors.password_confirmation || undefined}
+                {...form.register('password_confirmation', {
+                  required: true,
+                  validate: (value, values) =>
+                    value === values.password || t('reset_password.mismatch'),
+                })}
+              />
+              <FieldError errors={[errors.password_confirmation]} />
+            </Field>
+
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? t('reset_password.submitting') : t('reset_password.submit')}
+            </Button>
+
+            <Link to="/forgot-password" className="text-sm underline underline-offset-4">
+              {t('reset_password.request_new_link')}
+            </Link>
+          </FieldGroup>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/packages/seller-dashboard/src/routeTree.gen.ts
+++ b/packages/seller-dashboard/src/routeTree.gen.ts
@@ -9,7 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as resetPasswordRouteImport } from './routes/reset-password'
 import { Route as loginRouteImport } from './routes/login'
+import { Route as forgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as authenticatedRouteImport } from './routes/_authenticated'
 import { Route as authenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as acceptInvitationDotinvitationIdRouteImport } from './routes/accept-invitation.$invitationId'
@@ -27,9 +29,19 @@ import { Route as ProductsNewRouteImport } from './routes/_authenticated/$seller
 import { Route as ProductsProductIdRouteImport } from './routes/_authenticated/$sellerId/products/$productId'
 import { Route as OrdersOrderIdRouteImport } from './routes/_authenticated/$sellerId/orders/$orderId'
 
+const resetPasswordRoute = resetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const loginRoute = loginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const forgotPasswordRoute = forgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
   getParentRoute: () => rootRouteImport,
 } as any)
 const authenticatedRoute = authenticatedRouteImport.update({
@@ -115,7 +127,9 @@ const OrdersOrderIdRoute = OrdersOrderIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof authenticatedIndexRoute
+  '/forgot-password': typeof forgotPasswordRoute
   '/login': typeof loginRoute
+  '/reset-password': typeof resetPasswordRoute
   '/$sellerId': typeof authenticatedSellerIdRouteWithChildren
   '/accept-invitation/$invitationId': typeof acceptInvitationDotinvitationIdRoute
   '/$sellerId/onboarding': typeof OnboardingRoute
@@ -132,7 +146,9 @@ export interface FileRoutesByFullPath {
   '/$sellerId/settings/': typeof SettingsIndexRoute
 }
 export interface FileRoutesByTo {
+  '/forgot-password': typeof forgotPasswordRoute
   '/login': typeof loginRoute
+  '/reset-password': typeof resetPasswordRoute
   '/accept-invitation/$invitationId': typeof acceptInvitationDotinvitationIdRoute
   '/': typeof authenticatedIndexRoute
   '/$sellerId/onboarding': typeof OnboardingRoute
@@ -150,7 +166,9 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authenticated': typeof authenticatedRouteWithChildren
+  '/forgot-password': typeof forgotPasswordRoute
   '/login': typeof loginRoute
+  '/reset-password': typeof resetPasswordRoute
   '/_authenticated/$sellerId': typeof authenticatedSellerIdRouteWithChildren
   '/accept-invitation/$invitationId': typeof acceptInvitationDotinvitationIdRoute
   '/_authenticated/': typeof authenticatedIndexRoute
@@ -171,7 +189,9 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/$sellerId'
     | '/accept-invitation/$invitationId'
     | '/$sellerId/onboarding'
@@ -188,7 +208,9 @@ export interface FileRouteTypes {
     | '/$sellerId/settings/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/accept-invitation/$invitationId'
     | '/'
     | '/$sellerId/onboarding'
@@ -205,7 +227,9 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/_authenticated'
+    | '/forgot-password'
     | '/login'
+    | '/reset-password'
     | '/_authenticated/$sellerId'
     | '/accept-invitation/$invitationId'
     | '/_authenticated/'
@@ -225,17 +249,33 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   authenticatedRoute: typeof authenticatedRouteWithChildren
+  forgotPasswordRoute: typeof forgotPasswordRoute
   loginRoute: typeof loginRoute
+  resetPasswordRoute: typeof resetPasswordRoute
   acceptInvitationDotinvitationIdRoute: typeof acceptInvitationDotinvitationIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/reset-password': {
+      id: '/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof resetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof loginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/forgot-password': {
+      id: '/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof forgotPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated': {
@@ -414,7 +454,9 @@ const authenticatedRouteWithChildren = authenticatedRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   authenticatedRoute: authenticatedRouteWithChildren,
+  forgotPasswordRoute: forgotPasswordRoute,
   loginRoute: loginRoute,
+  resetPasswordRoute: resetPasswordRoute,
   acceptInvitationDotinvitationIdRoute: acceptInvitationDotinvitationIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/packages/seller-dashboard/src/routes/forgot-password.tsx
+++ b/packages/seller-dashboard/src/routes/forgot-password.tsx
@@ -1,0 +1,15 @@
+import { useAuth } from '@spree/dashboard-core'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
+import { ForgotPasswordPage } from '../pages/forgot-password'
+
+export const Route = createFileRoute('/forgot-password')({
+  component: ForgotPassword,
+})
+
+function ForgotPassword() {
+  const { isInitializing, isAuthenticated } = useAuth()
+  if (isInitializing) return null
+  // Someone already signed in has no use for a reset link.
+  if (isAuthenticated) return <Navigate to="/" replace />
+  return <ForgotPasswordPage />
+}

--- a/packages/seller-dashboard/src/routes/reset-password.tsx
+++ b/packages/seller-dashboard/src/routes/reset-password.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod/v4'
+import { ResetPasswordPage } from '../pages/reset-password'
+
+const resetSearchSchema = z.object({
+  token: z.string().min(1).optional(),
+})
+
+export const Route = createFileRoute('/reset-password')({
+  validateSearch: resetSearchSchema,
+  component: ResetPassword,
+})
+
+function ResetPassword() {
+  const { token } = Route.useSearch()
+
+  // No redirect for a live session: someone following a reset link means to
+  // change their password, and a stale session in the same browser must not
+  // silently swallow the link.
+  return <ResetPasswordPage token={token} />
+}

--- a/packages/seller-dashboard/src/vite/index.ts
+++ b/packages/seller-dashboard/src/vite/index.ts
@@ -64,6 +64,8 @@ function sellerRouterPlugin(hostRoot: string, options: SpreeSellerDashboardPlugi
 
   const virtualRouteConfig = rootRoute('__root.tsx', [
     route('/login', 'login.tsx'),
+    route('/forgot-password', 'forgot-password.tsx'),
+    route('/reset-password', 'reset-password.tsx'),
     route('/accept-invitation/$invitationId', 'accept-invitation.$invitationId.tsx'),
     layout('_authenticated.tsx', [
       index('_authenticated/index.tsx'),

--- a/packages/seller-sdk/src/seller-client.ts
+++ b/packages/seller-sdk/src/seller-client.ts
@@ -82,6 +82,35 @@ export class SellerClient {
         params: { token },
         body: params,
       }),
+
+    /**
+     * Asks for a password reset email. Always resolves (202) whether or not the
+     * address matches a seller, so this cannot be used to discover which
+     * accounts exist. The emailed link opens the seller panel — `redirect_url`
+     * when it passes the store's allowed-origin check, otherwise the panel
+     * origin the server resolves for itself.
+     */
+    requestPasswordReset: (
+      params: { email: string; redirect_url?: string },
+      options?: RequestOptions,
+    ): Promise<void> =>
+      this.request<void>('POST', '/auth/password_resets', { ...options, body: params }),
+
+    /**
+     * Spends a reset token: sets the new password and returns a signed-in
+     * seller session, so they land in the panel rather than on a login form.
+     * The token is single-use, and resetting revokes every other session the
+     * account holds.
+     */
+    resetPassword: (
+      token: string,
+      params: { password: string; password_confirmation: string },
+      options?: RequestOptions,
+    ): Promise<AuthTokens> =>
+      this.request<AuthTokens>('PATCH', `/auth/password_resets/${encodeURIComponent(token)}`, {
+        ...options,
+        body: params,
+      }),
   }
 
   /**

--- a/spree/api/app/controllers/spree/api/v3/seller/password_resets_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/seller/password_resets_controller.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module V3
+      module Seller
+        # Password reset for the marketplace seller panel.
+        #
+        # Parallel to the admin controller rather than a subclass of it, per
+        # Decision 10: what differs is the audience it issues and the panel the
+        # emailed link opens, and both are the point. A seller resetting their
+        # password must end up with a seller session on the seller panel, never
+        # an admin one on the dashboard.
+        class PasswordResetsController < Spree::Api::V3::BaseController
+          include Spree::Api::V3::Seller::AuthCookies
+          include Spree::Api::V3::JwtAuthentication
+
+          # No `skip_scope_check!`: this extends the plain v3 base, which has
+          # no authentication or scope gate to lift. The emailed token is the
+          # only credential, exactly as on the admin twin.
+          rate_limit to: Spree::Api::Config[:rate_limit_password_reset],
+                     within: Spree::Api::Config[:rate_limit_window].seconds,
+                     store: Rails.cache,
+                     with: RATE_LIMIT_RESPONSE
+
+          # POST /api/v3/seller/auth/password_resets
+          def create
+            user = Spree.admin_user_class.find_by(email: params[:email])
+
+            # Staff share this user class, so a match is not enough: a store
+            # admin who runs no seller has no panel to be sent to, and mailing
+            # them a seller reset link would be an invitation to a session they
+            # cannot hold.
+            if user&.seller_member?
+              user.publish_event('seller_user.password_reset_requested', event_payload(user))
+            end
+
+            # Always 202, whether or not anything matched — this endpoint must
+            # not become a way to discover which addresses exist.
+            render json: { message: Spree.t(:password_reset_requested, scope: :api) }, status: :accepted
+          end
+
+          # PATCH /api/v3/seller/auth/password_resets/:id
+          def update
+            user = Spree.admin_user_class.find_by_password_reset_token(params[:id])
+
+            # Membership is re-checked here rather than trusted from the token:
+            # it can be revoked between the email being sent and the link being
+            # opened, and signing in is what the success path does.
+            return render_token_invalid unless user&.seller_member?
+
+            unless user.update(password: params[:password], password_confirmation: params[:password_confirmation])
+              return render_errors(user.errors)
+            end
+
+            user.publish_event('seller_user.password_reset')
+
+            # A reset must kill every existing session — a stolen refresh token
+            # must not survive the victim resetting their password. Revoked
+            # across every audience, since the password is what they all rest
+            # on. Then mint the fresh one for this browser.
+            Spree::RefreshToken.revoke_all_for(user)
+            set_refresh_cookie(
+              Spree::RefreshToken.create_for(
+                user,
+                audience: Spree::Api::V3::JwtAuthentication::JWT_AUDIENCE_SELLER,
+                request_env: request_env_for_token
+              )
+            )
+
+            render json: auth_response(user)
+          end
+
+          private
+
+          # A token that no longer belongs to a seller is reported exactly as an
+          # expired or forged one: the caller is unauthenticated either way, and
+          # distinguishing them would leak that the address is a real account.
+          def render_token_invalid
+            render_error(
+              code: ErrorHandler::ERROR_CODES[:password_reset_token_invalid],
+              message: Spree.t(:password_reset_token_invalid, scope: :api),
+              status: :unprocessable_content
+            )
+          end
+
+          # The store is carried on the event so the mailer can resolve the
+          # right panel origin and locale without a request to read them from.
+          def event_payload(user)
+            store = seller_store(user)
+            payload = {
+              reset_token: user.generate_token_for(:password_reset),
+              email: user.email,
+              store_id: store&.prefixed_id
+            }
+            redirect_url = validated_redirect_url(store)
+            payload[:redirect_url] = redirect_url if redirect_url.present?
+            payload
+          end
+
+          # Which store's panel to send them to.
+          #
+          # Derived from the seller, never from `current_store`: this endpoint
+          # is unauthenticated, so the request carries no seller header and
+          # `current_store` is simply the default store — which on a
+          # multi-store install is the wrong marketplace entirely. The seller
+          # branch's rule is that the store follows the seller.
+          def seller_store(user)
+            user.sellers.first&.store
+          end
+
+          # Honoured only when it points somewhere the seller's own store has
+          # vouched for. An unvalidated value would let anyone with the reset
+          # form turn this endpoint into a token-exfiltration channel, and
+          # judging it against the default store's allowlist would let one
+          # marketplace's origins approve a link mailed to another's seller.
+          # Dropping it leaves the mailer to resolve the panel origin itself.
+          def validated_redirect_url(store)
+            url = params[:redirect_url].presence
+            return unless url && store
+            return unless store.allowed_origins.exists? && store.allowed_origin?(url)
+
+            url
+          end
+
+          # Same shape as the login response, so the panel can sign them
+          # straight in rather than bouncing them to a login form.
+          def auth_response(user)
+            {
+              token: generate_jwt(user, audience: Spree::Api::V3::JwtAuthentication::JWT_AUDIENCE_SELLER),
+              user: Spree.api.seller_team_member_serializer.new(
+                user, params: { store: seller_store(user) }
+              ).to_h,
+              sellers: serialized_sellers(user)
+            }
+          end
+
+          # The panel needs these to choose an X-Spree-Seller-Id before it can
+          # make any other request.
+          def serialized_sellers(user)
+            user.sellers.map { |seller| { id: seller.prefixed_id, name: seller.name, status: seller.status } }
+          end
+
+          def request_env_for_token
+            { ip_address: request.remote_ip, user_agent: request.user_agent&.truncate(255) }
+          end
+
+          def jwt_expiration
+            Spree::Api::Config[:admin_jwt_expiration]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spree/api/app/subscribers/spree/webhook_event_subscriber.rb
+++ b/spree/api/app/subscribers/spree/webhook_event_subscriber.rb
@@ -17,10 +17,14 @@ module Spree
   class WebhookEventSubscriber < Spree::Subscriber
     subscribes_to '*'
 
-    # Admin auth events carry live credentials (password reset tokens) and have
-    # no legitimate external consumer — core delivers those emails itself.
-    # Never forward them to webhook endpoints, including '*' subscriptions.
-    NON_DELIVERABLE_EVENTS = %w[admin_user.password_reset_requested].freeze
+    # Admin and seller auth events carry live credentials (password reset
+    # tokens) and have no legitimate external consumer — core delivers those
+    # emails itself. Never forward them to webhook endpoints, including '*'
+    # subscriptions.
+    NON_DELIVERABLE_EVENTS = %w[
+      admin_user.password_reset_requested
+      seller_user.password_reset_requested
+    ].freeze
 
     def handle(event)
       return unless Spree::Api::Config.webhooks_enabled

--- a/spree/api/config/routes.rb
+++ b/spree/api/config/routes.rb
@@ -717,6 +717,12 @@ Spree::Core::Engine.add_routes do
         get 'auth/invitations/:id/lookup', to: 'invitation_acceptances#lookup'
         post 'auth/invitations/:id/accept', to: 'invitation_acceptances#accept'
 
+        # Public password reset — unauthenticated; the emailed token is the
+        # credential. Under `auth/` so the refresh cookie issued on success
+        # shares its path with `/auth/refresh`.
+        post 'auth/password_resets', to: 'password_resets#create'
+        patch 'auth/password_resets/:id', to: 'password_resets#update'
+
         get 'me', to: 'me#show'
 
         # Singular: the seller in play is always `current_seller`.

--- a/spree/api/spec/controllers/spree/api/v3/seller/password_resets_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/seller/password_resets_controller_spec.rb
@@ -1,0 +1,203 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Api::V3::Seller::PasswordResetsController, type: :controller do
+  render_views
+
+  include_context 'API v3 Seller'
+
+  before { allow(Spree::Events).to receive(:enabled?).and_return(true) }
+
+  describe 'POST #create' do
+    # The seller and its role publish events of their own as they are built,
+    # so they are created before the spy goes up — otherwise every assertion
+    # below has to reason about calls this controller never made.
+    before do
+      seller_user
+      allow(Spree::Events).to receive(:publish)
+    end
+
+    it 'publishes the reset event and returns 202' do
+      post :create, params: { email: seller_user.email }, as: :json
+
+      expect(response).to have_http_status(:accepted)
+      expect(Spree::Events).to have_received(:publish).with(
+        'seller_user.password_reset_requested',
+        hash_including(reset_token: an_instance_of(String), email: seller_user.email, store_id: store.prefixed_id),
+        anything
+      )
+    end
+
+    it 'returns 202 for unknown emails without publishing (no enumeration)' do
+      post :create, params: { email: 'nobody@example.com' }, as: :json
+
+      expect(response).to have_http_status(:accepted)
+      expect(Spree::Events).not_to have_received(:publish)
+    end
+
+    # Staff share the user class, so matching an address is not enough: a store
+    # admin who runs no seller has no panel to be sent to.
+    it 'says nothing different for a staff member who runs no seller' do
+      staff = create(:admin_user, email: 'staff@example.com')
+
+      post :create, params: { email: staff.email }, as: :json
+
+      expect(response).to have_http_status(:accepted)
+      expect(Spree::Events).not_to have_received(:publish)
+    end
+
+    it 'ignores redirect_url when no allowed origins are configured' do
+      post :create, params: { email: seller_user.email, redirect_url: 'https://evil.example.com' }, as: :json
+
+      expect(Spree::Events).to have_received(:publish).
+        with('seller_user.password_reset_requested', hash_excluding(:redirect_url), anything)
+    end
+
+    it 'ignores a redirect_url outside the store allowed origins' do
+      store.allowed_origins.create!(origin: 'https://sellers.example.com')
+
+      post :create, params: { email: seller_user.email, redirect_url: 'https://evil.example.com' }, as: :json
+
+      expect(Spree::Events).to have_received(:publish).
+        with('seller_user.password_reset_requested', hash_excluding(:redirect_url), anything)
+    end
+
+    # The store follows the seller, never `current_store` — which on this
+    # unauthenticated endpoint is just the default store. Judged against that,
+    # one marketplace's allowlist would approve a live reset token mailed to
+    # another marketplace's seller.
+    context 'when the seller belongs to a store other than the default' do
+      let(:other_store) { create(:store) }
+      let(:other_seller) { create(:seller, :approved, store: other_store) }
+      let(:other_role) do
+        create(:role, name: 'Other seller', resource: other_seller, permissions: %w[write_products])
+      end
+      let(:other_user) do
+        create(:admin_user, :without_admin_role).tap { |user| other_seller.add_user(user, other_role) }
+      end
+
+      before do
+        other_user
+        allow(Spree::Events).to receive(:publish)
+      end
+
+      it 'refuses a redirect_url only the default store has vouched for' do
+        store.allowed_origins.create!(origin: 'https://sellers.default-store.test')
+
+        post :create,
+             params: { email: other_user.email, redirect_url: 'https://sellers.default-store.test/reset-password' },
+             as: :json
+
+        expect(Spree::Events).to have_received(:publish).
+          with('seller_user.password_reset_requested', hash_excluding(:redirect_url), anything)
+      end
+
+      it "keeps a redirect_url the seller's own store has vouched for" do
+        other_store.allowed_origins.create!(origin: 'https://sellers.other-store.test')
+
+        post :create,
+             params: { email: other_user.email, redirect_url: 'https://sellers.other-store.test/reset-password' },
+             as: :json
+
+        expect(Spree::Events).to have_received(:publish).with(
+          'seller_user.password_reset_requested',
+          hash_including(
+            redirect_url: 'https://sellers.other-store.test/reset-password',
+            store_id: other_store.prefixed_id
+          ),
+          anything
+        )
+      end
+    end
+
+    it 'keeps a redirect_url the store has vouched for' do
+      store.allowed_origins.create!(origin: 'https://sellers.example.com')
+
+      post :create,
+           params: { email: seller_user.email, redirect_url: 'https://sellers.example.com/reset-password' },
+           as: :json
+
+      expect(Spree::Events).to have_received(:publish).with(
+        'seller_user.password_reset_requested',
+        hash_including(redirect_url: 'https://sellers.example.com/reset-password'),
+        anything
+      )
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:reset_token) { seller_user.generate_token_for(:password_reset) }
+
+    it 'sets the new password and signs the seller in' do
+      patch :update,
+            params: { id: reset_token, password: 'new-secret-123', password_confirmation: 'new-secret-123' },
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['token']).to be_present
+      expect(json_response['user']['email']).to eq(seller_user.email)
+      expect(seller_user.reload.valid_password?('new-secret-123')).to be(true)
+    end
+
+    # The panel cannot make any other request until it knows which seller to
+    # name in X-Spree-Seller-Id.
+    it 'returns the sellers the user may act for' do
+      patch :update,
+            params: { id: reset_token, password: 'new-secret-123', password_confirmation: 'new-secret-123' },
+            as: :json
+
+      expect(json_response['sellers'].pluck('id')).to eq([seller.prefixed_id])
+    end
+
+    # The whole point of the branch: the session it mints must be redeemable on
+    # the seller panel, which only accepts its own audience.
+    it 'mints the fresh session for the seller surface' do
+      patch :update,
+            params: { id: reset_token, password: 'new-secret-123', password_confirmation: 'new-secret-123' },
+            as: :json
+
+      expect(Spree::RefreshToken.where(user: seller_user).last.audience).to eq('seller_api')
+    end
+
+    it 'revokes every pre-existing session, keeping only the fresh one' do
+      stolen = Spree::RefreshToken.create_for(
+        seller_user, audience: Spree::Api::V3::JwtAuthentication::JWT_AUDIENCE_SELLER, request_env: {}
+      )
+      token = reset_token
+
+      patch :update, params: { id: token, password: 'new-secret-123', password_confirmation: 'new-secret-123' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(Spree::RefreshToken.exists?(stolen.id)).to be(false)
+      expect(Spree::RefreshToken.where(user: seller_user).count).to eq(1)
+    end
+
+    it 'refuses an invalid token' do
+      patch :update,
+            params: { id: 'nonsense', password: 'new-secret-123', password_confirmation: 'new-secret-123' },
+            as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response['error']['code']).to eq('password_reset_token_invalid')
+    end
+
+    # Membership can be revoked between the email going out and the link being
+    # opened, and a token that no longer belongs to a seller is reported exactly
+    # as an expired one.
+    it 'refuses a valid token whose seller membership has gone' do
+      staff = create(:admin_user, email: 'staff@example.com')
+      token = staff.generate_token_for(:password_reset)
+
+      patch :update, params: { id: token, password: 'new-secret-123', password_confirmation: 'new-secret-123' }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response['error']['code']).to eq('password_reset_token_invalid')
+      expect(staff.reload.valid_password?('new-secret-123')).to be(false)
+    end
+
+    it 'reports a password the model refuses' do
+      patch :update, params: { id: reset_token, password: 'short', password_confirmation: 'short' }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+end

--- a/spree/api/spec/integration/spree/api/v3/seller/password_resets_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/seller/password_resets_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Seller Password Resets API', type: :request, swagger_doc: 'api-reference/seller.yaml' do
+  include_context 'API v3 Seller'
+
+  path '/api/v3/seller/auth/password_resets' do
+    post 'Request password reset' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+      description <<~DESC
+        Requests a password reset email for a seller.
+
+        Unauthenticated. Always answers `202`, whether or not the address
+        belongs to a seller, so this cannot be used to discover which accounts
+        exist. A store staff member who runs no seller is treated as no match:
+        they have no seller panel to be sent to.
+
+        `redirect_url` is where the emailed link should point, with the reset
+        token appended as a `token` query param. It is honoured only when it
+        matches one of the store's allowed origins; otherwise it is silently
+        ignored and the server resolves the seller panel origin itself. The
+        email is delivered by Spree via the
+        `seller_user.password_reset_requested` event, which is never forwarded
+        to webhook endpoints.
+      DESC
+
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string, format: 'email', example: 'seller@acme.test' },
+          redirect_url: {
+            type: :string,
+            example: 'https://sellers.your-store.com/reset-password',
+            description: 'Must match an allowed origin of the store; ignored otherwise.'
+          }
+        },
+        required: %w[email]
+      }
+
+      response '202', 'reset requested' do
+        let(:body) { { email: seller_user.email } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body)['message']).to be_present
+        end
+      end
+    end
+  end
+
+  path '/api/v3/seller/auth/password_resets/{id}' do
+    patch 'Reset password' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+      description <<~DESC
+        Spends a password reset token (the `token` query param from the emailed
+        link), sets the new password and signs the seller in: the response
+        carries a seller JWT and the rotatable refresh token is set in an
+        HttpOnly cookie, so they land in the panel rather than on a login form.
+
+        The token is single-use, and resetting revokes every other session the
+        account holds. A token whose seller membership has since been revoked is
+        refused exactly as an expired one.
+      DESC
+
+      parameter name: :id, in: :path, type: :string, description: 'The reset token from the emailed link'
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        properties: {
+          password: { type: :string, example: 'new-password-123' },
+          password_confirmation: { type: :string, example: 'new-password-123' }
+        },
+        required: %w[password password_confirmation]
+      }
+
+      response '200', 'password reset' do
+        let(:id) { seller_user.generate_token_for(:password_reset) }
+        let(:body) { { password: 'new-password-123', password_confirmation: 'new-password-123' } }
+
+        schema '$ref' => '#/components/schemas/AuthResponse'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['token']).to be_present
+          expect(data['user']['email']).to eq(seller_user.email)
+        end
+      end
+
+      response '422', 'invalid or expired token' do
+        let(:id) { 'invalid-token' }
+        let(:body) { { password: 'new-password-123', password_confirmation: 'new-password-123' } }
+
+        schema '$ref' => '#/components/schemas/ErrorResponse'
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spree/core/app/mailers/spree/seller_user_mailer.rb
+++ b/spree/core/app/mailers/spree/seller_user_mailer.rb
@@ -1,0 +1,47 @@
+module Spree
+  # Auth emails for seller panel users. Reached via the Seller API's
+  # `seller_user.password_reset_requested` event, delivered by
+  # Spree::SellerUserEmailSubscriber.
+  #
+  # Separate from AdminUserMailer even though both address the same user class:
+  # what differs is which panel the link opens, and sending a seller to the
+  # staff dashboard would land them on a form they cannot submit.
+  class SellerUserMailer < BaseMailer
+    def password_reset_email(seller_user, token, store, redirect_url: nil)
+      @user = seller_user
+      @current_store = store
+      @reset_url = password_reset_url(token, store, redirect_url)
+
+      with_store_locale(store, preferred_locale(seller_user, store)) do
+        mail(
+          to: seller_user.email,
+          subject: "#{store.name} #{Spree.t('seller_user_mailer.password_reset_email.subject')}",
+          store_url: store.formatted_url
+        )
+      end
+    end
+
+    private
+
+    # The seller's own panel language, then the store's admin locale, then nil —
+    # which lets with_store_locale fall back to the store's default.
+    def preferred_locale(seller_user, store)
+      [seller_user.try(:selected_locale), store&.preferred_admin_locale]
+        .find { |locale| available_locale?(locale) }
+    end
+
+    def available_locale?(locale)
+      locale.present? && I18n.available_locales.map(&:to_s).include?(locale.to_s)
+    end
+
+    # The panel passes a validated redirect URL when it has one. Without it the
+    # panel origin is resolved server-side rather than falling back to the store
+    # URL: a storefront link cannot reset a seller password, and the marketplace
+    # may never have added the panel to its allowed origins.
+    def password_reset_url(token, store, redirect_url)
+      target = redirect_url.presence || "#{Spree::Sellers::PanelUrl.call(store: store)}/reset-password"
+
+      append_token(target, token)
+    end
+  end
+end

--- a/spree/core/app/subscribers/spree/seller_user_email_subscriber.rb
+++ b/spree/core/app/subscribers/spree/seller_user_email_subscriber.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Spree
+  class SellerUserEmailSubscriber < Spree::Subscriber
+    subscribes_to 'seller_user.password_reset_requested'
+
+    def handle(event)
+      user = Spree.admin_user_class.find_by(email: event.payload['email'])
+      return unless user
+
+      SellerUserMailer.password_reset_email(
+        user,
+        event.payload['reset_token'],
+        find_store(event),
+        redirect_url: event.payload['redirect_url']
+      ).deliver_later
+    end
+
+    private
+
+    def find_store(event)
+      Spree::Store.find_by_prefix_id(event.payload['store_id']) ||
+        Spree::Current.store ||
+        Spree::Store.default
+    end
+  end
+end

--- a/spree/core/app/views/spree/seller_user_mailer/password_reset_email.html.erb
+++ b/spree/core/app/views/spree/seller_user_mailer/password_reset_email.html.erb
@@ -1,0 +1,8 @@
+<%= render layout: 'spree/shared/mailer_hero' do %>
+  <h1><%= Spree.t('seller_user_mailer.password_reset_email.action') %></h1>
+  <p class="greeting"><%= Spree.t('seller_user_mailer.password_reset_email.greeting', name: @user.first_name.presence || @user.email) %></p>
+  <p><%= Spree.t('seller_user_mailer.password_reset_email.instructions', store_name: @current_store.name) %></p>
+  <%= render 'spree/shared/mailer_button', url: @reset_url, label: Spree.t('seller_user_mailer.password_reset_email.action') %>
+  <p class="sub"><%= Spree.t('seller_user_mailer.password_reset_email.expiry_notice') %></p>
+  <p class="sub"><%= Spree.t('seller_user_mailer.password_reset_email.ignore_notice') %></p>
+<% end %>

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1606,6 +1606,14 @@ en:
       incomplete: "%{name} is not complete"
     seller_submission_no_file: This submission has no attached file.
     seller_team_last_member: A seller needs at least one team member. Invite someone else before removing this one.
+    seller_user_mailer:
+      password_reset_email:
+        action: Reset Password
+        expiry_notice: This password reset link will expire shortly. If you did not request this, no action is needed.
+        greeting: Hi %{name},
+        ignore_notice: If you did not request a password reset, you can safely ignore this email. Your password will not be changed.
+        instructions: We received a request to reset the password for your %{store_name} seller account. Click the button below to choose a new password.
+        subject: Password Reset Instructions
     send_consumer_transactional_emails: Send Customer Transactional Emails
     seo: SEO
     seo_title: SEO Title

--- a/spree/core/lib/spree/core/engine.rb
+++ b/spree/core/lib/spree/core/engine.rb
@@ -570,6 +570,7 @@ module Spree
           Spree::InvitationEmailSubscriber,
           Spree::SellerOnboardingSubscriber,
           Spree::AdminUserEmailSubscriber,
+          Spree::SellerUserEmailSubscriber,
           Spree::ProductMetricsSubscriber,
           Spree::TaxIdentifierValidationSubscriber
         ]

--- a/spree/core/lib/spree/core/previews/seller_user_preview.rb
+++ b/spree/core/lib/spree/core/previews/seller_user_preview.rb
@@ -1,0 +1,14 @@
+require_relative 'preview_data'
+
+# Preview Spree seller panel auth emails at /rails/mailers/spree/seller_user
+class Spree::SellerUserPreview < ActionMailer::Preview
+  include Spree::PreviewData::LocaleParam
+
+  def password_reset_email
+    Spree::SellerUserMailer.password_reset_email(
+      Spree::PreviewData.admin_user,
+      'preview-token',
+      Spree::PreviewData.store(locale)
+    )
+  end
+end

--- a/spree/core/spec/mailers/spree/seller_user_mailer_spec.rb
+++ b/spree/core/spec/mailers/spree/seller_user_mailer_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::SellerUserMailer, type: :mailer do
+  let(:store) { @default_store }
+  let(:seller_user) { create(:admin_user, email: 'seller@example.com') }
+  let(:token) { 'secret-reset-token' }
+
+  describe '#password_reset_email' do
+    it 'sends to the seller with the store-prefixed subject' do
+      message = described_class.password_reset_email(seller_user, token, store)
+
+      expect(message.to).to eq(['seller@example.com'])
+      expect(message.subject).to eq("#{store.name} #{Spree.t('seller_user_mailer.password_reset_email.subject')}")
+    end
+
+    it 'links with the reset token' do
+      message = described_class.password_reset_email(seller_user, token, store)
+
+      expect(message.body.encoded).to include("token=#{token}")
+    end
+
+    it 'prefers the redirect URL when the API validated one' do
+      message = described_class.password_reset_email(
+        seller_user, token, store, redirect_url: 'https://sellers.example.com/reset-password'
+      )
+
+      expect(message.body.encoded).to include("https://sellers.example.com/reset-password?token=#{token}")
+    end
+
+    # The point of the separate mailer: without a redirect URL the link must
+    # still open the seller panel. The storefront fallback the admin mailer
+    # uses would land a seller on a page that cannot reset anything.
+    it 'falls back to the seller panel origin, not the store URL' do
+      allow(Spree::Sellers::PanelUrl).to receive(:call).with(store: store).and_return('https://sellers.example.com')
+
+      message = described_class.password_reset_email(seller_user, token, store)
+
+      expect(message.body.encoded).to include("https://sellers.example.com/reset-password?token=#{token}")
+    end
+  end
+end

--- a/spree/core/spec/subscribers/spree/seller_user_email_subscriber_spec.rb
+++ b/spree/core/spec/subscribers/spree/seller_user_email_subscriber_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::SellerUserEmailSubscriber do
+  let(:store) { @default_store }
+  let(:seller_user) { create(:admin_user, email: 'seller@example.com') }
+  let(:subscriber) { described_class.new }
+
+  def mock_event(email:, redirect_url: nil, store_id: store.prefixed_id)
+    payload = { 'email' => email, 'reset_token' => 'secret-reset-token', 'store_id' => store_id }
+    payload['redirect_url'] = redirect_url if redirect_url
+    double('Event', payload: payload)
+  end
+
+  describe 'seller_user.password_reset_requested event' do
+    it 'sends the password reset email' do
+      expect(Spree::SellerUserMailer).to receive(:password_reset_email).
+        with(seller_user, 'secret-reset-token', store, redirect_url: nil).
+        and_return(double(deliver_later: true))
+
+      subscriber.handle(mock_event(email: seller_user.email))
+    end
+
+    it 'forwards the redirect URL from the event payload' do
+      expect(Spree::SellerUserMailer).to receive(:password_reset_email).
+        with(seller_user, 'secret-reset-token', store, redirect_url: 'https://sellers.example.com/reset-password').
+        and_return(double(deliver_later: true))
+
+      subscriber.handle(mock_event(email: seller_user.email, redirect_url: 'https://sellers.example.com/reset-password'))
+    end
+
+    it 'does nothing when no user matches the email' do
+      expect(Spree::SellerUserMailer).not_to receive(:password_reset_email)
+
+      subscriber.handle(mock_event(email: 'unknown@example.com'))
+    end
+  end
+end


### PR DESCRIPTION
Sellers had no way back into the panel once they forgot their password. The dashboard's reset flow could not serve them: it authenticates through the Admin API, which no seller may call, and its emailed link opens the staff dashboard — a seller sent there could not complete the reset.

The seller branch now has its own reset flow, mirroring the dashboard's.

## What's included

**Backend**
- `Spree::Api::V3::Seller::PasswordResetsController` — `POST /api/v3/seller/auth/password_resets` and `PATCH .../:id`, both unauthenticated with the emailed token as the credential. A sibling of the admin controller rather than a subclass, per the seller branch's rule that controllers are never shared.
- `Spree::SellerUserMailer` and its subscriber, in core alongside the admin auth mailer so they work without the optional emails gem.
- Routes under `auth/`, so the refresh cookie issued on success shares its path with `/auth/refresh`.

**Frontend**
- `requestPasswordReset` / `resetPassword` on `@spree/seller-sdk`.
- Forgot-password and reset-password pages and routes in the seller panel, plus a link on the login form.

## Where the link points

The reset URL resolves through the existing `Spree::Sellers::PanelUrl` (`SPREE_SELLER_PANEL_URL` → the `/sellers` mount → dashboard fallback), so it opens the seller panel. The panel also sends its own `redirect_url`, honoured when it matches the store's allowed origins.

The server-side fallback matters even when the panel and dashboard share a host in production, because the two differ by path (`/sellers/reset-password` vs `/reset-password`), and the admin mailer's fallback is the storefront URL — which cannot reset anything.

## Security notes

- **No enumeration.** Requesting a reset always answers `202`. A store staff member who runs no seller is treated as no match: they have no seller panel to be sent to, and mailing them a link would offer a session they could not hold. On consume, a token whose seller membership has since been revoked is refused exactly as an expired one.
- **The reset event carries a live token**, so it is added to `NON_DELIVERABLE_EVENTS` — otherwise a `*` webhook subscription would receive working reset tokens.
- **Resetting revokes every existing session** before minting the new one, so a stolen refresh token does not survive the reset.
- **The redirect is validated against the seller's own store**, not the request's. This endpoint is unauthenticated, so `current_store` is simply the default store; judged against that, one marketplace's allowlist would approve a link mailed to another marketplace's seller, and a store's own panel origin would be silently dropped. This follows the seller branch's existing rule that the store is derived from the seller, never defaulted.

## Testing

- 15 controller examples, 3 integration examples, 7 core mailer/subscriber examples.
- The two multi-store cases were confirmed to fail against the unfixed validation and pass against the fix.
- Full API suite: 3589 examples, 0 failures. Typecheck and lint clean across the affected packages.
- `docs/api-reference/seller.yaml` regenerated; the change is additive apart from factory-sequence and blob-signature drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seller password recovery with email-based reset requests.
  * Added “Forgot password?” access from the seller login page.
  * Added forgot-password and reset-password screens with validation and error handling.
  * Successful password resets sign sellers in and revoke previous sessions.
  * Added localized seller password-reset emails with secure, store-specific reset links.

* **Documentation**
  * Updated seller API documentation for password-reset endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->