### PR TITLE
Fix: Keep the configured calculator when editing promotion actions

### DIFF
--- a/packages/admin-sdk/tests/promotions.test.ts
+++ b/packages/admin-sdk/tests/promotions.test.ts
@@ -271,7 +271,7 @@ describe('promotionActions', () => {
         http.get(`${API_PREFIX}/promotion_actions/calculators`, ({ request }) => {
           url = new URL(request.url)
           return HttpResponse.json({
-            data: [{ type: 'Spree::Calculator::FlatRate', label: 'Flat Rate' }],
+            data: [{ type: 'flat_rate', label: 'Flat Rate' }],
           })
         }),
       )
@@ -281,7 +281,7 @@ describe('promotionActions', () => {
       )
 
       expect(url!.searchParams.get('type')).toBe('Spree::Promotion::Actions::CreateItemAdjustments')
-      expect(res.data[0]?.type).toBe('Spree::Calculator::FlatRate')
+      expect(res.data[0]?.type).toBe('flat_rate')
     })
   })
 })

--- a/packages/dashboard/e2e/promotions.spec.ts
+++ b/packages/dashboard/e2e/promotions.spec.ts
@@ -317,6 +317,39 @@ test.describe('promotions', () => {
     await expect(page.getByText(/currency:\s*USD/i).first()).toBeVisible({ timeout: 5_000 })
   })
 
+  test('reopens a Create Adjustment action on the configured calculator', async ({ page }) => {
+    const creds = await login(page)
+    await gotoIndex(page, PROMOTIONS_PATH(creds.store_id), CTA)
+
+    const name = `E2E Adjustment Edit ${Date.now()}`
+    await startNewPromotion(page, creds.store_id, name)
+
+    await pickAction(page, /^create whole-order adjustment\b/i)
+    await expect(
+      page.getByRole('heading', { name: /^create whole-order adjustment$/i }),
+    ).toBeVisible({ timeout: 5_000 })
+
+    const calculatorSelect = page.locator('#calculator-type')
+    await expect(calculatorSelect).toBeEnabled({ timeout: 10_000 })
+    await calculatorSelect.click()
+    await page.getByRole('option', { name: /^flat rate$/i }).click()
+    await saveEditor(page)
+
+    await submitCreate(page, name)
+
+    await page
+      .locator('div.items-stretch')
+      .filter({ hasText: /create whole-order adjustment/i })
+      .first()
+      .getByRole('button')
+      .first()
+      .click()
+    await expect(
+      page.getByRole('heading', { name: /^create whole-order adjustment$/i }),
+    ).toBeVisible({ timeout: 5_000 })
+    await expect(calculatorSelect).toContainText(/flat rate/i, { timeout: 10_000 })
+  })
+
   test('creates a promotion with a Create Adjustment action', async ({ page }) => {
     const creds = await login(page)
     await gotoIndex(page, PROMOTIONS_PATH(creds.store_id), CTA)

--- a/packages/dashboard/src/components/spree/promotion-editors/action-adjustment.tsx
+++ b/packages/dashboard/src/components/spree/promotion-editors/action-adjustment.tsx
@@ -14,6 +14,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { resolveCalculatorType } from '../../../lib/promotion-calculator-type'
+
 import { EditorShell } from './editor-shell'
 import type { PromotionActionEditorContext } from './types'
 
@@ -36,14 +38,18 @@ export function AdjustmentActionEditor({ draft, onSave, onClose }: PromotionActi
     () => draft.calculator?.preferences ?? {},
   )
 
-  // Once the catalog arrives, ensure `calculatorType` points at a known
-  // calculator. Falls back to the first entry if the draft has no
-  // calculator yet (newly-picked action) or carries a removed one.
+  // Once the catalog arrives, reconcile the draft's calculator against the
+  // list. Accepts api shorthand or legacy full class names, and only falls
+  // back to the first entry for a new action or a calculator that no longer
+  // exists. Runs when the catalog loads — not on every picker change.
   useEffect(() => {
     if (calculators.length === 0) return
-    const matches = calculators.some((c) => c.type === calculatorType)
-    if (!matches) setCalculatorType(calculators[0].type)
-  }, [calculators, calculatorType])
+
+    setCalculatorType((current) => {
+      const resolved = resolveCalculatorType(calculators, current)
+      return resolved ?? calculators[0].type
+    })
+  }, [calculators])
 
   const selectedCalculator: PromotionActionCalculator | undefined = useMemo(
     () => calculators.find((c) => c.type === calculatorType),

--- a/packages/dashboard/src/lib/promotion-calculator-type.test.ts
+++ b/packages/dashboard/src/lib/promotion-calculator-type.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeCalculatorType, resolveCalculatorType } from './promotion-calculator-type'
+
+const catalog = [{ type: 'flat_percent_item_total' }, { type: 'flat_rate' }, { type: 'flexi_rate' }]
+
+describe('normalizeCalculatorType', () => {
+  it('passes through api shorthand unchanged', () => {
+    expect(normalizeCalculatorType('flat_rate')).toBe('flat_rate')
+  })
+
+  it('derives api shorthand from a Ruby class name', () => {
+    expect(normalizeCalculatorType('Spree::Calculator::FlatRate')).toBe('flat_rate')
+    expect(normalizeCalculatorType('Spree::Calculator::FlatPercentItemTotal')).toBe(
+      'flat_percent_item_total',
+    )
+  })
+})
+
+describe('resolveCalculatorType', () => {
+  it('matches catalog entries by api shorthand', () => {
+    expect(resolveCalculatorType(catalog, 'flat_rate')).toBe('flat_rate')
+  })
+
+  it('matches catalog entries when the draft carries a Ruby class name', () => {
+    expect(resolveCalculatorType(catalog, 'Spree::Calculator::FlatRate')).toBe('flat_rate')
+  })
+
+  it('returns undefined when nothing matches', () => {
+    expect(resolveCalculatorType(catalog, 'Spree::Calculator::Gone')).toBeUndefined()
+  })
+})

--- a/packages/dashboard/src/lib/promotion-calculator-type.ts
+++ b/packages/dashboard/src/lib/promotion-calculator-type.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolves a draft calculator `type` against the catalog returned by
+ * `GET /promotion_actions/calculators`. The promotion action payload uses
+ * api shorthand (`flat_rate`) while older catalog responses used the full
+ * Ruby class name (`Spree::Calculator::FlatRate`).
+ */
+export function resolveCalculatorType(
+  calculators: ReadonlyArray<{ type: string }>,
+  type: string,
+): string | undefined {
+  if (!type) return undefined
+
+  const normalized = normalizeCalculatorType(type)
+
+  return calculators.find((calculator) => {
+    const catalogType = calculator.type
+    return (
+      catalogType === type ||
+      catalogType === normalized ||
+      normalizeCalculatorType(catalogType) === normalized
+    )
+  })?.type
+}
+
+/** Mirrors `Spree::Base.api_type`: demodulize + underscore. */
+export function normalizeCalculatorType(type: string): string {
+  if (!type.includes('::')) return type
+
+  const leaf = type.split('::').pop() ?? type
+  return leaf
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase()
+}

--- a/spree/api/spec/controllers/spree/api/v3/admin/promotion_actions_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/admin/promotion_actions_controller_spec.rb
@@ -44,4 +44,15 @@ RSpec.describe Spree::Api::V3::Admin::PromotionActionsController, type: :control
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe 'GET #calculators' do
+    it 'returns calculator api types that match the action serializer' do
+      get :calculators, params: { type: 'create_adjustment' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      types = json_response['data'].map { |entry| entry['type'] }
+      expect(types).to include('flat_rate')
+      expect(types).not_to include('Spree::Calculator::FlatRate')
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes V-3580

Editing a promotion action reset the calculator picker to the first catalog entry because the draft carried api shorthand (`flat_rate`) while the calculators list could still use Ruby class names (`Spree::Calculator::FlatRate`).

- Reconcile both formats when the catalog loads instead of overwriting the draft on every mismatch
- Add a controller spec so the calculators endpoint keeps returning api types
- Add unit and e2e coverage for reopening an action on Flat Rate
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [V-3580](https://linear.app/vendo/issue/V-3580/bug-editing-a-promotion-action-always-opens-on-the-first-calculator)

<div><a href="https://cursor.com/agents/bc-c93d8f71-a6f1-4247-9280-f4793b4784c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c93d8f71-a6f1-4247-9280-f4793b4784c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Promotion adjustment editors now reliably resolve calculator types, including previously saved promotions, so the selected calculator remains displayed correctly.
  * Calculator options are presented using consistent, user-friendly type names such as “Flat rate.”

* **Bug Fixes**
  * Fixed an issue where reopening a promotion could show an incorrect or missing calculator selection.
  * Added coverage to verify calculator choices persist after saving and reopening promotions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->