### PR TITLE
Let the bulk-edit variants table scroll to every column

### DIFF
--- a/.changeset/bulk-variants-dialog-scroll.md
+++ b/.changeset/bulk-variants-dialog-scroll.md
@@ -1,0 +1,6 @@
+---
+"@spree/dashboard-ui": patch
+"@spree/dashboard-core": patch
+---
+
+Let the bulk-edit-variants dialog scroll horizontally so every column stays reachable when the grid is wider than the dialog.

--- a/.changeset/bulk-variants-dialog-scroll.md
+++ b/.changeset/bulk-variants-dialog-scroll.md
@@ -1,6 +1,0 @@
----
-"@spree/dashboard-ui": patch
-"@spree/dashboard-core": patch
----
-
-Let the bulk-edit-variants dialog scroll horizontally so every column stays reachable when the grid is wider than the dialog.

--- a/packages/dashboard-core/src/products/bulk-variants-dialog.tsx
+++ b/packages/dashboard-core/src/products/bulk-variants-dialog.tsx
@@ -206,7 +206,7 @@ export function BulkVariantsDialog({ form, open, onOpenChange }: Props) {
             </Button>
           </div>
         </DialogHeader>
-        <DialogBody className="min-h-0 flex-1 overflow-auto p-3">
+        <DialogBody className="flex min-h-0 flex-1 flex-col overflow-hidden p-3">
           <BulkVariantsTable
             rows={rows}
             onChange={handleChange}

--- a/packages/dashboard-core/src/products/bulk-variants-dialog.tsx
+++ b/packages/dashboard-core/src/products/bulk-variants-dialog.tsx
@@ -189,7 +189,7 @@ export function BulkVariantsDialog({ form, open, onOpenChange }: Props) {
       <DialogContent
         // Edge-to-edge minus a 3-unit gutter, same overrides as the bulk
         // price dialog (see BulkPriceEditorDialog for why each is needed).
-        className="!inset-3 !w-auto !max-w-none !translate-x-0 !translate-y-0 flex flex-col p-0"
+        className="!inset-3 !w-auto !max-w-none !translate-x-0 !translate-y-0 flex min-w-0 flex-col overflow-hidden p-0"
         style={{ maxHeight: 'none' }}
         showCloseButton={false}
       >
@@ -206,7 +206,7 @@ export function BulkVariantsDialog({ form, open, onOpenChange }: Props) {
             </Button>
           </div>
         </DialogHeader>
-        <DialogBody className="flex min-h-0 flex-1 flex-col overflow-hidden p-3">
+        <DialogBody className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-3">
           <BulkVariantsTable
             rows={rows}
             onChange={handleChange}

--- a/packages/dashboard-ui/src/spree/bulk-variants-table.tsx
+++ b/packages/dashboard-ui/src/spree/bulk-variants-table.tsx
@@ -322,7 +322,7 @@ export function BulkVariantsTable({
   ])
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto">
+    <div className="min-h-0 min-w-0 flex-1 overflow-auto">
       <DataGrid<BulkVariantsRow>
         rows={rows}
         columns={columns}

--- a/packages/dashboard-ui/src/spree/bulk-variants-table.tsx
+++ b/packages/dashboard-ui/src/spree/bulk-variants-table.tsx
@@ -322,12 +322,12 @@ export function BulkVariantsTable({
   ])
 
   return (
-    <div className="overflow-x-auto">
+    <div className="min-h-0 flex-1 overflow-auto">
       <DataGrid<BulkVariantsRow>
         rows={rows}
         columns={columns}
         getRowId={(row) => row.id}
-        className={countryOptions ? 'min-w-[1500px]' : 'min-w-[1100px]'}
+        className={countryOptions ? 'min-w-[2000px]' : 'min-w-[1400px]'}
         aria-label={labels.gridAriaLabel}
       />
     </div>

--- a/packages/dashboard-ui/src/spree/data-grid/data-grid.tsx
+++ b/packages/dashboard-ui/src/spree/data-grid/data-grid.tsx
@@ -130,7 +130,8 @@ function DataGridShell<T>({
   return (
     <DataGridContext.Provider value={ctx}>
       <DataGridKeyboardMount gridRef={gridRef} />
-      <div className="relative overflow-hidden rounded-md">
+      {/* Grow to the table's min-width so a scroll parent can reach every column. */}
+      <div className="relative w-max min-w-full overflow-hidden rounded-md">
         <table
           ref={gridRef}
           className={cn(
@@ -152,7 +153,7 @@ function DataGridShell<T>({
             {table.getHeaderGroups().map((group) => (
               <tr key={group.id}>
                 {group.headers.map((header) => (
-                  <th key={header.id} className="h-8 px-3 text-left font-medium">
+                  <th key={header.id} className="h-8 whitespace-nowrap px-3 text-left font-medium">
                     {header.isPlaceholder
                       ? null
                       : flexRender(header.column.columnDef.header, header.getContext())}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Bulk edit variants dialog squeezes a 15-column spreadsheet into the dialog width. The last columns (including Customs description) are clipped by the dialog edge, and there is no usable horizontal scrollbar on the table.

Two layout issues stacked:

1. The data grid wrapper used `overflow-hidden` around a `min-width` table, so extra columns never reached a scroll parent.
2. Flex items default to `min-width: auto`, so even after the grid grew, the dialog refused to shrink and the extra columns spilled onto the page.

## Change

- The data grid grows to the table’s minimum width (while still filling a narrower parent), so a scroll container can see the overflow.
- Column headers no longer wrap, which was collapsing them.
- The dialog and table wrappers can shrink (`min-w-0`) and the table fills the dialog body, scrolling on both axes. The horizontal scrollbar stays at the bottom of the visible dialog.
- The table’s minimum width is a bit larger so the extra customs columns have room.

## How to verify

1. Open a product with at least one variant.
2. In the Variants card, click **Bulk edit**.
3. Confirm the dialog stays within the viewport and a horizontal scrollbar appears on the table.
4. Scroll right until **Customs description** is fully visible.
5. Confirm vertical scrolling still works when there are many variants, and that Cancel / Done still close the dialog.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aefa553b-1c66-473e-9529-230fc33cb263?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aefa553b-1c66-473e-9529-230fc33cb263&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

