### PR TITLE
Added Page Up and Page Down in the command palette

### DIFF
--- a/packages/dashboard/e2e/command-palette.spec.ts
+++ b/packages/dashboard/e2e/command-palette.spec.ts
@@ -76,27 +76,6 @@ test.describe('command palette', () => {
     await expect(page.getByRole('option', { name: /^new order$/i })).toBeVisible()
   })
 
-  test('PageDown and PageUp move the highlighted command by a page', async ({ page }) => {
-    const creds = await login(page)
-    await openPalette(page, creds.store_id)
-
-    const first = page.getByRole('option', { selected: true })
-    await expect(first).toBeVisible({ timeout: 15_000 })
-    const firstValue = await first.getAttribute('data-value')
-    expect(firstValue).toBeTruthy()
-
-    await page.keyboard.press('PageDown')
-    const afterDown = page.getByRole('option', { selected: true })
-    await expect(afterDown).toBeVisible()
-    await expect(afterDown).not.toHaveAttribute('data-value', firstValue as string)
-
-    await page.keyboard.press('PageUp')
-    await expect(page.getByRole('option', { selected: true })).toHaveAttribute(
-      'data-value',
-      firstValue as string,
-    )
-  })
-
   test('reports when a query matches nothing', async ({ page }) => {
     const creds = await login(page)
     const input = await openPalette(page, creds.store_id)

--- a/packages/dashboard/e2e/command-palette.spec.ts
+++ b/packages/dashboard/e2e/command-palette.spec.ts
@@ -76,6 +76,27 @@ test.describe('command palette', () => {
     await expect(page.getByRole('option', { name: /^new order$/i })).toBeVisible()
   })
 
+  test('PageDown and PageUp move the highlighted command by a page', async ({ page }) => {
+    const creds = await login(page)
+    await openPalette(page, creds.store_id)
+
+    const first = page.getByRole('option', { selected: true })
+    await expect(first).toBeVisible({ timeout: 15_000 })
+    const firstValue = await first.getAttribute('data-value')
+    expect(firstValue).toBeTruthy()
+
+    await page.keyboard.press('PageDown')
+    const afterDown = page.getByRole('option', { selected: true })
+    await expect(afterDown).toBeVisible()
+    await expect(afterDown).not.toHaveAttribute('data-value', firstValue as string)
+
+    await page.keyboard.press('PageUp')
+    await expect(page.getByRole('option', { selected: true })).toHaveAttribute(
+      'data-value',
+      firstValue as string,
+    )
+  })
+
   test('reports when a query matches nothing', async ({ page }) => {
     const creds = await login(page)
     const input = await openPalette(page, creds.store_id)

--- a/packages/dashboard/src/components/spree/command-palette/command-palette.tsx
+++ b/packages/dashboard/src/components/spree/command-palette/command-palette.tsx
@@ -31,7 +31,8 @@ import {
 import { LogOutIcon, PackageIcon, PlusIcon, SettingsIcon } from '@spree/dashboard-ui/icons'
 import { useNavigate, useParams } from '@tanstack/react-router'
 import type { LucideIcon } from 'lucide-react'
-import { type ReactNode, useMemo, useState } from 'react'
+import { type KeyboardEvent, type ReactNode, useMemo, useState } from 'react'
+import { pagedCommandItem } from './page-command-selection'
 
 export function CommandPalette() {
   const { open, setOpen } = useCommandPalette()
@@ -53,7 +54,23 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
   const settingsNav = useSettingsNav()
 
   const [input, setInput] = useState('')
+  // cmdk has no PageUp/PageDown binding. We take over selection for those
+  // keys and hand the value back so arrow-key navigation stays in sync.
+  const [selectedValue, setSelectedValue] = useState<string>()
   const { groups, hasResults, isLoading, isEnabled } = useGlobalSearch(input)
+
+  const handleListPageKey = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'PageDown' && event.key !== 'PageUp') return
+    if (event.metaKey || event.ctrlKey || event.altKey) return
+
+    event.preventDefault()
+    const item = pagedCommandItem(event.currentTarget, event.key)
+    const value = item?.getAttribute('data-value')
+    if (!item || !value) return
+
+    setSelectedValue(value)
+    item.scrollIntoView({ block: 'nearest' })
+  }
 
   const close = () => {
     setOpen(false)
@@ -172,7 +189,12 @@ function CommandPaletteContent({ setOpen }: { setOpen: (open: boolean) => void }
       >
         {/* The server filters resource results via Ransack; static commands
             are pre-filtered in JS. Either way, cmdk shouldn't filter again. */}
-        <Command shouldFilter={false}>
+        <Command
+          shouldFilter={false}
+          value={selectedValue}
+          onValueChange={setSelectedValue}
+          onKeyDown={handleListPageKey}
+        >
           <CommandInput
             value={input}
             onValueChange={setInput}

--- a/packages/dashboard/src/components/spree/command-palette/page-command-selection.test.ts
+++ b/packages/dashboard/src/components/spree/command-palette/page-command-selection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { nextPagedIndex } from './page-command-selection'
+
+// 8 rows, 40px apart — a 200px list shows five, so a page jumps past four.
+const OFFSETS = [0, 40, 80, 120, 160, 200, 240, 280]
+const PAGE = 200
+
+describe('nextPagedIndex', () => {
+  it('moves down by one viewport and lands on the first item at or past the target', () => {
+    expect(nextPagedIndex(OFFSETS, 0, PAGE, 1)).toBe(5)
+  })
+
+  it('moves up by one viewport toward the matching offset', () => {
+    expect(nextPagedIndex(OFFSETS, 5, PAGE, -1)).toBe(0)
+  })
+
+  it('stops at the last item when a page would overshoot', () => {
+    expect(nextPagedIndex(OFFSETS, 6, PAGE, 1)).toBe(7)
+  })
+
+  it('stops at the first item when a page would overshoot upward', () => {
+    expect(nextPagedIndex(OFFSETS, 1, PAGE, -1)).toBe(0)
+  })
+
+  it('stays put when the list is empty', () => {
+    expect(nextPagedIndex([], 0, PAGE, 1)).toBe(0)
+  })
+
+  it('clamps a current index that is out of range', () => {
+    expect(nextPagedIndex(OFFSETS, 99, PAGE, -1)).toBe(2)
+  })
+
+  it('keeps a single item selected', () => {
+    expect(nextPagedIndex([0], 0, PAGE, 1)).toBe(0)
+    expect(nextPagedIndex([0], 0, PAGE, -1)).toBe(0)
+  })
+})

--- a/packages/dashboard/src/components/spree/command-palette/page-command-selection.ts
+++ b/packages/dashboard/src/components/spree/command-palette/page-command-selection.ts
@@ -1,0 +1,58 @@
+const ITEM_SELECTOR = '[cmdk-item]:not([aria-disabled="true"])'
+const LIST_SELECTOR = '[cmdk-list]'
+
+/**
+ * Index of the item one viewport away from the current selection.
+ * Offsets are positions along the scrollable list, so group headings
+ * shrink the jump the same way they shrink the visible page.
+ */
+export function nextPagedIndex(
+  itemOffsets: readonly number[],
+  currentIndex: number,
+  pageHeight: number,
+  direction: 1 | -1,
+): number {
+  if (itemOffsets.length === 0) return 0
+
+  const current = Math.max(0, Math.min(itemOffsets.length - 1, currentIndex))
+  const target = itemOffsets[current] + direction * pageHeight
+
+  if (direction === 1) {
+    let index = current
+    while (index < itemOffsets.length - 1 && itemOffsets[index] < target) {
+      index += 1
+    }
+    return index
+  }
+
+  let index = current
+  while (index > 0 && itemOffsets[index] > target) {
+    index -= 1
+  }
+  return index
+}
+
+/** The command item one page from the current selection, or `undefined` if the list is empty. */
+export function pagedCommandItem(
+  root: ParentNode,
+  key: 'PageDown' | 'PageUp',
+): HTMLElement | undefined {
+  const list = root.querySelector(LIST_SELECTOR)
+  if (!(list instanceof HTMLElement)) return undefined
+
+  const items = Array.from(list.querySelectorAll(ITEM_SELECTOR)).filter(
+    (node): node is HTMLElement => node instanceof HTMLElement,
+  )
+  if (items.length === 0) return undefined
+
+  const selectedIndex = items.findIndex((item) => item.getAttribute('aria-selected') === 'true')
+  const listTop = list.getBoundingClientRect().top
+  const nextIndex = nextPagedIndex(
+    items.map((item) => item.getBoundingClientRect().top - listTop + list.scrollTop),
+    selectedIndex >= 0 ? selectedIndex : 0,
+    list.clientHeight,
+    key === 'PageDown' ? 1 : -1,
+  )
+
+  return items[nextIndex]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The command palette already moves one row at a time with the arrow keys. A long results list had no way to jump by a screen.

- Page Down and Page Up now move the highlight by one viewport
- The jump accounts for group headings, so it matches what is actually on screen
- Arrow-key navigation stays in sync after a page jump

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79ae33bb-155e-4b74-913a-91770eef98de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ae33bb-155e-4b74-913a-91770eef98de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Page Up and Page Down keyboard navigation to the command palette.
  * Selection now moves by viewport-sized increments and scrolls the newly selected item into view.
  * Navigation safely handles empty lists, single-item lists, and list boundaries.

* **Tests**
  * Added coverage for forward and backward paging, boundary handling, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->