### PR TITLE
Stop listing variants a query at a time

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/variants_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/variants_controller.rb
@@ -15,15 +15,22 @@ module Spree
             Spree.api.admin_variant_serializer
           end
 
+          # Chains onto the base scope rather than replacing it: building the
+          # relation from scratch dropped `scope_includes`, so every listed
+          # variant fell back to per-row price and stock queries.
           def scope
-            current_store.variants.eligible.accessible_by(current_ability, ability_action_for_request)
+            super.eligible.accessible_by(current_ability, ability_action_for_request)
           end
 
+          # `active_stock_reservations` rides along with the stock levels:
+          # without it the quantifier falls back to a SUM per variant, which
+          # is the whole cost of listing variants.
           def scope_includes
             [
-              :prices, stock_levels: :stock_location,
-              option_values: :option_type,
-              primary_media: [attachment_attachment: :blob, poster_attachment: :blob]
+              :prices,
+              { stock_levels: [:stock_location, :active_stock_reservations] },
+              { option_values: :option_type },
+              { primary_media: [{ attachment_attachment: :blob }, { poster_attachment: :blob }] }
             ]
           end
         end

--- a/spree/api/spec/controllers/spree/api/v3/admin/variants_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/variants_controller_spec.rb
@@ -46,8 +46,12 @@ RSpec.describe Spree::Api::V3::Admin::VariantsController, type: :controller do
 
           stock_and_price += 1
         end
-        get :index, as: :json
-        ActiveSupport::Notifications.unsubscribe(subscription)
+        begin
+          get :index, as: :json
+        ensure
+          # A leaked subscriber would keep counting into later examples.
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
 
         expect(response).to have_http_status(:ok)
         rows << json_response['data'].size

--- a/spree/api/spec/controllers/spree/api/v3/admin/variants_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/variants_controller_spec.rb
@@ -20,6 +20,41 @@ RSpec.describe Spree::Api::V3::Admin::VariantsController, type: :controller do
       expect(json_response['data'].map { |v| v['id'] }).to include(variant.prefixed_id)
     end
 
+    # The variant picker asks for only the three fields it renders; without
+    # this the autocomplete ships prices, stock and media it never shows.
+    it 'returns only the requested fields, plus id' do
+      get :index, params: { fields: 'product_name,sku,options_text' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      row = json_response['data'].first
+      expect(row.keys).to match_array(%w[id product_name sku options_text])
+    end
+
+    # The controller's `scope_includes` only applies if `scope` chains onto
+    # the base rather than rebuilding the relation. When it does not, prices
+    # and stock are read once per listed variant and nothing fails — so the
+    # guard is that the cost does not grow with the number of rows.
+    it 'reads prices and stock once, not once per variant' do
+      counts = [1, 4].map do |variant_count|
+        create_list(:variant, variant_count - 1, product: product) if variant_count > 1
+
+        stock_and_price = 0
+        subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          next if payload[:cached]
+          next unless payload[:name].to_s.match?(/Price|StockLevel|StockReservation/)
+
+          stock_and_price += 1
+        end
+        get :index, as: :json
+        ActiveSupport::Notifications.unsubscribe(subscription)
+
+        expect(response).to have_http_status(:ok)
+        stock_and_price
+      end
+
+      expect(counts.last).to eq(counts.first)
+    end
+
     it 'includes the default variant' do
       subject
       returned_ids = json_response['data'].map { |v| v['id'] }

--- a/spree/api/spec/controllers/spree/api/v3/admin/variants_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/variants_controller_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Spree::Api::V3::Admin::VariantsController, type: :controller do
       expect(json_response['data'].map { |v| v['id'] }).to include(variant.prefixed_id)
     end
 
-    # The variant picker asks for only the three fields it renders; without
-    # this the autocomplete ships prices, stock and media it never shows.
+    # The variant picker asks for only the three fields it renders, which
+    # keeps the autocomplete's payload to what it displays.
     it 'returns only the requested fields, plus id' do
       get :index, params: { fields: 'product_name,sku,options_text' }, as: :json
 
@@ -35,8 +35,9 @@ RSpec.describe Spree::Api::V3::Admin::VariantsController, type: :controller do
     # and stock are read once per listed variant and nothing fails — so the
     # guard is that the cost does not grow with the number of rows.
     it 'reads prices and stock once, not once per variant' do
-      counts = [1, 4].map do |variant_count|
-        create_list(:variant, variant_count - 1, product: product) if variant_count > 1
+      rows = []
+      counts = [0, 3].map do |extra_variants|
+        create_list(:variant, extra_variants, product: product) if extra_variants > 0
 
         stock_and_price = 0
         subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
@@ -49,9 +50,13 @@ RSpec.describe Spree::Api::V3::Admin::VariantsController, type: :controller do
         ActiveSupport::Notifications.unsubscribe(subscription)
 
         expect(response).to have_http_status(:ok)
+        rows << json_response['data'].size
         stock_and_price
       end
 
+      # The second request really did list more variants — otherwise equal
+      # query counts would prove nothing.
+      expect(rows.last).to eq(rows.first + 3)
       expect(counts.last).to eq(counts.first)
     end
 

--- a/spree/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/spree/core/spec/models/spree/stock/quantifier_spec.rb
@@ -21,6 +21,53 @@ module Spree
       specify { expect(subject.stock_levels).to eq([stock_level]) }
       specify { expect(subject.variant).to eq(stock_level.variant) }
 
+      # The quantifier answers from memory when the caller has already loaded
+      # the rows, and falls back to SQL when it has not. Listing endpoints
+      # preload precisely so they take the first path — without coverage, a
+      # dropped `includes` turns a page of variants back into a query per row
+      # with nothing failing.
+      describe 'preloaded associations' do
+        def count_queries
+          count = 0
+          subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+            next if payload[:cached] || payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
+            # Only stock reads matter here: `should_track_inventory?` looks up
+            # the product and store, which no amount of stock preloading avoids.
+            next unless payload[:name].to_s.match?(/StockLevel|StockReservation/)
+
+            count += 1
+          end
+          yield
+          count
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+
+        let(:variant) { stock_level.variant }
+
+        it 'answers from the loaded rows without querying' do
+          preloaded = Spree::Variant.
+            where(id: variant.id).
+            includes(stock_levels: [:stock_location, :active_stock_reservations]).
+            first
+          quantifier = described_class.new(preloaded)
+
+          queries = count_queries do
+            quantifier.available_stock
+            quantifier.reserved_quantity
+          end
+
+          expect(queries).to eq(0)
+          expect(quantifier.available_stock).to eq(described_class.new(variant).available_stock)
+        end
+
+        it 'queries when the rows are not loaded' do
+          quantifier = described_class.new(Spree::Variant.find(variant.id))
+
+          expect(count_queries { quantifier.available_stock }).to be > 0
+        end
+      end
+
       context 'with a single stock location/item' do
         it 'total_on_hand should match stock_level' do
           expect(subject.total_on_hand).to eq(stock_level.count_on_hand)


### PR DESCRIPTION
Listing eight variants took **134 queries and 2.4 seconds**, almost all of it
one query per row for prices, stock levels and reservations.

## What was wrong

`Admin::VariantsController#scope` built its relation from scratch instead of
chaining onto the base:

```ruby
def scope
  current_store.variants.eligible.accessible_by(...)   # never calls super
end
```

The base `scope` is where `scope_includes` is applied — so the preloads the
controller declares (prices, stock levels, option values, media) had **never
been used**. `Stock::Quantifier` already sums in memory when its rows are
loaded and falls back to SQL when they are not; it was simply never handed
loaded rows.

Fixed by chaining onto `super`, and by adding `active_stock_reservations` to
the preload — without it the reservation total is a query per variant even once
the stock levels are loaded.

The tenancy filter is unchanged: `Variant.for_store` is a purpose-built scope
joining through products onto `spree_products.store_id`, producing the same SQL
as the association it replaces.

## Measured

Queries for the same request, 4 products:

| | |
| --- | --- |
| Before | **49** |
| After | **20** |

Every per-row `Price Load`, `StockLevel Sum` and `StockReservation Sum` is
gone. What remains is fixed cost that does not grow with the number of rows.

## Coverage

Two specs, both counting queries — an output-shape assertion would pass while
the endpoint still paid the full cost:

- `variants_controller_spec` lists one variant, then four, and asserts the
  price and stock queries do not increase. It fails if the `super` chain is
  removed (verified by reverting it).
- `quantifier_spec` asserts the quantifier reads preloaded rows without
  querying and still queries when they are not loaded. This is the branch the
  fix depends on and it had no coverage.

## Checks

`spec/controllers/spree/api/v3/admin` passes in full (1728 examples), plus the
variant and serializer suites (289) and `quantifier_spec` (28). `typecheck` and
`build` pass across the workspace.

No API contract change — the serializers and generated SDK types are untouched.

## Not included

`Admin::DigitalLinksController` has the same dead `scope_includes`. Its spec is
already fully red on an unrelated broken factory, so the fix could not be
verified and is left out rather than shipped blind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved admin variant listings by loading pricing, stock, and media information more efficiently.
  - Reduced repeated database queries when displaying multiple variants.
  - Accelerated availability and reservation calculations by using preloaded stock information.

- **Bug Fixes**
  - Improved the consistency of variant details returned when specific fields are requested.
  - Prevented unnecessary database requests during stock calculations when the required information is already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->