### PR TITLE
Fix: remove double delete confirms in dashboard

### DIFF
--- a/docs/plans/6.0-beta-release.md
+++ b/docs/plans/6.0-beta-release.md
@@ -1,0 +1,239 @@
+# Spree 6.0 Beta Release
+
+**Status:** Draft
+**Target:** Spree 6.0
+**Depends on:** `5.6-project-layout-and-dashboard.md` (dashboard packaging, embedded starter)
+**Author:** Damian
+**Last updated:** 2026-09-12
+**Tracking:** Linear — · GitHub —
+
+## Summary
+
+Ship the first public beta of Spree 6.0: prerelease Ruby gems on RubyGems, the
+TypeScript packages on npm, and `create-spree-app` / `spree add` scaffolding a
+6.0 project by default. The npm side is the delicate half — `@spree/sdk@1.2.1`
+currently sits on `latest` and is the 5.x Store API, and every storefront (both
+branches) depends on `^1.2.1`. A 6.0 SDK published as `1.x` would silently
+upgrade every 5.x storefront onto an API that no longer exists. The release is
+therefore built around one rule: **the beta is reachable by opt-in tag or
+explicit range, and `latest` keeps meaning 5.x until 6.0 is final.**
+
+## Key Decisions (do not deviate without discussion)
+
+1. **Gems ship as `6.0.0.beta1`.** RubyGems treats it as a prerelease, so
+   `gem install spree` and an unpinned `gem 'spree'` keep resolving to 5.x —
+   only `--pre` or an explicit `6.0.0.beta1` pin reaches it. The version string
+   lives in one place (`spree/core/lib/spree/core/version.rb`), and
+   `rake gem:release` reads it for all nine gems. Use `beta1`, not `beta.1`:
+   both are valid prereleases and both sort correctly, and `beta1` matches the
+   existing `5.6.0.rc1` convention.
+
+2. **`@spree/sdk` goes to `2.0.0-beta.1`, published under the `beta` tag.**
+   This is the load-bearing decision. The major bump states the Store API
+   break, and the prerelease + non-`latest` tag means `^1.2.1` in both
+   storefront branches cannot resolve to it — semver ranges exclude
+   prereleases unless the range itself is a prerelease. `latest` stays on
+   `1.2.1` for 5.x users. **The `release-sdk` job must gain the tag logic the
+   admin-sdk job already has** — today it runs a bare `npm publish`, which
+   would push the beta straight to `latest` and break every 5.x storefront.
+   This is the single highest-risk item in the release.
+
+3. **Admin-side packages keep their existing 0.x / `next` scheme.**
+   `@spree/admin-sdk` (0.8.1) and the dashboard trio (0.13.1) are already
+   published under `next` and have no `latest` 6.0 consumers to protect. Bump
+   them normally through Changesets — no beta tag, no major. `latest` on those
+   packages still points at the ancient 0.1.0/0.2.1, which is the intended
+   Developer Preview posture. Revisit at 6.0 GA, not now.
+
+4. **`6-0-dev` merges into `main` on both scaffolding repos before the
+   release.** `create-spree-app` clones `spree/spree-starter` and
+   `spree/storefront` with no `--branch`, so it follows whatever `main` holds —
+   which is why merging is what makes 6.0 the default for new projects. No
+   `--branch` flag is added here, and nothing needs revising again at GA.
+   The merge lands *after* the gems and SDK are published, because the branches
+   being merged must pin released versions — and the moment `main` moves, every
+   new project gets it. So the order is: publish → pin → merge. See Migration
+   Path.
+
+5. **The starter must pin released gems, not a git branch — and this is a
+   merge blocker.** `starter/6-0-dev` pins
+   `github: 'spree/spree', branch: 'main'`. That is right for development and
+   wrong the instant it becomes `main`: every new project would build against
+   whatever landed that morning, with no reproducible version in a bug report,
+   and `bundle install` would clone this whole monorepo. Flip it to
+   `'6.0.0.beta1'` and regenerate the committed `Gemfile.lock` (currently
+   resolved against `6.0.0.alpha` from the git source) **as part of the merge**,
+   not after it.
+
+6. **Every gem in the monorepo publishes from the 6.0 line — providers and
+   opentelemetry included.** All nine gemspecs already read `Spree.version`, so
+   they version in lockstep; the only gap was `spree_stripe`, absent from
+   `SPREE_PROVIDER_GEMS` in `spree/Rakefile` (fixed — see Migration Path step 0).
+   That gap was a hard release blocker: the starter's Gemfile requires
+   `spree_stripe`, so `bundle install` would have fallen back to the standalone
+   `1.8.1` line, which targets 5.x. `spree_opentelemetry` already ships via
+   `SPREE_OPTIONAL_GEMS` and needs no change. The published set is now:
+   `spree`, `spree_core`, `spree_api`, `spree_emails`, `spree_dashboard`,
+   `spree_opentelemetry`, `spree_easypost`, `spree_meilisearch`, `spree_stripe`.
+
+   Jumping `spree_stripe` from its standalone `1.8.1` to `6.0.0.beta1` is safe:
+   the beta is a prerelease, so `gem 'spree_stripe'` and `~> 1.8` on 5.x keep
+   resolving to the 1.x line. A provider gem's version continuity is
+   deliberately subordinate to the monorepo's — that is what `Spree.version`
+   in every gemspec already encodes.
+
+7. **Clear the changeset backlog in one release train.** 30 unreleased
+   changesets have accumulated since ~July. Run `pnpm changeset version`
+   (not `version:preview`) so `@spree/sdk` is included — this is the release
+   where it must be.
+
+## Design Details
+
+### Current state
+
+| Package | Local | npm `latest` | npm `next` | Consumers to protect |
+| --- | --- | --- | --- | --- |
+| gems | `6.0.0.alpha` | `5.6.x` | — | unpinned `gem 'spree'` |
+| `@spree/sdk` | 1.2.1 | **1.2.1** | — | **storefront `^1.2.1`, both branches** |
+| `@spree/admin-sdk` | 0.8.1 | 0.1.0 | 0.8.1 | none |
+| `@spree/dashboard{,-core,-ui}` | 0.13.1 | 0.2.1 | 0.13.1 | none |
+| `@spree/cli` | 2.4.9 | 2.4.9 | — | 5.x users running `spree` |
+| `create-spree-app` | 1.2.1 | 1.2.1 | — | new projects |
+
+### Why the SDK needs a major, not a `0.x` or a `1.3.0`
+
+The storefront depends on `@spree/sdk: "^1.2.1"`. Under that range:
+
+- `1.3.0` → **resolves.** Every 5.x storefront silently moves to the 6.0 SDK on
+  its next `pnpm install`. Unacceptable.
+- `2.0.0` → does not resolve, but occupies `latest` and becomes the default
+  for anyone running `npm install @spree/sdk`. Premature for a beta.
+- `2.0.0-beta.1` under the `beta` tag → does not resolve into `^1.2.1`, does
+  not touch `latest`, and is reachable as `@spree/sdk@beta` or by exact pin.
+  This is the choice.
+
+Verified: `semver.satisfies("2.0.0-beta.1", "^1.2.1") === false`, and likewise
+for the embedded-template range below.
+
+### The CLI / create-spree-app pairing
+
+`@spree/cli` and `create-spree-app` are the user-facing front door and are
+**not** prerelease-tagged, because a user running the documented
+`npx create-spree-app` must land on 6.0 once we flip the default. Two options,
+and the choice determines how loud the beta is:
+
+- **(a) Ship them as normal `latest` releases** once the starter branches flip.
+  New projects get 6.0 beta; existing 5.x projects are unaffected (the CLI
+  operates on an already-generated project). This is the "6.0 is the default
+  for new projects" outcome you asked for.
+- **(b) Ship them as `beta`-tagged prereleases** (`3.0.0-beta.1`), so 6.0 is
+  opt-in via `npx create-spree-app@beta`. Safer, but then 6.0 is *not* the
+  default and the goal isn't met.
+
+Recommend (a), gated on the starter branches being flipped and a scaffold
+smoke test passing — the release chain (`admin-sdk → dashboard → cli →
+create-spree-app`) already encodes the ordering, and the embedded-template
+range `>=0.13.1 <2.0.0` floats scaffolds onto future dashboard releases
+without a CLI republish.
+
+### What already works and needs no change
+
+- `rake gem:release` builds and pushes all nine gems from the single `VERSION`
+  constant; the `Release` workflow fires on any `v*` tag with Trusted
+  Publishing. Tagging `v6.0.0.beta1` is the whole gem release.
+- The npm release chain is correctly ordered and gated
+  (`admin-sdk → dashboard → cli → create-spree-app`), each job idempotent via a
+  published-version check, so a re-run is safe.
+- `sync-dashboard-starter.mjs` floors the embedded template at the released
+  dashboard version with `>=x.y.z <2.0.0`, which correctly excludes
+  prereleases — scaffolds will not accidentally pick up a `1.0.0-beta`.
+
+## Migration Path
+
+Ordered; each step is independently verifiable. Steps 0-1 are repo hygiene that
+must land before any version bump, because both change what a publish *does*.
+
+0. **Publish every gem.** Add `spree_stripe` to `SPREE_PROVIDER_GEMS` in
+   `spree/Rakefile` (done). Verify the full set builds — all nine gemspecs read
+   `Spree.version`, and `spree_stripe`, `spree_easypost`, `spree_meilisearch`
+   and `spree_opentelemetry` were each confirmed to build cleanly.
+
+1. **Fix the SDK release job.** Add the `Determine npm tag` step to
+   `release-sdk` in `.github/workflows/packages.yml`, copied from
+   `release-admin-sdk`, extended so a version containing `-` publishes under
+   `beta`. **Do this before any version bump lands on main** — otherwise the
+   first push after the bump publishes the 6.0 SDK to `latest` and every 5.x
+   storefront breaks on its next install. Single highest-risk item.
+
+2. **Prepare `spree-starter` for the merge.** On `6-0-dev`, replace the
+   `github: 'spree/spree', branch: 'main'` block with `'6.0.0.beta1'` for all
+   six required gems, and regenerate `Gemfile.lock` (committed, currently
+   resolved against `6.0.0.alpha` from the git source). Leave the `SPREE_PATH`
+   development branch untouched — worktrees depend on it. This cannot be done
+   before step 3 publishes the gems, so the sequence is: publish gems → pin →
+   merge.
+
+3. **Bump and release the gems.** Set `VERSION = '6.0.0.beta1'` in
+   `spree/core/lib/spree/core/version.rb`, tag `v6.0.0.beta1`, and let the
+   `Release` workflow push all nine gems. Confirm each appears on RubyGems
+   before proceeding — the starter's pin depends on every one of them.
+
+4. **Version and publish the npm packages.** Add a changeset giving
+   `@spree/sdk` a major, then `pnpm changeset version` (plain — *not*
+   `version:preview`, which carries `--ignore @spree/sdk`). Hand-edit the
+   resulting `@spree/sdk` version to `2.0.0-beta.1`; Changesets has no
+   first-class prerelease-major path that plays well with a one-package
+   exception. Merge to main and let the release chain publish.
+
+5. **Merge `6-0-dev` into `main`** on `spree/spree-starter` and
+   `spree/storefront`. With steps 2-4 done, `main` on both repos resolves
+   released gems and a published SDK the moment it becomes the default, so
+   `create-spree-app` — which clones without `--branch` — scaffolds 6.0 with no
+   change to this repo. Point the storefront's `@spree/sdk` dependency at the
+   published `2.0.0-beta.1` in the same merge.
+
+6. **Smoke test the real path** — `npx create-spree-app@<candidate>` into a
+   temp dir, boot it, confirm the dashboard loads and the storefront talks to
+   the API. The scaffold is the only test that exercises gem pins, npm ranges
+   and branch defaults together, and it is the first thing a beta user runs.
+
+7. **Announce as beta**, naming the install commands explicitly: gems need
+   `--pre` or an exact pin, `@spree/sdk` needs `@beta`.
+
+## Constraints on Current Work
+
+- **Never publish `@spree/sdk` to `latest` until 6.0 is final.** Any 6.0-line
+  SDK release is `2.x` prerelease under the `beta` tag. The 5.x storefront
+  depends on `^1.2.1` and `latest` is what an unpinned install resolves to.
+- **Don't use `pnpm version:preview` for this release** — it carries
+  `--ignore @spree/sdk`, which is exactly the package that must move.
+- Gem version changes go in `spree/core/lib/spree/core/version.rb` only; every
+  gem and the release task read it.
+- Don't hand-edit `packages/*/package.json` versions — Changesets owns them.
+  The single exception is the SDK prerelease string in step 3, which should be
+  a deliberate, reviewed edit.
+- A dashboard release without a CLI release still reaches users (the embedded
+  template floats `>=x.y.z <2.0.0`); don't add a CLI republish "to pick it up".
+- **A new gem in the monorepo must be added to `spree/Rakefile` in the same
+  change that adds its gemspec.** A gemspec reading `Spree.version` looks
+  released but is invisible to `rake gem:release` — exactly how `spree_stripe`
+  came to be missing. Provider gems go in `SPREE_PROVIDER_GEMS` with an
+  explicit path; everything else in `SPREE_CORE_GEMS`/`SPREE_OPTIONAL_GEMS`.
+- Don't "restore version continuity" for a provider gem by giving it a version
+  of its own. All nine gemspecs read `Spree.version` deliberately; a provider
+  jumping from a standalone `1.x` to the monorepo line is expected.
+
+## Open Questions
+
+- CLI and create-spree-app: `latest` (option a, 6.0 becomes the default) or
+  `beta`-tagged (option b, opt-in)? Recommend (a); it's the stated goal.
+- Should `@spree/seller-sdk` and `@spree/seller-dashboard` (both unpublished,
+  0.1.0, with no release jobs) ship in this train or wait? They currently have
+  no publish jobs in `packages.yml` at all.
+
+## References
+
+- `.github/workflows/packages.yml` — npm release chain
+- `.github/workflows/release.yml` — gem release on `v*` tags
+- `scripts/sync-dashboard-starter.mjs` — embedded template version flooring
+- `docs/plans/5.6-project-layout-and-dashboard.md` — dashboard packaging

--- a/packages/dashboard-core/src/components/page-header.tsx
+++ b/packages/dashboard-core/src/components/page-header.tsx
@@ -85,14 +85,22 @@ interface PageHeaderProps {
   /** Slot context name. Defaults to inferring from `resource` keys. Optional. */
   slotContext?: Record<string, unknown>
   /**
-   * Called after the user confirms the auto-rendered Delete action.
-   * When provided, the Delete item is enabled. The confirmation prompt is
-   * fixed ("Are you sure? This action cannot be undone.") — pass `dropdownItems`
-   * directly if you need a custom delete flow.
+   * Called after the user confirms the auto-rendered Delete action. When
+   * provided, the Delete item is enabled. PageHeader owns the confirmation,
+   * so the handler must not prompt again — pass `dropdownItems` directly if
+   * you need a delete flow this cannot express.
    */
   onDelete?: () => void | Promise<void>
   /** Override the destructive label ("Delete order", "Delete product", etc.). */
   deleteLabel?: string
+  /**
+   * Replaces the generic "Are you sure?" prompt. Say what goes with the
+   * record — "Its zones and delivery methods go with it" — since that is what
+   * the reader cannot see from the button.
+   */
+  deleteConfirmMessage?: string
+  /** Heading for the delete prompt. Defaults to none, as the message carries it. */
+  deleteConfirmTitle?: string
   /**
    * When supplied, the more-actions dropdown gains a "View as JSON" item that
    * opens a developer-style drawer with the resource payload.
@@ -121,6 +129,8 @@ export function PageHeader({
   slotContext,
   onDelete,
   deleteLabel,
+  deleteConfirmMessage,
+  deleteConfirmTitle,
   jsonPreview,
 }: PageHeaderProps) {
   const { t } = useTranslation()
@@ -234,6 +244,8 @@ export function PageHeader({
             destructiveItems={destructiveItems}
             onDelete={onDelete}
             deleteLabel={deleteLabel ?? t('admin.actions.delete')}
+            deleteConfirmMessage={deleteConfirmMessage}
+            deleteConfirmTitle={deleteConfirmTitle}
             onOpenJson={jsonPreview ? openJson : undefined}
           />
         )}
@@ -259,6 +271,8 @@ interface PageActionsDropdownProps {
   destructiveItems?: ReactNode
   onDelete?: () => void | Promise<void>
   deleteLabel: string
+  deleteConfirmMessage?: string
+  deleteConfirmTitle?: string
   onOpenJson?: () => void
 }
 
@@ -269,6 +283,8 @@ function PageActionsDropdown({
   destructiveItems,
   onDelete,
   deleteLabel,
+  deleteConfirmMessage,
+  deleteConfirmTitle,
   onOpenJson,
 }: PageActionsDropdownProps) {
   const { t } = useTranslation()
@@ -329,7 +345,8 @@ function PageActionsDropdown({
               onClick={async () => {
                 if (
                   await confirm({
-                    message: t('admin.common.delete_confirm_message'),
+                    title: deleteConfirmTitle,
+                    message: deleteConfirmMessage ?? t('admin.common.delete_confirm_message'),
                     variant: 'destructive',
                     confirmLabel: deleteLabel,
                   })

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/$productId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/$productId.tsx
@@ -30,7 +30,6 @@ import {
   Skeleton,
   StatusBadge,
   toastManager,
-  useConfirm,
   useFormSubmitShortcut,
 } from '@spree/dashboard-ui'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
@@ -87,7 +86,6 @@ function ProductDetailPage() {
 
 function ProductForm({ product }: { product: Product }) {
   const { t } = useTranslation()
-  const confirm = useConfirm()
   const { productId, storeId } = Route.useParams()
   const router = useRouter()
   const updateProduct = useUpdateProduct()
@@ -231,12 +229,6 @@ function ProductForm({ product }: { product: Product }) {
   useFormSubmitShortcut(form, onSubmit)
 
   const handleDelete = async () => {
-    const confirmed = await confirm({
-      message: t('admin.products.delete_confirm'),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!confirmed) return
     try {
       await deleteProduct.mutateAsync(productId)
       toastManager.add({ type: 'success', title: t('admin.messages.product_deleted') })
@@ -270,6 +262,7 @@ function ProductForm({ product }: { product: Product }) {
               actions={<FormActions form={form} saveLabel={t('admin.products.save_label')} />}
               resource={{ id: product.id }}
               onDelete={handleDelete}
+              deleteConfirmMessage={t('admin.products.delete_confirm')}
               deleteLabel={t('admin.products.delete_label')}
               jsonPreview={{
                 title: `Product ${product.name}`,

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/categories/$categoryId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/categories/$categoryId.tsx
@@ -15,7 +15,6 @@ import {
   ResourceLayout,
   Skeleton,
   toastManager,
-  useConfirm,
   useFormSubmitShortcut,
 } from '@spree/dashboard-ui'
 import { useQueryClient } from '@tanstack/react-query'
@@ -72,7 +71,6 @@ function CategoryDetailPage() {
 function CategoryDetail({ categoryId, storeId }: { categoryId: string; storeId: string }) {
   const { t } = useTranslation()
   const router = useRouter()
-  const confirm = useConfirm()
   const { data: category } = useCategory(categoryId)
   const updateCategory = useUpdateCategory(categoryId)
   const deleteCategory = useDeleteCategory()
@@ -131,12 +129,6 @@ function CategoryDetail({ categoryId, storeId }: { categoryId: string; storeId: 
   useFormSubmitShortcut(form, onSubmit)
 
   const handleDelete = async () => {
-    const confirmed = await confirm({
-      message: t('admin.categories.delete_confirm', { name: category?.name ?? '' }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!confirmed) return
     try {
       await deleteCategory.mutateAsync(categoryId)
       await router.navigate({ to: '/$storeId/products/categories', params: { storeId } })
@@ -162,6 +154,9 @@ function CategoryDetail({ categoryId, storeId }: { categoryId: string; storeId: 
                 actions={<FormActions form={form} saveLabel={t('admin.actions.save')} />}
                 resource={category ? { id: category.id } : undefined}
                 onDelete={handleDelete}
+                deleteConfirmMessage={t('admin.categories.delete_confirm', {
+                  name: category?.name ?? '',
+                })}
                 deleteLabel={t('admin.categories.delete_label')}
                 jsonPreview={{
                   title: `Category ${category?.name ?? ''}`,

--- a/packages/dashboard/src/routes/_authenticated/$storeId/products/collections/$collectionId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/products/collections/$collectionId.tsx
@@ -15,7 +15,6 @@ import {
   ResourceLayout,
   Skeleton,
   toastManager,
-  useConfirm,
   useFormSubmitShortcut,
 } from '@spree/dashboard-ui'
 import { useQueryClient } from '@tanstack/react-query'
@@ -75,7 +74,6 @@ function CollectionDetailPage() {
 function CollectionDetail({ collectionId, storeId }: { collectionId: string; storeId: string }) {
   const { t } = useTranslation()
   const router = useRouter()
-  const confirm = useConfirm()
   const { data: collection } = useCollection(collectionId)
   const updateCollection = useUpdateCollection(collectionId)
   const deleteCollection = useDeleteCollection()
@@ -145,12 +143,6 @@ function CollectionDetail({ collectionId, storeId }: { collectionId: string; sto
   useFormSubmitShortcut(form, onSubmit)
 
   const handleDelete = async () => {
-    const confirmed = await confirm({
-      message: t('admin.collections.delete_confirm.message', { name: collection?.name ?? '' }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!confirmed) return
     try {
       await deleteCollection.mutateAsync(collectionId)
       await router.navigate({ to: '/$storeId/products/collections', params: { storeId } })
@@ -176,6 +168,9 @@ function CollectionDetail({ collectionId, storeId }: { collectionId: string; sto
                 actions={<FormActions form={form} saveLabel={t('admin.actions.save')} />}
                 resource={collection ? { id: collection.id } : undefined}
                 onDelete={handleDelete}
+                deleteConfirmMessage={t('admin.collections.delete_confirm.message', {
+                  name: collection?.name ?? '',
+                })}
                 deleteLabel={t('admin.collections.delete_label')}
                 jsonPreview={{
                   title: `Collection ${collection?.name ?? ''}`,

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/$profileId/index.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/delivery-profiles/$profileId/index.tsx
@@ -1,6 +1,6 @@
 import type { DeliveryProfile } from '@spree/admin-sdk'
 import { adminClient, PageHeader } from '@spree/dashboard-core'
-import { ErrorState, ResourceLayout, useConfirm } from '@spree/dashboard-ui'
+import { ErrorState, ResourceLayout } from '@spree/dashboard-ui'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { z } from 'zod/v4'
@@ -57,17 +57,10 @@ function DeliveryProfileDetailBody({ profile }: { profile: DeliveryProfile }) {
   const { storeId } = Route.useParams()
   const search = Route.useSearch()
   const navigate = useNavigate()
-  const confirm = useConfirm()
   const deleteMutation = useDeleteDeliveryProfile()
 
+  // PageHeader owns the confirmation; this runs once the user has confirmed.
   async function handleDelete() {
-    const ok = await confirm({
-      title: t('admin.delivery_profiles.delete_confirm.title'),
-      message: t('admin.delivery_profiles.delete_confirm.message', { name: profile.name }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
     await deleteMutation.mutateAsync(profile.id)
     navigate({ to: '/$storeId/settings/delivery-profiles', params: { storeId } })
   }
@@ -87,6 +80,10 @@ function DeliveryProfileDetailBody({ profile }: { profile: DeliveryProfile }) {
           }}
           onDelete={profile.default ? undefined : handleDelete}
           deleteLabel={t('admin.delivery_profiles.detail.delete_label')}
+          deleteConfirmTitle={t('admin.delivery_profiles.delete_confirm.title')}
+          deleteConfirmMessage={t('admin.delivery_profiles.delete_confirm.message', {
+            name: profile.name,
+          })}
         />
       }
       main={<DeliveryZonesAndMethodsSection profile={profile} search={search} />}

--- a/packages/dashboard/src/routes/_authenticated/$storeId/settings/webhooks/$webhookEndpointId.tsx
+++ b/packages/dashboard/src/routes/_authenticated/$storeId/settings/webhooks/$webhookEndpointId.tsx
@@ -33,7 +33,6 @@ import {
   SheetHeader,
   SheetTitle,
   Skeleton,
-  useConfirm,
   useFormSubmitShortcut,
   useRowClickBridge,
 } from '@spree/dashboard-ui'
@@ -111,7 +110,6 @@ function WebhookEndpointDetailBody({ endpoint }: { endpoint: WebhookEndpoint }) 
   const { storeId, webhookEndpointId } = Route.useParams()
   const search = Route.useSearch() as z.infer<typeof detailSearchSchema>
   const navigate = useNavigate()
-  const confirm = useConfirm()
 
   const updateMutation = useUpdateWebhookEndpoint(webhookEndpointId)
   const deleteMutation = useDeleteWebhookEndpoint()
@@ -150,15 +148,6 @@ function WebhookEndpointDetailBody({ endpoint }: { endpoint: WebhookEndpoint }) 
 
   // ---- Header actions ---------------------------------------------------
   async function handleDelete() {
-    const ok = await confirm({
-      title: t('admin.pages.settings.webhooks.delete_confirm.title'),
-      message: t('admin.pages.settings.webhooks.delete_confirm.message', {
-        name: endpoint.name || endpoint.url,
-      }),
-      variant: 'destructive',
-      confirmLabel: t('admin.actions.delete'),
-    })
-    if (!ok) return
     await deleteMutation.mutateAsync(endpoint.id)
     navigate({ to: '/$storeId/settings/webhooks', params: { storeId } })
   }
@@ -239,6 +228,10 @@ function WebhookEndpointDetailBody({ endpoint }: { endpoint: WebhookEndpoint }) 
               resolveLink: spreeJsonLinkResolver(storeId),
             }}
             onDelete={handleDelete}
+            deleteConfirmTitle={t('admin.pages.settings.webhooks.delete_confirm.title')}
+            deleteConfirmMessage={t('admin.pages.settings.webhooks.delete_confirm.message', {
+              name: endpoint.name || endpoint.url,
+            })}
             deleteLabel={t('admin.pages.settings.webhooks.detail.delete_label')}
             actions={
               <Can I="update" a={Subject.WebhookEndpoint}>


### PR DESCRIPTION
some resources have their own dedicated delte dialogs to better spell out the consequences, others use the standard one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delete confirmation dialogs across products, categories, collections, delivery profiles, and webhooks now support customized titles and messages.
  - Confirmation prompts are handled consistently through the page header, improving the deletion experience across the dashboard.

- **Documentation**
  - Added planning documentation for the upcoming 6.0 beta release, including release sequencing and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->