### PR TITLE
Fix promotion action adding line item

### DIFF
--- a/spree/core/app/models/concerns/spree/purchase/line_item_lookup.rb
+++ b/spree/core/app/models/concerns/spree/purchase/line_item_lookup.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Purchase
+    # Finding a line item by the variant it sells, shared by Spree::Cart and
+    # Spree::Order. Promotions and the coupon handler reach for these on
+    # whichever of the two they were handed, so both have to answer.
+    module LineItemLookup
+      # @param variant [Spree::Variant]
+      # @param options [Hash] passed to the line item comparison service
+      # @return [Integer] units of the variant already on this purchase
+      def quantity_of(variant, options = {})
+        find_line_item_by_variant(variant, options)&.quantity || 0
+      end
+
+      # @param variant [Spree::Variant]
+      # @param options [Hash] passed to the line item comparison service
+      # @return [Spree::LineItem, nil]
+      def find_line_item_by_variant(variant, options = {})
+        line_items.detect do |line_item|
+          line_item.variant_id == variant.id &&
+            Spree.cart_compare_line_items_service.new.call(order: self, line_item: line_item, options: options).value
+        end
+      end
+    end
+  end
+end

--- a/spree/core/app/models/spree/cart.rb
+++ b/spree/core/app/models/spree/cart.rb
@@ -29,6 +29,7 @@ module Spree
     include Spree::Purchase::StoreCredits
     include Spree::Purchase::GiftCards
     include Spree::Purchase::LineItemCurrencies
+    include Spree::Purchase::LineItemLookup
     include Spree::Purchase::PaymentProcessing
     include Spree::Purchase::Addresses
     include Spree::Purchase::Validations

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -37,6 +37,7 @@ module Spree
     include Spree::Purchase::StoreCredits
     include Spree::Purchase::GiftCards
     include Spree::Purchase::LineItemCurrencies
+    include Spree::Purchase::LineItemLookup
     include Spree::Purchase::PaymentProcessing
     include Spree::Purchase::Addresses
     include Spree::Purchase::Validations
@@ -636,18 +637,6 @@ module Spree
     def disassociate_user!
       Spree::Deprecation.warn('Spree::Order#disassociate_user! is deprecated and will be removed in Spree 6.1. Use #disassociate_customer! instead.')
       disassociate_customer!
-    end
-
-    def quantity_of(variant, options = {})
-      line_item = find_line_item_by_variant(variant, options)
-      line_item ? line_item.quantity : 0
-    end
-
-    def find_line_item_by_variant(variant, options = {})
-      line_items.detect do |line_item|
-        line_item.variant_id == variant.id &&
-          Spree.cart_compare_line_items_service.new.call(order: self, line_item: line_item, options: options).value
-      end
     end
 
     # Re-estimates tax through the configured provider (writes TaxLine rows

--- a/spree/core/spec/models/concerns/spree/purchase/line_item_lookup_spec.rb
+++ b/spree/core/spec/models/concerns/spree/purchase/line_item_lookup_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'a line item lookup host' do
+  let(:record) { new_record_with_line_items }
+  let(:line_item) { record.line_items.first }
+  let(:absent_variant) { create(:variant) }
+
+  describe '#find_line_item_by_variant' do
+    it 'finds the line item selling the variant' do
+      expect(record.find_line_item_by_variant(line_item.variant)).to eq(line_item)
+    end
+
+    it 'answers nil for a variant that is not on the record' do
+      expect(record.find_line_item_by_variant(absent_variant)).to be_nil
+    end
+  end
+
+  describe '#quantity_of' do
+    it 'returns the units already on the record' do
+      line_item.update_column(:quantity, 3)
+
+      expect(record.quantity_of(line_item.variant)).to eq(3)
+    end
+
+    it 'returns zero for a variant that is not on the record' do
+      expect(record.quantity_of(absent_variant)).to eq(0)
+    end
+  end
+end
+
+RSpec.describe Spree::Purchase::LineItemLookup do
+  context 'included in Spree::Cart' do
+    def new_record_with_line_items
+      create(:cart_with_line_items, store: @default_store)
+    end
+
+    it_behaves_like 'a line item lookup host'
+  end
+
+  context 'included in Spree::Order' do
+    def new_record_with_line_items
+      create(:order_with_line_items, store: @default_store)
+    end
+
+    it_behaves_like 'a line item lookup host'
+  end
+end

--- a/spree/core/spec/models/spree/order_spec.rb
+++ b/spree/core/spec/models/spree/order_spec.rb
@@ -550,8 +550,6 @@ describe Spree::Order, type: :model do
   describe '#products' do
     let(:variant1) { create(:variant) }
     let(:variant2) { create(:variant) }
-    let!(:variant3) { create(:variant) }
-    let(:other_variant) { create(:variant) }
     let!(:line_items) do
       [
         create(:line_item, product: variant1.product, variant: variant1, quantity: 1),
@@ -560,17 +558,6 @@ describe Spree::Order, type: :model do
     end
 
     before { allow(order).to receive_messages(line_items: line_items) }
-
-    it 'gets the quantity of a given variant' do
-      expect(order.quantity_of(variant1)).to eq(1)
-
-      expect(order.quantity_of(variant3)).to eq(0)
-    end
-
-    it 'can find a line item matching a given variant' do
-      expect(order.find_line_item_by_variant(variant1)).not_to be_nil
-      expect(order.find_line_item_by_variant(other_variant)).to be_nil
-    end
 
     context 'match line item with options' do
       before do

--- a/spree/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/spree/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -64,6 +64,28 @@ describe Spree::Promotion::Actions::CreateLineItems, type: :model do
     end
   end
 
+  context 'when the promotable is a cart' do
+    let(:cart) { create(:cart) }
+
+    before do
+      allow(action).to receive_messages promotion: promotion
+      action.promotion_action_line_items.create!(variant: mug, quantity: 2)
+    end
+
+    it 'adds the gift to the cart' do
+      expect(action.perform(order: cart)).to be(true)
+      expect(cart.line_items.reload.find_by(variant_id: mug.id).quantity).to eq(2)
+    end
+
+    it 'takes the gift back when the promotion stops applying' do
+      action.perform(order: cart)
+      allow(promotion).to receive(:eligible?).and_return(false)
+
+      expect(action.revert(order: cart)).to be(true)
+      expect(cart.line_items.reload.find_by(variant_id: mug.id)).to be_nil
+    end
+  end
+
   describe '#item_available?' do
     let(:item_out_of_stock) do
       action.promotion_action_line_items.create!(variant: mug, quantity: 1)


### PR DESCRIPTION
https://linear.app/vendo/issue/V-3595/bug-create-line-items-promotion-action-returns-a-500-when-applied-to-a

<img width="800" alt="Screenshot 2026-09-08 at 13 48 15" src="https://github.com/user-attachments/assets/3b6fa33d-a5a3-44ff-8b8a-6ab9a6917f72" />

<img width="400" alt="Screenshot 2026-09-08 at 13 49 28" src="https://github.com/user-attachments/assets/8e88002d-fa54-4b5c-877b-0254ed747d02" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cart and order line items now provide consistent variant lookup and quantity retrieval.
  - Promotion-based gift items can be added to carts and removed when the promotion no longer applies.

- **Bug Fixes**
  - Variant quantities return zero when the requested variant is not present.

- **Tests**
  - Added coverage for line-item lookup across carts and orders.
  - Added coverage for promotional gift item creation and removal in carts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->