### PR TITLE
Use proper endpoint for paying with store credits, validate payment max_amount properly for store credits

### DIFF
--- a/.changeset/store-credit-checkout-payment.md
+++ b/.changeset/store-credit-checkout-payment.md
@@ -1,0 +1,7 @@
+---
+"@spree/sdk": patch
+---
+
+Document that store credit is applied with `carts.storeCredits.apply()`, not `carts.payments.create()`.
+
+Store credit is a non-session payment method, so reaching for `payments.create()` was the natural mistake — and it failed with "Source can't be blank". That endpoint now answers with a `store_credits_endpoint_required` error naming the right one.

--- a/docs/developer/core-concepts/payments.mdx
+++ b/docs/developer/core-concepts/payments.mdx
@@ -168,6 +168,8 @@ const payment = await client.carts.payments.create(cart.id, {
 }, options)
 ```
 
+Store credit is the exception. It is also a non-session method, but it is applied through `POST /carts/:id/store_credits` rather than created here — a customer's balance can be spread over several credits, and no credit can pay more than its own remaining amount, so covering an order may take more than one payment. Posting it to the payments endpoint returns a `store_credits_endpoint_required` error.
+
 The payment is created in `checkout` state. When the order transitions to `complete`, Spree calls `process_payments!` which runs the payment method's `authorize` (or `purchase` if auto-capture is enabled). For manual payment methods like Check, this is a no-op that succeeds immediately — the payment moves to `pending` (or `completed` with auto-capture), allowing the order to complete.
 
 The merchant can later capture or void the payment from the Admin Panel once the actual payment is received (e.g., check arrives, bank transfer clears, cash is collected on delivery).

--- a/docs/developer/sdk/store/payments.mdx
+++ b/docs/developer/sdk/store/payments.mdx
@@ -42,6 +42,9 @@ const payment = await client.carts.payments.create(cartId, {
 <Note>
   `payments.create()` only works with non-session payment methods (where `session_required` is `false`).
   For session-based gateways like Stripe or Adyen, use `paymentSessions.create()` instead.
+  Store credit is the one non-session method it does not handle — apply that with
+  [`carts.storeCredits.apply()`](/developer/sdk/store/cart-checkout#store-credits), since a balance
+  spread over several credits takes more than one payment to draw.
 </Note>
 
 ## Payment Sessions

--- a/packages/sdk/src/store-client.ts
+++ b/packages/sdk/src/store-client.ts
@@ -631,6 +631,10 @@ export class StoreClient {
       /**
        * Create a payment for a non-session payment method (e.g. Check, Cash on Delivery, Bank Transfer).
        * For session-based payment methods (e.g. Stripe, PayPal), use carts.paymentSessions.create() instead.
+       *
+       * Store credit is the one non-session method this does not accept — apply it with
+       * carts.storeCredits.apply(), since a balance spread over several credits takes more
+       * than one payment to draw. Posting it here returns a `store_credits_endpoint_required` error.
        * @param cartId - Cart prefixed ID
        */
       create: (

--- a/spree/api/app/controllers/spree/api/v3/store/carts/payments_controller.rb
+++ b/spree/api/app/controllers/spree/api/v3/store/carts/payments_controller.rb
@@ -9,7 +9,8 @@ module Spree
             before_action :find_cart!
 
             # POST /api/v3/store/carts/:cart_id/payments
-            # Creates a payment for non-session payment methods (e.g. Check, Cash on Delivery, Bank Transfer)
+            # Creates a payment for non-session payment methods (e.g. Check, Cash on Delivery, Bank Transfer).
+            # Not for store credit — apply that with POST /carts/:cart_id/store_credits.
             def create
               payment_method = current_store.payment_methods.find_by_prefix_id!(params[:payment_method_id])
 
@@ -17,6 +18,14 @@ module Spree
                 return render_error(
                   code: 'payment_session_required',
                   message: Spree.t('api.v3.payments.session_required'),
+                  status: :unprocessable_content
+                )
+              end
+
+              if payment_method.store_credit?
+                return render_error(
+                  code: 'store_credits_endpoint_required',
+                  message: Spree.t('api.v3.payments.store_credits_endpoint_required'),
                   status: :unprocessable_content
                 )
               end

--- a/spree/api/config/locales/en.yml
+++ b/spree/api/config/locales/en.yml
@@ -61,4 +61,5 @@ en:
         payments:
           method_unavailable: This payment method is not available for this order.
           session_required: This payment method requires a payment session. Use the payment sessions endpoint instead.
+          store_credits_endpoint_required: Store credit cannot be created as a payment here. Apply it with POST /carts/{cart_id}/store_credits instead.
       wrong_shipment_target: target shipment is the same as original shipment

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/payments_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/payments_controller_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe Spree::Api::V3::Store::Carts::PaymentsController, type: :controll
       expect(json_response['error']['code']).to eq('payment_session_required')
     end
 
+    it 'points store credit at the store credits endpoint' do
+      store_credit_method = create(:store_credit_payment_method, store: store)
+
+      post :create, params: { cart_id: order.prefixed_id, payment_method_id: store_credit_method.prefixed_id }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(json_response['error']['code']).to eq('store_credits_endpoint_required')
+      expect(json_response['error']['message']).to include('store_credits')
+      expect(order.reload.payments).to be_empty
+    end
+
     it 'rejects unavailable payment methods' do
       unavailable_method = create(:check_payment_method)
       allow_any_instance_of(Spree::PaymentMethod::Check).to receive(:available_for_order?).and_return(false)

--- a/spree/api/spec/controllers/spree/api/v3/store/carts/store_credits_controller_spec.rb
+++ b/spree/api/spec/controllers/spree/api/v3/store/carts/store_credits_controller_spec.rb
@@ -23,6 +23,27 @@ RSpec.describe Spree::Api::V3::Store::Carts::StoreCreditsController, type: :cont
       expect(order.reload.payments.store_credits.count).to eq(1)
     end
 
+    context 'when the balance is spread over several credits' do
+      let!(:order) { create(:cart_with_line_items, customer: user, store: store, line_items_price: 30) }
+      # 35 available, no single credit covering the cart's 30.
+      let!(:store_credit) { create(:store_credit, customer: user, store: store, amount: 20) }
+      let!(:newer_store_credit) { create(:store_credit, customer: user, store: store, amount: 15) }
+
+      it 'draws from each credit in turn to cover the cart' do
+        post :create, params: { cart_id: order.prefixed_id }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['store_credit_total']).to eq('30.0')
+        expect(json_response['amount_due']).to eq('0.0')
+        expect(json_response['covered_by_store_credit']).to be(true)
+
+        payments = order.reload.payments.store_credits.valid
+        expect(payments.map { |payment| [payment.source, payment.amount] }).to contain_exactly(
+          [store_credit, 20.0], [newer_store_credit, 10.0]
+        )
+      end
+    end
+
     context 'without available store credit' do
       let(:user_without_credit) { create(:user) }
       let!(:order_without_credit) { create(:cart_with_line_items, customer: user_without_credit, store: store) }

--- a/spree/core/app/models/spree/payment.rb
+++ b/spree/core/app/models/spree/payment.rb
@@ -240,17 +240,15 @@ module Spree
       payment_method.payment_source_class.unscoped { super }
     end
 
+    # @return [BigDecimal]
     def max_amount
       return amount if owner.nil?
 
       amount_from_order = owner.total - owner.payment_total
+      return amount_from_order unless source.is_a?(Spree::StoreCredit)
 
-      if payment_method&.store_credit?
-        store_credits = owner.available_store_credits
-        store_credits.any? ? [store_credits.first.amount_remaining, amount_from_order].min : amount_from_order
-      else
-        amount_from_order
-      end
+      # The credit backing the payment can only pay up to its own amount_remaining
+      [source.amount_remaining, amount_from_order].min
     end
 
     def amount=(amount)

--- a/spree/core/spec/models/spree/payment_spec.rb
+++ b/spree/core/spec/models/spree/payment_spec.rb
@@ -205,6 +205,46 @@ describe Spree::Payment, type: :model do
           it { is_expected.to be(true) }
         end
       end
+
+      context 'with a store credit payment method' do
+        let(:order) { create(:order, store: store, total: 55) }
+        let(:payment_method) { create(:store_credit_payment_method, store: store) }
+        let(:payment) do
+          build(:payment, order: order, amount: payment_amount, payment_method: payment_method, source: source)
+        end
+
+        let!(:larger_credit) { create(:store_credit, customer: order.customer, store: store, amount: 45) }
+        let!(:smaller_credit) { create(:store_credit, customer: order.customer, store: store, amount: 20) }
+
+        context 'when the amount fits the credit backing the payment' do
+          let(:source) { smaller_credit }
+          let(:payment_amount) { 20 }
+
+          it { is_expected.to be(true) }
+        end
+
+        context 'when the amount exceeds the credit backing the payment' do
+          let(:source) { smaller_credit }
+          let(:payment_amount) { 55 }
+
+          it 'is invalid, since a credit cannot be drawn past its own balance' do
+            subject
+
+            expect(payment.errors.full_messages).to include('Amount is greater than the allowed maximum amount of 20.0')
+          end
+        end
+
+        context 'when a larger credit exists but does not back the payment' do
+          let(:source) { smaller_credit }
+          let(:payment_amount) { 45 }
+
+          it 'is invalid' do
+            subject
+
+            expect(payment.errors.full_messages).to include('Amount is greater than the allowed maximum amount of 20.0')
+          end
+        end
+      end
     end
   end
 

--- a/spree/core/spec/workflows/spree/carts/complete_spec.rb
+++ b/spree/core/spec/workflows/spree/carts/complete_spec.rb
@@ -180,6 +180,37 @@ module Spree
       end
     end
 
+    describe 'store credit' do
+      let(:customer) { create(:user) }
+      let(:cart) { create(:cart_ready_for_delivery, store: store, line_items_count: 1, customer: customer) }
+
+      before do
+        create(:store_credit_payment_method, store: store) unless Spree::PaymentMethod::StoreCredit.exists?
+        cart.recalculate_totals!
+      end
+
+      context 'when the balance is spread over several credits' do
+        let!(:credits) do
+          first_half = (cart.total / 2).ceil
+          [first_half, cart.total - first_half].map do |amount|
+            create(:store_credit, store: store, customer: customer, amount: amount, currency: cart.currency)
+          end
+        end
+        let(:ready_cart) do
+          cart.add_store_credit_payments
+          cart.reload
+        end
+
+        it 'draws from every credit and completes the order' do
+          order = described_class.call(cart: ready_cart).value
+
+          expect(order.total_applied_store_credit).to eq(order.total)
+          expect(order.amount_due).to be_zero
+          expect(credits.map { |credit| credit.reload.amount_used }).to eq(credits.map(&:amount))
+        end
+      end
+    end
+
     describe 'tax lifecycle' do
       it 'tells the tax engine the sale is final' do
         provider = instance_double(Spree::TaxProvider::Internal, estimate: nil, commit: nil)


### PR DESCRIPTION
Storefront part: https://github.com/spree/storefront/pull/220

## Full store credits coverage:

https://github.com/user-attachments/assets/7e7487d5-4494-4c7a-be3a-3fb64944ddaf

## Partial store credits coverage:

https://github.com/user-attachments/assets/61b10f39-b86a-48c4-baf3-3c54e807d887



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store credit can now be applied across multiple credits to fully cover a cart when needed.
  * Store credit usage is limited to each credit’s remaining balance.

* **Bug Fixes**
  * Attempting to submit store credit through the payments endpoint now returns a clear error directing you to the store credits endpoint.
  * Invalid amounts exceeding an individual credit’s balance are rejected.

* **Documentation**
  * Updated API and SDK guidance to clarify the correct store credit application workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->