### PR TITLE
Keep price lists priced in every currency the store adds

### DIFF
--- a/docs/plans/decisions.md
+++ b/docs/plans/decisions.md
@@ -5016,3 +5016,30 @@ leave it.
 the Wholesale list — the import sheet's example download is then a real
 ladder, and a fresh QA environment shows breaks without a script.
 
+## 2026-09-08 — Price list rows are the membership model, and a job keeps them in step with the store's currencies
+
+A store that added a market with a new currency found its existing price
+lists empty in that currency: the spreadsheet shows a currency's products
+through the list's quantity-1 placeholder rows, and those were materialized
+only for the currencies known when the products were added.
+
+**Kept: placeholder rows define membership.** `add_products` writes a
+row per variant × store currency; the products endpoint, the "N prices
+configured" count and the spreadsheet all read those rows. A
+`Spree::PriceLists::SyncCurrenciesJob` now runs for the store after a market
+is created or changes currency; it re-runs `add_products` for what each list
+already holds,
+which inserts only the missing currency's rows. A removed currency keeps its
+rows — dropping merchant-typed prices is not a side effect a market edit may
+have. Markets are the only trigger: a store's currency set is
+configured through them, and the legacy `supported_currencies` column is no
+longer editable. The CSV import materializes the same placeholders for the products it
+prices, so an imported product is on the list the way an added one is.
+
+**Not taken: derive the grid from membership.** The spreadsheet could build
+its rows from the list's products and variants and show empty cells for any
+currency with nothing to sync. It would move the row model out of the
+database into the editor: the products endpoint would have to hand the
+editor variant rows, and the count and empty-state logic would follow. One
+model in one place, kept true by an idempotent job, was the smaller change.
+

--- a/docs/user/manage-products/price-lists.mdx
+++ b/docs/user/manage-products/price-lists.mdx
@@ -78,6 +78,8 @@ Select which currency you'd like to update prices for, and update the values in 
 
 Once you’ve finished entering the custom prices, click **Save** to apply your changes. 
 
+<Note>A currency you start selling in later, by adding a market or changing an existing one, appears in every price list automatically: the list's products show up in that currency with empty prices, ready to fill in.</Note>
+
 ### Quantity Breaks
 
 A price list can charge less per unit from a given quantity up. In the price edit form, click **Add quantity break** under a variant, enter the quantity the break starts at and the unit price from that quantity, then **Save**. A variant can carry up to ten breaks per currency on one price list, and each break must start at a different quantity.

--- a/spree/core/app/jobs/spree/price_lists/sync_currencies_job.rb
+++ b/spree/core/app/jobs/spree/price_lists/sync_currencies_job.rb
@@ -1,0 +1,42 @@
+module Spree
+  module PriceLists
+    # Gives every price list of a store the quantity-1 placeholder rows it is
+    # missing in a currency the store started selling in after the list's
+    # products were added.
+    #
+    # A list's membership is its price rows, and the price spreadsheet shows a
+    # currency's products through the rows in that currency — so a currency
+    # with no rows reads as a list with no products. `add_products` inserts
+    # only the (variant, currency) rows that do not exist yet, which is what
+    # makes this safe to run on every market change. A currency the store
+    # stopped selling in keeps its rows: dropping prices a merchant typed is
+    # not this job's call.
+    #
+    # A store with many lists is walked on a Continuation: the cursor is the
+    # last list synced, so a deploy or a worker restart mid-run resumes with
+    # the next list rather than starting the walk over. Each list's own write
+    # is idempotent, so a list interrupted mid-insert is simply redone.
+    class SyncCurrenciesJob < ::Spree::BaseJob
+      include ActiveJob::Continuable
+
+      # @param store_id [String, Integer]
+      def perform(store_id)
+        # Outside the step on purpose: runs on every execution, resumes included.
+        @store = Spree::Store.find_by(id: store_id)
+        return if @store.nil?
+
+        step :sync_price_lists
+      end
+
+      private
+
+      def sync_price_lists(step)
+        @store.price_lists.find_each(start: step.cursor) do |price_list|
+          product_ids = price_list.products.ids
+          price_list.add_products(product_ids) if product_ids.any?
+          step.advance! from: price_list.id
+        end
+      end
+    end
+  end
+end

--- a/spree/core/app/models/spree/market.rb
+++ b/spree/core/app/models/spree/market.rb
@@ -86,6 +86,7 @@ module Spree
 
     before_save :ensure_single_default
     before_destroy :ensure_can_be_deleted
+    after_commit :sync_price_list_currencies, on: %i[create update], if: :saved_change_to_currency?
 
     #
     # Scopes
@@ -211,6 +212,13 @@ module Spree
         store.association(:default_market).reset
         store.association(:markets).reset if store.association_cached?(:markets)
       end
+    end
+
+    # A new currency has to reach every price list of the store, or the
+    # price spreadsheet shows the lists as empty in it
+    # (Spree::PriceLists::SyncCurrenciesJob).
+    def sync_price_list_currencies
+      Spree::PriceLists::SyncCurrenciesJob.perform_later(store_id)
     end
 
     def ensure_can_be_deleted

--- a/spree/core/app/services/spree/imports/row_processors/price_list_price.rb
+++ b/spree/core/app/services/spree/imports/row_processors/price_list_price.rb
@@ -46,6 +46,10 @@ module Spree
           result = Spree::Prices::BulkUpsert.call(rows: [row])
           raise ArgumentError, failure_message(result) unless result.success?
 
+          # After the write, and only for a row that priced something: a
+          # refused row must not put its product on the list, and neither
+          # must a blank one, whose whole job is to take a rung away.
+          ensure_membership(price_list, variant) if row[:amount].present?
           remember_compare_at(variant, currency, (quantity || 1).to_i, row)
           variant
         end
@@ -98,6 +102,18 @@ module Spree
           raise ArgumentError, Spree.t(:price_list_import_invalid_amount, column: column, value: text) unless text.match?(AMOUNT_FORMAT)
 
           BigDecimal(text)
+        end
+
+        # A product added through the dashboard gets a placeholder row per
+        # store currency, which is what puts it in every currency's grid. A
+        # variant the file prices gets the same, once per product per job, so
+        # an imported product is on the list the way an added one is rather
+        # than only in the currencies the file mentioned.
+        def ensure_membership(price_list, variant)
+          cached_lookup(:price_list_import_membership, variant.product_id) do
+            price_list.add_products([variant.product_id])
+            true
+          end
         end
 
         def mapped?(field)

--- a/spree/core/spec/jobs/spree/price_lists/sync_currencies_job_spec.rb
+++ b/spree/core/spec/jobs/spree/price_lists/sync_currencies_job_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'active_job/continuation/test_helper'
+
+describe Spree::PriceLists::SyncCurrenciesJob, type: :job do
+  describe '#perform' do
+    subject { described_class.perform_now(store.id) }
+
+    let(:store) { create(:store, supported_currencies: 'USD') }
+    let(:product) { create(:product, store: store) }
+    let(:price_list) { create(:price_list, store: store) }
+    let!(:empty_list) { create(:price_list, store: store) }
+
+    before do
+      price_list.add_products([product.id])
+      price_list.bulk_update_prices(price_list.prices.map { |price| { id: price.id, amount: '9.50' } })
+      # The store starts selling in EUR after the products were added.
+      store.update_columns(supported_currencies: 'USD,EUR')
+    end
+
+    it 'adds the missing currency\'s placeholder rows and leaves the rest alone' do
+      usd_before = price_list.prices.where(currency: 'USD').pluck(:id, :amount)
+
+      expect { subject }.to change { price_list.prices.where(currency: 'EUR').count }.from(0).to(product.variants_including_master.count)
+
+      expect(price_list.prices.where(currency: 'EUR').pluck(:amount).uniq).to eq([nil])
+      expect(price_list.prices.where(currency: 'USD').pluck(:id, :amount)).to match_array(usd_before)
+      expect(empty_list.prices).to be_empty
+    end
+
+    it 'does nothing twice' do
+      subject
+
+      expect { described_class.perform_now(store.id) }.not_to change { Spree::Price.count }
+    end
+
+    it 'skips a store that no longer exists' do
+      expect { described_class.perform_now(0) }.not_to raise_error
+    end
+
+    describe 'interruption and resume' do
+      include ActiveJob::Continuation::TestHelper
+
+      around do |example|
+        original = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        example.run
+      ensure
+        ActiveJob::Base.queue_adapter = original
+      end
+
+      let(:other_product) { create(:product, store: store) }
+      let!(:second_list) { create(:price_list, store: store) }
+
+      before do
+        # Built the way the first list was: while the store sold in USD only,
+        # so the walk has a missing currency to add on both lists.
+        store.update_columns(supported_currencies: 'USD')
+        second_list.add_products([other_product.id])
+        store.update_columns(supported_currencies: 'USD,EUR')
+      end
+
+      it 'picks up with the next list rather than starting the walk over' do
+        described_class.perform_later(store.id)
+
+        # The cursor is the list synced last, so the interruption lands after
+        # the first list's rows exist and before the second's.
+        interrupt_job_during_step(described_class, :sync_price_lists, cursor: price_list.id + 1) { perform_enqueued_jobs }
+        expect(price_list.prices.where(currency: 'EUR')).to exist
+        expect(second_list.prices.where(currency: 'EUR')).not_to exist
+
+        perform_enqueued_jobs
+
+        expect(second_list.prices.where(currency: 'EUR').count).to eq(other_product.variants_including_master.count)
+      end
+    end
+  end
+end

--- a/spree/core/spec/models/spree/market_spec.rb
+++ b/spree/core/spec/models/spree/market_spec.rb
@@ -265,6 +265,24 @@ RSpec.describe Spree::Market, type: :model do
     end
   end
 
+  describe 'price list currency sync' do
+    # Created up front: a new store bootstraps a default market of its own,
+    # which would otherwise count as an enqueue inside the block.
+    before { store }
+
+    it 'enqueues a sync for the store when a market brings a currency' do
+      expect { create(:market, store: store, currency: 'EUR') }.
+        to have_enqueued_job(Spree::PriceLists::SyncCurrenciesJob).with(store.id)
+    end
+
+    it 'enqueues again only when the currency changes' do
+      market = create(:market, store: store, currency: 'EUR')
+
+      expect { market.update!(name: 'Europe') }.not_to have_enqueued_job(Spree::PriceLists::SyncCurrenciesJob)
+      expect { market.update!(currency: 'GBP') }.to have_enqueued_job(Spree::PriceLists::SyncCurrenciesJob).with(store.id)
+    end
+  end
+
   describe 'has_prefix_id' do
     it 'generates prefixed id with mkt prefix' do
       market = create(:market, store: store)

--- a/spree/core/spec/services/spree/imports/row_processors/price_list_price_spec.rb
+++ b/spree/core/spec/services/spree/imports/row_processors/price_list_price_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Spree::Imports::RowProcessors::PriceListPrice, type: :service do
       expect(rung(1).amount).to eq(18)
       expect(rung(1).compare_at_amount).to eq(20)
     end
+
+    # An added product gets a placeholder per store currency; an imported one
+    # must too, or it is only on the list in the currencies the file named.
+    it 'puts the variant on the list in every store currency' do
+      subject.process!
+
+      other = price_list.prices.where(variant: variant).where.not(currency: 'USD')
+      expect(other.pluck(:currency)).to match_array(store.supported_currencies_list.map(&:iso_code) - ['USD'])
+      expect(other.pluck(:amount).uniq).to eq([nil])
+    end
   end
 
   context 'with a quantity break' do
@@ -42,7 +52,8 @@ RSpec.describe Spree::Imports::RowProcessors::PriceListPrice, type: :service do
       subject.process!
 
       expect(rung(24).amount).to eq(16.5)
-      expect(rung(1)).to be_nil
+      # Membership only: the bottom rung is a placeholder, not a price.
+      expect(rung(1).amount).to be_nil
     end
   end
 
@@ -78,6 +89,26 @@ RSpec.describe Spree::Imports::RowProcessors::PriceListPrice, type: :service do
 
     it 'fails the row rather than guessing the locale' do
       expect { subject.process! }.to raise_error(ArgumentError, /price must be/)
+    end
+  end
+
+  context 'when the row is refused' do
+    let(:row_data) { csv_row_hash('sku' => 'DENIM-M', 'min_quantity' => '2.5', 'price' => '10') }
+
+    it 'leaves the product off the list' do
+      expect { subject.process! }.to raise_error(ArgumentError)
+
+      expect(price_list.prices.where(variant: variant)).to be_empty
+    end
+  end
+
+  context 'when the row only removes a rung' do
+    let(:row_data) { csv_row_hash('sku' => 'DENIM-M', 'currency' => 'USD', 'price' => '') }
+
+    it 'does not put a product the list never held onto it' do
+      subject.process!
+
+      expect(price_list.prices.where(variant: variant)).to be_empty
     end
   end
 


### PR DESCRIPTION
Fixes a pre-existing gap surfaced while reviewing #14591: a store that adds a market with a new currency finds its existing price lists empty in that currency. The price spreadsheet shows a currency's products through the list's placeholder rows, and those were only created for the currencies known when the products were added.

## What changes

- **A sync job on market change.** Creating a market, changing a market's currency, or changing the store's own currency column queues a job that re-runs the list's add-products step for every price list of the store. The step inserts only the missing rows, so only the new currency's placeholders appear; a currency the store stops selling in keeps its rows.
- **The CSV import puts imported products on the list in every currency**, the way adding a product does, instead of only in the currencies the file named.
- Decision recorded in `docs/plans/decisions.md` (why placeholder rows stay the membership model rather than deriving the grid from membership), and a note in the price lists user guide.

## Testing

Job, market, store and import row-processor specs. Verified on a sample-data store: adding a market with a currency the store did not have puts the Wholesale list's products into that currency's spreadsheet with empty cells.

## QA

1. `pnpm wt:dev` and `pnpm wt:dashboard` in this worktree; sign in as the admin.
2. Products → Price lists → Wholesale → Edit prices. The currency selector offers the store's currencies; each shows the list's products.
3. Settings → Markets → add a market with a currency the store does not sell in yet (say GBP), save.
4. Back on the Wholesale list, Edit prices, switch the selector to the new currency. Expected: the products appear with empty price cells. Failure: "Pick products on the price list to start setting prices."
5. Import a CSV with a single USD row for a product not yet on a list. Expected: the product appears in every currency's grid, priced only in USD.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price lists now automatically gain empty price rows when a market adds or changes currencies.
  * Existing prices remain unchanged, and removed currencies retain their existing rows.
  * CSV imports create currency placeholders for products with valid, non-blank prices.

* **Bug Fixes**
  * Invalid quantity entries and blank-price-only rows no longer add products to a price list.

* **Documentation**
  * Added guidance explaining how newly supported currencies appear in price lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->