### PR TITLE
Memoize applicable catalogs during product pricing

### DIFF
--- a/spree/core/app/models/spree/catalog.rb
+++ b/spree/core/app/models/spree/catalog.rb
@@ -33,6 +33,13 @@ module Spree
     validates :name, presence: true
     validate :price_list_in_same_store
 
+    # Request-scoped catalog memoization must not keep a set that a write
+    # in the same request has already superseded.
+    after_commit -> {
+      Spree::Current.applicable_catalogs = nil
+      Spree::Current.catalog_bound_price_list_ids = nil
+    }
+
     scope :active, -> { where(active: true) }
     scope :by_position, -> { order(position: :asc) }
 
@@ -84,6 +91,33 @@ module Spree
         where(catalog_id: all.select(:id)).
         includes(:catalog).
         map(&:catalog).select(&:active?).sort_by { |catalog| catalog.position.to_i }.uniq
+    end
+
+    # Catalogs that apply to a buyer: the company subtree first, then the
+    # customer's groups, then the channel's default catalog. Pricing asks
+    # this once per request context via {Spree::Current#catalogs_for}.
+    #
+    # @param store [Spree::Store, nil]
+    # @param company [Spree::Company, nil]
+    # @param user [Object, nil]
+    # @param channel [Spree::Channel, nil]
+    # @return [Array<Spree::Catalog>]
+    def self.for_context(store:, company: nil, user: nil, channel: nil)
+      return [] if store.nil?
+
+      catalogs = store.catalogs.for_company(company)
+      if catalogs.empty? && user
+        groups = user.try(:customer_groups)
+        groups = if groups.respond_to?(:where)
+                   groups.where(store_id: store.id)
+                 else
+                   Array(groups).select { |group| group.store_id == store.id }
+                 end
+        catalogs = store.catalogs.for_customer_groups(groups)
+      end
+      catalogs = [channel&.default_catalog].compact.select(&:active?) if catalogs.empty?
+      ActiveRecord::Associations::Preloader.new(records: catalogs, associations: :price_list).call if catalogs.any?
+      catalogs
     end
 
     # Adds products to the assortment, appending to the manual order and

--- a/spree/core/app/models/spree/catalog_assignment.rb
+++ b/spree/core/app/models/spree/catalog_assignment.rb
@@ -22,6 +22,8 @@ module Spree
     validates :catalog_id, uniqueness: { scope: [:assignable_type, :assignable_id, *spree_base_uniqueness_scope] }
     validate :assignable_in_same_store
 
+    after_commit -> { Spree::Current.applicable_catalogs = nil }
+
     delegate :store, :store_id, to: :catalog
 
     private

--- a/spree/core/app/models/spree/current.rb
+++ b/spree/core/app/models/spree/current.rb
@@ -4,7 +4,7 @@ module Spree
   # All attributes are automatically reset between requests by Rails.
   # Fallback chains ensure sensible defaults when attributes are not explicitly set.
   class Current < ::ActiveSupport::CurrentAttributes
-    attribute :store, :channel, :market, :currency, :locale, :content_locale, :tax_country, :price_lists, :global_pricing_context, :provider_cache, :integrations
+    attribute :store, :channel, :market, :currency, :locale, :content_locale, :tax_country, :price_lists, :applicable_catalogs, :catalog_bound_price_list_ids, :global_pricing_context, :provider_cache, :integrations
 
     # Scratch space for provider strategies to memoize a call across the
     # request — part of the delivery rate provider contract (nothing in core
@@ -88,6 +88,42 @@ module Spree
         context = global_pricing_context
         self.price_lists = Spree::PriceList.for_context(context)
       end
+    end
+
+    # Catalogs that apply to a buyer in this request, keyed by that buyer.
+    # A store can have many catalogs; only the company / customer-group /
+    # channel-default set is kept. Product listings price every variant
+    # through a new resolver, so the first call loads the set and the rest
+    # reuse it.
+    #
+    # @param company [Spree::Company, nil]
+    # @param user [Object, nil]
+    # @param channel [Spree::Channel, nil]
+    # @return [Array<Spree::Catalog>]
+    def catalogs_for(company: nil, user: nil, channel: nil)
+      channel ||= self.channel
+      key = [store&.id, company&.id, user&.id, channel&.id]
+      applicable_catalogs[key] ||= Spree::Catalog.for_context(
+        store: store, company: company, user: user, channel: channel
+      )
+    end
+
+    # Price-list ids claimed by any active catalog in the current store.
+    # One pluck per request — the listing path asked this for every variant.
+    # @return [Set<Integer>]
+    def catalog_bound_price_list_ids
+      super || (self.catalog_bound_price_list_ids =
+        if store
+          Spree::Catalog.active.where(store_id: store.id).where.not(price_list_id: nil).
+            distinct.pluck(:price_list_id).to_set
+        else
+          Set.new
+        end)
+    end
+
+    # @return [Hash]
+    def applicable_catalogs
+      super || (self.applicable_catalogs = {})
     end
 
     # Returns the current global pricing context, built from store, currency, country, and market.

--- a/spree/core/app/models/spree/pricing_provider/internal.rb
+++ b/spree/core/app/models/spree/pricing_provider/internal.rb
@@ -61,21 +61,7 @@ module Spree
         # status and dates.
         # @return [Array<Spree::PriceList>]
         def catalog_price_lists
-          @catalog_price_lists ||= begin
-            # Every lookup starts from the context's store, so a catalog is
-            # only ever reached through the tenant being priced for.
-            store = context.store
-            catalogs = store ? store.catalogs.for_company(context.company) : []
-            if catalogs.empty? && context.user && store
-              groups = context.user.try(:customer_groups)&.where(store_id: store.id) || []
-              catalogs = store.catalogs.for_customer_groups(groups)
-            end
-            if catalogs.empty?
-              catalogs = [context.channel&.default_catalog].compact.select(&:active?)
-            end
-
-            catalogs.filter_map(&:price_list).uniq.select(&:currently_active?)
-          end
+          @catalog_price_lists ||= catalogs_for_context.filter_map(&:price_list).uniq.select(&:currently_active?)
         end
 
         # Returns the price lists that are applicable to the context.
@@ -94,12 +80,28 @@ module Spree
         # that was working before the catalog draft existed.
         def catalog_bound_price_list_ids
           @catalog_bound_price_list_ids ||=
-            if context.store
+            if context.store == Spree::Current.store
+              Spree::Current.catalog_bound_price_list_ids
+            elsif context.store
               Spree::Catalog.active.where(store_id: context.store.id).where.not(price_list_id: nil).
                 distinct.pluck(:price_list_id).to_set
             else
               Set.new
             end
+        end
+
+        # Catalogs that apply to this buyer. Reused from {Spree::Current}
+        # when the context is the current store, so a product listing does
+        # not re-resolve the same company / group / channel set per variant.
+        # @return [Array<Spree::Catalog>]
+        def catalogs_for_context
+          if context.store == Spree::Current.store
+            Spree::Current.catalogs_for(company: context.company, user: context.user, channel: context.channel)
+          else
+            Spree::Catalog.for_context(
+              store: context.store, company: context.company, user: context.user, channel: context.channel
+            )
+          end
         end
 
         # Returns the price lists for the context's store

--- a/spree/core/spec/lib/spree/core/pricing/catalog_pricing_spec.rb
+++ b/spree/core/spec/lib/spree/core/pricing/catalog_pricing_spec.rb
@@ -91,4 +91,44 @@ describe 'catalog-aware pricing' do
     expect(resolve(company: company).amount).to eq(80)
     expect(resolve.amount).to eq(80)
   end
+
+  # Product listings build one Pricing::Context per variant. The bound
+  # price-list ids and the catalogs that apply to this buyer are request
+  # scoped, so later rows must not query catalogs again.
+  it 'loads applicable catalogs once across many variant resolutions' do
+    catalog = create(:catalog, store: store, price_list: price_list_with_price(80))
+    create(:catalog_assignment, catalog: catalog, assignable: company)
+    variants = create_list(:variant, 3)
+
+    catalog_query_count = lambda do |&block|
+      queries = 0
+      counter = lambda do |*, payload|
+        next if payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
+
+        queries += 1 if payload[:sql].include?('spree_catalogs')
+      end
+      ActiveSupport::Notifications.subscribed(counter, 'sql.active_record', &block)
+      queries
+    end
+
+    price_variants = lambda do |records|
+      records.each do |priced_variant|
+        Spree::Pricing::PriceResolution.call(
+          Spree::Pricing::Context.new(
+            variant: priced_variant, currency: 'USD', store: store, company: company
+          )
+        )
+      end
+    end
+
+    Spree::Current.store = store
+    single = catalog_query_count.call { price_variants.call(variants.take(1)) }
+
+    Spree::Current.reset
+    Spree::Current.store = store
+    batched = catalog_query_count.call { price_variants.call(variants) }
+
+    expect(batched).to eq(single)
+    expect(single).to be > 0
+  end
 end

--- a/spree/core/spec/models/spree/catalog_spec.rb
+++ b/spree/core/spec/models/spree/catalog_spec.rb
@@ -93,6 +93,26 @@ describe Spree::Catalog, type: :model do
     end
   end
 
+  describe '.for_context' do
+    let(:company) { create(:company, store: store) }
+
+    it 'returns company catalogs and ignores ones that do not apply' do
+      assigned = create(:catalog, store: store)
+      create(:catalog, store: store)
+      create(:catalog_assignment, catalog: assigned, assignable: company)
+
+      expect(described_class.for_context(store: store, company: company)).to eq([assigned])
+    end
+
+    it 'falls back to the channel default catalog when nothing narrower applies' do
+      catalog = create(:catalog, store: store)
+      channel = store.default_channel
+      channel.update!(default_catalog: catalog)
+
+      expect(described_class.for_context(store: store, channel: channel)).to eq([catalog])
+    end
+  end
+
   describe 'assignments' do
     let(:catalog) { create(:catalog, store: store) }
 

--- a/spree/core/spec/models/spree/current_spec.rb
+++ b/spree/core/spec/models/spree/current_spec.rb
@@ -243,6 +243,66 @@ RSpec.describe Spree::Current do
     end
   end
 
+  describe '#catalogs_for' do
+    let!(:store) { create(:store, default: true) }
+    let!(:company) { create(:company, store: store) }
+    let!(:assigned_catalog) { create(:catalog, store: store) }
+    let!(:other_catalog) { create(:catalog, store: store) }
+
+    before do
+      create(:catalog_assignment, catalog: assigned_catalog, assignable: company)
+      described_class.store = store
+    end
+
+    it 'returns only catalogs that apply to the buyer, not every catalog in the store' do
+      expect(described_class.catalogs_for(company: company)).to eq([assigned_catalog])
+      expect(described_class.catalogs_for(company: company)).not_to include(other_catalog)
+    end
+
+    it 'memoizes the applicable set for the same buyer' do
+      first = described_class.catalogs_for(company: company)
+      second = described_class.catalogs_for(company: company)
+      expect(first).to be(second)
+    end
+
+    it 'does not reuse one buyer set for another' do
+      other_company = create(:company, store: store)
+      other_assigned = create(:catalog, store: store)
+      create(:catalog_assignment, catalog: other_assigned, assignable: other_company)
+
+      expect(described_class.catalogs_for(company: company)).to eq([assigned_catalog])
+      expect(described_class.catalogs_for(company: other_company)).to eq([other_assigned])
+    end
+
+    it 'drops the memoized set when a catalog is written' do
+      expect(described_class.catalogs_for(company: company)).to eq([assigned_catalog])
+
+      created = create(:catalog, store: store)
+      create(:catalog_assignment, catalog: created, assignable: company)
+
+      expect(described_class.catalogs_for(company: company)).to contain_exactly(assigned_catalog, created)
+    end
+  end
+
+  describe '#catalog_bound_price_list_ids' do
+    let!(:store) { create(:store, default: true) }
+    let!(:price_list) { create(:price_list, :active, store: store) }
+
+    before { described_class.store = store }
+
+    it 'includes price lists claimed by an active catalog' do
+      create(:catalog, store: store, price_list: price_list)
+
+      expect(described_class.catalog_bound_price_list_ids).to include(price_list.id)
+    end
+
+    it 'memoizes the id set' do
+      first = described_class.catalog_bound_price_list_ids
+      second = described_class.catalog_bound_price_list_ids
+      expect(first).to be(second)
+    end
+  end
+
   describe '.reset' do
     let(:store) { create(:store) }
     let(:country) { create(:country) }
@@ -275,6 +335,22 @@ RSpec.describe Spree::Current do
 
       # After reset, price_lists should be fetched fresh
       expect(described_class.instance_variable_get(:@price_lists)).to be_nil
+    end
+
+    it 'clears memoized applicable catalogs' do
+      described_class.catalogs_for
+
+      described_class.reset
+
+      expect(described_class.instance_variable_get(:@applicable_catalogs)).to be_nil
+    end
+
+    it 'clears memoized catalog_bound_price_list_ids' do
+      described_class.catalog_bound_price_list_ids
+
+      described_class.reset
+
+      expect(described_class.instance_variable_get(:@catalog_bound_price_list_ids)).to be_nil
     end
 
     it 'clears memoized global_pricing_context' do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Product listings (Admin and Store API) resolve a price for every variant. Each resolver was querying `spree_catalogs` again for the same buyer — a distinct `price_list_id` pluck per row, plus the company / group / channel-default walk.

This keeps two request-scoped snapshots on `Spree::Current`, the same way price lists already work:

- **Applicable catalogs** for the current buyer (company, customer group, or the channel default). A store can have many catalogs; only that set is held in memory.
- **Bound price-list ids** claimed by any *active* catalog, so a catalog-attached list still does not leak through generic rule matching.

Writes to a catalog or assignment drop the snapshot so a later read in the same request sees the new rows.

## Testing
- `spree/core` specs for `Current`, `Catalog.for_context`, and catalog-aware pricing (including that N variants issue the same catalog queries as one)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3d4c512-b803-45c7-a06f-0eebaffb89bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3d4c512-b803-45c7-a06f-0eebaffb89bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalogs are now selected automatically based on the buyer’s company, customer groups, sales channel, and store.
  * Pricing uses the applicable catalog and its price lists for more consistent contextual pricing.

* **Bug Fixes**
  * Catalog and price-list changes are reflected promptly, preventing outdated selections within a request.
  * Improved catalog lookup efficiency when resolving prices for multiple products.

* **Tests**
  * Added coverage for buyer-specific catalog selection, fallback behavior, cache isolation, and cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->