### PR TITLE
Fix silent failure when promotion code is not yet eligible (V-3587)

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/store/carts/discount_codes_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts/discount_codes_controller.rb
@@ -23,6 +23,7 @@ module Spree
                 if coupon_handler.successful? || pending_eligibility?
                   @cart.save!(validate: false) if @cart.changed?
                   @cart.reload
+                  attach_pending_coupon_warning if pending_eligibility?
                   render_cart(status: :created)
                 else
                   @cart.update_column(:coupon_code, nil) if @cart.read_attribute(:coupon_code).present?
@@ -56,6 +57,15 @@ module Spree
             # kept and recalculation activates it later.
             def pending_eligibility?
               coupon_handler.status_code == :coupon_code_not_eligible
+            end
+
+            # The code is kept for Shopify-parity retry-on-recalculation, but
+            # the shopper still needs to hear why nothing applied yet.
+            def attach_pending_coupon_warning
+              @cart.warnings |= [{
+                code: coupon_handler.status_code.to_s,
+                message: coupon_handler.error.presence || Spree.t(:coupon_code_not_eligible)
+              }]
             end
 
             def permitted_params

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/discount_codes_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/discount_codes_controller_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe Spree::Api::V3::Store::Carts::DiscountCodesController, type: :con
         expect(order.reload.read_attribute(:coupon_code)).to eq('big50')
         expect(order.discounts.where(promotion_id: promotion.id)).to be_empty
       end
+
+      it 'returns the rule message in warnings' do
+        post :create, params: { cart_id: order.prefixed_id, code: 'BIG50' }
+
+        warning = json_response['warnings'].sole
+        expect(warning['code']).to eq('coupon_code_not_eligible')
+        expect(warning['message']).to be_present
+      end
     end
 
     context 'with a multi-code promotion' do

--- a/spree/api/spec/integration/spree/api/v3/store/discount_codes_spec.rb
+++ b/spree/api/spec/integration/spree/api/v3/store/discount_codes_spec.rb
@@ -65,6 +65,28 @@ RSpec.describe 'Cart Discount Codes API', type: :request, swagger_doc: 'api-refe
           expect(data['error']).to be_present
         end
       end
+
+      response '201', 'real code kept pending with eligibility warning' do
+        let!(:promotion) do
+          create(:promotion_with_item_total_rule, :with_line_item_adjustment,
+                 code: 'BIG50', kind: :coupon_code, store: store,
+                 item_total_threshold_amount: 1_000_000, adjustment_rate: 50)
+        end
+        let(:'x-spree-api-key') { api_key.token }
+        let(:'Authorization') { "Bearer #{jwt_token}" }
+        let(:body) { { code: 'BIG50' } }
+
+        schema '$ref' => '#/components/schemas/Cart'
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['coupon_code']).to eq('big50')
+          expect(data['discount_total']).to eq('0.0')
+          warning = data['warnings'].sole
+          expect(warning['code']).to eq('coupon_code_not_eligible')
+          expect(warning['message']).to be_present
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [V-3587](https://linear.app/spree/issue/V-3587): when a customer applies a real promotion code that is not yet eligible for their cart, the Store API now returns the rule's explanation in the cart `warnings` array instead of an empty success payload.

The code is still persisted for Shopify-parity retry-on-recalculation — only the missing feedback is added.

## Changes

- After accepting a pending (`coupon_code_not_eligible`) code, attach a warning with the handler's error message (rule-specific when available, generic fallback otherwise).
- Controller and integration specs cover the warning shape.

## Testing

- `bundle exec rspec spec/controllers/spree/api/v3/store/carts/discount_codes_controller_spec.rb spec/integration/spree/api/v3/store/discount_codes_spec.rb` — 18 examples, 0 failures
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3587](https://linear.app/vendo/issue/V-3587/bug-ineligible-promotion-codes-fail-silently-no-reason-returned-or)

<div><a href="https://cursor.com/agents/bc-0b10f845-d9f7-4cfe-9b8b-42092cd44099?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b10f845-d9f7-4cfe-9b8b-42092cd44099&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added warnings when a discount code is pending eligibility.
  - Warning responses include a specific status code and a helpful message.

- **Bug Fixes**
  - Discount codes that do not yet meet cart eligibility requirements remain pending instead of being rejected.
  - Cart totals remain unchanged until the code becomes eligible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->