### PR TITLE
Fix Create Line Items promotion action editor in dashboard

### DIFF
--- a/packages/dashboard/e2e/promotions.spec.ts
+++ b/packages/dashboard/e2e/promotions.spec.ts
@@ -332,6 +332,26 @@ test.describe('promotions', () => {
     await submitCreate(page, name)
   })
 
+  test('creates a promotion with a Create Line Items action', async ({ page }) => {
+    const creds = await login(page)
+    await gotoIndex(page, PROMOTIONS_PATH(creds.store_id), CTA)
+
+    const name = `E2E Line Items Promo ${Date.now()}`
+    await startNewPromotion(page, creds.store_id, name)
+
+    await pickAction(page, /^create line items$/i)
+    await expect(page.getByRole('heading', { name: /^create line items$/i })).toBeVisible({
+      timeout: 5_000,
+    })
+
+    await pickAutocompleteOption(page, /search variants by name or sku/i, FIXTURE_PROMO_PRODUCT)
+    await saveEditor(page)
+
+    await expect(page.getByText(/1 variants/i).first()).toBeVisible({ timeout: 5_000 })
+
+    await submitCreate(page, name)
+  })
+
   test('deletes a promotion', async ({ page }) => {
     const creds = await login(page)
     await gotoIndex(page, PROMOTIONS_PATH(creds.store_id), CTA)

--- a/packages/dashboard/src/components/spree/promotion-editors/action-create-line-items.tsx
+++ b/packages/dashboard/src/components/spree/promotion-editors/action-create-line-items.tsx
@@ -1,0 +1,212 @@
+import type { Variant } from '@spree/admin-sdk'
+import { adminClient, formatPrice, ResourceCombobox } from '@spree/dashboard-core'
+import {
+  Button,
+  Field,
+  FieldGroup,
+  FieldLabel,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@spree/dashboard-ui'
+import { TrashIcon } from '@spree/dashboard-ui/icons'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { EditorShell } from './editor-shell'
+import type { PromotionActionEditorContext, PromotionActionLineItemParams } from './types'
+
+interface LineItemDraft extends PromotionActionLineItemParams {
+  variant?: Variant
+}
+
+export function CreateLineItemsActionEditor({
+  draft,
+  onSave,
+  onClose,
+}: PromotionActionEditorContext) {
+  const { t } = useTranslation()
+  const initialIds = useMemo(
+    () => (draft.line_items ?? []).map((row) => row.variant_id),
+    [draft.line_items],
+  )
+  const variantById = useRef(new Map<string, Variant>())
+
+  const { data: loadedVariants = [], isLoading: variantsLoading } = useQuery({
+    queryKey: ['promotion-create-line-items-variants', initialIds],
+    queryFn: async () => {
+      const variants = await Promise.all(
+        initialIds.map(async (id) => {
+          try {
+            return await adminClient.variants.get(id)
+          } catch {
+            return null
+          }
+        }),
+      )
+      for (const variant of variants) {
+        if (variant) variantById.current.set(variant.id, variant)
+      }
+      return variants.filter(Boolean) as Variant[]
+    },
+    enabled: initialIds.length > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+  })
+
+  const [lineItems, setLineItems] = useState<LineItemDraft[]>(() =>
+    (draft.line_items ?? []).map((row) => ({
+      variant_id: row.variant_id,
+      quantity: row.quantity,
+    })),
+  )
+
+  const resolvedLineItems = useMemo(
+    () =>
+      lineItems.map((row) => ({
+        ...row,
+        variant:
+          row.variant ??
+          variantById.current.get(row.variant_id) ??
+          loadedVariants.find((variant) => variant.id === row.variant_id),
+      })),
+    [lineItems, loadedVariants],
+  )
+
+  function addVariant(variant: Variant) {
+    setLineItems((current) => {
+      const existing = current.find((row) => row.variant_id === variant.id)
+      if (existing) {
+        return current.map((row) =>
+          row.variant_id === variant.id ? { ...row, quantity: row.quantity + 1, variant } : row,
+        )
+      }
+      variantById.current.set(variant.id, variant)
+      return [...current, { variant_id: variant.id, quantity: 1, variant }]
+    })
+  }
+
+  function updateQuantity(variantId: string, quantity: number) {
+    const nextQuantity = Number.isFinite(quantity) && quantity > 0 ? Math.floor(quantity) : 1
+    setLineItems((current) =>
+      current.map((row) =>
+        row.variant_id === variantId ? { ...row, quantity: nextQuantity } : row,
+      ),
+    )
+  }
+
+  function removeVariant(variantId: string) {
+    setLineItems((current) => current.filter((row) => row.variant_id !== variantId))
+  }
+
+  function handleSave() {
+    onSave({
+      ...draft,
+      line_items: lineItems.map(({ variant_id, quantity }) => ({ variant_id, quantity })),
+    })
+    onClose()
+  }
+
+  return (
+    <EditorShell
+      onSave={handleSave}
+      onCancel={onClose}
+      pending={variantsLoading}
+      saveDisabled={lineItems.length === 0}
+    >
+      <p className="text-sm text-muted-foreground">
+        {t('admin.components.create_line_items_action_editor.description')}
+      </p>
+
+      {resolvedLineItems.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t('admin.components.create_line_items_action_editor.empty')}
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table roundedBottom>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('admin.orders.new.items_table.variant')}</TableHead>
+                <TableHead>{t('admin.orders.new.items_table.sku')}</TableHead>
+                <TableHead className="text-right">{t('admin.fields.quantity.label')}</TableHead>
+                <TableHead className="w-10" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {resolvedLineItems.map((row) => (
+                <TableRow key={row.variant_id}>
+                  <TableCell className="font-medium">
+                    {row.variant?.product_name ?? row.variant?.sku ?? row.variant_id}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{row.variant?.sku ?? '—'}</TableCell>
+                  <TableCell className="text-right">
+                    <Input
+                      type="number"
+                      min={1}
+                      value={row.quantity}
+                      onChange={(event) =>
+                        updateQuantity(row.variant_id, Number(event.target.value))
+                      }
+                      className="ml-auto w-20 text-right"
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      onClick={() => removeVariant(row.variant_id)}
+                    >
+                      <TrashIcon className="size-4" />
+                      <span className="sr-only">{t('admin.actions.remove')}</span>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <FieldGroup>
+        <Field>
+          <FieldLabel>
+            {t('admin.components.create_line_items_action_editor.variant_label')}
+          </FieldLabel>
+          <ResourceCombobox<Variant>
+            queryKey="promotion-create-line-items-variant-picker"
+            value=""
+            onChange={(id) => {
+              const variant = id ? variantById.current.get(id) : undefined
+              if (variant) addVariant(variant)
+            }}
+            search={async (query) => {
+              const res = await adminClient.variants.list({ search: query, limit: 8 })
+              for (const variant of res.data) variantById.current.set(variant.id, variant)
+              return res
+            }}
+            hydrate={async () => ({ data: [] })}
+            getOptionLabel={(variant) => variant.product_name ?? variant.sku ?? variant.id}
+            renderOption={(variant) => (
+              <div className="flex flex-col">
+                <span className="font-medium">
+                  {variant.product_name ?? variant.sku ?? variant.id}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {variant.options_text && <span>{variant.options_text} · </span>}
+                  {t('admin.orders.detail.variant_search.sku_prefix')}: {variant.sku || '—'} ·{' '}
+                  {formatPrice(variant.price)}
+                </span>
+              </div>
+            )}
+            placeholder={t('admin.components.create_line_items_action_editor.search_placeholder')}
+          />
+        </Field>
+      </FieldGroup>
+    </EditorShell>
+  )
+}

--- a/packages/dashboard/src/components/spree/promotion-editors/register.ts
+++ b/packages/dashboard/src/components/spree/promotion-editors/register.ts
@@ -1,5 +1,6 @@
 import { registerSlot } from '@spree/dashboard-core'
 import { AdjustmentActionEditor } from './action-adjustment'
+import { CreateLineItemsActionEditor } from './action-create-line-items'
 import { CategoryRuleEditor } from './rule-category'
 import { ChannelRuleEditor } from './rule-channel'
 import { CountryRuleEditor } from './rule-country'
@@ -67,4 +68,9 @@ registerSlot(actionFormSlot('create_adjustment'), {
 registerSlot(actionFormSlot('create_item_adjustments'), {
   id: 'builtin',
   component: AdjustmentActionEditor,
+})
+
+registerSlot(actionFormSlot('create_line_items'), {
+  id: 'builtin',
+  component: CreateLineItemsActionEditor,
 })

--- a/packages/dashboard/src/locales/ar.json
+++ b/packages/dashboard/src/locales/ar.json
@@ -580,6 +580,12 @@
         "select_calculator": "اختر آلة حاسبة",
         "settings_label": "إعدادات الآلة الحاسبة"
       },
+      "create_line_items_action_editor": {
+        "description": "عند تأهل العرض الترويجي، تُضاف هذه العناصر إلى السلة.",
+        "empty": "لا توجد متغيرات بعد. ابحث أدناه لإضافة واحد.",
+        "search_placeholder": "ابحث عن المتغيرات بالاسم أو SKU…",
+        "variant_label": "إضافة متغير"
+      },
       "custom_fields": {
         "default_resource": "السجلات",
         "empty_description": "تتبّع تفاصيل منظمة مثل الخامة أو المقاس أو تعليمات العناية.",

--- a/packages/dashboard/src/locales/de.json
+++ b/packages/dashboard/src/locales/de.json
@@ -573,6 +573,12 @@
         "select_calculator": "Kalkulator auswählen",
         "settings_label": "Kalkulator-Einstellungen"
       },
+      "create_line_items_action_editor": {
+        "description": "Wenn die Promotion greift, werden diese Artikel dem Warenkorb hinzugefügt.",
+        "empty": "Noch keine Varianten. Suchen Sie unten, um eine hinzuzufügen.",
+        "search_placeholder": "Varianten nach Name oder SKU suchen…",
+        "variant_label": "Variante hinzufügen"
+      },
       "custom_fields": {
         "default_resource": "Datensätzen",
         "empty_description": "Erfassen Sie strukturierte Details wie Material, Passform oder Pflegehinweise.",

--- a/packages/dashboard/src/locales/en.json
+++ b/packages/dashboard/src/locales/en.json
@@ -573,6 +573,12 @@
         "select_calculator": "Select a calculator",
         "settings_label": "Calculator settings"
       },
+      "create_line_items_action_editor": {
+        "description": "When the promotion qualifies, these items are added to the cart.",
+        "empty": "No variants yet. Search below to add one.",
+        "search_placeholder": "Search variants by name or SKU…",
+        "variant_label": "Add variant"
+      },
       "custom_fields": {
         "default_resource": "records",
         "empty_description": "Track structured details like material, fit, or care instructions.",

--- a/packages/dashboard/src/locales/fr.json
+++ b/packages/dashboard/src/locales/fr.json
@@ -573,6 +573,12 @@
         "select_calculator": "Sélectionner un calculateur",
         "settings_label": "Paramètres du calculateur"
       },
+      "create_line_items_action_editor": {
+        "description": "Lorsque la promotion est éligible, ces articles sont ajoutés au panier.",
+        "empty": "Aucune variante pour l'instant. Recherchez ci-dessous pour en ajouter une.",
+        "search_placeholder": "Rechercher des variantes par nom ou SKU…",
+        "variant_label": "Ajouter une variante"
+      },
       "custom_fields": {
         "default_resource": "enregistrements",
         "empty_description": "Suivez des détails structurés comme la matière, la coupe ou les instructions d’entretien.",

--- a/packages/dashboard/src/locales/pl.json
+++ b/packages/dashboard/src/locales/pl.json
@@ -579,6 +579,12 @@
         "select_calculator": "Wybierz kalkulator",
         "settings_label": "Ustawienia kalkulatora"
       },
+      "create_line_items_action_editor": {
+        "description": "Gdy promocja kwalifikuje się, te pozycje są dodawane do koszyka.",
+        "empty": "Brak wariantów. Wyszukaj poniżej, aby dodać.",
+        "search_placeholder": "Szukaj wariantów po nazwie lub SKU…",
+        "variant_label": "Dodaj wariant"
+      },
       "custom_fields": {
         "default_resource": "rekordy",
         "empty_description": "Śledź ustrukturyzowane szczegóły, takie jak materiał, krój czy instrukcje pielęgnacji.",

--- a/packages/dashboard/src/locales/zh-CN.json
+++ b/packages/dashboard/src/locales/zh-CN.json
@@ -571,6 +571,12 @@
         "select_calculator": "选择一个计算器",
         "settings_label": "计算器设置"
       },
+      "create_line_items_action_editor": {
+        "description": "当促销符合条件时，这些商品会加入购物车。",
+        "empty": "尚无变体。请在下方搜索以添加。",
+        "search_placeholder": "按名称或 SKU 搜索变体…",
+        "variant_label": "添加变体"
+      },
       "custom_fields": {
         "default_resource": "记录",
         "empty_description": "记录结构化的详细信息，例如材质、版型或保养说明。",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [V-3576](https://linear.app/spree/issue/V-3576): the **Create line items** promotion action could be added in the dashboard but showed "This action has no configurable options," so merchants could not pick a variant or quantity.

## Cause

Only `create_adjustment` and `create_item_adjustments` had custom action editors registered. Unregistered types fell through to the preferences-only default editor, but `CreateLineItems` stores configuration on the `line_items` association (`variant_id`, `quantity`), not preferences.

## Fix

- Register `CreateLineItemsActionEditor` for `create_line_items`
- Variant search picker + quantity table, writing `line_items: [{ variant_id, quantity }]` as the Admin API already expects
- E2E coverage for the full add-action → pick variant → save flow

## Verification

- Playwright: `creates a promotion with a Create Line Items action` passes
- Manual dashboard test: variant picker, quantity field, and "1 variants" summary all work

[Create line items editor with variant picker](https://cursor.com/agents/bc-7f8862f9-38a0-4a72-a235-4171aadb4543/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate-line-items-editor-variant-picker.webp)

[Saved action showing variant count](https://cursor.com/agents/bc-7f8862f9-38a0-4a72-a235-4171aadb4543/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate-line-items-action-summary.webp)

[create-line-items-promotion-editor-demo.mp4](https://cursor.com/agents/bc-7f8862f9-38a0-4a72-a235-4171aadb4543/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate-line-items-promotion-editor-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3576](https://linear.app/vendo/issue/V-3576/bug-create-line-items-promotion-action-cannot-be-configured-in-the)

<div><a href="https://cursor.com/agents/bc-7f8862f9-38a0-4a72-a235-4171aadb4543?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f8862f9-38a0-4a72-a235-4171aadb4543&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a promotion action editor for automatically creating line items.
  * Select product variants, adjust quantities, remove items, and search available variants.
  * Display selected variant details and a summary of configured variants.
  * Added translations for the editor in Arabic, German, English, French, Polish, and Simplified Chinese.

* **Tests**
  * Added end-to-end coverage for configuring and submitting a promotion with the new action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->