### PR TITLE
Remove store credits from Discounts & Gift card section in admin dasbboard order page

### DIFF
--- a/packages/dashboard/src/components/spree/orders/order-discounts-sidebar-card.tsx
+++ b/packages/dashboard/src/components/spree/orders/order-discounts-sidebar-card.tsx
@@ -40,15 +40,7 @@ export function DiscountsCard({ order }: { order: Order }) {
   const removeCouponMutation = useOrderMutation(orderId, () =>
     adminClient.orders.discountCodes.delete(orderId, order.coupon_code ?? ''),
   )
-  const applyStoreCreditMutation = useOrderMutation(orderId, () =>
-    adminClient.orders.storeCredits.apply(orderId),
-  )
-  const removeStoreCreditMutation = useOrderMutation(orderId, () =>
-    adminClient.orders.storeCredits.remove(orderId),
-  )
 
-  const hasStoreCredit = Number.parseFloat(order.store_credit_total) > 0
-  const hasCustomer = Boolean(order.customer_id)
   const isEditable = !order.completed_at
   const couponPending = Boolean(order.coupon_code) && Number.parseFloat(order.discount_total) === 0
 
@@ -141,58 +133,6 @@ export function DiscountsCard({ order }: { order: Order }) {
               </Button>
             ) : (
               <Button size="sm" variant="outline" onClick={() => setGiftCardOpen(true)}>
-                <PlusIcon className="size-4" />
-                {t('admin.actions.apply')}
-              </Button>
-            )}
-          </div>
-
-          <Separator />
-
-          {/* Store credit */}
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex flex-col">
-              <span className="text-sm font-medium">
-                {t('admin.orders.detail.gift_card_section.store_credit_label')}
-              </span>
-              {hasStoreCredit ? (
-                <span className="text-xs text-muted-foreground">
-                  {order.display_store_credit_total}{' '}
-                  {t('admin.orders.detail.gift_card_section.applied_suffix')}
-                </span>
-              ) : (
-                <span className="text-xs text-muted-foreground">
-                  {hasCustomer
-                    ? t('admin.orders.detail.gift_card_section.apply_balance')
-                    : t('admin.orders.detail.gift_card_section.requires_customer')}
-                </span>
-              )}
-            </div>
-            {hasStoreCredit ? (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={async () => {
-                  if (
-                    await confirm({
-                      message: t('admin.orders.detail.confirm.remove_store_credit_message'),
-                      confirmLabel: t('admin.actions.remove'),
-                    })
-                  ) {
-                    removeStoreCreditMutation.mutate(undefined)
-                  }
-                }}
-                disabled={removeStoreCreditMutation.isPending}
-              >
-                {t('admin.actions.remove')}
-              </Button>
-            ) : (
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={!hasCustomer || applyStoreCreditMutation.isPending}
-                onClick={() => applyStoreCreditMutation.mutate(undefined)}
-              >
                 <PlusIcon className="size-4" />
                 {t('admin.actions.apply')}
               </Button>

--- a/packages/dashboard/src/locales/ar.json
+++ b/packages/dashboard/src/locales/ar.json
@@ -2727,7 +2727,6 @@
           "complete_message": "هل تريد إكمال مسودة الطلب هذه الآن؟",
           "remove_gift_card_message": "هل تريد إزالة بطاقة الهدايا هذه من الطلب؟",
           "remove_item_message": "هل تريد إزالة هذا العنصر من الطلب؟",
-          "remove_store_credit_message": "هل تريد إزالة رصيد المتجر من الطلب؟",
           "ship_message": "شحن هذا الوفاء؟",
           "void_message": "Void هذه الدفعة؟"
         },
@@ -2835,16 +2834,12 @@
           "upload_label_title": "رفع ملصق"
         },
         "gift_card_section": {
-          "applied_suffix": "مُطبَّق",
-          "apply_balance": "قم بتطبيق الرصيد المتاح لـ العميل",
           "apply_dialog_description": "أدخل رمز بطاقة الهدايا لتطبيقه على هذا الطلب.",
           "apply_dialog_title": "Apply Gift Card",
           "code_placeholder": "GIFT-XXXX-YYYY",
           "gift_card_label": "بطاقة هدية",
           "none_applied": "لم يتم تطبيق أي شيء",
-          "requires_customer": "يتطلب العميل",
-          "store_credit_label": "Store credit",
-          "title": "الخصومات والرصيد"
+          "title": "الخصومات وبطاقة الهدايا"
         },
         "load_failed_message": "لم نتمكن من تحميل الطلب {{orderId}}.",
         "messages": {

--- a/packages/dashboard/src/locales/de.json
+++ b/packages/dashboard/src/locales/de.json
@@ -2709,7 +2709,6 @@
           "complete_message": "Diesen Auftragsentwurf jetzt abschließen?",
           "remove_gift_card_message": "Diese Geschenkkarte aus dem Auftrag entfernen?",
           "remove_item_message": "Diesen Artikel aus dem Auftrag entfernen?",
-          "remove_store_credit_message": "Guthaben aus dem Auftrag entfernen?",
           "ship_message": "Diese Lieferung versenden?",
           "void_message": "Diese Zahlung stornieren?"
         },
@@ -2818,16 +2817,12 @@
           "upload_label_title": "Etikett hochladen"
         },
         "gift_card_section": {
-          "applied_suffix": "angewendet",
-          "apply_balance": "Verfügbares Guthaben des Kunden anwenden",
           "apply_dialog_description": "Geben Sie einen Geschenkkartencode ein, der auf diesen Auftrag angewendet werden soll.",
           "apply_dialog_title": "Geschenkkarte anwenden",
           "code_placeholder": "GIFT-XXXX-YYYY",
           "gift_card_label": "Geschenkkarte",
           "none_applied": "Keine angewendet",
-          "requires_customer": "Erfordert einen Kunden",
-          "store_credit_label": "Guthaben",
-          "title": "Rabatte & Guthaben"
+          "title": "Rabatte & Geschenkkarte"
         },
         "load_failed_message": "Auftrag {{orderId}} konnte nicht geladen werden.",
         "messages": {

--- a/packages/dashboard/src/locales/en.json
+++ b/packages/dashboard/src/locales/en.json
@@ -2709,7 +2709,6 @@
           "complete_message": "Complete this draft order now?",
           "remove_gift_card_message": "Remove this gift card from the order?",
           "remove_item_message": "Remove this item from the order?",
-          "remove_store_credit_message": "Remove store credit from the order?",
           "ship_message": "Ship this fulfillment?",
           "void_message": "Void this payment?"
         },
@@ -2818,16 +2817,12 @@
           "upload_label_title": "Upload label"
         },
         "gift_card_section": {
-          "applied_suffix": "applied",
-          "apply_balance": "Apply customer's available balance",
           "apply_dialog_description": "Enter a gift card code to apply to this order.",
           "apply_dialog_title": "Apply Gift Card",
           "code_placeholder": "GIFT-XXXX-YYYY",
           "gift_card_label": "Gift card",
           "none_applied": "None applied",
-          "requires_customer": "Requires a customer",
-          "store_credit_label": "Store credit",
-          "title": "Discounts & Credit"
+          "title": "Discounts & Gift card"
         },
         "load_failed_message": "We couldn't load order {{orderId}}.",
         "messages": {

--- a/packages/dashboard/src/locales/fr.json
+++ b/packages/dashboard/src/locales/fr.json
@@ -2709,7 +2709,6 @@
           "complete_message": "Finaliser cette commande brouillon maintenant ?",
           "remove_gift_card_message": "Retirer cette carte cadeau de la commande ?",
           "remove_item_message": "Retirer cet article de la commande ?",
-          "remove_store_credit_message": "Retirer l'avoir de la commande ?",
           "ship_message": "Expédier cet envoi ?",
           "void_message": "Annuler ce paiement ?"
         },
@@ -2818,16 +2817,12 @@
           "upload_label_title": "Téléverser une étiquette"
         },
         "gift_card_section": {
-          "applied_suffix": "appliqué",
-          "apply_balance": "Appliquer le solde disponible du client",
           "apply_dialog_description": "Saisissez un code de carte cadeau à appliquer à cette commande.",
           "apply_dialog_title": "Appliquer une carte cadeau",
           "code_placeholder": "GIFT-XXXX-YYYY",
           "gift_card_label": "Carte cadeau",
           "none_applied": "Aucun appliqué",
-          "requires_customer": "Nécessite un client",
-          "store_credit_label": "Avoir",
-          "title": "Remises et avoirs"
+          "title": "Remises et carte cadeau"
         },
         "load_failed_message": "Impossible de charger la commande {{orderId}}.",
         "messages": {

--- a/packages/dashboard/src/locales/pl.json
+++ b/packages/dashboard/src/locales/pl.json
@@ -2733,7 +2733,6 @@
           "complete_message": "Sfinalizować teraz to zamówienie robocze?",
           "remove_gift_card_message": "Usunąć tę kartę podarunkową z zamówienia?",
           "remove_item_message": "Usunąć tę pozycję z zamówienia?",
-          "remove_store_credit_message": "Usunąć kredyt sklepowy z zamówienia?",
           "ship_message": "Wysłać tę realizację?",
           "void_message": "Unieważnić tę płatność?"
         },
@@ -2844,16 +2843,12 @@
           "upload_label_title": "Wgraj etykietę"
         },
         "gift_card_section": {
-          "applied_suffix": "zastosowano",
-          "apply_balance": "Zastosuj dostępne saldo klienta",
           "apply_dialog_description": "Wprowadź kod karty podarunkowej, aby zastosować ją do tego zamówienia.",
           "apply_dialog_title": "Zastosuj kartę podarunkową",
           "code_placeholder": "GIFT-XXXX-YYYY",
           "gift_card_label": "Karta podarunkowa",
           "none_applied": "Brak zastosowanych",
-          "requires_customer": "Wymaga klienta",
-          "store_credit_label": "Kredyt sklepowy",
-          "title": "Rabaty i środki"
+          "title": "Rabaty i karta podarunkowa"
         },
         "load_failed_message": "Nie udało się załadować zamówienia {{orderId}}.",
         "messages": {

--- a/packages/dashboard/src/locales/zh-CN.json
+++ b/packages/dashboard/src/locales/zh-CN.json
@@ -2702,7 +2702,6 @@
           "complete_message": "现在完成此草稿订单吗？",
           "remove_gift_card_message": "从订单中移除此礼品卡吗？",
           "remove_item_message": "从订单中移除此商品吗？",
-          "remove_store_credit_message": "从订单中移除商店积分吗？",
           "ship_message": "发货此履约单吗？",
           "void_message": "作废此付款吗？"
         },
@@ -2810,16 +2809,12 @@
           "upload_label_title": "上传面单"
         },
         "gift_card_section": {
-          "applied_suffix": "已应用",
-          "apply_balance": "应用客户的可用余额",
           "apply_dialog_description": "输入要应用到此订单的礼品卡代码。",
           "apply_dialog_title": "应用礼品卡",
           "code_placeholder": "GIFT-XXXX-YYYY",
           "gift_card_label": "礼品卡",
           "none_applied": "未应用",
-          "requires_customer": "需要客户",
-          "store_credit_label": "店铺积分",
-          "title": "折扣与余额"
+          "title": "折扣与礼品卡"
         },
         "load_failed_message": "无法加载订单 {{orderId}}。",
         "messages": {


### PR DESCRIPTION
https://linear.app/vendo/issue/V-3601/bug-orders-discounts-and-credit-section-double-counts-gift-card-money

Not needed there, causes confusion. Store credits are displayed & can be added under Payments section:
<img width="1515" height="366" alt="Screenshot 2026-09-09 at 11 54 41" src="https://github.com/user-attachments/assets/c0ac749d-4090-4c08-8ed7-0b355f1a33cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Store credit application and removal controls are no longer available in the order discounts panel.
  * The order details section is now labeled “Discounts & Gift Card” across supported languages.
  * Store credit balance and removal confirmation text have been removed from order details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->