### PR TITLE
Fix commission rate condition pickers empty on open

### DIFF
--- a/packages/dashboard-core/src/components/resource-multi-autocomplete.tsx
+++ b/packages/dashboard-core/src/components/resource-multi-autocomplete.tsx
@@ -20,9 +20,8 @@ export interface ResourceMultiAutocompleteProps<T extends AutocompleteOption>
     | 'disabled'
   > {
   /**
-   * Server-side search. Receives the trimmed query string. Should return
-   * `{ data: T[] }`. Called any time the user types (with debouncing
-   * provided by the caller's queryClient if needed).
+   * Server-side search. Receives the trimmed query string (empty on open).
+   * Should return `{ data: T[] }`. Called on mount and as the user types.
    */
   search: (query: string) => Promise<{ data: T[] }>
 
@@ -105,10 +104,12 @@ export function ResourceMultiAutocomplete<T extends AutocompleteOption>({
 
   const trimmedInput = inputValue.trim()
 
+  // Match ResourceCombobox: run search with an empty query on open so the
+  // dropdown shows the first page instead of a false "nothing found" state.
   const { data: searchData, isFetching } = useQuery({
     queryKey: [queryKey, 'search', trimmedInput],
     queryFn: () => search(trimmedInput),
-    enabled: trimmedInput.length > 0,
+    staleTime: 30_000,
   })
 
   // Mirror query results into the local id→option cache via an effect, not


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes V-3591: commission rate condition pickers (Category, Seller, Product) showed "No categories found" / "No sellers found" / an empty panel until the operator typed.

## Cause

`ResourceMultiAutocomplete` only ran its search query when the input was non-empty. On open, `items` was empty and the empty state read as "nothing in the store."

## Fix

Run search with an empty query on mount/open, matching `ResourceCombobox` (used by the catalog audience picker). The first page of results loads immediately; typing still narrows via the same search endpoint.

## Testing

- `pnpm --filter @spree/dashboard-core typecheck`
- `pnpm --filter @spree/dashboard-core test` (175 tests passed)
- Manual UI verification blocked in this environment (Ruby/portless not available)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3591](https://linear.app/vendo/issue/V-3591/the-commission-rate-condition-pickers-say-there-is-nothing-to-pick)

<div><a href="https://cursor.com/agents/bc-bc2156f3-97b6-430f-8a3a-c3284ccb1aba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc2156f3-97b6-430f-8a3a-c3284ccb1aba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

