### PR TITLE
Display all company members including subunits

### DIFF
--- a/docs/developer/core-concepts/companies.mdx
+++ b/docs/developer/core-concepts/companies.mdx
@@ -240,6 +240,8 @@ const division = await adminClient.companies.create({
 
 Moving a branch is an update with a new `parent_id`. Deleting a node removes its whole subtree, and is refused outright once any order exists beneath it — history doesn't get deleted to tidy up an org chart.
 
+Each row carries `children_count` and `members_count`. `children_count` is the node's direct sub-units, while `members_count` covers the whole subtree — everyone who can act for the node, counted once, whether their membership sits on it or on a unit below it. Because standing runs downward, that is the number of people the business actually has.
+
 ## Related
 
 - [Catalogs](/developer/core-concepts/catalogs) — giving a company its own range and prices

--- a/docs/developer/core-concepts/companies.mdx
+++ b/docs/developer/core-concepts/companies.mdx
@@ -240,7 +240,7 @@ const division = await adminClient.companies.create({
 
 Moving a branch is an update with a new `parent_id`. Deleting a node removes its whole subtree, and is refused outright once any order exists beneath it — history doesn't get deleted to tidy up an org chart.
 
-Each row carries `children_count` and `members_count`. `children_count` is the node's direct sub-units, while `members_count` covers the whole subtree — everyone who can act for the node, counted once, whether their membership sits on it or on a unit below it. Because standing runs downward, that is the number of people the business actually has.
+Each row carries `children_count` and `members_count`. `children_count` is the node's direct sub-units. `members_count` is the number of distinct customers holding a membership on the node or on any node below it, so somebody who is a member of both a parent and one of its sub-units is counted once rather than twice.
 
 ## Related
 

--- a/spree/api/app/serializers/spree/api/v3/admin/company_serializer.rb
+++ b/spree/api/app/serializers/spree/api/v3/admin/company_serializer.rb
@@ -16,9 +16,8 @@ module Spree
             company.children.size
           end
 
-          attribute :members_count do |company|
-            company.memberships.size
-          end
+          # The member count covers the node's whole subtree
+          attributes :members_count
 
           many :children,
                resource: proc { Spree.api.admin_company_serializer },

--- a/spree/api/spec/controllers/spree/api/v3/admin/companies_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/companies_controller_spec.rb
@@ -32,15 +32,19 @@ RSpec.describe Spree::Api::V3::Admin::CompaniesController, type: :controller do
       expect(json_response['data'].map { |row| row['id'] }).not_to include(other.prefixed_id)
     end
 
-    it 'counts children and members without a request per row' do
-      create(:company, store: store, parent: company, kind: 'division')
+    it 'counts children, and members across the whole subtree' do
+      division = create(:company, store: store, parent: company, kind: 'division')
       create(:company_membership, company: company)
+      create(:company_membership, company: division)
 
       get :index, as: :json
 
       row = json_response['data'].find { |r| r['id'] == company.prefixed_id }
       expect(row['children_count']).to eq(1)
-      expect(row['members_count']).to eq(1)
+      expect(row['members_count']).to eq(2)
+
+      division_row = json_response['data'].find { |r| r['id'] == division.prefixed_id }
+      expect(division_row['members_count']).to eq(1)
     end
 
     it 'filters roots and children through Ransack' do

--- a/spree/core/app/models/spree/company.rb
+++ b/spree/core/app/models/spree/company.rb
@@ -176,6 +176,12 @@ module Spree
       self_and_descendants.where.not(id: id)
     end
 
+    # @return [Integer]
+    def members_count
+      Spree::CompanyMembership.where(company_id: self_and_descendants.select(:id)).
+        distinct.count(:customer_id)
+    end
+
     # The single tax anchor: the nearest self-or-ancestor +company+ node. Tax
     # identifiers and exemption certificates are always read through it, and
     # the walk stops at the first legal entity whether or not it holds

--- a/spree/core/spec/models/spree/company_spec.rb
+++ b/spree/core/spec/models/spree/company_spec.rb
@@ -139,6 +139,32 @@ describe Spree::Company, type: :model do
     end
   end
 
+  describe '#members_count' do
+    let(:root) { create(:company, store: store) }
+
+    it 'counts the members of the node and of every unit below it' do
+      child = create(:company, store: store, parent: root, kind: 'division')
+      grandchild = create(:company, store: store, parent: child, kind: 'division')
+      create(:company_membership, company: root)
+      create(:company_membership, company: child)
+      create(:company_membership, company: grandchild)
+      create(:company_membership, company: create(:company, store: store)) # unrelated tree
+
+      expect(root.members_count).to eq(3)
+      expect(child.members_count).to eq(2)
+      expect(grandchild.members_count).to eq(1)
+    end
+
+    it 'counts a member of two units in the same subtree once' do
+      child = create(:company, store: store, parent: root, kind: 'division')
+      customer = create(:customer)
+      create(:company_membership, company: root, customer: customer)
+      create(:company_membership, company: child, customer: customer)
+
+      expect(root.members_count).to eq(1)
+    end
+  end
+
   describe '#legal_entity' do
     let(:root) { create(:company, store: store) }
 


### PR DESCRIPTION
Task left two options:
1. include members from subunits in the general count
or
2. add new count representing members from subunits

I decided to include members from subinits in the general count, as we do in categories -> products_count

https://linear.app/vendo/issue/V-3537/companies-list-shows-members-0-on-a-parent-whose-sub-units-hold-all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Company member counts now include distinct customers across the company and all subordinate units.
  - Customers with memberships in multiple units within the same company hierarchy are counted only once.
  - Company listings display accurate member counts for both parent companies and individual divisions.

- **Documentation**
  - Updated member-count documentation to clarify subtree coverage and duplicate counting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->