### PR TITLE
Add translatable locale keys for VolumeRule admin label and description

### DIFF
--- a/packages/admin-sdk/tests/price-lists.test.ts
+++ b/packages/admin-sdk/tests/price-lists.test.ts
@@ -171,7 +171,7 @@ describe('priceLists', () => {
             data: [
               {
                 type: 'volume_rule',
-                label: 'Volume Rule',
+                label: 'Volume pricing',
                 description: 'Apply pricing based on quantity purchased',
                 preference_schema: [{ key: 'min_quantity', type: 'integer', default: 1 }],
               },

--- a/packages/dashboard/e2e/price-lists.spec.ts
+++ b/packages/dashboard/e2e/price-lists.spec.ts
@@ -142,8 +142,8 @@ test.describe('price lists', () => {
     await submitCreate(page, name)
 
     // Rule-picker buttons include label + description; match by label only.
-    await pickRule(page, /^volume rule\b/i)
-    await expect(page.getByRole('heading', { name: /^volume rule$/i })).toBeVisible({
+    await pickRule(page, /^volume pricing\b/i)
+    await expect(page.getByRole('heading', { name: /^volume pricing$/i })).toBeVisible({
       timeout: 5_000,
     })
     await page
@@ -156,7 +156,7 @@ test.describe('price lists', () => {
 
     await saveForm(page)
 
-    await expect(page.getByText(/volume rule/i).first()).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText(/volume pricing/i).first()).toBeVisible({ timeout: 15_000 })
   })
 
   // The audience rules (customer group / customer) are superseded by catalog
@@ -175,7 +175,7 @@ test.describe('price lists', () => {
 
     const picker = page.getByRole('dialog')
     // The context rules stay first-class…
-    await expect(picker.getByRole('button', { name: /^volume rule\b/i })).toBeVisible()
+    await expect(picker.getByRole('button', { name: /^volume pricing\b/i })).toBeVisible()
     await expect(picker.getByRole('button', { name: /^market rule\b/i })).toBeVisible()
     // …the audience rules are gone.
     await expect(picker.getByRole('button', { name: /^customer group rule\b/i })).toHaveCount(0)
@@ -221,7 +221,7 @@ test.describe('price lists', () => {
     // Stage a Volume Rule so we have a row to remove. Picker opens the
     // editor sheet automatically on the new row; submit it with valid
     // defaults so it gets persisted on save below.
-    await pickRule(page, /^volume rule\b/i)
+    await pickRule(page, /^volume pricing\b/i)
     await page
       .getByRole('dialog')
       .getByLabel(/minimum quantity/i)
@@ -234,14 +234,14 @@ test.describe('price lists', () => {
     // and verify the row disappears. The rule list and the picker share
     // a single `<RuleRow>` div with `items-stretch`; scope to it so we
     // don't pick up unrelated buttons.
-    const ruleRow = page.locator('div.items-stretch').filter({ hasText: 'Volume Rule' }).first()
+    const ruleRow = page.locator('div.items-stretch').filter({ hasText: 'Volume pricing' }).first()
     await ruleRow.getByRole('button').last().click()
     await expect(page.getByRole('heading', { name: /remove rule\?/i })).toBeVisible()
     await page
       .getByRole('dialog')
       .getByRole('button', { name: /^remove$/i })
       .click()
-    await expect(page.getByText(/volume rule/i)).toHaveCount(0, { timeout: 5_000 })
+    await expect(page.getByText(/volume pricing/i)).toHaveCount(0, { timeout: 5_000 })
 
     // Save the form so the omission is persisted (the backend reconciles
     // "row omitted from payload" as a destroy).
@@ -249,7 +249,7 @@ test.describe('price lists', () => {
 
     // Reload and prove the row is actually gone, not just hidden client-side.
     await page.reload()
-    await expect(page.getByText(/volume rule/i)).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.getByText(/volume pricing/i)).toHaveCount(0, { timeout: 15_000 })
   })
 
   test('bulk-edits a price-list override via the dialog', async ({ page }) => {

--- a/spree/core/app/models/spree/price_rules/volume_rule.rb
+++ b/spree/core/app/models/spree/price_rules/volume_rule.rb
@@ -13,8 +13,12 @@ module Spree
         true
       end
 
+      def self.human_name
+        Spree.t('price_rules.volume_rule.name')
+      end
+
       def self.description
-        'Apply pricing based on quantity purchased'
+        Spree.t('price_rules.volume_rule.description')
       end
 
       # Quantity is a fact about the purchase, not the buyer, so this rule

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1456,8 +1456,8 @@ en:
       customer_group_rule:
         description: Apply pricing to specific customer groups
       volume_rule:
-        name: Volume pricing
         description: Apply pricing based on quantity purchased
+        name: Volume pricing
     price_sack: Price Sack
     prices: Prices
     pricing: Pricing

--- a/spree/core/config/locales/en.yml
+++ b/spree/core/config/locales/en.yml
@@ -1455,6 +1455,9 @@ en:
         description: Apply pricing based on the sales channel
       customer_group_rule:
         description: Apply pricing to specific customer groups
+      volume_rule:
+        name: Volume pricing
+        description: Apply pricing based on quantity purchased
     price_sack: Price Sack
     prices: Prices
     pricing: Pricing

--- a/spree/core/spec/models/spree/price_rules/volume_rule_spec.rb
+++ b/spree/core/spec/models/spree/price_rules/volume_rule_spec.rb
@@ -61,4 +61,16 @@ describe Spree::PriceRules::VolumeRule, type: :model do
       expect(described_class.new.geographic?).to be(false)
     end
   end
+
+  describe '.human_name' do
+    it 'returns the translated name' do
+      expect(described_class.human_name).to eq(Spree.t('price_rules.volume_rule.name'))
+    end
+  end
+
+  describe '.description' do
+    it 'returns the translated description' do
+      expect(described_class.description).to eq(Spree.t('price_rules.volume_rule.description'))
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes V-3604.

`Spree::PriceRules::VolumeRule` was the only price rule without authored locale strings. Its admin label came from `titleize` ("Volume Rule") and its description was a hardcoded English literal.

This adds `spree.price_rules.volume_rule.name` and `spree.price_rules.volume_rule.description` in `en.yml`, matching the pattern already used by `channel_rule` and `customer_group_rule`, and wires both `human_name` and `description` through `Spree.t`. The canonical English label is now **Volume pricing** instead of the auto-derived "Volume Rule".

## Testing

- `bundle exec rspec spec/models/spree/price_rules/volume_rule_spec.rb` — 11 examples, 0 failures
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3604](https://linear.app/vendo/issue/V-3604/volume-pricing-rule-has-no-locale-key-admin-label-is-auto-derived-and)

<div><a href="https://cursor.com/agents/bc-bbb2b9ad-912f-426d-98c2-f874a90d0e62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbb2b9ad-912f-426d-98c2-f874a90d0e62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the volume-based pricing rule label to **“Volume pricing.”**
  * Added a localized name and description for the rule, including: “Apply pricing based on quantity purchased.”
  * Improved consistency of the volume pricing rule’s displayed text across the dashboard and administrative tools.
* **Tests**
  * Updated automated checks to verify the new label and localized rule details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->