### PR TITLE
Fix filter panel crash in the seller panel

### DIFF
--- a/.changeset/table-toolbar-tenant-scoped.md
+++ b/.changeset/table-toolbar-tenant-scoped.md
@@ -1,0 +1,5 @@
+---
+"@spree/dashboard-core": patch
+---
+
+Fix the filter panel crashing in the seller panel. `TableToolbar`, `ResourceCombobox` and `MediaPickerSheet` required a `StoreProvider` to scope their query keys, so opening a filter panel in a panel that has no store — the seller panel, whose tenant is a seller — threw "useStore must be used within a StoreProvider". They now scope by tenant, which is the store in the operator's dashboard and the seller in the seller panel, so cached results can no longer be shared between two sellers of the same store either.

--- a/packages/dashboard-core/src/components/media-picker-sheet.tsx
+++ b/packages/dashboard-core/src/components/media-picker-sheet.tsx
@@ -12,7 +12,7 @@ import { useQuery } from '@tanstack/react-query'
 import { CheckIcon, ImageIcon, Loader2Icon, PlayIcon, UploadIcon } from 'lucide-react'
 import { useDeferredValue, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore } from '../providers/store-provider'
+import { useTenantId } from '../providers/tenant-provider'
 
 /** The shape the picker needs; a full Media record satisfies it. */
 export interface MediaPickerOption {
@@ -73,7 +73,7 @@ export function MediaPickerSheet<T extends MediaPickerOption>({
   onConfirmError,
 }: MediaPickerSheetProps<T>) {
   const { t } = useTranslation()
-  const { storeId } = useStore()
+  const tenantId = useTenantId()
 
   const [input, setInput] = useState('')
   const deferredInput = useDeferredValue(input)
@@ -87,11 +87,11 @@ export function MediaPickerSheet<T extends MediaPickerOption>({
   // would otherwise still set the field the merchant cancelled.
   const sessionRef = useRef(0)
 
-  // The store id is part of the key: a library is one store's, and without it
-  // reopening the picker after a store switch serves the previous store's
-  // files from cache — whose ids the new store's API would then reject.
+  // The tenant id is part of the key: a library is one tenant's, and without
+  // it reopening the picker after a store or seller switch serves the previous
+  // tenant's files from cache — whose ids the new tenant's API would reject.
   const { data, isFetching, refetch } = useQuery({
-    queryKey: [queryKey, 'media-picker', storeId, trimmedQuery],
+    queryKey: [queryKey, 'media-picker', tenantId, trimmedQuery],
     queryFn: () => search(trimmedQuery),
     enabled: open,
     staleTime: 30_000,

--- a/packages/dashboard-core/src/components/resource-combobox.tsx
+++ b/packages/dashboard-core/src/components/resource-combobox.tsx
@@ -6,7 +6,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { useDeferredValue, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useStore } from '../providers/store-provider'
+import { useTenantId } from '../providers/tenant-provider'
 
 export type { ComboboxOption } from '@spree/dashboard-ui'
 
@@ -79,9 +79,10 @@ export function ResourceCombobox<T extends ComboboxOption>({
   // `onInputChange` on the Root rather than controlling
   // `<ComboboxInput value>` directly — controlling the input blocks Base UI
   // from updating it on selection.
-  // Scoped here, not at the call site: results are store-specific, and a caller
-  // passing a constant key would otherwise serve one store's records in another.
-  const { storeId } = useStore()
+  // Scoped here, not at the call site: results are tenant-specific (a store in
+  // the dashboard, a seller in the seller panel), and a caller passing a
+  // constant key would otherwise serve one tenant's records in another.
+  const tenantId = useTenantId()
   const [input, setInput] = useState('')
   // Defer the search query so a fast typist doesn't fire one request per
   // keystroke — React batches the search to the next idle paint.
@@ -89,7 +90,7 @@ export function ResourceCombobox<T extends ComboboxOption>({
   const trimmedQuery = deferredInput.trim()
 
   const { data: searchData } = useQuery({
-    queryKey: [queryKey, storeId, 'search', trimmedQuery],
+    queryKey: [queryKey, tenantId, 'search', trimmedQuery],
     queryFn: () => search(trimmedQuery),
     staleTime: 30_000,
   })
@@ -99,7 +100,7 @@ export function ResourceCombobox<T extends ComboboxOption>({
   // Skipped when the search results already include the ID.
   const searchHasValue = !!(value && searchData?.data.some((r) => r.id === value))
   const { data: hydratedData } = useQuery({
-    queryKey: [queryKey, storeId, 'hydrate', value],
+    queryKey: [queryKey, tenantId, 'hydrate', value],
     queryFn: () => hydrate([value as string]),
     enabled: !!value && !searchHasValue,
     staleTime: 60_000,

--- a/packages/dashboard-core/src/components/table-toolbar.tsx
+++ b/packages/dashboard-core/src/components/table-toolbar.tsx
@@ -41,7 +41,8 @@ import {
   parseFilterIds,
   type SortOption,
 } from '../lib/table-registry'
-import { useStore } from '../providers/store-provider'
+import { useOptionalStore } from '../providers/store-provider'
+import { useTenantId } from '../providers/tenant-provider'
 import { ResourceMultiAutocomplete } from './resource-multi-autocomplete'
 import { StoreDatePicker } from './store-date-picker'
 import { TagCombobox } from './tag-combobox'
@@ -144,6 +145,10 @@ function getOperatorLabelKey(type: string, operator: string) {
 }
 
 const noValueOperators = ['present', 'blank']
+
+/** Stable empty list, so a panel with no store doesn't rebuild `items` (and
+ *  re-emit Base UI Select state) on every render. */
+const noCurrencies: string[] = []
 
 // ============================================================================
 // TableToolbar
@@ -372,13 +377,13 @@ function ResourceFilterValue({
   value: string
   config: NonNullable<ColumnDef['filterResource']>
 }) {
-  const { storeId } = useStore()
+  const tenantId = useTenantId()
   const ids = useMemo(() => parseFilterIds(value), [value])
 
   const { data } = useQuery({
-    // Store-scope the cache key so chips don't resolve against another store's
-    // hydrate results after a store switch.
-    queryKey: ['filter-chip', config.queryKey, storeId, ids],
+    // Tenant-scope the cache key so chips don't resolve against another
+    // tenant's hydrate results after a store or seller switch.
+    queryKey: ['filter-chip', config.queryKey, tenantId, ids],
     queryFn: () => config.hydrate(ids),
     enabled: ids.length > 0,
     staleTime: 60_000,
@@ -410,7 +415,10 @@ function CurrencyFilterPicker({
   onChange: (next: string) => void
 }) {
   const { t } = useTranslation()
-  const { currencies } = useStore()
+  // `filterType: 'currency'` is only declared by tables in the operator's
+  // dashboard, which always has a store. Reading the store optionally keeps
+  // the panel mountable in a panel that has none.
+  const currencies = useOptionalStore()?.currencies ?? noCurrencies
   const items = useMemo(
     () => currencies.map((code) => ({ value: code, label: code })),
     [currencies],
@@ -633,7 +641,7 @@ function FilterPanel({
   onClose: () => void
 }) {
   const { t } = useTranslation()
-  const { storeId } = useStore()
+  const tenantId = useTenantId()
   const [draft, setDraft] = useState<FilterRule[]>(initialFilters)
   const booleanItems = useMemo(
     () => [
@@ -752,9 +760,9 @@ function FilterPanel({
                 (col?.filterType === 'resource' && col.filterResource ? (
                   <div className="flex-1 min-w-0">
                     <ResourceMultiAutocomplete
-                      // Store-scope the cache key so a store switch can't reuse
-                      // the previous store's search/hydrate results.
-                      queryKey={`${col.filterResource.queryKey}-${storeId}`}
+                      // Tenant-scope the cache key so a store or seller switch
+                      // can't reuse the previous tenant's search results.
+                      queryKey={`${col.filterResource.queryKey}-${tenantId}`}
                       value={parseFilterIds(filter.value)}
                       onChange={(ids) => updateFilter(filter.id, { value: ids.join(',') })}
                       search={col.filterResource.search}


### PR DESCRIPTION
Opening a table's filter panel in the seller panel crashed the page with `useStore must be used within a StoreProvider`.

The seller panel mounts no `StoreProvider` by design — its tenant is a seller, and the store is derived server-side. But three shared components in `@spree/dashboard-core` required one anyway, purely to scope their TanStack query keys: `TableToolbar`, `ResourceCombobox` and `MediaPickerSheet`. `FilterPanel` called `useStore()` as soon as it rendered, which is why the Filter button was enough to take the page down.

They now read the tenant instead, via the existing `useTenantId()` — the store in the operator's dashboard, the seller in the seller panel. Nothing changes for the operator dashboard, where the tenant falls back to the store id.

Scoping by tenant is also the more correct key in the seller panel: one store has many sellers, and the seller switcher moves a user between them, so a store-scoped key would have let one seller's cached lookups surface under another. Mounting a store context in the seller panel would have stopped the crash but introduced exactly that silent cache sharing.

The currency filter picker keeps reading the store, optionally — `filterType: 'currency'` is only declared by operator tables, and the seller API reports no locale list to build a general store stand-in from.

## Testing

- `tsc -b` clean on `@spree/dashboard-core`, `@spree/dashboard` and `@spree/seller-dashboard`
- 142 `dashboard-core` tests pass; Biome clean

## Follow-up, not in this PR

The seller tables (`orders`, `products`, `policies`) declare no `filterable` columns, so the panel now opens without crashing but has no fields to offer. Marking those columns up is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cached results from being shared between sellers in the same store.
  * Fixed seller-panel filter crashes when store context is unavailable.
  * Updated media, resource, and filter queries to refresh correctly when the active tenant changes.
  * Improved currency filter handling when store data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->