### PR TITLE
Drop the post-sale cards from a draft order

### DIFF
--- a/packages/dashboard-ui/src/ui/accordion.tsx
+++ b/packages/dashboard-ui/src/ui/accordion.tsx
@@ -45,7 +45,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'group/accordion-trigger flex flex-1 cursor-pointer items-center gap-3 px-4 py-3.5 text-left text-base font-medium transition-colors outline-none hover:bg-accent focus-visible:bg-accent',
+          'group/accordion-trigger flex flex-1 cursor-pointer items-center gap-3 px-4 py-3.5 text-left text-base font-medium transition-colors outline-none hover:bg-accent/50 focus-visible:bg-accent',
           className,
         )}
         {...props}

--- a/packages/dashboard/src/routes/_authenticated/$storeId/orders/$orderId/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/orders/$orderId/index.tsx
@@ -61,9 +61,16 @@ function OrderDetailPage() {
         <>
           <FulfillmentsCard order={order} />
           <OrderDigitalLinksCard order={order} />
-          <OrderReturnsCard order={order} />
-          <OrderExchangesCard order={order} />
-          <OrderClaimsCard order={order} />
+          {/* Nothing can come back from an order that has not been placed:
+              all three read fulfilled units, and a draft has none, so they
+              would only ever render an empty card with a disabled action. */}
+          {order.completed_at && (
+            <>
+              <OrderReturnsCard order={order} />
+              <OrderExchangesCard order={order} />
+              <OrderClaimsCard order={order} />
+            </>
+          )}
           <PaymentsCard order={order} />
           <TaxLinesCard order={order} />
           <OrderDiscountsCard order={order} />


### PR DESCRIPTION
A draft order showed Returns, Exchanges and Claims cards that could never do
anything.

All three read `fulfilledUnits(order)`, which walks
`order.fulfillments[].fulfillment_items`. A draft has no fulfillments, so the
count is always zero and each card rendered an empty state with a permanently
disabled create button — three cards of noise on every draft.

They now render only once the order is placed. `order.completed_at` is the
existing test rather than a new concept: `OrderHeader` already uses it to
decide whether Back returns to orders or to drafts.

## Left alone deliberately

- **Digital links** already self-hides when it has no rows, so a draft never
  sees it.
- **Payments, taxes, discounts, fees and the summary** all stay. Payment can be
  taken on a draft and totals apply before placement, so those belong there.

## Also

An accordion trigger's hover softens to `bg-accent/50`, matching the other menu
surfaces.

## Checks

`lint`, `typecheck`, `test` and `build` pass across all 45 workspace tasks.

No E2E spec asserted these cards — `order-fulfillments.spec.ts` exercises drafts
but does not touch them, and there are no returns, exchanges or claims specs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Order return, exchange, and claim options are now shown only for completed orders.
  - Improved accordion trigger styling with a subtler hover background.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->