### PR TITLE
Fix price refusal error codes on admin order line items (V-3559)

### DIFF
--- a/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
@@ -47,6 +47,8 @@ module Spree
           variant_not_found: 'variant_not_found',
           insufficient_stock: 'insufficient_stock',
           invalid_quantity: 'invalid_quantity',
+          invalid_price: 'invalid_price',
+          price_override_not_allowed: 'price_override_not_allowed',
 
           # Validation errors
           validation_error: 'validation_error',
@@ -125,6 +127,20 @@ module Spree
             status: :unprocessable_content,
             details: details
           )
+        end
+
+        # Maps symbolic line-item rejections onto the API error-code vocabulary.
+        # Callers pass a default for failures that carry no recognized symbol
+        # (stock, availability strings, and so on).
+        def infer_line_item_error_code(errors, default:)
+          return default unless errors.is_a?(ActiveModel::Errors)
+
+          base_symbols = (errors.details[:base] || []).pluck(:error)
+          return ERROR_CODES[:price_override_not_allowed] if base_symbols.include?(:price_override_not_allowed)
+          return ERROR_CODES[:invalid_price] if base_symbols.include?(:invalid_price)
+          return ERROR_CODES[:invalid_quantity] if base_symbols.include?(:quantity_rule_violated)
+
+          default
         end
 
         # Convenience method for service result errors

--- a/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
+++ b/spree/api/app/controllers/concerns/spree/api/v3/error_handler.rb
@@ -130,8 +130,10 @@ module Spree
         end
 
         # Maps symbolic line-item rejections onto the API error-code vocabulary.
-        # Callers pass a default for failures that carry no recognized symbol
-        # (stock, availability strings, and so on).
+        #
+        # @param errors [ActiveModel::Errors, Object] structured rejection from a workflow
+        # @param default [String] fallback when no recognized symbol is present
+        # @return [String] a value from {ERROR_CODES}
         def infer_line_item_error_code(errors, default:)
           return default unless errors.is_a?(ActiveModel::Errors)
 

--- a/spree/api/app/controllers/spree/api/v3/admin/orders/items_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders/items_controller.rb
@@ -18,7 +18,7 @@ module Spree
                 if result.success?
                   render json: serialize_resource(result.value), status: :created
                 else
-                  render_service_error(result.error, code: ERROR_CODES[:insufficient_stock])
+                  render_order_item_error(result, default_code: ERROR_CODES[:insufficient_stock])
                 end
               end
             end
@@ -37,7 +37,7 @@ module Spree
                 if result.success?
                   render json: serialize_resource(@resource.reload)
                 else
-                  render_service_error(result.error, code: ERROR_CODES[:invalid_quantity])
+                  render_order_item_error(result, default_code: ERROR_CODES[:invalid_quantity])
                 end
               end
             end
@@ -87,6 +87,14 @@ module Spree
 
             def variant
               @variant ||= current_store.variants.find_by_prefix_id!(permitted_params[:variant_id])
+            end
+
+            def render_order_item_error(result, default_code:)
+              error = result.error
+              errors = error.respond_to?(:value) ? error.value : error
+              code = infer_line_item_error_code(errors, default: default_code)
+
+              render_service_error(error, code: code)
             end
           end
         end

--- a/spree/api/app/controllers/spree/api/v3/admin/orders/items_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders/items_controller.rb
@@ -89,6 +89,10 @@ module Spree
               @variant ||= current_store.variants.find_by_prefix_id!(permitted_params[:variant_id])
             end
 
+            # Renders a failed add/update with a code inferred from symbolic errors.
+            #
+            # @param result [Spree::ServiceModule::Result] failed service outcome
+            # @param default_code [String] fallback when the error carries no symbol
             def render_order_item_error(result, default_code:)
               error = result.error
               errors = error.respond_to?(:value) ? error.value : error

--- a/spree/api/spec/controllers/spree/api/v3/admin/orders/items_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/orders/items_controller_spec.rb
@@ -97,6 +97,34 @@ RSpec.describe Spree::Api::V3::Admin::Orders::ItemsController, type: :controller
       expect(line_item.price_source).to eq('manual')
       expect(json_response['price_source']).to eq('manual')
     end
+
+    context 'with an unusable price' do
+      subject do
+        post :create, params: { order_id: order.prefixed_id, variant_id: variant.prefixed_id, quantity: 1, price: 'NaN' }, as: :json
+      end
+
+      it 'refuses with the invalid_price code' do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq('invalid_price')
+      end
+    end
+
+    context 'with a price on a placed order' do
+      before { order.update_columns(status: 'placed', completed_at: Time.current) }
+
+      subject do
+        post :create, params: { order_id: order.prefixed_id, variant_id: variant.prefixed_id, quantity: 1, price: '7.20' }, as: :json
+      end
+
+      it 'refuses with the price_override_not_allowed code' do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq('price_override_not_allowed')
+      end
+    end
   end
 
   describe 'PATCH #update' do
@@ -159,12 +187,12 @@ RSpec.describe Spree::Api::V3::Admin::Orders::ItemsController, type: :controller
         subject
 
         expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq('price_override_not_allowed')
         expect(response.body).to include('placed order')
         expect(line_item.reload.price_source).to be_nil
       end
     end
 
-    # A 422 whose message is blank leaves the dashboard with nothing to show.
     context 'with an unusable price' do
       subject { patch :update, params: { order_id: order.prefixed_id, id: line_item.prefixed_id, price: 'NaN' }, as: :json }
 
@@ -172,8 +200,20 @@ RSpec.describe Spree::Api::V3::Admin::Orders::ItemsController, type: :controller
         subject
 
         expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq('invalid_price')
         expect(response.body).to include('non-negative number')
         expect(line_item.reload.price_source).to be_nil
+      end
+    end
+
+    context 'with a negative price' do
+      subject { patch :update, params: { order_id: order.prefixed_id, id: line_item.prefixed_id, price: '-1' }, as: :json }
+
+      it 'refuses with the invalid_price code' do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['code']).to eq('invalid_price')
       end
     end
   end

--- a/spree/api/spec/controllers/spree/api/v3/admin/orders/items_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/orders/items_controller_spec.rb
@@ -124,6 +124,19 @@ RSpec.describe Spree::Api::V3::Admin::Orders::ItemsController, type: :controller
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_response['error']['code']).to eq('price_override_not_allowed')
       end
+
+      context 'with a non-numeric price' do
+        subject do
+          post :create, params: { order_id: order.prefixed_id, variant_id: variant.prefixed_id, quantity: 1, price: 'NaN' }, as: :json
+        end
+
+        it 'still refuses with price_override_not_allowed' do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json_response['error']['code']).to eq('price_override_not_allowed')
+        end
+      end
     end
   end
 
@@ -190,6 +203,17 @@ RSpec.describe Spree::Api::V3::Admin::Orders::ItemsController, type: :controller
         expect(json_response['error']['code']).to eq('price_override_not_allowed')
         expect(response.body).to include('placed order')
         expect(line_item.reload.price_source).to be_nil
+      end
+
+      context 'with a non-numeric price' do
+        subject { patch :update, params: { order_id: order.prefixed_id, id: line_item.prefixed_id, price: 'NaN' }, as: :json }
+
+        it 'still refuses with price_override_not_allowed' do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json_response['error']['code']).to eq('price_override_not_allowed')
+        end
       end
     end
 

--- a/spree/core/app/services/spree/orders/update_item.rb
+++ b/spree/core/app/services/spree/orders/update_item.rb
@@ -58,6 +58,11 @@ module Spree
       # failure(record, message) drops the message when the record responds to
       # +errors+; :base rather than :price so Rails does not prefix the
       # attribute name onto it.
+      #
+      # @param line_item [Spree::LineItem]
+      # @param code [Symbol] symbolic rejection carried in +details+
+      # @param message [String] human-readable explanation
+      # @return [Spree::ServiceModule::Result]
       def reject_price(line_item, code, message)
         line_item.errors.add(:base, code, message: message)
         failure(line_item)

--- a/spree/core/app/services/spree/orders/update_item.rb
+++ b/spree/core/app/services/spree/orders/update_item.rb
@@ -21,7 +21,7 @@ module Spree
         price_provided = !price.equal?(PRICE_NOT_PROVIDED)
 
         if price_provided && order.completed?
-          return reject_price(line_item, Spree.t('cart_line_item.price_override_not_allowed'))
+          return reject_price(line_item, :price_override_not_allowed, Spree.t('cart_line_item.price_override_not_allowed'))
         end
 
         attributes = {}
@@ -30,7 +30,7 @@ module Spree
 
         if price_provided && !price.nil?
           manual_price = parse_manual_price(price)
-          return reject_price(line_item, Spree.t('cart_line_item.invalid_price')) if manual_price.nil?
+          return reject_price(line_item, :invalid_price, Spree.t('cart_line_item.invalid_price')) if manual_price.nil?
 
           attributes[:price] = manual_price
           attributes[:price_source] = Spree::LineItem::MANUAL_PRICE_SOURCE
@@ -58,8 +58,8 @@ module Spree
       # failure(record, message) drops the message when the record responds to
       # +errors+; :base rather than :price so Rails does not prefix the
       # attribute name onto it.
-      def reject_price(line_item, message)
-        line_item.errors.add(:base, message)
+      def reject_price(line_item, code, message)
+        line_item.errors.add(:base, code, message: message)
         failure(line_item)
       end
 

--- a/spree/core/app/workflows/spree/carts/add_item.rb
+++ b/spree/core/app/workflows/spree/carts/add_item.rb
@@ -60,6 +60,8 @@ module Spree
       # finite? is not redundant: BigDecimal parses "NaN" and "Infinity" and
       # neither is negative. reject! rather than failure(cart, message), which
       # would drop the message.
+      #
+      # @return [Spree::ServiceModule::Result, nil] failure when the price is refused
       def parse_manual_price
         if cart.completed?
           errors.add(:base, :price_override_not_allowed, message: Spree.t('cart_line_item.price_override_not_allowed'))

--- a/spree/core/app/workflows/spree/carts/add_item.rb
+++ b/spree/core/app/workflows/spree/carts/add_item.rb
@@ -61,12 +61,19 @@ module Spree
       # neither is negative. reject! rather than failure(cart, message), which
       # would drop the message.
       def parse_manual_price
-        reject!(Spree.t('cart_line_item.price_override_not_allowed'), cart) if cart.completed?
+        if cart.completed?
+          errors.add(:base, :price_override_not_allowed, message: Spree.t('cart_line_item.price_override_not_allowed'))
+          return failure(cart, errors)
+        end
 
         @manual_price = BigDecimal(price.to_s)
-        reject!(Spree.t('cart_line_item.invalid_price'), cart) if @manual_price.negative? || !@manual_price.finite?
+        if @manual_price.negative? || !@manual_price.finite?
+          errors.add(:base, :invalid_price, message: Spree.t('cart_line_item.invalid_price'))
+          return failure(cart, errors)
+        end
       rescue ArgumentError
-        reject!(Spree.t('cart_line_item.invalid_price'), cart)
+        errors.add(:base, :invalid_price, message: Spree.t('cart_line_item.invalid_price'))
+        failure(cart, errors)
       end
 
       # Checked against the quantity the line will END UP at, not the

--- a/spree/core/app/workflows/spree/carts/upsert_items.rb
+++ b/spree/core/app/workflows/spree/carts/upsert_items.rb
@@ -114,8 +114,16 @@ module Spree
 
       # Never coerced — "12,50".to_d is 12, a mispriced order. finite? is not
       # redundant: BigDecimal parses "NaN"/"Infinity" and neither is negative.
+      #
+      # @param value [Object] raw price from the request
+      # @return [BigDecimal, nil] parsed amount, or nil for an explicit revert
       def parse_manual_price(value)
         return nil if value.nil?
+
+        if cart.completed?
+          errors.add(:base, :price_override_not_allowed, message: Spree.t('cart_line_item.price_override_not_allowed'))
+          reject!(nil, cart)
+        end
 
         parsed = BigDecimal(value.to_s)
         if parsed.negative? || !parsed.finite?

--- a/spree/core/app/workflows/spree/carts/upsert_items.rb
+++ b/spree/core/app/workflows/spree/carts/upsert_items.rb
@@ -107,7 +107,8 @@ module Spree
         # Price overrides are pre-placement only. reject! rather than
         # failure(cart, message), which would drop the message.
         if cart.completed? && @resolved_items.any?(&:price_provided)
-          reject!(Spree.t('cart_line_item.price_override_not_allowed'), cart)
+          errors.add(:base, :price_override_not_allowed, message: Spree.t('cart_line_item.price_override_not_allowed'))
+          reject!(nil, cart)
         end
       end
 
@@ -117,10 +118,15 @@ module Spree
         return nil if value.nil?
 
         parsed = BigDecimal(value.to_s)
-        reject!(Spree.t('cart_line_item.invalid_price'), cart) if parsed.negative? || !parsed.finite?
+        if parsed.negative? || !parsed.finite?
+          errors.add(:base, :invalid_price, message: Spree.t('cart_line_item.invalid_price'))
+          reject!(nil, cart)
+        end
+
         parsed
       rescue ArgumentError
-        reject!(Spree.t('cart_line_item.invalid_price'), cart)
+        errors.add(:base, :invalid_price, message: Spree.t('cart_line_item.invalid_price'))
+        reject!(nil, cart)
       end
 
       # Only external inventory is asked here: Spree's own records are already

--- a/spree/core/spec/workflows/spree/orders/upsert_items_spec.rb
+++ b/spree/core/spec/workflows/spree/orders/upsert_items_spec.rb
@@ -361,6 +361,16 @@ module Spree
           it 'refuses the price override — placed-order money edits are fees and discounts' do
             expect(subject).to be_failure
             expect(line_item.reload.price_source).to be_nil
+            expect(subject.error.value.details[:base].first[:error]).to eq(:price_override_not_allowed)
+          end
+
+          context 'with a non-numeric price' do
+            let(:items) { [{ variant_id: variant.prefixed_id, quantity: 2, price: 'NaN' }] }
+
+            it 'refuses with price_override_not_allowed rather than invalid_price' do
+              expect(subject).to be_failure
+              expect(subject.error.value.details[:base].first[:error]).to eq(:price_override_not_allowed)
+            end
           end
         end
       end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes V-3559.

Admin order line item price refusals now return specific API error codes (`invalid_price`, `price_override_not_allowed`) instead of generic quantity/stock codes, so clients can show messages on the right field.

**CodeRabbit follow-up:** `UpsertItems#parse_manual_price` now checks `cart.completed?` before validating price format, so a placed order with a bad price returns `price_override_not_allowed` rather than `invalid_price`. Yard docstrings added for touched helpers.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3559](https://linear.app/vendo/issue/V-3559/price-refusals-are-returned-under-the-error-code-for-quantity)

<div><a href="https://cursor.com/agents/bc-7c7d97f8-026c-4dc5-b469-b58888f9429d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7d97f8-026c-4dc5-b469-b58888f9429d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API responses now provide specific error codes for invalid prices and disallowed price overrides.
  * Order item creation and updates now consistently identify non-numeric, negative, and otherwise invalid prices.
  * Completed orders and carts now reject price changes with a clear `price_override_not_allowed` error, including when the submitted price is invalid.
  * Validation messages are preserved when manual price entries are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->