### PR TITLE
Let the suite see a callback pointing at an action that is gone

### DIFF
--- a/spree/api/app/controllers/spree/api/v3/admin/orders/fulfillments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders/fulfillments_controller.rb
@@ -6,7 +6,7 @@ module Spree
           class FulfillmentsController < BaseController
             scoped_resource :fulfillments
 
-            before_action :set_resource, only: [:show, :update, :fulfill, :purchase_label, :mark_delivered, :cancel, :resume, :split]
+            before_action :set_resource, only: [:show, :update, :fulfill, :purchase_label, :mark_delivered, :cancel, :split]
 
             # POST /api/v3/admin/orders/:order_id/fulfillments
             #

--- a/spree/api/app/controllers/spree/api/v3/admin/orders_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/admin/orders_controller.rb
@@ -14,7 +14,7 @@ module Spree
           rescue_from ActiveSupport::MessageVerifier::InvalidSignature, with: :render_invalid_po_document
 
           skip_before_action :set_resource, only: [:index, :create]
-          before_action :set_resource, only: [:show, :update, :destroy, :complete, :cancel, :approve, :resume, :resend_confirmation, :resend_digital_links, :po_document]
+          before_action :set_resource, only: [:show, :update, :destroy, :complete, :cancel, :approve, :resend_confirmation, :resend_digital_links, :po_document]
 
           # POST /api/v3/admin/orders
           def create
@@ -175,7 +175,7 @@ module Spree
           # Map state transition actions to :update permission
           def authorize_resource!(resource = @resource, action = action_name.to_sym)
             mapped_action = case action
-                            when :complete, :cancel, :approve, :resume, :resend_confirmation, :resend_digital_links
+                            when :complete, :cancel, :approve, :resend_confirmation, :resend_digital_links
                               :update
                             when :po_document
                               :show

--- a/spree/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/spree/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -23,6 +23,11 @@ Dummy::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
+  # A `before_action ... only: [:gone_action]` naming an action that no longer
+  # exists makes Rails refuse every request to that controller. Enabled here so
+  # the suite sees it, as every real Spree app does.
+  config.action_controller.raise_on_missing_callback_actions = true
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.


### PR DESCRIPTION
Removing the order resume workflow left three before_action filters naming an action that no longer exists, which makes Rails refuse every request to the admin orders and fulfillments controllers. The orders list has been returning 404 since.

The specs could not catch it: the generated dummy app enables the check that reports a dead callback reference in development but not in test, so the suite ran with it switched off while every real Spree app has it on. The suite now enables it for itself, and passes.

fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes invalid callback configuration and tightens test config; restores normal admin order routing with no new behavior.
> 
> **Overview**
> Fixes admin **orders** and **fulfillments** APIs returning 404 after the order/fulfillment **resume** endpoints were removed but `before_action :set_resource` still listed `:resume`. Those dead callback references are dropped from `OrdersController` and `FulfillmentsController`, including the `:resume` → `:update` permission mapping on orders.
> 
> The generated dummy app’s **test** environment now sets `config.action_controller.raise_on_missing_callback_actions = true`, matching real Spree apps so the suite fails when a filter targets a non-existent action instead of silently passing with the check disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca3d33c4481198ca7cad75445a2b2d57145e5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected order and fulfillment controller handling for the resume action, preventing it from being processed through unrelated resource-loading and authorization callbacks.

- **Tests**
  - Test environments now flag callbacks that reference unavailable controller actions, helping identify configuration issues earlier and keeping test behavior aligned with production applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->