### PR TITLE
Fix calculating discounts for Spree::Cart as well as for Spree::Order

### DIFF
--- a/spree/common_spree_dependencies.rb
+++ b/spree/common_spree_dependencies.rb
@@ -6,6 +6,12 @@ source 'https://rubygems.org'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'rails', ENV.fetch('RAILS_VERSION', '~> 8.1.0'), require: false
 
+# Held below 3.0: json 3.0 made JSON.parse's options keyword-only, and Active
+# Support 8.1 still passes them positionally, so reading any JSON column raises
+# ArgumentError — which is every metadata column we have. Drop the pin once
+# Rails ships a release that calls the new signature.
+gem 'json', '< 3'
+
 platforms :jruby do
   gem 'jruby-openssl'
 end

--- a/spree/core/app/models/concerns/spree/purchase/totals.rb
+++ b/spree/core/app/models/concerns/spree/purchase/totals.rb
@@ -12,7 +12,7 @@ module Spree
 
       # @return [BigDecimal]
       def amount
-        line_items.sum(&:amount)
+        line_items.sum(BigDecimal('0'), &:amount)
       end
 
       # Re-sums what the customer has actually paid, and nothing else. A

--- a/spree/core/app/models/concerns/spree/purchase/totals.rb
+++ b/spree/core/app/models/concerns/spree/purchase/totals.rb
@@ -10,6 +10,11 @@ module Spree
         line_items.sum(:quantity)
       end
 
+      # @return [BigDecimal]
+      def amount
+        line_items.sum(&:amount)
+      end
+
       # Re-sums what the customer has actually paid, and nothing else. A
       # payment settling moves only the payment side of the ledger — item
       # and delivery money is the totals workflow's business, and

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -357,11 +357,6 @@ module Spree
       update_hooks.add(hook)
     end
 
-    # For compatibility with Calculator::PriceSack
-    def amount
-      line_items.inject(0.0) { |sum, li| sum + li.amount }
-    end
-
     # Sum of the eligible promotion adjustments applied to the order itself
     # (whole-order discounts created by Promotion::Actions::CreateAdjustment,
     # distributed proportionally across line items), as opposed to promotions

--- a/spree/core/spec/models/concerns/spree/purchase/totals_spec.rb
+++ b/spree/core/spec/models/concerns/spree/purchase/totals_spec.rb
@@ -16,6 +16,13 @@ RSpec.shared_examples 'a purchase totals host' do
 
       expect(record.amount).to eq(5)
     end
+
+    it 'stays a zero BigDecimal with no line items' do
+      amount = new_record.amount
+
+      expect(amount).to eq(0)
+      expect(amount).to be_a(BigDecimal)
+    end
   end
 
   describe '#outstanding_balance?' do

--- a/spree/core/spec/models/concerns/spree/purchase/totals_spec.rb
+++ b/spree/core/spec/models/concerns/spree/purchase/totals_spec.rb
@@ -10,6 +10,14 @@ RSpec.shared_examples 'a purchase totals host' do
     end
   end
 
+  describe '#amount' do
+    it 'sums line item amounts' do
+      record = new_record_with_line_items(line_items_count: 2, line_items_price: 2.5)
+
+      expect(record.amount).to eq(5)
+    end
+  end
+
   describe '#outstanding_balance?' do
     it 'reflects a non-zero balance' do
       expect(new_record(total: 10.10, payment_total: 9.50).outstanding_balance?).to be(true)
@@ -57,8 +65,8 @@ RSpec.describe Spree::Purchase::Totals do
       build(:cart, store: @default_store, **attributes)
     end
 
-    def new_record_with_line_items
-      create(:cart_with_line_items, store: @default_store)
+    def new_record_with_line_items(**attributes)
+      create(:cart_with_line_items, store: @default_store, **attributes)
     end
 
     def create_fulfillment(record)
@@ -77,8 +85,8 @@ RSpec.describe Spree::Purchase::Totals do
       build(:order, store: @default_store, **attributes)
     end
 
-    def new_record_with_line_items
-      create(:order_with_line_items, store: @default_store)
+    def new_record_with_line_items(**attributes)
+      create(:order_with_line_items, store: @default_store, **attributes)
     end
 
     def create_fulfillment(record)

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -967,18 +967,6 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe '#amount' do
-    before do
-      @order = create(:order, customer: user)
-      @order.line_items = [create(:line_item, price: 1.0, quantity: 2),
-                           create(:line_item, price: 1.0, quantity: 1)]
-    end
-
-    it 'returns the correct sum of items' do
-      expect(@order.amount).to eq(3.0)
-    end
-  end
-
   describe '#can_cancel?' do
     it 'is false for a canceled order' do
       order.status = 'canceled'

--- a/spree/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/spree/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -20,6 +20,23 @@ describe Spree::Promotion::Actions::CreateAdjustment, type: :model do
       zero = described_class.create!(promotion: promotion, calculator: Spree::Calculator::FlatRate.new(preferred_amount: 0))
       expect(zero.perform(order: order, promotion: promotion)).to be(false)
     end
+
+    context 'when the promotable is a cart' do
+      let(:cart) { create(:cart_with_line_items, line_items_count: 2, line_items_price: 10, store: promotion.store) }
+
+      {
+        'a flat percent of the item total' => -> { Spree::Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) },
+        'a tiered percent' => -> { Spree::Calculator::TieredPercent.new(preferred_base_percent: 10, preferred_tiers: { 100 => 50 }) },
+        'a tiered flat rate' => -> { Spree::Calculator::TieredFlatRate.new(preferred_base_amount: 2, preferred_currency: 'USD', preferred_tiers: { 100 => 50 }) }
+      }.each do |calculator_description, build_calculator|
+        it "discounts it by #{calculator_description}" do
+          action = described_class.create!(promotion: promotion, calculator: build_calculator.call)
+
+          expect(action.perform(order: cart, promotion: promotion)).to be(true)
+          expect(cart.discounts.reload.sum(&:amount)).to eq(-2)
+        end
+      end
+    end
   end
 
   describe '#compute_amount' do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Purchase totals now provide a consolidated amount calculated from all line items.
  - Cart-based promotions now support verified discount calculations across percentage and tiered pricing rules.

- **Changes**
  - Order-level amount calculation is no longer provided directly; use purchase totals for the consolidated line-item amount.

- **Bug Fixes**
  - Improved compatibility when processing JSON-backed data.

- **Tests**
  - Added coverage for purchase totals and cart promotion discounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->