### PR TITLE
Make a fee's tax follow the fee it was charged on

### DIFF
--- a/spree/core/app/services/spree/carts/split_by_seller.rb
+++ b/spree/core/app/services/spree/carts/split_by_seller.rb
@@ -255,14 +255,59 @@ module Spree
       def move_typed_lines(sibling, line_item_ids, divided = {})
         moved_fulfillment_ids = sibling.fulfillments.reload.pluck(:id) - divided.values.map(&:first)
 
-        [Spree::TaxLine, Spree::Discount, Spree::Fee].each do |klass|
-          klass.where(line_item_id: line_item_ids).update_all(order_id: sibling.id, updated_at: Time.current)
+        # Fees first, and their tax straight after: a fee is something tax is
+        # charged on, so where a tax line belongs is only knowable once its fee
+        # has landed.
+        divided_fees = move_class_rows(Spree::Fee, sibling, line_item_ids, moved_fulfillment_ids, divided)
+        # A fee that moved whole takes its tax with it; one that was divided
+        # has its tax divided instead, so the two sets never overlap.
+        moved_whole = sibling.fees.reload.ids - divided_fees.values.map(&:first)
+        move_fee_tax_lines(sibling, moved_whole, divided_fees)
 
-          next unless klass.column_names.include?('fulfillment_id')
+        [Spree::Discount, Spree::TaxLine].each do |klass|
+          move_class_rows(klass, sibling, line_item_ids, moved_fulfillment_ids, divided)
+        end
+      end
 
-          klass.where(fulfillment_id: moved_fulfillment_ids).update_all(order_id: sibling.id, updated_at: Time.current)
-          divided.each do |original_id, (replacement_id, weights)|
-            divide_fulfillment_rows(klass, original_id, replacement_id, weights, sibling)
+      # Re-points one class of typed row onto the sibling: the rows hanging off
+      # a moved line item, then those off a whole-moved parcel, then the halves
+      # of any parcel that had to be divided.
+      #
+      # @return [Hash{Integer => Array(Integer, Array<Integer>)}] what
+      #   {#divide_fulfillment_rows} reported for the rows it divided
+      def move_class_rows(klass, sibling, line_item_ids, moved_fulfillment_ids, divided)
+        klass.where(line_item_id: line_item_ids).update_all(order_id: sibling.id, updated_at: Time.current)
+        return {} unless klass.column_names.include?('fulfillment_id')
+
+        klass.where(fulfillment_id: moved_fulfillment_ids).update_all(order_id: sibling.id, updated_at: Time.current)
+
+        divided.each_with_object({}) do |(original_id, (replacement_id, weights)), placed|
+          placed.merge!(divide_fulfillment_rows(klass, original_id, replacement_id, weights, sibling))
+        end
+      end
+
+      # A fee's tax follows the fee itself, which nothing else here does for
+      # it: a tax line hangs off no line item and no parcel of its own, so
+      # neither move above ever picks it up. Left behind it taxes a fee its
+      # order no longer holds, and the child that took the fee is untaxed.
+      #
+      # @param divided_fees [Hash{Integer => Array(Integer, Array<Integer>)}]
+      #   fee id → the id of the half that moved and the weights it divided by
+      def move_fee_tax_lines(sibling, moved_fee_ids, divided_fees)
+        if moved_fee_ids.any?
+          Spree::TaxLine.where(fee_id: moved_fee_ids).
+            update_all(order_id: sibling.id, updated_at: Time.current)
+        end
+
+        # A fee that was divided leaves its tax whole on the half that stayed,
+        # so it divides by the weights the fee itself did — otherwise one child
+        # pays all the tax on a charge it only half carries.
+        divided_fees.each do |fee_id, (replacement_id, weights)|
+          next if weights.sum <= 0
+
+          Spree::TaxLine.where(fee_id: fee_id).find_each do |tax_line|
+            apportion_row(tax_line, weights,
+                          [{}, { 'order_id' => sibling.id, 'fee_id' => replacement_id }])
           end
         end
       end
@@ -270,11 +315,16 @@ module Spree
       # Splits one parcel's money rows between the two halves it became, by
       # what each half now carries — the same basis its delivery cost was
       # divided on, so the tax still describes the charge.
+      #
+      # @return [Hash{Integer => Array(Integer, Array<Integer>)}] for each row
+      #   that was divided, the id of the half that moved and the weights used
       def divide_fulfillment_rows(klass, original_id, replacement_id, weights, sibling)
-        return if weights.sum <= 0
+        return {} if weights.sum <= 0
 
-        klass.where(fulfillment_id: original_id).find_each do |row|
-          apportion_row(row, weights, [{}, { 'order_id' => sibling.id, 'fulfillment_id' => replacement_id }])
+        klass.where(fulfillment_id: original_id).find_each.with_object({}) do |row, placed|
+          shares = apportion_row(row, weights, [{}, { 'order_id' => sibling.id, 'fulfillment_id' => replacement_id }])
+          moved = shares[1]
+          placed[row.id] = [moved.id, weights] if moved
         end
       end
 

--- a/spree/core/app/workflows/spree/carts/complete.rb
+++ b/spree/core/app/workflows/spree/carts/complete.rb
@@ -342,10 +342,14 @@ module Spree
 
       # The cart's rows are the record of what the sale was costed at, so the
       # order receives them verbatim rather than being re-estimated.
+      # Fees before tax lines, because a fee is something tax is charged on: a
+      # tax line copied first would reach the order still naming the cart's
+      # fee, and that row is then destroyed with it.
       def copy_typed_lines!(cart, order, line_item_map, fulfillment_map)
         line_item_id_map = line_item_map.transform_keys(&:id).transform_values(&:id)
+        fee_map = {}
 
-        [Spree::TaxLine, Spree::Discount, Spree::Fee].each do |klass|
+        [Spree::Fee, Spree::Discount, Spree::TaxLine].each do |klass|
           klass.where(cart_id: cart.id).find_each do |row|
             attributes = row.attributes.except('id', 'cart_id', 'created_at', 'updated_at')
             attributes['order_id'] = order.id
@@ -358,8 +362,13 @@ module Spree
               attributes['fulfillment_id'] = fulfillment_map[row.fulfillment_id]
               next if attributes['fulfillment_id'].nil?
             end
+            if row.respond_to?(:fee_id) && row.fee_id
+              attributes['fee_id'] = fee_map[row.fee_id]
+              next if attributes['fee_id'].nil?
+            end
 
-            klass.create!(attributes)
+            copy = klass.create!(attributes)
+            fee_map[row.id] = copy.id if klass == Spree::Fee
           end
         end
       end

--- a/spree/core/spec/workflows/spree/carts/complete_spec.rb
+++ b/spree/core/spec/workflows/spree/carts/complete_spec.rb
@@ -256,6 +256,36 @@ module Spree
           order = result.value
           expect(order_rows(order).sum(:amount)).to eq(order.additional_tax_total)
         end
+
+        # Tax charged on a fee has to name the order's own copy of that fee.
+        # Copied in the wrong order it names the cart's fee instead, which is
+        # then destroyed with the cart's rows — so the charge survives on the
+        # order while the tax explaining it either dangles or disappears.
+        context 'when an order-level fee was taxed' do
+          # A fee carries no category of its own, so it is taxed under the
+          # store's default — which the surrounding context's category is not.
+          before do
+            default_category = create(:tax_category, store: store, is_default: true)
+            create(:tax_rate, store: store, country_code: ready_cart.tax_country&.iso, amount: 0.2,
+                              included_in_price: false, tax_category: default_category)
+            create(:fee, order: nil, cart: ready_cart, amount: 9, kind: 'payment', label: 'Card surcharge')
+            ready_cart.reload.recalculate_totals!
+            ready_cart.payments.first.update!(amount: ready_cart.reload.total)
+          end
+
+          it 'points the fee’s tax at the order’s own fee' do
+            charged = ready_cart.tax_lines.reload.where.not(fee_id: nil).sum(:amount)
+            expect(charged).to be > 0
+
+            result = described_class.call(cart: ready_cart)
+            expect(result).to be_success
+            order = result.value
+
+            rows = order_rows(order).where.not(fee_id: nil)
+            expect(rows.sum(:amount)).to eq(charged)
+            expect(rows.pluck(:fee_id).uniq).to match_array(order.fees.order_level.ids)
+          end
+        end
       end
     end
 

--- a/spree/core/spec/workflows/spree/carts/complete_split_spec.rb
+++ b/spree/core/spec/workflows/spree/carts/complete_split_spec.rb
@@ -203,6 +203,55 @@ module Spree
         end
       end
 
+      # The delivery charge is divided between the two halves, so the tax
+      # charged on it has to be divided the same way. Left whole, the half that
+      # kept the original parcel is taxed on delivery it no longer provides and
+      # the sibling ships with none at all.
+      context 'when the delivery was taxed' do
+        let!(:tax_category) { create(:tax_category, store: store, is_default: true) }
+        let!(:tax_rate) do
+          create(:tax_rate, store: store, country_code: cart.tax_country&.iso, amount: 0.2,
+                            included_in_price: false, tax_category: tax_category)
+        end
+
+        let(:cart) do
+          built = cart_for(nil, seller, seller)
+          built.reload.recalculate_totals!
+          built.payments.each { |payment| payment.update!(amount: built.reload.total) }
+          built.reload
+        end
+
+        # The rate has to exist before the cart is costed, and the cart has to
+        # exist before the rate can read its country — so the rate is written
+        # once the cart is built, and the cart re-costed against it.
+        before do
+          tax_rate
+          cart.reload.recalculate_totals!
+          cart.payments.each { |payment| payment.update!(amount: cart.reload.total) }
+        end
+
+        it 'taxes the delivery in the first place' do
+          expect(cart.tax_lines.where.not(fulfillment_id: nil).sum(:amount)).to be > 0
+        end
+
+        it 'divides the delivery tax rather than charging it on both halves' do
+          charged = cart.tax_lines.where.not(fulfillment_id: nil).sum(:amount)
+          delivery_tax = group.orders.sum do |order|
+            order.tax_lines.where.not(fulfillment_id: nil).sum(:amount)
+          end
+
+          expect(delivery_tax).to eq(charged)
+        end
+
+        it 'leaves each parcel’s tax on the order that ships it' do
+          group.orders.each do |order|
+            order.tax_lines.where.not(fulfillment_id: nil).each do |tax_line|
+              expect(order.fulfillments.ids).to include(tax_line.fulfillment_id)
+            end
+          end
+        end
+      end
+
       it 'survives a later amounts refresh without doubling the delivery charge' do
         before_total = group.orders.sum(&:delivery_total)
         group.orders.each { |order| order.fulfillments.each(&:update_amounts) }
@@ -250,6 +299,161 @@ module Spree
         expect(group.total).to eq(paid)
         expect(group.orders.sum(&:discount_total)).to eq(-6)
         expect(group.orders.map { |order| order.discounts.count }).to all(eq(1))
+      end
+
+      # An order-level fee — a payment surcharge, handling — was charged for
+      # the checkout as a whole and hangs off nothing that can be moved, so it
+      # is the one thing here divided rather than re-pointed.
+      context 'with an order-level fee' do
+        let(:cart) { cart_for(nil, seller, other_seller) }
+
+        before do
+          create(:fee, order: nil, cart: cart, amount: 9, kind: 'payment', label: 'Card surcharge')
+          cart.reload.recalculate_totals!
+          cart.payments.each { |payment| payment.update!(amount: cart.reload.total) }
+        end
+
+        it 'shares it out across the children rather than charging it once' do
+          group = described_class.call(cart: cart).value
+
+          expect(group.orders.sum(&:fee_total)).to eq(9)
+        end
+
+        it 'gives every child a share of it' do
+          group = described_class.call(cart: cart).value
+          order_level = group.orders.map { |order| order.fees.order_level.sum(:amount) }
+
+          expect(order_level.size).to eq(3)
+          expect(order_level).to all(be > 0)
+        end
+
+        it 'keeps the customer’s total exactly what they paid' do
+          paid = cart.total
+          group = described_class.call(cart: cart).value
+
+          expect(group.total).to eq(paid)
+        end
+      end
+
+      # A fee's tax was charged on the share the fee was charged on, so it has
+      # to land on the same order — a tax line left behind on a fee that now
+      # holds a third of the amount overstates one child and leaves its
+      # siblings untaxed.
+      context 'when an order-level fee was taxed' do
+        let!(:tax_category) { create(:tax_category, store: store, is_default: true) }
+        let(:cart) { cart_for(nil, seller, other_seller) }
+
+        before do
+          create(:tax_rate, store: store, country_code: cart.tax_country&.iso, amount: 0.2,
+                            included_in_price: false, tax_category: tax_category)
+          create(:fee, order: nil, cart: cart, amount: 9, kind: 'payment', label: 'Card surcharge')
+          cart.reload.recalculate_totals!
+          cart.payments.each { |payment| payment.update!(amount: cart.reload.total) }
+        end
+
+        it 'taxes the fee in the first place' do
+          fee = cart.fees.order_level.first
+
+          expect(cart.tax_lines.where(fee_id: fee.id).sum(:amount)).to be > 0
+        end
+
+        it 'sends each share of the tax to the order holding the fee it was charged on' do
+          group = described_class.call(cart: cart).value
+
+          group.orders.each do |order|
+            order.tax_lines.where.not(fee_id: nil).each do |tax_line|
+              expect(order.fees.ids).to include(tax_line.fee_id)
+            end
+          end
+        end
+
+        it 'divides the fee’s tax rather than duplicating or dropping it' do
+          charged = cart.tax_lines.where.not(fee_id: nil).sum(:amount)
+          group = described_class.call(cart: cart).value
+          fee_tax = group.orders.sum { |order| order.tax_lines.where.not(fee_id: nil).sum(:amount) }
+
+          expect(charged).to be > 0
+          expect(fee_tax).to eq(charged)
+        end
+      end
+
+      # A fee hanging off a line item travels with that item, and its tax has
+      # to travel too — nothing else moves it, since the tax line names no line
+      # item and no parcel of its own.
+      context 'when a fee on one seller’s item was taxed' do
+        let!(:tax_category) { create(:tax_category, store: store, is_default: true) }
+        let(:cart) { cart_for(nil, seller) }
+
+        before do
+          create(:tax_rate, store: store, country_code: cart.tax_country&.iso, amount: 0.2,
+                            included_in_price: false, tax_category: tax_category)
+          create(:fee, order: nil, cart: cart, line_item: cart.line_items.reload.last,
+                       amount: 10, kind: 'gift_wrap', label: 'Gift wrap')
+          cart.reload.recalculate_totals!
+          cart.payments.each { |payment| payment.update!(amount: cart.reload.total) }
+        end
+
+        it 'moves the fee’s tax onto the order that took the fee' do
+          group = described_class.call(cart: cart).value
+
+          group.orders.each do |order|
+            order.tax_lines.where.not(fee_id: nil).each do |tax_line|
+              expect(order.fees.ids).to include(tax_line.fee_id)
+            end
+          end
+        end
+
+        it 'leaves the tax on the child holding the item it was charged for' do
+          group = described_class.call(cart: cart).value
+          taxed = group.orders.select { |order| order.tax_lines.where.not(fee_id: nil).any? }
+
+          expect(taxed.size).to eq(1)
+          expect(taxed.first.fees.count).to eq(1)
+        end
+      end
+
+      # A fee on a parcel holding two sellers' goods is divided with it, so its
+      # tax divides the same way. Left whole, one child pays all the tax on a
+      # charge it only half carries and its sibling pays none — and because
+      # nothing is lost in aggregate, totals alone never show it.
+      context 'when a fee on a shared parcel was taxed' do
+        let!(:tax_category) { create(:tax_category, store: store, is_default: true) }
+        let(:cart) { cart_for(nil, seller) }
+
+        before do
+          create(:tax_rate, store: store, country_code: cart.tax_country&.iso, amount: 0.2,
+                            included_in_price: false, tax_category: tax_category)
+          create(:fee, order: nil, cart: cart, fulfillment: cart.fulfillments.first,
+                       amount: 10, kind: 'handling', label: 'Handling')
+          cart.reload.recalculate_totals!
+          cart.payments.each { |payment| payment.update!(amount: cart.reload.total) }
+        end
+
+        it 'divides the fee across both halves' do
+          group = described_class.call(cart: cart).value
+          shares = group.orders.map { |order| order.fees.sum(:amount) }
+
+          expect(shares).to all(be > 0)
+          expect(shares.sum).to eq(10)
+        end
+
+        it 'divides the fee’s tax alongside the fee rather than leaving it whole' do
+          group = described_class.call(cart: cart).value
+          taxes = group.orders.map { |order| order.tax_lines.where.not(fee_id: nil).sum(:amount) }
+
+          expect(taxes).to all(be > 0)
+        end
+
+        it 'keeps each child’s fee tax proportional to the fee it holds' do
+          group = described_class.call(cart: cart).value
+
+          group.orders.each do |order|
+            fee = order.fees.sum(:amount)
+            tax = order.tax_lines.where.not(fee_id: nil).sum(:amount)
+
+            expect(tax).to eq((fee * 0.2).round(2))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What

Tax charged on a fee was left behind whenever the fee moved. Three places, all the same defect:

1. **Completion** copied tax lines *before* the fees they name, and never mapped `fee_id`. An order-level fee's tax reached the order still pointing at the cart's fee — dangling there, or destroyed outright when no rate applied (`Fee has_many :tax_lines, dependent: :destroy` takes it when the cart's fee goes).
2. **The seller split** moved a fee to a child order without its tax, so one child was taxed for a fee it no longer held and the child that took the fee was untaxed.
3. **A shared parcel's fee** was correctly divided in two, but its tax stayed whole on one half — that child paid the full tax on a charge it only half carried, its sibling paid none.

## Why it matters

Order totals stayed correct in every case, because `fee_total` and `additional_tax_total` sum the rows rather than follow the pointers. The damage fell entirely on anything reading *which* fee a tax line belongs to: invoices, the `fee_id` the API serializer exposes, e-invoicing exports, a tax return.

Case 3 is the least visible of the three — nothing is lost in aggregate, so no totals-level assertion could catch it.

The split code also could not have worked as written: `distribute_fee` looks up `TaxLine.where(fee_id: fee.id)` by the order's fee id, which case 1 guaranteed would never match.

## How

- `Carts::Complete#copy_typed_lines!` copies `[Fee, Discount, TaxLine]` and threads a `fee_map`, so a copied tax line names the order's own fee.
- `Carts::SplitBySeller#move_typed_lines` handles fees first, then moves a whole-moved fee's tax with it and divides a divided fee's tax by the same weights the fee itself used.

## Testing

Seven new examples across the two workflow specs, all of which fail on `main` and pass here — verified by reverting each production file in turn. 675 examples green across carts, orders, order groups, tax providers, fees, tax lines and the API serializers.

Worth knowing for future specs in this area: fees and fulfillments carry no tax category of their own, so they are taxed under the store's **default** category. A spec needs `create(:tax_category, store: store, is_default: true)` for them to be taxed at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order completion and seller-split orders so fees and associated taxes are correctly transferred to the appropriate child orders.
  * Taxed delivery charges and fees are now allocated proportionally when shared, while remaining with the order responsible for the charge when applicable.
  * Prevented fee taxes from being duplicated, omitted, or incorrectly linked to the original cart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->