### PR TITLE
Fix delivery method amounts shown in the wrong currency

### DIFF
--- a/packages/dashboard/src/components/spree/shipping/delivery-method-form.tsx
+++ b/packages/dashboard/src/components/spree/shipping/delivery-method-form.tsx
@@ -58,6 +58,7 @@ import {
 import { useIntegrations, useIntegrationTypes } from '../../../hooks/use-integrations'
 import { productAutocompleteProps } from '../../../hooks/use-products'
 import { useTaxCategories } from '../../../hooks/use-tax-categories'
+import { amountForCurrency, applyCurrencyAmount } from '../../../lib/delivery-method-summary'
 import type { DeliveryMethodFormValues } from '../../../schemas/delivery-method'
 import { ConfigureIntegrationSheet } from '../integrations/configure-integration-sheet'
 import { StockLocationScopeField } from './stock-location-scope-field'
@@ -76,8 +77,8 @@ const AMOUNT_BASED_CALCULATORS = [
 
 /**
  * Preference keys the per-currency editor owns on those calculators. `amount`
- * and `currency` are the pre-6.0 single-currency pair, kept authoritative for
- * the store's default currency so an upgraded store quotes unchanged.
+ * and `currency` are the pre-6.0 single-currency pair: they belong to the
+ * currency the method names, not automatically to the store default.
  */
 const CURRENCY_AMOUNT_KEYS = ['amount', 'currency', 'amounts']
 
@@ -901,10 +902,10 @@ function ServiceOverridesSheet({
 
 /**
  * The amount an amount-based calculator charges, one input per currency the
- * store sells in. The default currency writes the legacy single `amount`
- * preference, so an upgraded store keeps quoting from the value it already
- * had; every other currency lives in the `amounts` hash. A currency left
- * blank has no amount, and the method is simply not offered to those carts.
+ * store sells in. Each row shows the amount for that currency — the
+ * per-currency `amounts` hash, or the pre-6.0 single `amount` when its
+ * `currency` preference names this row. A currency left blank has no
+ * amount, and the method is simply not offered to those carts.
  *
  * A single-currency store sees one plain amount field, exactly as before.
  */
@@ -932,24 +933,12 @@ function CurrencyAmountsField({
   const multiCurrency = codes.length > 1
 
   function amountFor(code: string): string {
-    const raw = code === defaultCurrency ? values.amount : amounts[code]
-    return raw === null || raw === undefined ? '' : String(raw)
+    const raw = amountForCurrency(values, code, defaultCurrency)
+    return raw === null ? '' : String(raw)
   }
 
   function setAmount(code: string, raw: string) {
-    if (code === defaultCurrency) {
-      onChange({ ...values, amount: raw === '' ? null : Number(raw) })
-      return
-    }
-    const nextAmounts = { ...amounts }
-    // An empty input is the absence of an amount, not a zero — a zero would
-    // offer the method free of charge in that currency.
-    if (raw === '') {
-      delete nextAmounts[code]
-    } else {
-      nextAmounts[code] = Number(raw)
-    }
-    onChange({ ...values, amounts: nextAmounts })
+    onChange(applyCurrencyAmount(values, code, raw, defaultCurrency))
   }
 
   return (

--- a/packages/dashboard/src/components/spree/shipping/delivery-method-list.tsx
+++ b/packages/dashboard/src/components/spree/shipping/delivery-method-list.tsx
@@ -14,7 +14,7 @@ import {
   useDeleteDeliveryMethod,
   useDeliveryRateProviders,
 } from '../../../hooks/use-delivery-methods'
-import { flatAmount, formatAmount, summarizeRules } from '../../../lib/delivery-method-summary'
+import { formatListedPrice, summarizeRules } from '../../../lib/delivery-method-summary'
 import { useMethodSheetNavigation } from './use-method-sheet-navigation'
 
 export function DeliveryMethodList({
@@ -69,12 +69,15 @@ export function DeliveryMethodList({
         const carrierPriced = rateProvider
           ? rateProvider.uses_calculator === false
           : !!method.rate_provider && method.rate_provider !== defaultRateProvider
-        const amount = flatAmount(method.calculator_preferences)
         const price = carrierPriced
           ? t('admin.delivery_methods.carrier_rates')
-          : amount === null || amount === 0
-            ? t('admin.delivery_methods.free')
-            : formatAmount(amount, defaultCurrency, i18n.language)
+          : formatListedPrice(
+              method.calculator_preferences,
+              defaultCurrency,
+              i18n.language,
+              t('admin.delivery_methods.free'),
+              t('admin.delivery_methods.rule_summary.separator'),
+            )
 
         const ruleSummary = summarizeRules(method.rules, {
           t,

--- a/packages/dashboard/src/lib/delivery-method-summary.test.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { formatListedPrice, listedAmounts } from './delivery-method-summary'
+
+describe('listedAmounts', () => {
+  it('reads the legacy single amount as the store default currency', () => {
+    expect(listedAmounts({ amount: 5 }, 'USD')).toEqual([{ amount: 5, currency: 'USD' }])
+  })
+
+  it('attributes the legacy amount to its own currency preference', () => {
+    expect(listedAmounts({ amount: 7, currency: 'EUR' }, 'USD')).toEqual([
+      { amount: 7, currency: 'EUR' },
+    ])
+  })
+
+  it('reads a non-default currency from the amounts hash when the default is empty', () => {
+    expect(listedAmounts({ amounts: { EUR: 7 } }, 'USD')).toEqual([{ amount: 7, currency: 'EUR' }])
+  })
+
+  it('keeps each hash amount against the currency it was entered in', () => {
+    expect(listedAmounts({ amounts: { GBP: 8, EUR: 7 } }, 'USD')).toEqual([
+      { amount: 7, currency: 'EUR' },
+      { amount: 8, currency: 'GBP' },
+    ])
+  })
+
+  it('lists the default-currency amount first when both sources have a price', () => {
+    expect(listedAmounts({ amount: 5, amounts: { EUR: 7 } }, 'USD')).toEqual([
+      { amount: 5, currency: 'USD' },
+      { amount: 7, currency: 'EUR' },
+    ])
+  })
+
+  it('lets the amounts hash override the legacy amount for the same currency', () => {
+    expect(listedAmounts({ amount: 5, amounts: { USD: 6, EUR: 7 } }, 'USD')).toEqual([
+      { amount: 6, currency: 'USD' },
+      { amount: 7, currency: 'EUR' },
+    ])
+  })
+
+  it('ignores blank hash entries so an emptied currency is not offered', () => {
+    expect(listedAmounts({ amounts: { EUR: '', GBP: 8 } }, 'USD')).toEqual([
+      { amount: 8, currency: 'GBP' },
+    ])
+  })
+})
+
+describe('formatListedPrice', () => {
+  const separator = ' · '
+
+  it('formats a default-currency amount with that currency symbol', () => {
+    expect(formatListedPrice({ amount: 5 }, 'USD', 'en', 'Free', separator)).toBe('$5.00')
+  })
+
+  it('formats an EUR-only method with a euro sign, not the store default symbol', () => {
+    expect(formatListedPrice({ amounts: { EUR: 7 } }, 'USD', 'en', 'Free', separator)).toBe('€7.00')
+  })
+
+  it('formats a GBP-only method with a pound sign', () => {
+    expect(formatListedPrice({ amounts: { GBP: 8 } }, 'USD', 'en', 'Free', separator)).toBe('£8.00')
+  })
+
+  it('joins one price per stored currency', () => {
+    expect(
+      formatListedPrice({ amount: 5, amounts: { EUR: 7 } }, 'USD', 'en', 'Free', separator),
+    ).toBe('$5.00 · €7.00')
+  })
+
+  it('reads an empty or zero-only method as free', () => {
+    expect(formatListedPrice({}, 'USD', 'en', 'Free', separator)).toBe('Free')
+    expect(formatListedPrice({ amount: 0 }, 'USD', 'en', 'Free', separator)).toBe('Free')
+    expect(formatListedPrice({ amounts: { EUR: 0 } }, 'USD', 'en', 'Free', separator)).toBe('Free')
+  })
+})

--- a/packages/dashboard/src/lib/delivery-method-summary.test.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.test.ts
@@ -107,6 +107,16 @@ describe('amountForCurrency', () => {
     expect(amountForCurrency({ amount: 5 }, 'USD', 'USD')).toBe(5)
     expect(amountForCurrency({ amount: 5 }, 'EUR', 'USD')).toBeNull()
   })
+
+  it('trims surrounding space on the legacy currency preference', () => {
+    const preferences = { amount: 7, currency: ' EUR ' }
+    expect(amountForCurrency(preferences, 'EUR', 'USD')).toBe(7)
+    expect(amountForCurrency(preferences, 'USD', 'USD')).toBeNull()
+  })
+
+  it('reads a lowercase amounts-hash key as that currency', () => {
+    expect(amountForCurrency({ amounts: { eur: 7 } }, 'EUR', 'USD')).toBe(7)
+  })
 })
 
 describe('applyCurrencyAmount', () => {
@@ -131,6 +141,15 @@ describe('applyCurrencyAmount', () => {
       amount: 5,
       currency: 'USD',
       amounts: { EUR: 11 },
+    })
+  })
+
+  it('updates and clears a lowercase stored hash key without leaving a stale entry', () => {
+    expect(applyCurrencyAmount({ amounts: { eur: 7 } }, 'EUR', '11', 'USD')).toEqual({
+      amounts: { EUR: 11 },
+    })
+    expect(applyCurrencyAmount({ amounts: { eur: 7 } }, 'EUR', '', 'USD')).toEqual({
+      amounts: {},
     })
   })
 })

--- a/packages/dashboard/src/lib/delivery-method-summary.test.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { formatListedPrice, listedAmounts } from './delivery-method-summary'
+import {
+  amountForCurrency,
+  applyCurrencyAmount,
+  formatListedPrice,
+  listedAmounts,
+} from './delivery-method-summary'
 
 describe('listedAmounts', () => {
   it('reads the legacy single amount as the store default currency', () => {
@@ -14,6 +19,13 @@ describe('listedAmounts', () => {
 
   it('reads a non-default currency from the amounts hash when the default is empty', () => {
     expect(listedAmounts({ amounts: { EUR: 7 } }, 'USD')).toEqual([{ amount: 7, currency: 'EUR' }])
+  })
+
+  it('reads the editor-written hash even when the single amount is zero', () => {
+    expect(listedAmounts({ amount: 0, amounts: { EUR: 11 } }, 'USD')).toEqual([
+      { amount: 0, currency: 'USD' },
+      { amount: 11, currency: 'EUR' },
+    ])
   })
 
   it('keeps each hash amount against the currency it was entered in', () => {
@@ -69,5 +81,56 @@ describe('formatListedPrice', () => {
     expect(formatListedPrice({}, 'USD', 'en', 'Free', separator)).toBe('Free')
     expect(formatListedPrice({ amount: 0 }, 'USD', 'en', 'Free', separator)).toBe('Free')
     expect(formatListedPrice({ amounts: { EUR: 0 } }, 'USD', 'en', 'Free', separator)).toBe('Free')
+  })
+
+  it('does not read a zero single amount as free when the hash has a real price', () => {
+    expect(
+      formatListedPrice({ amount: 0, amounts: { EUR: 11 } }, 'USD', 'en', 'Free', separator),
+    ).toBe('€11.00')
+  })
+})
+
+describe('amountForCurrency', () => {
+  it('puts a pre-6.0 euro amount in the euro row, not the store default', () => {
+    const preferences = { amount: 7, currency: 'EUR' }
+    expect(amountForCurrency(preferences, 'EUR', 'USD')).toBe(7)
+    expect(amountForCurrency(preferences, 'USD', 'USD')).toBeNull()
+  })
+
+  it('reads an editor-written euro price from the amounts hash', () => {
+    const preferences = { amount: 0, amounts: { EUR: 11 } }
+    expect(amountForCurrency(preferences, 'EUR', 'USD')).toBe(11)
+    expect(amountForCurrency(preferences, 'USD', 'USD')).toBe(0)
+  })
+
+  it('treats a blank currency preference as the store default', () => {
+    expect(amountForCurrency({ amount: 5 }, 'USD', 'USD')).toBe(5)
+    expect(amountForCurrency({ amount: 5 }, 'EUR', 'USD')).toBeNull()
+  })
+})
+
+describe('applyCurrencyAmount', () => {
+  it('keeps a pre-6.0 euro price when the dollar row is edited', () => {
+    expect(applyCurrencyAmount({ amount: 7, currency: 'EUR' }, 'USD', '10', 'USD')).toEqual({
+      amount: 10,
+      currency: 'USD',
+      amounts: { EUR: 7 },
+    })
+  })
+
+  it('updates the named currency in place on a pre-6.0 method', () => {
+    expect(applyCurrencyAmount({ amount: 7, currency: 'EUR' }, 'EUR', '11', 'USD')).toEqual({
+      amount: 11,
+      currency: 'EUR',
+      amounts: { EUR: 11 },
+    })
+  })
+
+  it('writes a non-default currency into the amounts hash', () => {
+    expect(applyCurrencyAmount({ amount: 5, currency: 'USD' }, 'EUR', '11', 'USD')).toEqual({
+      amount: 5,
+      currency: 'USD',
+      amounts: { EUR: 11 },
+    })
   })
 })

--- a/packages/dashboard/src/lib/delivery-method-summary.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.ts
@@ -1,19 +1,75 @@
 import type { DeliveryMethodRule } from '@spree/admin-sdk'
 import type { TFunction } from 'i18next'
 
-/**
- * The flat amount a calculator-priced method charges, or null when it is
- * priced some other way (per item, tiered, per carrier quote) and has no
- * single number to show.
- */
-export function flatAmount(preferences: Record<string, unknown> | null | undefined): number | null {
-  const amount = preferences?.amount
-  if (amount === null || amount === undefined || amount === '') return null
-  const parsed = Number(amount)
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const parsed = Number(value)
   return Number.isNaN(parsed) ? null : parsed
 }
 
-/** Formats an amount in the store's currency, falling back to a bare number. */
+export type ListedAmount = {
+  amount: number
+  currency: string
+}
+
+/**
+ * Every amount a calculator-priced method quotes, each with the currency it
+ * belongs to. The per-currency `amounts` hash is the source of truth; the
+ * legacy single `amount` fills in for its own currency (the `currency`
+ * preference, or the store default) when the hash has no entry there.
+ *
+ * A method priced only in a non-default currency therefore returns that
+ * currency's row, not a number that the caller would stamp with the store
+ * default's symbol.
+ */
+export function listedAmounts(
+  preferences: Record<string, unknown> | null | undefined,
+  defaultCurrency: string,
+): ListedAmount[] {
+  const listed: ListedAmount[] = []
+  const seen = new Set<string>()
+  const defaultCode = defaultCurrency.toUpperCase()
+
+  const amounts = preferences?.amounts
+  if (amounts && typeof amounts === 'object' && !Array.isArray(amounts)) {
+    for (const [code, value] of Object.entries(amounts as Record<string, unknown>)) {
+      const parsed = toNumber(value)
+      if (parsed === null) continue
+      const currency = code.toUpperCase()
+      listed.push({ amount: parsed, currency })
+      seen.add(currency)
+    }
+  }
+
+  const legacyAmount = toNumber(preferences?.amount)
+  if (legacyAmount !== null) {
+    const rawCurrency =
+      typeof preferences?.currency === 'string' && preferences.currency.trim() !== ''
+        ? preferences.currency
+        : defaultCurrency
+    const legacyCurrency = rawCurrency.toUpperCase()
+    if (!seen.has(legacyCurrency)) {
+      listed.push({ amount: legacyAmount, currency: legacyCurrency })
+    }
+  }
+
+  return listed.sort((left, right) => {
+    if (left.currency === defaultCode) return -1
+    if (right.currency === defaultCode) return 1
+    return left.currency.localeCompare(right.currency)
+  })
+}
+
+/**
+ * The flat amount a calculator-priced method charges, or null when it is
+ * priced some other way (per item, tiered, per carrier quote) and has no
+ * single number to show. Prefer `listedAmounts` when the currency matters.
+ */
+export function flatAmount(preferences: Record<string, unknown> | null | undefined): number | null {
+  return toNumber(preferences?.amount)
+}
+
+/** Formats an amount in the given currency, falling back to a bare number. */
 export function formatAmount(amount: number, currency: string, locale?: string): string {
   try {
     return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount)
@@ -22,10 +78,21 @@ export function formatAmount(amount: number, currency: string, locale?: string):
   }
 }
 
-function toNumber(value: unknown): number | null {
-  if (value === null || value === undefined || value === '') return null
-  const parsed = Number(value)
-  return Number.isNaN(parsed) ? null : parsed
+/**
+ * The glance price for a calculator-priced method on the delivery profile
+ * list. Each stored amount is formatted in its own currency; zero-only or
+ * empty preferences read as free.
+ */
+export function formatListedPrice(
+  preferences: Record<string, unknown> | null | undefined,
+  defaultCurrency: string,
+  locale: string | undefined,
+  freeLabel: string,
+  separator: string,
+): string {
+  const priced = listedAmounts(preferences, defaultCurrency).filter((row) => row.amount !== 0)
+  if (priced.length === 0) return freeLabel
+  return priced.map((row) => formatAmount(row.amount, row.currency, locale)).join(separator)
 }
 
 interface RuleSummaryContext {

--- a/packages/dashboard/src/lib/delivery-method-summary.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.ts
@@ -21,10 +21,24 @@ function amountsHash(
   return amounts as Record<string, unknown>
 }
 
-function hashEntry(amounts: Record<string, unknown>, currency: string): unknown {
+function hashKey(amounts: Record<string, unknown>, currency: string): string | undefined {
   const code = currency.toUpperCase()
-  const match = Object.entries(amounts).find(([key]) => key.toUpperCase() === code)
-  return match ? match[1] : undefined
+  return Object.keys(amounts).find((key) => key.toUpperCase() === code)
+}
+
+function hashEntry(amounts: Record<string, unknown>, currency: string): unknown {
+  const key = hashKey(amounts, currency)
+  return key === undefined ? undefined : amounts[key]
+}
+
+function writeHashAmount(
+  amounts: Record<string, unknown>,
+  currency: string,
+  value: number | null,
+): void {
+  const existing = hashKey(amounts, currency)
+  if (existing !== undefined) delete amounts[existing]
+  if (value !== null) amounts[currency.toUpperCase()] = value
 }
 
 /** The currency the pre-6.0 single `amount` belongs to. */
@@ -33,7 +47,7 @@ function legacyCurrency(
   defaultCurrency: string,
 ): string {
   if (typeof preferences?.currency === 'string' && preferences.currency.trim() !== '') {
-    return preferences.currency.toUpperCase()
+    return preferences.currency.trim().toUpperCase()
   }
   return defaultCurrency.toUpperCase()
 }
@@ -92,12 +106,8 @@ export function applyCurrencyAmount(
   }
 
   if (code === defaultCode) {
-    if (hashEntry(nextAmounts, code) !== undefined) {
-      if (parsed === null) {
-        delete nextAmounts[code]
-      } else {
-        nextAmounts[code] = parsed
-      }
+    if (hashKey(nextAmounts, code) !== undefined) {
+      writeHashAmount(nextAmounts, code, parsed)
     }
     return {
       ...preferences,
@@ -107,11 +117,7 @@ export function applyCurrencyAmount(
     }
   }
 
-  if (parsed === null) {
-    delete nextAmounts[code]
-  } else {
-    nextAmounts[code] = parsed
-  }
+  writeHashAmount(nextAmounts, code, parsed)
 
   if (namedCurrency === code) {
     return { ...preferences, amount: parsed, amounts: nextAmounts }

--- a/packages/dashboard/src/lib/delivery-method-summary.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.ts
@@ -13,6 +13,113 @@ export type ListedAmount = {
   currency: string
 }
 
+function amountsHash(
+  preferences: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const amounts = preferences?.amounts
+  if (!amounts || typeof amounts !== 'object' || Array.isArray(amounts)) return {}
+  return amounts as Record<string, unknown>
+}
+
+function hashEntry(amounts: Record<string, unknown>, currency: string): unknown {
+  const code = currency.toUpperCase()
+  const match = Object.entries(amounts).find(([key]) => key.toUpperCase() === code)
+  return match ? match[1] : undefined
+}
+
+/** The currency the pre-6.0 single `amount` belongs to. */
+function legacyCurrency(
+  preferences: Record<string, unknown> | null | undefined,
+  defaultCurrency: string,
+): string {
+  if (typeof preferences?.currency === 'string' && preferences.currency.trim() !== '') {
+    return preferences.currency.toUpperCase()
+  }
+  return defaultCurrency.toUpperCase()
+}
+
+/**
+ * The amount a calculator-priced method quotes for one currency — the same
+ * order the calculator uses. The per-currency `amounts` hash wins; the
+ * legacy single `amount` fills in only for its own currency (the `currency`
+ * preference, or the store default when that preference is blank).
+ *
+ * A pre-6.0 method that names EUR therefore returns 7 for EUR and nothing
+ * for USD. Reading the single amount as the store default is how a euro
+ * figure appeared in the dollar row of the editor.
+ */
+export function amountForCurrency(
+  preferences: Record<string, unknown> | null | undefined,
+  currency: string,
+  defaultCurrency: string,
+): number | null {
+  const code = currency.toUpperCase()
+  const fromHash = hashEntry(amountsHash(preferences), code)
+  if (fromHash !== undefined && fromHash !== null && fromHash !== '') {
+    return toNumber(fromHash)
+  }
+
+  if (legacyCurrency(preferences, defaultCurrency) !== code) return null
+  return toNumber(preferences?.amount)
+}
+
+/**
+ * Writes one currency's amount the way the delivery-method editor does,
+ * without moving a price that belongs to another currency.
+ *
+ * The default-currency row owns the legacy `amount` + `currency` pair. When
+ * that pair still names a different currency (a pre-6.0 EUR price), the
+ * existing figure is copied into the `amounts` hash first so typing in the
+ * dollar row cannot overwrite the euro price.
+ */
+export function applyCurrencyAmount(
+  preferences: Record<string, unknown>,
+  currency: string,
+  raw: string,
+  defaultCurrency: string,
+): Record<string, unknown> {
+  const code = currency.toUpperCase()
+  const defaultCode = defaultCurrency.toUpperCase()
+  const parsed = raw === '' ? null : toNumber(raw)
+  const nextAmounts = { ...amountsHash(preferences) }
+  const namedCurrency = legacyCurrency(preferences, defaultCurrency)
+
+  if (namedCurrency !== code && namedCurrency !== defaultCode) {
+    const existing = amountForCurrency(preferences, namedCurrency, defaultCurrency)
+    if (existing !== null && hashEntry(nextAmounts, namedCurrency) === undefined) {
+      nextAmounts[namedCurrency] = existing
+    }
+  }
+
+  if (code === defaultCode) {
+    if (hashEntry(nextAmounts, code) !== undefined) {
+      if (parsed === null) {
+        delete nextAmounts[code]
+      } else {
+        nextAmounts[code] = parsed
+      }
+    }
+    return {
+      ...preferences,
+      amount: parsed,
+      currency: defaultCurrency,
+      amounts: nextAmounts,
+    }
+  }
+
+  if (parsed === null) {
+    delete nextAmounts[code]
+  } else {
+    nextAmounts[code] = parsed
+  }
+
+  if (namedCurrency === code) {
+    return { ...preferences, amount: parsed, amounts: nextAmounts }
+  }
+
+  return { ...preferences, amounts: nextAmounts }
+}
+
 /**
  * Every amount a calculator-priced method quotes, each with the currency it
  * belongs to. The per-currency `amounts` hash is the source of truth; the
@@ -31,26 +138,19 @@ export function listedAmounts(
   const seen = new Set<string>()
   const defaultCode = defaultCurrency.toUpperCase()
 
-  const amounts = preferences?.amounts
-  if (amounts && typeof amounts === 'object' && !Array.isArray(amounts)) {
-    for (const [code, value] of Object.entries(amounts as Record<string, unknown>)) {
-      const parsed = toNumber(value)
-      if (parsed === null) continue
-      const currency = code.toUpperCase()
-      listed.push({ amount: parsed, currency })
-      seen.add(currency)
-    }
+  for (const [code, value] of Object.entries(amountsHash(preferences))) {
+    const parsed = toNumber(value)
+    if (parsed === null) continue
+    const currency = code.toUpperCase()
+    listed.push({ amount: parsed, currency })
+    seen.add(currency)
   }
 
   const legacyAmount = toNumber(preferences?.amount)
   if (legacyAmount !== null) {
-    const rawCurrency =
-      typeof preferences?.currency === 'string' && preferences.currency.trim() !== ''
-        ? preferences.currency
-        : defaultCurrency
-    const legacyCurrency = rawCurrency.toUpperCase()
-    if (!seen.has(legacyCurrency)) {
-      listed.push({ amount: legacyAmount, currency: legacyCurrency })
+    const named = legacyCurrency(preferences, defaultCurrency)
+    if (!seen.has(named)) {
+      listed.push({ amount: legacyAmount, currency: named })
     }
   }
 

--- a/packages/dashboard/src/lib/delivery-method-summary.ts
+++ b/packages/dashboard/src/lib/delivery-method-summary.ts
@@ -7,6 +7,7 @@ function toNumber(value: unknown): number | null {
   return Number.isNaN(parsed) ? null : parsed
 }
 
+/** One stored delivery amount and the ISO currency it was entered in. */
 export type ListedAmount = {
   amount: number
   currency: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Linear [V-3549](https://linear.app/vendo/issue/V-3549): two display bugs on delivery methods priced outside the store default currency. The money the calculator quotes is unchanged.

There are two failure modes, not one. The wrong symbol is the visible half.

## What was wrong

On a store whose default currency is USD, with EUR also enabled:

| What the method holds | Edit sheet showed | Profile list showed |
| --- | --- | --- |
| `7`, currency EUR (the pre-6.0 single amount) | 7 in the Amount in USD row, EUR row empty | `$7.00` |
| `11` in the EUR row of the amounts table | 11 in the Amount in EUR row, and 0 in the USD row | **Free** |

The second row is the one the dashboard's own editor writes. The list read only the single `amount`, which is zero, so a method priced at 11 euros displayed as Free. A wrong symbol beside a real number is something an operator can spot. "Free" states that delivery costs nothing, and the help text under the amount rows says a blank currency is not offered this method, so the operator is told there is free dollar delivery that the calculator never actually offers.

The edit sheet also misplaced the pre-6.0 shape: the euro figure sat in the dollar row. Correcting what looks like a mistake would overwrite the euro price with a dollar one.

## What changed

- The profile list reads the per-currency `amounts` table, then the legacy single amount in the currency the method names — not the store default.
- The edit sheet uses the same reader, so a pre-6.0 euro price appears in the EUR row.
- Editing the dollar row on a pre-6.0 method copies the euro figure into the amounts table first, so it cannot be overwritten.

A method priced only in EUR or GBP now prints with that symbol (`€7.00`, `€11.00`, `£8.00`). Empty or zero-only methods still read as Free.

## How to verify

1. Use a store whose default currency is USD, with EUR (and optionally GBP) added.
2. Open Settings → Delivery profiles → the default shipping profile.
3. Confirm a method written the way the editor writes it (`11` in the EUR amounts row, single amount `0`) lists as `€11.00`, not Free. Open its sheet: 11 is in Amount in EUR, not in USD.
4. Confirm a pre-6.0 method (`amount` 7, `currency` EUR) lists as `€7.00`, not `$7.00`. Open its sheet: 7 is in Amount in EUR, and the USD row is empty.

Unit tests cover both shapes and the write-path guard in `delivery-method-summary.test.ts`.

## Walkthrough

[Profile list: EU Standard €11.00, EU Legacy €7.00, UK Standard £8.00](https://cursor.com/agents/bc-4fc50423-dc79-4965-a44d-072e24c81203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelivery_profile_list_both_shapes.webp)

[EU Standard sheet: 11 in the EUR row](https://cursor.com/agents/bc-4fc50423-dc79-4965-a44d-072e24c81203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelivery_method_sheet_editor_written_eur.webp)

[EU Legacy sheet: 7 in the EUR row, USD empty](https://cursor.com/agents/bc-4fc50423-dc79-4965-a44d-072e24c81203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelivery_method_sheet_legacy_eur.webp)

[delivery_profile_list_and_sheets.mp4](https://cursor.com/agents/bc-4fc50423-dc79-4965-a44d-072e24c81203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelivery_profile_list_and_sheets.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fc50423-dc79-4965-a44d-072e24c81203?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fc50423-dc79-4965-a44d-072e24c81203&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Delivery methods now display prices in the correct currency, including multiple currency amounts.
  - Free delivery is clearly labeled when no charge applies.
  - Multiple listed prices use localized formatting and clear separators.
  - Currency-specific delivery prices can be edited while preserving amounts in other currencies.

- **Bug Fixes**
  - Improved handling of legacy, blank, and zero-valued price entries.
  - Price displays and edits now consistently reflect each amount’s associated currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->