### PR TITLE
Add currency preference to TieredFlatRate calculator

### DIFF
--- a/spree/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/spree/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -3,6 +3,7 @@ require_dependency 'spree/calculator'
 module Spree
   class Calculator::TieredFlatRate < Calculator
     preference :base_amount, :decimal, default: 0
+    preference :currency, :string, default: -> { Spree::Store.default.default_currency }
     preference :tiers, :hash, default: {}
 
     before_validation do
@@ -18,7 +19,9 @@ module Spree
       Spree.t(:tiered_flat_rate)
     end
 
-    def compute(object)
+    def compute(object = nil)
+      return 0 unless object && preferred_currency.casecmp(object.currency.upcase).zero?
+
       base, amount = preferred_tiers.sort.reverse.detect { |b, _| object.amount >= b }
       amount || preferred_base_amount
     end

--- a/spree/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/spree/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -20,7 +20,8 @@ module Spree
     end
 
     def compute(object = nil)
-      return 0 unless object && preferred_currency.casecmp(object.currency.upcase).zero?
+      return 0 unless object&.currency.present?
+      return 0 unless preferred_currency.casecmp(object.currency.upcase).zero?
 
       base, amount = preferred_tiers.sort.reverse.detect { |b, _| object.amount >= b }
       amount || preferred_base_amount

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
         zipcode: Zip Code
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Base Amount
+        preferred_currency: Currency
         preferred_tiers: Tiers
       spree/calculator/tiered_percent:
         preferred_base_percent: Base Percent

--- a/spree/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
+++ b/spree/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
@@ -66,6 +66,14 @@ describe Spree::Calculator::TieredFlatRate, type: :model do
       it { is_expected.to eq 0 }
     end
 
+    context 'when object currency is nil' do
+      before do
+        allow(line_item).to receive_messages(amount: 150, currency: nil)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
     context 'when there is no object' do
       subject { calculator.compute }
 

--- a/spree/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
+++ b/spree/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
@@ -28,10 +28,12 @@ describe Spree::Calculator::TieredFlatRate, type: :model do
 
     before do
       calculator.preferred_base_amount = 10
+      calculator.preferred_currency = 'USD'
       calculator.preferred_tiers = {
         100 => 15,
         200 => 20
       }
+      allow(line_item).to receive_messages(currency: 'USD')
     end
 
     context 'when amount falls within the first tier' do
@@ -44,6 +46,30 @@ describe Spree::Calculator::TieredFlatRate, type: :model do
       before { allow(line_item).to receive_messages(amount: 150) }
 
       it { is_expected.to eq 15 }
+    end
+
+    context 'when currency does not match' do
+      before do
+        calculator.preferred_currency = 'GBP'
+        allow(line_item).to receive_messages(amount: 150)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
+    context 'when currency is blank' do
+      before do
+        calculator.preferred_currency = ''
+        allow(line_item).to receive_messages(amount: 150)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+
+    context 'when there is no object' do
+      subject { calculator.compute }
+
+      it { is_expected.to eq 0 }
     end
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes V-3578

The Tiered Flat Rate promotion calculator had no `currency` preference, unlike other money-based calculators (`FlatRate`, `FlexiRate`). In a multi-currency store, its base amount and tier values were ambiguous and the admin dashboard had no currency selector to configure.

## Changes

- Add `preference :currency` to `Spree::Calculator::TieredFlatRate`, defaulting to the store's default currency (matching `FlatRate` and `FlexiRate`)
- Honor the currency in `#compute` — return `0` when the order/cart currency does not match, consistent with `FlatRate`
- Add locale label for `preferred_currency`
- Extend model specs for currency mismatch, blank currency, and nil object cases

## Testing

- `bundle exec rspec spec/models/spree/calculator/tiered_flat_rate_spec.rb` — 7 examples, 0 failures
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3578](https://linear.app/vendo/issue/V-3578/bug-whole-order-tiered-flat-rate-has-no-currency-setting)

<div><a href="https://cursor.com/agents/bc-c2b2547b-484c-48e5-a675-b89349494a96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2b2547b-484c-48e5-a675-b89349494a96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tiered flat-rate calculations now support a preferred currency, defaulting to the store’s currency.
  - Calculations return zero when no item is provided, the item has no currency, or its currency does not match the preferred currency, regardless of letter case.

- **Improvements**
  - Added the “Currency” label for the preferred-currency setting in the English interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->