### PR TITLE
Fix gift card not linked to order on cart completion (V-3597)

### DIFF
--- a/spree/core/app/services/spree/carts/destroy.rb
+++ b/spree/core/app/services/spree/carts/destroy.rb
@@ -11,6 +11,7 @@ module Spree
         rewrite_input!(remove: [:order], cart: cart)
         run :check_if_can_be_destroyed
         run :cancel_shipments
+        run :release_gift_card
         run :void_payments
         run :clear_addresses
         run :destroy_order
@@ -29,6 +30,18 @@ module Spree
       # workflow's restock and carrier stand-down.
       def cancel_shipments(cart:)
         cart.fulfillments.each { |fulfillment| fulfillment.update!(status: 'canceled') }
+
+        success(cart: cart)
+      end
+
+      # Apply draws the card down while the cart is open; deleting the cart
+      # must put that balance back through the same Remove path as an explicit
+      # detach, not only void the checkout payment.
+      def release_gift_card(cart:)
+        return success(cart: cart) if cart.gift_card.blank?
+
+        result = cart.remove_gift_card
+        return failure(false, result.error) if result.failure?
 
         success(cart: cart)
       end

--- a/spree/core/app/services/spree/carts/destroy.rb
+++ b/spree/core/app/services/spree/carts/destroy.rb
@@ -40,7 +40,7 @@ module Spree
       def release_gift_card(cart:)
         return success(cart: cart) if cart.gift_card.blank?
 
-        result = cart.remove_gift_card
+        result = Spree.gift_card_remove_workflow.call(order: cart)
         return failure(false, result.error) if result.failure?
 
         success(cart: cart)

--- a/spree/core/app/workflows/spree/carts/complete.rb
+++ b/spree/core/app/workflows/spree/carts/complete.rb
@@ -223,6 +223,7 @@ module Spree
             preferred_stock_location_id: cart.preferred_stock_location_id,
             customer_note: cart.customer_note,
             po_number: cart.po_number,
+            gift_card: cart.gift_card,
             last_ip_address: cart.last_ip_address,
             ship_address: cart.ship_address&.snapshot,
             bill_address: cart.bill_address&.snapshot

--- a/spree/core/spec/services/spree/carts/destroy_spec.rb
+++ b/spree/core/spec/services/spree/carts/destroy_spec.rb
@@ -120,6 +120,29 @@ module Spree
             expect(cart.destroyed?).to be true
           end
         end
+
+        context 'when a gift card is applied' do
+          let(:gift_card) { create(:gift_card, amount: 50, store: cart.store) }
+
+          before do
+            Spree::Config[:geocode_addresses] = false
+            cart.reload.recalculate_totals!
+            Spree::GiftCards::Apply.call(gift_card: gift_card, order: cart)
+          end
+
+          after do
+            Spree::Config[:geocode_addresses] = true
+          end
+
+          it 'releases the gift card balance before destroying the cart' do
+            expect(gift_card.reload.amount_used).to be_positive
+
+            subject
+
+            expect(gift_card.reload.amount_remaining).to eq(50)
+            expect(gift_card.amount_used).to eq(0)
+          end
+        end
       end
 
       context 'when it cannot be destroyed' do

--- a/spree/core/spec/workflows/spree/carts/complete_spec.rb
+++ b/spree/core/spec/workflows/spree/carts/complete_spec.rb
@@ -127,6 +127,59 @@ module Spree
       end
     end
 
+    describe 'gift card' do
+      let(:customer) { create(:user) }
+      let(:cart) { create(:cart_ready_for_delivery, store: store, line_items_count: 1, customer: customer) }
+
+      before do
+        create(:store_credit_payment_method, store: store) unless Spree::PaymentMethod::StoreCredit.exists?
+        cart.recalculate_totals!
+      end
+
+      context 'when the gift card fully covers the order' do
+        let(:gift_card) { create(:gift_card, store: store, amount: cart.total, customer: customer) }
+        let(:ready_cart) do
+          cart.apply_gift_card(gift_card)
+          cart.reload
+        end
+
+        it 'carries the gift card onto the completed order' do
+          order = described_class.call(cart: ready_cart).value
+
+          expect(order.gift_card_id).to eq(gift_card.id)
+          expect(order.gift_card).to eq(gift_card)
+          expect(order.gift_card_total).to eq(ready_cart.total)
+        end
+
+        it 'redeems the gift card when the order is placed' do
+          expect { described_class.call(cart: ready_cart) }
+            .to change { gift_card.reload.status }.from('active').to('redeemed')
+
+          expect(gift_card.amount_used).to eq(ready_cart.total)
+          expect(gift_card.redeemed_at).to be_present
+        end
+      end
+
+      context 'when the gift card covers only part of the total' do
+        let(:gift_card) { create(:gift_card, store: store, amount: cart.total + 1, customer: customer) }
+        let(:ready_cart) do
+          cart.apply_gift_card(gift_card)
+          cart.reload
+        end
+
+        it 'marks the gift card partially redeemed' do
+          expect { described_class.call(cart: ready_cart) }
+            .to change { gift_card.reload.status }.from('active').to('partially_redeemed')
+
+          order = Spree::Order.find_by(cart_id: ready_cart.id)
+          expect(order.gift_card_id).to eq(gift_card.id)
+          expect(order.gift_card_total).to eq(ready_cart.total)
+          expect(gift_card.amount_used).to eq(ready_cart.total)
+          expect(gift_card.redeemed_at).to be_nil
+        end
+      end
+    end
+
     describe 'tax lifecycle' do
       it 'tells the tax engine the sale is final' do
         provider = instance_double(Spree::TaxProvider::Internal, estimate: nil, commit: nil)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes V-3597.

When a cart completed, `gift_card_id` was not copied onto the draft order, so the placed order had no gift card link, redemption never ran, and the dashboard showed no card applied.

This change also closes a related gap: deleting an incomplete cart with a gift card applied only voided payments and left `amount_used` drawn down. Cart destroy now runs `GiftCards::Remove` first so the balance is restored before the cart record is deleted.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3597](https://linear.app/vendo/issue/V-3597/bug-gift-card-is-never-linked-to-the-completed-order-leaving-no-record)

<div><a href="https://cursor.com/agents/bc-40762953-6ba9-4e59-9dbe-5345dadad3be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40762953-6ba9-4e59-9dbe-5345dadad3be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gift cards are now correctly carried from carts to completed orders.
  * Completing an order correctly updates gift card status for full and partial redemption.
  * Destroying a cart releases any applied gift card balance for reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->