### PR TITLE
Fix Stripe checkout for logged-in customers

### DIFF
--- a/spree/core/app/models/spree/cart.rb
+++ b/spree/core/app/models/spree/cart.rb
@@ -115,6 +115,15 @@ module Spree
       prefixed_id
     end
 
+    # Billed or shipped name, matching {Spree::Order#name}.
+    #
+    # @return [String, nil]
+    def name
+      if (address = bill_address || ship_address)
+        address.full_name
+      end
+    end
+
     # A completed cart is an immutable audit record — post-checkout life
     # belongs to the order. Blocks save/update_columns/touch/destroy at the
     # model level; the completion write itself passes because it fires while

--- a/spree/core/spec/models/spree/cart_spec.rb
+++ b/spree/core/spec/models/spree/cart_spec.rb
@@ -255,6 +255,26 @@ describe Spree::Cart, type: :model do
     end
   end
 
+  describe '#name' do
+    it 'returns the billing address full name' do
+      bill_address = create(:address, firstname: 'John', lastname: 'Doe')
+      cart = create(:cart, store: store, bill_address: bill_address)
+
+      expect(cart.name).to eq('John Doe')
+    end
+
+    it 'falls back to the shipping address when billing is blank' do
+      ship_address = create(:address, firstname: 'Jane', lastname: 'Roe')
+      cart = create(:cart, store: store, bill_address: nil, ship_address: ship_address)
+
+      expect(cart.name).to eq('Jane Roe')
+    end
+
+    it 'is nil with no addresses' do
+      expect(build(:cart, store: store, bill_address: nil, ship_address: nil).name).to be_nil
+    end
+  end
+
   describe '#preferred_stock_location' do
     let(:cart) { create(:cart, store: store) }
     let(:pickup_location) { create(:stock_location, pickup_enabled: true) }

--- a/spree/providers/stripe/app/models/spree_stripe/gateway.rb
+++ b/spree/providers/stripe/app/models/spree_stripe/gateway.rb
@@ -260,13 +260,10 @@ module SpreeStripe
       errors.add(:base, 'Something went wrong with Stripe. Try again later.')
     end
 
-    # Checkout owns payment sessions on the cart, so `order` is a Cart or an
-    # Order. Cart has no `#name` (that helper is Order-only); both share
-    # bill/ship addresses, which is what Order#name reads anyway.
     def build_customer_payload(order: nil, customer: nil)
       customer ||= order&.customer
       address = order&.bill_address || customer&.bill_address
-      name = (order&.bill_address || order&.ship_address)&.full_name || customer&.full_name
+      name = order&.name || customer&.full_name
       email = order&.email || customer&.email
 
       SpreeStripe::CustomerPresenter.new(name: name, email: email, address: address).call

--- a/spree/providers/stripe/app/models/spree_stripe/gateway.rb
+++ b/spree/providers/stripe/app/models/spree_stripe/gateway.rb
@@ -124,7 +124,8 @@ module SpreeStripe
       end
     end
 
-    # @param customer [Spree::Customer]
+    # @param order [Spree::Cart, Spree::Order, nil]
+    # @param customer [Spree::Customer, nil]
     # @return [Spree::GatewayCustomer, nil]
     def fetch_or_create_customer(order: nil, customer: nil)
       customer ||= order&.customer
@@ -259,10 +260,13 @@ module SpreeStripe
       errors.add(:base, 'Something went wrong with Stripe. Try again later.')
     end
 
+    # Checkout owns payment sessions on the cart, so `order` is a Cart or an
+    # Order. Cart has no `#name` (that helper is Order-only); both share
+    # bill/ship addresses, which is what Order#name reads anyway.
     def build_customer_payload(order: nil, customer: nil)
       customer ||= order&.customer
       address = order&.bill_address || customer&.bill_address
-      name = order&.name || customer&.full_name
+      name = (order&.bill_address || order&.ship_address)&.full_name || customer&.full_name
       email = order&.email || customer&.email
 
       SpreeStripe::CustomerPresenter.new(name: name, email: email, address: address).call

--- a/spree/providers/stripe/spec/models/spree_stripe/gateway_spec.rb
+++ b/spree/providers/stripe/spec/models/spree_stripe/gateway_spec.rb
@@ -778,6 +778,36 @@ RSpec.describe SpreeStripe::Gateway do
         VCR.use_cassette('create_customer_based_on_user') { subject }
       end
     end
+
+    # Logged-in checkout creates the payment session on the cart. Cart has no
+    # `#name` (Order-only), and `order&.name` raises rather than falling through.
+    context 'when the purchase is a cart' do
+      let(:order) do
+        create(:cart, store: store, customer: customer, email: 'test@example.com', bill_address: bill_address)
+      end
+
+      before do
+        allow(Stripe::Customer).to receive(:create).and_return(double(id: 'cus_cart_123'))
+      end
+
+      it 'creates a Stripe customer from the cart' do
+        expect(order).to be_a(Spree::Cart)
+        expect(order).not_to respond_to(:name)
+
+        expect { subject }.to change(Spree::GatewayCustomer, :count).by(1)
+        expect(subject.customer).to eq(customer)
+        expect(subject.profile_id).to eq('cus_cart_123')
+        expect(subject.persisted?).to be(true)
+      end
+
+      it 'builds the Stripe payload from the cart address' do
+        expect(SpreeStripe::CustomerPresenter).to receive(:new).with(
+          name: bill_address.full_name, email: 'test@example.com', address: bill_address
+        ).and_call_original
+
+        subject
+      end
+    end
   end
 
   describe '#update_customer' do

--- a/spree/providers/stripe/spec/models/spree_stripe/gateway_spec.rb
+++ b/spree/providers/stripe/spec/models/spree_stripe/gateway_spec.rb
@@ -779,8 +779,6 @@ RSpec.describe SpreeStripe::Gateway do
       end
     end
 
-    # Logged-in checkout creates the payment session on the cart. Cart has no
-    # `#name` (Order-only), and `order&.name` raises rather than falling through.
     context 'when the purchase is a cart' do
       let(:order) do
         create(:cart, store: store, customer: customer, email: 'test@example.com', bill_address: bill_address)
@@ -791,18 +789,15 @@ RSpec.describe SpreeStripe::Gateway do
       end
 
       it 'creates a Stripe customer from the cart' do
-        expect(order).to be_a(Spree::Cart)
-        expect(order).not_to respond_to(:name)
-
         expect { subject }.to change(Spree::GatewayCustomer, :count).by(1)
         expect(subject.customer).to eq(customer)
         expect(subject.profile_id).to eq('cus_cart_123')
         expect(subject.persisted?).to be(true)
       end
 
-      it 'builds the Stripe payload from the cart address' do
+      it 'builds the Stripe payload from the cart' do
         expect(SpreeStripe::CustomerPresenter).to receive(:new).with(
-          name: bill_address.full_name, email: 'test@example.com', address: bill_address
+          name: order.name, email: order.email, address: bill_address
         ).and_call_original
 
         subject


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes logged-in Stripe checkout: `POST /api/v3/store/carts/payment_sessions` raised `NoMethodError: undefined method 'name' for an instance of Spree::Cart` while creating the Stripe customer, so the storefront received an HTML 500 instead of JSON (`Unexpected token '<'`).

Checkout owns payment sessions on the cart. The Stripe gateway built the customer payload with `order&.name`, which only existed on Order — safe navigation does not protect against a missing method. Guest checkout never reached that code because it returns before creating a Stripe customer.

Carts now expose the same `#name` helper as orders (billed address, then shipped). Stripe keeps reading `order&.name`.

Linear: V-3542
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3b7d3e0-6893-4d8b-9ec1-337ce6a09969?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3b7d3e0-6893-4d8b-9ec1-337ce6a09969&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cart name support, using the billing address first and shipping address as a fallback.
  * Stripe customer creation now supports cart-based purchases and includes cart contact and billing details.

* **Documentation**
  * Clarified payment gateway parameter documentation for optional customer and order details.

* **Tests**
  * Added coverage for cart names and cart-based Stripe customer creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->