### PR TITLE
Fix back navigation after create across dashboard and seller panel

### DIFF
--- a/packages/dashboard/e2e/categories.spec.ts
+++ b/packages/dashboard/e2e/categories.spec.ts
@@ -20,16 +20,14 @@ async function createCategory(page: Page, name: string) {
   await page.locator('#category-name').fill(name)
   await page.getByRole('button', { name: /^save$/i }).click()
 
-  // On success the create route navigates to the edit page; go back to the
-  // tree and confirm the row landed.
-  await page.goto(CATEGORIES_PATH((await currentStoreId(page)) ?? ''))
+  // Create replaces the new-form route in history; back lands on the tree.
+  await expect(page.locator('#category-name')).toHaveValue(name, { timeout: 15_000 })
+  await page.getByRole('button', { name: /^back$/i }).click()
+  await expect(page).toHaveURL(/\/products\/categories(?:\?|$)/, { timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: /^categories$/i })).toBeVisible({
+    timeout: 15_000,
+  })
   await expect(treeRow(page, name)).toBeVisible({ timeout: 15_000 })
-}
-
-// The store id is in the URL; read it so we can navigate back to the index.
-async function currentStoreId(page: Page): Promise<string | null> {
-  const match = page.url().match(/\/([^/]+)\/products\/categories/)
-  return match?.[1] ?? null
 }
 
 test.describe('categories management', () => {

--- a/packages/dashboard/e2e/categories.spec.ts
+++ b/packages/dashboard/e2e/categories.spec.ts
@@ -24,9 +24,9 @@ async function createCategory(page: Page, name: string) {
   await expect(page.locator('#category-name')).toHaveValue(name, { timeout: 15_000 })
   await page.getByRole('button', { name: /^back$/i }).click()
   await expect(page).toHaveURL(/\/products\/categories(?:\?|$)/, { timeout: 15_000 })
-  await expect(page.getByRole('heading', { name: /^categories$/i })).toBeVisible({
-    timeout: 15_000,
-  })
+  // List page title is a CardTitle (not a heading role); the CTA proves we're on the tree.
+  await expect(page.getByRole('button', { name: CTA })).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: CTA })).toHaveCount(0)
   await expect(treeRow(page, name)).toBeVisible({ timeout: 15_000 })
 }
 

--- a/packages/dashboard/e2e/promotions.spec.ts
+++ b/packages/dashboard/e2e/promotions.spec.ts
@@ -96,6 +96,15 @@ test.describe('promotions', () => {
     await cancelEditor(page)
 
     await submitCreate(page, name)
+
+    // Creating replaces the new-form route in history; back goes to the list,
+    // not the stale create form (which would duplicate on re-save).
+    await page.getByRole('button', { name: /^back$/i }).click()
+    await expect(page).toHaveURL(new RegExp(`/${creds.store_id}/promotions(?:\\?|$)`), {
+      timeout: 15_000,
+    })
+    await expect(page.getByRole('heading', { name: /^new promotion$/i })).toHaveCount(0)
+    await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
   })
 
   test('removes a rule and an action while editing', async ({ page }) => {

--- a/packages/dashboard/e2e/sellers.spec.ts
+++ b/packages/dashboard/e2e/sellers.spec.ts
@@ -34,6 +34,24 @@ test.describe('sellers', () => {
     await gotoIndex(page, SELLERS_PATH(creds.store_id), CTA)
   })
 
+  test('back from a new seller lands on the list', async ({ page }) => {
+    const creds = await login(page)
+    await gotoIndex(page, SELLERS_PATH(creds.store_id), CTA)
+
+    const name = `E2E Back Seller ${Date.now()}`
+    await page.getByRole('button', { name: CTA }).click()
+    await page.locator('#name').fill(name)
+    await page.getByRole('button', { name: /create seller/i }).click()
+    await expect(page.getByRole('heading', { name })).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole('button', { name: /^back$/i }).click()
+    await expect(page).toHaveURL(new RegExp(`/${creds.store_id}/sellers(?:\\?|$)`), {
+      timeout: 15_000,
+    })
+    await expect(page.getByRole('heading', { name: /new seller/i })).toHaveCount(0)
+    await expect(rowLink(page, name)).toBeVisible({ timeout: 15_000 })
+  })
+
   // The page is a profile you read, not a form you land in.
   test('shows the profile without dropping into an edit form', async ({ page }) => {
     const creds = await login(page)

--- a/packages/dashboard/src/routes/_authenticated/$storeId/companies/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/companies/index.tsx
@@ -66,6 +66,7 @@ function CompaniesPage() {
 
   const closeSheet = () =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) => {
         const { new: _n, ...rest } = prev
         return rest as never

--- a/packages/dashboard/src/routes/_authenticated/$storeId/companies/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/companies/index.tsx
@@ -152,6 +152,7 @@ function CreateCompanySheet({
       navigate({
         to: '/$storeId/companies/$companyId',
         params: { storeId, companyId: company.id },
+        replace: true,
       })
     } catch (err) {
       if (!mapSpreeErrorsToForm(err, form.setError)) throw err

--- a/packages/dashboard/src/routes/_authenticated/$storeId/customers/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/customers/index.tsx
@@ -393,6 +393,7 @@ function NewCustomerSheet({
       navigate({
         to: '/$storeId/customers/$customerId',
         params: { storeId, customerId: customer.id },
+        replace: true,
       })
     },
   })

--- a/packages/dashboard/src/routes/_authenticated/$storeId/orders/new.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/orders/new.tsx
@@ -114,7 +114,13 @@ function NewOrderPage() {
       return adminClient.orders.create(payload)
     },
     onSuccess: (order) => {
-      navigate({ to: '/$storeId/orders/$orderId', params: { storeId, orderId: order.id } })
+      // Replace history rather than pushing — otherwise back lands on the
+      // (now-stale) new order form.
+      navigate({
+        to: '/$storeId/orders/$orderId',
+        params: { storeId, orderId: order.id },
+        replace: true,
+      })
     },
   })
 

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/categories/new.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/categories/new.tsx
@@ -53,9 +53,12 @@ function NewCategoryPage() {
       })
       form.reset(values)
       // Land on the edit page so images + products can be managed next.
+      // Replace history rather than pushing — otherwise back lands on the
+      // (now-stale) new category form.
       await navigate({
         to: '/$storeId/products/categories/$categoryId',
         params: { storeId, categoryId: created.id },
+        replace: true,
       })
     } catch (err) {
       if (mapSpreeErrorsToForm(err, form.setError)) return

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/collections/new.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/collections/new.tsx
@@ -53,9 +53,12 @@ function NewCollectionPage() {
       })
       form.reset(values)
       // Land on the edit page so images + products can be managed next.
+      // Replace history rather than pushing — otherwise back lands on the
+      // (now-stale) new collection form.
       await navigate({
         to: '/$storeId/products/collections/$collectionId',
         params: { storeId, collectionId: created.id },
+        replace: true,
       })
     } catch (err) {
       if (mapSpreeErrorsToForm(err, form.setError)) return

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/price-lists/new.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/price-lists/new.tsx
@@ -16,9 +16,12 @@ function NewPriceListPage() {
       mode="create"
       onSubmit={async (payload) => {
         const list = await create.mutateAsync(payload)
+        // Replace history rather than pushing — otherwise the detail page's
+        // back button lands the merchant on the (now-stale) new form.
         navigate({
           to: '/$storeId/products/price-lists/$priceListId',
           params: { storeId, priceListId: list.id },
+          replace: true,
         })
       }}
     />

--- a/packages/dashboard/src/routes/_authenticated/$storeId/promotions/new.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/promotions/new.tsx
@@ -16,9 +16,12 @@ function NewPromotionPage() {
       mode="create"
       onSubmit={async (payload) => {
         const promotion = await createMutation.mutateAsync(payload)
+        // Replace history rather than pushing — otherwise the detail page's
+        // back button lands the merchant on the (now-stale) new promotion form.
         navigate({
           to: '/$storeId/promotions/$promotionId',
           params: { storeId, promotionId: promotion.id },
+          replace: true,
         })
       }}
     />

--- a/packages/dashboard/src/routes/_authenticated/$storeId/sellers/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/sellers/index.tsx
@@ -153,6 +153,7 @@ function CreateSellerSheet({
       navigate({
         to: '/$storeId/sellers/$sellerId',
         params: { storeId, sellerId: seller.id },
+        replace: true,
       })
     } catch (err) {
       if (!mapSpreeErrorsToForm(err, form.setError)) throw err

--- a/packages/dashboard/src/routes/_authenticated/$storeId/sellers/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/sellers/index.tsx
@@ -62,6 +62,7 @@ function SellersPage() {
 
   const closeSheet = () =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) => {
         const { new: _n, ...rest } = prev
         return rest as never

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/index.tsx
@@ -176,6 +176,7 @@ function CreateProfileDialog({ onClose }: { onClose: () => void }) {
       navigate({
         to: '/$storeId/settings/delivery-profiles/$profileId',
         params: { storeId, profileId: profile.id },
+        replace: true,
       })
     } catch (err) {
       if (!mapSpreeErrorsToForm(err, form.setError)) throw err

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/index.tsx
@@ -75,6 +75,7 @@ function ShippingPage() {
 
   const closeDialog = () =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) => {
         const { new: _n, ...rest } = prev
         return rest as never

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/webhooks/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/webhooks/index.tsx
@@ -217,6 +217,7 @@ function WebhooksPage() {
             navigate({
               to: '/$storeId/settings/webhooks/$webhookEndpointId',
               params: { storeId, webhookEndpointId: id },
+              replace: true,
             })
           }
         }}

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/webhooks/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/webhooks/index.tsx
@@ -85,6 +85,7 @@ function WebhooksPage() {
 
   const closeCreate = () =>
     navigate({
+      replace: true,
       search: (prev: Record<string, unknown>) => {
         const { new: _n, ...rest } = prev
         return rest as never

--- a/packages/seller-dashboard/src/pages/product.tsx
+++ b/packages/seller-dashboard/src/pages/product.tsx
@@ -141,9 +141,12 @@ export function ProductPage({ mode }: { mode: 'new' | 'edit' }) {
       void queryClient.invalidateQueries({ queryKey: ['seller', sellerId, 'product', saved.id] })
       toastManager.add({ type: 'success', title: t('products.saved') })
       if (!productId) {
+        // Replace history rather than pushing — otherwise back lands on the
+        // (now-stale) new product form.
         navigate({
           to: '/$sellerId/products/$productId',
           params: { sellerId, productId: saved.id },
+          replace: true,
         })
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After creating a record, the app navigates from a create form (or create sheet) to the new record's detail page. Without `replace: true`, browser history keeps the create step, so the back button returns to a stale form — which can lead to accidental duplicate creates.

This applies the same fix already used on **New product** and **New promotion** everywhere else we found the pattern.

## Changes

### Admin dashboard — full-page `/new` routes
- Price lists, categories, collections, orders

### Admin dashboard — list sheet/dialog → detail
- Companies, sellers, customers
- Webhooks (after secret reveal → detail)
- Delivery profiles

### Seller panel
- New product → product detail

### Tests
- Categories E2E: create flow now verifies back lands on the tree (not `/new`)
- Sellers E2E: new test for back from a newly created seller profile

## Already correct (no change)
- Products, promotions (fixed earlier)
- Delivery method create (redirects with replace)
- Catalog wizard (dialog on same page — no `/new` in history)
- Settings pages that create in-place via `?edit=` sheets (no separate detail route)

## Linear
Fixes V-3579
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3579](https://linear.app/vendo/issue/V-3579/bug-back-arrow-after-creating-a-promotion-returns-to-the-new-promotion)

<div><a href="https://cursor.com/agents/bc-b0372fde-4007-4d7d-bb8f-761ec6ca9cca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0372fde-4007-4d7d-bb8f-761ec6ca9cca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Browser back navigation after creating promotions, categories, sellers, companies, customers, orders, products, collections, price lists, delivery profiles, or webhooks now returns to the relevant list or detail view instead of reopening a completed form.
  - Newly created items remain visible in their respective lists when navigating back.
  - Closing creation dialogs and sheets no longer adds unnecessary history entries.
  - Category navigation now correctly returns to the categories tree after saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->