### PR TITLE
Fix commission rate code being rewritten on edit

### DIFF
--- a/packages/dashboard/e2e/commission-rates.spec.ts
+++ b/packages/dashboard/e2e/commission-rates.spec.ts
@@ -1,0 +1,70 @@
+import { expect, type Page, test } from '@playwright/test'
+import { gotoIndex, login, rowButton } from './helpers'
+
+const COMMISSION_RATES_PATH = (storeId: string) => `/${storeId}/settings/commission-rates`
+const ADD_CTA = /add commission rate/i
+
+async function createCommissionRate(
+  page: Page,
+  attrs: { name: string; code?: string; value?: string },
+) {
+  await page.getByRole('button', { name: ADD_CTA }).click()
+  await expect(page.getByRole('heading', { name: /add commission rate/i })).toBeVisible()
+
+  await page.getByLabel(/^name$/i).fill(attrs.name)
+  if (attrs.code !== undefined) {
+    await page.getByLabel(/^code$/i).fill(attrs.code)
+  }
+  if (attrs.value !== undefined) {
+    await page.getByLabel(/^value$/i).fill(attrs.value)
+  }
+
+  await page.getByRole('button', { name: /create commission rate/i }).click()
+}
+
+test.describe('settings / commission rates', () => {
+  test('lists commission rates', async ({ page }) => {
+    const creds = await login(page)
+    await gotoIndex(page, COMMISSION_RATES_PATH(creds.store_id), ADD_CTA)
+  })
+
+  test('auto-derives the code from the name while creating', async ({ page }) => {
+    const creds = await login(page)
+    await gotoIndex(page, COMMISSION_RATES_PATH(creds.store_id), ADD_CTA)
+
+    const suffix = Date.now()
+    const name = `E2E Commission ${suffix}`
+    const expectedCode = `e2e-commission-${suffix}`
+
+    await page.getByRole('button', { name: ADD_CTA }).click()
+    await page.getByLabel(/^name$/i).fill(name)
+    await expect(page.getByLabel(/^code$/i)).toHaveValue(expectedCode)
+
+    await page.getByRole('button', { name: /create commission rate/i }).click()
+    await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('cell', { name: expectedCode, exact: true })).toBeVisible()
+  })
+
+  test('keeps a custom code when editing an unrelated field', async ({ page }) => {
+    const creds = await login(page)
+    await gotoIndex(page, COMMISSION_RATES_PATH(creds.store_id), ADD_CTA)
+
+    const suffix = Date.now()
+    const name = `Kestrel negotiated ${suffix}`
+    const customCode = `kestrel-${suffix}`
+
+    await createCommissionRate(page, { name, code: customCode, value: '10' })
+    await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('cell', { name: customCode, exact: true })).toBeVisible()
+
+    await rowButton(page, name).click()
+    await expect(page.getByRole('heading', { name })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByLabel(/^code$/i)).toHaveValue(customCode)
+
+    await page.getByLabel(/^value$/i).fill('12')
+    await page.getByRole('button', { name: /^save$/i }).click()
+
+    await expect(rowButton(page, name)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('cell', { name: customCode, exact: true })).toBeVisible()
+  })
+})

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/commission-rates.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/commission-rates.tsx
@@ -190,6 +190,16 @@ function CreateCommissionRateSheet({
     defaultValues: COMMISSION_RATE_DEFAULTS,
   })
 
+  // Auto-derive code from name while the user hasn't touched code yet.
+  // The watch stops mirroring as soon as the user edits code directly, so
+  // we never clobber a deliberate value. Only runs during create — saved
+  // rates keep the code the operator chose.
+  const name = form.watch('name')
+  useEffect(() => {
+    if (form.getFieldState('code').isDirty) return
+    form.setValue('code', slugify(name ?? ''))
+  }, [name, form])
+
   async function onSubmit(values: CommissionRateFormValues) {
     try {
       await createMutation.mutateAsync(
@@ -319,15 +329,6 @@ function CommissionRateFormFields({ form }: { form: UseFormReturn<CommissionRate
   const { t } = useTranslation()
   const { errors } = form.formState
   const kind = form.watch('kind')
-  const name = form.watch('name')
-  // "Base Commission" becomes "base-commission" while the operator types, and
-  // stops the moment they write a code of their own — matching how a channel's
-  // code is derived.
-  useEffect(() => {
-    if (form.getFieldState('code').isDirty) return
-
-    form.setValue('code', slugify(name ?? ''))
-  }, [name, form])
 
   const kindOptions = COMMISSION_RATE_KINDS.map((value) => ({
     value,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes V-3590: editing a commission rate's percentage no longer silently rewrites its code.

The name-to-code auto-fill now runs only in the **create** sheet, matching how sales channels already behave. Opening an existing rate shows the saved code unchanged, and saving unrelated field edits leaves that code intact.

## Test plan

- [x] Dashboard TypeScript check passes
- [x] Added Playwright coverage in `commission-rates.spec.ts` for create-time auto-derive and edit-time code preservation (e2e not run in cloud — seller-dashboard build missing from test stack)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3590](https://linear.app/vendo/issue/V-3590/editing-a-commission-rate-silently-renames-its-code)

<div><a href="https://cursor.com/agents/bc-5313d6ec-b685-4bd3-a4ae-2f33abdbe53d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5313d6ec-b685-4bd3-a4ae-2f33abdbe53d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

