### PR TITLE
Customer page should display only customer orders

### DIFF
--- a/packages/dashboard/e2e/customers.spec.ts
+++ b/packages/dashboard/e2e/customers.spec.ts
@@ -1,5 +1,11 @@
 import { expect, type Page, test } from '@playwright/test'
-import { FIXTURE_PROMO_CUSTOMER_GROUP, fillAddressForm, gotoIndex, login } from './helpers'
+import {
+  FIXTURE_PROMO_CUSTOMER_GROUP,
+  FIXTURE_PROMO_PRODUCT,
+  fillAddressForm,
+  gotoIndex,
+  login,
+} from './helpers'
 
 const CUSTOMERS_PATH = (storeId: string) => `/${storeId}/customers`
 const CTA = /new customer/i
@@ -28,6 +34,34 @@ test.describe('customers', () => {
     // Back to the index, the row appears.
     await gotoIndex(page, CUSTOMERS_PATH(creds.store_id), CTA)
     await expect(page.getByRole('link', { name: email })).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('shows no orders on the profile of a customer who has not ordered', async ({ page }) => {
+    const creds = await login(page)
+
+    // Somebody else's order, so an unfiltered list would have something to show
+    await page.goto(`/${creds.store_id}/orders/new`)
+    await expect(page.getByRole('heading', { name: /new order/i })).toBeVisible({ timeout: 15_000 })
+    await page.locator('#order-email').fill(`e2e-other-buyer-${Date.now()}@example.com`)
+    await page.getByPlaceholder(/search variant/i).fill(FIXTURE_PROMO_PRODUCT)
+    await page
+      .getByRole('option', { name: new RegExp(FIXTURE_PROMO_PRODUCT, 'i') })
+      .first()
+      .click()
+    await page.locator('button[type="submit"]').click()
+    await expect(page).toHaveURL(new RegExp(`/${creds.store_id}/orders/or_[^/]+$`), {
+      timeout: 15_000,
+    })
+
+    await gotoIndex(page, CUSTOMERS_PATH(creds.store_id), CTA)
+    await createCustomer(page, `e2e-no-orders-${Date.now()}@example.com`)
+
+    const ordersCard = page.locator('[data-slot="card"]').filter({
+      has: page.locator('[data-slot="card-title"]', { hasText: /Orders/ }),
+    })
+    await expect(ordersCard.getByText(/no orders yet/i)).toBeVisible({ timeout: 15_000 })
+    await expect(ordersCard.getByRole('row')).toHaveCount(0)
+    await expect(ordersCard.locator('[data-slot="card-title"]')).toHaveText('Orders')
   })
 
   test('edits a customer profile', async ({ page }) => {

--- a/packages/dashboard/src/components/spree/customers/customer-orders-card.tsx
+++ b/packages/dashboard/src/components/spree/customers/customer-orders-card.tsx
@@ -55,7 +55,7 @@ export function CustomerOrdersCard({
             <Link
               to={'/$storeId/orders' as string}
               search={{
-                filters: [{ id: '1', field: 'user_id_eq', operator: 'eq', value: customer.id }],
+                filters: [{ id: '1', field: 'customer_id', operator: 'eq', value: customer.id }],
               }}
               className="text-sm text-primary hover:underline"
             >

--- a/packages/dashboard/src/hooks/use-customers.ts
+++ b/packages/dashboard/src/hooks/use-customers.ts
@@ -104,7 +104,7 @@ export function useCustomerOrders(customerId: string, params: { limit: number; s
     ),
     queryFn: () =>
       adminClient.orders.list({
-        user_id_eq: customerId,
+        customer_id_eq: customerId,
         ...(params.status ? { status_eq: params.status } : {}),
         limit: params.limit,
         sort: '-completed_at',

--- a/packages/dashboard/src/routes/_authenticated/$storeId/customers/$customerId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/customers/$customerId.tsx
@@ -51,7 +51,7 @@ function CustomerBody({ customer }: { customer: Customer }) {
   const { data, isLoading } = useCustomerOrders(customer.id, { limit: 10 })
   const orders = data?.data ?? []
   const totalCount = data?.meta?.count ?? orders.length
-  const lastCompletedOrder = orders.find((o) => o.status === 'complete')
+  const lastPlacedOrder = orders.find((o) => o.status === 'placed')
 
   const defaultShipping = customer.addresses?.find((a) => a.is_default_shipping)
   const location = [defaultShipping?.city, defaultShipping?.country_code].filter(Boolean).join(', ')
@@ -100,7 +100,7 @@ function CustomerBody({ customer }: { customer: Customer }) {
       }
       main={
         <>
-          {lastCompletedOrder && <CustomerLastOrderCard order={lastCompletedOrder} />}
+          {lastPlacedOrder && <CustomerLastOrderCard order={lastPlacedOrder} />}
           <CustomerOrdersCard
             customer={customer}
             orders={orders}

--- a/packages/dashboard/src/routes/_authenticated/$storeId/customers/$customerId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/customers/$customerId.tsx
@@ -51,7 +51,8 @@ function CustomerBody({ customer }: { customer: Customer }) {
   const { data, isLoading } = useCustomerOrders(customer.id, { limit: 10 })
   const orders = data?.data ?? []
   const totalCount = data?.meta?.count ?? orders.length
-  const lastPlacedOrder = orders.find((o) => o.status === 'placed')
+  const { data: placedOrders } = useCustomerOrders(customer.id, { limit: 1, status: 'placed' })
+  const lastPlacedOrder = placedOrders?.data?.[0]
 
   const defaultShipping = customer.addresses?.find((a) => a.is_default_shipping)
   const location = [defaultShipping?.city, defaultShipping?.country_code].filter(Boolean).join(', ')

--- a/spree/api/spec/controllers/spree/api/v3/admin/orders_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/orders_controller_spec.rb
@@ -67,6 +67,28 @@ RSpec.describe Spree::Api::V3::Admin::OrdersController, type: :controller do
           expect(ids).to include(pos_order.prefixed_id, default_channel_order.prefixed_id)
         end
       end
+
+      context 'filtering by customer_id' do
+        let(:customer) { create(:customer) }
+        let(:other_customer) { create(:customer) }
+        let!(:customer_order) { create(:order, store: store, customer: customer) }
+        let!(:other_customer_order) { create(:order, store: store, customer: other_customer) }
+
+        it 'returns only that customer orders' do
+          get :index, params: { q: { customer_id_eq: customer.prefixed_id } }, as: :json
+
+          expect(response).to have_http_status(:ok)
+          ids = json_response['data'].map { |o| o['id'] }
+          expect(ids).to eq([customer_order.prefixed_id])
+        end
+
+        it 'returns nothing for a customer who has not bought anything' do
+          get :index, params: { q: { customer_id_eq: create(:customer).prefixed_id } }, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(json_response['data']).to be_empty
+        end
+      end
     end
 
     context 'with q[search] (full-text search)' do

--- a/spree/core/app/models/spree/order.rb
+++ b/spree/core/app/models/spree/order.rb
@@ -117,7 +117,8 @@ module Spree
     self.whitelisted_ransackable_associations = %w[fulfillments shipments customer created_by approver canceler promotions bill_address ship_address line_items store channel tags seller order_group]
     self.whitelisted_ransackable_attributes = %w[
       completed_at email number status payment_status payment_state fulfillment_status shipment_state delivery_total
-      total item_total total_quantity considered_risky channel_id currency coupon_code seller_id order_group_id po_number
+      total item_total total_quantity considered_risky channel_id currency coupon_code customer_id seller_id
+      order_group_id po_number
     ]
     self.whitelisted_ransackable_scopes = %w[complete incomplete refunded partially_refunded search multi_search]
 


### PR DESCRIPTION
<img width="1021" height="501" alt="Screenshot 2026-09-09 at 14 32 14" src="https://github.com/user-attachments/assets/39aa5063-31c0-463b-8cc8-235d591d1cfe" />
<img width="1031" height="751" alt="Screenshot 2026-09-09 at 14 32 03" src="https://github.com/user-attachments/assets/61ad1ac8-4695-4e75-83bd-e5fdc5fa6afb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Customer profiles now display only orders belonging to the selected customer.
  - The “View all” orders link opens a correctly filtered order list.
  - Customers without orders now see an accurate empty state without unrelated orders.
  - The customer detail page now shows the most recent placed order in the last-order card.
  - Customer order searches now support filtering by customer ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->